### PR TITLE
Feat: paste blocks at target

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2117,7 +2117,7 @@
           result-blocks (if template-including-parent? sorted-blocks (drop 1 sorted-blocks))
           tree (blocks-vec->tree result-blocks)]
       (insert-command! id "" format {})
-      (let [last-block (paste-block-tree-at-point tree [:template :template-including-parent]
+      (let [last-block (paste-block-vec-tree-at-target tree [:template :template-including-parent]
                                                   (fn [content]
                                                     (->> content
                                                          (property/remove-property format "template")

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2006,12 +2006,13 @@
 
 (defn- paste-block-vec-tree-at-target
   ([tree exclude-properties]
-   (paste-block-vec-tree-at-target tree exclude-properties nil nil))
+   (paste-block-vec-tree-at-target tree exclude-properties nil nil nil))
   ([tree exclude-properties content-update-fn]
-   (paste-block-vec-tree-at-target tree exclude-properties content-update-fn nil))
-  ([tree exclude-properties content-update-fn get-pos-fn]
+   (paste-block-vec-tree-at-target tree exclude-properties content-update-fn nil nil))
+  ([tree exclude-properties content-update-fn get-pos-fn page-block]
    (let [repo (state/get-current-repo)
-         page (:block/page (db/entity (:db/id (state/get-edit-block))))
+         page (or page-block
+                  (:block/page (db/entity (:db/id (state/get-edit-block)))))
          file (:block/file page)]
      (when-let [[target-block sibling? delete-editing-block? editing-block]
                 ((or get-pos-fn get-block-tree-insert-pos-at-point))]
@@ -2090,7 +2091,8 @@
         block-tree (vec-tree->vec-block-tree vec-tree format)]
     (paste-block-vec-tree-at-target
      block-tree [] nil
-     #(get-block-tree-insert-pos-after-target target-block-id sibling?))))
+     #(get-block-tree-insert-pos-after-target target-block-id sibling?)
+     (db/entity (:db/id (:block/page (db/pull target-block-id)))))))
 
 (defn template-on-chosen-handler
   [_input id _q format _edit-block _edit-content]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2047,7 +2047,7 @@
   [
   {
     :content 'this is a block',
-    :props {\"key\" \"value\" \"key2\" \"value2\"},
+    :properties {\"key\" \"value\" \"key2\" \"value2\"},
     :children [
       { :content 'this is child block' }
     ]
@@ -2060,7 +2060,7 @@
   (into []
         (mapcat
          (fn [e]
-           (let [e* (select-keys e [:content :props])]
+           (let [e* (select-keys e [:content :properties])]
              (if-let [children (:children e)]
                [e* (tree->vec-tree (:children e))]
                [e*])))
@@ -2076,7 +2076,7 @@
           (if (vector? node)
             (recur (zip/next loc))
             (let [content (:content node)
-                  props (into [] (:props node))
+                  props (into [] (:properties node))
                   content* (str "- "
                                 (property/insert-properties format content props))
                   ast (mldoc/->edn content* (mldoc/default-config format))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2088,11 +2088,18 @@
 (defn paste-block-tree-after-target
   [target-block-id sibling? tree format]
   (let [vec-tree (tree->vec-tree tree)
-        block-tree (vec-tree->vec-block-tree vec-tree format)]
+        block-tree (vec-tree->vec-block-tree vec-tree format)
+        target-block (db/pull target-block-id)
+        page-block (if (:block/name target-block) target-block
+                       (db/entity (:db/id (:block/page (db/pull target-block-id)))))
+        ;; sibling? = false, when target-block is a page-block
+        sibling? (if (=  target-block-id (:db/id page-block))
+                   false
+                   sibling?)]
     (paste-block-vec-tree-at-target
      block-tree [] nil
      #(get-block-tree-insert-pos-after-target target-block-id sibling?)
-     (db/entity (:db/id (:block/page (db/pull target-block-id)))))))
+     page-block)))
 
 (defn template-on-chosen-handler
   [_input id _q format _edit-block _edit-content]

--- a/src/main/frontend/util/property.cljs
+++ b/src/main/frontend/util/property.cljs
@@ -224,6 +224,10 @@
          :else
          content)))))
 
+(defn insert-properties
+  [format content kvs]
+  (reduce (fn [content [k v]] (insert-property format content k v)) content kvs))
+
 (defn remove-property
   ([format key content]
    (remove-property format key content true))


### PR DESCRIPTION
```
(paste-block-tree-after-target 1762 false [
  {
    :content "this is a block",
    :props {"collapsed" "true" "another-key" "value"},
    :children [
      { :content "this is child block" }
    ]
  },
  {
    :content "this is sibling block"
  }
  ] :markdown)
```