### PR TITLE
fix: some overflow issues

### DIFF
--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -703,6 +703,7 @@ hr {
 .resize {
   resize: both;
   overflow: hidden;
+  max-width: -webkit-fill-available;
 }
 
 /* ideas from https://github.com/PiotrSss/logseq-bujo-theme/blob/main/main.css */

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1572,7 +1572,7 @@
                    edit-input-id
                    config)]
       [:div.flex.flex-row.block-content-wrapper
-       [:div.flex-1 {:style {:display (if (:slide? config) "block" "flex")}}
+       [:div.flex-1.w-full {:style {:display (if (:slide? config) "block" "flex")}}
         (block-content config block edit-input-id block-id slide?)]
        [:div.flex.flex-row
         (when (and (:embed? config)

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -2,7 +2,8 @@
 }
 
 .block-content-wrapper {
-    width: 100%;
+  width: 100%;
+  max-width: calc(100% - 40px);
 }
 
 .block-content {

--- a/src/main/frontend/components/sidebar.css
+++ b/src/main/frontend/components/sidebar.css
@@ -67,6 +67,7 @@
 }
 
 .cp__sidebar-main-content {
+  width: 100%;
   max-width: var(--ls-main-content-max-width);
   flex: 1;
 


### PR DESCRIPTION
There are some issues related to images and code blocks when their width is too big to fit, even their width is 100%, but since they are placed into flex containers we also need to use max-width to trap them to get overflow horizontal scrolling.  

## Before
![before](https://user-images.githubusercontent.com/584378/121918789-f8d60300-cd68-11eb-8ee5-be0acde812e8.gif)

## After
![after](https://user-images.githubusercontent.com/584378/121918834-fffd1100-cd68-11eb-8471-e6755fa8938e.gif)
