### PR TITLE
feat: add ui for calculator mode in editor

### DIFF
--- a/src/main/frontend/extensions/code.css
+++ b/src/main/frontend/extensions/code.css
@@ -9,6 +9,27 @@
     background: var(--ls-secondary-background-color);
   }
 
+  &-calc {
+    @apply absolute right-0 text-sm;
+    padding: 0 0.25em;
+    top: 3px;
+    z-index: 1;
+    background: transparent;
+    width: max-content;
+    text-align: right;
+
+    &-output-line {
+      height: 23px;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-around;
+
+      > span {
+          font-family: Fira Code, Monaco, Menlo, Consolas, 'COURIER NEW', monospace;
+      }
+    }
+  }
+
   > .CodeMirror {
     z-index: 0;
     height: auto;


### PR DESCRIPTION
## Description

Adds a UI for the calc interpreter introduced in https://github.com/logseq/logseq/pull/2052

![image](https://user-images.githubusercontent.com/5066487/121778205-d070bd80-cb4a-11eb-9571-0f6491136bf2.png)

The user must be in `calc` mode to get those results.

## TODO

* Add documentation to show what is possible in the calculator
