### PR TITLE
feat: toggle formatting of selected area instead of double-wrapping

### DIFF
--- a/src/main/frontend/util/cursor.cljs
+++ b/src/main/frontend/util/cursor.cljs
@@ -58,6 +58,9 @@
        (= (count (.-value input))
           (.-selectionStart input))))
 
+(defn set-selection-to [input n m]
+  (.setSelectionRange input n m))
+
 (defn move-cursor-to [input n]
   (.setSelectionRange input n n))
 


### PR DESCRIPTION
enhance: select formatted text after changing its formatting for toggle support
fix: place cursor between (pattern)(pattern) pair when selection is empty

---

Hopefully this is in line with behavior you'd like to support!

This PR makes the formatting shortcuts behave more like most editors:
- selection is preserved after applying formatting changes
- if nothing is selected, the next characters that you type after pressing a formatting shortcut are formatted (cursor position)
- if the current text is already formatted, the formatting is toggled off rather than double-wrapping in formatting

You can see the changes applied in this commit in the following GIF:

![CleanShot 2021-06-10 at 19 45 17](https://user-images.githubusercontent.com/63247/121610736-a6bd7680-ca24-11eb-850b-b6e26290ae56.gif)