### PR TITLE
fix: unexpected background color at light theme

### DIFF
--- a/src/main/frontend/components/sidebar.cljs
+++ b/src/main/frontend/components/sidebar.cljs
@@ -326,7 +326,7 @@
                                 :close-fn close-fn
                                 :route-match route-match})
 
-       [:div.cp__sidebar-layout
+       [:div.cp__sidebar-layout.h-screen
         (header/header {:open-fn open-fn
                         :white? white?
                         :current-repo current-repo


### PR DESCRIPTION
It seems that the problem is caused by https://github.com/logseq/logseq-internal/pull/218. The `.h-screen` was missed after the refactoring.

should fix https://github.com/logseq/logseq/issues/644