### PR TITLE
feat: hide specific block properties

### DIFF
--- a/src/main/frontend/config.cljs
+++ b/src/main/frontend/config.cljs
@@ -385,3 +385,7 @@
    (when repo
      (get-file-path repo
                     (str app-name "/" custom-css-file)))))
+
+(defn get-block-hidden-properties
+  []
+  (get-in @state/state [:config (state/get-current-repo) :block-hidden-properties]))

--- a/src/main/frontend/util/property.cljs
+++ b/src/main/frontend/util/property.cljs
@@ -22,6 +22,7 @@
   (set/union
    #{:id :custom-id :background-color :heading :collapsed :created-at :updated-at :last-modified-at :created_at :last_modified_at :query-table :query-properties :query-sort-by :query-sort-desc}
    (set (map keyword config/markers))
+   (set (config/get-block-hidden-properties))
    @built-in-extended-properties))
 
 (defn properties-built-in?

--- a/templates/config.edn
+++ b/templates/config.edn
@@ -165,4 +165,8 @@
 
  ;; the initial interval after the first successful review of a card (default 4)
  ;; :srs/initial-interval 4
+
+ ;; hide specific properties for blocks
+ ;; E.g. #{:created-at :updated-at}
+ ;; :block-hidden-properties #{}
  }


### PR DESCRIPTION
Hide properties specified in `config.edn`

Reference:
- https://discuss.logseq.com/t/control-which-block-properties-are-hidden-in-view-mode/884