### PR TITLE
fix: Stat.isFile is not available

### DIFF
--- a/src/main/frontend/fs.cljs
+++ b/src/main/frontend/fs.cljs
@@ -109,7 +109,7 @@
 
     :else
     (p/let [stat (js/window.pfs.stat path)]
-      (if (.-isFile stat)
+      (if (= (.-type stat) "file")
         (js/window.pfs.unlink path opts)
         (p/rejected "Unlinking a directory is not allowed")))))
 


### PR DESCRIPTION
This bug was introduced in https://github.com/logseq/logseq/pull/1018 which makes it unable to delete files from file system.