### PR TITLE
Fix: Page ref colors for custom themes

### DIFF
--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -348,11 +348,11 @@ h1.title {
 }
 
 a.page-ref {
-  color: var(--ls-link-text-color);
+  color: var(--ls-link-ref-text-color);
 }
 
 a.page-ref:hover {
-  color: var(--ls-link-text-hover-color)
+  color: var(--ls-link-ref-text-hover-color);
 }
 
 .block-ref {


### PR DESCRIPTION
The page refs colors got probably changed with the link colors in the recent CSS features, this fix will make it work as intended.