### PR TITLE
fix: resizer should not scroll with the container

### DIFF
--- a/src/main/frontend/components/right_sidebar.cljs
+++ b/src/main/frontend/components/right_sidebar.cljs
@@ -267,7 +267,7 @@
          [:div.cp__right-sidebar-inner.flex.flex-col.h-full#right-sidebar-container
 
           (sidebar-resizer)
-          [:div
+          [:div.cp__right-sidebar-scollable
            [:div.cp__right-sidebar-topbar.flex.flex-row.justify-between.items-center.px-4.h-12
            [:div.cp__right-sidebar-settings.hide-scrollbar {:key "right-sidebar-settings"}
             [:div.ml-4.text-sm

--- a/src/main/frontend/components/sidebar.css
+++ b/src/main/frontend/components/sidebar.css
@@ -113,15 +113,14 @@
     width: var(--ls-right-sidebar-width);
   }
 
-  &::-webkit-scrollbar {
-    display: none;
+  &-scollable {
+    min-height: 100%;
+    overflow-y: scroll;
   }
 
   &-inner {
     padding-top: 0;
     position: relative;
-    min-height: 100%;
-    overflow-y: scroll;
 
     .resizer {
       position: absolute;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/584378/115258164-52ec8a80-a163-11eb-8f18-44777b5cf4cd.png)
.resizer element is inside of a scrolling container so when the right sidebar scroll up, the resizer will also scroll up. As a result, the user may not be able to change the right bar size.

This fix will make sure the resizer is outside of the scrolling container.