### PR TITLE
Add collapse all key binding

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3016,3 +3016,18 @@
               (recur (dec level))
               (doseq [{:block/keys [uuid]} blocks-to-collapse]
                 (collapse-block! uuid)))))))))
+
+(defn collapse-all!
+  []
+  (let [blocks-with-level
+        (all-blocks-with-level {:collapse? true})
+        level 1]
+    (let [blocks-to-collapse
+          (->> blocks-with-level
+               (filter (fn [b] (= (:block/level b) level)))
+               (remove (fn [b]
+                         (or (not (db-model/has-children? (:block/uuid b)))
+                             (-> b :block/properties :collapsed)))))]
+      (when (seq blocks-to-collapse)
+        (doseq [{:block/keys [uuid]} blocks-to-collapse]
+          (collapse-block! uuid))))))

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -195,6 +195,10 @@
     {:desc    "Collapse"
      :binding "mod+up"
      :fn      editor-handler/collapse!}
+    :editor/collapse-top-blocks
+    {:desc    "Collapse all blocks"
+     :binding "mod+shift+l"
+     :fn      editor-handler/collapse-all!}
     :editor/indent
     {:desc    "Indent block"
      :binding "tab"
@@ -315,6 +319,7 @@
     :editor/new-line
     :editor/indent
     :editor/outdent
+    :editor/collapse-top-blocks
     :editor/collapse-block-children
     :editor/expand-block-children
     :go/search


### PR DESCRIPTION
A shortcut to collapse all top level blocks. It helps in getting
a quick summary of document, especially when there are too many headlines.

This relates to a [feature request to collapse blocks by default](https://discuss.logseq.com/t/outlines-collapsed-by-default/300).
Next steps could be
- toggle it
- recursively collapse children (with toggle?)