### PR TITLE
enhance: support web pdf link

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -936,8 +936,21 @@
                      (map-inline config label))))))
 
             ;; image
-            (show-link? config metadata href full_text)
+            (and (show-link? config metadata href full_text)
+                 (not (contains? #{"pdf"} (util/get-file-ext href))))
             (image-link config url href label metadata full_text)
+
+            ;; pdf link
+            (and
+             (util/electron?)
+             (= (util/get-file-ext href) "pdf")
+             (show-link? config metadata href full_text))
+            [:a.asset-ref.is-pdf
+             {:href "javascript:void(0);"
+              :on-mouse-down (fn [e]
+                               (when-let [current (pdf-assets/inflate-asset href)]
+                                 (state/set-state! :pdf/current current)))}
+             (get-label-text label)]
 
             (and
              (util/electron?)

--- a/src/main/frontend/extensions/pdf/assets.cljs
+++ b/src/main/frontend/extensions/pdf/assets.cljs
@@ -20,7 +20,11 @@
 (defn inflate-asset
   [full-path]
   (let [filename (util/node-path.basename full-path)
+        web-link?    (string/starts-with? full-path "http")
         url (cond
+              web-link?
+              full-path
+
               (util/absolute-path? full-path)
               (str "file://" full-path)
 
@@ -32,9 +36,12 @@
                "file://"                                  ;; TODO: bfs
                (config/get-repo-dir (state/get-current-repo))
                "assets" filename))]
-    (when-let [key (and
-                    (string/ends-with? filename ".pdf")
-                    (string/replace-first filename ".pdf" ""))]
+    (when-let [key
+               (if web-link?
+                 (str (hash url))
+                 (and
+                  (string/ends-with? filename ".pdf")
+                  (string/replace-first filename ".pdf" "")))]
       {:key      key
        :identity (subs key (- (count key) 15))
        :filename filename


### PR DESCRIPTION
`![sample.pdf](http://www.africau.edu/images/default/sample.pdf)` will open Logseq pdf annotation as file.