### PR TITLE
fix: page title in page-cp should use original-name

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -389,6 +389,7 @@
 
                                :else
                                page)
+          page-original-name (model/get-page-original-name redirect-page-name)
           href (if html-export?
                  (util/encode-str page)
                  (rfe/href :page {:name redirect-page-name}))
@@ -402,10 +403,10 @@
                                             :max-height     600
                                             :padding-bottom 64}}
                                    [:h2.font-bold.text-lg (if (= page redirect-page-name)
-                                                            page
+                                                            page-original-name
                                                             [:span
-                                                             [:span.text-sm.mr-2 "Alias:" ]
-                                                             redirect-page-name])]
+                                                             [:span.text-sm.mr-2 "Alias:"]
+                                                             page-original-name])]
                                    (let [page (db/entity [:block/name (string/lower-case redirect-page-name)])]
                                      (editor-handler/insert-first-page-block-if-not-exists! redirect-page-name)
                                      (when-let [f (state/get-page-blocks-cp)]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/584378/122433007-6338ae80-cfc8-11eb-8bae-a7156f962f84.png)
Should show the `original-name` of the page when possible.
