### PR TITLE
[wip] feat: add "Copy as document" to copy rich markdown into emails and documents

### DIFF
--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -185,6 +185,12 @@
            "Copy as TEXT")
 
           (ui/menu-link
+           {:key "Copy as document"
+            :on-click (fn [_e]
+                        (export-handler/copy-block-as-document! block-id))}
+           "Copy as DOCUMENT")
+
+          (ui/menu-link
            {:key "Copy as JSON"
             :on-click (fn [_e]
                         (export-handler/copy-block-as-json! block-id))}

--- a/src/main/frontend/handler/export.cljs
+++ b/src/main/frontend/handler/export.cljs
@@ -18,6 +18,7 @@
             [frontend.publishing.html :as html]
             [frontend.state :as state]
             [frontend.util :as util]
+            [frontend.util.property :as property]
             [goog.dom :as gdom]
             [promesa.core :as p]))
 
@@ -71,8 +72,9 @@
 (defn copy-block!
   [block-id]
   (when-let [block (db/pull [:block/uuid block-id])]
-    (let [content (:block/content block)]
-      (common-handler/copy-to-clipboard-without-id-property! (:block/format block) content))))
+    (let [plain-text (property/remove-id-property (:block/format block) (:block/content block))
+          html-text (f/to-html plain-text (:block/format block))]
+      (util/copy-to-clipboard! plain-text {:html-text html-text}))))
 
 (defn copy-block-as-json!
   [block-id]

--- a/src/main/frontend/modules/file/core.cljs
+++ b/src/main/frontend/modules/file/core.cljs
@@ -21,7 +21,7 @@
     (string/join (str "\n" spaces-tabs) lines)))
 
 (defn transform-content
-  [{:block/keys [format pre-block? title content unordered body heading-level left page scheduled deadline parent]} level {:keys [heading-to-list?]}]
+  [{:block/keys [format pre-block? title content unordered body heading-level left page scheduled deadline parent]} level {:keys [heading-to-list? markdown-list-char]}]
   (let [content (or content "")
         heading-with-title? (seq title)
         first-block? (= left page)
@@ -58,7 +58,7 @@
                                 spaces-tabs (->>
                                              (repeat (dec level) (state/get-export-bullet-indentation))
                                              (apply str))]
-                            [(str spaces-tabs "-") (str spaces-tabs "  ")]))
+                            [(str spaces-tabs markdown-list-char) (str spaces-tabs "  ")]))
                         content (if heading-to-list?
                                   (-> (string/replace content #"^\s?#+\s+" "")
                                       (string/replace #"^\s?#+\s?$" ""))
@@ -81,7 +81,7 @@
 
 (defn tree->file-content
   [tree {:keys [init-level heading-to-list?]
-         :or {heading-to-list? false}
+         :or {heading-to-list? false markdown-list-char "-"}
          :as opts}]
   (loop [block-contents []
          [f & r] tree


### PR DESCRIPTION
I will often write something in Logseq that I want to send via email or make part of a Google Doc / Dropbox Paper. "Copy as TEXT" has two problems:

- It gives me the contents of only one block and not its children
- It gives me content in markdown format (`_foo_` instead of _foo_) and then I need to transform it manually

I added "Copy as DOCUMENT" that changes both of those things. IMO, this should be the behavior of "Copy as TEXT" but maybe others use it differently and have other expectations.

Note that Copy as Document only gives you rich text when you paste into an editor that can handle it. Otherwise, it gives you the same format as Copy as TEXT but with the children contents

### TODO in this PR

- [ ] Handle embeds
- [ ] Handle references