### PR TITLE
feat: add paste-text-in-one-block-at-point (mod+shift+v)

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3028,3 +3028,12 @@
                                         block-content-without-prop
                                         (subs current-block-content end))]
                 (state/set-block-content-and-last-pos! input block-content* 1)))))))))
+
+
+(defn paste-text-in-one-block-at-point
+  []
+  (.then
+   (js/navigator.clipboard.readText)
+   (fn [clipboard-data]
+     (when-let [_ (state/get-input)]
+       (state/append-current-edit-content! clipboard-data)))))

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -150,7 +150,11 @@
     :editor/replace-block-reference-at-point
     {:desc "Replace block reference with its content at point"
      :binding "mod+shift+r"
-     :fn editor-handler/replace-block-reference-with-content-at-point}}
+     :fn editor-handler/replace-block-reference-with-content-at-point}
+    :editor-handler/paste-text-in-one-block-at-point
+    {:desc "Paste text into one block at point"
+     :binding "mod+shift+v"
+     :fn editor-handler/paste-text-in-one-block-at-point}}
 
    :shortcut.handler/editor-global
    ^{:before m/enable-when-not-component-editing!}


### PR DESCRIPTION
Normal paste (mod+v) will split paragraphs into multi blocks.
And `paste-text-in-one-block-at-point` (mod+shift+v) just paste text in clipboard into one block at point

![2021-06-24 17 52 15](https://user-images.githubusercontent.com/5608710/123242793-f6b43700-d514-11eb-9076-2443cf1c7a0a.gif)
