### PR TITLE
fix: output custom.css instead of append to style.css

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -94,7 +94,7 @@
                               (. fs copy (path/join app-path part) (path/join static-dir part)))
                             ["css" "fonts" "icons" "img" "js"])))
                 custom-css (. fs readFile custom-css-path)
-                _ (. fs appendFile (path/join static-dir "css" "style.css") custom-css)
+                _ (. fs writeFile (path/join static-dir "css" "custom.css") custom-css)
                 js-files ["main.js" "code-editor.js" "excalidraw.js"]
                 _ (p/all (map (fn [file]
                                 (. fs removeSync (path/join static-dir "js" file)))

--- a/src/main/frontend/publishing/html.cljs
+++ b/src/main/frontend/publishing/html.cljs
@@ -18,6 +18,7 @@
              "minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no",
              :name "viewport"}]
            [:link {:type "text/css", :href "/static/css/style.css", :rel "stylesheet"}]
+           [:link {:type "text/css", :href "/static/css/custom.css", :rel "stylesheet"}]
            [:link
             {:href icon
              :type "image/png",


### PR DESCRIPTION
Right now `custom.css` content is directly appended to `style.css`. There is an issue with it:
if the user provides an `@import` rule in `custom.css`, this rule will take no effect at all, since `@import` rule should be the first rule than any all other css rules, see https://developer.mozilla.org/en-US/docs/Web/CSS/@import

Alternatively, we could parse the concatenated style content and reorder the rules - which is clearly harder than the current solution in this PR.