### PR TITLE
enhance: custom editor command trigger

### DIFF
--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -23,7 +23,7 @@
 
 (defonce *show-commands (atom false))
 (defonce *slash-caret-pos (atom nil))
-(defonce command-menu-trigger "/")
+(defonce command-menu-trigger "\\")
 (defonce *show-block-commands (atom false))
 (defonce angle-bracket "<")
 (defonce *angle-bracket-caret-pos (atom nil))
@@ -238,7 +238,7 @@
        ["Underline" [[:editor/input "<ins></ins>"
                       {:last-pattern command-menu-trigger
                        :backward-pos 6}]] "Create a underline text decoration"])
-     ["Template" [[:editor/input "/" nil]
+     ["Template" [[:editor/input command-menu-trigger nil]
                   [:editor/search-template]] "Insert a created template here"]
      (cond
        (and (util/electron?) (config/local-db? (state/get-current-repo)))

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -23,7 +23,6 @@
 
 (defonce *show-commands (atom false))
 (defonce *slash-caret-pos (atom nil))
-(defonce command-menu-trigger "\\")
 (defonce *show-block-commands (atom false))
 (defonce angle-bracket "<")
 (defonce *angle-bracket-caret-pos (atom nil))
@@ -48,26 +47,29 @@
      "Queries documentation"]
     "."]])
 
-(def link-steps [[:editor/input (str command-menu-trigger "link")]
-                 [:editor/show-input [{:command :link
-                                       :id :link
-                                       :placeholder "Link"
-                                       :autoFocus true}
-                                      {:command :link
-                                       :id :label
-                                       :placeholder "Label"}]]])
+(defn link-steps []
+  [[:editor/input (str (state/get-editor-command-trigger) "link")]
+   [:editor/show-input [{:command :link
+                         :id :link
+                         :placeholder "Link"
+                         :autoFocus true}
+                        {:command :link
+                         :id :label
+                         :placeholder "Label"}]]])
 
-(def image-link-steps [[:editor/input (str command-menu-trigger "link")]
-                       [:editor/show-input [{:command :image-link
-                                             :id :link
-                                             :placeholder "Link"
-                                             :autoFocus true}
-                                            {:command :image-link
-                                             :id :label
-                                             :placeholder "Label"}]]])
+(defn image-link-steps []
+  [[:editor/input (str (state/get-editor-command-trigger) "link")]
+   [:editor/show-input [{:command :image-link
+                         :id :link
+                         :placeholder "Link"
+                         :autoFocus true}
+                        {:command :image-link
+                         :id :label
+                         :placeholder "Label"}]]])
 
-(def zotero-steps [[:editor/input (str command-menu-trigger "zotero")]
-                   [:editor/show-zotero]])
+(defn zotero-steps []
+  [[:editor/input (str (state/get-editor-command-trigger) "zotero")]
+   [:editor/show-zotero]])
 
 (def *extend-slash-commands (atom []))
 
