### PR TITLE
Add keyboard shortcuts for plain history forward/back without zooming

### DIFF
--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -252,6 +252,13 @@
     {:desc    "Jump to journals"
      :binding (if mac? "mod+j" "alt+j")
      :fn      route-handler/go-to-journals!}
+    :go/forward
+    {:desc    "Go back"
+     :binding ["mod+[" "mod+left"]
+     :fn      js/window.history.back}
+    {:desc    "Go forward"
+     :binding ["mod+]" "mod+right"]
+     :fn      js/window.history.forward}
     :search/re-index
     {:desc    "Rebuild search index"
      :binding "mod+c mod+s"
@@ -346,7 +353,9 @@
    [:editor/up
     :editor/down
     :editor/left
-    :editor/right]
+    :editor/right
+    :go/back
+    :go/forward]
 
    :shortcut.category/block-editing
    ^{:doc "Block editing general"}


### PR DESCRIPTION
Hi! New logseq user here, coming from Roam. I'm working from the desktop app, and there doesn't appear to be any way to simply navigate forward / back _without_ also getting hooked into zoom in / out.

E.g. I sometimes go back to a previous page, edit something, and then want to go forward to the page I started on to continue editing there. Currently after editing on the previous page, if I use the `Zoom In / Forward` shortcut the app zooms in onto the block I just edited, and loses the history stack. 😬 

I have _NOT_ yet tested this - didn't have time to do that today - but figured I'd go ahead and make the changes to the extent that I understand them in case someone else wants to pick up the torch.