### PR TITLE
feat: more bash-like basic in block editing shortcuts

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2356,7 +2356,6 @@
   [id]
   (fn [_e]
     (let [input (gdom/getElement id)]
-      (save-current-block! {:force? true})
       (close-autocomplete-if-outside input))))
 
 (defn editor-on-change!
@@ -2573,3 +2572,21 @@
 
 (defn end-of-block []
   (util/move-cursor-to-end (state/get-input)))
+
+(defn cursor-forward-word []
+  (util/move-cursor-forward-by-word (state/get-input)))
+
+(defn cursor-backward-word []
+  (util/move-cursor-backward-by-word (state/get-input)))
+
+(defn backward-kill-word []
+  (let [input (state/get-input)]
+    (save-current-block! {:force? true})
+    (util/backward-kill-word input)
+    (state/set-edit-content! (state/get-edit-input-id) (.-value input))))
+
+(defn forward-kill-word []
+  (let [input (state/get-input)]
+    (save-current-block! {:force? true})
+    (util/forward-kill-word input)
+    (state/set-edit-content! (state/get-edit-input-id) (.-value input))))

--- a/src/main/frontend/modules/shortcut/binding.cljc
+++ b/src/main/frontend/modules/shortcut/binding.cljc
@@ -59,23 +59,23 @@
    :editor/delete-selection ["backspace" "delete"]
 
    ;; clear the block content
-   :editor/clear-block "alt+l"
+   :editor/clear-block (if mac? "ctrl+l" "alt+l")
    ;; kill the line before the cursor position
-   :editor/kill-line-before "alt+u"
+   :editor/kill-line-before (if mac? "ctrl+u" "alt+u")
    ;; kill the line after the cursor position
-   :editor/kill-line-after "alt+k"
+   :editor/kill-line-after (if mac? "ctrl+k" "alt+k")
    ;; go to the beginning of the block
-   :editor/beginning-of-block "alt+a"
+   :editor/beginning-of-block (if mac? "ctrl+a" "alt+a")
    ;; go to the end of the block
-   :editor/end-of-block "alt+e"
+   :editor/end-of-block (if mac? "ctrl+e" "alt+e")
    ;; forward one word
-   :editor/forward-word "alt+f"
+   :editor/forward-word (if mac? "ctrl+f" "alt+f")
    ;; backward one word
-   :editor/backward-word "alt+b"
+   :editor/backward-word (if mac? "ctrl+b" "alt+b")
    ;; kill one word backward
-   :editor/backward-kill-word "alt+w"
+   :editor/backward-kill-word (if mac? "ctrl+w" "alt+w")
    ;; kill one word forward
-   :editor/forward-kill-word "alt+d"
+   :editor/forward-kill-word (if mac? "ctrl+d" "alt+d")
 
 
    :editor/selection-up "up"

--- a/src/main/frontend/modules/shortcut/binding.cljc
+++ b/src/main/frontend/modules/shortcut/binding.cljc
@@ -63,19 +63,19 @@
    ;; kill the line before the cursor position
    :editor/kill-line-before (if mac? "ctrl+u" "alt+u")
    ;; kill the line after the cursor position
-   :editor/kill-line-after (if mac? "ctrl+k" "alt+k")
+   :editor/kill-line-after (if mac? false "alt+k")
    ;; go to the beginning of the block
-   :editor/beginning-of-block (if mac? "ctrl+a" "alt+a")
+   :editor/beginning-of-block (if mac? false "alt+a")
    ;; go to the end of the block
-   :editor/end-of-block (if mac? "ctrl+e" "alt+e")
+   :editor/end-of-block (if mac? false "alt+e")
    ;; forward one word
-   :editor/forward-word (if mac? "ctrl+f" "alt+f")
+   :editor/forward-word (if mac? "ctrl+shift+f" "alt+f")
    ;; backward one word
-   :editor/backward-word (if mac? "ctrl+b" "alt+b")
+   :editor/backward-word (if mac? "ctrl+shift+b" "alt+b")
    ;; kill one word backward
    :editor/backward-kill-word (if mac? "ctrl+w" "alt+w")
    ;; kill one word forward
-   :editor/forward-kill-word (if mac? "ctrl+d" "alt+d")
+   :editor/forward-kill-word (if mac? "ctrl+shift+w" "alt+d")
 
 
    :editor/selection-up "up"

--- a/src/main/frontend/modules/shortcut/binding.cljc
+++ b/src/main/frontend/modules/shortcut/binding.cljc
@@ -69,13 +69,13 @@
    ;; go to the end of the block
    :editor/end-of-block (if mac? false "alt+e")
    ;; forward one word
-   :editor/forward-word (if mac? "ctrl+shift+f" "alt+f")
+   :editor/forward-word (if mac? "ctrl+f" "alt+f")
    ;; backward one word
-   :editor/backward-word (if mac? "ctrl+shift+b" "alt+b")
+   :editor/backward-word (if mac? "ctrl+b" "alt+b")
    ;; kill one word backward
    :editor/backward-kill-word (if mac? "ctrl+w" "alt+w")
    ;; kill one word forward
-   :editor/forward-kill-word (if mac? "ctrl+shift+w" "alt+d")
+   :editor/forward-kill-word (if mac? false "alt+d")
 
 
    :editor/selection-up "up"

--- a/src/main/frontend/modules/shortcut/binding.cljc
+++ b/src/main/frontend/modules/shortcut/binding.cljc
@@ -68,6 +68,15 @@
    :editor/beginning-of-block "alt+a"
    ;; go to the end of the block
    :editor/end-of-block "alt+e"
+   ;; forward one word
+   :editor/forward-word "alt+f"
+   ;; backward one word
+   :editor/backward-word "alt+b"
+   ;; kill one word backward
+   :editor/backward-kill-word "alt+w"
+   ;; kill one word forward
+   :editor/forward-kill-word "alt+d"
+
 
    :editor/selection-up "up"
    :editor/selection-down "down"

--- a/src/main/frontend/modules/shortcut/binding.cljc
+++ b/src/main/frontend/modules/shortcut/binding.cljc
@@ -58,6 +58,17 @@
    :editor/delete "delete"
    :editor/delete-selection ["backspace" "delete"]
 
+   ;; clear the block content
+   :editor/clear-block "alt+l"
+   ;; kill the line before the cursor position
+   :editor/kill-line-before "alt+u"
+   ;; kill the line after the cursor position
+   :editor/kill-line-after "alt+k"
+   ;; go to the beginning of the block
+   :editor/beginning-of-block "alt+a"
+   ;; go to the end of the block
+   :editor/end-of-block "alt+e"
+
    :editor/selection-up "up"
    :editor/selection-down "down"
 

--- a/src/main/frontend/modules/shortcut/binding.cljc
+++ b/src/main/frontend/modules/shortcut/binding.cljc
@@ -69,9 +69,9 @@
    ;; go to the end of the block
    :editor/end-of-block (if mac? false "alt+e")
    ;; forward one word
-   :editor/forward-word (if mac? "ctrl+f" "alt+f")
+   :editor/forward-word (if mac? "ctrl+shift+f" "alt+f")
    ;; backward one word
-   :editor/backward-word (if mac? "ctrl+b" "alt+b")
+   :editor/backward-word (if mac? "ctrl+shift+b" "alt+b")
    ;; kill one word backward
    :editor/backward-kill-word (if mac? "ctrl+w" "alt+w")
    ;; kill one word forward

--- a/src/main/frontend/modules/shortcut/core.cljs
+++ b/src/main/frontend/modules/shortcut/core.cljs
@@ -21,13 +21,19 @@
   [id]
   (let [shortcut (or (state/get-shortcut id)
                      (get (apply merge @binding-profile) id))]
-    (when-not shortcut
-      (log/error :shortcut/binding-not-found {:id id}))
-    (->>
-     (if (string? shortcut)
-       [shortcut]
-       shortcut)
-     (mapv mod-key))))
+    (cond
+      (nil? shortcut)
+      (log/error :shortcut/binding-not-found {:id id})
+
+      (false? shortcut)
+      (log/debug :shortcut/disabled {:id id})
+
+      :else
+      (->>
+       (if (string? shortcut)
+         [shortcut]
+         shortcut)
+       (mapv mod-key)))))
 
 (def global-keys #js
   [KeyCodes/TAB

--- a/src/main/frontend/modules/shortcut/handler.cljs
+++ b/src/main/frontend/modules/shortcut/handler.cljs
@@ -34,7 +34,12 @@
     :editor/insert-link editor-handler/html-link-format!
     :editor/select-all-blocks editor-handler/select-all-blocks!
     :editor/move-block-up (editor-handler/move-up-down true)
-    :editor/move-block-down (editor-handler/move-up-down false)}))
+    :editor/move-block-down (editor-handler/move-up-down false)
+    :editor/clear-block editor-handler/clear-block-content!
+    :editor/kill-line-before editor-handler/kill-line-before!
+    :editor/kill-line-after editor-handler/kill-line-after!
+    :editor/beginning-of-block editor-handler/beginning-of-block
+    :editor/end-of-block editor-handler/end-of-block}))
 
 (def handler
   [;; global editor shortcut

--- a/src/main/frontend/modules/shortcut/handler.cljs
+++ b/src/main/frontend/modules/shortcut/handler.cljs
@@ -39,7 +39,11 @@
     :editor/kill-line-before editor-handler/kill-line-before!
     :editor/kill-line-after editor-handler/kill-line-after!
     :editor/beginning-of-block editor-handler/beginning-of-block
-    :editor/end-of-block editor-handler/end-of-block}))
+    :editor/end-of-block editor-handler/end-of-block
+    :editor/forward-word editor-handler/cursor-forward-word
+    :editor/backward-word editor-handler/cursor-backward-word
+    :editor/backward-kill-word editor-handler/backward-kill-word
+    :editor/forward-kill-word editor-handler/forward-kill-word}))
 
 (def handler
   [;; global editor shortcut

--- a/src/main/frontend/modules/shortcut/handler.cljs
+++ b/src/main/frontend/modules/shortcut/handler.cljs
@@ -62,12 +62,14 @@
     :editor/redo history/redo!}
 
    ;; global
-   {:ui/toggle-brackets config-handler/toggle-ui-show-brackets!
-    :go/search route-handler/go-to-search!
-    :go/journals route-handler/go-to-journals!
+   (before
+    m/prevent-default-behavior
+    {:ui/toggle-brackets config-handler/toggle-ui-show-brackets!
+     :go/search route-handler/go-to-search!
+     :go/journals route-handler/go-to-journals!
 
-    :search/re-index search-handler/rebuild-indices!
-    :graph/re-index #(repo-handler/re-index! nfs-handler/rebuild-index!)}
+     :search/re-index search-handler/rebuild-indices!
+     :graph/re-index #(repo-handler/re-index! nfs-handler/rebuild-index!)})
 
    ;; non-editing only
    (before

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1341,4 +1341,4 @@
                         (remove nil?)
                         (apply min))
                    (count val))]
-       (.setRangeText input "" current idx))))
+       (.setRangeText input "" current (inc idx)))))

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1276,3 +1276,69 @@
    coll))
 
 (def pprint clojure.pprint/pprint)
