### PR TITLE
Make sure the code raises error in case repo dir is missing

### DIFF
--- a/src/main/frontend/components/commit.cljs
+++ b/src/main/frontend/components/commit.cljs
@@ -4,6 +4,8 @@
             [frontend.handler.repo :as repo-handler]
             [frontend.state :as state]
             [frontend.mixins :as mixins]
+            [frontend.handler.notification :as notification]
+            [promesa.core :as p]
             [goog.dom :as gdom]
             [goog.object :as gobj]))
 
@@ -11,7 +13,9 @@
   []
   (let [value (gobj/get (gdom/getElement "commit-message") "value")]
     (when (and value (>= (count value) 1))
-      (repo-handler/git-commit-and-push! value)
+      (-> (repo-handler/git-commit-and-push! value)
+          (p/catch (fn [error]
+                     (notification/show! error :error false))))
       (state/close-modal!))))
 
 (rum/defcs add-commit-message <

--- a/src/main/frontend/components/repo.cljs
+++ b/src/main/frontend/components/repo.cljs
@@ -105,6 +105,13 @@
                 git-status (state/sub [:git/status repo])
                 pushing? (= :pushing git-status)
                 pulling? (= :pulling git-status)
+                git-failed? (contains?
+                             #{:push-failed
+                               :clone-failed
+                               :checkout-failed
+                               :fetch-failed
+                               :merge-failed}
+                             git-status)
                 push-failed? (= :push-failed git-status)
                 last-pulled-at (db/sub-key-value repo :git/last-pulled-at)
                 ;; db-persisted? (state/sub [:db/persisted? repo])
@@ -115,7 +122,7 @@
               (fn [{:keys [toggle-fn]}]
                 [:div.cursor.w-2.h-2.sync-status.mr-2
                  {:class (cond
-                           push-failed?
+                           git-failed?
                            "bg-red-500"
                            (or
                             ;; (not db-persisted?)

--- a/src/main/frontend/fs.cljs
+++ b/src/main/frontend/fs.cljs
@@ -108,7 +108,10 @@
                                            :error error})))))
 
     :else
-    (js/window.pfs.unlink path opts)))
+    (p/let [stat (js/window.pfs.stat path)]
+      (if (.-isFile stat)
+        (js/window.pfs.unlink path opts)
+        (p/rejected "Unlinking a directory is not allowed")))))
 
 (defn rmdir
   "Remove the directory recursively."
@@ -232,6 +235,10 @@
 (defn rename
   [repo old-path new-path]
   (cond
+    ; See https://github.com/isomorphic-git/lightning-fs/issues/41
+    (= old-path new-path)
+    (p/resolved nil)
+
     (local-db? old-path)
     ;; create new file
     ;; delete old file

--- a/src/main/frontend/git.cljs
+++ b/src/main/frontend/git.cljs
@@ -110,6 +110,14 @@
   "Equivalent to `git add --all`. Returns changed files."
   [repo-url]
   (p/let [repo-dir (util/get-repo-dir repo-url)
+
+          ; statusMatrix will return `[]` rather than raising an error if the repo directory does
+          ; not exist. So checks whether repo-dir exists before proceeding.
+          _ (-> (js/window.pfs.stat repo-dir)
+                (p/catch #(p/rejected (str "Cannot find repo dir '"
+                                           repo-dir
+                                           "' in fs when `git add --all`"))))
+
           status-matrix (js/window.workerThread.statusMatrixChanged repo-dir)
           changed-files (for [[file head work-dir _stage] status-matrix
                               :when (not= head work-dir)]

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -253,7 +253,7 @@
         (let [file (db/get-page-file page-name)
               file-path (:file/path file)]
           ;; delete file
-          (when file-path
+          (when-not (string/blank? file-path)
             (db/transact! [[:db.fn/retractEntity [:file/path file-path]]])
             (when-let [files-conn (db/get-files-conn repo)]
               (d/transact! files-conn [[:db.fn/retractEntity [:file/path file-path]]]))

--- a/src/main/frontend/handler/repo.cljs
+++ b/src/main/frontend/handler/repo.cljs
@@ -407,7 +407,8 @@
                             (pull repo-url new-opts))
                           (let [error-msg
                                 (util/format "Failed to fetch %s. It may be caused by token expiration or missing." repo-url)]
-                            (log/error :git/pull-error error)
+                            (git-handler/set-git-status! repo-url :fetch-failed)
+                            (log/error :repo/pull-error error)
                             (notification/show! error-msg :error false))))
 
                       :else
@@ -454,7 +455,7 @@
                            (pull repo-url {:force-pull? true
                                            :show-diff? true}))))))))))
           (p/catch (fn [error]
-                     (log/error :git/get-changed-files-error error)
+                     (log/error :repo/push-error error)
                      (git-handler/set-git-status! repo-url :push-failed)
                      (git-handler/set-git-error! repo-url error)
                      (js/console.dir error)))))))


### PR DESCRIPTION
For unknown reason, the entire repo directory might be missing in some rare cases. If it does happen, we should notify users of the error, and prevent them from further editing as the content will be lost due to sync failure.

This PR

- Makes some operations defensive.
- Always show error notification when manual push/pull fails.