@@ -90,19 +92,19 @@
   [type]
   (let [template (util/format "@@%s: @@"
                               type)]
-    [[:editor/input template {:last-pattern command-menu-trigger
+    [[:editor/input template {:last-pattern (state/get-editor-command-trigger)
                               :backward-pos 2}]]))
 
 (defn embed-page
   []
   (conj
-   [[:editor/input "{{embed [[]]}}" {:last-pattern command-menu-trigger
+   [[:editor/input "{{embed [[]]}}" {:last-pattern (state/get-editor-command-trigger)
                                      :backward-pos 4}]]
    [:editor/search-page :embed]))
 
 (defn embed-block
   []
-  [[:editor/input "{{embed (())}}" {:last-pattern command-menu-trigger
+  [[:editor/input "{{embed (())}}" {:last-pattern (state/get-editor-command-trigger)
                                     :backward-pos 4}]
    [:editor/search-block :embed]])
 
@@ -232,13 +234,13 @@
      ["Block reference" [[:editor/input "(())" {:backward-pos 2}]
                          [:editor/search-block :reference]] "Create a backlink to a block"]
      ["Block embed" (embed-block) "Embed a block here" "Embed a block here"]
-     ["Link" link-steps "Create a HTTP link"]
-     ["Image link" image-link-steps "Create a HTTP link to a image"]
+     ["Link" (link-steps) "Create a HTTP link"]
+     ["Image link" (image-link-steps) "Create a HTTP link to a image"]
      (when (state/markdown?)
        ["Underline" [[:editor/input "<ins></ins>"
-                      {:last-pattern command-menu-trigger
+                      {:last-pattern (state/get-editor-command-trigger)
                        :backward-pos 6}]] "Create a underline text decoration"])
-     ["Template" [[:editor/input command-menu-trigger nil]
+     ["Template" [[:editor/input (state/get-editor-command-trigger) nil]
                   [:editor/search-template]] "Insert a created template here"]
      (cond
        (and (util/electron?) (config/local-db? (state/get-current-repo)))
@@ -277,7 +279,7 @@
     ;; advanced
 
     [["Query" [[:editor/input "{{query }}" {:backward-pos 2}]] query-doc]
-     ["Zotero" zotero-steps "Import Zotero journal article"]
+     ["Zotero" (zotero-steps) "Import Zotero journal article"]
      ["Query table function" [[:editor/input "{{function }}" {:backward-pos 2}]] "Create a query table function"]
      ["Calculator" [[:editor/input "```calc\n\n```" {:backward-pos 4}]
                     [:codemirror/focus]] "Insert a calculator"]
@@ -290,19 +292,19 @@
                  text)) "Draw a graph with Excalidraw"]
 
      (when (util/zh-CN-supported?)
-       ["Embed Bilibili video" [[:editor/input "{{bilibili }}" {:last-pattern command-menu-trigger
+       ["Embed Bilibili video" [[:editor/input "{{bilibili }}" {:last-pattern (state/get-editor-command-trigger)
                                                                 :backward-pos 2}]]])
      ["Embed HTML " (->inline "html")]
 
-     ["Embed Youtube video" [[:editor/input "{{youtube }}" {:last-pattern command-menu-trigger
+     ["Embed Youtube video" [[:editor/input "{{youtube }}" {:last-pattern (state/get-editor-command-trigger)
                                                             :backward-pos 2}]]]
 
      ["Embed Youtube timestamp" [[:youtube/insert-timestamp]]]
 
-     ["Embed Vimeo video" [[:editor/input "{{vimeo }}" {:last-pattern command-menu-trigger
+     ["Embed Vimeo video" [[:editor/input "{{vimeo }}" {:last-pattern (state/get-editor-command-trigger)
                                                         :backward-pos 2}]]]
 
-     ["Embed Twitter tweet" [[:editor/input "{{tweet }}" {:last-pattern command-menu-trigger
+     ["Embed Twitter tweet" [[:editor/input "{{tweet }}" {:last-pattern (state/get-editor-command-trigger)
                                                           :backward-pos 2}]]]]
 
     @*extend-slash-commands
@@ -333,12 +335,11 @@
 
 (defn insert!
   [id value
-   {:keys [last-pattern postfix-fn backward-pos forward-pos
-           end-pattern]
-    :or {last-pattern command-menu-trigger}
+   {:keys [last-pattern postfix-fn backward-pos forward-pos end-pattern]
     :as _option}]
   (when-let [input (gdom/getElement id)]
-    (let [edit-content (gobj/get input "value")
+    (let [last-pattern (or last-pattern (state/get-editor-command-trigger))
+          edit-content (gobj/get input "value")
           current-pos (cursor/pos input)
           current-pos (or
                        (when (and end-pattern (string? end-pattern))
@@ -470,7 +471,7 @@
 (defn get-command-input
   [edit-content]
   (when-not (string/blank? edit-content)
-    (let [result (last (util/split-last command-menu-trigger edit-content))]
+    (let [result (last (util/split-last (state/get-editor-command-trigger) edit-content))]
       (if (string/blank? result)
         nil
         result))))
@@ -518,7 +519,7 @@
       (let [edit-content (gobj/get current-input "value")
             current-pos (cursor/pos current-input)
             prefix (subs edit-content 0 current-pos)
-            prefix (util/replace-last command-menu-trigger prefix "" (boolean space?))
+            prefix (util/replace-last (state/get-editor-command-trigger) prefix "" (boolean space?))
             new-value (str prefix
                            (subs edit-content current-pos))]
         (state/set-block-content-and-last-pos! input-id

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -23,7 +23,7 @@
 
 (defonce *show-commands (atom false))
 (defonce *slash-caret-pos (atom nil))
-(defonce slash "/")
+(defonce command-menu-trigger "/")
 (defonce *show-block-commands (atom false))
 (defonce angle-bracket "<")
 (defonce *angle-bracket-caret-pos (atom nil))
@@ -48,7 +48,7 @@
      "Queries documentation"]
     "."]])
 
-(def link-steps [[:editor/input (str slash "link")]
+(def link-steps [[:editor/input (str command-menu-trigger "link")]
                  [:editor/show-input [{:command :link
                                        :id :link
                                        :placeholder "Link"
@@ -57,7 +57,7 @@
                                        :id :label
                                        :placeholder "Label"}]]])
 
-(def image-link-steps [[:editor/input (str slash "link")]
+(def image-link-steps [[:editor/input (str command-menu-trigger "link")]
                        [:editor/show-input [{:command :image-link
                                              :id :link
                                              :placeholder "Link"
@@ -66,7 +66,7 @@
                                              :id :label
                                              :placeholder "Label"}]]])
 
-(def zotero-steps [[:editor/input (str slash "zotero")]
+(def zotero-steps [[:editor/input (str command-menu-trigger "zotero")]
                    [:editor/show-zotero]])
 
 (def *extend-slash-commands (atom []))
@@ -90,19 +90,19 @@
   [type]
   (let [template (util/format "@@%s: @@"
                               type)]
-    [[:editor/input template {:last-pattern slash
+    [[:editor/input template {:last-pattern command-menu-trigger
                               :backward-pos 2}]]))
 
 (defn embed-page
   []
   (conj
-   [[:editor/input "{{embed [[]]}}" {:last-pattern slash
+   [[:editor/input "{{embed [[]]}}" {:last-pattern command-menu-trigger
                                      :backward-pos 4}]]
    [:editor/search-page :embed]))
 
 (defn embed-block
   []
-  [[:editor/input "{{embed (())}}" {:last-pattern slash
+  [[:editor/input "{{embed (())}}" {:last-pattern command-menu-trigger
                                     :backward-pos 4}]
    [:editor/search-block :embed]])
 
@@ -236,7 +236,7 @@
      ["Image link" image-link-steps "Create a HTTP link to a image"]
      (when (state/markdown?)
        ["Underline" [[:editor/input "<ins></ins>"
-                      {:last-pattern slash
+                      {:last-pattern command-menu-trigger
                        :backward-pos 6}]] "Create a underline text decoration"])
      ["Template" [[:editor/input "/" nil]
                   [:editor/search-template]] "Insert a created template here"]
@@ -290,19 +290,19 @@
                  text)) "Draw a graph with Excalidraw"]
 
      (when (util/zh-CN-supported?)
-       ["Embed Bilibili video" [[:editor/input "{{bilibili }}" {:last-pattern slash
+       ["Embed Bilibili video" [[:editor/input "{{bilibili }}" {:last-pattern command-menu-trigger
                                                                 :backward-pos 2}]]])
      ["Embed HTML " (->inline "html")]
 
-     ["Embed Youtube video" [[:editor/input "{{youtube }}" {:last-pattern slash
+     ["Embed Youtube video" [[:editor/input "{{youtube }}" {:last-pattern command-menu-trigger
                                                             :backward-pos 2}]]]
 
      ["Embed Youtube timestamp" [[:youtube/insert-timestamp]]]
 
-     ["Embed Vimeo video" [[:editor/input "{{vimeo }}" {:last-pattern slash
+     ["Embed Vimeo video" [[:editor/input "{{vimeo }}" {:last-pattern command-menu-trigger
                                                         :backward-pos 2}]]]
 
-     ["Embed Twitter tweet" [[:editor/input "{{tweet }}" {:last-pattern slash
+     ["Embed Twitter tweet" [[:editor/input "{{tweet }}" {:last-pattern command-menu-trigger
                                                           :backward-pos 2}]]]]
 
     @*extend-slash-commands
@@ -335,7 +335,7 @@
   [id value
    {:keys [last-pattern postfix-fn backward-pos forward-pos
            end-pattern]
-    :or {last-pattern slash}
+    :or {last-pattern command-menu-trigger}
     :as _option}]
   (when-let [input (gdom/getElement id)]
     (let [edit-content (gobj/get input "value")
@@ -470,7 +470,7 @@
 (defn get-command-input
   [edit-content]
   (when-not (string/blank? edit-content)
-    (let [result (last (util/split-last slash edit-content))]
+    (let [result (last (util/split-last command-menu-trigger edit-content))]
       (if (string/blank? result)
         nil
         result))))
@@ -518,7 +518,7 @@
       (let [edit-content (gobj/get current-input "value")
             current-pos (cursor/pos current-input)
             prefix (subs edit-content 0 current-pos)
-            prefix (util/replace-last slash prefix "" (boolean space?))
+            prefix (util/replace-last command-menu-trigger prefix "" (boolean space?))
             new-value (str prefix
                            (subs edit-content current-pos))]
         (state/set-block-content-and-last-pos! input-id

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -278,6 +278,7 @@
                           (.focus input)))}
       "/"]]]])
 
+;; TODO: `Warning: Each child in a list should have a unique "key" prop.`
 (rum/defcs input < rum/reactive
   (rum/local {} ::input-value)
   (mixins/event-mixin

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -278,7 +278,6 @@
                           (.focus input)))}
       "/"]]]])
 
-;; TODO: `Warning: Each child in a list should have a unique "key" prop.`
 (rum/defcs input < rum/reactive
   (rum/local {} ::input-value)
   (mixins/event-mixin
@@ -305,7 +304,7 @@
         (let [command (:command (first input-option))]
           [:div.p-2.rounded-md.shadow-lg
            (for [{:keys [id placeholder type autoFocus] :as input-item} input-option]
-             [:div.my-3
+             [:div.my-3 {:key id}
               [:input.form-input.block.w-full.pl-2.sm:text-sm.sm:leading-5
                (merge
                 (cond->

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2009,14 +2009,15 @@
   (let [input           (state/get-input)
         pos             (cursor/pos input)
         last-input-char (util/nth-safe (.-value input) (dec pos))]
-    (case last-input-char
-      "/"
+
       ;; TODO: is it cross-browser compatible?
       ;; (not= (gobj/get native-e "inputType") "insertFromPaste")
+    (if (= last-input-char commands/command-menu-trigger) ;"/"
       (when (seq (get-matched-commands input))
         (reset! commands/*slash-caret-pos (cursor/get-caret-pos input))
-        (reset! commands/*show-commands true))
-      "<"
+        (reset! commands/*show-commands true)))
+
+    (if (= last-input-char commands/angle-bracket)
       (when (seq (get-matched-block-commands input))
         (reset! commands/*angle-bracket-caret-pos (cursor/get-caret-pos input))
         (reset! commands/*show-block-commands true))
@@ -2836,8 +2837,8 @@
         (when (and (= "〈" c)
                    (= "《" (util/nth-safe value (dec (dec current-pos))))
                    (> current-pos 0))
-          (commands/handle-step [:editor/input "<" {:last-pattern "《〈"
-                                                    :backward-pos 0}])
+          (commands/handle-step [:editor/input commands/angle-bracket {:last-pattern "《〈"}
+                                                    :backward-pos 0])
           (reset! commands/*angle-bracket-caret-pos (cursor/get-caret-pos input))
           (reset! commands/*show-block-commands true))
 

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1594,7 +1594,7 @@
                                        (if file (.-name file) (if image? "image" "asset"))
                                        image?)
                   format
-                  {:last-pattern (if drop-or-paste? "" commands/command-menu-trigger)
+                  {:last-pattern (if drop-or-paste? "" (state/get-editor-command-trigger))
                    :restore?     true})))))
           (p/finally
             (fn []
@@ -1611,7 +1611,7 @@
             (insert-command! id
                              (get-asset-file-link format signed-url file-name true)
                              format
-                             {:last-pattern (if drop-or-paste? "" commands/command-menu-trigger)
+                             {:last-pattern (if drop-or-paste? "" (state/get-editor-command-trigger))
                               :restore?     true})
 
             (reset! *asset-uploading? false)
@@ -1748,7 +1748,7 @@
           last-command (and last-slash-caret-pos (subs edit-content last-slash-caret-pos pos))]
       (when (> pos 0)
         (or
-         (and (= commands/command-menu-trigger (util/nth-safe edit-content (dec pos)))
+         (and (= (state/get-editor-command-trigger) (util/nth-safe edit-content (dec pos)))
               @commands/*initial-commands)
          (and last-command
               (commands/get-matched-commands last-command)))))
@@ -1901,7 +1901,7 @@
                id
                (get-link format link label)
                format
-               {:last-pattern (str commands/command-menu-trigger "link")})))
+               {:last-pattern (str (state/get-editor-command-trigger) "link")})))
 
     :image-link (let [{:keys [link label]} m]
                   (when (not (string/blank? link))
@@ -1909,7 +1909,7 @@
                      id
                      (get-image-link format link label)
                      format
-                     {:last-pattern (str commands/command-menu-trigger "link")})))
+                     {:last-pattern (str (state/get-editor-command-trigger) "link")})))
 
     nil)
 
@@ -2007,7 +2007,7 @@
 
       ;; TODO: is it cross-browser compatible?
       ;; (not= (gobj/get native-e "inputType") "insertFromPaste")
-    (if (= last-input-char commands/command-menu-trigger)
+    (if (= last-input-char (state/get-editor-command-trigger))
       (when (seq (get-matched-commands input))
         (reset! commands/*slash-caret-pos (cursor/get-caret-pos input))
         (reset! commands/*show-commands true)))
@@ -2640,7 +2640,7 @@
         (delete-block! repo e false))
 
       (and (> current-pos 1)
-           (= (util/nth-safe value (dec current-pos)) commands/command-menu-trigger))
+           (= (util/nth-safe value (dec current-pos)) (state/get-editor-command-trigger)))
       (do
         (util/stop e)
         (reset! *slash-caret-pos nil)
@@ -2844,7 +2844,7 @@
                          (not= (util/nth-safe value current-pos) "]")))
             (state/set-editor-show-page-search-hashtag! false)))
 
-        (when (and @*show-commands (not= key-code 192)) ; not /   TODO: is this the .charCodeAt or the event code?
+        (when (and @*show-commands (not= key-code 191)) ; not /   TODO: is this the .charCodeAt or the event code?
           (let [matched-commands (get-matched-commands input)]
             (if (seq matched-commands)
               (do

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1598,7 +1598,7 @@
                                        (if file (.-name file) (if image? "image" "asset"))
                                        image?)
                   format
-                  {:last-pattern (if drop-or-paste? "" commands/slash)
+                  {:last-pattern (if drop-or-paste? "" commands/command-menu-trigger)
                    :restore?     true})))))
           (p/finally
             (fn []
@@ -1615,7 +1615,7 @@
             (insert-command! id
                              (get-asset-file-link format signed-url file-name true)
                              format
-                             {:last-pattern (if drop-or-paste? "" commands/slash)
+                             {:last-pattern (if drop-or-paste? "" commands/command-menu-trigger)
                               :restore?     true})
 
             (reset! *asset-uploading? false)
@@ -1906,7 +1906,7 @@
         (insert-command! id
                          (get-link format link label)
                          format
-                         {:last-pattern (str commands/slash "link")})))
+                         {:last-pattern (str commands/command-menu-trigger "link")})))
     :image-link
     (let [{:keys [link label]} m]
       (if (and (string/blank? link)
@@ -1915,7 +1915,7 @@
         (insert-command! id
                          (get-image-link format link label)
                          format
-                         {:last-pattern (str commands/slash "link")})))
+                         {:last-pattern (str commands/command-menu-trigger "link")})))
     nil)
 
   (state/set-editor-show-input! nil)
@@ -2644,7 +2644,7 @@
         (delete-block! repo e false))
 
       (and (> current-pos 1)
-           (= (util/nth-safe value (dec current-pos)) commands/slash))
+           (= (util/nth-safe value (dec current-pos)) commands/command-menu-trigger))
       (do
         (util/stop e)
         (reset! *slash-caret-pos nil)

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2844,7 +2844,7 @@
                          (not= (util/nth-safe value current-pos) "]")))
             (state/set-editor-show-page-search-hashtag! false)))
 
-        (when (and @*show-commands (not= key-code 220)) ; not /   TODO: generalize this!!!!!!
+        (when (and @*show-commands (not= key-code 192)) ; not /   TODO: is this the .charCodeAt or the event code?
           (let [matched-commands (get-matched-commands input)]
             (if (seq matched-commands)
               (do

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2832,8 +2832,8 @@
         (when (and (= "〈" c)
                    (= "《" (util/nth-safe value (dec (dec current-pos))))
                    (> current-pos 0))
-          (commands/handle-step [:editor/input commands/angle-bracket {:last-pattern "《〈"}
-                                                    :backward-pos 0])
+          (commands/handle-step [:editor/input commands/angle-bracket {:last-pattern "《〈"
+                                                                       :backward-pos 0}])
           (reset! commands/*angle-bracket-caret-pos (cursor/get-caret-pos input))
           (reset! commands/*show-block-commands true))
 

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1752,7 +1752,7 @@
           last-command (and last-slash-caret-pos (subs edit-content last-slash-caret-pos pos))]
       (when (> pos 0)
         (or
-         (and (= \/ (util/nth-safe edit-content (dec pos)))
+         (and (= commands/command-menu-trigger (util/nth-safe edit-content (dec pos)))
               @commands/*initial-commands)
          (and last-command
               (commands/get-matched-commands last-command)))))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -349,6 +349,13 @@
 
      (get-in @state [:me :preferred_format] "markdown")))))
 
+(defn get-editor-command-trigger
+  ([] (get-editor-command-trigger (get-current-repo)))
+  ([repo-url]
+   (or
+    (:editor/command-trigger (get-config repo-url)) ;; Get from user config
+    "/"))) ;; Set the default
+
 (defn markdown?
   []
   (= (keyword (get-preferred-format))
@@ -1163,8 +1170,8 @@
   (if (util/mobile?)
     false
     (get (get (sub-config) (get-current-repo))
-        :ui/enable-tooltip?
-        true)))
+         :ui/enable-tooltip?
+         true)))
 
 (defn show-command-doc?
   []

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -349,6 +349,8 @@
 
      (get-in @state [:me :preferred_format] "markdown")))))
 
+;; TODO: consider adding a pane in Settings to set this through the GUI (rather
+;; than having to go through the config.edn file)
 (defn get-editor-command-trigger
   ([] (get-editor-command-trigger (get-current-repo)))
   ([repo-url]


### PR DESCRIPTION
This PR makes it possible to customize the character that triggers the editor command palette. [Here is the discussion in Discuss.](https://discuss.logseq.com/t/custom-command-trigger/3081) The default trigger will remain `"/"` as it's always been, but if a user wants to customize it (e.g. to `"\"` as shown below), then they can do that. 

<img width="60%" src="https://user-images.githubusercontent.com/6979755/138575661-1fd21b43-4cb8-4458-bc3d-0df4c908122c.png" />

In a future PR, we could consider adding an input on the Settings panel to make this changeable from the GUI, rather than requiring the user to go into `config.edn` to change it (which makes it unlikely that they'll find it).

Note that updating the custom trigger config requires a full refresh of the app.

---

This PR also introduces a few smaller changes, which are not directly related to the primary change but came up while I was poking around the code:
- fixes some inconsistent capitalization
- fixes a `Warning: Each child in a list should have a unique "key" prop`