### PR TITLE
fix: do not push local repo when switching repos

### DIFF
--- a/src/main/frontend/handler/repo.cljs
+++ b/src/main/frontend/handler/repo.cljs
@@ -436,7 +436,7 @@
            (or (not= status :pushing)
                custom-commit?))
       (->
-       (p/let [files (git/add-all (state/get-current-repo))
+       (p/let [files (git/add-all repo-url)
                changed-files? (some? (seq files))
                should-commit? (or changed-files? merge-push-no-diff?)
 


### PR DESCRIPTION
When switching from a GitHub repo to a local repo, Logseq will try to push the local one and then print the "Cannot find repo dir" error. Also the GitHub repo will be mistakenly marked as with Git push error so the sync dot will turn red.

（这是昨天 @dale502 报的 bug）