### PR TITLE
fix: remove line breaks when all inlines types are timestamps or line…

### DIFF
--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -654,7 +654,12 @@
 (defn break-line-paragraph?
   [[typ break-lines]]
   (and (= typ "Paragraph")
-       (every? #(= % ["Break_Line"]) break-lines)))
+       (every?
+        (fn
+          [line]
+          (let [type (first line)]
+            (or (= type "Break_Line") (= type "Timestamp"))))
+        break-lines)))
 
 (defn trim-break-lines!
   [ast]


### PR DESCRIPTION
Notice: This change needs careful review because I don't fully understand the context here.

## Issue

Extra space appears below two or more timestamps

## Root cause

There is a line break added below

## Solution

In the `break-line-paragraph?` function I add a situation where there are only timestamps and line breaks, which let the `trim-break-lines!` trim away the extra line breaks.
