### PR TITLE
fix(org): remove extra lines

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -990,9 +990,10 @@
             new-line (str (string/upper-case key) ": " value)
             new-content (let [lines (string/split-lines content)
                               new-lines (map (fn [line]
-                                               (if (string/starts-with? (string/lower-case line) key)
-                                                 new-line
-                                                 line))
+                                               (string/trim
+                                                (if (string/starts-with? (string/lower-case line) key)
+                                                  new-line
+                                                  line)))
                                              lines)
                               new-lines (if (not= lines new-lines)
                                           new-lines

--- a/src/main/frontend/util/property.cljs
+++ b/src/main/frontend/util/property.cljs
@@ -284,7 +284,7 @@
         content (reduce (fn [content key]
                           (remove-property format key content)) content built-in-properties*)]
     (if (= format :org)
-      (string/replace-first content ":PROPERTIES:\n:END:" "")
+      (string/replace-first content ":PROPERTIES:\n:END:\n" "")
       content)))
 
 (defn ->new-properties


### PR DESCRIPTION
As the gif shows, logseq always add extra empty lines in orgmode. These two patches offer a solution to fix this. There might be some edge cases that the patches do not cover, but they work pretty well in most conditions as I tested. Please give them a review. Thanks.
 
![unpatched](https://user-images.githubusercontent.com/3996879/130350288-b4f126c4-94ca-43d7-9d3a-598f4dd22f27.gif)
