### PR TITLE
fix: linux title bar not showing

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -1,7 +1,7 @@
 (ns electron.core
   (:require [electron.handler :as handler]
             [electron.updater :refer [init-updater]]
-            [electron.utils :refer [mac? win32? prod? dev? logger open]]
+            [electron.utils :refer [mac? linux? win32? prod? dev? logger open]]
             [clojure.string :as string]
             ["fs" :as fs]
             ["path" :as path]
@@ -23,7 +23,7 @@
   []
   (let [win-opts {:width         980
                   :height        700
-                  :frame         win32?
+                  :frame         (or win32? linux?)
                   :autoHideMenuBar win32?
                   :titleBarStyle (if mac? "hidden" nil)
                   :webPreferences
@@ -34,6 +34,7 @@
                    :preload                 (path/join js/__dirname "js/preload.js")}}
         url MAIN_WINDOW_ENTRY
         win (BrowserWindow. (clj->js win-opts))]
+    (when linux?  (.removeMenu win))
     (.loadURL win url)
     (when dev? (.. win -webContents (openDevTools)))
     win))

--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -1,7 +1,7 @@
 (ns electron.core
   (:require [electron.handler :as handler]
             [electron.updater :refer [init-updater]]
-            [electron.utils :refer [mac? linux? win32? prod? dev? logger open]]
+            [electron.utils :refer [mac? win32? prod? dev? logger open]]
             [clojure.string :as string]
             ["fs" :as fs]
             ["path" :as path]
@@ -23,8 +23,8 @@
   []
   (let [win-opts {:width         980
                   :height        700
-                  :frame         (or win32? linux?)
-                  :autoHideMenuBar win32?
+                  :frame         (not mac?)
+                  :autoHideMenuBar (not mac?)
                   :titleBarStyle (if mac? "hidden" nil)
                   :webPreferences
                   {:nodeIntegration         false
@@ -34,7 +34,6 @@
                    :preload                 (path/join js/__dirname "js/preload.js")}}
         url MAIN_WINDOW_ENTRY
         win (BrowserWindow. (clj->js win-opts))]
-    (when linux?  (.removeMenu win))
     (.loadURL win url)
     (when dev? (.. win -webContents (openDevTools)))
     win))

--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -2,6 +2,7 @@
 
 (defonce mac? (= (.-platform js/process) "darwin"))
 (defonce win32? (= (.-platform js/process) "win32"))
+(defonce linux? (= (.-platform js/process) "linux"))
 
 (defonce prod? (= js/process.env.NODE_ENV "production"))
 (defonce dev? (not prod?))

--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -2,7 +2,6 @@
 
 (defonce mac? (= (.-platform js/process) "darwin"))
 (defonce win32? (= (.-platform js/process) "win32"))
-(defonce linux? (= (.-platform js/process) "linux"))
 
 (defonce prod? (= js/process.env.NODE_ENV "production"))
 (defonce dev? (not prod?))


### PR DESCRIPTION
Currently on linux, the app does not have title bar, thus on desktop env, I cannot move the boderless window...

![wrong](https://user-images.githubusercontent.com/9002575/110766971-b516bd80-8290-11eb-8ba0-be0c58493f6c.png)

After the fix, it'll look like below on my linux env:

![correct](https://user-images.githubusercontent.com/9002575/110767136-decfe480-8290-11eb-8e8c-d88c2169d6b7.png)
