### PR TITLE
enhance: renaming namespace page will update all its children's links

### DIFF
--- a/src/main/frontend/db.cljs
+++ b/src/main/frontend/db.cljs
@@ -49,7 +49,7 @@
   get-all-pages get-pages get-pages-relation get-pages-that-mentioned-page get-public-pages get-tag-pages
   journal-page? local-native-fs? mark-repo-as-cloned! page-alias-set page-blocks-transform pull-block
   set-file-last-modified-at! transact-files-db! page-empty? page-empty-or-dummy? get-alias-source-page
-  set-file-content! has-children? get-namespace-pages get-all-namespace-relation]
+  set-file-content! has-children? get-namespace-pages get-all-namespace-relation get-nested-pages]
 
  [frontend.db.react
   get-current-marker get-current-page get-current-priority set-key-value

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -572,6 +572,19 @@
   (when-let [block (db-utils/entity repo [:block/uuid block-id])]
     (db-utils/entity repo (:db/id (:block/page block)))))
 
+(defn get-nested-pages
+  [repo page-name]
+  (when-let [conn (conn/get-conn repo)]
+    (let [nested-page-name (->> (string/trim page-name)
+                                (util/format "[[%s]]"))]
+      (d/q '[:find ?e ?n
+             :in $ ?x
+             :where
+             [?e :block/name ?n]
+             [(clojure.string/includes? ?n ?x)]]
+           conn
+           nested-page-name))))
+
 (defn block-and-children-transform
   [result repo-url block-uuid]
   (some->> result

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -454,10 +454,7 @@
           (rename-nested-pages old-name new-name))
       (cond
         (string/blank? new-name)
-        (notification/show! "Please use a valid name, empty name is not allowed!" :error)
-
-        (not name-changed?)
-        (notification/show! "Cannot rename to page with same name!" :error)))))
+        (notification/show! "Please use a valid name, empty name is not allowed!" :error)))))
 
 (defn- split-col-by-element
   [col element]

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -435,26 +435,34 @@
         new-name      (string/trim new-name)
         namespace     (or (string/includes? old-name "/")
                           (db/get-namespace-pages repo old-name))
-        name-changed? (not= old-name new-name)]
+        name-changed? (not= old-name new-name)
+        rename-fn    (fn [old-name new-name]
+                       (rename-page-aux old-name new-name)
+                       (rename-nested-pages old-name new-name))]
     (if (and old-name
              new-name
              (not (string/blank? new-name))
              name-changed?)
       (cond
+        (= (string/lower-case old-name) (string/lower-case new-name))
+        (rename-fn old-name new-name)
+
         (db/pull [:block/name (string/lower-case new-name)])
         (notification/show! "Page already exists!" :error)
 
+        namespace
+        (do
+          (rename-namespace-pages! repo old-name new-name)
+          (rename-nested-pages old-name new-name))
+
         :else
-        (do (if namespace
-              (rename-namespace-pages! repo old-name new-name)
-              (rename-page-aux old-name new-name))
-            (rename-nested-pages old-name new-name)))
+        (rename-fn old-name new-name))
       (cond
         (string/blank? new-name)
         (notification/show! "Please use a valid name, empty name is not allowed!" :error)
 
         (not name-changed?)
-        (notification/show! "Cannot rename to page with same same!" :error)))))
+        (notification/show! "Cannot rename to page with same name!" :error)))))
 
 (defn- split-col-by-element
   [col element]

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -4,13 +4,13 @@
   #?(:cljs (:require
             ["/frontend/selection" :as selection]
             ["/frontend/utils" :as utils]
-            [frontend.mobile.util :refer [is-native-platform?]]
             [camel-snake-kebab.core :as csk]
             [camel-snake-kebab.extras :as cske]
             [cljs-bean.core :as bean]
             [cljs-time.coerce :as tc]
             [cljs-time.core :as t]
             [dommy.core :as d]
+            [frontend.mobile.util :refer [is-native-platform?]]
             [frontend.react-impls :as react-impls]
             [goog.dom :as gdom]
             [goog.object :as gobj]
@@ -620,6 +620,12 @@
          (concat-without-spaces prefix new-value)
          (str prefix new-value)))
      s)))
+
+(defn replace-ignore-case [s old-value new-value]
+  (string/replace s (re-pattern (str "(?i)" old-value)) new-value))
+
+(defn replace-first-ignore-case [s old-value new-value]
+  (string/replace-first s (re-pattern (str "(?i)" old-value)) new-value))
 
 ;; copy from https://stackoverflow.com/questions/18735665/how-can-i-get-the-positions-of-regex-matches-in-clojurescript
 #?(:cljs


### PR DESCRIPTION
1. Renaming namespace page will update all its children's links
    fix https://github.com/logseq/logseq/issues/3023
2. Update corresponding pages when renaming a page which referenced by other pages in title.
    fix https://github.com/logseq/logseq/issues/1489