+
+#?(:cljs
+   (defn move-cursor-forward-by-word
+     [input]
+     (let [val   (.-value input)
+           current (.-selectionStart input)
+           current (loop [idx current]
+                     (if (#{\space \newline} (nth-safe val idx))
+                       (recur (inc idx))
+                       idx))
+           idx (or (->> [(string/index-of val \space current)
+                         (string/index-of val \newline current)]
+                        (remove nil?)
+                        (apply min))
+                   (count val))]
+       (move-cursor-to input idx))))
+
+#?(:cljs
+   (defn move-cursor-backward-by-word
+     [input]
+     (let [val     (.-value input)
+           current (.-selectionStart input)
+           prev    (or
+                    (max
+                     (string/last-index-of val \space (dec current))
+                     (string/last-index-of val \newline (dec current)))
+                    0)
+           idx     (loop [idx prev]
+                     (if (#{\space \newline} (nth-safe val idx))
+                       (recur (dec idx))
+                       idx))
+           idx     (if (zero? idx) idx (inc idx))]
+       (move-cursor-to input idx))))
+
+#?(:cljs
+   (defn backward-kill-word
+     [input]
+     (let [val     (.-value input)
+           current (.-selectionStart input)
+           prev    (or
+                    (max
+                     (string/last-index-of val \space (dec current))
+                     (string/last-index-of val \newline (dec current)))
+                    0)
+           idx     (loop [idx prev]
+                     (if (#{\space \newline} (nth-safe val idx))
+                       (recur (dec idx))
+                       idx))
+           idx     (if (zero? idx) idx (inc idx))]
+       (.setRangeText input "" idx current))))
+
+#?(:cljs
+   (defn forward-kill-word
+     [input]
+     (let [val   (.-value input)
+           current (.-selectionStart input)
+           current (loop [idx current]
+                     (if (#{\space \newline} (nth-safe val idx))
+                       (recur (inc idx))
+                       idx))
+           idx (or (->> [(string/index-of val \space current)
+                         (string/index-of val \newline current)]
+                        (remove nil?)
+                        (apply min))
+                   (count val))]
+       (.setRangeText input "" current idx))))

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -645,6 +645,24 @@
        (move-cursor-to input pos))))
 
 #?(:cljs
