### PR TITLE
fix: delete alias page cause wrong alias relations

### DIFF
--- a/src/main/frontend/db_schema.cljs
+++ b/src/main/frontend/db_schema.cljs
@@ -147,3 +147,17 @@
     :block/updated-at
     }
   )
+
+
+;;; use `(map [:db.fn/retractAttribute <id> <attr>] retract-page-attributes)`
+;;; to remove attrs to make the page as it's just created and no file attached to it
+(def retract-page-attributes
+  #{:block/created-at
+    :block/updated-at
+    :block/file
+    :block/format
+    :block/content
+    :block/properties
+    :block/alias
+    :block/tags
+    :block/unordered})

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -21,6 +21,7 @@
             [frontend.commands :as commands]
             [frontend.date :as date]
             [frontend.db-schema :as db-schema]
+            [frontend.db.conn :as conn]
             [clojure.walk :as walk]
             [frontend.git :as git]
             [frontend.fs :as fs]
@@ -181,15 +182,21 @@
                           (js/console.error "error: " err))))))
 
 
-          ;; not removing entire entity, because :block/alias still use this entity.
-          ;; so just delete related file and make remove most page-related attrs.
-          ;; (db/transact! [[:db.fn/retractEntity [:block/name page-name]]])
-
-          (when-let [id (:db/id (db/entity [:block/name page-name]))]
-            (let [txs (mapv (fn [attribute]
-                             [:db/retract id attribute])
-                           db-schema/retract-page-attributes)]
-              (db/transact! txs)))
+          ;; if other page alias this pagename,
+          ;; then just remove some attrs of this entity instead of retractEntity
+          (if (empty?
+               (d/q '[:find ?a
+                      :in $ ?page-name
+                      :where
+                      [?p :block/alias ?als]
+                      [?a :block/name ?page-name]
+                      [(= ?als ?a)]] (conn/get-conn true) page-name))
+            (db/transact! [[:db.fn/retractEntity [:block/name page-name]]])
+            (when-let [id (:db/id (db/entity [:block/name page-name]))]
+              (let [txs (mapv (fn [attribute]
+                                [:db/retract id attribute])
+                              db-schema/retract-page-attributes)]
+                (db/transact! txs))))
 
           (ok-handler))))))
 


### PR DESCRIPTION
reproduce steps:
1. create page "page1", and add "alias: page2"
2. click [[page2]] will redirect to [[page1]], which is good
3. goto [[page2]], input some text
4. click [[page2]] will goto [[page2]], good
5. delete page "page2"
6. click [[page2]] will goto an empty [[page2]], BAD, it should goto [[page1]]