### PR TITLE
fix: find all directives in ast

### DIFF
--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -570,7 +570,8 @@
         (->> (string/split-lines content)
              (take-while (fn [line]
                            (or (string/blank? line)
-                               (string/starts-with? line "#+"))))
+                               (string/starts-with? line "#+")
+                               (re-find #"^:.+?:" line))))
              (string/join "\n"))
 
         :markdown

--- a/src/main/frontend/format/mldoc.cljs
+++ b/src/main/frontend/format/mldoc.cljs
@@ -95,6 +95,7 @@
                                            v
                                            (text/split-page-refs-without-brackets v comma?))]
                                    [k v])))
+                          (reverse)
                           (into {}))
           macro-properties (filter (fn [x] (= :macro (first x))) properties)
           macros (if (seq macro-properties)

--- a/src/main/frontend/format/mldoc.cljs
+++ b/src/main/frontend/format/mldoc.cljs
@@ -82,8 +82,12 @@
   (if (seq ast)
     (let [original-ast ast
           ast (map first ast)           ; without position meta
-          directive? (fn [item] (= "directive" (string/lower-case (first item))))
-          properties (->> (take-while directive? ast)
+          directive?
+          (fn [[item _]] (= "directive" (string/lower-case (first item))))
+          grouped-ast (group-by directive? original-ast)
+          [directive-ast other-ast]
+          [(get grouped-ast true) (get grouped-ast false)]
+          properties (->> (map first directive-ast)
                           (map (fn [[_ k v]]
                                  (let [k (keyword (string/lower-case k))
                                        comma? (contains? #{:tags :alias :roam_tags} k)
@@ -134,8 +138,7 @@
                          (update :roam_alias ->vec)
                          (update :roam_tags (constantly roam-tags))
                          (update :filetags (constantly filetags)))
-          properties (medley/filter-kv (fn [k v] (not (empty? v))) properties)
-          other-ast (drop-while (fn [[item _pos]] (directive? item)) original-ast)]
+          properties (medley/filter-kv (fn [k v] (not (empty? v))) properties)]
       (if (seq properties)
         (cons [["Properties" properties] nil] other-ast)
         original-ast))

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -102,7 +102,9 @@
             file (db/entity (:db/id (:page/file page)))
             file-path (:file/path file)
             file-content (db/get-file file-path)
-            after-content (subs file-content (inc (count properties-content)))
+            after-content (if (empty? properties-content)
+                            file-content
+                            (subs file-content (inc (count properties-content))))
             new-properties-content (db/add-properties! page-format properties-content properties)
             full-content (str new-properties-content "\n\n" (string/trim after-content))]
         (file-handler/alter-file (state/get-current-repo)


### PR DESCRIPTION
A directive like '#+TITLE: foobar' probably is not the first ast item.

see also https://github.com/logseq/logseq/issues/694