### PR TITLE
fix: registerSlashCommand/registerBlockContextMenu do not need to expose this

### DIFF
--- a/libs/src/LSPlugin.d.ts
+++ b/libs/src/LSPlugin.d.ts
@@ -125,8 +125,8 @@ interface IAppProxy {
 }
 
 interface IEditorProxy {
-  registerSlashCommand: (this: LSPluginUser, tag: string, actions: Array<SlashCommandAction>) => boolean
-  registerBlockContextMenu: (this: LSPluginUser, tag: string, action: () => void) => boolean
+  registerSlashCommand: (tag: string, actions: Array<SlashCommandAction>) => boolean
+  registerBlockContextMenu: (tag: string, action: () => void) => boolean
 
   // block related APIs
   getCurrentPage: () => Promise<Partial<BlockEntity>>


### PR DESCRIPTION
`this` for `registerSlashCommand` and `registerBlockContextMenu` is useless for the users, and they will also cause TS errors like the following, so I suggest removing them, which should be safe

![image](https://user-images.githubusercontent.com/584378/119164714-470c2500-ba8f-11eb-8fc6-bc4c5d11bb0a.png)
