### PR TITLE
Disable mock textarea (enable only when in developer-mode)

### DIFF
--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -500,7 +500,8 @@
        :auto-focus        false
        :class             (get-editor-heading-class content)})
 
-     (mock-textarea)
+     (when (state/sub [:ui/developer-mode?])
+      (mock-textarea))
      (modals id format)
 
      (when format


### PR DESCRIPTION
I've disabled mock-textarea for normal (non-developer) users, because it **destroys** typing performance, especially on blocks with lots of text.
That component does a lot of allocations and copying for each key press.
