### PR TITLE
fix: insert page attributes instead of block property when creating and renaming page

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1,12 +1,14 @@
 (ns frontend.handler.editor
-  (:require [cljs.core.match :refer [match]]
+  (:require ["/frontend/utils" :as utils]
+            [cljs.core.match :refer [match]]
             [clojure.set :as set]
             [clojure.string :as string]
             [clojure.walk :as w]
             [clojure.zip :as zip]
             [dommy.core :as dom]
             [frontend.commands :as commands
-             :refer [*angle-bracket-caret-pos *show-block-commands *show-commands *slash-caret-pos]]
+             :refer [*angle-bracket-caret-pos *show-block-commands
+                     *show-commands *slash-caret-pos]]
             [frontend.config :as config]
             [frontend.date :as date]
             [frontend.db :as db]
@@ -18,19 +20,19 @@
             [frontend.format.block :as block]
             [frontend.format.mldoc :as mldoc]
             [frontend.fs :as fs]
-            [frontend.util.clock :as clock]
             [frontend.handler.block :as block-handler]
             [frontend.handler.common :as common-handler]
+            [frontend.handler.export :as export]
             [frontend.handler.image :as image-handler]
             [frontend.handler.notification :as notification]
             [frontend.handler.repeated :as repeated]
             [frontend.handler.repo :as repo-handler]
             [frontend.handler.route :as route-handler]
             [frontend.handler.ui :as ui-handler]
-            [frontend.handler.export :as export]
-            [frontend.util.drawer :as drawer]
             [frontend.image :as image]
+            [frontend.mobile.util :as mobile]
             [frontend.modules.outliner.core :as outliner-core]
+            [frontend.modules.outliner.datascript :as ds]
             [frontend.modules.outliner.tree :as tree]
             [frontend.search :as search]
             [frontend.state :as state]
@@ -38,8 +40,11 @@
             [frontend.text :as text]
             [frontend.utf8 :as utf8]
             [frontend.util :as util :refer [profile]]
+            [frontend.util.clock :as clock]
             [frontend.util.cursor :as cursor]
+            [frontend.util.drawer :as drawer]
             [frontend.util.marker :as marker]
+            [frontend.util.page-property :as page-property]
             [frontend.util.property :as property]
             [frontend.util.thingatpt :as thingatpt]
             [goog.dom :as gdom]
@@ -47,10 +52,7 @@
             [goog.object :as gobj]
             [lambdaisland.glogi :as log]
             [medley.core :as medley]
-            [promesa.core :as p]
-            ["/frontend/utils" :as utils]
-            [frontend.mobile.util :as mobile]
-            [frontend.modules.outliner.datascript :as ds]))
+            [promesa.core :as p]))
 
 ;; FIXME: should support multiple images concurrently uploading
 
@@ -745,7 +747,7 @@
   ([title format page properties]
    (let [p (common-handler/get-page-default-properties title)
          ps (merge p properties)
-         content (property/insert-properties format "" ps)
+         content (page-property/insert-properties format "" ps)
          refs (block/get-page-refs-from-properties properties)]
      {:block/pre-block? true
       :block/uuid (db/new-block-id)

--- a/src/main/frontend/util/page_property.cljs
+++ b/src/main/frontend/util/page_property.cljs
@@ -32,7 +32,8 @@
                                          (str elem "\n*")))
                            ""))
                         content before)]
