### PR TITLE
feat: add electron-window-state to remember the window state

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,11 +66,13 @@
         "diff": "5.0.0",
         "diff-match-patch": "^1.0.5",
         "electron": "^11.2.0",
+        "electron-window-state": "^5.0.3",
         "fs": "^0.0.1-security",
         "fs-extra": "^9.1.0",
         "fuse.js": "^6.4.6",
         "gulp-cached": "^1.1.1",
         "ignore": "^5.1.8",
+        "is-svg": "4.2.2",
         "jszip": "^3.5.0",
         "mldoc": "0.5.6",
         "mousetrap": "^1.6.5",
@@ -81,7 +83,6 @@
         "react-textarea-autosize": "^8.0.1",
         "react-transition-group": "^4.3.0",
         "url": "^0.11.0",
-        "yargs-parser": "^20.2.4",
-        "is-svg": "4.2.2"
+        "yargs-parser": "^20.2.4"
     }
 }

--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -7,6 +7,7 @@
             ["fs-extra" :as fs]
             ["path" :as path]
             ["electron" :refer [BrowserWindow app protocol ipcMain dialog] :as electron]
+            ["electron-window-state" :as windowStateKeeper]
             [clojure.core.async :as async]
             [electron.state :as state]))
 
@@ -22,8 +23,9 @@
 (defn create-main-window
   "Creates main app window"
   []
-  (let [win-opts {:width         980
-                  :height        700
+  (let [win-state (windowStateKeeper (clj->js {:defaultWidth 980 :defaultHeight 700}))
+        win-opts {:width         (.-width win-state)
+                  :height        (.-height win-state)
                   :frame         (not mac?)
                   :autoHideMenuBar (not mac?)
                   :titleBarStyle (if mac? "hidden" nil)
@@ -35,6 +37,7 @@
                    :preload                 (path/join js/__dirname "js/preload.js")}}
         url MAIN_WINDOW_ENTRY
         win (BrowserWindow. (clj->js win-opts))]
+    (.manage win-state win)
     (.loadURL win url)
     (when dev? (.. win -webContents (openDevTools)))
     win))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1854,6 +1854,14 @@ electron-to-chromium@^1.3.649:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.657.tgz#a9c307f2612681245738bb8d36d997cbb568d481"
   integrity sha512-/9ROOyvEflEbaZFUeGofD+Tqs/WynbSTbNgNF+/TJJxH1ePD/e6VjZlDJpW3FFFd3nj5l3Hd8ki2vRwy+gyRFw==
 
+electron-window-state@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/electron-window-state/-/electron-window-state-5.0.3.tgz#4f36d09e3f953d87aff103bf010f460056050aa8"
+  integrity sha512-1mNTwCfkolXl3kMf50yW3vE2lZj0y92P/HYWFBrb+v2S/pCka5mdwN3cagKm458A7NjndSwijynXgcLWRodsVg==
+  dependencies:
+    jsonfile "^4.0.0"
+    mkdirp "^0.5.1"
+
 electron@^11.2.0:
   version "11.2.3"
   resolved "https://registry.yarnpkg.com/electron/-/electron-11.2.3.tgz#8ad1d9858436cfca0e2e5ea7fea326794ae58ebb"
@@ -3846,7 +3854,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5.4, mkdirp@~0.5.1:
+mkdirp@^0.5.1, mkdirp@^0.5.4, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==


### PR DESCRIPTION
The application opens with the default width and height every time, resulting in an adjustment every time it is reopened. So this PR uses [electron-window-state](https://github.com/mawie81/electron-window-state) to remember the last window state.