### PR TITLE
Do not log error when resolving ref fails in check-changed-files-status

### DIFF
--- a/src/main/frontend/handler/common.cljs
+++ b/src/main/frontend/handler/common.cljs
@@ -6,7 +6,8 @@
             [frontend.util :as util]
             [frontend.text :as text]
             [frontend.git :as git]
-            [frontend.db :as db]))
+            [frontend.db :as db]
+            [lambdaisland.glogi :as log]))
 
 (defn get-ref
   [repo-url]
@@ -28,17 +29,20 @@
           (gobj/get js/window "workerThread")
           (gobj/get js/window.workerThread "getChangedFiles"))
      (->
-      (p/let [files (js/window.workerThread.getChangedFiles (util/get-repo-dir repo))]
-        (let [files (bean/->clj files)]
-          (p/let [remote-latest-commit (get-remote-ref repo)
-                  local-latest-commit (get-ref repo)
-                  descendent? (git/descendent? repo local-latest-commit remote-latest-commit)
-                  diffs (git/get-diffs repo local-latest-commit remote-latest-commit)]
-            (let [files (if descendent?
-                          (->> (concat (map :path diffs) files)
-                               distinct)
-                          files)]
-              (state/set-changed-files! repo files)))))
+      (p/let [files (js/window.workerThread.getChangedFiles (util/get-repo-dir repo))
+              files (bean/->clj files)]
+        (->
+         (p/let [remote-latest-commit (get-remote-ref repo)
+                 local-latest-commit (get-ref repo)]
+           (p/let [descendent? (git/descendent? repo local-latest-commit remote-latest-commit)
+                   diffs (git/get-diffs repo local-latest-commit remote-latest-commit)]
+             (let [files (if descendent?
+                           (->> (concat (map :path diffs) files)
+                                distinct)
+                           files)]
+               (state/set-changed-files! repo files))))
+         (p/catch (fn [error]
+                    (log/warn :git/ref-not-found {:error error})))))
       (p/catch (fn [error]
                  (js/console.dir error)))))))
 

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -456,10 +456,9 @@
                                       (or (:page/original-name page)
                                           (:page/name page)))
                                     (text/remove-level-spaces value (keyword format)))]
-                   (p/let [_ (fs/create-if-not-exists dir file-path content)]
+                   (p/let [_ (fs/create-if-not-exists dir file-path content)
+                           _ (git-handler/git-add repo path)]
                      (db/reset-file! repo path content)
-                     (git-handler/git-add repo path)
-
                      (ui-handler/re-render-root!)
 
                      ;; Continue to edit the last block
@@ -695,13 +694,13 @@
             (let [content (util/default-content-with-title format (or
                                                                    (:page/original-name page)
                                                                    (:page/name page)))]
-              (p/let [_ (fs/create-if-not-exists dir file-path content)]
+              (p/let [_ (fs/create-if-not-exists dir file-path content)
+                      _ (git-handler/git-add repo path)]
                 (db/reset-file! repo path
                                 (str content
                                      (text/remove-level-spaces value (keyword format))
                                      "\n"
                                      snd-block-text))
-                (git-handler/git-add repo path)
                 (ui-handler/re-render-root!)
 
                 ;; Continue to edit the last block

--- a/src/main/frontend/handler/file.cljs
+++ b/src/main/frontend/handler/file.cljs
@@ -206,11 +206,10 @@
           git-add-f (fn []
                       (let [add-helper
                             (fn []
-                              (doall
-                               (map
-                                (fn [[path content]]
-                                  (git-handler/git-add repo path update-status?))
-                                files)))]
+                              (map
+                               (fn [[path content]]
+                                 (git-handler/git-add repo path update-status?))
+                               files))]
                         (-> (p/all (add-helper))
                             (p/then (fn [_]
                                       (when git-add-cb
@@ -224,7 +223,7 @@
                                                (let [original-content (get file->content path)]
                                                  [path original-content content])) files)]
                           (history/add-history! repo files-tx))))]
-      (-> (p/all (doall (map write-file-f files)))
+      (-> (p/all (map write-file-f files))
           (p/then (fn []
                     (git-add-f)
                     ;; TODO: save logseq/metadata

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -63,9 +63,9 @@
                 :error)
                ;; create the file
                (let [content (util/default-content-with-title format title)]
-                 (p/let [_ (fs/create-if-not-exists dir file-path content)]
+                 (p/let [_ (fs/create-if-not-exists dir file-path content)
+                         _ (git-handler/git-add repo path)]
                    (db/reset-file! repo path content)
-                   (git-handler/git-add repo path)
                    (when redirect?
                      (route-handler/redirect! {:to :page
                                                :path-params {:name page}})


### PR DESCRIPTION
Due to some concurrency issue, `git/resolve-ref` may fail in `check-changed-files-status` and an error is reported. This is unnecessary.