### PR TITLE
fix: use better option for scrolling into moving blocks

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1658,7 +1658,7 @@
                       :data [block]}]
             (db/refresh! repo opts)))
         (when-let [block-node (util/get-first-block-by-id block-id)]
-          (.scrollIntoView block-node #js {:behavior "smooth" :block "center"}))))))
+          (.scrollIntoView block-node #js {:behavior "smooth" :block "nearest"}))))))
 
 ;; selections
 (defn on-tab


### PR DESCRIPTION
Changes the behavior of #2187 to fix #2275

It now only scrolls when the block is moving out of the viewport but there is no scrolling in most cases.