### PR TITLE
feat: also honor hr when check if block content is empty

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1231,6 +1231,13 @@
                (rum/with-key (block-container config child)
                  (:block/uuid child)))))]))))
 
+(defn block-content-empty?
+  [block]
+  (and
+    (property/properties-built-in? (:block/properties block))
+    (= (:block/title block) [])
+    (every? #(= % ["Horizontal_Rule"]) (:block/body block))))
+
 (rum/defcs block-control < rum/reactive
   [state config block uuid block-id body children collapsed? *ref-collapsed? *control-show? edit-input-id edit? doc-mode?]
   (let [doc-mode? (state/sub :document/mode?)
@@ -1247,10 +1254,8 @@
         dark? (= "dark" (state/sub :ui/theme))
         ref? (:ref? config)
         collapsed? (if ref? ref-collapsed? collapsed?)
-        empty-content? (string/blank?
-                        (property/remove-built-in-properties
-                         (:block/format block)
-                         (:block/content block)))]
+        empty-content? (block-content-empty? block)]
+    (println empty-content?)
     [:div.mr-2.flex.flex-row.items-center
      {:style {:height 24
               :margin-top 0

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1255,7 +1255,6 @@
         ref? (:ref? config)
         collapsed? (if ref? ref-collapsed? collapsed?)
         empty-content? (block-content-empty? block)]
-    (println empty-content?)
     [:div.mr-2.flex.flex-row.items-center
      {:style {:height 24
               :margin-top 0

--- a/src/main/frontend/util/property.cljs
+++ b/src/main/frontend/util/property.cljs
@@ -27,8 +27,9 @@
 (defn properties-built-in?
   [properties]
   (and (seq properties)
-       (let [ks (map (comp keyword string/lower-case name) (keys properties))]
-         (every? (built-in-properties) ks))))
+       (let [ks (map (comp keyword string/lower-case name) (keys properties))
+             built-in-properties* (built-in-properties)]
+         (every? #(contains? built-in-properties* %) ks))))
 
 (defn contains-properties?
   [content]


### PR DESCRIPTION
So that if a row only contains hr, the bullet is also hidden 