### PR TITLE
Make Electron frameless

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -28,7 +28,7 @@
         win-opts (cond->
                   {:width         (.-width win-state)
                    :height        (.-height win-state)
-                   :frame         true
+                   :frame         false
                    :autoHideMenuBar (not mac?)
                    :webPreferences
                    {:plugins                 true ; pdf

--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -26,9 +26,9 @@
   []
   (let [win-state (windowStateKeeper (clj->js {:defaultWidth 980 :defaultHeight 700}))
         win-opts (cond->
-                  {:width         (.-width win-state)
-                   :height        (.-height win-state)
-                   :frame         false
+                  {:width           (.-width win-state)
+                   :height          (.-height win-state)
+                   :frame           (not mac?)
                    :autoHideMenuBar (not mac?)
                    :webPreferences
                    {:plugins                 true ; pdf


### PR DESCRIPTION
I propose making the Electron app frameless, because I think it looks nicer and is more space-efficient.

**Before:**

![image](https://user-images.githubusercontent.com/6979755/123834421-68093680-d8d5-11eb-9a70-5356bd6158fe.png)

**After:**

![image](https://user-images.githubusercontent.com/6979755/123834259-37290180-d8d5-11eb-93b3-a819f9625a82.png)
