### PR TITLE
fix: pos and space when cycling marker in header

### DIFF
--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -542,7 +542,6 @@
   [edit-content marker pos]
   (let [old-marker (some->> (first (util/safe-re-find marker/bare-marker-pattern edit-content))
                             (string/trim))
-        old-marker (if old-marker old-marker "")
         pos-delta (- (count marker)
                      (count old-marker))
         pos-delta (cond (string/blank? old-marker)
@@ -552,7 +551,7 @@
 
                         :else
                         pos-delta)]
-    (+ pos pos-delta)))
+    (max (+ pos pos-delta) 0)))
 
 (defmethod handle-step :editor/set-marker [[_ marker] format]
   (when-let [input-id (state/get-edit-input-id)]

--- a/src/main/frontend/util/marker.cljs
+++ b/src/main/frontend/util/marker.cljs
@@ -13,7 +13,7 @@
   #"^(NOW|LATER|TODO|DOING|DONE|WAITING|WAIT|CANCELED|CANCELLED|STARTED|IN-PROGRESS)?\s?")
 
 (def bare-marker-pattern
-  #"^(NOW|LATER|TODO|DOING|DONE|WAITING|WAIT|CANCELED|CANCELLED|STARTED|IN-PROGRESS){1}\s+")
+  #"(NOW|LATER|TODO|DOING|DONE|WAITING|WAIT|CANCELED|CANCELLED|STARTED|IN-PROGRESS){1}\s+")
 
 
 (defn add-or-update-marker
@@ -42,7 +42,9 @@
   [content markdown? old-marker new-marker]
   (string/replace-first content (header-marker-pattern markdown? old-marker)
                         (fn [match]
-                          (string/replace match old-marker new-marker))))
+                          (if (and markdown? (= new-marker "")  (string/starts-with? match "#"))
+                            (string/replace match (str " " old-marker) "")
+                            (string/replace match old-marker new-marker)))))
 
 (defn cycle-marker-state
   [preferred-workflow marker]


### PR DESCRIPTION
Fixes #3036 

-  minimum value of `pos-delta` is now 0
-  rm leading `^` in marker-pattern
    - Is it better to use `#*\s*[TODO|...]\s*`?
- remove additional space in `replace-marker`, when cycling to nil marker in header line