### PR TITLE
fix: scroll to follow the moving block

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1693,7 +1693,9 @@
         (when-let [repo (state/get-current-repo)]
           (let [opts {:key :block/change
                       :data [block]}]
-            (db/refresh! repo opts)))))))
+            (db/refresh! repo opts)))
+        (when-let [block-node (util/get-first-block-by-id block-id)]
+          (.scrollIntoView block-node #js {:behavior "smooth" :block "center"}))))))
 
 ;; selections
 (defn on-tab


### PR DESCRIPTION
## Description

When you are moving a block up or down with the keyboard shortcut `ctrl+shift+down`, it is easy for the block to move out of the viewport where you can't see it anymore. This change scrolls the viewport to follow the block as you move it.