### PR TITLE
feat: page autocomplete preview

### DIFF
--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -102,13 +102,14 @@
             {:on-chosen   (page-handler/on-chosen-handler input id q pos format)
              :on-enter    #(page-handler/page-not-exists-handler input id q current-pos)
              :item-render (fn [page-name chosen?]
-                            [:div.py-2 (block/page-preview-trigger
-                                         {:children        [:div (search/highlight-exact-query page-name q)]
-                                          :open?           chosen?
-                                          :fixed-position? true
-                                          :tippy-distance  24
-                                          :tippy-position  (if sidebar? "left" "right")}
-                                         page-name)])
+                            [:div.py-2.preview-trigger-wrapper
+                             (block/page-preview-trigger
+                               {:children        [:div (search/highlight-exact-query page-name q)]
+                                :open?           chosen?
+                                :fixed-position? true
+                                :tippy-distance  24
+                                :tippy-position  (if sidebar? "left" "right")}
+                               page-name)])
              :empty-div   [:div.text-gray-500.pl-4.pr-4 "Search for a page"]
              :class       "black"}))))))
 

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -6,6 +6,7 @@
             [frontend.components.datetime :as datetime-comp]
             [frontend.components.search :as search]
             [frontend.components.svg :as svg]
+            [frontend.components.block :as block]
             [frontend.config :as config]
             [frontend.db :as db]
             [frontend.handler.editor :as editor-handler :refer [get-state]]
@@ -94,11 +95,19 @@
                               (editor-handler/get-matched-pages q))]
           (ui/auto-complete
            matched-pages
-           {:on-chosen (page-handler/on-chosen-handler input id q pos format)
-            :on-enter #(page-handler/page-not-exists-handler input id q current-pos)
-            :item-render (fn [item] [:div.py-2 (search/highlight-exact-query item q)])
-            :empty-div [:div.text-gray-500.pl-4.pr-4 "Search for a page"]
-            :class     "black"}))))))
+           {:on-chosen   (page-handler/on-chosen-handler input id q pos format)
+            :on-enter    #(page-handler/page-not-exists-handler input id q current-pos)
+            :item-render (fn [item chosen?]
+                           [:div.py-2.flex.page-search-menu-item
+                            [[:div (search/highlight-exact-query item q)]
+                             [:div.flex-1]
+                             ;; Ideally, we may want to trigger preview on focused
+                             (block/page-preview-trigger
+                               {:children [:div.page-search-menu-item-preview "Preview"]
+                                :tippy-position "right"}
+                               item)]])
+            :empty-div   [:div.text-gray-500.pl-4.pr-4 "Search for a page"]
+            :class       "black"}))))))
 
 (rum/defcs block-search-auto-complete < rum/reactive
   {:init (fn [state]

--- a/src/main/frontend/components/editor.css
+++ b/src/main/frontend/components/editor.css
@@ -63,3 +63,8 @@ pre {
   background: #f6f8fa;
   background: var(--ls-secondary-background-color);
 }
+
+/* Fix autocomplete preview  */
+.preview-trigger-wrapper > [data-tooltipped] {
+  display: block !important;
+}

--- a/src/main/frontend/components/editor.css
+++ b/src/main/frontend/components/editor.css
@@ -63,3 +63,17 @@ pre {
   background: #f6f8fa;
   background: var(--ls-secondary-background-color);
 }
+
+
+.page-search-menu-item-preview {
+  opacity: 0;
+}
+
+.page-search-menu-item:hover {
+  .page-search-menu-item-preview {
+    opacity: 0.5;
+    &:hover {
+      opacity: 1;
+    }
+  }
+}

--- a/src/main/frontend/components/editor.css
+++ b/src/main/frontend/components/editor.css
@@ -63,17 +63,3 @@ pre {
   background: #f6f8fa;
   background: var(--ls-secondary-background-color);
 }
-
-
-.page-search-menu-item-preview {
-  opacity: 0;
-}
-
-.page-search-menu-item:hover {
-  .page-search-menu-item-preview {
-    opacity: 0.5;
-    &:hover {
-      opacity: 1;
-    }
-  }
-}

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -62,16 +62,18 @@
 (defn- open-first-block!
   [state]
   (let [blocks (nth (:rum/args state) 1)
-        block (first blocks)]
+        block (first blocks)
+        preview? (nth (:rum/args state) 4)]
     (when (and (= (count blocks) 1)
-               (string/blank? (:block/content block)))
+               (string/blank? (:block/content block))
+               (not preview?))
       (editor-handler/edit-block! block :max (:block/format block) (:block/uuid block))))
   state)
 
 (rum/defc page-blocks-inner <
   {:did-mount open-first-block!
    :did-update open-first-block!}
-  [page-name page-blocks hiccup sidebar?]
+  [page-name page-blocks hiccup sidebar? preview?]
   [:div.page-blocks-inner
    (rum/with-key
      (content/content page-name
@@ -129,7 +131,7 @@
                              config)
               hiccup-config (common-handler/config-with-document-mode hiccup-config)
               hiccup (block/->hiccup page-blocks hiccup-config {})]
-          (page-blocks-inner page-name page-blocks hiccup sidebar?))))))
+          (page-blocks-inner page-name page-blocks hiccup sidebar? preview?))))))
 
 (defn contents-page
   [page]

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -710,6 +710,23 @@
    (vector? block)
    (= "Heading" (first block))))
 