+   (defn kill-line-before!
+     [input]
+     (let [val (.-value input)
+           end (.-selectionStart input)
+           n-pos (string/last-index-of val \newline (dec end))
+           start (if n-pos (inc n-pos) 0)]
+       (.setRangeText input "" start end))))
+
+#?(:cljs
+   (defn kill-line-after!
+     [input]
+     (let [val   (.-value input)
+           start (.-selectionStart input)
+           end   (or (string/index-of val \newline start)
+                     (count val))]
+       (.setRangeText input "" start end))))
+
+#?(:cljs
    (defn move-cursor-up
      "Move cursor up. If EOL, always move cursor to previous EOL."
      [input]

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1299,15 +1299,19 @@
      (let [val     (.-value input)
            current (.-selectionStart input)
            prev    (or
-                    (max
-                     (string/last-index-of val \space (dec current))
-                     (string/last-index-of val \newline (dec current)))
+                    (->> [(string/last-index-of val \space (dec current))
+                          (string/last-index-of val \newline (dec current))]
+                         (remove nil?)
+                         (apply max))
                     0)
-           idx     (loop [idx prev]
-                     (if (#{\space \newline} (nth-safe val idx))
-                       (recur (dec idx))
-                       idx))
-           idx     (if (zero? idx) idx (inc idx))]
+           idx     (if (zero? prev)
+                     0
+                     (->
+                      (loop [idx prev]
+                        (if (#{\space \newline} (nth-safe val idx))
+                          (recur (dec idx))
+                          idx))
+                      inc))]
        (move-cursor-to input idx))))
 
 #?(:cljs
