### PR TITLE
enhance: pretty print pages-metadata.edn

### DIFF
--- a/src/main/frontend/handler/metadata.cljs
+++ b/src/main/frontend/handler/metadata.cljs
@@ -1,5 +1,6 @@
 (ns frontend.handler.metadata
   (:require [cljs.reader :as reader]
+            [cljs.pprint]
             [clojure.string :as string]
             [datascript.db :as ddb]
             [frontend.config :as config]
@@ -47,7 +48,7 @@
                        (vec))]
     (p/let [_ (-> (file-handler/create-pages-metadata-file repo)
                   (p/catch (fn [] nil)))]
-      (let [new-content (pr-str all-pages)]
+      (let [new-content (with-out-str (cljs.pprint/pprint all-pages))]
         (fs/write-file! repo
                         (config/get-repo-dir repo)
                         path


### PR DESCRIPTION
This change allows for smaller git diffs of the versioned
pages-metadata.edn. Instead of one large line, the diff contains only
the actual changes.

## Before

![image](https://user-images.githubusercontent.com/78416057/135710146-c149456e-b351-4799-b746-f036983fe0f4.png)

## After

![image](https://user-images.githubusercontent.com/78416057/135710170-e5db8fd6-b202-4bd1-b641-7971232f9374.png)

## Feature request on discord

[Format pages-metadata.edn before saving - Feature Requests - Logseq](https://discuss.logseq.com/t/format-pages-metadata-edn-before-saving/2506/3)