### PR TITLE
enhance page-ref-un-bracket!

### DIFF
--- a/src/main/frontend/text.cljs
+++ b/src/main/frontend/text.cljs
@@ -53,10 +53,7 @@
 
 (defn page-ref-un-brackets!
   [s]
-  (when (string? s)
-    (if (page-ref? s)
-      (subs s 2 (- (count s) 2))
-      s)))
+  (or (get-page-name s) s))
 
 (defn block-ref-un-brackets!
   [s]

--- a/src/test/frontend/text_test.cljs
+++ b/src/test/frontend/text_test.cljs
@@ -10,6 +10,9 @@
     "[single bracket]" nil
     "no brackets" nil
 
+    "[[another page]]" "another page"
+    "[[nested [[page]]]]" "nested [[page]]"
+
     "[[file:./page.org][page]]" "page"
     "[[file:./pages/page.org][page]]" "page"
 


### PR DESCRIPTION
This solves some issues when renaming page.
1. The embeded references will be updated which was not supported before.
2. query supports orgmode link now.