### PR TITLE
fix: some contains query doesn't work

### DIFF
--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -226,7 +226,8 @@
                                               (string? v)
                                               (contains? #{:alias :aliases :tags} k))
                                            (set [v])
-                                           v)]
+                                           v)
+                                       v (if (coll? v) (set v) v)]
                                    [k v]))))]
       {:properties (into {} properties)
        :properties-order (map first properties)


### PR DESCRIPTION
a user reported issue on discord:

sample page with the first block:
```
type:: feature
head:: [[redacted]] 
communication_poc:: [[test]]
```

sample query doesn't work in 0.3.3:
```
{{query (and (property communication_poc [[test]]) (or (property type feature) (property type internal_feature)))}}
```

found out that page property value for collection was treated as list, not sure which commit introduced this regression.
`:head '("redacted"), :communication_poc '("test")`

this caused the `(contains? ?v "test")` cause always return false.

Added a safeguard to always convert coll v to set would fix the issue. Maybe a little hacky..