### PR TITLE
feat: add body/title data attributes to block container

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1692,6 +1692,8 @@
       {:id block-id
        :data-refs data-refs
        :data-refs-self data-refs-self
+       :data-title (str title)
+       :data-body (str body)
        :style {:position "relative"}
        :class (str uuid
                    (when dummy? " dummy")


### PR DESCRIPTION
I have seen people in the community that want to do some custom styling with the block bullets, for example, hide the block bullet if the content is empty. This is only possible if we can get use css selectors to query them.

In this PR, I would like to include two new data attributes for block title and body. So I can use this css snippet to hide the bullet when
- both title and body is empty
- or body only contains `<hr />`

```css

.ls-block[data-title="[]"]:not(:focus-within):not(:hover):is([data-body="[]"], [data-body='[["Horizontal_Rule"]]'])
  .bullet-container {
  visibility: hidden;
}

```

https://user-images.githubusercontent.com/584378/116338259-0f9eb580-a80e-11eb-8c56-072b5c04957a.mp4


One major drawback is that this change will significantly increase the length of the rendered HTML. However, I think this might not impact the render performance ...

![image](https://user-images.githubusercontent.com/584378/116338179-eed66000-a80d-11eb-84d4-7c7bafe58ae4.png)



Also, I guess this should be better to be done with plugins anyway
