### PR TITLE
Emphasize the user's freedom and their control in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Use it to organize your todo list, to write your journals, or to record your uni
 
 ## Why Logseq?
 
-[Logseq](https://logseq.com) is an open-source platform for knowledge sharing and management. It focuses on privacy, longevity, and user control.
+[Logseq](https://logseq.com) is a freedom-respecting (and open-source too) platform for knowledge sharing and management. It focuses on privacy, longevity, and user control.
 
 The server will never store or analyze your private notes. Your data are plain text files and we currently support both Markdown and Emacs Org mode (more to be added soon).
 


### PR DESCRIPTION
Richard Stallman, author of AGPLv3, said:

> I wrote to him:
>   > The word open-source is sometimes associated with the ideals of free
>   > software. So, I'll write "freedom-respecting and open-source" or "(aka open
>   > source)" or "(sometimes known as "open-source", a false flag movement by
>   > Microsoft)."
> 
> Those are subtly misleading.  How about this?
> 
>   freedom-respecting (and open source too)

Let's emphasize the control, customizability, reliability, etc. the user has by rewording the README this way.