### PR TITLE
fix: disable-auto-commit should default to true

### DIFF
--- a/src/electron/electron/state.cljs
+++ b/src/electron/electron/state.cljs
@@ -31,4 +31,4 @@
 
 (defn git-auto-commit-disabled?
   []
-  (get-in @state [:config :git/disable-auto-commit?]))
+  (get-in @state [:config :git/disable-auto-commit?] true))


### PR DESCRIPTION
Fixes #3157

The option in the setting menu is "enable git auto commit".
While the option in code is "disable-auto-commit".

