### PR TITLE
Feat: Multi-functional Enter/Tab key

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2252,26 +2252,8 @@
                         (db/entity [:block/name (string/lower-case id)]))]
       (= (:block/uuid entity) (tree/-get-parent-id current-node)))))
 
-(defn- keydown-new-block
-  [state]
-  (when-not (auto-complete?)
-    (let [{:keys [block config]} (get-state)]
-      (when block
-        (let [content (state/get-edit-content)
-              current-node (outliner-core/block block)
-              has-right? (-> (tree/-get-right current-node)
-                             (tree/satisfied-inode?))]
-          (if (and
-               (string/blank? content)
-               (not has-right?)
-               (not (last-top-level-child? config current-node)))
-            (outdent-on-enter current-node)
-            (profile
-             "Insert block"
-             (insert-new-block! state))))))))
-
-(defn- keydown-new-line
-  []
+(defn- keydown-insert
+  [insertion]
   (when-not (auto-complete?)
     (let [^js input (state/get-input)
           selected-start (gobj/get input "selectionStart")
@@ -2280,8 +2262,70 @@
           s1 (subs value 0 selected-start)
           s2 (subs value selected-end)]
       (state/set-edit-content! (state/get-edit-input-id)
-                               (str s1 "\n" s2))
-      (cursor/move-cursor-to input (inc selected-start)))))
+                               (str s1 insertion s2))
+      (cursor/move-cursor-to input (+ selected-start (count insertion))))))
+
+(defn- keydown-new-line []
+  (keydown-insert "\n"))
+
+(defn- keydown-new-block
+  [state]
+  (when-not (auto-complete?)
+    (let [{:keys [block config]} (get-state)]
+      (when block
+        (let [input (state/get-input)
+              content (gobj/get input "value")
+              pos (cursor/pos input)
+              current-node (outliner-core/block block)
+              has-right? (-> (tree/-get-right current-node)
+                             (tree/satisfied-inode?))]
+          
+          (cond
+            ;; empty block
+            (and
+             (string/blank? content)
+             (not has-right?)
+             (not (last-top-level-child? config current-node)))
+            (outdent-on-enter current-node)
+
+            ;; cursor in block ref
+            (thingatpt/block-ref-at-point content pos)
+            (open-block-in-sidebar! 
+             (uuid (:raw-content (thingatpt/block-ref-at-point content pos))))
+
+            ;; cursor in page ref
+            (thingatpt/page-ref-at-point content pos)
+            (route-handler/redirect!
+             {:to :page
+              :path-params {:name (:raw-content (thingatpt/page-ref-at-point content pos))}})
+
+            ;; cursor in properties drawer
+            (thingatpt/properties-at-point content pos)
+            (if-let [pro-key (thingatpt/thing-at-point {:left ":" :right ":"} content pos "\n")]
+              (case (:raw-content pro-key)
+                "PROPERTIES"
+                ;;When cursor in "PROPERTIES", add :|: in a new line and move cursor to | 
+                (do
+                  (cursor/move-cursor-to input (text/goto-end-of-line content pos))
+                  (keydown-insert "\n:: ")
+                  (cursor/move-cursor-backward input 2))
+                "END"
+                ;; When cursor in "END", new block (respect the previous enter behavior)
+                (do
+                  (cursor/move-cursor-to-end input)
+                  (insert-new-block! state))
+                ;; cursor in other positions of :ke|y:, move to line end for inserting value.
+                (cursor/move-cursor-to input (text/goto-end-of-line content pos)))
+              
+              ;;When cursor in other place of PROPERTIES drawer, add :|: in a new line and move cursor to | 
+              (do
+                (keydown-insert "\n:: ")
+                (cursor/move-cursor-backward input 2)))
+            
+            :else
+            (profile
+             "Insert block"
+             (insert-new-block! state))))))))
 
 (defn keydown-new-block-handler [state e]
   (if (state/doc-mode-enter-for-new-line?)

--- a/src/main/frontend/util/thingatpt.cljs
+++ b/src/main/frontend/util/thingatpt.cljs
@@ -1,34 +1,52 @@
 (ns frontend.util.thingatpt
   (:require [clojure.string :as string]
             [frontend.state :as state]
+            [frontend.util.property :as property-util]
             [frontend.util.cursor :as cursor]
+            [frontend.handler.route :as handler-route]
             [goog.object :as gobj]))
 
 (defn- get-content&pos-at-point []
   (when-let [input (state/get-input)]
     [(gobj/get input "value") (cursor/pos input)]))
 
-
-(defn block-ref-at-point []
-  (when-let [[content pos] (get-content&pos-at-point)]
-    (let [start (string/last-index-of content "((" pos)
-          end (string/index-of content "))" (- pos 2))
-          end* (+ 2 end)]
+(defn thing-at-point
+  [{:keys [left right] :as bounds} & [content pos ignore]]
+  (when-let [[content pos] (if (and content pos)
+                             [content pos]
+                             (get-content&pos-at-point))]
+    (let [start (string/last-index-of
+                 content left (if (= left right) (- pos (count left)) (dec pos)))
+          end (string/index-of
+               content right (if (= left right) pos (inc (- pos (count right)))))
+          end* (+ (count right) end)]
       (when (and start end)
-        (let [block-ref-id (subs content (+ start 2) end)]
-          (when (every? false? (mapv #(string/includes? block-ref-id %) ["((" "))" " "]))
-            {:content (subs content start end*)
+        (let [thing (subs content (+ start (count left)) end)]
+          (when (every?
+                 false?
+                 (mapv #(string/includes? thing %)
+                       [left right ignore]))
+            {:full-content (subs content start end*)
+             :raw-content (subs content (+ start (count left)) end)
              :start start
              :end end*}))))))
 
-(defn embed-macro-at-point []
-  (when-let [[content pos] (get-content&pos-at-point)]
-    (let [start (string/last-index-of content "{{embed" pos)
-          end (string/index-of content "}}" (- pos 2))
-          end* (+ 2 end)]
-      (when (and start end)
-        (let [macro-content (subs content (+ start 2) end)]
-          (when (every? false? (mapv #(string/includes? macro-content %) ["{{embed" "}}"]))
-            {:content (subs content start end*)
-             :start start
-             :end end*}))))))
+(defn block-ref-at-point [& [content pos]]
+  (thing-at-point {:left "((" :right "))"} content pos " "))
+
+(defn page-ref-at-point [& [content pos]]
+  (thing-at-point {:left "[[" :right "]]"} content pos " "))
+
+(defn embed-macro-at-point [& [content pos]]
+  (thing-at-point {:left "{{embed" :right "}}"} content pos " "))
+
+(defn properties-at-point [& [content pos]]
+  (case (state/get-preferred-format)
+    :org (thing-at-point
+          {:left property-util/properties-start
+           :right property-util/properties-end}
+          content
+          pos)
+    nil))
+
+


### PR DESCRIPTION
DWIM (do what I mean) for Enter/Tab key when editing.
Context-awareness of Enter/Tab key makes editing more easily.

Move cursor to the following element when editing, press `Enter` or `Tab`. More elements will be supported. 
### 1.Enter key
- [X] open page ref 
  - [X] plain `[[logseq]]` page ref
  - [ ] org styled `[[file:./pages/logseq.org][logseq]]` page ref  
- [X] open embedded block in sidebar
- [X] insert properties more quickly. One single enter key is pretty enough.

### 2.Tab key