### PR TITLE
fix: add externs for external JS libs to prevent name been munged

### DIFF
--- a/externs.js
+++ b/externs.js
@@ -50,3 +50,15 @@ dummy.values = function() {};
 // Do we really need those?
 dummy.filter = function() {};
 dummy.concat = function() {};
+
+/**
+ * @typedef {{
+ *     recursive: (undefined | boolean),
+ * }}
+ */
+var openDirectoryOptions;
+/**
+ * @param {(undefined | openDirectoryOptions)} options
+ * @param {function} cb
+ */
+var openDirectory = function(options, cb) {};

--- a/src/main/frontend/utils.js
+++ b/src/main/frontend/utils.js
@@ -128,10 +128,10 @@ export var verifyPermission = async function (handle, readWrite) {
   throw new Error("Permission is not granted");
 }
 
+// NOTE: Need externs to prevent `options.recursive` been munged
+//       When building with release.
 export var openDirectory = async function (options = {}, cb) {
-  // FIXME: options.recursive will be undefined after the `getFiles` call get resolved
-  // It's caused by bumping shadow-cljs to 2.11.11.
-  options.recursive = true;
+  options.recursive = options.recursive || false;
   const handle = await window.showDirectoryPicker({ mode: 'readwrite' });
   const _ask = await verifyPermission(handle, true);
   return [handle, getFiles(handle, options.recursive, cb)];


### PR DESCRIPTION
Add externs for external JS libs to prevent name been munged when building with release.

**Problem**

The issue happens when calling module `utils.js` from cljs :

```
(utils/openDirectory #js {:recursive true} (fn [] ))
```

But this is a external JS library,  which has been optimized by Google closure compiler in release mode into something like follows:

![Screen Shot 2021-01-05 at 21 30 56](https://user-images.githubusercontent.com/724608/103906405-d47f5600-513a-11eb-8385-8c86bd5e43cd.png)

Which cause weird issue mentioned in c611a7a8e1d70fbc9f7aa969edfb89ed8758884f