### PR TITLE
Remember scroll positions of visited pages

### DIFF
--- a/src/main/frontend/handler/route.cljs
+++ b/src/main/frontend/handler/route.cljs
@@ -15,13 +15,10 @@
   "If `push` is truthy, previous page will be left in history."
   [{:keys [to path-params query-params push]
     :or {push true}}]
-  (if push
-    (do
-      (rfe/push-state to path-params query-params)
-      (util/scroll-to-top))
-    (do
-      (rfe/replace-state to path-params query-params)
-      (util/scroll-to-top))))
+  (let [route-fn (if push rfe/push-state rfe/replace-state)]
+    (state/save-scroll-position! (util/scroll-top))
+    (route-fn to path-params query-params)
+    (util/scroll-to (state/get-saved-scroll-position))))
 
 (defn redirect-to-home!
   []

--- a/src/main/frontend/handler/route.cljs
+++ b/src/main/frontend/handler/route.cljs
@@ -16,8 +16,12 @@
   [{:keys [to path-params query-params push]
     :or {push true}}]
   (if push
-    (rfe/push-state to path-params query-params)
-    (rfe/replace-state to path-params query-params)))
+    (do
+      (rfe/push-state to path-params query-params)
+      (util/scroll-to-top))
+    (do
+      (rfe/replace-state to path-params query-params)
+      (util/scroll-to-top))))
 
 (defn redirect-to-home!
   []

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -65,6 +65,9 @@
     :ui/show-recent? false
     :ui/developer-mode? (or (= (storage/get "developer-mode") "true")
                             false)
+    ;; remember scroll positions of visited pages
+    :ui/pages-scroll-positions {}
+
     :document/mode? (or (storage/get :document/mode?) false)
 
     :github/contents {}
@@ -856,6 +859,18 @@
 (defn get-custom-query-components
   []
   (vals (get @state :ui/custom-query-components)))
+
+(defn save-scroll-position!
+  ([value]
+   (save-scroll-position! value (get-current-page)))
+  ([value page]
+   (set-state! [:ui/page-scroll-positions page] value)))
+
+(defn get-saved-scroll-position
+  ([]
+   (get-saved-scroll-position (get-current-page)))
+  ([page]
+   (get-in @state [:ui/page-scroll-positions page] 0)))
 
 (defn get-journal-template
   []

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -427,6 +427,13 @@
      []
      (scroll-to (app-scroll-container-node) 0 false)))
 
+#?(:cljs
+   (defn scroll-top
+     ([]
+      (scroll-top (app-scroll-container-node)))
+     ([node]
+      (.-scrollTop node))))
+
 (defn url-encode
   [string]
   #?(:cljs (some-> string str (js/encodeURIComponent) (.replace "+" "%20"))))

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -429,6 +429,8 @@
 
 #?(:cljs
    (defn scroll-top
+     "Returns the scroll top position of the `node`. If `node` is not specified,
+     returns the scroll top position of the `app-scroll-container-node`."
      ([]
       (scroll-top (app-scroll-container-node)))
      ([node]


### PR DESCRIPTION
Fixes #1614 and adds the following feature,
- If a previously visited page is visited again, it will resume from the last known scroll position.