### PR TITLE
enhance: add hotkeys for open file in directory / default app

### DIFF
--- a/src/main/frontend/components/page_menu.cljs
+++ b/src/main/frontend/components/page_menu.cljs
@@ -91,12 +91,6 @@
                                   :page-presentation
                                   {:page page}))}}
 
-          (when-let [file-path (and (util/electron?) (page-handler/get-page-file-path))]
-            [{:title   (t :page/open-in-finder)
-              :options {:on-click #(js/window.apis.showItemInFolder file-path)}}
-             {:title   (t :page/open-with-default-app)
-              :options {:on-click #(js/window.apis.openPath file-path)}}])
-
           (when-not contents?
             {:title   (t :page/delete)
              :options {:on-click #(state/set-modal! (delete-page-dialog page-name))}})

--- a/src/main/frontend/components/page_menu.cljs
+++ b/src/main/frontend/components/page_menu.cljs
@@ -91,6 +91,16 @@
                                   :page-presentation
                                   {:page page}))}}
 
+          ;; TODO: In the future, we'd like to extract file-related actions
+          ;; (such as open-in-finder & open-with-default-app) into a sub-menu of
+          ;; this one. However this component doesn't yet exist. PRs are welcome!
+          ;; Details: https://github.com/logseq/logseq/pull/3003#issuecomment-952820676
+          (when-let [file-path (and (util/electron?) (page-handler/get-page-file-path))]
+            [{:title   (t :page/open-in-finder)
+              :options {:on-click #(js/window.apis.showItemInFolder file-path)}}
+             {:title   (t :page/open-with-default-app)
+              :options {:on-click #(js/window.apis.openPath file-path)}}])
+
           (when-not contents?
             {:title   (t :page/delete)
              :options {:on-click #(state/set-modal! (delete-page-dialog page-name))}})
@@ -131,8 +141,9 @@
                                       [:div
                                        [:pre.code page-data]
                                        [:br]
-                                       (ui/button "Copy to clipboard"
-                                         :on-click #(.writeText js/navigator.clipboard page-data))]
+                                       (ui/button
+                                        "Copy to clipboard"
+                                        :on-click #(.writeText js/navigator.clipboard page-data))]
                                       :success
                                       false)))}})]
          (flatten)

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -690,3 +690,11 @@
      (:db/id page)
      :page
      page)))
+
+(defn open-file-in-default-app []
+  (when-let [file-path (and (util/electron?) (get-page-file-path))]
+    (js/window.apis.openPath file-path)))
+
+(defn open-file-in-directory []
+  (when-let [file-path (and (util/electron?) (get-page-file-path))]
+    (js/window.apis.showItemInFolder file-path)))

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -15,6 +15,9 @@
             [frontend.util :refer [mac?] :as util]
             [frontend.commands :as commands]))
 
+;; Note – when you change this file, you will need to do a hard reset.
+;; The commands are registered when the Clojurescript code runs for the first time.
+
 ;; TODO: how to extend this for plugins usage? An atom?
 (def default-config
   {:shortcut.handler/date-picker
@@ -376,6 +379,14 @@
     {:desc    "Toggle Favorites in sidebar"
      :binding "t f"
      :fn      ui-handler/toggle-contents!}
+    :editor/open-file-in-default-app
+    {:desc    "Open file in default app"
+     :binding "o f"
+     :fn      page-handler/open-file-in-default-app}
+    :editor/open-file-in-directory
+    {:desc    "Open file in parent directory"
+     :binding "o d"
+     :fn      page-handler/open-file-in-directory}
     :ui/toggle-wide-mode
     {:desc    "Toggle wide mode"
      :binding "t w"


### PR DESCRIPTION
This PR adds the following hotkeys:
- <kbd>o</kbd><kbd>f</kbd> to open current file with the default app
- <kbd>o</kbd><kbd>d</kbd> to open file the parent directory

~It also removes these same commands from the dropdown at the top. These commands aren't super commonly used, so I think it's best to declutter that dropdown. However I'm happy to remove this change if the maintainers disagree!~