### PR TITLE
Consolidate shortcut docs

### DIFF
--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -1119,6 +1119,10 @@ a.tooltip-priority {
   border-color: var(--ls-primary-text-color);
 }
 
+#help-latex .katex-html {
+  text-align: right;
+}
+
 a.page-op {
     svg {
         transform: scale(0.9);

--- a/src/main/frontend/components/onboarding.cljs
+++ b/src/main/frontend/components/onboarding.cljs
@@ -177,39 +177,46 @@
                 "https://asset.logseq.com/static/img/credits.png")
               :style {:margin "12px 0 0 0"}}]]]]))
 
-(defn links [t]
-  (let [discord-with-icon [:div.flex-row.inline-flex.items-center
-                           [:span.mr-1 (t :help/community)]
-                           svg/discord]
-        list
-        [[(t :help/start) "https://logseq.github.io/#/page/getting%20started"]
-         [(t :help/about) "https://logseq.com/blog/about"]
-         [(t :help/roadmap) "https://trello.com/b/8txSM12G/roadmap"]
-         [(t :help/bug) "https://github.com/logseq/logseq/issues/new?assignees=&labels=&template=bug_report.md&title="]
-         [(t :help/feature) "https://github.com/logseq/logseq/issues/new?assignees=&labels=&template=feature_request.md&title="]
-         [(t :help/changelog) "https://logseq.github.io/#/page/changelog"]
-         ["FAQ" "https://logseq.github.io/#/page/faq"]
-         [(t :help/docs) "https://logseq.github.io/"]
-         [(t :help/privacy) "https://logseq.com/blog/privacy-policy"]
-         [(t :help/terms) "https://logseq.com/blog/terms"]
-         [(t :help/awesome-logseq) "https://github.com/logseq/awesome-logseq"]
-         [discord-with-icon "https://discord.gg/KpN4eHY"]]]
-    (map (fn [[title href]]
-           [:li [:a {:href href :target "_blank"} title]]) list)))
-
 (defn help
   []
   (rum/with-context [[t] i18n/*tongue-context*]
     [:div.help.cp__sidebar-help-docs
-     [:ul
-      (links t)
-      [:li
-       (t :help/shortcuts)
-       (ui/button
-        "Customize"
-        :class "text-sm p-1 ml-3"
-        :on-click
-        (fn []
-          (route-handler/redirect! {:to :shortcut-setting})))]
+     (let [discord-with-icon [:div.flex-row.inline-flex.items-center
+                              [:span.mr-1 (t :help/community)]
+                              svg/discord]
+           list
+           [{:title "About"
+             :children [[(t :help/start) "https://logseq.github.io/#/page/getting%20started"]
+                        [(t :help/about) "https://logseq.com/blog/about"]]}
 
-      ]]))
+            {:title "Documentation"
+             :children [["FAQ" "https://logseq.github.io/#/page/faq"]
+                        [(t :help/docs) "https://logseq.github.io/"]
+                        [[:a
+                          {:on-click (fn [] (route-handler/redirect! {:to :shortcut-setting}))}
+                          (t :help/shortcuts)]]]}
+
+            {:title "Development"
+             :children [[(t :help/roadmap) "https://trello.com/b/8txSM12G/roadmap"]
+                        [(t :help/bug) "https://github.com/logseq/logseq/issues/new?assignees=&labels=&template=bug_report.md&title="]
+                        [(t :help/feature) "https://github.com/logseq/logseq/issues/new?assignees=&labels=&template=feature_request.md&title="]
+                        [(t :help/changelog) "https://logseq.github.io/#/page/changelog"]]}
+
+            {:title "Terms"
+             :children [[(t :help/privacy) "https://logseq.com/blog/privacy-policy"]
+                        [(t :help/terms) "https://logseq.com/blog/terms"]]}
+
+            {:title "Community"
+             :children [[(t :help/awesome-logseq) "https://github.com/logseq/awesome-logseq"]
+                        [discord-with-icon "https://discord.gg/KpN4eHY"]]}]]
+
+       (map (fn [sublist]
+              [[:p.mt-4.mb-1 [:b (:title sublist)]]
+              [:ul
+               (map (fn [[title href]]
+                      [:li
+                       (if href
+                         [:a {:href href :target "_blank"} title]
+                         title)])
+                    (:children sublist))]])
+            list))]))

--- a/src/main/frontend/components/onboarding.cljs
+++ b/src/main/frontend/components/onboarding.cljs
@@ -185,16 +185,18 @@
                               [:span.mr-1 (t :help/community)]
                               svg/discord]
            list
-           [{:title "About"
-             :children [[(t :help/start) "https://logseq.github.io/#/page/getting%20started"]
-                        [(t :help/about) "https://logseq.com/blog/about"]]}
-
-            {:title "Documentation"
+           [{:title "Usage"
              :children [[[:a
                           {:on-click (fn [] (route-handler/redirect! {:to :shortcut-setting}))}
-                          (t :help/shortcuts)]]
+                          [:div.flex-row.inline-flex.items-center
+                           [:span.mr-1 (t :help/shortcuts)]
+                           (svg/icon-cmd 18)]]]
                         [(t :help/docs) "https://logseq.github.io/"]
                         ["FAQ" "https://logseq.github.io/#/page/faq"]]}
+
+            {:title "About"
+             :children [[(t :help/start) "https://logseq.github.io/#/page/getting%20started"]
+                        [(t :help/about) "https://logseq.com/blog/about"]]}
 
             {:title "Development"
              :children [[(t :help/roadmap) "https://trello.com/b/8txSM12G/roadmap"]

--- a/src/main/frontend/components/onboarding.cljs
+++ b/src/main/frontend/components/onboarding.cljs
@@ -190,11 +190,11 @@
                         [(t :help/about) "https://logseq.com/blog/about"]]}
 
             {:title "Documentation"
-             :children [["FAQ" "https://logseq.github.io/#/page/faq"]
-                        [(t :help/docs) "https://logseq.github.io/"]
-                        [[:a
+             :children [[[:a
                           {:on-click (fn [] (route-handler/redirect! {:to :shortcut-setting}))}
-                          (t :help/shortcuts)]]]}
+                          (t :help/shortcuts)]]
+                        [(t :help/docs) "https://logseq.github.io/"]
+                        ["FAQ" "https://logseq.github.io/#/page/faq"]]}
 
             {:title "Development"
              :children [[(t :help/roadmap) "https://trello.com/b/8txSM12G/roadmap"]

--- a/src/main/frontend/components/onboarding.cljs
+++ b/src/main/frontend/components/onboarding.cljs
@@ -3,7 +3,6 @@
             [frontend.components.svg :as svg]
             [frontend.context.i18n :as i18n]
             [frontend.handler.route :as route-handler]
-            [frontend.ui :as ui]
             [frontend.util :as util]
             [rum.core :as rum]
             [frontend.config :as config]))

--- a/src/main/frontend/components/onboarding.cljs
+++ b/src/main/frontend/components/onboarding.cljs
@@ -2,8 +2,6 @@
   (:require [frontend.components.shortcut :as shortcut]
             [frontend.components.svg :as svg]
             [frontend.context.i18n :as i18n]
-            [frontend.extensions.highlight :as highlight]
-            [frontend.extensions.latex :as latex]
             [frontend.handler.route :as route-handler]
             [frontend.ui :as ui]
             [frontend.util :as util]
@@ -212,78 +210,6 @@
         :class "text-sm p-1 ml-3"
         :on-click
         (fn []
-          (route-handler/redirect! {:to :shortcut-setting})))
-       (shortcut/trigger-table)
-       (shortcut/shortcut-table :shortcut.category/basics)
-       (shortcut/shortcut-table :shortcut.category/block-editing)
-       (shortcut/shortcut-table :shortcut.category/formatting)]
+          (route-handler/redirect! {:to :shortcut-setting})))]
 
-      [:li
-       (t :help/markdown-syntax)
-       [:table
-        [:tbody
-         (let [list [[(str "**" (t :bold) "**")
-                      [:b (t :bold)]]
-
-                     [(str "_" (t :italics) "_")
-                      [:i (t :italics)]]
-
-                     [(str "~~" (t :strikethrough) "~~")
-                      [:del (t :strikethrough)]]
-
-                     [(str "^^" (t :highlight) "^^")
-                      [:mark (t :highlight)]]
-
-                     ["$$E = mc^2$$"
-                      (latex/latex "help-latex" "E = mc^2" true false)]
-
-                     [(str "`" (t :code) "`")
-                      [:code (t :code)]]
-
-                     ["```clojure\n  (println \"Hello world!\")\n```"
-                      (highlight/highlight "help-highlight" {:data-lang "clojure"} "(println \"Hello world!\")")]
-
-                     ["[label](https://www.example.com)"
-                      [:a {:href "https://www.example.com" :target "_blank"} "label"]]
-
-                     ["![image](https://asset.logseq.com/static/img/logo.png)"
-                      [:img {:style {:float "right" :width 32 :height 32}
-                             :src "https://asset.logseq.com/static/img/logo.png"
-                             :alt "image"}]]]]
-
-           (map (fn [[trigger shortcut]] [:tr [:td [:pre trigger]] [:td.text-right shortcut]]) list))]]]
-
-      [:li
-       (t :help/org-mode-syntax)
-       [:table
-        [:tbody
-         (let [list [[(str "*" (t :bold) "*")
-                      [:b (t :bold)]]
-
-                     [(str "/" (t :italics) "/")
-                      [:i (t :italics)]]
-
-                     [(str "+" (t :strikethrough) "+") [:del (t :strikethrough)]]
-
-
-                     [(str "^^" (t :highlight) "^^")
-                      [:mark (t :highlight)]]
-
-                     ["$$E = mc^2$$"
-                      (latex/latex "help-latex" "E = mc^2" true false)]
-
-                     ["~Code~"
-                      [:code (t :code)]]
-
-                     [[:pre "#+BEGIN_SRC clojure\n  (println \"Hello world!\")\n#+END_SRC"]
-                      (highlight/highlight "help-highlight-org" {:data-lang "clojure"} "(println \"hello world\")")]
-
-                     ["[[https://www.example.com][label]]"
-                      [:a {:href "https://www.example.com"} "label"]]
-
-                     ["[[https://asset.logseq.com/static/img/logo.png][image]]"
-                      [:img {:style {:float "right" :width 32 :height 32}
-                             :src "https://asset.logseq.com/static/img/logo.png"
-                             :alt "image"}]]]]
-
-           (map (fn [[trigger shortcut]] [:tr [:td [:pre trigger]] [:td.text-right shortcut]]) list))]]]]]))
+      ]]))

--- a/src/main/frontend/components/shortcut.cljs
+++ b/src/main/frontend/components/shortcut.cljs
@@ -82,16 +82,16 @@
      [:tbody
       [:tr
        [:td.text-left (t :help/slash-autocomplete)]
-       [:td.text-right "/"]]
+       [:td.text-right [:code "/"]]]
       [:tr
        [:td.text-left (t :help/block-content-autocomplete)]
-       [:td.text-right "<"]]
+       [:td.text-right [:code "<"]]]
       [:tr
        [:td.text-left (t :help/reference-autocomplete)]
-       [:td.text-right "[[]]"]]
+       [:td.text-right [:code "[[]]"]]]
       [:tr
        [:td.text-left (t :help/block-reference)]
-       [:td.text-right "(())"]]
+       [:td.text-right [:code "(())"]]]
       [:tr
        [:td.text-left (t :command.editor/open-link-in-sidebar)]
        [:td.text-right "shift-click"]]

--- a/src/main/frontend/components/shortcut.cljs
+++ b/src/main/frontend/components/shortcut.cljs
@@ -5,12 +5,14 @@
             [frontend.modules.shortcut.data-helper :as dh]
             [frontend.state :as state]
             [frontend.ui :as ui]
+            [frontend.extensions.latex :as latex]
+            [frontend.extensions.highlight :as highlight]
             [rum.core :as rum]))
 
 (rum/defcs customize-shortcut-dialog-inner <
   (rum/local "")
   (shortcut/record!)
-  [state _ action-name current-binding]
+  [state k action-name current-binding]
   (let [keypress (:rum/local state)
         keyboard-shortcut (if (= "" @keypress) current-binding @keypress)]
     [:div
@@ -19,12 +21,22 @@
       [:p.mb-4.mt-4
        (ui/keyboard-shortcut (-> keyboard-shortcut
                                  (str/trim)
-                                 (str/split  #" |\+")))]]
+                                 (str/lower-case)
+                                 (str/split  #" |\+")))
+       " "
+       [:a.text-sm
+        {:style {:margin-left "12px"}
+         :on-click (fn []
+                     (dh/remove-shortcut k)
+                     (shortcut/refresh!)
+                     (swap! keypress (fn [] "")) ;; Clear local state
+                     )}
+        "Reset"]]]
      [:div.cancel-save-buttons.text-right.mt-4
       (ui/button "Save" :on-click state/close-modal!)
       [:a.ml-4
        {:on-click (fn []
-                    (reset! keypress current-binding)
+                    (reset! keypress (dh/binding-for-storage current-binding))
                     (state/close-modal!))} "Cancel"]]]))
 
 (defn customize-shortcut-dialog [k action-name displayed-binding]
@@ -33,22 +45,21 @@
 
 (rum/defc shortcut-col [k binding configurable? action-name]
   (let [conflict?         (dh/potential-confilct? k)
-        displayed-binding (dh/binding-for-display k binding)]
+        displayed-binding (dh/binding-for-display k binding)
+        disabled?         (clojure.string/includes? displayed-binding "system default")]
     (if (not configurable?)
       [:td.text-right displayed-binding]
       [:td.text-right
        (ui/button
         displayed-binding
         :class "text-sm p-1"
+        :style {:cursor (if disabled? "not-allowed" "pointer")}
         :title (if conflict?
                  "Shortcut conflict!"
-                 "Click to modify")
-        :background (when conflict? "pink")
-        :on-click #(state/set-modal! (customize-shortcut-dialog k action-name displayed-binding)))
-       [:a.text-sm
-        {:style {:margin-left "12px"}
-         :on-click (fn [] (dh/remove-shortcut k) (shortcut/refresh!))}
-        "Reset"]])))
+                 (if disabled? "Cannot override system default" "Click to modify"))
+        :background (if conflict? "pink" (when disabled? "gray"))
+        :on-click (if-not disabled?
+                    #(state/set-modal! (customize-shortcut-dialog k action-name displayed-binding))))])))
 
 (rum/defc shortcut-table < rum/reactive
   ([name]
@@ -94,16 +105,76 @@
        [:td.text-right [:code "(())"]]]
       [:tr
        [:td.text-left (t :command.editor/open-link-in-sidebar)]
-       [:td.text-right "shift-click"]]
+       [:td.text-right (ui/keyboard-shortcut ["shift" "click"])]]
       [:tr
        [:td.text-left (t :help/context-menu)]
-       [:td.text-right "right click"]]]]))
+       [:td.text-right (ui/keyboard-shortcut ["right click"])]]]]))
+
+(defn markdown-and-orgmode-syntax []
+  (rum/with-context [[t] i18n/*tongue-context*]
+    (let [list [:bold :italics :del :mark :latex :code :link :pre :img]
+
+          preferred-format (state/get-preferred-format) ; markdown/org
+
+          title (case preferred-format
+                  :markdown (t :help/markdown-syntax)
+                  :org (t :help/org-mode-syntax))
+
+          learn-more (case preferred-format
+                       :markdown "https://www.markdownguide.org/basic-syntax"
+                       :org "https://orgmode.org/worg/dev/org-syntax.html")
+
+          raw (case preferred-format
+                :markdown {:bold (str "**" (t :bold) "**")
+                           :italics (str "_" (t :italics) "_")
+                           :link "[Link](https://www.example.com)"
+                           :del (str "~~" (t :strikethrough) "~~")
+                           :mark (str "^^" (t :highlight) "^^")
+                           :latex "$$E = mc^2$$"
+                           :code (str "`" (t :code) "`")
+                           :pre "```clojure\n  (println \"Hello world!\")\n```"
+                           :img "![image](https://asset.logseq.com/static/img/logo.png)"}
+                :org {:bold (str "*" (t :bold) "*")
+                      :italic (str "/" (t :italics) "/")
+                      :del (str "+" (t :strikethrough) "+")
+                      :pre [:pre "#+BEGIN_SRC clojure\n  (println \"Hello world!\")\n#+END_SRC"]
+                      :link "[[https://www.example.com][Link]]"
+                      :mark (str "^^" (t :highlight) "^^")
+                      :latex "$$E = mc^2$$"
+                      :code "~Code~"
+                      :img "[[https://asset.logseq.com/static/img/logo.png][image]]"})
+
+          rendered {:italics [:i (t :italics)]
+                    :bold [:b (t :bold)]
+                    :link [:a {:href "https://www.example.com"} "Link"]
+                    :del [:del (t :strikethrough)]
+                    :mark [:mark (t :highlight)]
+                    :latex (latex/latex "help-latex" "E = mc^2" true false)
+                    :code [:code (t :code)]
+                    :pre (highlight/highlight "help-highlight" {:data-lang "clojure"} "(println \"Hello world!\")")
+                    :img [:img {:style {:float "right" :width 32 :height 32}
+                                :src "https://asset.logseq.com/static/img/logo.png"
+                                :alt "image"}]}]
+
+      [:table
+       [:thead
+        [:tr
+         [:th.text-left [:b title]]
+         [:th.text-right [:a {:href learn-more} "Learn more →"]]]]
+       [:tbody
+        (map (fn [name]
+               [:tr
+                [:td.text-left [(if (= :pre name) :pre :code) (get raw name)]]
+                [:td.text-right (get rendered name)]])
+             list)]])))
 
 (rum/defc shortcut
   []
   (rum/with-context [[t] i18n/*tongue-context*]
     [:div
      [:h1.title (t :help/shortcut-page-title)]
+     (trigger-table)
+     (markdown-and-orgmode-syntax)
      (shortcut-table :shortcut.category/basics true)
      (shortcut-table :shortcut.category/navigating true)
      (shortcut-table :shortcut.category/block-editing true)

--- a/src/main/frontend/dicts.cljs
+++ b/src/main/frontend/dicts.cljs
@@ -82,7 +82,7 @@
         :more "More"
         :search/result-for "Search result for "
         :search/items "items"
-        :help/context-menu "Context menu"
+        :help/context-menu "Block context menu"
         :help/fold-unfold "Fold/unfold blocks (when not in edit mode)"
         :help/markdown-syntax "Markdown syntax"
         :help/org-mode-syntax "Org mode syntax"

--- a/src/main/frontend/dicts.cljs
+++ b/src/main/frontend/dicts.cljs
@@ -70,7 +70,7 @@
         :help/shortcuts-triggers "Triggers"
         :help/shortcut "Shortcut"
         :help/slash-autocomplete "Slash autocomplete"
-        :help/block-content-autocomplete "Block content (Src, Quote, Query, etc) Autocomplete"
+        :help/block-content-autocomplete "Block content autocomplete"
         :help/reference-autocomplete "Page reference autocomplete"
         :help/block-reference "Block reference"
         :help/key-commands "Key commands"

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -344,6 +344,10 @@
     {:desc    "Go to home"
      :binding "g h"
      :fn      #(route-handler/redirect! {:to :home})}
+    :go/keyboard-shortcuts
+    {:desc    "Go to keyboard shortcuts"
+     :binding "g s"
+     :fn      #(route-handler/redirect! {:to :shortcut-setting})}
     :ui/toggle-document-mode
     {:desc    "Toggle document mode"
      :binding "t d"

--- a/src/main/frontend/modules/shortcut/data_helper.cljs
+++ b/src/main/frontend/modules/shortcut/data_helper.cljs
@@ -111,10 +111,10 @@
   (let [tmp (cond
               (false? binding)
               (cond
-                (and util/mac? (= k :editor/kill-line-after))    "disabled (system default: ctrl+k)"
-                (and util/mac? (= k :editor/beginning-of-block)) "disabled (system default: ctrl+a)"
-                (and util/mac? (= k :editor/end-of-block))       "disabled (system default: ctrl+e)"
-                (and util/mac? (= k :editor/backward-kill-word)) "disabled (system default: opt+delete)"
+                (and util/mac? (= k :editor/kill-line-after))    "system default: ctrl+k"
+                (and util/mac? (= k :editor/beginning-of-block)) "system default: ctrl+a"
+                (and util/mac? (= k :editor/end-of-block))       "system default: ctrl+e"
+                (and util/mac? (= k :editor/backward-kill-word)) "system default: opt+delete"
                 :else "disabled")
 
               (string? binding)
@@ -129,6 +129,9 @@
     ;; mod key, because that's what the Mac keyboards actually say.
     (str/replace tmp "meta" "cmd")))
 
+;; Given the displayed binding, prepare it to be put back into config.edn
+(defn binding-for-storage [binding]
+  (str/replace binding "cmd" "meta"))
 
 (defn remove-shortcut [k]
   (let [repo (state/get-current-repo)

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -70,7 +70,7 @@
        :as   opts}]]
   (let [{:keys [open? toggle-fn]} state
         modal-content (modal-content-fn state)]
-    [:div.ml-1.relative {:style {:z-index z-index}}
+    [:div.relative {:style {:z-index z-index}}
      (content-fn state)
      (css-transition
       {:in @open? :timeout 0}


### PR DESCRIPTION
This PR polishes the user experience of viewing and customizing keyboard shortcuts. In particular, the documentation for keyboard shortcuts and Markdown/Org Mode was duplicated across the sidebar and the Keyboard Shortcuts page, which was a confusing user experience. This PR...:
- consolidates that documentation into the Keyboard Shortcuts page and removes them from the sidebar. (It is reachable from the sidebar from the Keyboard Shortcuts link.)
- organizes the Help links into categories, to make them easier to find.
- adds the new hotkey <kbd>g</kbd><kbd>s</kbd> to go to keyboard shortcuts, which is also available from the command palette.
- adds a small button to the header to go to the keyboard shortcuts page. (This may not be important to warrant usage of that prime real estate; very open to pushback on this decision!)

**Before:**

![image](https://user-images.githubusercontent.com/6979755/135358730-5a3a2767-12d9-4cd7-aec7-e717239d6229.png)


**After:**

![image](https://user-images.githubusercontent.com/6979755/135362562-b4d0f733-e1a9-4bd3-b33f-6fd018370906.png)