### PR TITLE
Fix: Apply font size to all divs.

### DIFF
--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -542,11 +542,11 @@ button.menu {
 #root > div {
   color: #24292e;
   color: var(--ls-primary-text-color);
+  font-size: var(--ls-page-text-size);
 }
 
 #main-content-container {
   font-size: 1em;
-  font-size: var(--ls-page-text-size);
 }
 
 .form-checkbox {


### PR DESCRIPTION
Right now, the global `font-size` variable is only applied to the `#main-content-container` and does not change the `font-size` of the sidebar content.
This fix will make it work on both.