### PR TITLE
fix: block ref should be able to wrap

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -498,7 +498,7 @@
     (let [block (and (util/uuid-string? id)
                      (db/pull-block (uuid id)))]
       (if block
-        [:div.block-ref-wrap
+        [:span.block-ref-wrap
          {:on-mouse-down
           (fn [e]
             (util/stop e)

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -129,10 +129,6 @@
   border-bottom-color: var(--ls-block-ref-link-text-color);
   cursor: alias;
 
-  &-wrap {
-    display: inline-block;
-  }
-
   &:hover {
     color: var(--ls-link-text-hover-color)
   }


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/584378/114575220-871c0300-9cac-11eb-88a0-9fb4b03fae95.png)


After:
![image](https://user-images.githubusercontent.com/584378/114575104-723f6f80-9cac-11eb-8e06-30c7201622b8.png)
