### PR TITLE
Transform text into blocks when pasting text from external

### DIFF
--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -400,7 +400,6 @@
 
 (defn- get-block-content
   [utf8-content block format]
-  (def aaa [utf8-content block format])
   (let [meta (:meta block)
         content (if-let [end-pos (:end-pos meta)]
                   (utf8/substring utf8-content

--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -416,7 +416,7 @@
                         (remove-indentation-spaces content (:level block)))))]
       (if (= format :org)
         content
-        (text/->new-properties content)))))
+        (property/->new-properties content)))))
 
 (defn extract-blocks
   [blocks content with-id? format]

--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -487,7 +487,8 @@
                                        :body (vec (reverse block-body))
                                        :properties (:properties properties)
                                        :refs ref-pages-in-properties
-                                       :children (or current-block-children []))
+                                       :children (or current-block-children [])
+                                       :format format)
                                 (assoc-in [:meta :start-pos] start_pos)
                                 (assoc-in [:meta :end-pos] last-pos)
                                 ((fn [block]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1863,6 +1863,56 @@
     (state/set-editor-show-block-search! false)
     (util/cursor-move-forward input 2)))
 
+(defn- get-block-tree-insert-pos-at-point
+  "return [target-block sibling?]"
+  []
+  (when-let [editing-block (or (db/pull (:db/id (state/get-edit-block)))
+                               (when (:block/dummy? (state/get-edit-block)) (state/get-edit-block)))]
+    (let [dummy? (:block/dummy? editing-block)
+          input (gdom/getElement (state/get-edit-input-id))
+          pos (util/get-input-pos input)
+          value (:value (get-state))
+          [fst-block-text snd-block-text] (compute-fst-snd-block-text value pos)
+          parent (:db/id (:block/parent editing-block))
+          parent-block (db/pull parent)
+          left (:db/id (:block/left editing-block))
+          left-block (db/pull left)
+          [_ _ config] (state/get-editor-args)
+          block-id (:block/uuid editing-block)
+          block-self? (block-self-alone-when-insert? config block-id)
+          has-children? (db/has-children? (state/get-current-repo)
+                                          (:block/uuid editing-block))
+          collapsed? (:collapsed (:block/properties editing-block))]
+      (match (mapv boolean [dummy? (seq fst-block-text) (seq snd-block-text)
+                           block-self? has-children? (= parent left) collapsed?])
+        ;; if editing-block is dummy, insert after page-block
+        [true _ _ _ _ _ _]
+        [parent-block false]
+
+        ;; when zoom at editing-block
+        [false _ _ true _ _ _]
+        [editing-block false]
+
+        ;; insert after editing-block
+        [false true _ false true _ false]
+        [editing-block false]
+        [false true _ false true _ true]
+        [editing-block true]
+        [false true _ false false _ _]
+        [editing-block true]
+        [false false false false true _ false]
+        [editing-block false]
+        [false false false false true _ true]
+        [editing-block true]
+        [false false false false false _ _]
+        [editing-block true]
+
+        ;; insert before editing-block
+        [false false true false _ true _]
+        [parent-block false]
+        [false false true false _ false _]
+        [left-block true]))))
+
 (defn- paste-block-tree-at-point
   ([tree exclude-properties] (paste-block-tree-at-point tree exclude-properties nil))
   ([tree exclude-properties content-update-fn]
@@ -1871,12 +1921,8 @@
                   (db/entity [:block/original-name (state/get-current-page)])
                   (:block/page (db/entity (:db/id (state/get-edit-block)))))
          file (:block/file page)]
