### PR TITLE
CI: add check for Docker image consistency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
     paths-ignore:
       - '*.md'
 
+env:
+  CLOJURE_VERSION: '1.10.1.727'
+
 jobs:
 
   test:
@@ -44,10 +47,15 @@ jobs:
         with:
           node-version: '12'
 
+      - name: Check Dockerfile consistency
+        run: |
+          DOCKER_VERSION=$(grep -Po 'FROM clojure:.*-deps-?\K(.*)' Dockerfile)
+          [[ $CLOJURE_VERSION == $DOCKER_VERSION ]] || { echo "Please make sure Docker container version matches CLOJURE_VERSION" && exit 1; }
+
       - name: Install Clojure tools.deps
         uses: DeLaGuardo/setup-clojure@master
         with:
-          cli: '1.10.1.727'
+          cli: ${{ env.CLOJURE_VERSION }}
 
       - name: Fetch Maven deps
         if: steps.maven-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Otherwise it might cause weird build errors

Sadly, it seems that there is still a version mismatch between `build` and `build-desktop-release` for example....

YAML :vomiting_face:  https://github.community/t/reusing-sharing-inheriting-steps-between-jobs-declarations/16851/23

But hopefully it's a start...
