### PR TITLE
Fix animated modals timing

### DIFF
--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -415,12 +415,10 @@
     (ui/css-transition
      {:key key
       :class-names {:enter "origin-top-left opacity-0 transform scale-95"
-                    :enter-done "origin-top-left transition opacity-100"
-                    :enter-active "origin-top-left transition"
-                    :exit "origin-top-left transition opacity-0 transform scale-95"
-                    :exit-active "origin-top-left transition"
-                    :exit-done "origin-top-left transition opacity-0 transform scale-95"}
-      :timeout 100}
+                    :enter-done "origin-top-left transition opacity-100 transform scale-100"
+                    :exit "origin-top-left transition opacity-0 transform scale-95"}
+      :timeout {:enter 0
+                :exit 150}}
      (fn [_]
        (absolute-modal
         component


### PR DESCRIPTION
The enter animation was delayed by 100ms (it was a bit annoying), while the exit timeout was
100ms: the css transition is 150ms and the exit timeout should be the
same.