### PR TITLE
Perf/db serialization

### DIFF
--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -725,10 +725,6 @@ a.fade-link:hover {
     height: 20px;
 }
 
-#head {
-    background: none;
-}
-
 /* < > buttons */
 
 a.navigation {

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -7,7 +7,9 @@
             [promesa.core :as p]
             [goog.object :as gobj]
             [clojure.string :as string]
-            [electron.utils :as utils]))
+            [electron.utils :as utils]
+            [electron.state :as state]
+            [clojure.core.async :as async]))
 
 (defmulti handle (fn [_window args] (keyword (first args))))
 
@@ -78,6 +80,10 @@
 
 (defmethod handle :getFiles [window [_ path]]
   (get-files path))
+
+(defmethod handle :persistent-dbs-saved [window _]
+  (async/put! state/persistent-dbs-chan true )
+  true)
 
 (defn- get-file-ext
   [file]

--- a/src/electron/electron/state.cljs
+++ b/src/electron/electron/state.cljs
@@ -1,0 +1,4 @@
+(ns electron.state
+  (:require [clojure.core.async :as async]))
+
+(defonce persistent-dbs-chan (async/chan 1))

--- a/src/main/electron/listener.cljs
+++ b/src/main/electron/listener.cljs
@@ -2,7 +2,11 @@
   (:require [frontend.state :as state]
             [frontend.handler.route :as route-handler]
             [cljs-bean.core :as bean]
-            [frontend.fs.watcher-handler :as watcher-handler]))
+            [frontend.fs.watcher-handler :as watcher-handler]
+            [frontend.db :as db]
+            [frontend.idb :as idb]
+            [promesa.core :as p]
+            [electron.ipc :as ipc]))
 
 (defn listen-to-open-dir!
   []
@@ -20,7 +24,23 @@
                        (let [{:keys [type payload]} (bean/->clj data)]
                          (watcher-handler/handle-changed! type payload)))))
 
+(defn listen-persistent-dbs!
+  []
+  ;; TODO: move "file-watcher" to electron.ipc.channels
+  (js/window.apis.on "persistent-dbs"
+                     (fn [req]
+                       (p/let [repos (idb/get-nfs-dbs)
+                               repos (-> repos
+                                         (conj (state/get-current-repo))
+                                         (distinct))]
+                         (-> (p/all (map db/persist! repos))
+                             (p/then (fn []
+                                       (ipc/ipc "persistent-dbs-saved")))
+                             (p/catch (fn [error]
+                                        (js/console.dir error))))))))
+
 (defn listen!
   []
   (listen-to-open-dir!)
-  (run-dirs-watcher!))
+  (run-dirs-watcher!)
+  (listen-persistent-dbs!))

--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -87,7 +87,9 @@
           :options {:href (rfe/href :graph)}
           :icon svg/graph-sm})
 
