### PR TITLE
feat: set text/html when copy html text

### DIFF
--- a/src/main/frontend/components/export.cljs
+++ b/src/main/frontend/components/export.cljs
@@ -149,5 +149,5 @@
 
      (ui/button (if @copied? "Copied to clipboard!" "Copy to clipboard")
                 :on-click (fn []
-                            (util/copy-to-clipboard! content)
+                            (util/copy-to-clipboard! content (= type :html))
                             (reset! copied? true)))]))

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -771,16 +771,11 @@
 #?(:cljs (def clear-selection! selection/clearSelection))
 
 #?(:cljs
-   (defn copy-to-clipboard! [s]
-     (let [el (js/document.createElement "textarea")]
-       (set! (.-value el) s)
-       (.setAttribute el "readonly" "")
-       (set! (-> el .-style .-position) "absolute")
-       (set! (-> el .-style .-left) "-9999px")
-       (js/document.body.appendChild el)
-       (.select el)
-       (js/document.execCommand "copy")
-       (js/document.body.removeChild el))))
+   (defn copy-to-clipboard!
+     ([s]
+      (utils/writeClipboard s false))
+     ([s html?]
+      (utils/writeClipboard s html?))))
 
 (def uuid-pattern "[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}")
 (defonce exactly-uuid-pattern (re-pattern (str "(?i)^" uuid-pattern "$")))

--- a/src/main/frontend/utils.js
+++ b/src/main/frontend/utils.js
@@ -231,3 +231,22 @@ export const getClipText = function (cb, errorHandler) {
     }
   })
 }
+
+export const writeClipboard = function(text, isHtml) {
+    if (isHtml) {
+	var blob = new Blob([text], {type:["text/plain", "text/html"]})
+	var data = [new ClipboardItem({["text/plain"]: blob, ["text/html"]:blob})];
+    } else{
+	var blob = new Blob([text], {type:["text/plain"]})
+	var data = [new ClipboardItem({["text/plain"]: blob})];
+    }
+    navigator.permissions.query({ name: "clipboard-write" }).then((result) => {
+	if (result.state == "granted" || result.state == "prompt") {
+	    navigator.clipboard.write(data).then(function() {
+		/* success */
+	    }, function(e) {
+		console.log(e, "fail")
+	    })
+	}
+    })
+}


### PR DESCRIPTION
when “Copy as” Html，set 'text/html' option on copied text.
|Copy as HTML| Google Doc |
|---|---|
| ![image](https://user-images.githubusercontent.com/5608710/128472520-a62e6315-c497-4a65-b314-d16eea025b30.png) |![image](https://user-images.githubusercontent.com/5608710/128472743-6c175b33-a014-4073-bcf9-831f57736b1c.png)|
