### PR TITLE
feat(shortcut): add shift+enter to open auto complete item

### DIFF
--- a/src/main/frontend/components/search.cljs
+++ b/src/main/frontend/components/search.cljs
@@ -211,8 +211,14 @@
                                  :block
                                  block))
 
-                              nil)
-                            (search-handler/clear-search!))
+                              :new-page
+                              (page-handler/create! search-q)
+
+                              :file
+                              (route/redirect! {:to :file
+                                                :path-params {:path data}})
+
+                              nil))
          :item-render (fn [{:keys [type data]}]
                         (let [search-mode (state/get-search-mode)]
                           [:div {:class "py-2"} (case type

--- a/src/main/frontend/handler/ui.cljs
+++ b/src/main/frontend/handler/ui.cljs
@@ -147,6 +147,17 @@
       (on-chosen (nth matched @current-idx) false)
       (and on-enter (on-enter state)))))
 
+(defn auto-complete-shift-complete
+  [state e]
+  (let [[matched {:keys [on-chosen on-shift-chosen on-enter]}] (:rum/args state)
+        current-idx (get state :frontend.ui/current-idx)]
+    (util/stop e)
+    (if (and (seq matched)
+             (> (count matched)
+                @current-idx))
+      (on-shift-chosen (nth matched @current-idx) false)
+      (and on-enter (on-enter state)))))
+
 ;; date-picker
 ;; TODO: find a better way
 (def *internal-model (rum/cursor state/state :date-picker/date))

--- a/src/main/frontend/handler/ui.cljs
+++ b/src/main/frontend/handler/ui.cljs
@@ -155,7 +155,7 @@
     (if (and (seq matched)
              (> (count matched)
                 @current-idx))
-      (on-shift-chosen (nth matched @current-idx) false)
+      ((or on-shift-chosen on-chosen) (nth matched @current-idx) false)
       (and on-enter (on-enter state)))))
 
 ;; date-picker

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -47,7 +47,11 @@
     :auto-complete/complete
     {:desc    "Auto-complete choose selected item"
      :binding "enter"
-     :fn      ui-handler/auto-complete-complete}}
+     :fn      ui-handler/auto-complete-complete}
+    :auto-complete/shift-complete
+    {:desc    "Auto-complete open selected item in sidebar"
+     :binding "shift+enter"
+     :fn      ui-handler/auto-complete-shift-complete}}
 
    :shortcut.handler/block-editing-only
    ^{:before m/enable-when-editing-mode!}
@@ -412,6 +416,7 @@
     :auto-complete/prev
     :auto-complete/next
     :auto-complete/complete
+    :auto-complete/shift-complete
     :date-picker/prev-day
     :date-picker/next-day
     :date-picker/prev-week


### PR DESCRIPTION
Per request from [discord server](https://discord.com/channels/725182569297215569/725182570131751005/860797035888115732):
> Is it somehow possible to hit shift+enter to open a page on the sidebar while in the search box? (instead of having to shift left click on it)

Should fix https://github.com/logseq/logseq/issues/2271
