### PR TITLE
feat: add vimeo video embed block command

### DIFF
--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -138,6 +138,10 @@
 
      ["Embed Youtube Video" [[:editor/input "{{youtube }}" {:last-pattern slash
                                                             :backward-pos 2}]]]
+
+     ["Embed Vimeo Video" [[:editor/input "{{vimeo }}" {:last-pattern slash
+                                                        :backward-pos 2}]]]
+
      ["Html Inline " (->inline "html")]
 
      ;; TODO:

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -800,6 +800,23 @@
                     :height height
                     :width width}])))))
 
+        (= name "vimeo")
+        (let [url (first arguments)]
+          (let [Vimeo-regex #"^((?:https?:)?//)?((?:www).)?((?:player.vimeo.com|vimeo.com)?)((?:/video/)?)([\w-]+)(\S+)?$"]
+            (when-let [vimeo-id (nth (re-find Vimeo-regex url) 5)]
+              (when-not (string/blank? vimeo-id)
+                (let [width (min (- (util/get-width) 96)
+                                 560)
+                      height (int (* width (/ 315 560)))]
+                  [:iframe
+                   {:allow-full-screen "allowfullscreen"
+                    :allow
+                    "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    :frame-border "0"
+                    :src (str "https://player.vimeo.com/video/" vimeo-id)
+                    :height height
+                    :width width}])))))
+
         ;; TODO: support fullscreen mode, maybe we need a fullscreen dialog?
         (= name "bilibili")
         (let [url (first arguments)


### PR DESCRIPTION
Adds `/vimeo` & `{{vimeo }}`

![image](https://user-images.githubusercontent.com/302375/110245901-443f7080-7f33-11eb-9ee0-af4566cd3ae4.png)


[Regex](https://regex101.com/r/6jOSWk/1) should match:

```
https://vimeo.com/48510638
https://player.vimeo.com/video/48510638
vimeo.com/48510638
player.vimeo.com/video/48510638
48510638
```

I didn't see a good existing place to add tests, happy to do that with some guidance.