### PR TITLE
fix: link syntax behavior

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -640,7 +640,9 @@
       (or
        (and
         (nil? metadata-show)
-        (text/image-link? img-formats s))
+        (or
+         (config/local-asset? s)
+         (text/image-link? img-formats s)))
        (true? (boolean metadata-show)))))))
 
 (defn inline
@@ -743,7 +745,6 @@
                   (map-inline config label))
 
           (and (util/electron?)
-               (config/local-asset? s)
                (show-link? config metadata s full_text))
           (asset-reference (second (first label)) s)
 

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -710,10 +710,6 @@
           (let [page (text/page-ref-un-brackets! s)]
             (page-reference (:html-export? config) page config label))
 
-          ;; image
-          (text/image-link? img-formats s)
-          (image-link config url s label metadata full_text)
-
           (= \# (first s))
           (->elem :a {:on-click #(route-handler/jump-to-anchor! (mldoc/anchorLink (subs s 1)))} (subs s 1))
 
@@ -728,8 +724,14 @@
                       :target "_blank"}
                   (map-inline config label))
 
-          (and (util/electron?) (config/local-asset? s))
+          (and (util/electron?)
+               (config/local-asset? s)
+               (string/starts-with? (string/triml full_text) "!"))
           (asset-reference (second (first label)) s)
+
+          ;; image
+          (string/starts-with? (string/triml full_text) "!")
+          (image-link config url s label metadata full_text)
 
           :else
           (page-reference html-export? s config label))
@@ -774,7 +776,7 @@
                    (map-inline config label)))))
 
             ;; image
-            (text/image-link? img-formats href)
+            (string/starts-with? (string/triml full_text) "!")
             (image-link config url href label metadata full_text)
 
             :else

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -624,6 +624,25 @@
 
 (declare custom-query)
 
+(defn- show-link?
+  [config metadata s full-text]
+  (let [img-formats (set (map name (config/img-formats)))
+        metadata-show (:show (safe-read-string metadata))]
+    (or
+     ;; markdown
+     (and
+      (= :markdown (get-in config [:block :block/format]))
+      (string/starts-with? (string/triml full-text) "!"))
+
+     ;; org
+     (and
+      (= :org (get-in config [:block :block/format]))
+      (or
+       (and
+        (nil? metadata-show)
+        (text/image-link? img-formats s))
+       (true? (boolean metadata-show)))))))
+
 (defn inline
   [{:keys [html-export?] :as config} item]
   (match item
@@ -694,8 +713,7 @@
     (nested-link config html-export? link)
 
     ["Link" link]
-    (let [{:keys [url label title metadata full_text]} link
-          img-formats (set (map name (config/img-formats)))]
+    (let [{:keys [url label title metadata full_text]} link]
       (match url
         ["Search" s]
         (cond
@@ -726,11 +744,11 @@
 
           (and (util/electron?)
                (config/local-asset? s)
-               (string/starts-with? (string/triml full_text) "!"))
+               (show-link? config metadata s full_text))
           (asset-reference (second (first label)) s)
 
           ;; image
-          (string/starts-with? (string/triml full_text) "!")
+          (show-link? config metadata s full_text)
           (image-link config url s label metadata full_text)
 
           :else
@@ -751,7 +769,7 @@
             (block-reference config (:link (second url)) nil)
 
             (= protocol "file")
-            (if (text/image-link? img-formats href)
+            (if (show-link? config metadata href full_text)
               (image-link config url href label metadata full_text)
               (let [label-text (get-label-text label)
                     page (if (string/blank? label-text)
@@ -776,7 +794,7 @@
                    (map-inline config label)))))
 
             ;; image
-            (string/starts-with? (string/triml full_text) "!")
+            (show-link? config metadata href full_text)
             (image-link config url href label metadata full_text)
 
             :else

--- a/src/main/frontend/handler/editor/lifecycle.cljs
+++ b/src/main/frontend/handler/editor/lifecycle.cljs
@@ -16,14 +16,15 @@
   [state]
   (let [[{:keys [format block-parent-id]} id] (:rum/args state)
         content (get-in @state/state [:editor/content id])
-        input (gdom/getElement id)]
+        input (gdom/getElement id)
+        element (gdom/getElement "main-content")]
     (when block-parent-id
       (state/set-editing-block-dom-id! block-parent-id))
     (editor-handler/restore-cursor-pos! id content)
 
-    (when input
+    (when (and input element)
       (dnd/subscribe!
-       input
+       element
        :upload-images
        {:drop (fn [e files]
                 (editor-handler/upload-asset id files format editor-handler/*asset-uploading? true))}))


### PR DESCRIPTION
markdown:
- `![label](url)`
   - pdf preview (desktop app)
   - image inline display
- `[label](url)` only display as clickable label
  
org:
- `[[url][label]]{:show true}`
   - pdf preview (desktop app)
   - image inline display
- `[[url][label]]{:show false}` just display as clickable label
- `[[url][label]]`   
   - keep same behaviors as before: inline images if its suffix included in #{:gif :svg :jpeg :ico :png :jpg :bmp}


![2021-06-23 20 06 37](https://user-images.githubusercontent.com/5608710/123094245-433d3b00-d45f-11eb-9d90-2598e089f920.gif)
