### PR TITLE
feat: Add /calc slash command

### DIFF
--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -243,6 +243,8 @@
     ;; advanced
 
     [["Query" [[:editor/input "{{query }}" {:backward-pos 2}]] "Create a DataScript query"]
+     ["Calculator" [[:editor/input "```calc\n\n```" {:backward-pos 4}]
+                    [:codemirror/focus]] "Insert a calculator"]
      ["Draw" (fn []
                (let [file (draw/file-name)
                      path (str config/default-draw-directory "/" file)


### PR DESCRIPTION
Adds a /calc command that goes directly into the CodeMirror editor, rather than the raw content editor with the `` ```code `` fence.

The following screen capture shows (1) selecting the /calc slash command with the mouse and then (2) selecting it with the arrow + enter keys.

https://user-images.githubusercontent.com/6979755/122676683-13670c80-d1ad-11eb-89fb-9f87f2aea480.mp4