### PR TITLE
Fix missing argument for input-secret dialog

### DIFF
--- a/src/main/frontend/handler/repo.cljs
+++ b/src/main/frontend/handler/repo.cljs
@@ -237,6 +237,7 @@
       (if db-encrypted?
         (let [close-fn #(parse-files-and-create-default-files! repo-url files delete-files delete-blocks file-paths first-clone? db-encrypted? re-render? re-render-opts metadata)]
           (state/pub-event! [:modal/encryption-input-secret-dialog repo-url
+                             db-encrypted-secret
                              close-fn]))
         (parse-files-and-create-default-files! repo-url files delete-files delete-blocks file-paths first-clone? db-encrypted? re-render? re-render-opts metadata)))))
 


### PR DESCRIPTION
Regressed by 45533ce77b3488d107d82a7bfc12b105a4a83135, that is why Canary build's decryption wasn't working.