### PR TITLE
feat: command palette

### DIFF
--- a/src/main/frontend/components/command_palette.cljs
+++ b/src/main/frontend/components/command_palette.cljs
@@ -41,13 +41,13 @@
         :class       "cp__command-palette-results"
         :on-chosen   (fn [{:keys [action]}]
                        (state/set-state! :ui/command-palette-open? false)
-                       (state/close-modal!)
                        (action))})]]))
 
 
 (rum/defc command-palette-modal < rum/reactive
   []
   (let [open? (state/sub :ui/command-palette-open?)]
-    (when open?
-      (state/set-modal! #(command-palette {:commands (cp/get-commands)})))
+    (if open?
+      (state/set-modal! #(command-palette {:commands (cp/get-commands)}))
+      (state/close-modal!))
     nil))

--- a/src/main/frontend/components/command_palette.cljs
+++ b/src/main/frontend/components/command_palette.cljs
@@ -1,0 +1,49 @@
+(ns frontend.components.command-palette
+  (:require [frontend.handler.command-palette :as cp]
+            [frontend.search :as search]
+            [frontend.state :as state]
+            [frontend.modules.shortcut.core :as shortcut]
+            [frontend.ui :as ui]
+            [frontend.util :as util]
+            [rum.core :as rum]))
+
+(defn get-matched-commands [commands input]
+  (search/fuzzy-search commands input :limit 7 :extract-fn :desc))
+
+(defn render-command [{:keys [id desc shortcut]} chosen?]
+  [:div
+   {:class (when chosen? "chosen")}
+   [:span (namespace id)]
+   [:span desc]
+   [:code shortcut]])
+
+(rum/defcs command-palette <
+  (shortcut/disable-all-shortcuts)
+  (rum/local "" ::input)
+  {:will-unmount (fn [state]
+                   (state/set-state! :ui/command-palette-open? false)
+                   state)}
+  [state {:keys [commands]}]
+  (let [input (::input state)]
+    [:div#command-palette
+     [:input.cp__command-palette-input
+      {:type        "text"
+       :placeholder "Type a command"
+       :auto-focus   true
+       :value       @input
+       :on-change   (fn [e] (reset! input (util/evalue e)))}]
+     (ui/auto-complete
+      (get-matched-commands commands @input)
+      {:item-render render-command
+       :class       "cp__command-palette-results"
+       :on-chosen   (fn [{:keys [action]}]
+                      (state/set-state! :ui/command-palette-open? false)
+                      (action))})]))
+
+
+(rum/defc command-palette-modal < rum/reactive
+  []
+  (let [open? (state/sub :ui/command-palette-open?)]
+    (when open?
+      (state/set-modal! #(command-palette {:commands (cp/get-commands)})))
+    nil))

--- a/src/main/frontend/components/command_palette.cljs
+++ b/src/main/frontend/components/command_palette.cljs
@@ -11,11 +11,13 @@
   (search/fuzzy-search commands input :limit 7 :extract-fn :desc))
 
 (defn render-command [{:keys [id desc shortcut]} chosen?]
-  [:div
+  [:div.inline-grid.grid-cols-4.gap-x-4.w-full
    {:class (when chosen? "chosen")}
-   [:span (namespace id)]
-   [:span desc]
-   [:code shortcut]])
+   [:span.col-span-3 desc]
+   [:div.col-span-1.justify-end
+    (when (and (keyword? id) (namespace id))
+      [:code.bg-blue-400 (namespace id)])
+    [:code shortcut]]])
 
 (rum/defcs command-palette <
   (shortcut/disable-all-shortcuts)
@@ -25,20 +27,22 @@
                    state)}
   [state {:keys [commands]}]
   (let [input (::input state)]
-    [:div#command-palette
-     [:input.cp__command-palette-input
+    [:div#command-palette.cp__command-palette-main
+     [:input.cp__command-palette-input.w-full
       {:type        "text"
        :placeholder "Type a command"
        :auto-focus   true
        :value       @input
        :on-change   (fn [e] (reset! input (util/evalue e)))}]
-     (ui/auto-complete
-      (get-matched-commands commands @input)
-      {:item-render render-command
-       :class       "cp__command-palette-results"
-       :on-chosen   (fn [{:keys [action]}]
-                      (state/set-state! :ui/command-palette-open? false)
-                      (action))})]))
+     [:div.w-full
+      (ui/auto-complete
+       (get-matched-commands commands @input)
+       {:item-render render-command
+        :class       "cp__command-palette-results"
+        :on-chosen   (fn [{:keys [action]}]
+                       (state/set-state! :ui/command-palette-open? false)
+                       (state/close-modal!)
+                       (action))})]]))
 
 
 (rum/defc command-palette-modal < rum/reactive

--- a/src/main/frontend/components/command_palette.cljs
+++ b/src/main/frontend/components/command_palette.cljs
@@ -14,10 +14,10 @@
   [:div.inline-grid.grid-cols-4.gap-x-4.w-full
    {:class (when chosen? "chosen")}
    [:span.col-span-3 desc]
-   [:div.col-span-1.justify-end
+   [:div.col-span-1.justify-end.tip.flex
     (when (and (keyword? id) (namespace id))
-      [:code.bg-blue-400 (namespace id)])
-    [:code shortcut]]])
+      [:code.opacity-20.bg-transparent (namespace id)])
+    [:code.ml-1 shortcut]]])
 
 (rum/defcs command-palette <
   (shortcut/disable-all-shortcuts)
@@ -48,6 +48,6 @@
   []
   (let [open? (state/sub :ui/command-palette-open?)]
     (if open?
-      (state/set-modal! #(command-palette {:commands (cp/get-commands)}))
+      (state/set-modal! #(command-palette {:commands (cp/get-commands)}) false false)
       (state/close-modal!))
     nil))

--- a/src/main/frontend/components/command_palette.css
+++ b/src/main/frontend/components/command_palette.css
@@ -1,0 +1,11 @@
+cp__command-palette {
+    &-input {
+    }
+
+    &-results {
+        @apply flex;
+    }
+    .chosen {
+        background: var(--ls-a-chosen-bg);
+    }
+}

--- a/src/main/frontend/components/command_palette.css
+++ b/src/main/frontend/components/command_palette.css
@@ -1,11 +1,14 @@
-cp__command-palette {
+.cp__command-palette {
+    &-main {
+    }
+
     &-input {
     }
 
     &-results {
-        @apply flex;
     }
-    .chosen {
-        background: var(--ls-a-chosen-bg);
-    }
+
+    /* .chosen { */
+    /*     background: var(--ls-a-chosen-bg); */
+    /* } */
 }

--- a/src/main/frontend/components/command_palette.css
+++ b/src/main/frontend/components/command_palette.css
@@ -2,6 +2,12 @@
   &-main {
     margin: -1rem;
 
+    width: 80vw;
+
+    @screen sm {
+      width: 760px;
+    }
+
     .menu-link {
       background-color: transparent;
       transition: none;

--- a/src/main/frontend/components/command_palette.css
+++ b/src/main/frontend/components/command_palette.css
@@ -1,14 +1,25 @@
 .cp__command-palette {
-    &-main {
+  &-main {
+    margin: -1rem;
+
+    .menu-link {
+      background-color: transparent;
+      transition: none;
+      border: none;
     }
 
-    &-input {
+    .chosen {
+      background-color: var(--ls-quaternary-background-color);
     }
+  }
 
-    &-results {
-    }
+  &-input {
+    padding: 16px;
+    font-size: 20px;
+    outline: none;
+    margin-bottom: 5px;
+  }
 
-    /* .chosen { */
-    /*     background: var(--ls-a-chosen-bg); */
-    /* } */
+  &-results {
+  }
 }

--- a/src/main/frontend/components/sidebar.cljs
+++ b/src/main/frontend/components/sidebar.cljs
@@ -8,6 +8,7 @@
             [frontend.components.settings :as settings]
             [frontend.components.theme :as theme]
             [frontend.components.widgets :as widgets]
+            [frontend.components.command-palette :as command-palette]
             [frontend.config :as config]
             [frontend.context.i18n :as i18n]
             [frontend.db :as db]
@@ -368,6 +369,7 @@
                          (ui/notification)
                          (ui/modal)
                          (settings-modal)
+                         (command-palette/command-palette-modal)
                          (custom-context-menu)
                          [:a#download.hidden]
                          (when

--- a/src/main/frontend/handler.cljs
+++ b/src/main/frontend/handler.cljs
@@ -14,6 +14,7 @@
             [frontend.handler.page :as page-handler]
             [frontend.handler.repo :as repo-handler]
             [frontend.handler.ui :as ui-handler]
+            [frontend.handler.command-palette :as command-palette]
             [frontend.idb :as idb]
             [frontend.modules.instrumentation.core :as instrument]
             [frontend.modules.shortcut.core :as shortcut]
@@ -173,7 +174,8 @@
 (defn- register-components-fns!
   []
   (state/set-page-blocks-cp! page/page-blocks-cp)
-  (state/set-editor-cp! editor/box))
+  (state/set-editor-cp! editor/box)
+  (command-palette/register-global-shortcut-commands))
 
 (defn start!
   [render]

--- a/src/main/frontend/handler/command_palette.cljs
+++ b/src/main/frontend/handler/command_palette.cljs
@@ -7,7 +7,9 @@
 
 (s/def :command/id keyword?)
 (s/def :command/desc string?)
-(s/def :command/action fn?)
+(s/def :command/action (and fn?
+                            ;; action fn expects zero number of arities
+                            (fn [action] (zero? (.-length action)))))
 (s/def :command/shortcut string?)
 
 (s/def :command/command
@@ -18,7 +20,11 @@
   (->> [:shortcut.handler/editor-global
         :shortcut.handler/global-prevent-default
         :shortcut.handler/global-non-editing-only]
-       (mapcat shortcut-helper/shortcuts->commands)))
+       (mapcat shortcut-helper/shortcuts->commands)
+       ;; some of the shortcut fn takes the shape of (fn [e] xx)
+       ;; instead of (fn [] xx)
+       ;; remove them for now
+       (remove (fn [{:keys [action]}] (not (zero? (.-length action)))))))
 
 (defn get-commands []
   (->> (get @state/state :command-palette/commands)

--- a/src/main/frontend/handler/command_palette.cljs
+++ b/src/main/frontend/handler/command_palette.cljs
@@ -1,0 +1,43 @@
+(ns frontend.handler.command-palette
+  (:require [cljs.spec.alpha :as s]
+            [frontend.modules.shortcut.data-helper :as shortcut-helper]
+            [frontend.spec :as spec]
+            [frontend.state :as state]
+            [lambdaisland.glogi :as log]))
+
+(s/def :command/id keyword?)
+(s/def :command/desc string?)
+(s/def :command/action fn?)
+(s/def :command/shortcut string?)
+
+(s/def :command/command
+  (s/keys :req-un [:command/id :command/desc :command/action]
+          :opt-un [:command/shortcut]))
+
+(defn global-shortcut-commands []
+  (->> [:shortcut.handler/editor-global
+        :shortcut.handler/global-prevent-default
+        :shortcut.handler/global-non-editing-only]
+       (mapcat shortcut-helper/shortcuts->commands)))
+
+(defn get-commands []
+  (get @state/state :command-palette/commands))
+
+(defn register [{:keys [id] :as command}]
+  (spec/validate :command/command command)
+  (let [cmds (get-commands)]
+    (if (some (fn [existing-cmd] (= (:id existing-cmd) id)) cmds)
+      (log/error :command/register {:msg "Failed to register command. Command with same id already exist"
+                                    :id  id})
+      (state/set-state! :command-palette/commands (conj cmds command)))))
+
+(defn register-global-shortcut-commands []
+  (let [cmds (global-shortcut-commands)]
+    (doseq [cmd cmds] (register cmd))))
+
+(comment
+  ;; register custom command example
+  (register
+   {:id :document/open-logseq-doc
+    :desc "Document: open Logseq documents"
+    :action (fn [] (js/window.open "https://logseq.github.io/"))}))

--- a/src/main/frontend/handler/command_palette.cljs
+++ b/src/main/frontend/handler/command_palette.cljs
@@ -21,7 +21,8 @@
        (mapcat shortcut-helper/shortcuts->commands)))
 
 (defn get-commands []
-  (get @state/state :command-palette/commands))
+  (->> (get @state/state :command-palette/commands)
+       (sort-by :id)))
 
 (defn register [{:keys [id] :as command}]
   (spec/validate :command/command command)

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -322,7 +322,12 @@
    ;; always overrides the copy due to "mod+c mod+s"
    {:misc/copy
     {:binding "mod+c"
-     :fn     (fn [] (js/document.execCommand "copy"))}}
+     :fn     (fn [] (js/document.execCommand "copy"))}
+
+    :command-palette/toggle
+    {:desc "Toggle command palette"
+     :binding "mod+shift+p"
+     :fn  (fn [] (state/toggle! :ui/command-palette-open?))}}
 
    :shortcut.handler/global-non-editing-only
    ^{:before m/enable-when-not-editing-mode!}

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -72,6 +72,7 @@
       :ui/file-component nil
       :ui/custom-query-components {}
       :ui/show-recent? false
+      :ui/command-palette-open? false
       :ui/developer-mode? (or (= (storage/get "developer-mode") "true")
                               false)
       ;; remember scroll positions of visited paths
@@ -155,6 +156,9 @@
       :copy/export-block-text-remove-options (or (storage/get :copy/export-block-text-remove-options)
                                                  #{})
       :date-picker/date nil
+
+      ;; command palette
+      :command-palette/commands []
 
       :view/components {}})))
 

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1065,12 +1065,13 @@
 
 (defn set-modal!
   ([modal-panel-content]
-   (set-modal! modal-panel-content false))
-  ([modal-panel-content fullscreen?]
+   (set-modal! modal-panel-content false true))
+  ([modal-panel-content fullscreen? close-btn?]
    (swap! state assoc
           :modal/show? (boolean modal-panel-content)
           :modal/panel-content modal-panel-content
-          :modal/fullscreen? fullscreen?)))
+          :modal/fullscreen? fullscreen?
+          :modal/close-btn? close-btn?)))
 
 (defn close-modal!
   []

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -447,7 +447,7 @@
   (panel-content close-fn))
 
 (rum/defc modal-panel
-  [show? panel-content transition-state close-fn fullscreen?]
+  [show? panel-content transition-state close-fn fullscreen? close-btn?]
   [:div.ui__modal-panel.transform.transition-all.sm:min-w-lg.sm
    {:class (case transition-state
              "entering" "ease-out duration-300 opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
@@ -455,17 +455,18 @@
              "exiting" "ease-in duration-200 opacity-100 translate-y-0 sm:scale-100"
              "exited" "ease-in duration-200 opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95")}
    [:div.absolute.top-0.right-0.pt-2.pr-2
-    [:a.ui__modal-close.opacity-60.hover:opacity-100
-     {:aria-label "Close"
-      :type       "button"
-      :on-click   close-fn}
-     [:svg.h-6.w-6
-      {:stroke "currentColor", :view-box "0 0 24 24", :fill "none"}
-      [:path
-       {:d               "M6 18L18 6M6 6l12 12"
-        :stroke-width    "2"
-        :stroke-linejoin "round"
-        :stroke-linecap  "round"}]]]]
+    (if close-btn?
+      [:a.ui__modal-close.opacity-60.hover:opacity-100
+       {:aria-label "Close"
+        :type       "button"
+        :on-click   close-fn}
+       [:svg.h-6.w-6
+        {:stroke "currentColor", :view-box "0 0 24 24", :fill "none"}
+        [:path
+         {:d               "M6 18L18 6M6 6l12 12"
+          :stroke-width    "2"
+          :stroke-linejoin "round"
+          :stroke-linecap  "round"}]]])]
 
    (when show?
      [:div {:class (if fullscreen? "" "panel-content")}
@@ -491,6 +492,7 @@
   []
   (let [modal-panel-content (state/sub :modal/panel-content)
         fullscreen? (state/sub :modal/fullscreen?)
+        close-btn? (state/sub :modal/close-btn?)
         show? (boolean modal-panel-content)
         close-fn (fn []
                    (state/close-modal!)
@@ -505,7 +507,7 @@
      (css-transition
       {:in show? :timeout 0}
       (fn [state]
-        (modal-panel show? modal-panel-content state close-fn fullscreen?)))]))
+        (modal-panel show? modal-panel-content state close-fn fullscreen? close-btn?)))]))
 
 (defn make-confirm-modal
   [{:keys [tag title sub-title sub-checkbox? on-cancel on-confirm]


### PR DESCRIPTION
`cmd+shift+p` to toggle.

Currently, all commands are taken from global scope shortcuts.

A command looks like:
{:id uniqte namespaced id
 :desc description
 :action (fn [] do...)
 :shortcut optional shortcut description}

Users can register custom commands by providing the above map.

Basic functionality is there. The UI may need a little tweak help from charlie. Eg, I'm not sure how to make the outside modal to a fixed width and height?

![2021-08-27 21 04 41](https://user-images.githubusercontent.com/9002575/131131826-872b9950-65d3-44a4-b0d9-5c4f403be081.gif)
