### PR TITLE
feat: Use current title as default when renaming page

### DIFF
--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -203,6 +203,7 @@
 
        [:input.form-input.block.w-full.sm:text-sm.sm:leading-5.my-2
         {:auto-focus true
+         :default-value title
          :on-change (fn [e]
                       (reset! input (util/evalue e)))}]
 


### PR DESCRIPTION
When renaming a page often you just want to adjust the existing title. Therefore, default the input field with the current page title.