### PR TITLE
Fix empty queries in journal

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1538,9 +1538,10 @@
 
 (defn built-in-custom-query?
   [title]
-  (let [queries (state/sub [:config repo :default-queries :journals])]
-    (when (seq queries)
-      (boolean (some #(= % title) (map :title queries))))))
+  (let [repo (state/get-current-repo)]
+    (let [queries (state/sub [:config repo :default-queries :journals])]
+      (when (seq queries)
+        (boolean (some #(= % title) (map :title queries)))))))
 
 (rum/defcs custom-query < rum/reactive
   {:will-mount (fn [state]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1538,8 +1538,9 @@
 
 (defn built-in-custom-query?
   [title]
-  (contains? #{"🔨 NOW" "📅 NEXT"}
-             title))
+  (let [queries (state/sub [:config repo :default-queries :journals])]
+    (when (seq queries)
+      (boolean (some #(= % title) (map :title queries))))))
 
 (rum/defcs custom-query < rum/reactive
   {:will-mount (fn [state]


### PR DESCRIPTION
If query in :default-queries journals from config.edn returns empty result it doesn't hidden.