### PR TITLE
set page tags to the root block

### DIFF
--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -360,7 +360,7 @@
              {:uuid uuid
               :content content
               :anchor (str uuid)
-              :level 2
+              :level 0
               :meta {:start-pos 0
                      :end-pos (or first-block-start-pos
                                   (utf8/length encoded-content))}

--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -365,6 +365,10 @@
                      :end-pos (or first-block-start-pos
                                   (utf8/length encoded-content))}
               :body (take-while (fn [block] (not (heading-block? block))) blocks)
+              :children (set (mapcat (fn [block]
+                                       (when (= 1 (:block/level block))
+                                         [[:block/uuid (:block/uuid block)]]))
+                                     blocks))
               :pre-block? true}
              (block-keywordize)))
           (select-keys first-block [:block/file :block/format :block/page]))

--- a/src/main/frontend/handler/extract.cljs
+++ b/src/main/frontend/handler/extract.cljs
@@ -36,7 +36,11 @@
                    (fn [[page blocks]]
                      (if page
                        (map (fn [block]
-                              (let [block-ref-pages (seq (:block/ref-pages block))]
+                              (let [block-ref-pages (seq (:block/ref-pages block))
+                                    is-root (= 0 (:block/level block))
+                                    block-ref-pages (if is-root
+                                                      (vec (:tags properties))
+                                                      block-ref-pages)]
                                 (when block-ref-pages
                                   (swap! ref-pages set/union (set block-ref-pages)))
                                 (-> block


### PR DESCRIPTION
this will potentially allow for more consistent db queries
e.g. you won't need to treat the page as a special case