### PR TITLE
Fix: Better font rendering and alignement

### DIFF
--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -1080,6 +1080,7 @@ a.login:hover {
   opacity: 0.5;
   padding: 0 2px 0 2px;
   border: 1px solid;
+  line-height: 1.225;
 }
 
 a.marker-switch:hover {

--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -149,6 +149,7 @@ textarea {
     resize: none;
     outline: none;
     font-weight: inherit;
+    letter-spacing: inherit;
 }
 
 ul {

--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -1080,7 +1080,7 @@ a.login:hover {
   opacity: 0.5;
   padding: 0 2px 0 2px;
   border: 1px solid;
-  line-height: 1.225;
+  line-height: 1.3;
 }
 
 a.marker-switch:hover {

--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -148,6 +148,7 @@ textarea {
     width: 100%;
     resize: none;
     outline: none;
+    font-weight: inherit;
 }
 
 ul {


### PR DESCRIPTION
This will fix a two minor bugs:

Editing text with a different setting than the default one.
Before:
![Before](https://user-images.githubusercontent.com/1410462/99910540-e7ef7280-2cee-11eb-9c69-5cfadaddec5a.gif)

After:
![after](https://user-images.githubusercontent.com/1410462/99910555-f6d62500-2cee-11eb-99c3-ededba939fda.gif)


Better todo marker alignment:
Before:
![Screen Shot 2020-11-22 at 21 39 47](https://user-images.githubusercontent.com/1410462/99916662-b76a0180-2d0b-11eb-9a50-0afa90c6f1c2.png)

After: 
![Screen Shot 2020-11-22 at 21 39 13](https://user-images.githubusercontent.com/1410462/99916671-bd5fe280-2d0b-11eb-868d-e5498ccbf833.png)
