### PR TITLE
feat: upgrade some dependencies

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -28,20 +28,20 @@
   hiccups/hiccups             {:mvn/version "0.3.0"}
   tongue/tongue               {:mvn/version "0.2.9"}
   org.clojure/core.async      {:mvn/version "1.3.610"}
-  thheller/shadow-cljs        {:mvn/version "2.8.81"}
+  thheller/shadow-cljs        {:mvn/version "2.11.11"}
   expound/expound             {:mvn/version "0.8.6"}
   lambdaisland/glogi          {:mvn/version "1.0.74"}}
 
  :aliases {:cljs {:extra-paths ["src/dev-cljs/" "src/test/"]
-                  :extra-deps  {org.clojure/clojurescript   {:mvn/version "1.10.520"}
-                                thheller/shadow-cljs        {:mvn/version "2.8.81"}
-                                binaryage/devtools          {:mvn/version "0.9.10"}
+                  :extra-deps  {org.clojure/clojurescript   {:mvn/version "1.10.764"}
+                                thheller/shadow-cljs        {:mvn/version "2.11.11"}
+                                binaryage/devtools          {:mvn/version "1.0.2"}
                                 org.clojure/tools.namespace {:mvn/version "0.2.11"}
-                                cider/cider-nrepl           {:mvn/version "0.23.0-SNAPSHOT"}}
+                                cider/cider-nrepl           {:mvn/version "0.25.5"}}
                   :main-opts ["-m" "shadow.cljs.devtools.cli"]}
            :test
            {:extra-paths ["src/test/"]
-            :extra-deps  {org.clojure/clojurescript {:mvn/version "1.10.520"}
+            :extra-deps  {org.clojure/clojurescript {:mvn/version "1.10.764"}
                           org.clojure/test.check {:mvn/version "RELEASE"}}
             :main-opts   ["-m" "shadow.cljs.devtools.cli"]}
            :runner

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "postcss-cli": "8.3.0",
         "postcss-nested": "^5.0.1",
         "purgecss": "3.0.0",
-        "shadow-cljs": "2.8.81",
+        "shadow-cljs": "2.11.11",
         "stylelint": "^13.8.0",
         "stylelint-config-standard": "^20.0.0",
         "tailwindcss": "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3597,7 +3597,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5.1, mkdirp@~0.5.1:
+mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -3680,7 +3680,7 @@ node-emoji@^1.8.1:
   dependencies:
     lodash.toarray "^4.4.0"
 
-node-libs-browser@^2.0.0:
+node-libs-browser@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
   integrity sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==
@@ -5207,20 +5207,19 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shadow-cljs-jar@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.3.1.tgz#a5f8ab7664b40e11345837e4c6bce8e0ac9b2cc3"
-  integrity sha512-IJSm4Gfu/wWDsOQ0wNrSxuaGdjzsd78us+3bop3cpWsoO2Igdu6VIBItYrZHRRBKl5LIZKXfnSh/2eWG3C1EFw==
+shadow-cljs-jar@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz#97273afe1747b6a2311917c1c88d9e243c81957b"
+  integrity sha512-XmeffAZHv8z7451kzeq9oKh8fh278Ak+UIOGGrapyqrFBB773xN8vMQ3O7J7TYLnb9BUwcqadKkmgaq7q6fhZg==
 
-shadow-cljs@2.8.81:
-  version "2.8.81"
-  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.8.81.tgz#d4f28313ef3d0023a9d7b9a0891ee0e124f0cfb8"
-  integrity sha512-ux+S7yB2isXxna8/BHRkkp80C6fXPwVrKnDd0SfTbLgjUE9TMjqHCgsO0jLejw/cjjAzAvyG4uVLyK60NxIwEg==
+shadow-cljs@2.11.11:
+  version "2.11.11"
+  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.11.11.tgz#1e549e8422d7754c8969af5caf7c0e712e1337e1"
+  integrity sha512-6Ld1QutApHYjEsil1HBUxCsoihxe4p0EhqCoJSXLy7TCksrousoq7fdCdElMX+qcoPclUkHijTge40s/9ewjGA==
   dependencies:
-    mkdirp "^0.5.1"
-    node-libs-browser "^2.0.0"
+    node-libs-browser "^2.2.1"
     readline-sync "^1.4.7"
-    shadow-cljs-jar "1.3.1"
+    shadow-cljs-jar "1.3.2"
     source-map-support "^0.4.15"
     which "^1.3.1"
     ws "^3.0.0"


### PR DESCRIPTION
### Problem

My develop env:

- OS: macOS Big Sur version 11.1
- JDK: openjdk version 1.8.0_275
- Node.js: v15.4.0

Currently, run command `yarn watch` throws many error messages like follows:

```
[:failed-to-compare "^16.8.1" "16.13.1" #error {
 :cause "Cannot invoke \"Object.getClass()\" because \"target\" is null"
 :via
 [{:type java.lang.NullPointerException
   :message "Cannot invoke \"Object.getClass()\" because \"target\" is null"
   :at [clojure.lang.Reflector invokeInstanceMethod "Reflector.java" 97]}]
 :trace
 [[clojure.lang.Reflector invokeInstanceMethod "Reflector.java" 97]
  [shadow.cljs.devtools.server.npm_deps$make_engine invokeStatic "npm_deps.clj" 39]
  [shadow.cljs.devtools.server.npm_deps$make_engine invoke "npm_deps.clj" 32]
  [shadow.cljs.devtools.server.npm_deps$fn__17468$fn__17469 invoke "npm_deps.clj" 46]
  [clojure.lang.Delay deref "Delay.java" 42]
  [clojure.core$deref invokeStatic "core.clj" 2320]
  [clojure.core$deref invoke "core.clj" 2306]
  [shadow.cljs.devtools.server.npm_deps$fn__17468$fn__17471 invoke "npm_deps.clj" 52]
  [shadow.build.targets.browser$check_npm_versions$fn__38261$fn__38262 invoke "browser.clj" 826]
  [clojure.core.protocols$iter_reduce invokeStatic "protocols.clj" 49]
  [clojure.core.protocols$fn__8123 invokeStatic "protocols.clj" 75]
  [clojure.core.protocols$fn__8123 invoke "protocols.clj" 75]
  [clojure.core.protocols$fn__8073$G__8068__8086 invoke "protocols.clj" 13]
  [clojure.core$reduce invokeStatic "core.clj" 6828]
  [clojure.core$reduce invoke "core.clj" 6810]
  [shadow.build.targets.browser$check_npm_versions$fn__38261 invoke "browser.clj" 818]
  [shadow.build.targets.browser$check_npm_versions invokeStatic "browser.clj" 817]
  [shadow.build.targets.browser$check_npm_versions invoke "browser.clj" 799]
  [shadow.build.targets.browser$process invokeStatic "browser.clj" 854]
  [shadow.build.targets.browser$process invoke "browser.clj" 838]
  [clojure.lang.Var invoke "Var.java" 384]
  [shadow.build$process_stage$fn__14209 invoke "build.clj" 148]
  [shadow.build$process_stage invokeStatic "build.clj" 145]
  [shadow.build$process_stage invoke "build.clj" 137]
  [shadow.build$compile invokeStatic "build.clj" 408]
  [shadow.build$compile invoke "build.clj" 397]
  [shadow.cljs.devtools.server.worker.impl$build_compile invokeStatic "impl.clj" 316]
  [shadow.cljs.devtools.server.worker.impl$build_compile invoke "impl.clj" 302]
  [shadow.cljs.devtools.server.worker.impl$eval15836$fn__15838 invoke "impl.clj" 738]
  [clojure.lang.MultiFn invoke "MultiFn.java" 234]
  [shadow.cljs.devtools.server.util$server_thread$fn__15450$fn__15451$fn__15459 invoke "util.clj" 285]
  [shadow.cljs.devtools.server.util$server_thread$fn__15450$fn__15451 invoke "util.clj" 284]
  [shadow.cljs.devtools.server.util$server_thread$fn__15450 invoke "util.clj" 257]
  [clojure.lang.AFn run "AFn.java" 22]
  [java.lang.Thread run "Thread.java" 832]]}]
```

### Solution

Upgrade [shadow-cljs](https://github.com/thheller/shadow-cljs) to version 2.11.11 resolve those errors.