### PR TITLE
fix(react): fix react warning

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1208,7 +1208,8 @@
                             (reset! parents-atom parents)
                             (when (seq parents)
                               (interpose [:span.mx-2.opacity-50 "➤"]
-                                         parents))))]]
+                                         parents))))]
+             component (filterv identity component)]
          (when (or (seq @parents-atom) show-page?)
            component))))))
 

--- a/src/main/frontend/components/reference.cljs
+++ b/src/main/frontend/components/reference.cljs
@@ -95,5 +95,5 @@
             (if @n-ref
               (str @n-ref " Unlinked References")
               "Unlinked References")]
-           (unlinked-references-aux page-name n-ref)
+            (fn [] (unlinked-references-aux page-name n-ref))
            true)]]))))

--- a/src/main/frontend/components/reference.cljs
+++ b/src/main/frontend/components/reference.cljs
@@ -95,6 +95,5 @@
             (if @n-ref
               (str @n-ref " Unlinked References")
               "Unlinked References")]
-           (fn []
-             (unlinked-references-aux page-name n-ref))
+           (unlinked-references-aux page-name n-ref)
            true)]]))))

--- a/src/main/frontend/components/reference.cljs
+++ b/src/main/frontend/components/reference.cljs
@@ -67,10 +67,15 @@
               (content/content page-name
                                {:hiccup ref-hiccup}))])]]))))
 
-(rum/defc unlinked-references-aux < rum/reactive db-mixins/query
-  [page-name n-ref]
-  (let [ref-blocks (db/get-page-unlinked-references page-name)]
-    (reset! n-ref (count ref-blocks))
+(rum/defcs unlinked-references-aux
+  < rum/reactive db-mixins/query
+    {:will-mount (fn [state]
+                   (let [[page-name n-ref] (:rum/args state)
+                         ref-blocks (db/get-page-unlinked-references page-name)]
+                     (reset! n-ref (count ref-blocks))
+                     (assoc state ::ref-blocks ref-blocks)))}
+  [state page-name n-ref]
+  (let [ref-blocks (::ref-blocks state)]
     [:div.references-blocks
      (let [ref-hiccup (block/->hiccup ref-blocks
                                       {:id (str page-name "-unlinked-")

--- a/src/main/frontend/components/sidebar.cljs
+++ b/src/main/frontend/components/sidebar.cljs
@@ -352,11 +352,11 @@
        [:a#download.hidden]
        (when (and (not config/mobile?)
                   (not config/publishing?))
-         [(help-button)
+         (help-button)
          ;; [:div.font-bold.absolute.bottom-4.bg-base-2.rounded-full.h-8.w-8.flex.items-center.justify-center.font-bold.cursor.opacity-70.hover:opacity-100
          ;;  {:style {:left 24}
          ;;   :title "Click to show/hide sidebar"
          ;;   :on-click (fn []
          ;;               (state/set-left-sidebar-open! (not (state/get-left-sidebar-open?))))}
          ;;  (if (state/sub :ui/left-sidebar-open?) "<" ">")]
-])])))
+         )])))

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -472,8 +472,14 @@
      [:div {:class (if @collapsed?
                      "hidden"
                      "initial")}
-      (if (and (fn? content) (not @collapsed?))
+      (cond
+        (and (fn? content) (not @collapsed?))
         (content)
+
+        (fn? content)
+        nil
+
+        :else
         content)]]))
 
 (defn admonition


### PR DESCRIPTION
fix warning in `page` URL, including:

`help` element warning

![image](https://user-images.githubusercontent.com/3728028/100207337-73147680-2f42-11eb-965a-6295463408cb.png)

two others react warning

![image](https://user-images.githubusercontent.com/3728028/100207540-a9ea8c80-2f42-11eb-8eaf-ae70861e7a66.png)
![image](https://user-images.githubusercontent.com/3728028/100207566-b1aa3100-2f42-11eb-87f0-7b7c627138d2.png)

