### PR TITLE
fix: truncate repo name in small screen and show repo switch header

### DIFF
--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -191,8 +191,8 @@
 
        (repo/sync-status current-repo)
 
-       [:div.repos.hidden.md:block
-        (repo/repos-dropdown true nil)]
+       [:div.repos
+        (repo/repos-dropdown nil)]
 
        (when (and (nfs/supported?) (empty? repos)
                   (not config/publishing?))

--- a/src/main/frontend/components/header.css
+++ b/src/main/frontend/components/header.css
@@ -85,3 +85,14 @@
     align-items: center;
   }
 }
+
+
+#repo-name {
+    @apply md:max-w-none;
+    vertical-align: middle;
+    display: inline-block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 7ch;
+}

--- a/src/main/frontend/components/repo.cljs
+++ b/src/main/frontend/components/repo.cljs
@@ -183,16 +183,14 @@
                      (t :git/version) (str " " version/version)]]])))]))))))
 
 (rum/defc repos-dropdown < rum/reactive
-  [head? on-click]
+  [on-click]
   (when-let [current-repo (state/sub :git/current-repo)]
     (let [logged? (state/logged?)
           local-repo? (= current-repo config/local-repo)
           get-repo-name (fn [repo]
                           (if (config/local-db? repo)
                             (config/get-local-dir repo)
-                            (if head?
-                              (db/get-repo-path repo)
-                              (util/take-at-most (repo-handler/get-repo-name repo) 20))))]
+                            (db/get-repo-path repo)))]
       (let [repos (->> (state/sub [:me :repos])
                        (remove (fn [r] (= config/local-repo (:url r)))))]
         (cond
@@ -204,7 +202,7 @@
                     repo-name (if (util/electron?)
                                 (last (string/split repo-name #"/"))
                                 repo-name)]
-                [:span repo-name])
+                [:span#repo-name repo-name])
               [:span.dropdown-caret.ml-1 {:style {:border-top-color "#6b7280"}}]])
            (mapv
             (fn [{:keys [id url]}]
@@ -226,11 +224,11 @@
           (and current-repo (not local-repo?))
           (let [repo-name (get-repo-name current-repo)]
             (if (config/local-db? current-repo)
-              [:span.fade-link
+              [:span.fade-link#repo-name
                (if (util/electron?)
                  (last (string/split repo-name #"/"))
                  repo-name)]
-              [:a.fade-link
+              [:a.fade-link#repo-name
                {:href current-repo
                 :target "_blank"}
                repo-name]))

--- a/src/main/frontend/components/sidebar.cljs
+++ b/src/main/frontend/components/sidebar.cljs
@@ -100,7 +100,7 @@
            :stroke-linejoin "round"
            :stroke-linecap "round"}]]]])
     [:div.flex-shrink-0.flex.items-center.px-4.h-16.head-wrap
-     (repo/repos-dropdown false nil)]
+     (repo/repos-dropdown nil)]
     [:div.flex-1.h-0.overflow-y-auto
      (sidebar-nav route-match close-fn)]]])
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/9002575/113869455-56872580-97e3-11eb-80fd-c252b7ff8d22.png)
