### PR TITLE
Fix: Dark theme for notification area

### DIFF
--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -205,6 +205,7 @@ ol {
 p {
   line-height: 1.5;
   margin: 0.5rem 0;
+  color: var(--ls-primary-text-color)
 }
 
 li p:first-child, .block-body p:first-child {
@@ -1050,6 +1051,8 @@ button.context-menu-option {
 
 .notification-area {
   background-color: #FFF;
+  background-color: var(--ls-tertiary-background-color);
+  color: var(--ls-primary-text-color);
 }
 
 .content img {


### PR DESCRIPTION
This will fix the colors of the notification area for the dark theme.

Before:
![Screen Shot 2020-11-23 at 14 52 09](https://user-images.githubusercontent.com/1410462/99970096-aa94ee80-2d9b-11eb-876d-a4ee24cdf1d2.png)

After:
![Screen Shot 2020-11-23 at 14 52 36](https://user-images.githubusercontent.com/1410462/99970109-b08acf80-2d9b-11eb-9302-fa6a825c3d62.png)