### PR TITLE
fix: .resize should be inline-flex

### DIFF
--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -73,7 +73,7 @@
   }
 
   .resize {
-    display: flex;
+    display: inline-flex;
   }
 
   .draw [aria-labelledby="shapes-title"] {


### PR DESCRIPTION
The resize handler of the images was always at the right-bottom of the image block because by default the block level item will take 100% width of the parent container.

After changing the resize block to `display: inline-flex`, the default width will be the contained item size and the little resize handle will be in the right-bottom corner of the image, instead of the whole block. Also, this change makes it possible to have images placed inline, e.g., having two horizontal images in the same row; place image in the texts. 

# Before
![image](https://user-images.githubusercontent.com/584378/113251389-c46bb280-92f4-11eb-9ae6-7d842473757a.png)

# After
![image](https://user-images.githubusercontent.com/584378/113251420-cfbede00-92f4-11eb-8160-6e0fcdf752a5.png)
