### PR TITLE
fix: incorrect timestamp log in org-mode

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -768,7 +768,8 @@
       (when content
         (str (string/trimr content)
              "\n"
-             (util/format (str "*" " %s -> DONE [%s]")
+             (util/format (str (if (= :org (state/get-preferred-format)) "-" "*")
+                               " %s -> DONE [%s]")
                           marker
                           (date/get-local-date-time-string)))))
     content))


### PR DESCRIPTION
Timestamp log started with "`*`" in org-mode got rendered as a
first-level headline. This patch fixes it.