### PR TITLE
feat: add ui for calculator into editor

### DIFF
--- a/src/main/frontend/extensions/calc.cljc
+++ b/src/main/frontend/extensions/calc.cljc
@@ -2,12 +2,16 @@
   (:refer-clojure :exclude [eval])
   (:require #?(:clj [clojure.java.io :as io])
             #?(:cljs [shadow.resource :as rc])
+            #?(:cljs [rum.core :as rum])
             [clojure.string :as str]
             [clojure.edn :as edn]
             [clojure.test :as test :refer [deftest testing is are]]
             [frontend.util :as util]
             #?(:clj [instaparse.core :as insta]
                :cljs [instaparse.core :as insta :refer-macros [defparser]])))
+
+;; ======================================================================
+;; Interpreter
 
 #?(:clj (def parse (insta/parser (io/resource "grammar/calc.bnf")))
    :cljs (defparser parse (rc/inline "grammar/calc.bnf")))
@@ -53,3 +57,30 @@
                           (throw (ex-info (util/format "Can't find variable %s" var)
                                           {:var var})))))}
      ast))))
+
+#?(:cljs
+   (defn eval-lines [s]
+     {:pre [(string? s)]}
+     (let [env (new-env)]
+       (->> (str/split-lines s)
+            (mapv (fn [line]
+                    (try
+                      (first (eval env (parse line)))
+                      (catch js/Error e
+                        nil))))))))
+
+;; ======================================================================
+;; UI
+
+#?(:cljs
+   (rum/defc results < rum/reactive
+     [calc-atom]
+     (when-let [output-lines (rum/react calc-atom)]
+       ;; the editor's parent will go into edit mode if any elements are clicked
+       ;; if we stop click propagation on this element, we allow the user to
+       ;; copy and paste the calc results
+       [:div.extensions__code-calc {:on-mouse-down (fn [e]
+                                                     (.stopPropagation e))}
+        (for [[i line] (map-indexed vector output-lines)]
+          [:div.extensions__code-calc-output-line {:key i}
+           [:span (or line "?")]])])))

--- a/src/main/frontend/extensions/code.css
+++ b/src/main/frontend/extensions/code.css
@@ -9,6 +9,27 @@
     background: var(--ls-secondary-background-color);
   }
 
+  &-calc {
+    @apply absolute right-0 text-sm;
+    padding: 0 0.25em;
+    top: 3px;
+    z-index: 1;
+    background: transparent;
+    width: max-content;
+    text-align: right;
+
+    &-output-line {
+      height: 23px;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-around;
+
+      > span {
+          font-family: Fira Code, Monaco, Menlo, Consolas, 'COURIER NEW', monospace;
+      }
+    }
+  }
+
   > .CodeMirror {
     z-index: 0;
     height: auto;


### PR DESCRIPTION
## Description

Adds a UI for the calc interpreter introduced in https://github.com/logseq/logseq/pull/2052

![image](https://user-images.githubusercontent.com/5066487/121778205-d070bd80-cb4a-11eb-9571-0f6491136bf2.png)

The user must be in `calc` mode to get those results.

## TODO

* Add documentation to show what is possible in the calculator
