### PR TITLE
fix: git add unstaged files before committing

### DIFF
--- a/resources/js/worker.js
+++ b/resources/js/worker.js
@@ -282,7 +282,11 @@ if (detect() === 'Worker') {
       })
     },
     statusMatrix: async function (dir) {
-      await git.statusMatrix({ fs, dir });
+      return git.statusMatrix({ fs, dir });
+    },
+    statusMatrixChanged: async function (dir) {
+      return (await git.statusMatrix({ fs, dir }))
+        .filter(([_, head, workDir, stage]) => !(head == 1 && workDir == 1 && stage == 1));
     },
     getChangedFiles: async function (dir) {
       try {

--- a/src/main/frontend/handler/repo.cljs
+++ b/src/main/frontend/handler/repo.cljs
@@ -139,8 +139,8 @@
                file-exists? (fs/create-if-not-exists repo-url repo-dir file-path content)]
          (when-not file-exists?
            (file-handler/reset-file! repo-url path content)
-           (ui-handler/re-render-root!))
-         (git-handler/git-add repo-url path))))))
+           (ui-handler/re-render-root!)
+           (git-handler/git-add repo-url path)))))))
 
 (defn create-today-journal!
   []
@@ -427,7 +427,7 @@
          (state/input-idle? repo-url)
          (or (not= status :pushing)
              custom-commit?))
-      (-> (p/let [files (js/window.workerThread.getChangedFiles (util/get-repo-dir (state/get-current-repo)))]
+      (-> (p/let [files (git/add-all (state/get-current-repo))]
             (when (or (seq files) merge-push-no-diff?)
               ;; auto commit if there are any un-committed changes
               (let [commit-message (if (string/blank? commit-message)


### PR DESCRIPTION
The current implementation assumes Git's working tree and staging area are exactly the same, however, due to some mysterious concurrency bug, a file might be modified but unstaged, leaving the user in a state where neither pulling nor pushing is possible.

This PR will `git add` all unstaged files before committing and pushing.

- It might fix https://github.com/logseq/logseq/issues/919 and https://github.com/logseq/logseq/issues/958.
-  It should fix https://github.com/logseq/logseq/issues/773.
- Related to https://github.com/logseq/logseq/issues/848.
- Depends on https://github.com/logseq/logseq-backend/pull/16.