### PR TITLE
enhance(properties): display various links well

### DIFF
--- a/src/main/frontend/handler/link.cljs
+++ b/src/main/frontend/handler/link.cljs
@@ -1,0 +1,39 @@
+(ns frontend.handler.link 
+  (:require
+    [frontend.util :as util]))
+
+(def plain-link "(?:http://www\\.|https://www\\.|http://|https://){1}[a-z0-9]+(?:[\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}(?:.*)*")
+(def plain-link-re (re-pattern plain-link))
+(def org-link-re-1 (re-pattern (util/format "\\[\\[(%s)\\]\\[(.+)\\]\\]" plain-link)))
+(def org-link-re-2 (re-pattern (util/format "\\[\\[(%s)\\]\\]" plain-link)))
+(def markdown-link-re (re-pattern (util/format "^\\[(.+)\\]\\((%s)\\)" plain-link)))
+
+(defn- plain-link?
+  [link]
+  (let [matches (re-matches plain-link-re link)]
+    (when matches
+      {:type "plain-link"
+       :url matches})))
+
+(defn- org-link?
+  [link]
+  (let [matches (or (re-matches org-link-re-1 link)
+                    (re-matches org-link-re-2 link))]
+    (when matches
+      {:type "org-link"
+       :url (second matches)
+       :label (nth matches 2 nil)})))
+
+(defn- markdown-link?
+  [link]
+  (let [matches (re-matches markdown-link-re link)]
+    (when matches
+      {:type "markdown-link"
+       :url (nth matches 2)
+       :label (second matches)})))
+
+(defn link?
+  [link]
+  (or (plain-link? link)
+      (org-link? link)
+      (markdown-link? link)))

--- a/src/main/frontend/util/property.cljs
+++ b/src/main/frontend/util/property.cljs
@@ -5,6 +5,7 @@
             [frontend.config :as config]
             [medley.core :as medley]
             [frontend.format.mldoc :as mldoc]
+            [frontend.handler.link :as link]
             [frontend.text :as text]
             [frontend.util.cursor :as cursor]))
 
@@ -447,7 +448,7 @@
       (contains? @non-parsing-properties (string/lower-case k))
       v
 
-      (string/starts-with? v "http")
+      (link/link? v)
       v
 
       :else

--- a/src/test/frontend/handler/test_link.cljs
+++ b/src/test/frontend/handler/test_link.cljs
@@ -1,0 +1,51 @@
+(ns frontend.handler.test-link
+  (:require [cljs.test :refer [are deftest testing]]
+            [frontend.handler.link :as link]))
+
+(deftest test-link?
+  (testing "non-link"
+    (are [x y] (= (link/link? x) y)
+      "google.com" nil
+      "[[google.com][google]]" nil
+      "[[google.com]]" nil
+      "[google](google.com)" nil))
+  
+  (testing "plain links"
+    (are [x y] (= (link/link? x) y)
+      "http://www.google.com"
+      {:type "plain-link" :url "http://www.google.com"}
+
+      "http://google.com"
+      {:type "plain-link" :url "http://google.com"}))
+
+  (testing "org links"
+    (are [x y] (= (link/link? x) y)
+      "[[http://www.google.com][google]]"
+      {:type "org-link" :url "http://www.google.com" :label "google"}
+
+      "[[http://google.com][google]]"
+      {:type "org-link" :url "http://google.com" :label "google"}
+
+      "[[https://www.google.com][google]]"
+      {:type "org-link" :url "https://www.google.com" :label "google"}
+
+      "[[https://google.com][google]]"
+      {:type "org-link" :url "https://google.com" :label "google"}))
+
+  (testing "org links"
+    (are [x y] (= (link/link? x) y)
+      "[[http://www.google.com]]"
+      {:type "org-link" :url "http://www.google.com" :label nil}
+
+      "[[https://www.google.com]]"
+      {:type "org-link" :url "https://www.google.com" :label nil}))
+
+  (testing "markdown links"
+    (are [x y] (= (link/link? x) y)
+      "[google](http://www.google.com)"
+      {:type "markdown-link" :url "http://www.google.com" :label "google"}
+
+      "[google](https://www.google.com)"
+      {:type "markdown-link" :url "https://www.google.com" :label "google"})))
+
+#_(cljs.test/test-ns 'frontend.test-link)


### PR DESCRIPTION
Fix link display in properties drawer in Org-Mode

Before:
<img width="536" alt="CleanShot 2021-11-09 at 19 43 02@2x" src="https://user-images.githubusercontent.com/3996879/140918459-540e612a-c47a-4cc5-9c0c-81148ff7c7f1.png">

After:
<img width="684" alt="CleanShot 2021-11-09 at 19 47 01@2x" src="https://user-images.githubusercontent.com/3996879/140918750-abad9a0a-8782-43d3-aa1b-3586c519719a.png">

