### PR TITLE
tiny missing step in instructions for compiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ We also have [a dedicated page](https://github.com/logseq/logseq/blob/master/COD
 
 ```bash
 git clone https://github.com/logseq/logseq
+cd logseq
 yarn
 yarn watch
 ```


### PR DESCRIPTION
added "cd logseq" line after git clone line, before running yarn