### PR TITLE
feat: allow get page by db id

### DIFF
--- a/libs/src/LSPlugin.d.ts
+++ b/libs/src/LSPlugin.d.ts
@@ -170,7 +170,7 @@ interface IEditorProxy extends Record<string, any> {
   updateBlock: (srcBlock: BlockIdentity, content: string, opts?: Partial<{ props: {} }>) => Promise<void>
   removeBlock: (srcBlock: BlockIdentity, opts?: Partial<{ includeChildren: boolean }>) => Promise<void>
   getBlock: (srcBlock: BlockIdentity | BlockID, opts?: Partial<{ includeChildren: boolean }>) => Promise<BlockEntity | null>
-  getPage: (srcPage: PageIdentity, opts?: Partial<{ includeChildren: boolean }>) => Promise<PageEntity | null>
+  getPage: (srcPage: PageIdentity | BlockID, opts?: Partial<{ includeChildren: boolean }>) => Promise<PageEntity | null>
 
   getPreviousSiblingBlock: (srcBlock: BlockIdentity) => Promise<BlockEntity | null>
   getNextSiblingBlock: (srcBlock: BlockIdentity) => Promise<BlockEntity | null>

--- a/src/main/logseq/api.cljs
+++ b/src/main/logseq/api.cljs
@@ -210,8 +210,10 @@
         (bean/->js (normalize-keyword-for-json (db-utils/pull (:db/id page))))))))
 
 (def ^:export get_page
-  (fn [page-name]
-    (when-let [page (db-model/get-page page-name)]
+  (fn [id-or-page-name]
+    (when-let [page (cond
+                      (number? id-or-page-name) (db-utils/pull id-or-page-name)
+                      (string? id-or-page-name) (db-model/get-page id-or-page-name))]
       (if-not (contains? page :block/left)
         (bean/->js (normalize-keyword-for-json (db-utils/pull (:db/id page))))))))
 


### PR DESCRIPTION
My use case is that when querying a page from a block entity, I only have "db/id" but no page name or page uuid.
