### PR TITLE
add comment with "asset.logseq.com" so it's easier to find where it's hardcoded

### DIFF
--- a/src/main/frontend/config.cljs
+++ b/src/main/frontend/config.cljs
@@ -25,6 +25,7 @@
     "http://localhost:3000/api/v1/"
     (str website "/api/v1/")))
 
+;; change if you want to use your own domain instead of default asset.logseq.com
 (def asset-domain (util/format "https://asset.%s.com"
                                app-name))
 


### PR DESCRIPTION
Now sure what's the right way to properly specify domains, but hopefully the comment will at least help people who can't figure out why logseq is making queries to `asset.logseq.com` by searching in code.