### PR TITLE
fix: set the codemirror block as the edited block when it is clicked

### DIFF
--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -155,9 +155,11 @@
                                  (save-file-or-block-when-blur-or-esc! editor textarea config state))))
           (.addEventListener element "mousedown"
                              (fn [e]
-                               (state/clear-selection!)
-                               (util/stop e)
-                               (state/set-block-component-editing-mode! true)))
+                               (let [block (into {} (db/get-block-by-uuid (:block/uuid config)))]
+                                 (state/clear-selection!)
+                                 (state/set-editing! id (.getValue editor) block nil false)
+                                 (util/stop e)
+                                 (state/set-block-component-editing-mode! true))))
           (.save editor)
           (.refresh editor)))
       editor)))


### PR DESCRIPTION
When you click on a Codemirror, the state isn't updated with the right block being edited. When you type `*`, the `autopair` function inserts the double `*` in the block returned by `(state/get-edit-input)`, which is the last block that was selected before clicking in the Codemirror editor.

This PR sets the Codemirror editor's block as the block being edited.

Fixes https://github.com/logseq/logseq/issues/2278

Please review closely given that I am not entirely familiar with the state model of the app and this may have other repercussions that I am not aware of.