### PR TITLE
Fix code block wide mode toggle

### DIFF
--- a/src/main/frontend/extensions/code.css
+++ b/src/main/frontend/extensions/code.css
@@ -36,7 +36,7 @@
     margin-top: 4px;
     margin-bottom: 6px;
     font-family: Fira Code, Monaco, Menlo, Consolas, 'COURIER NEW', monospace;
-    max-width: var(--ls-main-content-max-width);
+    max-width: var(--ls-main-content-max-width-wide);
     border-radius: 2px;
     line-height: 1.45em;
 


### PR DESCRIPTION
Simple fix on wide mode toggle for code block. `max-width` should be controlled by its root content.  

Before:
![2021-05-19-logseq wide mode toggle before](https://user-images.githubusercontent.com/2519905/139496678-f1c4f2e2-defe-4bc6-8442-ee41b3055e6c.gif)

After:
![2021-05-19-logseq wide mode toggle-after](https://user-images.githubusercontent.com/2519905/139496708-10fd913a-7e6f-417c-b990-0dc3ea4879c9.gif)