### PR TITLE
 fix(token): calculate expiration based on user's system time

### DIFF
--- a/src/main/frontend/helper.cljs
+++ b/src/main/frontend/helper.cljs
@@ -36,7 +36,7 @@
       (if (and (map? token-state)
                (string? expires_at))
         (let [expires-at (tf/parse (tf/formatters :date-time-no-ms) expires_at)
-              request-time-gap (t/minutes 1)
+              request-time-gap (t/minutes 5)
               now (t/now)
               expired? (t/after? now (t/minus expires-at request-time-gap))]
           {:exist? true

--- a/src/main/frontend/helper.cljs
+++ b/src/main/frontend/helper.cljs
@@ -36,9 +36,8 @@
       (if (and (map? token-state)
                (string? expires_at))
         (let [expires-at (tf/parse (tf/formatters :date-time-no-ms) expires_at)
-              request-time-gap (t/minutes 5)
               now (t/now)
-              expired? (t/after? now (t/minus expires-at request-time-gap))]
+              expired? (t/after? now expires-at)]
           {:exist? true
            :expired? expired?
            :token token})

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -8,7 +8,9 @@
             [goog.dom :as gdom]
             [dommy.core :as dom]
             [cljs.core.async :as async]
-            [lambdaisland.glogi :as log]))
+            [lambdaisland.glogi :as log]
+            [cljs-time.core :as t]
+            [cljs-time.format :as tf]))
 
 (defonce ^:private state
   (atom
@@ -519,9 +521,15 @@
       (when (seq repos)
         (let [set-token-f
               (fn [{:keys [installation_id] :as repo}]
-                (let [{:keys [token expires_at] :as m} (get tokens installation_id)]
-                  (if (and token expires_at)
-                    (merge repo {:token token :expires_at expires_at})
+                (let [{:keys [token] :as m} (get tokens installation_id)]
+                  (if (string? token)
+                    ;; Github API returns a expires_at key which is a timestamp (expires after 60 minutes at present),
+                    ;; however, user's system time may be inaccurate. Here, based on the client system time, we use
+                    ;; 60-minutes duration directly.
+                    (let [formatter (tf/formatters :date-time-no-ms)
+                          expires-at (->> (t/plus (t/now) (t/minutes 60))
+                                          (tf/unparse formatter))]
+                      (merge repo {:token token :expires_at expires-at}))
                     (do (log/error :token/cannot-set-token {:repo-m repo :token-m m}) repo))))
               repos (mapv set-token-f repos)]
           (swap! state assoc-in [:me :repos] repos))))))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -525,9 +525,9 @@
                   (if (string? token)
                     ;; Github API returns a expires_at key which is a timestamp (expires after 60 minutes at present),
                     ;; however, user's system time may be inaccurate. Here, based on the client system time, we use
-                    ;; 60-minutes duration directly.
+                    ;; 40-minutes interval to deal with some critical conditions, for e.g. http request time consume.
                     (let [formatter (tf/formatters :date-time-no-ms)
-                          expires-at (->> (t/plus (t/now) (t/minutes 60))
+                          expires-at (->> (t/plus (t/now) (t/minutes 40))
                                           (tf/unparse formatter))]
                       (merge repo {:token token :expires_at expires-at}))
                     (do (log/error :token/cannot-set-token {:repo-m repo :token-m m}) repo))))


### PR DESCRIPTION
As the user's system time may be inaccurate, this PR uses the expiration interval (60 minutes ) directly. This solution might cause some problems while Github changes the expiration interval.