@@ -1316,15 +1320,19 @@
      (let [val     (.-value input)
            current (.-selectionStart input)
            prev    (or
-                    (max
-                     (string/last-index-of val \space (dec current))
-                     (string/last-index-of val \newline (dec current)))
+                    (->> [(string/last-index-of val \space (dec current))
+                          (string/last-index-of val \newline (dec current))]
+                         (remove nil?)
+                         (apply max))
                     0)
-           idx     (loop [idx prev]
-                     (if (#{\space \newline} (nth-safe val idx))
-                       (recur (dec idx))
-                       idx))
-           idx     (if (zero? idx) idx (inc idx))]
+           idx     (if (zero? prev)
+                     0
+                     (->
+                      (loop [idx prev]
+                        (if (#{\space \newline} (nth-safe val idx))
+                          (recur (dec idx))
+                          idx))
+                      inc))]
        (.setRangeText input "" idx current))))
 
 #?(:cljs


### PR DESCRIPTION
- clear block content
![clear](https://user-images.githubusercontent.com/9002575/117420090-d2de6700-af4f-11eb-86be-cab696377b1b.gif)
- word move/kill
![word-move](https://user-images.githubusercontent.com/9002575/117420199-e7bafa80-af4f-11eb-9377-97a9781befa9.gif)
- line kill
![line-kill](https://user-images.githubusercontent.com/9002575/117420216-edb0db80-af4f-11eb-9039-751c56d3f989.gif)
- move cursor start/end
![start-end](https://user-images.githubusercontent.com/9002575/117420226-f0abcc00-af4f-11eb-95bf-3a60906cfab7.gif)
