### PR TITLE
enhance page rename

### DIFF
--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -257,7 +257,12 @@
            :on-blur       (fn [e]
                             (page-handler/rename! (or title page-name) @*title-value)
                             (reset! *edit? false)
-                            (reset! *title-value ""))}]]
+                            (reset! *title-value ""))
+           :on-key-down   (fn [e]
+                            (when (= (gobj/get e "key") "Enter")
+                              (page-handler/rename! (or title page-name) @*title-value)
+                              (reset! *edit? false)
+                              (reset! *title-value "")))}]]
         [:a.page-title {:on-mouse-down (fn [e]
                                          (when (util/right-click? e)
                                            (state/set-state! :page-title/context {:page page-name})))

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -225,7 +225,7 @@
 
 (rum/defcs page-title <
   {:will-update (fn [state]
-                  (assoc state ::title-value (atom (second (:rum/args state)))))}
+                  (assoc state ::title-value (atom (nth (:rum/args state) 2))))}
   (rum/local false ::edit?)
   [state page-name emoji title format fmt-journal?]
   (when title


### PR DESCRIPTION
1. Clicking the page title clears its content. `page-title` function introduced a new emoji argument as its second argument, so the default value of title should be the third one of the state instead of the second one.
2. Enter key can rename page now.  
3. Add a confirm window before renaming page.
<img width="688" alt="CleanShot 2021-11-03 at 17 15 56@2x" src="https://user-images.githubusercontent.com/3996879/140034899-1137c3cb-6ae8-4c09-a185-585937ff0fce.png">
