### PR TITLE
fix: handle empty block embed

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -690,6 +690,9 @@
         (= name "embed")
         (let [a (first arguments)]
           (cond
+            (nil? a) ; empty embed
+            nil
+
             (and (string/starts-with? a "[[")
                  (string/ends-with? a "]]"))
             (let [page-name (-> (string/replace a "[[" "")


### PR DESCRIPTION
Fixes https://github.com/logseq/logseq/issues/871.