### PR TITLE
Add support for change start of week in calendar

### DIFF
--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1021,4 +1021,12 @@
   []
   @editor-op)
 
+(defn get-start-of-week
+  []
+  (or
+   (when-let [repo (get-current-repo)]
+     (get-in @state [:config repo :start-of-week]))
+   (get-in @state [:me :settings :start-of-week])
+   6))
+
 (defonce diffs (atom nil))

--- a/src/main/frontend/ui/date_picker.cljs
+++ b/src/main/frontend/ui/date_picker.cljs
@@ -7,6 +7,7 @@
    [frontend.util          :refer [deref-or-value now->utc]]
    [frontend.mixins :as mixins]
    [frontend.util :as util]
+   [frontend.state :as state]
    [goog.object :as gobj]))
 
 ;; Adapted from re-com date-picker

--- a/src/main/frontend/ui/date_picker.cljs
+++ b/src/main/frontend/ui/date_picker.cljs
@@ -211,7 +211,7 @@
            (reset! *internal-model (first (:rum/args state)))
            state)}
   [model {:keys [on-change on-switch disabled? start-of-week class style attr]
-          :or   {start-of-week 6} ;; Default to Sunday
+          :or   {start-of-week (state/get-start-of-week)} ;; Default to Sunday
           :as   args}]
   (let [internal-model (util/react *internal-model)
         display-month (first-day-of-the-month (or internal-model (now->utc)))


### PR DESCRIPTION
According to https://github.com/logseq/logseq/issues/901

Is your feature request related to a problem? Please describe.
In my country week is started from monday. Now calendar a bit confused.

Describe the solution you'd like
I'm want to able change start day of week in calendar via config.edn

Add new setting :start-of-week in config.edn. 6 - Sunday, 0 - Monday. Default is 6 - Sunday.