-     (when-let [editing-block (or (db/entity (:db/id (state/get-edit-block)))
-                                  (when (:block/dummy? (state/get-edit-block)) (state/get-edit-block)))]
-       (let [parent (:block/parent editing-block)
-             left (:block/left editing-block)
-             sibling? (not= parent left)
-             target-block (outliner-core/block (db/pull (if sibling? (:db/id left) (:db/id parent))))
+     (when-let [[target-block sibling?] (get-block-tree-insert-pos-at-point)]
+       (let [target-block (outliner-core/block target-block)
              format (or (:block/format target-block) (state/get-preferred-format))
              new-block-uuids (atom #{})
              metadata-replaced-blocks
@@ -1914,8 +1960,8 @@
                                                    :block/file (select-keys file [:db/id])
                                                    :block/format format
                                                    :block/properties (apply dissoc (:block/properties %)
-                                                                       (concat [:id :custom_id :custom-id]
-                                                                               exclude-properties))
+                                                                            (concat [:id :custom_id :custom-id]
+                                                                                    exclude-properties))
                                                    :block/meta (dissoc (:block/meta %) :start-pos :end-pos)
                                                    :block/content new-content
                                                    :block/title new-title}

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2513,24 +2513,22 @@
 
       (do
         ;; from external
-        (let [format (or (db/get-page-format (state/get-current-page)) :markdown)
-              editing-block-content (:block/content (db/entity (:db/id (state/get-edit-block))))]
-          (when (empty? editing-block-content)
-            (match [format
-                    (nil? (re-find #"^\s*(?:[-+*]|#+)\s+" text))
-                    (nil? (re-find #"^\s*\*+\s+" text))]
-                   [:markdown false _]
-                   (paste-text-parseable format text)
+        (let [format (or (db/get-page-format (state/get-current-page)) :markdown)]
+          (match [format
+                  (nil? (re-find #"^\s*(?:[-+*]|#+)\s+" text))
+                  (nil? (re-find #"^\s*\*+\s+" text))]
+                 [:markdown false _]
+                 (paste-text-parseable format text)
 
-                   [:org _ false]
-                   (paste-text-parseable format text)
+                 [:org _ false]
+                 (paste-text-parseable format text)
 
-                   [:markdown true _]
-                   (paste-segmented-text format text)
+                 [:markdown true _]
+                 (paste-segmented-text format text)
 
-                   [:org _ true]
-                   (paste-segmented-text format text))
-            (util/stop e)))))))
+                 [:org _ true]
+                 (paste-segmented-text format text))
+          (util/stop e))))))
 
 (defn editor-on-paste!
   [id]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -914,7 +914,7 @@
 
 (defn- blocks-with-level
   [blocks]
-  (let [level-blocks (mapv #(assoc % :level 0) blocks)
+  (let [level-blocks (mapv #(assoc % :level 1) blocks)
         level-blocks-map (into {} (mapv (fn [b] [(:db/id b) b]) level-blocks))
         [level-blocks-map _]
         (reduce (fn [[r state] [id block]]
@@ -931,7 +931,7 @@
                       (let [loc*
                             (loop [loc (zip/vector-zip (zip/root loc))
                                    level level]
-                              (if (> level 0)
+                              (if (> level 1)
                                 (if-let [down (zip/rightmost (zip/down loc))]
                                   (recur down (dec level))
                                   loc)
@@ -1938,7 +1938,7 @@
           blocks (if including-parent? (db/get-block-and-children repo block-uuid) (db/get-block-children repo block-uuid))
           level-blocks (vals (blocks-with-level blocks))
           grouped-blocks (group-by #(= db-id (:db/id %)) level-blocks)
-          root-block (or (first (get grouped-blocks true)) (assoc (db/pull db-id) :level 0))
+          root-block (or (first (get grouped-blocks true)) (assoc (db/pull db-id) :level 1))
           blocks-exclude-root (get grouped-blocks false)
           sorted-blocks (tree/sort-blocks blocks-exclude-root root-block)
           result-blocks (if including-parent? sorted-blocks (drop 1 sorted-blocks))
@@ -2462,22 +2462,66 @@
   (when-let [page (state/get-current-page)]
     (db/get-page-format page)))
 
+(defn- paste-text-parseable
+  [format text]
+  (let [tree (->>
+              (block/extract-blocks
+               (mldoc/->edn text (mldoc/default-config format)) text true format)
+              (mapv #(assoc % :level (:block/level %)))
+              (blocks-vec->tree))]
+    (paste-block-tree-at-point tree [])))
+
+(defn- paste-segmented-text
+  [format text]
+  (let [paragraphs (string/split text #"(?:\r?\n){2,}")
+        updated-paragraphs
+        (string/join "\n"
+                     (mapv (fn [p] (->> (string/trim p)
+                                        ((fn [p]
+                                           (if (re-find (if (= format :org)
+                                                          #"\s*\*+\s+"
+                                                          #"\s*-\s+") p)
+                                             p
+                                             (str (if (= format :org) "* " "- ") p))))))
+                           paragraphs))]
+    (paste-text-parseable format updated-paragraphs)))
+
 (defn- paste-text
   [text e]
   (let [repo (state/get-current-repo)
         page (or (db/entity [:block/name (state/get-current-page)])
                  (db/entity [:block/original-name (state/get-current-page)])
-                 (:block/page (db/entity (:db/id(state/get-edit-block)))))
+                 (:block/page (db/entity (:db/id (state/get-edit-block)))))
         file (:block/file page)
         copied-blocks (state/get-copied-blocks)
         copied-block-tree (:copy/block-tree copied-blocks)]
-    (when (and
-           (:copy/content copied-blocks)
-           (not (string/blank? text))
-           (= (string/trim text) (string/trim (:copy/content copied-blocks))))
-      ;; copy from logseq internally
-      (paste-block-tree-at-point copied-block-tree [])
-      (util/stop e))))
+    (if (and
+         (:copy/content copied-blocks)
+         (not (string/blank? text))
+         (= (string/trim text) (string/trim (:copy/content copied-blocks))))
+      (do
+        ;; copy from logseq internally
+        (paste-block-tree-at-point copied-block-tree [])
+        (util/stop e))
+
+      (do
+        ;; from external
+        (let [format (or (db/get-page-format (state/get-current-page)) :markdown)]
+          (match [format
+                  (nil? (re-find #"^\s*(?:[-+*]|#+)\s+" text))
+                  (nil? (re-find #"^\s*\*+\s+" text))]
+            [:markdown false _]
+            (paste-text-parseable format text)
+
+            [:org _ false]
+            (paste-text-parseable format text)
+
+            [:markdown true _]
+            (paste-segmented-text format text)
+
+            [:org _ true]
+            (paste-segmented-text format text))
+          (util/stop e))))))
 
 (defn editor-on-paste!
   [id]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1871,7 +1871,8 @@
                   (db/entity [:block/original-name (state/get-current-page)])
                   (:block/page (db/entity (:db/id (state/get-edit-block)))))
          file (:block/file page)]
-     (when-let [editing-block (db/entity (:db/id (state/get-edit-block)))]
+     (when-let [editing-block (or (db/entity (:db/id (state/get-edit-block)))
+                                  (when (:block/dummy? (state/get-edit-block)) (state/get-edit-block)))]
        (let [parent (:block/parent editing-block)
              left (:block/left editing-block)
              sibling? (not= parent left)

--- a/src/main/frontend/handler/extract.cljs
+++ b/src/main/frontend/handler/extract.cljs
@@ -27,34 +27,7 @@
          (map string/lower-case)
          (distinct))))
 
-(defn- remove-indentation-spaces
-  [s level]
-  (let [level (inc level)
-        lines (string/split-lines s)
-        [f & r] lines
-        body (map (fn [line]
-                    (if (string/blank? (util/safe-subs line 0 level))
-                      (util/safe-subs line level)
-                      line))
-                  r)
-        content (cons f body)]
-    (string/join "\n" content)))
 
-(defn- get-block-content
-  [utf8-content block format]
-  (let [meta (:block/meta block)
-        content (if-let [end-pos (:end-pos meta)]
-                  (utf8/substring utf8-content
-                                  (:start-pos meta)
-                                  end-pos)
-                  (utf8/substring utf8-content
-                                  (:start-pos meta)))]
-    (when content
-      (let [content (text/remove-level-spaces content format)]
-        (if (or (:block/pre-block? block)
-                (= (:block/format block) :org))
-          content
-          (remove-indentation-spaces content (:block/level block)))))))
 
 (defn get-page-name
   [file ast]
@@ -91,17 +64,12 @@
           ref-tags (atom #{})
           blocks (map (fn [block]
                         (let [block-ref-pages (seq (:block/refs block))
-                              block-path-ref-pages (seq (:block/path-refs block))
-                              content (get-block-content utf8-content block format)
-                              content (if (= format :org)
-                                        content
-                                        (property/->new-properties content))]
+                              block-path-ref-pages (seq (:block/path-refs block))]
                           (when block-ref-pages
                             (swap! ref-pages set/union (set block-ref-pages)))
                           (-> block
                               (dissoc :ref-pages)
-                              (assoc :block/content content
-                                     :block/file [:file/path file]
+                              (assoc :block/file [:file/path file]
                                      :block/format format
                                      :block/page [:block/name (string/lower-case page)]
                                      :block/refs block-ref-pages

--- a/src/main/frontend/modules/outliner/core.cljs
+++ b/src/main/frontend/modules/outliner/core.cljs
@@ -319,7 +319,7 @@
            down-node (tree/-get-down target-node)]
        ;; update node's left&parent after inserted nodes
        (cond
-         (and (not sibling?) (some? right-node))
+         (and (not sibling?) (some? right-node) (nil? down-node))
          nil            ;ignore
          (and sibling? (some? right-node) topmost-last-loc) ;; right-node.left=N
          (let [topmost-last-node (zip/node topmost-last-loc)


### PR DESCRIPTION
<del>Prerequisites: current editing block's content is empty(sometimes just want to paste the raw text into the block, e.g copy some codes into a code block) <del>

1. transform md/org text into blocks
2. split normal paragraphs by double newline 

![image](https://user-images.githubusercontent.com/5608710/118472863-ea7dd280-b73b-11eb-9512-7bcb72424598.png)
![image](https://user-images.githubusercontent.com/5608710/118475856-60376d80-b73f-11eb-98a1-5843f338bb98.png)
