### PR TITLE
enhance: add CSS classes to enable custom styles

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1678,9 +1678,9 @@
                    state)}
   [state block typ ast]
   (let [show? (get state ::show?)]
-    [:div.flex.flex-col
-     [:div.text-sm.mt-1.flex.flex-row
-      [:div.opacity-50.font-medium
+    [:div.flex.flex-col.timestamp
+     [:div.text-sm.mb-1.flex.flex-row
+      [:div.opacity-50.font-medium.timestamp-label
        (str typ ": ")]
       [:a.opacity-80.hover:opacity-100
        {:on-click (fn []
@@ -2385,8 +2385,8 @@
         (when-not (and built-in? (empty? result))
           (ui/foldable
            [:div.custom-query-title
-            title
-            [:span.opacity-60.text-sm.ml-2
+            [:span.title-text title]
+            [:span.opacity-60.text-sm.ml-2.results-count
              (str (count transformed-query-result) " results")]]
            [:div
             (when current-block

--- a/src/main/frontend/extensions/srs.cljs
+++ b/src/main/frontend/extensions/srs.cljs
@@ -580,11 +580,9 @@
             card-query-block (db/entity [:block/uuid (:block/uuid config)])
             filtered-total (count result)
             modal? (:modal? config)]
-        [:div.flex-1 {:style (when modal? {:height "100%"})}
+        [:div.flex-1.cards-review {:style (when modal? {:height "100%"})}
          [:div.flex.flex-row.items-center.justify-between.cards-title
-          [:div
-           [:span.text-sm [:span.font-bold "🗂️"]
-            (str ": " query-string)]]
+          [:code.text-sm.opacity-50 query-string]
 
           [:div.flex.flex-row.items-center
 
@@ -592,7 +590,7 @@
            (ui/tippy {:html [:div.text-sm "overdue/total"]
                       ;; :class "tippy-hover"
                       :interactive true}
-                     [:div.opacity-60.text-sm
+                     [:div.opacity-60.text-sm.mr-3
                       (let [idx (- filtered-total @card-index)]
                         (max idx 0))
                       [:span "/"]
@@ -604,8 +602,9 @@
              :class "tippy-hover"
              :interactive true
              :disabled false}
-            [:a.opacity-60.hover:opacity-100.svg-small.inline.ml-3.font-bold
-             {:on-click (fn [_]
+            [:a.opacity-60.hover:opacity-100.svg-small.inline.mr-3.font-bold
+             {:id "preview-all-cards"
+              :on-click (fn [_]
                           (let [blocks query-result]
                             (when (> (count blocks) 0)
                               (state/set-modal! #(view-modal


### PR DESCRIPTION
I wanted to be able to add custom CSS styles to change the way **timestamps** and **custom queries** are rendered, but they didn't have classes that made it easy to change those styles.

This tiny PR adds classnames so users can add custom CSS on those elements.