### PR TITLE
enhance(org): page-ref embeding allows different page-name and label

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1189,7 +1189,7 @@
 
             (and (string/starts-with? a "[[")
                  (string/ends-with? a "]]"))
-            (let [page-name (text/extract-page-name-from-ref a)]
+            (let [page-name (text/get-page-name a)]
               (when-not (string/blank? page-name)
                 (page-embed config page-name)))
 

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -464,8 +464,10 @@
     (let [page-name-in-block (util/remove-boundary-slashes page-name-in-block)
           page-name (string/lower-case page-name-in-block)
           page-entity (db/entity [:block/name page-name])
-          redirect-page-name (or redirect-page-name
-                                 (model/get-redirect-page-name page-name (:block/alias? config)))
+          redirect-page-name (or (and (= :org (state/get-preferred-format))
+                                      (:org-mode/insert-file-link? (state/get-config))
+                                      redirect-page-name)
+                              (model/get-redirect-page-name page-name (:block/alias? config)))
           inner (page-inner config
                             page-name-in-block
                             page-name

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -459,12 +459,13 @@
       children)))
 
 (rum/defc page-cp
-  [{:keys [html-export? label children contents-page? preview?] :as config} page]
+  [{:keys [html-export? redirect-page-name label children contents-page? preview?] :as config} page]
   (when-let [page-name-in-block (:block/name page)]
     (let [page-name-in-block (util/remove-boundary-slashes page-name-in-block)
           page-name (string/lower-case page-name-in-block)
           page-entity (db/entity [:block/name page-name])
-          redirect-page-name (model/get-redirect-page-name page-name (:block/alias? config))
+          redirect-page-name (or redirect-page-name
+                                 (model/get-redirect-page-name page-name (:block/alias? config)))
           inner (page-inner config
                             page-name-in-block
                             page-name
@@ -950,6 +951,9 @@
 
               :else
               (let [label-text (get-label-text label)
+                    redirect-page-name (-> (second url)
+                                           text/get-file-basename)
+                    config (assoc config :redirect-page-name redirect-page-name)
                     page (if (string/blank? label-text)
                            {:block/name (db/get-file-page (string/replace href "file:" ""))}
                            (get-page label))]

--- a/src/main/frontend/text.cljs
+++ b/src/main/frontend/text.cljs
@@ -5,6 +5,19 @@
             [clojure.set :as set]
             [medley.core :as medley]))
 
+(def page-ref-re-0 #"\[\[(.*)\]\]")
+(def org-page-ref-re #"\[\[(file:.*)\]\[.+?\]\]")
+
+(defn get-page-name
+  [s]
+  (and (not (string/blank? s))
+       (or (when-let [[_ path _label] (re-matches org-page-ref-re s)]
+             (-> (util/node-path.basename path)
+                 (string/split #"\.")
+                 first))
+           (-> (re-matches page-ref-re-0 s)
+               second))))
+
 (defn page-ref?
   [s]
   (and
@@ -12,20 +25,16 @@
    (string/starts-with? s "[[")
    (string/ends-with? s "]]")))
 
+(def block-ref-re #"\(\(([a-zA-z0-9]{8}-[a-zA-z0-9]{4}-[a-zA-z0-9]{4}-[a-zA-z0-9]{4}-[a-zA-z0-9]{12})\)\)")
+
+(defn get-block-ref
+  [s]
+  (and (not (string/blank? s))
+       (second (re-matches block-ref-re s))))
+
 (defn block-ref?
   [s]
-  (and
-   (string? s)
-   (string/starts-with? s "((")
-   (string/ends-with? s "))")))
-
-(defn extract-page-name-from-ref
-  [ref]
-  (when-not (string/blank? ref)
-    (if-let [matches (or (re-matches #"\[\[file:.+\]\[(.+)\]\]" ref)
-                         (re-matches #"\[\[(.+)\]\]" ref))]
-      (string/trim (last matches))
-      ref)))
+  (boolean (get-block-ref s)))
 
 (defonce page-ref-re #"\[\[(.*?)\]\]")
 

--- a/src/main/frontend/text.cljs
+++ b/src/main/frontend/text.cljs
@@ -17,7 +17,7 @@
 
 (defn get-page-name
   [s]
-  (and (not (string/blank? s))
+  (and (string? s)
        (or (when-let [[_ path _label] (re-matches org-page-ref-re s)]
              (get-file-basename path))
            (-> (re-matches page-ref-re-0 s)
@@ -34,7 +34,7 @@
 
 (defn get-block-ref
   [s]
-  (and (not (string/blank? s))
+  (and (string? s)
        (second (re-matches block-ref-re s))))
 
 (defn block-ref?

--- a/src/main/frontend/text.cljs
+++ b/src/main/frontend/text.cljs
@@ -8,13 +8,18 @@
 (def page-ref-re-0 #"\[\[(.*)\]\]")
 (def org-page-ref-re #"\[\[(file:.*)\]\[.+?\]\]")
 
+(defn get-file-basename
+  [path]
+  (when-not (string/blank? path)
+    (-> (util/node-path.basename path)
+        (string/split #"\.")
+        first)))
+
 (defn get-page-name
   [s]
   (and (not (string/blank? s))
        (or (when-let [[_ path _label] (re-matches org-page-ref-re s)]
-             (-> (util/node-path.basename path)
-                 (string/split #"\.")
-                 first))
+             (get-file-basename path))
            (-> (re-matches page-ref-re-0 s)
                second))))
 

--- a/src/main/frontend/util/thingatpt.cljs
+++ b/src/main/frontend/util/thingatpt.cljs
@@ -55,7 +55,7 @@
   (when-let [page-ref (thing-at-point ["[[" "]]"] input)]
     (assoc page-ref
            :type "page-ref"
-           :link (text/extract-page-name-from-ref
+           :link (text/get-page-name
                   (:full-content page-ref)))))
 
 (defn embed-macro-at-point [& [input]]


### PR DESCRIPTION
Logseq indirects to a wrong page if org-styled page-reference or embed link (like `[[file:./demo.org][other name]]`, `{{embed [[file:./demo.org][other name]]}}`) has different page-name and label. This PR fixes this.