### PR TITLE
enhance: remove extra whitespace in src-block-command for better compatibility with other markdown editors

### DIFF
--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -149,7 +149,7 @@
                  (util/format "\n#+END_%s" (string/upper-case type)))
          template (str
                    left
-                   (if optional (str " " optional) "")
+                   (if optional (str optional) "")
                    "\n"
                    right)
          backward-pos (if (= type "src")


### PR DESCRIPTION
this whitespace doesn't seem to be markdown compliant. Some editors won't syntax highlight correctly (e.g. Markor)