### PR TITLE
feat: block bullet path

### DIFF
--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -60,6 +60,7 @@ html[data-theme='dark'] {
   --ls-slide-background-color: var(--ls-primary-background-color);
   --ls-block-bullet-border-color: #0f4958;
   --ls-block-bullet-color: #608e91;
+  --ls-block-bullet-active-color: var(--ls-link-text-color);
   --ls-block-highlight-color: #0a3d4b;
   --ls-selection-background-color: #338fff;
   --ls-page-checkbox-color: #6093a0;
@@ -115,6 +116,7 @@ html[data-theme='light'] {
   --ls-slide-background-color: #fff;
   --ls-block-bullet-border-color: #dedede;
   --ls-block-bullet-color: rgba(67, 63, 56, 0.25);
+  --ls-block-bullet-active-color: var(--ls-link-text-color);
   --ls-block-highlight-color: #c0e6fd;
   --ls-selection-background-color: #e4f2ff;
   --ls-page-checkbox-color: #9dbbd8;
@@ -174,7 +176,7 @@ textarea {
   border: 1px solid rgba(39, 41, 43, 0.15);
   border-radius: var(--ls-border-radius-low);
   font-size: 1em;
-  line-height: 1.5;
+  line-height: inherit;
   width: 100%;
   resize: none;
   outline: none;

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1313,8 +1313,8 @@
         ref? (:ref? config)
         collapsed? (if ref? ref-collapsed? collapsed?)
         empty-content? (block-content-empty? block)]
-    [:div.mr-2.flex.flex-row.items-center
-     {:style {:height 24
+    [:div.block-control-wrapper.mr-2.flex.flex-row.items-center.relative
+     {:style {:height 26
               :margin-top 0
               :float "left"}}
 
@@ -2041,7 +2041,8 @@
         :style {:position "relative"}
         :class (str uuid
                     (when (and collapsed? has-child?) " collapsed")
-                    (when pre-block? " pre-block"))
+                    (when pre-block? " pre-block")
+                    (when (not (:ui/hide-block-bullet-path? (state/get-config))) " show-bullet-path"))
         :blockid (str uuid)
         :repo repo
         :haschild (str has-child?)}
@@ -2064,7 +2065,7 @@
        (dnd-separator-wrapper block block-id slide? true false))
 
      [:div.flex.flex-row.pr-2
-      {:class (if heading? "items-baseline" "")
+      {:class (if heading? "items-baseline heading" "")
        :on-mouse-over (fn [e]
                         (block-mouse-over e has-child? *control-show? block-id doc-mode?))
        :on-mouse-leave (fn [e]

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -1,4 +1,5 @@
 .block-content-wrapper {
+  position: relative;
   width: 100%;
 }
 
@@ -378,6 +379,7 @@
   border-radius: 50%;
   justify-content: center;
   align-items: center;
+  transform: translateX(-0.5px);
 
   .bullet-heading {
     background-color: var(--ls-block-bullet-color, #8fbc8f);
@@ -491,4 +493,75 @@ span.cloze-revealed {
 
 .page-property-key {
   color: var(--ls-secondary-text-color);
+}
+
+/* Block bullet path should only show in a nested block */
+.ls-block.show-bullet-path {
+  .bullet {
+    background-color: var(--ls-block-bullet-active-color);
+  }
+
+  &:not(:focus-within) .bullet {
+    background-color: var(--ls-block-bullet-color);
+    box-shadow: none;
+    opacity: 0.3;
+    transform: scale(1);
+  }
+
+  .ls-block {
+    > div > .block-control-wrapper::before {
+      content: "";
+      left: 0;
+      right: 0.5rem;
+      top: -1px;
+      bottom: -1px;
+      transform: translate(-1px, -50%); /* shift left 1px for border */
+      position: absolute;
+      border-left: 1px solid transparent;
+      border-bottom: 1px solid transparent;
+      border-bottom-left-radius: 10px;
+    }
+
+    &:focus-within > div > .block-control-wrapper::before {
+      border-color: var(--ls-block-bullet-active-color);
+    }
+  }
+
+  .block-children {
+    > .ls-block::before {
+      content: "";
+      top: -1rem;
+      bottom: 0;
+      border-left: 1px solid transparent;
+      left: -1px; /* shift left 1px for border */
+      position: absolute;
+    }
+
+    &:focus-within > .ls-block:not(:focus-within)::before  {
+      border-color: var(--ls-block-bullet-active-color);
+    }
+
+    &:focus-within > .ls-block:focus-within ~ .ls-block::before {
+      border-color: transparent;
+    }
+  }
+}
+
+.ls-block.show-bullet-path[haschild="true"] {
+  > div > .block-content-wrapper::before {
+    content: "";
+    top: 12px;
+    bottom: 0;
+    left: -15px;
+    position: absolute;
+    border-left: 1px solid transparent;
+  }
+
+  > .heading > .block-content-wrapper::before {
+    top: calc(50% + 2px);
+  }
+
+  &:focus-within > div > .block-content-wrapper::before {
+    border-color: var(--ls-block-bullet-active-color);
+  }
 }

--- a/templates/config.edn
+++ b/templates/config.edn
@@ -98,6 +98,9 @@
  ;; Whether to show empty bullets for non-document mode (the default mode)
  :ui/show-empty-bullets? false
 
+ ;; Whether to hide block bullet path. Default is false
+ :ui/hide-block-bullet-path? false
+
  ;; The app will show those queries in today's journal page,
  ;; the "NOW" query asks the tasks which need to be finished "now",
  ;; the "NEXT" query asks the future tasks.


### PR DESCRIPTION
Bringing the bullet threading (or bullet path) feature from https://github.com/pengx17/logseq-dev-theme to Logseq core. This feature is one demanding feature that Logseq users want to have for other themes as well.

The "bullet path" is enabled by default. The user can turn it off by setting `:ui/hide-block-bullet-path?` to false in `config.edn`.

It inherits the `--ls-link-text-color` theme color and adapts for both light and dark themes by default. I believe if the theme authors correctly alter this color, the thread color will also change accordingly.

The implementation is not ideal since it basically brings in the original implementation with some minor changes. I think there should be a cleaner solution with some trivial cljs code, than using CSS pseudo-classes all over the place.

Demo:
![image](https://user-images.githubusercontent.com/584378/128737371-7c627c1d-ab7d-4c83-9ae3-c353a2b338f2.png)

https://user-images.githubusercontent.com/584378/128737927-519096cf-5683-41ff-83a7-7e211552884d.mp4
