### PR TITLE
Fix missing css global variables 

### DIFF
--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -1,6 +1,6 @@
 :root {
-  --ls-tag-text-opacity: 0.6;
-  --ls-tag-text-hover-opacity: 0.8;
+  --ls-tag-text-opacity: 0.8;
+  --ls-tag-text-hover-opacity: 1;
   --ls-page-text-size: 1em;
   --ls-page-title-size: 36px;
   --ls-font-family: 'Inter';
@@ -662,11 +662,13 @@ a.tag {
     text-decoration: none;
     display: inline-block;
     cursor: pointer;
-    opacity: 0.8;
+    color: var(--ls-tag-text-color, #045591);
+    opacity: var(--ls-tag-text-opacity, 0.8);
 }
 
 a.tag:hover {
-    opacity: 1;
+  opacity: var(--ls-tag-text-hover-opacity, 1);
+  color: var(--ls-tag-text-hover-color, #045591);
 }
 
 svg.note {

--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -36,7 +36,7 @@ html[data-theme=dark] {
   --ls-active-secondary-color: #d0e8e8;
   --ls-block-properties-background-color: #02222a;
   --ls-block-ref-link-text-color: #1a6376;
-  --ls-search-background-color: var(--ls-primary-background-color);
+  --ls-search-background-color: linear-gradient(to right,#021c23 0,#021b21 200px,#002b36 100%);
   --ls-border-color: #0e5263;
   --ls-secondary-border-color: #126277;
   --ls-guideline-color: #0b4a5a;
@@ -806,12 +806,12 @@ a {
 /* search-field */
 
 .dark-theme #search_field {
-    background: linear-gradient(to right, #021c23 0%, #021b21 200px, #002b36 100%);
+    background: var(--ls-search-background-color);
     transition: background .3s;
 }
 
 .dark-theme #search_field:focus {
-    box-shadow: 0px 0px 20px 0px rgba(18, 18, 18, .8);
+    box-shadow: 0px 0px 20px 0px rgba(18, 18, 18, .3);
 }
 
 .page-reference:hover {


### PR DESCRIPTION
Opacity and color variables were removed from the `a` tags in the last css tweaks, this fix is to put them back on.
It will also fix the background color for the new wide search field.