### PR TITLE
feat: enhance embed block/page ux

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -494,10 +494,18 @@
 
 (declare blocks-container)
 
+(defn- edit-parent-block [e parent-block]
+  (when-not (state/editing?)
+    (.stopPropagation e)
+    (editor-handler/edit-block! parent-block :max (:block/format parent-block) (:block/uuid parent-block))))
+
 (rum/defc block-embed < rum/reactive db-mixins/query
   [config id]
   (let [blocks (db/get-block-and-children (state/get-current-repo) id)]
-    [:div.color-level.embed-block.bg-base-2 {:style {:z-index 2}}
+    [:div.color-level.embed-block.bg-base-2
+     {:style {:z-index 2}
+      :on-double-click #(edit-parent-block % config)
+      :on-mouse-down (fn [e] (.stopPropagation e))}
      [:div.px-3.pt-1.pb-2
       (blocks-container blocks (assoc config
                                       :id (str id)
@@ -510,7 +518,9 @@
   (let [page-name (string/trim (string/lower-case page-name))
         current-page (state/get-current-page)]
     [:div.color-level.embed.embed-page.bg-base-2
-     {:class (if (:sidebar? config) "in-sidebar")}
+     {:class (if (:sidebar? config) "in-sidebar")
+      :on-double-click #(edit-parent-block % config)
+      :on-mouse-down #(.stopPropagation %)}
      [:section.flex.items-center.p-1.embed-header
       [:div.mr-3 svg/page]
       (page-cp config {:block/name page-name})]


### PR DESCRIPTION
There is an issue that makes embed block/page UX not ideal: the user will easily get into the host block editing mode when interacting with the embedded block/page.
This pr fixes this issue by
- the embed container will swallow the bubbling `mousedown` event
- the user still can edit the host block when the user double clicks the embed element, unless he is already in editing mode

This pr also fixes an issue that the user cannot fold a block in an embedded context.

![demo-4](https://user-images.githubusercontent.com/584378/124492668-5b11a900-dde7-11eb-974a-6bc076086913.gif)
