### PR TITLE
chore: use qualified lib names

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,31 +1,33 @@
 {:paths ["src/main"]
  :deps
  {org.clojure/clojure         {:mvn/version "1.10.0"}
-  rum                         {:mvn/version "0.12.3"}
+  rum/rum                     {:mvn/version "0.12.3"}
   ;; rum                         {:local/root "/home/tienson/codes/source/clj/rum"}
   ;; persistent-sorted-set       {:mvn/version "0.1.2"}
   ;; FIXME: doesn't work on my archlinux laptop (tienson)
   ;; The required namespace "datascript.core" is not available, it was required by "frontend/db.cljs".
-  datascript                  {:git/url "https://github.com/tiensonqin/datascript",
+  datascript/datascript       {:git/url "https://github.com/tiensonqin/datascript",
                                :sha "7c2822565d9a114c7d8604c335af89de4640e2e5"}
   ;; datascript                  {:mvn/version "1.0.1"}
-  datascript-transit          {:mvn/version "0.3.0"
+  datascript-transit/datascript-transit
+                              {:mvn/version "0.3.0"
                                :exclusions [datascript]}
   funcool/promesa             {:mvn/version "4.0.2"}
-  medley                      {:mvn/version "1.2.0"}
+  medley/medley               {:mvn/version "1.2.0"}
   metosin/reitit-frontend     {:mvn/version "0.3.10"}
-  cljs-bean                   {:mvn/version "1.5.0"}
+  cljs-bean/cljs-bean         {:mvn/version "1.5.0"}
   prismatic/dommy             {:mvn/version "1.1.0"}
   org.clojure/core.match      {:mvn/version "1.0.0"}
   com.andrewmcveigh/cljs-time {:mvn/version "0.5.2"}
-  cljs-drag-n-drop            {:mvn/version "0.1.0"}
+  cljs-drag-n-drop/cljs-drag-n-drop
+                              {:mvn/version "0.1.0"}
   borkdude/sci                {:mvn/version "0.1.1-alpha.6"}
-  hickory                     {:mvn/version "0.7.1"}
-  hiccups                     {:mvn/version "0.3.0"}
-  tongue                      {:mvn/version "0.2.9"}
+  hickory/hickory             {:mvn/version "0.7.1"}
+  hiccups/hiccups             {:mvn/version "0.3.0"}
+  tongue/tongue               {:mvn/version "0.2.9"}
   org.clojure/core.async      {:mvn/version "1.3.610"}
   thheller/shadow-cljs        {:mvn/version "2.8.81"}
-  expound                     {:mvn/version "0.8.6"}
+  expound/expound             {:mvn/version "0.8.6"}
   lambdaisland/glogi          {:mvn/version "1.0.74"}}
 
  :aliases {:cljs {:extra-paths ["src/dev-cljs/"]

--- a/package.json
+++ b/package.json
@@ -27,15 +27,15 @@
         "clean": "gulp clean",
         "gulp:watch": "gulp watch",
         "gulp:build": "NODE_ENV=production gulp build",
-        "cljs:watch": "clojure -A:cljs watch app publishing",
-        "cljs:release": "clojure -A:cljs release app publishing",
+        "cljs:watch": "clojure -M:cljs watch app publishing",
+        "cljs:release": "clojure -M:cljs release app publishing",
         "cljs:test": "clojure -A:test compile test",
-        "cljs:watch-app": "clojure -A:cljs watch app",
-        "cljs:release-app": "clojure -A:cljs release app",
-        "cljs:release-publishing": "clojure -A:cljs release publishing",
-        "cljs:dev-release-app": "clojure -A:cljs release app --config-merge '{:closure-defines {frontend.config/DEV-RELEASE true}}'",
-        "cljs:debug": "clojure -A:cljs release app --debug",
-        "cljs:report": "clojure -A:cljs run shadow.cljs.build-report app report.html"
+        "cljs:watch-app": "clojure -M:cljs watch app",
+        "cljs:release-app": "clojure -M:cljs release app",
+        "cljs:release-publishing": "clojure -M:cljs release publishing",
+        "cljs:dev-release-app": "clojure -M:cljs release app --config-merge '{:closure-defines {frontend.config/DEV-RELEASE true}}'",
+        "cljs:debug": "clojure -M:cljs release app --debug",
+        "cljs:report": "clojure -M:cljs run shadow.cljs.build-report app report.html"
     },
     "dependencies": {
         "codemirror": "^5.58.1",


### PR DESCRIPTION
After updating to Clojure 1.10.1.727, `yarn watch` prints the following warning messages:

```console
DEPRECATED: Libs must be qualified, change lib => lib/lib (deps.edn)

WARNING: Use of :main-opts with -A is deprecated. Use -M instead.
WARNING: When invoking clojure.main, use -M
```

This PR fixes the warnings.