### PR TITLE
feat: add :editor/strike-through binding (fixes #701)

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -104,6 +104,9 @@
 (defn highlight-format! []
   (format-text! config/get-highlight))
 
+(defn strike-through-format! []
+  (format-text! config/get-strike-through))
+
 (defn html-link-format! []
   (when-let [m (get-selection-and-format)]
     (let [{:keys [selection-start selection-end format value block edit-id input]} m

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -91,6 +91,10 @@
     {:desc    "Highlight"
      :binding "mod+shift+h"
      :fn      editor-handler/highlight-format!}
+    :editor/strike-through
+    {:desc    "Strikethrough"
+     :binding "mod+shift+s"
+     :fn      editor-handler/strike-through-format!}
     :editor/insert-link
     {:desc    "Html Link"
      :binding "mod+k"


### PR DESCRIPTION
Per #701 it would be nice to be able to strike through text with a key binding.

I've added the function for strikethrough (matching how highlight was done), as well as a tentative binding.

Since users can rebind now, hopefully this can be added in, even if you may wish to set a different default binding. :)