### PR TITLE
feat: replace block-reference with its content

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3012,3 +3012,18 @@
        (->> (:block/uuid (state/get-edit-block))
             select-block!)
        (state/clear-edit!)))))
+
+(defn replace-block-reference-with-content-at-point
+  []
+  (when-let [{:keys [content start end]} (thingatpt/block-ref-at-point)]
+    (let [block-ref-id (subs content 2 (- (count content) 2))]
+      (when-let [block (db/pull [:block/uuid (uuid block-ref-id)])]
+        (let [block-content (:block/content block)
+              format (or (:block/format block) :markdown)
+              block-content-without-prop (property/remove-properties format block-content)]
+          (when-let [input (state/get-input)]
+            (when-let [current-block-content (gobj/get input "value")]
+              (let [block-content* (str (subs current-block-content 0 start)
+                                        block-content-without-prop
+                                        (subs current-block-content end))]
+                (state/set-block-content-and-last-pos! input block-content* 1)))))))))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -38,6 +38,7 @@
             [frontend.util.cursor :as cursor]
             [frontend.util.marker :as marker]
             [frontend.util.property :as property]
+            [frontend.util.thingatpt :as thingatpt]
             [goog.dom :as gdom]
             [goog.dom.classes :as gdom-classes]
             [goog.object :as gobj]

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -149,7 +149,7 @@
      :fn      editor-handler/backward-kill-word}
     :editor/replace-block-reference-at-point
     {:desc "Replace block reference with its content at point"
-     :binding "ctrl+c ctrl+c"
+     :binding "mod+shift+r"
      :fn editor-handler/replace-block-reference-with-content-at-point}}
 
    :shortcut.handler/editor-global

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -146,7 +146,11 @@
     :editor/backward-kill-word
     {:desc    "Kill a word backwards"
      :binding (if mac? false "alt+w")
-     :fn      editor-handler/backward-kill-word}}
+     :fn      editor-handler/backward-kill-word}
+    :editor/replace-block-reference-at-point
+    {:desc "Replace block reference with its content at point"
+     :binding "ctrl+c ctrl+c"
+     :fn editor-handler/replace-block-reference-with-content-at-point}}
 
    :shortcut.handler/editor-global
    ^{:before m/enable-when-not-component-editing!}
@@ -376,7 +380,8 @@
     :editor/forward-word
     :editor/backward-word
     :editor/forward-kill-word
-    :editor/backward-kill-word]
+    :editor/backward-kill-word
+    :editor/replace-block-reference-at-point]
 
    :shortcut.category/block-selection
    ^{:doc "Block selection (press Esc to quit selection)"}

--- a/src/main/frontend/util/thingatpt.cljs
+++ b/src/main/frontend/util/thingatpt.cljs
@@ -1,0 +1,36 @@
+(ns frontend.util.thingatpt
+  (:require [clojure.string :as string]
+            [frontend.util :as util]
+            [frontend.state :as state]
+            [goog.object :as gobj]
+            [frontend.util.cursor :as cursor]
+            ))
+
+(defn- get-content&pos-at-point []
+  (when-let [input (state/get-input)]
+    [(gobj/get input "value") (cursor/pos input)]))
+
+
+(defn block-ref-at-point []
+  (when-let [[content pos] (get-content&pos-at-point)]
+    (let [start (string/last-index-of content "((" pos)
+          end (string/index-of content "))" (- pos 2))
+          end* (+ 2 end)]
+      (when (and start end)
+        (let [block-ref-id (subs content (+ start 2) end)]
+          (when (every? false? (mapv #(string/includes? block-ref-id %) ["((" "))" " "]))
+            {:content (subs content start end*)
+             :start start
+             :end end*}))))))
+
+(defn embed-macro-at-point []
+  (when-let [[content pos] (get-content&pos-at-point)]
+    (let [start (string/last-index-of content "{{embed" pos)
+          end (string/index-of content "}}" (- pos 2))
+          end* (+ 2 end)]
+      (when (and start end)
+        (let [macro-content (subs content (+ start 2) end)]
+          (when (every? false? (mapv #(string/includes? macro-content %) ["{{embed" "}}"]))
+            {:content (subs content start end*)
+             :start start
+             :end end*}))))))


### PR DESCRIPTION
- [X] add `thing-at-point`
- [x] impl `replace-block-ref-with-content`
- [x] add a new command `replace-block-ref-with-content` (binding to ~`ctrl+c ctrl+c`~ `mod+shift+r` currently)