### PR TITLE
enhance: keep settings window from jumping

### DIFF
--- a/src/main/frontend/ui.css
+++ b/src/main/frontend/ui.css
@@ -65,7 +65,7 @@
 
   @screen sm {
     & {
-      @apply inset-0 flex items-center justify-center;
+      @apply inset-0 flex items-baseline justify-center top-24;
     }
   }
 


### PR DESCRIPTION
Prevents settings window from jumping up and down when switching between submenus. 

Note there is still slight horizontal jumping once a scrollbar appears. This has been left unchanged.