### PR TITLE
Fix(rename): get the right page name if namespace exists in the path 

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -920,11 +920,8 @@
 
         :else
         (let [href (string-of-url url)
-              protocol (or
-                        (and (= "Complex" (first url))
-                             (:protocol (second url)))
-                        (and (= "File" (first url))
-                             "file"))]
+              [protocol path] (or (and (= "Complex" (first url)) url)
+                                  (and (= "File" (first url)) ["file" (second url)]))]
           (cond
             (and (= (get-in config [:block :block/format]) :org)
                  (= "Complex" (first url))
@@ -949,10 +946,9 @@
               (asset-reference config label href)
 
               :else
-              (let [label-text (get-label-text label)
-                    redirect-page-name (-> (second url)
-                                           text/get-file-basename)
+              (let [redirect-page-name (when (string? path) (text/get-file-basename path))
                     config (assoc config :redirect-page-name redirect-page-name)
+                    label-text (get-label-text label)
                     page (if (string/blank? label-text)
                            {:block/name (db/get-file-page (string/replace href "file:" ""))}
                            (get-page label))]
@@ -1173,7 +1169,6 @@
                     :src (str "https://player.bilibili.com/player.html?bvid=" id "&high_quality=1")
                     :width width
                     :height (max 500 height)}])))))
-
 
         (contains? #{"tweet" "twitter"} name)
         (when-let [url (first arguments)]

--- a/src/main/frontend/text.cljs
+++ b/src/main/frontend/text.cljs
@@ -11,9 +11,7 @@
 (defn get-file-basename
   [path]
   (when-not (string/blank? path)
-    (-> (util/node-path.basename path)
-        (string/split #"\.")
-        first)))
+    (util/node-path.name path)))
 
 (defn get-page-name
   [s]

--- a/src/main/frontend/text.cljs
+++ b/src/main/frontend/text.cljs
@@ -7,6 +7,7 @@
 
 (def page-ref-re-0 #"\[\[(.*)\]\]")
 (def org-page-ref-re #"\[\[(file:.*)\]\[.+?\]\]")
+(def markdown-page-ref-re #"\[(.*)\]\(file:.*\)")
 
 (defn get-file-basename
   [path]
@@ -16,7 +17,9 @@
 (defn get-page-name
   [s]
   (and (string? s)
-       (or (when-let [[_ path _label] (re-matches org-page-ref-re s)]
+       (or (when-let [[_ label _path] (re-matches markdown-page-ref-re s)]
+             (string/trim label))
+           (when-let [[_ path _label] (re-matches org-page-ref-re s)]
              (get-file-basename path))
            (-> (re-matches page-ref-re-0 s)
                second))))

--- a/src/main/frontend/utils.js
+++ b/src/main/frontend/utils.js
@@ -1,4 +1,4 @@
-import path from 'path'
+import path from 'path/path.js'
 
 if (typeof window === 'undefined') {
   global.window = {}
@@ -277,5 +277,20 @@ export const nodePath = Object.assign({}, path, {
   basename (input) {
     input = toPosixPath(input)
     return path.basename(input)
-  }
+  },
+
+  name (input) {
+    input = toPosixPath(input)
+    return path.parse(input).name
+  },
+
+  dirname (input) {
+    input = toPosixPath(input)
+    return path.dirname(input)
+  },
+  
+  extname (input) {
+    input = toPosixPath(input)
+    return path.extname(input)
+  }  
 })


### PR DESCRIPTION
- Fix https://github.com/logseq/logseq/issues/3085
<img width="726" alt="CleanShot 2021-11-08 at 19 18 55@2x" src="https://user-images.githubusercontent.com/3996879/140733095-92e9fcd1-e19a-4045-9d8c-99ac5a001fa7.png">
- Fix issue: https://discord.com/channels/725182569297215569/735747000649252894/906585990108414033