### PR TITLE
fix: plugin api moveBlock not working

### DIFF
--- a/src/main/frontend/handler/dnd.cljs
+++ b/src/main/frontend/handler/dnd.cljs
@@ -35,7 +35,7 @@
   [^js event current-block target-block move-to]
   (let [top? (= move-to :top)
         nested? (= move-to :nested)
-        alt-key? (.-altKey event)
+        alt-key? (and event (.-altKey event))
         repo (state/get-current-repo)]
     (cond
       alt-key?


### PR DESCRIPTION
fix `Cannot read property 'altKey' of null`
![image](https://user-images.githubusercontent.com/13582742/135578344-573a44e2-bae9-4360-8957-18b18f9418b6.png)
