### PR TITLE
Tweak modal + fix typos + boost contrast on icons

### DIFF
--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -126,7 +126,7 @@ html[data-theme='light'] {
   --ls-scrollbar-background-color: rgba(0, 0, 0, 0.05);
   --ls-scrollbar-thumb-hover-color: rgba(0, 0, 0, 0.2);
   --ls-head-text-color: var(--ls-link-text-color);
-  --ls-icon-color: #c1bdb7;
+  --ls-icon-color: #908e8b;
   --ls-search-icon-color: var(--ls-icon-color);
   --ls-a-chosen-bg: #f4f5f7;
   --ls-right-sidebar-code-bg-color: var(--ls-secondary-background-color);
@@ -722,7 +722,7 @@ hr {
 
 .cp__header-logo,
 .fade-link {
-  opacity: 0.3;
+  opacity: 0.6;
   transition: 0.3s;
 }
 

--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -168,12 +168,12 @@
        (logo {:white? white?})
 
        (when (util/electron?)
-         [:a.mr-1.opacity-30.hover:opacity-100.it.navigation
+         [:a.mr-1.opacity-60.hover:opacity-100.it.navigation
           {:style {:margin-left -10}
            :title "Go Back" :on-click #(js/window.history.back)} (svg/arrow-left)])
 
        (when (util/electron?)
-         [:a.opacity-30.hover:opacity-100.it.navigation
+         [:a.opacity-60.hover:opacity-100.it.navigation
           {:style {:margin-right 15}
            :title "Go Forward" :on-click #(js/window.history.forward)} (svg/arrow-right)])
 

--- a/src/main/frontend/components/header.css
+++ b/src/main/frontend/components/header.css
@@ -95,4 +95,5 @@
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 7ch;
+  color: var(--ls-icon-color, #045591);
 }

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -368,13 +368,13 @@
                                     (remove nil?)))]
                    [:div.flex.flex-row
                     (plugins/hook-ui-slot :page-head-actions-slotted nil)
-                    [:a.opacity-30.hover:opacity-100.page-op.mr-1
+                    [:a.opacity-60.hover:opacity-100.page-op.mr-1
                      {:title "Search in current page"
                       :on-click #(route-handler/go-to-search! :page)}
                      svg/search]
                     (ui/dropdown-with-links
                      (fn [{:keys [toggle-fn]}]
-                       [:a.cp__vertial-menu-button
+                       [:a.cp__vertical-menu-button
                         {:title    "More options"
                          :on-click toggle-fn}
                         (svg/vertical-dots nil)])

--- a/src/main/frontend/components/page.css
+++ b/src/main/frontend/components/page.css
@@ -29,16 +29,16 @@
   }
 }
 
-.cp__vertial-menu-button {
-    opacity: 0.3;
+.cp__vertical-menu-button {
+    opacity: 60%;
     display: block;
 }
 
-.cp__vertial-menu-button:hover {
+.cp__vertical-menu-button:hover {
     opacity: 1;
 }
 
-.cp__vertial-menu-button svg {
+.cp__vertical-menu-button svg {
     width: 20px;
     height: 20px;
 }

--- a/src/main/frontend/components/repo.cljs
+++ b/src/main/frontend/components/repo.cljs
@@ -99,7 +99,7 @@
       (when-not (= repo config/local-repo)
         (if (and nfs-repo? (nfs-handler/supported?))
           (let [syncing? (state/sub :graph/syncing?)]
-            [:div.ml-3.mr-1.mt-1.opacity-30.refresh.hover:opacity-100 {:class (if syncing? "loader" "initial")}
+            [:div.ml-3.mr-1.mt-1.opacity-60.refresh.hover:opacity-100 {:class (if syncing? "loader" "initial")}
              [:a
               {:on-click #(nfs-handler/refresh! repo refresh-cb)
                :title (str "Import files from the local directory: " (config/get-local-dir repo) ".\nVersion: "

--- a/src/main/frontend/components/right_sidebar.cljs
+++ b/src/main/frontend/components/right_sidebar.cljs
@@ -28,7 +28,7 @@
 (rum/defc toggle
   []
   (when-not (util/mobile?)
-    [:a.opacity-50.hover:opacity-100.ml-4 {:on-click state/toggle-sidebar-open?!}
+    [:a.opacity-60.hover:opacity-100.ml-4 {:on-click state/toggle-sidebar-open?!}
     (svg/menu)]))
 
 (rum/defc block-cp < rum/reactive

--- a/src/main/frontend/components/right_sidebar.cljs
+++ b/src/main/frontend/components/right_sidebar.cljs
@@ -265,7 +265,7 @@
          [:div.cp__right-sidebar-inner.flex.flex-col.h-full#right-sidebar-container
 
           (sidebar-resizer)
-          [:div.cp__right-sidebar-scollable
+          [:div.cp__right-sidebar-scrollable
            [:div.cp__right-sidebar-topbar.flex.flex-row.justify-between.items-center.px-4.h-12
            [:div.cp__right-sidebar-settings.hide-scrollbar {:key "right-sidebar-settings"}
             [:div.ml-4.text-sm

--- a/src/main/frontend/components/search.css
+++ b/src/main/frontend/components/search.css
@@ -10,7 +10,7 @@
 
 #search-wrapper svg {
     color: var(--ls-search-icon-color, #9fa6b2);
-    opacity: 0.3;
+    opacity: 0.6;
     transition: .3s;
 }
 

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -680,7 +680,7 @@
                                         ; FIXME: No need to call `distinct`?
                                           (distinct))))
     (open-right-sidebar!)
-    (when-let [elem (gdom/getElementByClass "cp__right-sidebar-scollable")]
+    (when-let [elem (gdom/getElementByClass "cp__right-sidebar-scrollable")]
       (util/scroll-to elem 0))))
 
 (defn sidebar-remove-block!

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -373,15 +373,19 @@
       {:class       (if on? (if small? "translate-x-4" "translate-x-5") "translate-x-0")
        :aria-hidden "true"}]]]))
 
+(defn apply-close-fn [close-fn]
+  (fn [] (apply (or (gobj/get close-fn "user-close") close-fn) [])))
+
 (defonce modal-show? (atom false))
 (rum/defc modal-overlay
-  [state]
+  [state close-fn]
   [:div.ui__modal-overlay
    {:class (case state
              "entering" "ease-out duration-300 opacity-0"
              "entered" "ease-out duration-300 opacity-100"
              "exiting" "ease-in duration-200 opacity-100"
-             "exited" "ease-in duration-200 opacity-0")}
+             "exited" "ease-in duration-200 opacity-0")
+    :on-click (apply-close-fn close-fn)}
    [:div.absolute.inset-0.opacity-75]])
 
 (rum/defc modal-panel
@@ -396,7 +400,7 @@
     [:button.ui__modal-close
      {:aria-label "Close"
       :type       "button"
-      :on-click   (fn [] (apply (or (gobj/get close-fn "user-close") close-fn) []))}
+      :on-click   close-fn}
      [:svg.h-6.w-6
       {:stroke "currentColor", :view-box "0 0 24 24", :fill "none"}
       [:path
@@ -436,7 +440,7 @@
      (css-transition
       {:in show? :timeout 0}
       (fn [state]
-        (modal-overlay state)))
+        (modal-overlay state close-fn)))
      (css-transition
       {:in show? :timeout 0}
       (fn [state]


### PR DESCRIPTION
1. Makes it so that clicking out of a modal closes it, just as if you clicked the `x` in the top right corner of if you'd hit the `esc` key
2. Fixes a tiny typo ("scollable" → "scrollable")
3. Increases contrast on the icons. Previously, they were very hard to see.

    **Before:** ![image](https://user-images.githubusercontent.com/6979755/122305825-728aff80-ced5-11eb-812b-538744d80640.png)

    **After:** ![image](https://user-images.githubusercontent.com/6979755/122307580-9c91f100-ced8-11eb-85eb-3ccbcb4b700d.png)


    If it makes more sense to just put this in my `custom.css` that's fine too, but since it's an accessibility issue I figured it might be useful to others too.

    We may want to boost the contrast even more—the change I made still technically doesn't conform to the [Web Content Accessibility Guidelines](https://coolors.co/contrast-checker), but I didn't want to deviate from the original design too too much.