### PR TITLE
enhance: shortcut installation improve

### DIFF
--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -178,6 +178,7 @@
         [:span.flex.w-full.rounded-md.shadow-sm.sm:ml-3.sm:w-auto
          [:button.inline-flex.justify-center.w-full.rounded-md.border.border-transparent.px-4.py-2.bg-indigo-600.text-base.leading-6.font-medium.text-white.shadow-sm.hover:bg-indigo-500.focus:outline-none.focus:border-indigo-700.focus:shadow-outline-indigo.transition.ease-in-out.duration-150.sm:text-sm.sm:leading-5
           {:type "button"
+           :class "ui__modal-enter"
            :on-click (fn []
                        (delete-page! page-name))}
           (t :yes)]]

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -208,6 +208,7 @@
         [:span.flex.w-full.rounded-md.shadow-sm.sm:ml-3.sm:w-auto
          [:button.inline-flex.justify-center.w-full.rounded-md.border.border-transparent.px-4.py-2.bg-indigo-600.text-base.leading-6.font-medium.text-white.shadow-sm.hover:bg-indigo-500.focus:outline-none.focus:border-indigo-700.focus:shadow-outline-indigo.transition.ease-in-out.duration-150.sm:text-sm.sm:leading-5
           {:type "button"
+           :class "ui__modal-enter"
            :on-click (fn []
                        (let [value (string/trim @input)]
                          (when-not (string/blank? value)

--- a/src/main/frontend/components/repo.cljs
+++ b/src/main/frontend/components/repo.cljs
@@ -11,6 +11,7 @@
             [frontend.handler.export :as export-handler]
             [frontend.handler.web.nfs :as nfs-handler]
             [frontend.handler.page :as page-handler]
+            [frontend.modules.shortcut.core :as shortcut]
             [frontend.util :as util]
             [frontend.config :as config]
             [reitit.frontend.easy :as rfe]
@@ -84,6 +85,10 @@
                  "Unlink"]]]))]]
         (widgets/add-graph)))))
 
