### PR TITLE
Fixing /Current Time showing midnight as 24:xx

### DIFF
--- a/src/main/frontend/date.cljs
+++ b/src/main/frontend/date.cljs
@@ -127,7 +127,7 @@
      (gobj/get js/window.navigator "language")
      (bean/->js {:hour "2-digit"
                  :minute "2-digit"
-                 :hour12 false}))))
+                 :hourCycle "h23"}))))
 
 (defn valid?
   [s]


### PR DESCRIPTION
fixing #1182 when /Current Time shows midnight as 24:xx instead of 00:xx