### PR TITLE
Improve/common plugin command patterns

### DIFF
--- a/libs/package.json
+++ b/libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logseq/libs",
-  "version": "0.0.1-alpha.20",
+  "version": "0.0.1-alpha.21",
   "description": "Logseq SDK libraries",
   "main": "dist/lsplugin.user.js",
   "typings": "index.d.ts",

--- a/libs/src/LSPlugin.ts
+++ b/libs/src/LSPlugin.ts
@@ -170,6 +170,7 @@ export interface IAppProxy {
   // native
   relaunch: () => Promise<void>
   quit: () => Promise<void>
+  openExternalLink: (url: string) => Promise<void>
 
   // graph
   getCurrentGraph: () => Promise<AppGraphInfo | null>

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -263,7 +263,8 @@
                                                         :backward-pos 2}]]]]
 
     ;; Allow user to modify or extend, should specify how to extend.
-    (state/get-commands))
+    (state/get-commands)
+    (state/get-plugins-commands))
    (remove nil?)
    (util/distinct-by-last-wins first)))
 

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -7,6 +7,7 @@
             [frontend.state :as state]
             [frontend.search :as search]
             [frontend.config :as config]
+            [frontend.db.utils :as db-util]
             [frontend.db :as db]
             [clojure.string :as string]
             [goog.dom :as gdom]
@@ -554,3 +555,9 @@
   [vector format]
   (doseq [step vector]
     (handle-step step format)))
+
+(defn exec-plugin-simple-command!
+  [pid {:keys [key label block-id] :as cmd} action]
+  (let [format (and block-id (:block/format (db-util/pull [:block/uuid block-id])))
+        inputs (vector (conj action (assoc cmd :pid pid)))]
+    (handle-steps inputs format)))

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -6,6 +6,7 @@
             [frontend.handler.editor :as editor-handler]
             [frontend.handler.export :as export-handler]
             [frontend.handler.image :as image-handler]
+            [frontend.commands :as commands]
             [frontend.util :as util :refer [profile]]
             [frontend.state :as state]
             [frontend.mixins :as mixins]
@@ -194,6 +195,15 @@
             :on-click (fn [_e]
                         (editor-handler/cut-block! block-id))}
            "Cut")
+
+          (when (state/sub [:plugin/simple-commands])
+            (when-let [cmds (state/get-plugins-commands-with-type :block-context-menu)]
+              (for [[_ {:keys [key label] :as cmd} action pid] cmds]
+                (ui/menu-link
+                  {:key      key
+                   :on-click #(commands/exec-plugin-simple-command!
+                                pid (assoc cmd :block-id block-id) action)}
+                  label))))
 
           (when (state/sub [:ui/developer-mode?])
             (ui/menu-link

--- a/src/main/logseq/api.cljs
+++ b/src/main/logseq/api.cljs
@@ -67,7 +67,7 @@
   (fn []
     (when-let [repo (state/get-current-repo)]
       (when-not (= config/local-repo repo)
-        (bean/->js {:url repo
+        (bean/->js {:url  repo
                     :name (util/node-path.basename repo)
                     :path (config/get-repo-dir repo)})))))
 
@@ -161,6 +161,11 @@
 (def ^:export quit
   (fn []
     (ipc/ipc "quitApp")))
+
+(def ^:export open_external_link
+  (fn [url]
+    (when (re-find #"https?://" url)
+      (js/apis.openExternal url))))
 
 (def ^:export push_state
   (fn [^js k ^js params]


### PR DESCRIPTION
- fix broken slash command registry
- support [`logseq.Editor.registerBlockContextMenu`](https://logseq.github.io/plugins/interfaces/ieditorproxy.html#registerblockcontextmenu) api

![676FA9B5-E015-40B9-8E3F-9758EC341005](https://user-images.githubusercontent.com/1779837/122701445-d881d900-d27f-11eb-9f89-95498163dcc6.png)