-       (when (or logged? (and (nfs/supported?) current-repo))
+       (when (or logged?
+                 (util/electron?)
+                 (and (nfs/supported?) current-repo))
          {:title (t :all-graphs)
           :options {:href (rfe/href :repos)}
           :icon svg/repos-sm})

--- a/src/main/frontend/db.cljs
+++ b/src/main/frontend/db.cljs
@@ -108,10 +108,11 @@
   [repo conn files-db?]
   (d/listen! conn :persistence
              (fn [tx-report]
-               (let [tx-id (get-tx-id tx-report)]
-                 (state/set-last-transact-time! repo (util/time-ms))
-                 ;; (state/persist-transaction! repo files-db? tx-id (:tx-data tx-report))
-                 (persist-if-idle! repo))
+               (when-not (util/electron?)
+                (let [tx-id (get-tx-id tx-report)]
+                  (state/set-last-transact-time! repo (util/time-ms))
+                  ;; (state/persist-transaction! repo files-db? tx-id (:tx-data tx-report))
+                  (persist-if-idle! repo)))
 
                ;; rebuild search indices
                (when-not files-db?

--- a/src/main/frontend/db/conn.cljs
+++ b/src/main/frontend/db/conn.cljs
@@ -88,7 +88,8 @@
 
      (d/transact! db-conn default-db/built-in-pages)
 
-     (when listen-handler (listen-handler repo)))))
+     (when (and listen-handler (not (util/electron?)))
+       (listen-handler repo)))))
 
 (defn destroy-all!
   []

--- a/src/main/frontend/fs/node.cljs
+++ b/src/main/frontend/fs/node.cljs
@@ -25,34 +25,22 @@
 
 (defn- write-file-impl!
   [repo dir path content {:keys [ok-handler error-handler] :as opts} stat]
-  (->
-   (p/let [result (ipc/ipc "writeFile" path content)
-           mtime (gobj/get result "mtime")]
-     (db/set-file-last-modified-at! repo path mtime)
-     (when ok-handler
-       (ok-handler repo path result))
-     result)
-   (p/catch (fn [error]
-              (if error-handler
-                (error-handler error)
-                (log/error :write-file-failed error)))))
-  ;; (p/let [disk-mtime (when stat (gobj/get stat "mtime"))
-  ;;         db-mtime (db/get-file-last-modified-at repo path)]
-  ;;   (if (not= disk-mtime db-mtime)
-  ;;     (js/alert (str "The file has been modified in your local disk! File path: " path
-  ;;                    ", please save your changes and click the refresh button to reload it."))
-  ;;     (->
-  ;;      (p/let [result (ipc/ipc "writeFile" path content)
-  ;;              mtime (gobj/get result "mtime")]
-  ;;        (db/set-file-last-modified-at! repo path mtime)
-  ;;        (when ok-handler
-  ;;          (ok-handler repo path result))
-  ;;        result)
-  ;;      (p/catch (fn [error]
-  ;;                 (if error-handler
-  ;;                   (error-handler error)
-  ;;                   (log/error :write-file-failed error)))))))
-)
+  (p/let [disk-mtime (when stat (gobj/get stat "mtime"))
+          db-mtime (db/get-file-last-modified-at repo path)]
+    (if (not= disk-mtime db-mtime)
+      (js/alert (str "The file has been modified in your local disk! File path: " path
+                     ", please save your changes and click the refresh button to reload it."))
+      (->
+       (p/let [result (ipc/ipc "writeFile" path content)
+               mtime (gobj/get result "mtime")]
+         (db/set-file-last-modified-at! repo path mtime)
+         (when ok-handler
+           (ok-handler repo path result))
+         result)
+       (p/catch (fn [error]
+                  (if error-handler
+                    (error-handler error)
+                    (log/error :write-file-failed error))))))))
 
 (defrecord Node []
   protocol/Fs

--- a/src/main/frontend/fs/watcher_handler.cljs
+++ b/src/main/frontend/fs/watcher_handler.cljs
@@ -40,19 +40,8 @@
                (> mtime last-modified-at)))
 
         (let [_ (file-handler/alter-file repo path content {:re-render-root? true
-                                                              :from-disk? true})]
+                                                            :from-disk? true})]
           (db/set-file-last-modified-at! repo path mtime))
-
-        ;; (= "unlink" type)
-        ;; (when-let [page-name (db/get-file-page path)]
-        ;;   (page-handler/delete!
-        ;;    page-name
-        ;;    (fn []
-        ;;      (notification/show! (str "Page " page-name " was deleted on disk.")
-        ;;                          :success)
-        ;;      (when (= (state/get-current-page) page-name)
-        ;;        ;; redirect to home
-        ;;        (route-handler/redirect-to-home!)))))
 
         (contains? #{"add" "change" "unlink"} type)
         nil

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -138,7 +138,7 @@
                 :stroke-linejoin "round"
                 :stroke-linecap  "round"}]]]
             :warning
-            ["text-gray-900"
+            ["text-gray-900 dark:text-gray-300 "
              [:svg.h-6.w-6.text-yellow-500
               {:stroke "currentColor", :viewBox "0 0 24 24", :fill "none"}
               [:path


### PR DESCRIPTION
The performance on Desktop is much better now since we only serialize and save the graphs when the app is closed or refreshed.
I tested https://github.com/Zettelkasten-Method/10000-markdown-files which is working fine.
The only slow part is the graph view since there're about 10k pages.