+(defn get-redirect-page-name
+  ([page-name] (get-redirect-page-name page-name false))
+  ([page-name alias?]
+   (let [page-entity (db-utils/entity [:block/name page-name])]
+     (cond
+       alias?
+       page-name
+
+       (page-empty-or-dummy? (state/get-current-repo) (:db/id page-entity))
+       (let [source-page (get-alias-source-page (state/get-current-repo)
+                                                      (string/lower-case page-name))]
+         (or (when source-page (:block/name source-page))
+             page-name))
+
+       :else
+       page-name))))
+
 (defn get-page-original-name
   [page-name]
   (when page-name

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -5,7 +5,6 @@
             ["react-textarea-autosize" :as TextareaAutosize]
             ["react-resize-context" :as Resize]
             ["react-tippy" :as react-tippy]
-            ["@popperjs/core" :as popperjs]
             [frontend.util :as util]
             [frontend.mixins :as mixins]
             [frontend.handler.notification :as notification-handler]

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -349,16 +349,16 @@
            {:key idx}
            (let [item-cp
                  [:div {:key idx}
-                  (menu-link
-                   {:id       (str "ac-" idx)
-                    :class    (when (= @current-idx idx)
-                                "chosen")
-                    :on-mouse-down (fn [e]
-                                     (util/stop e)
-                                     (if (and (gobj/get e "shiftKey") on-shift-chosen)
-                                       (on-shift-chosen item)
-                                       (on-chosen item)))}
-                   (if item-render (item-render item) item))]]
+                  (let [chosen? (= @current-idx idx)]
+                    (menu-link
+                      {:id            (str "ac-" idx)
+                       :class         (when chosen? "chosen")
+                       :on-mouse-down (fn [e]
+                                        (util/stop e)
+                                        (if (and (gobj/get e "shiftKey") on-shift-chosen)
+                                          (on-shift-chosen item)
+                                          (on-chosen item)))}
+                      (if item-render (item-render item chosen?) item)))]]
 
              (if get-group-name
                (if-let [group-name (get-group-name item)]
@@ -609,7 +609,7 @@
 
 (rum/defcs tippy < rum/static
   (rum/local false ::mounted?)
-  [state opts child]
+  [state {:keys [fixed-position?] :as opts} child]
   (let [*mounted? (::mounted? state)
         mounted? @*mounted?]
     (Tippy (->
@@ -619,6 +619,12 @@
                     :disabled (not (state/enable-tooltip?))
                     :unmountHTMLWhenHide true
                     :open @*mounted?
+                    ;; See https://github.com/tvkhoa/react-tippy/issues/13
+                    :popperOptions (if fixed-position?
+                                      {:modifiers {:preventOverflow {:enabled false}
+                                                   :flip {:enabled false}
+                                                   :hide {:enabled false}}}
+                                      {})
                     :onShow #(reset! *mounted? true)
                     :onHide #(reset! *mounted? false)}
                    opts)

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -353,6 +353,7 @@
                     (menu-link
                       {:id            (str "ac-" idx)
                        :class         (when chosen? "chosen")
+                       :on-mouse-enter #(reset! current-idx idx)
                        :on-mouse-down (fn [e]
                                         (util/stop e)
                                         (if (and (gobj/get e "shiftKey") on-shift-chosen)

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -5,6 +5,7 @@
             ["react-textarea-autosize" :as TextareaAutosize]
             ["react-resize-context" :as Resize]
             ["react-tippy" :as react-tippy]
+            ["@popperjs/core" :as popperjs]
             [frontend.util :as util]
             [frontend.mixins :as mixins]
             [frontend.handler.notification :as notification-handler]
@@ -609,26 +610,28 @@
 
 (rum/defcs tippy < rum/static
   (rum/local false ::mounted?)
-  [state {:keys [fixed-position?] :as opts} child]
+  [state {:keys [fixed-position? open?] :as opts} child]
   (let [*mounted? (::mounted? state)
-        mounted? @*mounted?]
+        mounted? @*mounted?
+        manual (not= open? nil)]
     (Tippy (->
             (merge {:arrow true
                     :sticky true
                     :theme "customized"
                     :disabled (not (state/enable-tooltip?))
                     :unmountHTMLWhenHide true
-                    :open @*mounted?
+                    :open (if manual open? @*mounted?)
+                    :trigger (if manual "manual" "mouseenter focus")
                     ;; See https://github.com/tvkhoa/react-tippy/issues/13
                     :popperOptions (if fixed-position?
-                                      {:modifiers {:preventOverflow {:enabled false}
-                                                   :flip {:enabled false}
-                                                   :hide {:enabled false}}}
+                                      {:modifiers {:flip {:enabled false}
+                                                   :hide {:enabled false}
+                                                   :preventOverflow {:enabled false}}}
                                       {})
                     :onShow #(reset! *mounted? true)
                     :onHide #(reset! *mounted? false)}
                    opts)
-            (assoc :html (if mounted?
+            (assoc :html (if (or open? mounted?)
                            (when-let [html (:html opts)]
                              (if (fn? html)
                                (html)


### PR DESCRIPTION
Inspired by Innos Note, this PR enables page previewing within block auto-complete of page-search.

Some details:
- The preview will be debounced for 1s on open and active selected item's name
- Will be closed immediately without debouncing
- Will change the active selected item on mouseenter

![demo-3](https://user-images.githubusercontent.com/584378/124381716-8f596c80-dcf6-11eb-8820-7a48d2f911a0.gif)
