### PR TITLE
feat: adapt correct light theme mode for plugins

### DIFF
--- a/src/main/frontend/components/theme.cljs
+++ b/src/main/frontend/components/theme.cljs
@@ -15,7 +15,7 @@
       (if (= theme "dark")                                 ;; for tailwind dark mode
         (.add cls "dark")
         (.remove cls "dark"))
-      (plugin-handler/hook-plugin-app :theme-mode-changed {:mode theme} nil))
+      (plugin-handler/hook-plugin-app :theme-mode-changed {:mode (if (= theme "white") "light" theme)} nil))
    [theme])
 
   (rum/use-effect!

--- a/src/main/logseq/api.cljs
+++ b/src/main/logseq/api.cljs
@@ -54,7 +54,7 @@
     (bean/->js
       (normalize-keyword-for-json
         {:preferred-language   (:preferred-language @state/state)
-         :preferred-theme-mode (:ui/theme @state/state)
+         :preferred-theme-mode (if (= (:ui/theme @state/state) "light") "white" "dark")
          :preferred-format     (state/get-preferred-format)
          :preferred-workflow   (state/get-preferred-workflow)
          :preferred-todo       (state/get-preferred-todo)


### PR DESCRIPTION
it seems in the DB theme mode for "light" theme is "white", but the LSP developers may always expect `getAppConfigs` or `onThemeModeChanged` returns `light`, which returns `white` for the moment.

The change in this PR is not clean - later there should be an utility adapter function to be used for similar purposes, or maybe change the db theme mode value from "white" to "light."