### PR TITLE
Make block control available via CSS selectors so it can be customized

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1157,15 +1157,10 @@
                        (if collapsed?
                          (editor-handler/expand-block! uuid)
                          (editor-handler/collapse-block! uuid)))))}
-      (cond
-        (and control-show? collapsed?)
-        (svg/caret-right)
-
-        (and control-show? has-child?)
-        (svg/caret-down)
-
-        :else
-        [:span ""])]
+      [:span {:class (if control-show? "control-show" "control-hide")}
+         (cond
+           collapsed? (svg/caret-right)
+           has-child? (svg/caret-down))]]
      [:a {:on-click (fn [e]
                       (bullet-on-click e block config uuid))}
       [:span.bullet-container.cursor
@@ -2387,8 +2382,7 @@
   [blocks config option]
   [:div.content
    (cond-> option
-     (:document/mode? config)
-     (assoc :class "doc-mode"))
+     (:document/mode? config) (assoc :class "doc-mode"))
    (if (and (:group-by-page? config)
             (vector? (first blocks)))
      [:div.flex.flex-col

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -147,6 +147,10 @@
   min-width: 10px;
   color: initial;
   user-select: none;
+
+  .control-hide {
+    display: none;
+  }
 }
 
 .block-ref {

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -547,29 +547,16 @@
           :on-click (fn [e]
                       (util/stop e)
                       (swap! collapsed? not))}
-         (cond
-           @collapsed?
-           (svg/caret-right)
-
-           @control?
-           (svg/caret-down)
-
-           :else
-           [:span ""])]
+         [:span {:class (if @control? "control-show" "control-hide")}
+          (if @collapsed?
+            (svg/caret-right)
+            (svg/caret-down))]]
         (if (fn? header)
           (header @collapsed?)
           header)]]]
-     [:div {:class (if @collapsed?
-                     "hidden"
-                     "initial")}
-      (cond
-        (and (fn? content) (not @collapsed?))
-        (content)
-
-        (fn? content)
-        nil
-
-        :else
+     [:div {:class (if @collapsed? "hidden" "initial")}
+      (if (fn? content)
+        (if (not @collapsed?) (content) nil)
         content)]]))
 
 (defn admonition


### PR DESCRIPTION
I personally wanted to make the block control visible at all times, even though the current behavior is for it to be hidden in doc-mode until you hover over a block.

This PR changes the code so that this behavior is controlled via CSS selectors rather than removing the content entirely so that people like me can have the behavior I want without imposing it on everyone else.

---

This PR also refactors a few small bits of code I stumbled upon to make it a little more readable, nothing major.