### PR TITLE
Fixing typo  for the tooltip 'Block reference'

### DIFF
--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -205,7 +205,7 @@
                         [:editor/search-page]] "Create a backlink to a page"]
      ["Page Embed" (embed-page) "Embed a page here"]
      ["Block Reference" [[:editor/input "(())" {:backward-pos 2}]
-                         [:editor/search-block :reference]] "Create a backlink to a blcok"]
+                         [:editor/search-block :reference]] "Create a backlink to a block"]
      ["Block Embed" (embed-block) "Embed a block here" "Embed a block here"]
      ["Link" link-steps "Create a HTTP link"]
      ["Image Link" link-steps "Create a HTTP link to a image"]


### PR DESCRIPTION
This pull request is for fixing the typo error in the tool-tip for the 'Block reference' option. A screenshot of the issue is added below.

I have raised bug #2774  on this issue previously. Today, I got an opportunity to fix it. 

As this is a small fix. It would be great if this can be reviewed quickly so that this issue is resolved and deployed.

![image](https://user-images.githubusercontent.com/8463823/132154893-ed94dcb0-b8ca-4e9b-b368-634a58f7b726.png)
