### PR TITLE
fix: entity not found err when import opml with non-existed block-ref-id

### DIFF
--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -615,7 +615,7 @@
                 [blocks parents' (last parents') result]))]
         (recur blocks parents sibling result)))))
 
-(defn parse-block
+(defn- parse-block
   ([block]
    (parse-block block nil))
   ([{:block/keys [uuid content meta file page parent left format] :as block} {:keys [with-id?]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -325,13 +325,12 @@
         new-properties (merge
                         (select-keys properties property/built-in-properties)
                         (:block/properties block))]
-    (merge
-     (-> block
-         (dissoc :block/top?
-                 :block/block-refs-count)
-         (assoc :block/content content
-                :block/properties new-properties)
-         (merge (if level {:block/level level} {}))))))
+    (-> block
+        (dissoc :block/top?
+                :block/block-refs-count)
+        (assoc :block/content content
+               :block/properties new-properties)
+        (merge (if level {:block/level level} {})))))
 
 (defn- save-block-inner!
   [repo block value {:keys [refresh?]

--- a/src/main/frontend/handler/external.cljs
+++ b/src/main/frontend/handler/external.cljs
@@ -69,7 +69,9 @@
   [data finished-ok-handler]
   (when-let [repo (state/get-current-repo)]
     (let [[headers parsed-blocks] (mldoc/opml->edn data)
-          parsed-blocks (block/extract-blocks parsed-blocks "" true :markdown) ; TODO: only support md in opml's text attr yet
+          parsed-blocks (->>
+                          (block/extract-blocks parsed-blocks "" true :markdown)
+                          (mapv editor/wrap-parse-block))
           page-name (:title headers)]
       (when (not (page/page-exists? page-name))
         (page/create! page-name {:redirect? false}))


### PR DESCRIPTION
fix for https://github.com/logseq/logseq/issues/2224