### PR TITLE
fix(timestamp): remove old SCHEDULED/DEADLINE timestamp

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1006,7 +1006,8 @@
     (when-let [block (db/pull [:block/uuid block-id])]
       (let [{:block/keys [content scheduled deadline format]} block
             content (or (state/get-edit-content) content)
-            new-content (text/add-timestamp content key value)]
+            new-content (-> (text/remove-timestamp content key)
+                            (text/add-timestamp key value))]
         (when (not= content new-content)
           (if-let [input-id (state/get-edit-input-id)]
             (state/set-edit-content! input-id new-content)

--- a/src/main/frontend/handler/repeated.cljs
+++ b/src/main/frontend/handler/repeated.cljs
@@ -96,12 +96,13 @@
         now (tl/local-now)
         start-time' (case kind
                       "Dotted"
-                      (if (t/after? start-time now)
-                        start-time
-                        (t/plus now delta))
+                      (repeat-until-future-timestamp start-time now delta week?)
 
                       "DoublePlus"
-                      (repeat-until-future-timestamp start-time now delta week?)
+                      (if (t/after? start-time now)
+                        start-time
+                        (t/plus start-time delta))
+
 
                       ;; "Plus"
                       (t/plus start-time delta))]

--- a/src/main/frontend/text.cljs
+++ b/src/main/frontend/text.cljs
@@ -240,3 +240,13 @@
                            new-line
                            (rest new-lines))))]
     (string/join "\n" new-lines)))
+
+(defn remove-timestamp
+  [content key]
+  (let [lines (string/split-lines content)
+        new-lines (filter (fn [line]
+                            (not (string/starts-with? (string/lower-case line) key)))
+                          lines)]
+    (println "new-lines" new-lines)
+    (string/join "\n" new-lines)))
+


### PR DESCRIPTION
When using `date-picker` to update the SCHEDULED/DEADLINE timestamp by clicking the existing one, logseq will add a new timestamp. This patch tries to remove the old timestamp before adding it.