### PR TITLE
enhance: page rename confirm window

### DIFF
--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -185,12 +185,12 @@
          {:default-collapsed? false})]])))
 
 (rum/defcs page-title <
-  {:will-update (fn [state]
-                  (assoc state ::title-value (atom (nth (:rum/args state) 2))))}
   (rum/local false ::edit?)
+  (rum/local "" ::title-value)
   [state page-name icon title format fmt-journal?]
   (when title
     (let [*title-value (get state ::title-value)
+          *input-ref (rum/create-ref)
           *edit? (get state ::edit?)
           repo (state/get-current-repo)
           title-element (if (and (string/includes? title "[[")
@@ -208,36 +208,47 @@
           title (if hls-file?
                   (pdf-assets/human-hls-filename-display title)
                   (if fmt-journal? (date/journal-title->custom-format title) title))
+          old-name (or title page-name)
+          new-page-exist? (when @*title-value
+                            (db/entity [:block/name @*title-value]))
           confirm-fn (ui/make-confirm-modal
-                      {:title         (str "Do you really want to change the page name?")
+                      {:title         "Do you really want to change the page name?"
                        :on-confirm    (fn [_e {:keys [close-fn]}]
                                         (close-fn)
                                         (page-handler/rename! (or title page-name) @*title-value)
                                         (reset! *edit? false)
+                                        (reset! *title-value ""))
+                       :on-cancel     (fn []
+                                        (set! (.-value (rum/deref *input-ref)) old-name)
+                                        (reset! *edit? true)
                                         (reset! *title-value ""))})]
       (if @*edit?
-        (let [old-name (or title page-name)]
-          [:h1.title {:style {:margin-left -2}}
-           [:input.w-full
-            {:type          "text"
-             :auto-focus    true
-             :style         {:outline "none"
-                             :font-weight 600}
-             :auto-complete (if (util/chrome?) "chrome-off" "off") ; off not working here
-             :default-value @*title-value
-             :on-change     (fn [e]
-                              (let [value (util/evalue e)]
-                                (when-not (string/blank? value)
-                                  (reset! *title-value value))))
-             :on-blur       (fn [e]
+        [:h1.title {:style {:margin-left -2}}
+         [:input.w-full
+          {:type          "text"
+           :ref           *input-ref
+           :auto-focus    true
+           :style         {:outline "none"
+                           :font-weight 600}
+           :auto-complete (if (util/chrome?) "chrome-off" "off") ; off not working here
+           :default-value old-name
+           :on-change     (fn [e]
+                            (let [value (util/evalue e)]
+                              (when-not (string/blank? value)
+                                (reset! *title-value (string/trim value)))))
+           :on-blur       (fn [e]
+                            (if-not new-page-exist?
                               (when (not= old-name @*title-value)
                                 (state/set-modal! confirm-fn))
-                              (util/stop e))
-             :on-key-down   (fn [e]
-                              (when (= (gobj/get e "key") "Enter")
+                             (notification/show! "Page already exists!" :error))
+                            (util/stop e))
+           :on-key-down   (fn [e]
+                            (when (= (gobj/get e "key") "Enter")
+                              (if-not new-page-exist?
                                 (when (not= old-name @*title-value)
                                   (state/set-modal! confirm-fn))
-                                (util/stop e)))}]])
+                                (notification/show! "Page already exists!" :error))
+                              (util/stop e)))}]]
         [:a.page-title {:on-mouse-down (fn [e]
                                          (when (util/right-click? e)
                                            (state/set-state! :page-title/context {:page page-name})))


### PR DESCRIPTION
- Cancel to reset the page name to its old one
- If new page already exists, popup notification instead of confirm window