### PR TITLE
fix: do not pass theme to react-tippy

### DIFF
--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -301,7 +301,6 @@
         (toggle "preferred_outdenting"
                 (ui/tippy {:html (outdenting-hint)
                            :interactive true
-                           :theme "customized"
                            :disabled false}
                           (t :settings-page/preferred-outdenting))
                 logical-outdenting?

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -613,7 +613,7 @@
     (Tippy (->
            (merge {:arrow true
                    :sticky true
-                   :theme (:ui/theme @state/state)
+                   :theme "customized"
                    :disabled (not (state/enable-tooltip?))
                    :unmountHTMLWhenHide true
                    :open @*mounted?


### PR DESCRIPTION
When react-tippy is given a theme, the tippy content will get a `${themename}-theme` class. 
![image](https://user-images.githubusercontent.com/584378/122674087-3245bd00-d206-11eb-9850-b2c5f7faae66.png)

There are some issues about it:
- the theme value will not change when user changes theme with `t t`
- some weird ui styling issues

Also, logseq's theme and react-tippy's theme have different meanings and we are not importing react-tippy's theme file, which is another reason why we do not need to pass it down.

---

I also noticed that there is an unused `@tippyjs/react` dep, which is similar to `react-tippy` but is provided by `tippyjs` officially. Is there any plan to migrate to this one in the future?