### PR TITLE
Fix - opening non ml-doc file links in org syntax

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -121,8 +121,9 @@
 (defn- string-of-url
   [url]
   (match url
-    (:or ["File" s] ["Search" s])
-    s
+    ["File" s]
+    (string/replace s "file:" "")
+
     ["Complex" m]
     (let [{:keys [link protocol]} m]
       (if (= protocol "file")


### PR DESCRIPTION
One potential fix for #2220 

We have two scenarios to handle
1. either the file link is a ml-doc file and we show a page reference, or 
2. it is a file with unknown ext and the system should handle it.

The bug was that we were handling both Complex type with file protocol and File
type the same way. In case of File type it would add extra `file://` and causing
unexpected behavior.
Since we handle search beforehand, the fix can be to simple remove `file:`
prefix, to keep the behavior consistent with markdown syntax