### PR TITLE
feat: frameless desktop app on Mac

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -29,6 +29,8 @@
                   {:width         (.-width win-state)
                    :height        (.-height win-state)
                    :frame         true
+                   :titleBarStyle "hidden"
+                   :trafficLightPosition {:x 15 :y 15}
                    :autoHideMenuBar (not mac?)
                    :webPreferences
                    {:plugins                 true ; pdf

--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -29,7 +29,7 @@
                   {:width         (.-width win-state)
                    :height        (.-height win-state)
                    :frame         true
-                   :titleBarStyle "hidden"
+                   :titleBarStyle "hiddenInset"
                    :trafficLightPosition {:x 15 :y 15}
                    :autoHideMenuBar (not mac?)
                    :webPreferences

--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -158,7 +158,8 @@
         electron-mac? (and util/mac? (util/electron?))]
     (rum/with-context [[t] i18n/*tongue-context*]
       [:div.cp__header#head
-       {:on-double-click (fn [^js e]
+       {:class (when electron-mac? "electron-mac")
+        :on-double-click (fn [^js e]
                            (when-let [target (.-target e)]
                              (when (and (util/electron?)
                                         (or (.. target -classList (contains "cp__header"))))
@@ -197,13 +198,13 @@
 
        (when (and (nfs/supported?) (empty? repos)
                   (not config/publishing?))
-         [:a.text-sm.font-medium.opacity-70.hover:opacity-100.ml-3.block
+         [:a.text-sm.font-medium.opacity-70.hover:opacity-100.ml-3.block.open-button
           {:on-click (fn []
                        (page-handler/ls-dir-files!))}
-          [:div.flex.flex-row.text-center
-           [:span.inline-block svg/folder-add]
+          [:div.flex.flex-row.text-center.open-button__inner
+           [:span.inline-block.open-button__icon-wrapper svg/folder-add]
            (when-not config/mobile?
-             [:span.ml-1 {:style {:margin-top 2}}
+             [:span.ml-1 {:style {:margin-top (if electron-mac? 0 2)}}
               (t :open)])]])
 
        (if config/publishing?

--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -20,6 +20,7 @@
             [frontend.components.right-sidebar :as sidebar]
             [frontend.handler.page :as page-handler]
             [frontend.handler.web.nfs :as nfs]
+            [frontend.mixins :as mixins]
             [goog.dom :as gdom]
             [goog.object :as gobj]
             [frontend.handler.migrate :as migrate]))
@@ -149,12 +150,12 @@
      ;;                  [:div.px-2.py-2 (login logged?)])}
      )))
 
-(rum/defc header
-  < rum/reactive
+(rum/defc header < rum/reactive
   [{:keys [open-fn current-repo white? logged? page? route-match me default-home new-block-mode]}]
   (let [local-repo? (= current-repo config/local-repo)
         repos (->> (state/sub [:me :repos])
-                   (remove #(= (:url %) config/local-repo)))]
+                   (remove #(= (:url %) config/local-repo)))
+        electron-mac? (and util/mac? (util/electron?))]
     (rum/with-context [[t] i18n/*tongue-context*]
       [:div.cp__header#head
        {:on-double-click (fn [^js e]
@@ -169,14 +170,13 @@
        (logo {:white? white?})
 
        (when (util/electron?)
-         [:a.mr-1.opacity-60.hover:opacity-100.it.navigation
-          {:style {:margin-left -10}
-           :title "Go Back" :on-click #(js/window.history.back)} (svg/arrow-left)])
+         [:a.opacity-60.hover:opacity-100.mr-1.it.navigation.nav-left
+          {:title "Go Back" :on-click #(js/window.history.back)} svg/arrow-narrow-left])
 
        (when (util/electron?)
-         [:a.opacity-60.hover:opacity-100.it.navigation
-          {:style {:margin-right 15}
-           :title "Go Forward" :on-click #(js/window.history.forward)} (svg/arrow-right)])
+         [:a.opacity-60.hover:opacity-100.it.navigation.nav-right
+          {:style {:margin-right 5}
+           :title "Go Forward" :on-click #(js/window.history.forward)} svg/arrow-narrow-right])
 
        (if current-repo
          (search/search)

--- a/src/main/frontend/components/header.css
+++ b/src/main/frontend/components/header.css
@@ -1,5 +1,6 @@
 .cp__header {
   @apply shadow z-10 h-12;
+  -webkit-app-region: drag;
 
   padding-right: 1rem;
   display: flex;
@@ -27,6 +28,26 @@
   }
 }
 
+.is-electron.is-mac .cp__header {
+    padding-left: 72px;
+    -moz-transition: padding-left .3s ease-in;
+    -o-transition: padding-left  .3s ease-in;
+    -webkit-transition: padding-left  .3s ease-in;
+    transition: padding-left  .3s ease-in;
+}
+
+.cp__header .navigation svg {
+    transform: scale(0.7);
+}
+
+.is-electron.is-mac.is-fullscreen .cp__header {
+    padding-left: 0;
+}
+
+.cp__header a, .cp__header svg {
+    -webkit-app-region: no-drag;
+}
+
 .cp__header-left-menu {
   @apply px-4 mr-4;
   border-right: 1px solid var(--ls-secondary-background-color);
@@ -41,7 +62,7 @@
 }
 
 .cp__header-logo {
-  @apply px-4 mr-3;
+  @apply px-4;
   height: 100%;
 }
 

--- a/src/main/frontend/components/header.css
+++ b/src/main/frontend/components/header.css
@@ -26,6 +26,37 @@
       min-width: 14rem;
     }
   }
+
+  &.electron-mac {
+    height: auto;
+    border-bottom: 1px solid var(--ls-secondary-border-color);
+
+    .open-button__icon-wrapper {
+      margin-right: 7px;
+    }
+
+    svg {
+      width: 15px;
+      height: 15px;
+    }
+
+    .navigation svg {
+      width: 24px;
+      height: 24px;
+    }
+
+    .open-button {
+      &__inner {
+        @apply items-center;
+
+        svg {
+          width: 18px;
+          height: 18px;
+        }
+      }
+    }
+
+  }
 }
 
 .is-electron.is-mac .cp__header {

--- a/src/main/frontend/components/header.css
+++ b/src/main/frontend/components/header.css
@@ -28,7 +28,7 @@
   }
 
   &.electron-mac {
-    height: auto;
+    height: 38px;
     border-bottom: 1px solid var(--ls-secondary-border-color);
 
     .open-button__icon-wrapper {
@@ -36,8 +36,8 @@
     }
 
     svg {
-      width: 15px;
-      height: 15px;
+      width: 18px;
+      height: 18px;
     }
 
     .navigation svg {

--- a/src/main/frontend/components/header.css
+++ b/src/main/frontend/components/header.css
@@ -29,7 +29,10 @@
 
   &.electron-mac {
     height: 38px;
-    border-bottom: 1px solid var(--ls-secondary-border-color);
+
+    .refresh {
+      margin: 0;
+    }
 
     .open-button__icon-wrapper {
       margin-right: 7px;

--- a/src/main/frontend/components/svg.cljs
+++ b/src/main/frontend/components/svg.cljs
@@ -71,6 +71,12 @@
      :stroke "currentColor"
      :d "M10 19L3 12M3 12L10 5M3 12L21 12"}]])
 
+(def arrow-narrow-left
+  [:svg.h-6.w-6 {:xmlns "http://www.w3.org/2000/svg" :fill "none" :viewbox "0 0 24 24" :stroke "currentColor"} [:path {:stroke-linecap "round" :stroke-linejoin "round" :stroke-width "2" :d "M7 16l-4-4m0 0l4-4m-4 4h18"}]])
+
+(def arrow-narrow-right
+  [:svg.h-6.w-6 {:xmlns "http://www.w3.org/2000/svg" :fill "none" :viewbox "0 0 24 24" :stroke "currentColor"} [:path {:stroke-linecap "round" :stroke-linejoin "round" :stroke-width "2" :d "M17 8l4 4m0 0l-4 4m4-4H3"}]])
+
 (defonce arrow-right-v2
   [:svg.h-3.w-3
    {:version "1.1"

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -52,6 +52,7 @@
       :modal/show? false
 
       ;; right sidebar
+      :ui/fullscreen? false
       :ui/settings-open? false
       :ui/sidebar-open? false
       :ui/left-sidebar-open? false


### PR DESCRIPTION
This PR is similar to #2335 with some minor differences:
1. it uses `titleBarStyle` which only works on Mac
2. the traffic lights are still there
3. some UI polish

cc @devonzuegel 

![CleanShot 2021-06-30 at 12 24 20](https://user-images.githubusercontent.com/479169/123901742-1d072600-d99e-11eb-8c92-f1574155f709.png)
