### PR TITLE
feat: add ctrl-n/p shortcut support

### DIFF
--- a/src/main/frontend/mixins.cljs
+++ b/src/main/frontend/mixins.cljs
@@ -110,7 +110,9 @@
      (listen state js/window "keydown"
              (fn [e]
                (let [key-code (.-keyCode e)]
-                 (if-let [f (get keycode-map key-code)]
+                 (if-let [f (if (fn? keycode-map)
+                              (keycode-map key-code e)
+                              (get keycode-map key-code))]
                    (f state e)
                    (when (and not-matched-handler (fn? not-matched-handler))
                      (not-matched-handler e key-code)))


### PR DESCRIPTION
I usually use ctrl-n/p to move up or down in most software, but currently logseq commands only support up and down arrow keys, which is not very convenient. So this PR add ctrl-n/p support.