### PR TITLE
Add more content-aware classes to textarea for a more WYSIWYG experience

### DIFF
--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -447,18 +447,21 @@
 
 (defn get-editor-heading-class [content]
   (let [content (if content (str content) "")]
-    (cond
-      (string/includes? content "\n") "multiline-block"
-      (starts-with? content "# ") "h1"
-      (starts-with? content "## ") "h2"
-      (starts-with? content "### ") "h3"
-      (starts-with? content "#### ") "h4"
-      (starts-with? content "##### ") "h5"
-      (starts-with? content "###### ") "h6"
-      (starts-with? content "TODO ") "todo-block"
-      (starts-with? content "DOING ") "doing-block"
-      (starts-with? content "DONE ") "done-block"
-      :else "normal-block")))
+    (str
+     (if (string/includes? content "\n") "multiline-block" "uniline-block")
+     " "
+     (cond
+       (starts-with? content "# ") "h1"
+       (starts-with? content "## ") "h2"
+       (starts-with? content "### ") "h3"
+       (starts-with? content "#### ") "h4"
+       (starts-with? content "##### ") "h5"
+       (starts-with? content "###### ") "h6"
+       (starts-with? content "TODO ") "todo-block"
+       (starts-with? content "DOING ") "doing-block"
+       (starts-with? content "DONE ") "done-block"
+       (and (starts-with? content "---\n") (.endsWith content "\n---")) "page-properties"
+       :else "normal-block"))))
 
 (rum/defc mock-textarea <
   rum/static


### PR DESCRIPTION
- Adds a `.page-properties` class to textarea so that user can style the editor differently when editing properties on a page vs other blocks.
- Fixes the `.multiline-block` class so that it applies **in addition to** the `h1`, `h2`, etc classes rather than **instead of** them.