### PR TITLE
feat: support previewing videos in desktop mode

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -389,6 +389,10 @@
        [:iframe {:src full-path
                  :fullscreen true
                  :height 800}]
+       ;; https://en.wikipedia.org/wiki/HTML5_video
+       ("mp4" "ogg" "webm")
+       [:video {:src full-path
+                :controls true}]
 
        nil)]))
 


### PR DESCRIPTION
similar to previewing PDF files, this PR will use `<video>` to inlining videos into the editor.

![image](https://user-images.githubusercontent.com/584378/113266011-55e42000-9307-11eb-903a-ed47c62e00cf.png)
