### PR TITLE
Emit image links as image embeds rather than as html links

### DIFF
--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -37,6 +37,15 @@
                                        :id :label
                                        :placeholder "Label"}]]])
 
+(def image-link-steps [[:editor/input (str slash "link")]
+                       [:editor/show-input [{:command :image-link
+                                             :id :link
+                                             :placeholder "Link"
+                                             :autoFocus true}
+                                            {:command :image-link
+                                             :id :label
+                                             :placeholder "Label"}]]])
+
 (def zotero-steps [[:editor/input (str slash "zotero")]
                    [:editor/show-zotero]])
 
@@ -207,7 +216,7 @@
                          [:editor/search-block :reference]] "Create a backlink to a block"]
      ["Block embed" (embed-block) "Embed a block here" "Embed a block here"]
      ["Link" link-steps "Create a HTTP link"]
-     ["Image link" link-steps "Create a HTTP link to a image"]
+     ["Image link" image-link-steps "Create a HTTP link to a image"]
      (when (state/markdown?)
        ["Underline" [[:editor/input "<ins></ins>"
                       {:last-pattern slash

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1826,6 +1826,14 @@
       :org (util/format "[[%s][%s]]" link label)
       nil)))
 
+(defn- get-image-link
+  [format link label]
+  (let [link (or link "")
+        label (or label "")]
+    (case (keyword format)
+      :markdown (util/format "![%s](%s)" label link)
+      :org (util/format "[[%s]]"))))
+
 (defn handle-command-input
   [command id format m pos]
   (case command
@@ -1836,6 +1844,15 @@
         nil
         (insert-command! id
                          (get-link format link label)
+                         format
+                         {:last-pattern (str commands/slash "link")})))
+    :image-link
+    (let [{:keys [link label]} m]
+      (if (and (string/blank? link)
+               (string/blank? label))
+        nil
+        (insert-command! id
+                         (get-image-link format link label)
                          format
                          {:last-pattern (str commands/slash "link")})))
     nil)


### PR DESCRIPTION
Hello!

Currently the "Image link" slash command emits a markdown HTML link rather than embedding an image.

This patch changes the Image link command emitting a markdown link for an embedded image rather than a link to an image.
