### PR TITLE
fix: stricter parsing for variables

### DIFF
--- a/src/main/grammar/calc.bnf
+++ b/src/main/grammar/calc.bnf
@@ -20,6 +20,6 @@ asin = <#'\s*'> <'asin('> expr <')'> <#'\s*'>
 <term> = scientific | number | variable | <#'\s*'> <'('> expr <')'> <#'\s*'>
 scientific = #'\s*[0-9]+\.?[0-9]*(e|E)-?[0-9]+()\s*'
 number = #'\s*[0-9]+\.?[0-9]*()\s*'
-variable = #'\s*[[a-zA-Z]+[\_*[a-zA-Z]*]*]*\s*'
-toassign = #'\s*[[a-zA-Z]+[\_*[a-zA-Z]*]*]*\s*'
+variable = #'\s*[a-zA-Z]+(\_+[a-zA-Z]+)*\s*'
+toassign = #'\s*[a-zA-Z]+(\_+[a-zA-Z]+)*\s*'
 assignment = toassign <#'\s*'> <'='> <#'\s*'> expr

--- a/src/test/frontend/extensions/calc_test.cljc
+++ b/src/test/frontend/extensions/calc_test.cljc
@@ -89,6 +89,7 @@
                                (calc/eval env (calc/parse expr)))
                              (= final-env @env))
       {"a" 1 "b" 2}          ["a = 1" "b = a + 1"]
+      {"a" 1 "b" 3}          ["a = 1" "b=a*2+1"]
       {"a_a" 1 "b_b" 2}      ["a_a = 1" "b_b = a_a + 1"]
       {"variable" 1 "x" 0.0} ["variable = 1 + 0 * 2" "x = log(variable)"]
       {"x" 1 "u" 23 "v" 24}  ["x= 2 * 1 - 1 " "23 + 54" "u= 23" "v = x + u"]))


### PR DESCRIPTION
Makes the calc parser more careful not to match `*` or other symbols.

Fixes https://github.com/logseq/logseq/issues/2234