-      (string/join "\n" (concat before [other])))))
+      (string/join "\n" (remove #(= "" %)
+                                (concat before [other]))))))
 
 (defn insert-property
   [format content key value]
@@ -62,7 +63,8 @@
        format
        (if (key-exists? key)
          (string/replace content old-property-str new-property-str)
-         (string/join "\n" [new-property-str content]))))))
+         (string/join "\n" (remove #(= "" %)
+                            [new-property-str content])))))))
 
 (defn insert-properties
   [format content kvs]

--- a/src/main/frontend/util/page_property.cljs
+++ b/src/main/frontend/util/page_property.cljs
@@ -1,0 +1,130 @@
+(ns frontend.util.page-property
+  (:require [clojure.string :as string]
+            [frontend.db :as db]
+            [frontend.handler.ui :as ui-handler]
+            [frontend.modules.outliner.core :as outliner-core]
+            [frontend.modules.outliner.file :as outliner-file]
+            [frontend.format.mldoc :as mldoc]
+            [frontend.state :as state]
+            [frontend.util.property :as property]
+            [frontend.util :as util]))
+
+(defn- reorder-properties
+  [format content]
+  (when (string? content)
+    (let [ast (mldoc/->edn content (mldoc/default-config format))
+          key-exist? (fn [k] (k (last (ffirst ast))))
+          build-property-fn (fn [k]
+                              (when-let [v (key-exist? k)]
+                                (util/format (case format
+                                               :org "#+%s: %s"
+                                               "%s:: %s")
+                                             (name k)
+                                             (if (coll? v)
+                                               (string/join ", " v)
+                                               v))))
+          before (remove nil? (map #(build-property-fn %) [:title :alias :aliases]))
+          other (reduce (fn [content elem]
+                          (string/replace
+                           content
+                           (re-pattern (case format
+                                         :org (str "#\\+" (subs elem 2) "\n*")
+                                         (str elem "\n*")))
+                           ""))
+                        content before)]
+      (string/join "\n" (concat before [other])))))
+
+(defn insert-property
+  [format content key value]
+  (when (string? content)
+    (let [ast (mldoc/->edn content (mldoc/default-config format))
+          key-exists? (fn [k] (boolean (k (last (ffirst ast)))))
+          key (if (string? key) (keyword key) key)
+          old-value (key (last (ffirst ast)))
+          new-value (case key
+                      :title value
+                      (-> (if (coll? old-value)
+                            (concat old-value [value])
+                            (conj [old-value] value))
+                          (distinct)))
+          build-property-fn (fn [value]
+                              (util/format (case format
+                                             :org "#+%s: %s"
+                                             "%s:: %s")
+                                           (name key)
+                                           (if (coll? value)
+                                             (->> (remove nil? value)
+                                                  (string/join ", "))
+                                             value)))
+          old-property-str (when old-value (build-property-fn old-value))
+          new-property-str (build-property-fn new-value)]
+      (reorder-properties
+       format
+       (if (key-exists? key)
+         (string/replace content old-property-str new-property-str)
+         (string/join "\n" [new-property-str content]))))))
+
+(defn insert-properties
+  [format content kvs]
+  (let [new-content (reduce
+                     (fn [content [k v]]
+                       (let [k (if (string? k)
+                                 (keyword (-> (string/lower-case k)
+                                              (string/replace " " "-")))
+                                 k)
+                             v (if (coll? v)
+                                 (some->>
+                                  (seq v)
+                                  (distinct)
+                                  (string/join ", "))
+                                 v)]
+                         (insert-property format content k v)))
+                     content kvs)]
+    (reorder-properties format new-content)))
+
+(defn add-property!
+  [page-name key value]
+  (when-let [page (db/pull [:block/name (string/lower-case page-name)])]
+    (let [repo (state/get-current-repo)
+          key (keyword key)
+          pre-block (db/get-pre-block repo (:db/id page))
+          format (state/get-preferred-format)
+          page-id {:db/id (:db/id page)}
+          org? (= format :org)
+          value (if (contains? #{:filters} key) (pr-str value) value)]
+      (if pre-block
+        (let [properties (:block/properties pre-block)
+              new-properties (assoc properties key value)
+              content (:block/content pre-block)
+              front-matter? (property/front-matter? content)
+              new-content (insert-property format content key value)
+              block {:db/id (:db/id pre-block)
+                     :block/properties new-properties
+                     :block/content new-content
+                     :block/page page-id}
+              tx [(assoc page-id :block/properties new-properties)
+                  block]]
+          ;; (util/pprint tx)
+          (db/transact! tx)
+          (db/refresh! repo {:key :block/change
+                             :data [block]}))
+        (let [block {:block/uuid (db/new-block-id)
+                     :block/left page-id
+                     :block/parent page-id
+                     :block/page page-id
+                     :block/title []
+                     :block/content (if org?
+                                      (str "#+" (string/upper-case (name key)) ": " value)
+                                      (str (name key) ":: " value))
+                     :block/format format
+                     :block/properties {key value}
+                     :block/pre-block? true}]
+          (outliner-core/insert-node (outliner-core/block block)
+                                     (outliner-core/block page)
+                                     false)
+          (db/transact! [(assoc page-id :block/properties {key value})])
+          (db/refresh! repo {:key :block/change
+                             :data [block]})
+          (ui-handler/re-render-root!)))
+      (outliner-file/sync-to-file page-id))))
+

--- a/src/test/frontend/util/page_property_test.cljs
+++ b/src/test/frontend/util/page_property_test.cljs
@@ -5,6 +5,9 @@
 (deftest test-insert-property
   (testing "add org page property"
     (are [x y] (= x y)
+      (property/insert-property :org "" :title "title")
+      "#+title: title"
+
       (property/insert-property :org "hello" :title "title")
       "#+title: title\nhello"
 
@@ -28,6 +31,9 @@
 
   (testing "add markdown page property"
     (are [x y] (= x y)
+      (property/insert-property :markdown "" :title "title")
+      "title:: title"
+
       (property/insert-property :markdown "hello" :title "title")
       "title:: title\nhello"
 
@@ -52,6 +58,10 @@
 (deftest test-insert-properties
   (testing "add org page properties"
     (are [x y] (= x y)
+
+      (property/insert-properties :org "" {:title "title"})
+      "#+title: title"
+
       (property/insert-properties :org "hello" {:title "title"})
       "#+title: title\nhello"
 
@@ -74,6 +84,9 @@
 
   (testing "add markdown page properties"
     (are [x y] (= x y)
+      (property/insert-properties :markdown "" {:title "title"})
+      "title:: title"
+
       (property/insert-properties :markdown "hello" {:title "title"})
       "title:: title\nhello"
 

--- a/src/test/frontend/util/page_property_test.cljs
+++ b/src/test/frontend/util/page_property_test.cljs
@@ -1,0 +1,97 @@
+(ns frontend.util.page-property-test
+  (:require [cljs.test :refer [are deftest testing]]
+            [frontend.util.page-property :as property]))
+
+(deftest test-insert-property
+  (testing "add org page property"
+    (are [x y] (= x y)
+      (property/insert-property :org "hello" :title "title")
+      "#+title: title\nhello"
+
+      (property/insert-property :org "#+title: title\nhello" :title "new title")
+      "#+title: new title\nhello"
+
+      (property/insert-property :org "#+title: title\nhello" :alias "alias1")
+      "#+title: title\n#+alias: alias1\nhello"
+
+      (property/insert-property :org "#+title: title\n#+alias: alias1\nhello" :alias "alias2")
+      "#+title: title\n#+alias: alias1, alias2\nhello"
+
+      (property/insert-property :org "#+title: title\n#+alias: alias1, alias2\nhello" :alias "alias3")
+      "#+title: title\n#+alias: alias1, alias2, alias3\nhello"
+
+      (property/insert-property :org "#+title: title\n#+alias: alias1, alias2\nhello" :aliases "aliases1")
+      "#+title: title\n#+alias: alias1, alias2\n#+aliases: aliases1\nhello"
+
+      (property/insert-property :org "#+title: title\n#+alias: alias1, alias2\n#+aliases: aliases1\nhello" :aliases "aliases2")
+      "#+title: title\n#+alias: alias1, alias2\n#+aliases: aliases1, aliases2\nhello"))
+
+  (testing "add markdown page property"
+    (are [x y] (= x y)
+      (property/insert-property :markdown "hello" :title "title")
+      "title:: title\nhello"
+
+      (property/insert-property :markdown "title:: title\nhello" :title "new title")
+      "title:: new title\nhello"
+
+      (property/insert-property :markdown "title:: title\nhello" :alias "alias1")
+      "title:: title\nalias:: alias1\nhello"
+
+      (property/insert-property :markdown "title:: title\nalias:: alias1\nhello" :alias "alias2")
+      "title:: title\nalias:: alias1, alias2\nhello"
+
+      (property/insert-property :markdown "title:: title\nalias:: alias1, alias2\nhello" :alias "alias3")
+      "title:: title\nalias:: alias1, alias2, alias3\nhello"
+
+      (property/insert-property :markdown "title:: title\nalias:: alias1, alias2\nhello" :aliases "aliases1")
+      "title:: title\nalias:: alias1, alias2\naliases:: aliases1\nhello"
+
+      (property/insert-property :markdown "title:: title\nalias:: alias1, alias2\naliases:: aliases1\nhello" :aliases "aliases2")
+      "title:: title\nalias:: alias1, alias2\naliases:: aliases1, aliases2\nhello")))
+
+(deftest test-insert-properties
+  (testing "add org page properties"
+    (are [x y] (= x y)
+      (property/insert-properties :org "hello" {:title "title"})
+      "#+title: title\nhello"
+
+      (property/insert-properties :org "#+title: title\nhello"
+                                  {:title "new title"
+                                   :alias "alias1"})
+      "#+title: new title\n#+alias: alias1\nhello"
+
+      (property/insert-properties :org "#+title: title\n#+alias: alias1\nhello"
+                                  {:title "new title"
+                                   :alias "alias2"
+                                   :aliases "aliases1"})
+      "#+title: new title\n#+alias: alias1, alias2\n#+aliases: aliases1\nhello"
+
+      (property/insert-properties :org "#+title: title\n#+alias: alias1, alias2\n#+aliases: aliases1\nhello"
+                                  {:title "new title"
+                                   :alias "alias2"
+                                   :aliases "aliases1"})
+      "#+title: new title\n#+alias: alias1, alias2\n#+aliases: aliases1\nhello"))
+
+  (testing "add markdown page properties"
+    (are [x y] (= x y)
+      (property/insert-properties :markdown "hello" {:title "title"})
+      "title:: title\nhello"
+
+      (property/insert-properties :markdown "title:: title\nhello"
+                                  {:title "new title"
+                                   :alias "alias1"})
+      "title:: new title\nalias:: alias1\nhello"
+
+      (property/insert-properties :markdown "title:: title\nalias:: alias1\nhello"
+                                  {:title "new title"
+                                   :alias "alias2"
+                                   :aliases "aliases1"})
+      "title:: new title\nalias:: alias1, alias2\naliases:: aliases1\nhello"
+
+      (property/insert-properties :markdown "title:: title\nalias:: alias1, alias2\naliases:: aliases1\nhello"
+                                  {:title "new title"
+                                   :alias "alias2"
+                                   :aliases "aliases1"})
+      "title:: new title\nalias:: alias1, alias2\naliases:: aliases1\nhello")))
+
+#_(cljs.test/run-tests)


### PR DESCRIPTION
Creating or renaming a page with namespace will add block-styled title
property, which is not proper. This PR fixed this issue.

Before: 
<img width="381" alt="CleanShot 2021-11-04 at 16 03 20@2x" src="https://user-images.githubusercontent.com/3996879/140278235-b7459a5b-27c9-47f3-9da5-bcb5ed32e597.png">
After:
<img width="412" alt="CleanShot 2021-11-04 at 16 01 40@2x" src="https://user-images.githubusercontent.com/3996879/140278026-c7e247d0-f334-4000-a88c-ba07a22de5f3.png">