+(defn refresh-cb []
+  (repo-handler/create-today-journal!)
+  (shortcut/refresh!))
+
 (rum/defc sync-status < rum/reactive
   {:did-mount (fn [state]
                 (js/setTimeout common-handler/check-changed-files-status 1000)
@@ -96,8 +101,7 @@
           (let [syncing? (state/sub :graph/syncing?)]
             [:div.ml-3.mr-1.mt-1.opacity-30.refresh.hover:opacity-100 {:class (if syncing? "loader" "initial")}
              [:a
-              {:on-click #(nfs-handler/refresh! repo
-                                                repo-handler/create-today-journal!)
+              {:on-click #(nfs-handler/refresh! repo refresh-cb)
                :title (str "Import files from the local directory: " (config/get-local-dir repo) ".\nVersion: "
                            version/version)}
               svg/refresh]])
@@ -217,6 +221,7 @@
                                      (state/set-current-repo! url)
                                      ;; load config
                                      (common-handler/reset-config! url nil)
+                                     (shortcut/refresh!)
                                      (when-not (= :draw (state/get-current-route))
                                        (route-handler/redirect-to-home!))
                                      (when on-click

--- a/src/main/frontend/handler.cljs
+++ b/src/main/frontend/handler.cljs
@@ -84,6 +84,10 @@
                                    (ui-handler/add-style-if-exists!))))
                          (p/then
                           (fn []
+
+                            ;; install after config is restored
+                            (shortcut/refresh!)
+
                             (cond
                               (and (not logged?)
                                    (not (seq (db/get-files config/local-repo)))
@@ -190,7 +194,6 @@
     (reset! db/*sync-search-indice-f search/sync-search-indice!)
     (db/run-batch-txs!)
     (file-handler/run-writes-chan!)
-    (shortcut/install-shortcuts!)
     (when (util/electron?)
       (el/listen!))))
 

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -472,7 +472,7 @@
    {:keys [ok-handler]
     :as opts}]
   (let [input (gdom/getElement (state/get-edit-input-id))
-        pos (util/get-input-pos input)
+        pos (cursor/pos input)
         repo (or repo (state/get-current-repo))
         [fst-block-text snd-block-text] (compute-fst-snd-block-text value pos)
         current-block (assoc block :block/content snd-block-text)
@@ -503,7 +503,7 @@
     :as opts}]
   (let [block-self? (block-self-alone-when-insert? config uuid)
         input (gdom/getElement (state/get-edit-input-id))
-        pos (util/get-input-pos input)
+        pos (cursor/pos input)
         repo (or repo (state/get-current-repo))
         [fst-block-text snd-block-text] (compute-fst-snd-block-text value pos)
         current-block (assoc block :block/content fst-block-text)
@@ -599,7 +599,7 @@
              [properties value] (with-timetracking-properties block value)
              block-self? (block-self-alone-when-insert? config block-id)
              input (gdom/getElement (state/get-edit-input-id))
-             pos (util/get-input-pos input)
+             pos (cursor/pos input)
              repo (or repo (state/get-current-repo))
              [fst-block-text snd-block-text] (compute-fst-snd-block-text value pos)
              insert-fn (match (mapv boolean [block-self? (seq fst-block-text) (seq snd-block-text)])
@@ -745,7 +745,7 @@
                                    [(marker/add-or-update-marker (string/triml content) format marker)  marker]))
           new-content (string/triml new-content)]
       (let [new-pos (commands/compute-pos-delta-when-change-marker
-                     current-input content new-content marker (util/get-input-pos current-input))]
+                     current-input content new-content marker (cursor/pos current-input))]
         (state/set-edit-content! edit-input-id new-content)
         (cursor/move-cursor-to current-input new-pos)))))
 
@@ -1080,7 +1080,7 @@
     (when-let [id (:block/uuid block)]
       (when-let [edit-id (state/get-edit-input-id)]
         (when-let [input (gdom/getElement edit-id)]
-          (when-let [pos (util/get-input-pos input)]
+          (when-let [pos (cursor/pos input)]
             (let [value (gobj/get input "value")
                   page-pattern #"\[\[([^\]]+)]]"
                   block-pattern #"\(\(([^\)]+)\)\)"
@@ -1545,7 +1545,7 @@
   [input before after]
   (when input
     (let [value (gobj/get input "value")
-          pos (util/get-input-pos input)
+          pos (cursor/pos input)
           start-pos (if (= :start before) 0 (- pos (count before)))
           end-pos (if (= :end after) (count value) (+ pos (count after)))]
       (when (>= (count value) end-pos)
@@ -1598,7 +1598,7 @@
   [input]
   (try
     (let [edit-content (or (gobj/get input "value") "")
-          pos (util/get-input-pos input)
+          pos (cursor/pos input)
           last-slash-caret-pos (:pos @*slash-caret-pos)
           last-command (and last-slash-caret-pos (subs edit-content last-slash-caret-pos pos))]
       (when (> pos 0)
@@ -1615,7 +1615,7 @@
   [input]
   (try
     (let [edit-content (gobj/get input "value")
-          pos (util/get-input-pos input)
+          pos (cursor/pos input)
           last-command (subs edit-content
                              (:pos @*angle-bracket-caret-pos)
                              pos)]
@@ -1645,7 +1645,7 @@
 
 (defn get-previous-input-char
   [input]
-  (when-let [pos (util/get-input-pos input)]
+  (when-let [pos (cursor/pos input)]
     (let [value (gobj/get input "value")]
       (when (and (>= (count value) pos)
                  (>= pos 1))
@@ -1653,7 +1653,7 @@
 
 (defn get-previous-input-chars
   [input length]
-  (when-let [pos (util/get-input-pos input)]
+  (when-let [pos (cursor/pos input)]
     (let [value (gobj/get input "value")]
       (when (and (>= (count value) pos)
                  (>= pos 1))
@@ -1661,7 +1661,7 @@
 
 (defn get-current-input-char
   [input]
-  (when-let [pos (util/get-input-pos input)]
+  (when-let [pos (cursor/pos input)]
     (let [value (gobj/get input "value")]
       (when (and (>= (count value) (inc pos))
                  (>= pos 1))
@@ -1920,7 +1920,7 @@
   []
   (when-let [editing-block (db/pull (:db/id (state/get-edit-block)))]
     (let [input (gdom/getElement (state/get-edit-input-id))
-          pos (util/get-input-pos input)
+          pos (cursor/pos input)
           value (:value (get-state))
           [fst-block-text snd-block-text] (compute-fst-snd-block-text value pos)
           parent (:db/id (:block/parent editing-block))
@@ -2303,8 +2303,8 @@
           (cursor/move-cursor-to input selected-start)
           (cursor/move-cursor-to input selected-end))
 
-        (or (and left? (util/input-start? input))
-            (and right? (util/input-end? input)))
+        (or (and left? (cursor/start? input))
+            (and right? (cursor/end? input)))
         (move-to-block-when-cross-boundrary direction)
 
         :else
@@ -2319,7 +2319,7 @@
 (defn- delete-concat [current-block]
   (let [input-id (state/get-edit-input-id)
         ^js input (state/get-input)
-        current-pos (util/get-input-pos input)
+        current-pos (cursor/pos input)
         value (gobj/get input "value")
         repo (state/get-current-repo)
         right (outliner-core/get-right-node (outliner-core/block current-block))
@@ -2345,7 +2345,7 @@
 (defn keydown-delete-handler
   [e]
   (let [^js input (state/get-input)
-        current-pos (util/get-input-pos input)
+        current-pos (cursor/pos input)
         value (gobj/get input "value")
         end? (= current-pos (count value))
         current-block (state/get-edit-block)
@@ -2488,7 +2488,7 @@
           value (gobj/get input "value")
           ctrlKey (gobj/get e "ctrlKey")
           metaKey (gobj/get e "metaKey")
-          pos (util/get-input-pos input)]
+          pos (cursor/pos input)]
       (cond
         (or ctrlKey metaKey)
         nil
@@ -2562,7 +2562,7 @@
   (fn [e key-code]
     (let [k (gobj/get e "key")
           format (:format (get-state))
-          current-pos (util/get-input-pos input)
+          current-pos (cursor/pos input)
           value (gobj/get input "value")
           c (util/nth-safe value (dec current-pos))]
       (when-not (state/get-editor-show-input)

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -13,6 +13,7 @@
             [frontend.handler.web.nfs :as web-nfs]
             [frontend.handler.notification :as notification]
             [frontend.handler.config :as config-handler]
+            [frontend.modules.shortcut.core :as shortcut]
             [frontend.handler.ui :as ui-handler]
             [frontend.modules.outliner.file :as outliner-file]
             [frontend.modules.outliner.core :as outliner-core]
@@ -379,7 +380,8 @@
   []
   (web-nfs/ls-dir-files-with-handler!
    (fn []
-     (init-commands!))))
+     (init-commands!)
+     (shortcut/refresh!))))
 
 ;; TODO: add use :file/last-modified-at
 (defn get-pages-with-modified-at

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -712,7 +712,7 @@
     (when container
       {:last-edit-block edit-block
        :container (gobj/get container "id")
-       :pos (util/get-input-pos (gdom/getElement edit-input-id))})))
+       :pos (cursor/pos (gdom/getElement edit-input-id))})))
 
 (defn set-editing!
   ([edit-input-id content block cursor-range]

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -906,13 +906,8 @@
   [repo-url value]
   (swap! state assoc-in [:git/status repo-url] value))
 
-(defn get-shortcut
-  ([key]
-   (get-shortcut (get-current-repo) key))
-  ([repo key]
-   (or
-    (get (storage/get (str repo "-shortcuts")) key)
-    (get-in @state [:config repo :shortcuts key]))))
+(defn shortcuts []
+  (get-in @state [:config (get-current-repo) :shortcuts]))
 
 (defn get-me
   []
@@ -1056,9 +1051,7 @@
 
 (defn set-config!
   [repo-url value]
-  (set-state! [:config repo-url] value)
-  (let [shortcuts (or (:shortcuts value) {})]
-    (storage/set (str repo-url "-shortcuts") shortcuts)))
+  (set-state! [:config repo-url] value))
 
 (defn get-git-auto-push?
   ([]

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -714,23 +714,6 @@
          nil))))
 
 #?(:cljs
-   (defn get-input-pos
-     [input]
-     (and input (.-selectionStart input))))
-
-#?(:cljs
-   (defn input-start?
-     [input]
-     (and input (zero? (.-selectionStart input)))))
-
-#?(:cljs
-   (defn input-end?
-     [input]
-     (and input
-          (= (count (.-value input))
-             (.-selectionStart input)))))
-
-#?(:cljs
    (defn input-selected?
      [input]
      (not= (.-selectionStart input)

--- a/src/main/frontend/util/cursor.cljs
+++ b/src/main/frontend/util/cursor.cljs
@@ -22,6 +22,12 @@
              int)})
 
 (defn get-caret-pos
+  "Get caret offset position as well as input element rect.
+
+  This function is only used by autocomplete command or up/down command
+  where offset position is needed.
+
+  If you only need character position, use `pos` instead. Do NOT call this."
   [input]
   (let [pos (.-selectionStart input)
         rect (bean/->clj (.. input (getBoundingClientRect) (toJSON)))]
@@ -43,6 +49,14 @@
 (defn pos [input]
   (when input
     (.-selectionStart input)))
+
+(defn start? [input]
+  (and input (zero? (.-selectionStart input))))
+
+(defn end? [input]
+  (and input
+       (= (count (.-value input))
+          (.-selectionStart input))))
 
 (defn move-cursor-to [input n]
   (.setSelectionRange input n n))


### PR DESCRIPTION
- refactor and improve shortcut installation
 - shortcuts shall reinstall itself correctly
   1. when user click the refresh button, force re-install
   2. when user switch repo, it will pick up the correct shortcut from the repo config
   3. when user create new repo, refresh to default shortcut
 - fix two places where enter key shall working when prompted (rename page, delete page)