### PR TITLE
Set aria-checked to "true" if toggle is on

### DIFF
--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -409,7 +409,7 @@
    [:a.ui__toggle {:on-click on-click
                    :class (if small? "is-small" "")}
     [:span.wrapper.transition-colors.ease-in-out.duration-200
-     {:aria-checked "false", :tab-index "0", :role "checkbox"
+     {:aria-checked (if on? "true" "false"), :tab-index "0", :role "checkbox"
       :class        (if on? "bg-indigo-600" "bg-gray-200")}
      [:span.switcher.transform.transition.ease-in-out.duration-200
       {:class       (if on? (if small? "translate-x-4" "translate-x-5") "translate-x-0")


### PR DESCRIPTION
## Description

Even if the switch/toggle was on, the `aria-checked` property stays "false". This PR fix this behavior.

![image](https://user-images.githubusercontent.com/8608517/133299763-acf1bf38-1751-43cf-ad5f-4dbd3aa90855.png)

![image](https://user-images.githubusercontent.com/8608517/133299904-87823b10-9eff-47eb-b685-439cecb45a27.png)
