### PR TITLE
feat: extract template files

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:paths ["src/main"]
+{:paths ["src/main" "templates"]
  :deps
  {org.clojure/clojure         {:mvn/version "1.10.0"}
   cheshire/cheshire {:mvn/version "5.10.0"}

--- a/src/main/frontend/config.cljs
+++ b/src/main/frontend/config.cljs
@@ -2,7 +2,8 @@
   (:require [clojure.set :as set]
             [clojure.string :as string]
             [frontend.state :as state]
-            [frontend.util :as util]))
+            [frontend.util :as util]
+            [shadow.resource :as rc]))
 
 (goog-define DEV-RELEASE false)
 (defonce dev-release? DEV-RELEASE)
@@ -282,8 +283,7 @@
 (def custom-css-file "custom.css")
 (def metadata-file "metadata.edn")
 
-(def config-default-content
-  "{;; Currently, we support either \"Markdown\" or \"Org\".\n ;; This can overwrite your global preference so that\n ;; maybe your personal preferred format is Org but you'd\n ;; need to use Markdown for some projects.\n ;; :preferred-format \"\"\n \n ;; Preferred workflow style. \n ;; Value is either \":now\" for NOW/LATER style,\n ;; or \":todo\" for TODO/DOING style.\n :preferred-workflow :now\n\n ;; Git settings\n :git-pull-secs 60\n :git-push-secs 10\n :git-auto-push true\n\n ;; The app will ignore those directories or files.\n ;; E.g. \"/archived\" \"/test.md\"\n :hidden []\n\n ;; When creating the new journal page, the app will use your template content here.\n ;; Example for Markdown users: \"[[Work]]\\n  -\\n- [[Family]]\\n  -\\n\"\n ;; Example for Org mode users: \"** [[Work]]\\n***\\n** [[Family]]\\n***\\n\"\n :default-templates\n {:journals \"\"}\n\n ;; The app will show those queries in today's journal page,\n ;; the \"NOW\" query asks the tasks which need to be finished \"now\",\n ;; the \"NEXT\" query asks the future tasks.\n :default-queries\n {:journals\n  [{:title \"🔨 NOW\"\n    :query [:find (pull ?h [*])\n            :in $ ?start ?today\n            :where\n            [?h :block/marker ?marker]\n            [?h :block/page ?p]\n            [?p :block/journal? true]\n            [?p :block/journal-day ?d]\n            [(>= ?d ?start)]\n            [(<= ?d ?today)]\n            [(contains? #{\"NOW\" \"DOING\"} ?marker)]]\n    :inputs [:14d :today]\n    :result-transform (fn [result]\n                        (sort-by (fn [h]\n                                   (get h :block/priority \"Z\")) result))\n    :collapsed? false}\n   {:title \"📅 NEXT\"\n    :query [:find (pull ?h [*])\n            :in $ ?start ?next\n            :where\n            [?h :block/marker ?marker]\n            [?h :block/ref-pages ?p]\n            [?p :block/journal? true]\n            [?p :block/journal-day ?d]\n            [(> ?d ?start)]\n            [(< ?d ?next)]\n            [(contains? #{\"NOW\" \"LATER\" \"TODO\"} ?marker)]]\n    :inputs [:today :7d-after]\n    :collapsed? false}]}\n\n ;; Add your own commands to speedup.\n ;; E.g. [[\"js\" \"Javascript\"]]\n :commands\n []\n\n ;; Macros replace texts and will make you more productive.\n ;; For example:\n ;; Add this to the macros below:\n ;; {\"poem\" \"Rose is $1, violet's $2. Life's ordered: Org assists you.\"}\n ;; input \"{{{poem red,blue}}}\"\n ;; becomes\n ;; Rose is red, violet's blue. Life's ordered: Org assists you.\n :macros {}}\n")
+(def config-default-content (rc/inline "config.edn"))
 
 (def markers
   #{"now" "later" "todo" "doing" "done" "wait" "waiting"

--- a/src/main/frontend/dicts.cljs
+++ b/src/main/frontend/dicts.cljs
@@ -1,60 +1,11 @@
 (ns frontend.dicts
-  (:require [tongue.core :as tongue]
-            [frontend.config :as config]))
+  (:require [frontend.config :as config]
+            [shadow.resource :as rc]
+            [tongue.core :as tongue]))
 
 (def dicts
-  {:en {:tutorial/text "## Hi, welcome to Logseq!
-- Logseq is a _privacy-first_, _open-source_ platform for _knowledge_ sharing and management.
-- This is a 3 minute tutorial on how to use Logseq. Let's get started!
-- (Feel free to edit anything, no change will be saved at this moment. If you do want to persist your work, click the **top-right** corner of the screen to connect Logseq to either Github or local directory.)
-- Here are some tips might be useful.
-#+BEGIN_TIP
-Click to edit any block.
-Type `Enter` to create a new block.
-Type `Shift+Enter` to create a new line.
-Type `/` to show all the commands.
-#+END_TIP
-- 1. Let's create a page called [[How to take dummy notes?]]. You can click it to go to that page, or you can `Shift+Click` to open it in the right sidebar! Now you should see both _Linked References_ and _Unlinked References_.
-- 2. Let's reference some blocks on [[How to take dummy notes?]], you can `Shift+Click` any block reference to open it in the right sidebar. Try making
-some changes on the right sidebar, those referenced blocks will be changed too!
-    - ((5f713e91-8a3c-4b04-a33a-c39482428e2d)) : This is a block reference.
-    - ((5f713ea8-8cba-403d-ac00-9964b1ec7190)) : This is another block reference.
-- 3. Do you support tags?
-    - Of course, this is a #dummy tag.
-- 4. Do you support tasks like todo/doing/done and priorities?
-    - Yes, type `/` and pick your favorite todo keyword or priority (A/B/C).
-    - NOW [#A] A dummy tutorial on \"How to take dummy notes?\"
-    - LATER [#A] Check out this awesome video by [:a {:href \"https://twitter.com/EdTravelling\" :target \"_blank\"} \"@EdTravelling\"], which shows how to use logseq to open your local directory.
-
-[:div.video-wrapper.mb-4
-        [:iframe
-         {:allowFullScreen \"allowfullscreen\"
-          :allow
-          \"accelerometer; autoplay; encrypted-media; gyroscope\"
-        :frameBorder \"0\"
-        :src \"https://www.youtube.com/embed/Afmqowr0qEQ\"
-        :height \"367\"
-        :width \"653\"}]]
-    - DONE Create a page
-    - CANCELED [#C] Write a page with more than 1000 blocks
-- That's it! You can create more bullets or open a local directory to import some notes now!
-- You can also download our desktop app at https://github.com/logseq/logseq/releases
-"
-        :tutorial/dummy-notes "---
-title: How to take dummy notes?
----
-
-- Hello, I'm a block!
-:PROPERTIES:
-:id: 5f713e91-8a3c-4b04-a33a-c39482428e2d
-:END:
-    - I'm a child block!
-    - I'm another child block!
-- Hey, I'm another block!
-:PROPERTIES:
-:id: 5f713ea8-8cba-403d-ac00-9964b1ec7190
-:END:
-"
+  {:en {:tutorial/text (rc/inline "tutorial-en.md")
+        :tutorial/dummy-notes (rc/inline "dummy-notes-en.md")
         :on-boarding/title "Hi, welcome to Logseq!"
         :on-boarding/sharing "sharing"
         :on-boarding/is-a " is a "

--- a/src/main/frontend/handler/repo.cljs
+++ b/src/main/frontend/handler/repo.cljs
@@ -1,30 +1,31 @@
 (ns frontend.handler.repo
   (:refer-clojure :exclude [clone])
-  (:require [frontend.util :as util :refer-macros [profile]]
+  (:require [cljs-bean.core :as bean]
+            [clojure.string :as string]
+            [frontend.config :as config]
+            [frontend.date :as date]
+            [frontend.db :as db]
+            [frontend.dicts :as dicts]
+            [frontend.encrypt :as encrypt]
+            [frontend.format :as format]
             [frontend.fs :as fs]
             [frontend.fs.nfs :as nfs]
-            [promesa.core :as p]
-            [lambdaisland.glogi :as log]
-            [frontend.state :as state]
-            [frontend.db :as db]
-            [frontend.idb :as idb]
             [frontend.git :as git]
-            [cljs-bean.core :as bean]
-            [frontend.date :as date]
-            [frontend.config :as config]
-            [frontend.format :as format]
-            [frontend.search :as search]
-            [frontend.handler.ui :as ui-handler]
-            [frontend.handler.git :as git-handler]
-            [frontend.handler.file :as file-handler]
-            [frontend.handler.notification :as notification]
-            [frontend.handler.route :as route-handler]
             [frontend.handler.common :as common-handler]
             [frontend.handler.extract :as extract-handler]
-            [clojure.string :as string]
-            [frontend.dicts :as dicts]
+            [frontend.handler.file :as file-handler]
+            [frontend.handler.git :as git-handler]
+            [frontend.handler.notification :as notification]
+            [frontend.handler.route :as route-handler]
+            [frontend.handler.ui :as ui-handler]
+            [frontend.idb :as idb]
+            [frontend.search :as search]
             [frontend.spec :as spec]
-            [frontend.encrypt :as encrypt]))
+            [frontend.state :as state]
+            [frontend.util :as util]
+            [lambdaisland.glogi :as log]
+            [promesa.core :as p]
+            [shadow.resource :as rc]))
 
 ;; Project settings should be checked in two situations:
 ;; 1. User changes the config.edn directly in logseq.com (fn: alter-file)
@@ -54,10 +55,8 @@
                   (config/get-file-extension format))
         file-path (str "/" path)
         default-content (case (name format)
-                          "org"
-                          "* What's **Contents**?\n** It's a normal page called [[Contents]], you can use it for:\n*** 1. table of content/index/MOC\n*** 2. pinning/bookmarking favorites pages/blocks (e.g. [[Logseq]])\n*** 3. You can also put many different things, depending on your personal workflow."
-                          "markdown"
-                          "- What's **Contents**?\n    - It's a normal page called [[Contents]], you can use it for:\n    - 1. table of content/index/MOC\n    - 2. pinning/bookmarking favorites pages/blocks (e.g. [[Logseq]])\n    - 3. You can also put many different things, depending on your personal workflow."
+                          "org" (rc/inline "contents.org")
+                          "markdown" (rc/inline "contents.md")
                           "")]
     (p/let [_ (fs/mkdir-if-not-exists (str repo-dir "/" (state/get-pages-directory)))
             file-exists? (fs/create-if-not-exists repo-url repo-dir file-path default-content)]

--- a/templates/config.edn
+++ b/templates/config.edn
@@ -16,7 +16,7 @@
 
  ;; The app will ignore those directories or files.
  ;; E.g. "/archived" "/test.md"
- :hiddenabc []
+ :hidden []
 
  ;; When creating the new journal page, the app will use your template content here.
  ;; Example for Markdown users: "[[Work]]\n  -\n- [[Family]]\n  -\n"

--- a/templates/config.edn
+++ b/templates/config.edn
@@ -1,0 +1,74 @@
+{;; Currently, we support either "Markdown" or "Org".
+ ;; This can overwrite your global preference so that
+ ;; maybe your personal preferred format is Org but you'd
+ ;; need to use Markdown for some projects.
+ ;; :preferred-format ""
+
+ ;; Preferred workflow style.
+ ;; Value is either ":now" for NOW/LATER style,
+ ;; or ":todo" for TODO/DOING style.
+ :preferred-workflow :now
+
+ ;; Git settings
+ :git-pull-secs 60
+ :git-push-secs 10
+ :git-auto-push true
+
+ ;; The app will ignore those directories or files.
+ ;; E.g. "/archived" "/test.md"
+ :hiddenabc []
+
+ ;; When creating the new journal page, the app will use your template content here.
+ ;; Example for Markdown users: "[[Work]]\n  -\n- [[Family]]\n  -\n"
+ ;; Example for Org mode users: "** [[Work]]\n***\n** [[Family]]\n***\n"
+ :default-templates
+ {:journals ""}
+
+ ;; The app will show those queries in today's journal page,
+ ;; the "NOW" query asks the tasks which need to be finished "now",
+ ;; the "NEXT" query asks the future tasks.
+ :default-queries
+ {:journals
+  [{:title "🔨 NOW"
+    :query [:find (pull ?h [*])
+            :in $ ?start ?today
+            :where
+            [?h :block/marker ?marker]
+            [?h :block/page ?p]
+            [?p :block/journal? true]
+            [?p :block/journal-day ?d]
+            [(>= ?d ?start)]
+            [(<= ?d ?today)]
+            [(contains? #{"NOW" "DOING"} ?marker)]]
+    :inputs [:14d :today]
+    :result-transform (fn [result]
+                        (sort-by (fn [h]
+                                   (get h :block/priority "Z")) result))
+    :collapsed? false}
+   {:title "📅 NEXT"
+    :query [:find (pull ?h [*])
+            :in $ ?start ?next
+            :where
+            [?h :block/marker ?marker]
+            [?h :block/ref-pages ?p]
+            [?p :block/journal? true]
+            [?p :block/journal-day ?d]
+            [(> ?d ?start)]
+            [(< ?d ?next)]
+            [(contains? #{"NOW" "LATER" "TODO"} ?marker)]]
+    :inputs [:today :7d-after]
+    :collapsed? false}]}
+
+ ;; Add your own commands to speedup.
+ ;; E.g. [["js" "Javascript"]]
+ :commands
+ []
+
+ ;; Macros replace texts and will make you more productive.
+ ;; For example:
+ ;; Add this to the macros below:
+ ;; {"poem" "Rose is $1, violet's $2. Life's ordered: Org assists you."}
+ ;; input "{{{poem red,blue}}}"
+ ;; becomes
+ ;; Rose is red, violet's blue. Life's ordered: Org assists you.
+ :macros {}}

--- a/templates/contents.md
+++ b/templates/contents.md
@@ -1,0 +1,5 @@
+- What's **Contents**?
+    - It's a normal page called [[Contents]], you can use it for:
+    - 1. table of content/index/MOC
+    - 2. pinning/bookmarking favorites pages/blocks (e.g. [[Logseq]])
+    - 3. You can also put many different things, depending on your personal workflow.

--- a/templates/contents.org
+++ b/templates/contents.org
@@ -1,0 +1,5 @@
+* What's **Contents**?
+** It's a normal page called [[Contents]], you can use it for:
+*** 1. table of content/index/MOC
+*** 2. pinning/bookmarking favorites pages/blocks (e.g. [[Logseq]])
+*** 3. You can also put many different things, depending on your personal workflow.

--- a/templates/dummy-notes-en.md
+++ b/templates/dummy-notes-en.md
@@ -1,0 +1,14 @@
+---
+title: How to take dummy notes?
+---
+
+- Hello, I'm a block!
+:PROPERTIES:
+:id: 5f713e91-8a3c-4b04-a33a-c39482428e2d
+:END:
+    - I'm a child block!
+    - I'm another child block!
+- Hey, I'm another block!
+:PROPERTIES:
+:id: 5f713ea8-8cba-403d-ac00-9964b1ec7190
+:END:

--- a/templates/tutorial-en.md
+++ b/templates/tutorial-en.md
@@ -1,0 +1,36 @@
+## Hi, welcome to Logseq!
+- Logseq is a _privacy-first_, _open-source_ platform for _knowledge_ sharing and management.
+- This is a 3 minute tutorial on how to use Logseq. Let's get started!
+- (Feel free to edit anything, no change will be saved at this moment. If you do want to persist your work, click the **top-right** corner of the screen to connect Logseq to either Github or local directory.)
+- Here are some tips might be useful.
+#+BEGIN_TIP
+Click to edit any block.
+Type `Enter` to create a new block.
+Type `Shift+Enter` to create a new line.
+Type `/` to show all the commands.
+#+END_TIP
+- 1. Let's create a page called [[How to take dummy notes?]]. You can click it to go to that page, or you can `Shift+Click` to open it in the right sidebar! Now you should see both _Linked References_ and _Unlinked References_.
+- 2. Let's reference some blocks on [[How to take dummy notes?]], you can `Shift+Click` any block reference to open it in the right sidebar. Try making
+some changes on the right sidebar, those referenced blocks will be changed too!
+    - ((5f713e91-8a3c-4b04-a33a-c39482428e2d)) : This is a block reference.
+    - ((5f713ea8-8cba-403d-ac00-9964b1ec7190)) : This is another block reference.
+- 3. Do you support tags?
+    - Of course, this is a #dummy tag.
+- 4. Do you support tasks like todo/doing/done and priorities?
+    - Yes, type `/` and pick your favorite todo keyword or priority (A/B/C).
+    - NOW [#A] A dummy tutorial on \"How to take dummy notes?\"
+    - LATER [#A] Check out this awesome video by [:a {:href \"https://twitter.com/EdTravelling\" :target \"_blank\"} \"@EdTravelling\"], which shows how to use logseq to open your local directory.
+
+[:div.video-wrapper.mb-4
+        [:iframe
+         {:allowFullScreen \"allowfullscreen\"
+          :allow
+          \"accelerometer; autoplay; encrypted-media; gyroscope\"
+        :frameBorder \"0\"
+        :src \"https://www.youtube.com/embed/Afmqowr0qEQ\"
+        :height \"367\"
+        :width \"653\"}]]
+    - DONE Create a page
+    - CANCELED [#C] Write a page with more than 1000 blocks
+- That's it! You can create more bullets or open a local directory to import some notes now!
+- You can also download our desktop app at https://github.com/logseq/logseq/releases


### PR DESCRIPTION
shadow-cljs has this nice inline function for us to extract static resource as part of the compilation
https://clojureverse.org/t/using-none-code-resources-in-cljs-builds/3745

this PR extract large chunk of md file and config.edn to templates for eazy editing, modifying those esacped string in cljs is pain!