### PR TITLE
fix an issue when clicking bullets in embedded block/page

### DIFF
--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -311,15 +311,18 @@
     transition: transform .2s;
   }
 
-  &:hover {
-    .bullet {
-      transform: scale(1.2);
-    }
-  }
-
   &.bullet-closed {
     background-color: var(--ls-block-bullet-border-color, #ced9e0);
   }
+}
+
+a > .bullet-container {
+  /* fix the bullet element sometimes becomes a click event */
+  pointer-events: none;
+}
+
+a:hover > .bullet-container .bullet {
+  transform: scale(1.2);
 }
 
 .doc-mode {


### PR DESCRIPTION
I found an issue when trying to click (or shift+click) a bullet in an embedded block, that the editing mode will be turned on, instead of navigating to that block (or shown in the right panel).

After some investigation, I believe this is because the `link` check failed [in this line of code](https://github.com/logseq/logseq/blob/83eb8278aa908b550e3aa0aead3e969a05c0b2b9/src/main/frontend/components/block.cljs#L1359).

The `event.target` is the bullet span instead of the anchor when the event we used is `mouseown`. But if I change the event to `mouseclick`, the target is what we want (anchor).  

I am not sure why yet, but the current workaround is to give `pointer-events: none` to the `.bullet-container` inside of an anchor.


The bug screenshot:
![QQ20210409-222321](https://user-images.githubusercontent.com/584378/114194582-3b9ee780-9982-11eb-81dd-2b9ea89c8175.gif)