### PR TITLE
fix: adjust the window header dragging area on Mac

### DIFF
--- a/src/main/frontend/components/theme.css
+++ b/src/main/frontend/components/theme.css
@@ -105,22 +105,22 @@ html.is-electron {
   }
 
   &.is-mac {
+    .theme-inner:before {
+      content: ' ';
+      position: fixed;
+      top: 0;
+      left: 0;
+      z-index: 8;
+      -webkit-app-region: drag;
+      width: 100%;
+      height: var(--frame-top-height);
+    }
+
     .cp__header {
       height: calc(2.2rem + var(--frame-top-height));
       padding-top: var(--frame-top-height);
 
       &-logo {
-        height: var(--frame-top-height);
-      }
-
-      &:before {
-        content: ' ';
-        position: fixed;
-        top: 0;
-        left: 0;
-        z-index: 8;
-        -webkit-app-region: drag;
-        width: 100%;
         height: var(--frame-top-height);
       }
     }


### PR DESCRIPTION
On Mac electron version, the window drag area has the same width with `.cp__header`. When the right side bar is shown, the user could not move around the window by dragging the top edge of the right side bar.
This fix moves the window dragging area to the root container. 