### PR TITLE
fix: add back missing resize icon in Chrome

### DIFF
--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -74,6 +74,8 @@
 
   .resize {
     display: inline-flex;
+    /* Fix chrome missing resize handle issue. Ref: https://github.com/logseq/logseq/pull/1692/files */
+    transform: translate3d(0, 0, 0);
   }
 
   .draw [aria-labelledby="shapes-title"] {


### PR DESCRIPTION
After git bisects, I found the issue is introduced since https://github.com/logseq/logseq/pull/1634.
However, these changes still seem not that quite relevant to this issue.

I spend some time deep-diving into the issue. It looks like the resize handle will disappear when one of the parent containers overflows with scrollbars and the resize container is `position: relative`.
I think this might be a Chrome bug because this is not reproducible on Firefox. See:
https://codepen.io/pengx17/pen/zYNbmJv?editors=1100

Since this is very fragile that the user can easily apply some custom styles to some of the elements in custom.css, I guess the ultimate solution is to render resize handles with real DOM elements, instead of depending on the Browser to render it.