### PR TITLE
fix(pdf): incorrect joined full url path of pdf asset

### DIFF
--- a/src/main/frontend/extensions/pdf/assets.cljs
+++ b/src/main/frontend/extensions/pdf/assets.cljs
@@ -38,10 +38,10 @@
               full-path
 
               :else
-              (util/node-path.join
-                "file://"                                   ;; TODO: bfs
-                (config/get-repo-dir (state/get-current-repo))
-                "assets" filename))]
+              (str "file://"                                ;; TODO: bfs
+                   (util/node-path.join
+                     (config/get-repo-dir (state/get-current-repo))
+                     "assets" filename)))]
     (when-let [key
                (if web-link?
                  (str (hash url))


### PR DESCRIPTION
This issue maybe cause the illusion of highlights data loss!

![Screen_Recording_2021-08-23_at_19 49 16](https://user-images.githubusercontent.com/1779837/130447525-a31bf803-1e5a-4c7e-a87b-213aff010722.gif)
