### PR TITLE
enhance shortcut tooltips

### DIFF
--- a/resources/css/tooltip.css
+++ b/resources/css/tooltip.css
@@ -22,7 +22,7 @@
 }
 
 .tippy-popper[x-placement^=top] [x-arrow] {
-  border-top: 7px solid var(--ls-tertiary-background-color);
+  border-top: 7px solid var(--ls-quaternary-background-color);
   border-right: 7px solid transparent;
   border-left: 7px solid transparent;
   bottom: -7px;
@@ -30,14 +30,14 @@
 }
 
 .tippy-popper[x-placement^=top] [x-arrow].arrow-small {
-  border-top: 5px solid var(--ls-tertiary-background-color);
+  border-top: 5px solid var(--ls-quaternary-background-color);
   border-right: 5px solid transparent;
   border-left: 5px solid transparent;
   bottom: -5px
 }
 
 .tippy-popper[x-placement^=top] [x-arrow].arrow-big {
-  border-top: 10px solid var(--ls-tertiary-background-color);
+  border-top: 10px solid var(--ls-quaternary-background-color);
   border-right: 10px solid transparent;
   border-left: 10px solid transparent;
   bottom: -10px
@@ -158,7 +158,7 @@
 }
 
 .tippy-popper[x-placement^=bottom] [x-arrow] {
-  border-bottom: 7px solid var(--ls-tertiary-background-color);
+  border-bottom: 7px solid var(--ls-quaternary-background-color);
   border-right: 7px solid transparent;
   border-left: 7px solid transparent;
   top: -7px;
@@ -166,14 +166,14 @@
 }
 
 .tippy-popper[x-placement^=bottom] [x-arrow].arrow-small {
-  border-bottom: 5px solid var(--ls-tertiary-background-color);
+  border-bottom: 5px solid var(--ls-quaternary-background-color);
   border-right: 5px solid transparent;
   border-left: 5px solid transparent;
   top: -5px
 }
 
 .tippy-popper[x-placement^=bottom] [x-arrow].arrow-big {
-  border-bottom: 10px solid var(--ls-tertiary-background-color);
+  border-bottom: 10px solid var(--ls-quaternary-background-color);
   border-right: 10px solid transparent;
   border-left: 10px solid transparent;
   top: -10px
@@ -294,7 +294,7 @@
 }
 
 .tippy-popper[x-placement^=left] [x-arrow] {
-  border-left: 7px solid var(--ls-tertiary-background-color);
+  border-left: 7px solid var(--ls-quaternary-background-color);
   border-top: 7px solid transparent;
   border-bottom: 7px solid transparent;
   right: -7px;
@@ -302,14 +302,14 @@
 }
 
 .tippy-popper[x-placement^=left] [x-arrow].arrow-small {
-  border-left: 5px solid var(--ls-tertiary-background-color);
+  border-left: 5px solid var(--ls-quaternary-background-color);
   border-top: 5px solid transparent;
   border-bottom: 5px solid transparent;
   right: -5px
 }
 
 .tippy-popper[x-placement^=left] [x-arrow].arrow-big {
-  border-left: 10px solid var(--ls-tertiary-background-color);
+  border-left: 10px solid var(--ls-quaternary-background-color);
   border-top: 10px solid transparent;
   border-bottom: 10px solid transparent;
   right: -10px
@@ -430,7 +430,7 @@
 }
 
 .tippy-popper[x-placement^=right] [x-arrow] {
-  border-right: 7px solid var(--ls-tertiary-background-color);
+  border-right: 7px solid var(--ls-quaternary-background-color);
   border-top: 7px solid transparent;
   border-bottom: 7px solid transparent;
   left: -7px;
@@ -438,14 +438,14 @@
 }
 
 .tippy-popper[x-placement^=right] [x-arrow].arrow-small {
-  border-right: 5px solid var(--ls-tertiary-background-color);
+  border-right: 5px solid var(--ls-quaternary-background-color);
   border-top: 5px solid transparent;
   border-bottom: 5px solid transparent;
   left: -5px
 }
 
 .tippy-popper[x-placement^=right] [x-arrow].arrow-big {
-  border-right: 10px solid var(--ls-tertiary-background-color);
+  border-right: 10px solid var(--ls-quaternary-background-color);
   border-top: 10px solid transparent;
   border-bottom: 10px solid transparent;
   left: -10px
@@ -587,12 +587,11 @@
   position: relative;
   color: var(--ls-primary-text-color);
   border-radius: 4px;
-  padding-left: 0.8em;
   text-align: center;
   will-change: transform;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: var(--ls-tertiary-background-color)
+  background-color: var(--ls-quaternary-background-color);
 }
 
 .tippy-tooltip--small {
@@ -627,7 +626,7 @@
 .tippy-tooltip [x-circle] {
   position: absolute;
   will-change: transform;
-  background-color: var(--ls-tertiary-background-color);
+  background-color: var(--ls-quaternary-background-color);
   border-radius: 50%;
   width: 130%;
   width: calc(110% + 2rem);
@@ -656,7 +655,7 @@
 }
 
 .tippy-wrapper {
-  background-color: var(--ls-tertiary-background-color);
+  background-color: var(--ls-quaternary-background-color);
 }
 
 .tippy-hover {

--- a/resources/css/tooltip.css
+++ b/resources/css/tooltip.css
@@ -661,3 +661,7 @@
 .tippy-hover {
   cursor: pointer;
 }
+
+.tippy-popper .tippy-tooltip.monospace-theme {
+  font-family: 'Fira Code', Monaco, Menlo, Consolas, 'COURIER NEW', monospace;
+}

--- a/resources/css/tooltip.css
+++ b/resources/css/tooltip.css
@@ -661,8 +661,3 @@
 .tippy-hover {
   cursor: pointer;
 }
-
-.tippy-popper .tippy-tooltip.extra-padding-y .py-1 {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-}

--- a/resources/css/tooltip.css
+++ b/resources/css/tooltip.css
@@ -661,3 +661,8 @@
 .tippy-hover {
   cursor: pointer;
 }
+
+.tippy-popper .tippy-tooltip.extra-padding-y .py-1 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}

--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -31,7 +31,6 @@
    {:html [:div.text-sm.font-medium (ui/keyboard-shortcut-from-config :go/home)]
     :interactive true
     :position    "left"
-    :theme       "extra-padding-y"
     :arrow       true}
    [:a.button
     {:href     (rfe/href :home)
@@ -135,7 +134,6 @@
     {:html [:div.text-sm.font-medium (ui/keyboard-shortcut-from-config :go/backward)]
      :interactive true
      :position    "bottom"
-     :theme       "extra-padding-y"
      :arrow       true}
     [:a.it.navigation.nav-left.button
      {:title "Go back" :on-click #(js/window.history.back)}
@@ -145,7 +143,6 @@
     {:html [:div.text-sm.font-medium (ui/keyboard-shortcut-from-config :go/forward)]
      :interactive true
      :position    "bottom"
-     :theme       "extra-padding-y"
      :arrow       true}
     [:a.it.navigation.nav-right.button
      {:title "Go forward" :on-click #(js/window.history.forward)}

--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -31,6 +31,7 @@
    {:html [:div.text-sm.font-medium (ui/keyboard-shortcut-from-config :go/home)]
     :interactive true
     :position    "left"
+    :theme       "monospace"
     :arrow       true}
    [:a.button
     {:href     (rfe/href :home)
@@ -65,6 +66,7 @@
   (ui/tippy
    {:html [:div.text-sm.font-medium (ui/keyboard-shortcut-from-config :ui/toggle-left-sidebar)]
     :position    "bottom"
+    :theme       "monospace"
     :interactive true
     :arrow       true}
 
@@ -134,6 +136,7 @@
     {:html [:div.text-sm.font-medium (ui/keyboard-shortcut-from-config :go/backward)]
      :interactive true
      :position    "bottom"
+     :theme       "monospace"
      :arrow       true}
     [:a.it.navigation.nav-left.button
      {:title "Go back" :on-click #(js/window.history.back)}
@@ -143,6 +146,7 @@
     {:html [:div.text-sm.font-medium (ui/keyboard-shortcut-from-config :go/forward)]
      :interactive true
      :position    "bottom"
+     :theme       "monospace"
      :arrow       true}
     [:a.it.navigation.nav-right.button
      {:title "Go forward" :on-click #(js/window.history.forward)}
@@ -201,6 +205,7 @@
             {:html [:div.text-sm.font-medium (ui/keyboard-shortcut-from-config :go/search)]
              :interactive true
              :position    "right"
+             :theme       "monospace"
              :arrow       true}
             [:a.button#search-button
              {:on-click #(state/pub-event! [:go/search])}

--- a/src/main/frontend/components/right_sidebar.cljs
+++ b/src/main/frontend/components/right_sidebar.cljs
@@ -26,6 +26,7 @@
       {:html [:div.text-sm.font-medium
               (ui/keyboard-shortcut-from-config :ui/toggle-right-sidebar)]
        :position    "left"
+       :theme       "monospace"
        :interactive true
        :arrow       true}
 

--- a/src/main/frontend/components/right_sidebar.cljs
+++ b/src/main/frontend/components/right_sidebar.cljs
@@ -24,13 +24,11 @@
   (when-not (util/mobile?)
     (ui/tippy
       {:html [:div.text-sm.font-medium
-              "Shortcut: "
-              [:code (util/->platform-shortcut "t r")]]
-       :delay 2000
-       :hideDelay 1
-       :position "left"
+              (ui/keyboard-shortcut-from-config :ui/toggle-right-sidebar)]
+       :position    "left"
+       :theme       "extra-padding-y"
        :interactive true
-       :arrow true}
+       :arrow       true}
 
       [:a.button.fade-link.toggle
        {:on-click state/toggle-sidebar-open?!}

--- a/src/main/frontend/components/right_sidebar.cljs
+++ b/src/main/frontend/components/right_sidebar.cljs
@@ -26,7 +26,6 @@
       {:html [:div.text-sm.font-medium
               (ui/keyboard-shortcut-from-config :ui/toggle-right-sidebar)]
        :position    "left"
-       :theme       "extra-padding-y"
        :interactive true
        :arrow       true}
 

--- a/src/main/frontend/components/search.cljs
+++ b/src/main/frontend/components/search.cljs
@@ -276,10 +276,11 @@
    [:div.px-4.py-2.text-sm.opacity-70.flex.flex-row.justify-between.align-items
     [:div "Recent search:"]
     (ui/tippy {:html [:div.text-sm.font-medium
-                      "Shortcut: "
-                      [:code (util/->platform-shortcut "Ctrl + Shift + k")]]
+                      (ui/keyboard-shortcut-from-config :go/search-in-page)]
+               :arrow           true
                :interactive     true
-               :arrow true}
+               :theme           "extra-padding-y"
+               }
               [:div.flex-row.flex.align-items
                [:div.mr-2 "Search in page:"]
                [:div {:style {:margin-top 3}}
@@ -288,9 +289,12 @@
                              (state/set-search-mode! (if in-page-search? :global :page)))
                            true)]
                (ui/tippy {:html [:div
-                                 "Tip: " [:code (util/->platform-shortcut "Ctrl+Shift+p")] " to open the commands palette"]
+                                  ;; TODO: fetch from config
+                                 "Tip: " [:code (util/->platform-shortcut "Ctrl + Shift + p")] " to open the commands palette"]
                           :interactive     true
-                          :arrow true}
+                          :arrow           true
+                          :theme           "extra-padding-y"
+                          }
                          [:a.inline-block.fade-link
                           {:style {:margin-left 12}
                            :on-click #(state/toggle! :ui/command-palette-open?)}

--- a/src/main/frontend/components/search.cljs
+++ b/src/main/frontend/components/search.cljs
@@ -279,7 +279,6 @@
                       (ui/keyboard-shortcut-from-config :go/search-in-page)]
                :arrow           true
                :interactive     true
-               :theme           "extra-padding-y"
                }
               [:div.flex-row.flex.align-items
                [:div.mr-2 "Search in page:"]
@@ -293,7 +292,6 @@
                                  "Tip: " [:code (util/->platform-shortcut "Ctrl + Shift + p")] " to open the commands palette"]
                           :interactive     true
                           :arrow           true
-                          :theme           "extra-padding-y"
                           }
                          [:a.inline-block.fade-link
                           {:style {:margin-left 12}

--- a/src/main/frontend/components/search.cljs
+++ b/src/main/frontend/components/search.cljs
@@ -279,7 +279,7 @@
                       (ui/keyboard-shortcut-from-config :go/search-in-page)]
                :arrow           true
                :interactive     true
-               }
+               :theme       "monospace"}
               [:div.flex-row.flex.align-items
                [:div.mr-2 "Search in page:"]
                [:div {:style {:margin-top 3}}
@@ -292,7 +292,7 @@
                                  "Tip: " [:code (util/->platform-shortcut "Ctrl + Shift + p")] " to open the commands palette"]
                           :interactive     true
                           :arrow           true
-                          }
+                          :theme       "monospace"}
                          [:a.inline-block.fade-link
                           {:style {:margin-left 12}
                            :on-click #(state/toggle! :ui/command-palette-open?)}

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -176,7 +176,7 @@
                 config-handler/toggle-ui-show-brackets!
                 true)]]
    [:div {:style {:text-align "right"}}
-    (ui/keyboard-shortcut (shortcut-helper/gen-shortcut-seq :ui/toggle-brackets))]])
+    (ui/render-keyboard-shortcut (shortcut-helper/gen-shortcut-seq :ui/toggle-brackets))]])
 
 (rum/defcs switch-spell-check-row < rum/reactive
   [state t]
@@ -286,7 +286,7 @@
             :class    (classnames [{:active system-theme?}])} [:i.mode-system] [:strong "system"]]]]
 
     [:div.pl-16
-     (ui/keyboard-shortcut (shortcut-helper/gen-shortcut-seq :ui/toggle-theme))]]])
+     (ui/render-keyboard-shortcut (shortcut-helper/gen-shortcut-seq :ui/toggle-theme))]]])
 
 (defn file-format-row [t preferred-format]
   [:div.it.sm:grid.sm:grid-cols-3.sm:gap-4.sm:items-start

--- a/src/main/frontend/components/shortcut.cljs
+++ b/src/main/frontend/components/shortcut.cljs
@@ -19,10 +19,10 @@
      [:div
       [:p.mb-4 "Press any sequence of keys to set the shortcut for the " [:b action-name] " action."]
       [:p.mb-4.mt-4
-       (ui/keyboard-shortcut (-> keyboard-shortcut
-                                 (str/trim)
-                                 (str/lower-case)
-                                 (str/split  #" |\+")))
+       (ui/render-keyboard-shortcut (-> keyboard-shortcut
+                                        (str/trim)
+                                        (str/lower-case)
+                                        (str/split  #" |\+")))
        " "
        [:a.text-sm
         {:style {:margin-left "12px"}
@@ -44,7 +44,7 @@
     (customize-shortcut-dialog-inner k action-name displayed-binding)))
 
 (rum/defc shortcut-col [k binding configurable? action-name]
-  (let [conflict?         (dh/potential-confilct? k)
+  (let [conflict?         (dh/potential-conflict? k)
         displayed-binding (dh/binding-for-display k binding)
         disabled?         (clojure.string/includes? displayed-binding "system default")]
     (if (not configurable?)
@@ -105,10 +105,10 @@
        [:td.text-right [:code "(())"]]]
       [:tr
        [:td.text-left (t :command.editor/open-link-in-sidebar)]
-       [:td.text-right (ui/keyboard-shortcut ["shift" "click"])]]
+       [:td.text-right (ui/render-keyboard-shortcut ["shift" "click"])]]
       [:tr
        [:td.text-left (t :help/context-menu)]
-       [:td.text-right (ui/keyboard-shortcut ["right click"])]]]]))
+       [:td.text-right (ui/render-keyboard-shortcut ["right" "click"])]]]]))
 
 (defn markdown-and-orgmode-syntax []
   (rum/with-context [[t] i18n/*tongue-context*]

--- a/src/main/frontend/components/sidebar.cljs
+++ b/src/main/frontend/components/sidebar.cljs
@@ -453,11 +453,11 @@
                       [:p.mb-2 [:b "Document mode"]]
                       [:ul
                        [:li
-                        [:div.inline-block.mr-1 (ui/keyboard-shortcut (shortcut-dh/gen-shortcut-seq :editor/new-line))]
+                        [:div.inline-block.mr-1 (ui/render-keyboard-shortcut (shortcut-dh/gen-shortcut-seq :editor/new-line))]
                         [:p.inline-block  "to create new block"]]
                        [:li
                         [:p.inline-block.mr-1 "Click `D` or type"]
-                        [:div.inline-block.mr-1 (ui/keyboard-shortcut (shortcut-dh/gen-shortcut-seq :ui/toggle-document-mode))]
+                        [:div.inline-block.mr-1 (ui/render-keyboard-shortcut (shortcut-dh/gen-shortcut-seq :ui/toggle-document-mode))]
                         [:p.inline-block "to toggle document mode"]]]]}
               [:a.block.px-1.text-sm.font-medium.bg-base-2.rounded-md.mx-2
                {:on-click state/toggle-document-mode!}

--- a/src/main/frontend/extensions/srs.cljs
+++ b/src/main/frontend/extensions/srs.cljs
@@ -457,15 +457,15 @@
             [:div.flex-1
              (when-not (and (not preview?) (= next-phase 1))
                (ui/button (case next-phase
-                            1 [:span "Hide answers " (ui/keyboard-shortcut [:s])]
-                            2 [:span "Show answers " (ui/keyboard-shortcut [:s])]
-                            3 [:span "Show clozes " (ui/keyboard-shortcut [:s])])
+                            1 [:span "Hide answers " (ui/render-keyboard-shortcut [:s])]
+                            2 [:span "Show answers " (ui/render-keyboard-shortcut [:s])]
+                            3 [:span "Show clozes " (ui/render-keyboard-shortcut [:s])])
                           :id "card-answers"
                           :class "mr-2"
                  :on-click #(reset! phase next-phase)))
 
              (when (and (> (count cards) 1) preview?)
-               (ui/button [:span "Next " (ui/keyboard-shortcut [:n])]
+               (ui/button [:span "Next " (ui/render-keyboard-shortcut [:n])]
                           :id "card-next"
                           :class "mr-2"
                  :on-click #(skip-card card card-index cards phase review-records cb)))
@@ -477,7 +477,7 @@
                  [:div.flex.flex-row.justify-between
                   (ui/button (if (util/mobile?)
                                "Forgotten"
-                               [:span "Forgotten " (ui/keyboard-shortcut [:f])])
+                               [:span "Forgotten " (ui/render-keyboard-shortcut [:f])])
                     :id "card-forgotten"
                     :on-click (fn []
                                 (score-and-next-card 1 card card-index cards phase review-records cb)
@@ -486,13 +486,13 @@
 
                   (ui/button (if (util/mobile?)
                                  "Remembered"
-                                 [:span "Remembered " (ui/keyboard-shortcut [:r])])
+                                 [:span "Remembered " (ui/render-keyboard-shortcut [:r])])
                     :id "card-remembered"
                     :on-click #(score-and-next-card 5 card card-index cards phase review-records cb))
 
                   (ui/button (if (util/mobile?)
                                "Hard"
-                               [:span "Took a while to recall " (ui/keyboard-shortcut [:t])])
+                               [:span "Took a while to recall " (ui/render-keyboard-shortcut [:t])])
                     :id "card-recall"
                     :on-click #(score-and-next-card 3 card card-index cards phase review-records cb))]))]
 

--- a/src/main/frontend/handler.cljs
+++ b/src/main/frontend/handler.cljs
@@ -233,7 +233,7 @@
                                             [:div
                                              [:h1.title "Reload Logseq?"]
                                              (ui/button
-                                              [:span "Yes " (ui/keyboard-shortcut ["enter"])]
+                                              [:span "Yes " (ui/render-keyboard-shortcut ["enter"])]
                                               :autoFocus "on"
                                               :large? true
                                               :on-click (fn []

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -18,414 +18,510 @@
             [medley.core :as medley]))
 
 ;; Note – when you change this file, you will need to do a hard reset.
-;; The commands are registered when the Clojurescript code runs for the first time.
+;; The commands are registered when the Clojurescript code runs for the fir
+(defonce all-default-keyboard-shortcuts
+  {:date-picker/complete         {:desc    "Date picker: Choose selected day"
+                                  :binding "enter"
+                                  :fn      ui-handler/shortcut-complete}
+
+   :date-picker/prev-day         {:desc    "Date picker: Select previous day"
+                                  :binding "left"
+                                  :fn      ui-handler/shortcut-prev-day}
+
+   :date-picker/next-day         {:desc    "Date picker: Select next day"
+                                  :binding "right"
+                                  :fn      ui-handler/shortcut-next-day}
+
+   :date-picker/prev-week        {:desc    "Date picker: Select previous week"
+                                  :binding "up"
+                                  :fn      ui-handler/shortcut-prev-week}
+
+   :date-picker/next-week        {:desc    "Date picker: Select next week"
+                                  :binding "down"
+                                  :fn      ui-handler/shortcut-next-week}
+
+   :pdf/previous-page            {:desc    "Previous page of current pdf doc"
+                                  :binding "alt+p"
+                                  :fn      pdf-utils/prev-page}
+
+   :pdf/next-page                {:desc    "Next page of current pdf doc"
+                                  :binding "alt+n"
+                                  :fn      pdf-utils/next-page}
+
+   :auto-complete/complete       {:desc    "Auto-complete: Choose selected item"
+                                  :binding "enter"
+                                  :fn      ui-handler/auto-complete-complete}
+
+   :auto-complete/prev           {:desc    "Auto-complete: Select previous item"
+                                  :binding "up"
+                                  :fn      ui-handler/auto-complete-prev}
+
+   :auto-complete/next           {:desc    "Auto-complete: Select next item"
+                                  :binding "down"
+                                  :fn      ui-handler/auto-complete-next}
+
+   :auto-complete/shift-complete {:desc    "Auto-complete: Open selected item in sidebar"
+                                  :binding "shift+enter"
+                                  :fn      ui-handler/auto-complete-shift-complete}
+
+   :cards/toggle-answers         {:desc    "Cards: show/hide answers/clozes"
+                                  :binding "s"
+                                  :fn      srs/toggle-answers}
+
+   :cards/next-card              {:desc    "Cards: next card"
+                                  :binding "n"
+                                  :fn      srs/next-card}
+
+   :cards/forgotten              {:desc    "Cards: forgotten"
+                                  :binding "f"
+                                  :fn      srs/forgotten}
+
+   :cards/remembered             {:desc    "Cards: remembered"
+                                  :binding "r"
+                                  :fn      srs/remembered}
+
+   :cards/recall                 {:desc    "Cards: take a while to recall"
+                                  :binding "t"
+                                  :fn      srs/recall}
+
+   :editor/escape-editing        {:desc    "Escape editing (remap to ctrl+open-square-bracket for example)"
+                                  :binding false
+                                  :fn      (fn [_ _] (editor-handler/escape-editing))}
+
+   :editor/backspace             {:desc    "Backspace / Delete backwards"
+                                  :binding "backspace"
+                                  :fn      editor-handler/editor-backspace}
+
+   :editor/delete                {:desc    "Delete / Delete forwards"
+                                  :binding "delete"
+                                  :fn      editor-handler/editor-delete}
+
+   :editor/new-block             {:desc    "Create new block"
+                                  :binding "enter"
+                                  :fn      editor-handler/keydown-new-block-handler}
+
+   :editor/new-line              {:desc    "New line in current block"
+                                  :binding "shift+enter"
+                                  :fn      editor-handler/keydown-new-line-handler}
+
+   :editor/follow-link           {:desc    "Follow link under cursor"
+                                  :binding "mod+o"
+                                  :fn      editor-handler/follow-link-under-cursor!}
+
+   :editor/open-link-in-sidebar  {:desc    "Open link in sidebar"
+                                  :binding "mod+shift+o"
+                                  :fn      editor-handler/open-link-in-sidebar!}
+
+   :editor/bold                  {:desc    "Bold"
+                                  :binding "mod+b"
+                                  :fn      editor-handler/bold-format!}
+
+   :editor/italics               {:desc    "Italics"
+                                  :binding "mod+i"
+                                  :fn      editor-handler/italics-format!}
+
+   :editor/highlight             {:desc    "Highlight"
+                                  :binding "mod+shift+h"
+                                  :fn      editor-handler/highlight-format!}
+
+   :editor/strike-through        {:desc    "Strikethrough"
+                                  :binding "mod+shift+s"
+                                  :fn      editor-handler/strike-through-format!}
+
+   :editor/clear-block           {:desc    "Delete entire block content"
+                                  :binding (if mac? "ctrl+l" "alt+l")
+                                  :fn      editor-handler/clear-block-content!}
+
+   :editor/kill-line-before      {:desc    "Delete line before cursor position"
+                                  :binding (if mac? "ctrl+u" "alt+u")
+                                  :fn      editor-handler/kill-line-before!}
+
+   :editor/kill-line-after       {:desc    "Delete line after cursor position"
+                                  :binding (if mac? false "alt+k")
+                                  :fn      editor-handler/kill-line-after!}
+
+   :editor/beginning-of-block    {:desc    "Move cursor to the beginning of a block"
+                                  :binding (if mac? false "alt+a")
+                                  :fn      editor-handler/beginning-of-block}
+
+   :editor/end-of-block          {:desc    "Move cursor to the end of a block"
+                                  :binding (if mac? false "alt+e")
+                                  :fn      editor-handler/end-of-block}
+
+   :editor/forward-word          {:desc    "Move cursor forward a word"
+                                  :binding (if mac? "ctrl+shift+f" "alt+f")
+                                  :fn      editor-handler/cursor-forward-word}
+
+   :editor/backward-word         {:desc    "Move cursor backward a word"
+                                  :binding (if mac? "ctrl+shift+b" "alt+b")
+                                  :fn      editor-handler/cursor-backward-word}
+
+   :editor/forward-kill-word     {:desc    "Delete a word forwards"
+                                  :binding (if mac? "ctrl+w" "alt+d")
+                                  :fn      editor-handler/forward-kill-word}
+
+   :editor/backward-kill-word    {:desc    "Delete a word backwards"
+                                  :binding (if mac? false "alt+w")
+                                  :fn      editor-handler/backward-kill-word}
+
+   :editor/replace-block-reference-at-point {:desc    "Replace block reference with its content at point"
+                                             :binding "mod+shift+r"
+                                             :fn      editor-handler/replace-block-reference-with-content-at-point}
+
+   :editor/paste-text-in-one-block-at-point {:desc    "Paste text into one block at point"
+                                             :binding "mod+shift+v"
+                                             :fn      editor-handler/paste-text-in-one-block-at-point}
+
+   :editor/insert-youtube-timestamp         {:desc    "Insert youtube timestamp"
+                                             :binding "mod+shift+y"
+                                             :fn      commands/insert-youtube-timestamp}
+
+   :editor/cycle-todo              {:desc    "Rotate the TODO state of the current item"
+                                    :binding "mod+enter"
+                                    :fn      editor-handler/cycle-todo!}
+
+   :editor/up                      {:desc    "Move cursor up / Select up"
+                                    :binding "up"
+                                    :fn      (editor-handler/shortcut-up-down :up)}
+
+   :editor/down                    {:desc    "Move cursor down / Select down"
+                                    :binding "down"
+                                    :fn      (editor-handler/shortcut-up-down :down)}
+
+   :editor/left                    {:desc    "Move cursor left / Open selected block at beginning"
+                                    :binding "left"
+                                    :fn      (editor-handler/shortcut-left-right :left)}
+
+   :editor/right                   {:desc    "Move cursor right / Open selected block at end"
+                                    :binding "right"
+                                    :fn      (editor-handler/shortcut-left-right :right)}
+
+   :editor/move-block-up           {:desc    "Move block up"
+                                    :binding (if mac? "mod+shift+up" "alt+shift+up")
+                                    :fn      (editor-handler/move-up-down true)}
+
+   :editor/move-block-down         {:desc    "Move block down"
+                                    :binding (if mac? "mod+shift+down" "alt+shift+down")
+                                    :fn      (editor-handler/move-up-down false)}
+
+   ;; FIXME: add open edit in non-selection mode
+   :editor/open-edit               {:desc    "Edit selected block"
+                                    :binding "enter"
+                                    :fn      (partial editor-handler/open-selected-block! :right)}
+
+   :editor/select-block-up         {:desc    "Select block above"
+                                    :binding "shift+up"
+                                    :fn      (editor-handler/on-select-block :up)}
+
+   :editor/select-block-down       {:desc    "Select block below"
+                                    :binding "shift+down"
+                                    :fn      (editor-handler/on-select-block :down)}
+
+   :editor/delete-selection        {:desc    "Delete selected blocks"
+                                    :binding ["backspace" "delete"]
+                                    :fn      editor-handler/delete-selection}
+
+   :editor/expand-block-children   {:desc    "Expand"
+                                    :binding "mod+down"
+                                    :fn      editor-handler/expand!}
+
+   :editor/collapse-block-children {:desc    "Collapse"
+                                    :binding "mod+up"
+                                    :fn      editor-handler/collapse!}
+
+   :editor/indent                  {:desc    "Indent block"
+                                    :binding "tab"
+                                    :fn      (editor-handler/keydown-tab-handler :right)}
+
+   :editor/outdent                 {:desc    "Outdent block"
+                                    :binding "shift+tab"
+                                    :fn      (editor-handler/keydown-tab-handler :left)}
+
+   :editor/copy                    {:desc    "Copy (copies either selection, or block reference)"
+                                    :binding "mod+c"
+                                    :fn      editor-handler/shortcut-copy}
+
+   :editor/cut                     {:desc    "Cut"
+                                    :binding "mod+x"
+                                    :fn      editor-handler/shortcut-cut}
+
+   :editor/undo                    {:desc    "Undo"
+                                    :binding "mod+z"
+                                    :fn      history/undo!}
+
+   :editor/redo                    {:desc    "Redo"
+                                    :binding ["shift+mod+z" "mod+y"]
+                                    :fn      history/redo!}
+
+   :editor/insert-link             {:desc    "HTML Link"
+                                    :binding "mod+l"
+                                    :fn      editor-handler/html-link-format!}
+
+   :editor/select-all-blocks       {:desc    "Select all blocks"
+                                    :binding "mod+shift+a"
+                                    :fn      editor-handler/select-all-blocks!}
+
+   :editor/zoom-in                 {:desc    "Zoom in editing block / Forwards otherwise"
+                                    :binding (if mac? "mod+." "alt+right")
+                                    :fn      editor-handler/zoom-in!}
+
+   :editor/zoom-out                {:desc    "Zoom out editing block / Backwards otherwise"
+                                    :binding (if mac? "mod+," "alt+left")
+                                    :fn      editor-handler/zoom-out!}
+
+   :ui/toggle-brackets             {:desc    "Toggle whether to display brackets"
+                                    :binding "mod+c mod+b"
+                                    :fn      config-handler/toggle-ui-show-brackets!}
+
+   :go/search-in-page              {:desc    "Search in the current page"
+                                    :binding ["mod+shift+k" "mod+shift+u"]
+                                    :fn      #(route-handler/go-to-search! :page)}
+
+   :go/search                      {:desc    "Full text search"
+                                    :binding ["mod+k" "mod+u"]
+                                    :fn      #(route-handler/go-to-search! :global)}
+
+   :go/journals                    {:desc    "Jump to journals"
+                                    :binding (if mac? "mod+j" "alt+j")
+                                    :fn      route-handler/go-to-journals!}
+
+   :go/backward                    {:desc    "Backwards"
+                                    :binding "mod+open-square-bracket"
+                                    :fn      (fn [_] (js/window.history.back))}
+
+   :go/forward                     {:desc    "Forwards"
+                                    :binding "mod+close-square-bracket"
+                                    :fn      (fn [_] (js/window.history.forward))}
+
+   :search/re-index                {:desc    "Rebuild search index"
+                                    :binding "mod+c mod+s"
+                                    :fn      search-handler/rebuild-indices!}
+
+   :sidebar/open-today-page        {:desc    "Open today's page in the right sidebar"
+                                    :binding (if mac? "mod+shift+j" "alt+shift+j")
+                                    :fn      page-handler/open-today-in-sidebar}
+
+   :sidebar/clear                  {:desc    "Clear all in the right sidebar"
+                                    :binding "mod+c mod+c"
+                                    :fn      #(do
+                                                (state/clear-sidebar-blocks!)
+                                                (state/hide-right-sidebar!))}
+
+   :misc/copy                      {:binding "mod+c"
+                                    :fn      (fn [] (js/document.execCommand "copy"))}
+
+   :command-palette/toggle         {:desc    "Toggle command palette"
+                                    :binding "mod+shift+p"
+                                    :fn      (fn [] (state/toggle! :ui/command-palette-open?))}
+
+   :command/run                    {:desc    "Run git command"
+                                    :binding "mod+shift+1"
+                                    :fn      #(state/pub-event! [:command/run])}
+
+   :go/home                        {:desc    "Go to home"
+                                    :binding "g h"
+                                    :fn      #(route-handler/redirect-to-home!)}
+
+   :go/keyboard-shortcuts          {:desc    "Go to keyboard shortcuts"
+                                    :binding "g s"
+                                    :fn      #(route-handler/redirect! {:to :shortcut-setting})}
+
+   :go/tomorrow                    {:desc    "Go to tomorrow"
+                                    :binding "g t"
+                                    :fn      journal-handler/go-to-tomorrow!}
+
+   :go/next-journal                {:desc    "Go to next journal"
+                                    :binding "g n"
+                                    :fn      journal-handler/go-to-next-journal!}
+
+   :go/prev-journal                {:desc    "Go to previous journal"
+                                    :binding "g p"
+                                    :fn      journal-handler/go-to-prev-journal!}
+
+   :ui/toggle-document-mode        {:desc    "Toggle document mode"
+                                    :binding "t d"
+                                    :fn      state/toggle-document-mode!}
+
+   :ui/toggle-settings              {:desc    "Toggle settings"
+                                     :binding (if mac? "t s" ["t s" "mod+,"])
+                                     :fn      ui-handler/toggle-settings-modal!}
+
+   :ui/toggle-right-sidebar         {:desc    "Toggle right sidebar"
+                                     :binding "t r"
+                                     :fn      ui-handler/toggle-right-sidebar!}
+
+   :ui/toggle-left-sidebar          {:desc    "Toggle left sidebar"
+                                     :binding "t l"
+                                     :fn      ui-handler/toggle-left-sidebar!}
+
+   :ui/toggle-help                  {:desc    "Toggle help"
+                                     :binding "shift+/"
+                                     :fn      ui-handler/toggle-help!}
+
+   :ui/toggle-theme                 {:desc    "Toggle between dark/light theme"
+                                     :binding "t t"
+                                     :fn      state/toggle-theme!}
+
+   :ui/toggle-contents              {:desc    "Toggle Favorites in sidebar"
+                                     :binding "t f"
+                                     :fn      ui-handler/toggle-contents!}
+
+   :editor/open-file-in-default-app {:desc    "Open file in default app"
+                                     :binding "o f"
+                                     :fn      page-handler/open-file-in-default-app}
+
+   :editor/open-file-in-directory   {:desc    "Open file in parent directory"
+                                     :binding "o d"
+                                     :fn      page-handler/open-file-in-directory}
+
+   :ui/toggle-wide-mode             {:desc    "Toggle wide mode"
+                                     :binding "t w"
+                                     :fn      ui-handler/toggle-wide-mode!}
+
+   :ui/select-theme-color           {:desc    "Select available theme colors"
+                                     :binding "t i"
+                                     :fn      plugin-handler/show-themes-modal!}
+
+   :ui/goto-plugins                 {:desc    "Go to plugins dashboard"
+                                     :binding "t p"
+                                     :fn      plugin-handler/goto-plugins-dashboard!}
+
+   :editor/toggle-open-blocks       {:desc    "Toggle open blocks (collapse or expand all blocks)"
+                                     :binding "t o"
+                                     :fn      editor-handler/toggle-open!}
+
+   :ui/toggle-cards                 {:desc    "Toggle cards"
+                                     :binding "t c"
+                                     :fn      ui-handler/toggle-cards!}
+  ;; :ui/toggle-between-page-and-file route-handler/toggle-between-page-and-file!
+
+   :git/commit                      {:desc    "Git commit message"
+                                     :binding "c"
+                                     :fn      commit/show-commit-modal!}})
+
+(defn build-category-map [symbols]
+  (reduce into {}
+          (map (fn [sym] {sym (get all-default-keyboard-shortcuts sym)}) symbols)))
 
 (defonce config
   (atom
    {:shortcut.handler/date-picker
-    {:date-picker/complete
-     {:desc    "Date picker: Choose selected day"
-      :binding "enter"
-      :fn      ui-handler/shortcut-complete}
-     :date-picker/prev-day
-     {:desc    "Date picker: Select previous day"
-      :binding "left"
-      :fn      ui-handler/shortcut-prev-day}
-     :date-picker/next-day
-     {:desc    "Date picker: Select next day"
-      :binding "right"
-      :fn      ui-handler/shortcut-next-day}
-     :date-picker/prev-week
-     {:desc    "Date picker: Select previous week"
-      :binding "up"
-      :fn      ui-handler/shortcut-prev-week}
-     :date-picker/next-week
-     {:desc    "Date picker: Select next week"
-      :binding "down"
-      :fn      ui-handler/shortcut-next-week}}
+    (build-category-map [:date-picker/complete
+                         :date-picker/prev-day
+                         :date-picker/next-day
+                         :date-picker/prev-week
+                         :date-picker/next-week])
 
     :shortcut.handler/pdf
     ^{:before m/enable-when-not-editing-mode!}
-    {:pdf/previous-page
-     {:desc    "Previous page of current pdf doc"
-      :binding "alt+p"
-      :fn      pdf-utils/prev-page}
-     :pdf/next-page
-     {:desc    "Next page of current pdf doc"
-      :binding "alt+n"
-      :fn      pdf-utils/next-page}}
+    (build-category-map [:pdf/previous-page
+                         :pdf/next-page])
 
     :shortcut.handler/auto-complete
-    {:auto-complete/complete
-     {:desc    "Auto-complete: Choose selected item"
-      :binding "enter"
-      :fn      ui-handler/auto-complete-complete}
-     :auto-complete/prev
-     {:desc    "Auto-complete: Select previous item"
-      :binding "up"
-      :fn      ui-handler/auto-complete-prev}
-     :auto-complete/next
-     {:desc    "Auto-complete: Select next item"
-      :binding "down"
-      :fn      ui-handler/auto-complete-next}
-     :auto-complete/shift-complete
-     {:desc    "Auto-complete: Open selected item in sidebar"
-      :binding "shift+enter"
-      :fn      ui-handler/auto-complete-shift-complete}}
+    (build-category-map [:auto-complete/complete
+                         :auto-complete/prev
+                         :auto-complete/next
+                         :auto-complete/shift-complete])
 
     :shortcut.handler/cards
-    {:cards/toggle-answers
-     {:desc    "Cards: show/hide answers/clozes"
-      :binding "s"
-      :fn      srs/toggle-answers}
-     :cards/next-card
-     {:desc    "Cards: next card"
-      :binding "n"
-      :fn      srs/next-card}
-     :cards/forgotten
-     {:desc    "Cards: forgotten"
-      :binding "f"
-      :fn      srs/forgotten}
-     :cards/remembered
-     {:desc    "Cards: remembered"
-      :binding "r"
-      :fn      srs/remembered}
-     :cards/recall
-     {:desc    "Cards: take a while to recall"
-      :binding "t"
-      :fn      srs/recall}}
+    (build-category-map [:cards/toggle-answers
+                         :cards/next-card
+                         :cards/forgotten
+                         :cards/remembered
+                         :cards/recall])
 
     :shortcut.handler/block-editing-only
     ^{:before m/enable-when-editing-mode!}
-    {:editor/escape-editing
-     {:desc    "Escape editing (remap to ctrl+open-square-bracket for example)"
-      :binding false
-      :fn      (fn [_ _] (editor-handler/escape-editing))}
-     :editor/backspace
-     {:desc    "Backspace / Delete backwards"
-      :binding "backspace"
-      :fn      editor-handler/editor-backspace}
-     :editor/delete
-     {:desc    "Delete / Delete forwards"
-      :binding "delete"
-      :fn      editor-handler/editor-delete}
-     :editor/new-block
-     {:desc    "Create new block"
-      :binding "enter"
-      :fn      editor-handler/keydown-new-block-handler}
-     :editor/new-line
-     {:desc    "New line in current block"
-      :binding "shift+enter"
-      :fn      editor-handler/keydown-new-line-handler}
-     :editor/follow-link
-     {:desc    "Follow link under cursor"
-      :binding "mod+o"
-      :fn      editor-handler/follow-link-under-cursor!}
-     :editor/open-link-in-sidebar
-     {:desc    "Open link in sidebar"
-      :binding "mod+shift+o"
-      :fn      editor-handler/open-link-in-sidebar!}
-     :editor/bold
-     {:desc    "Bold"
-      :binding "mod+b"
-      :fn      editor-handler/bold-format!}
-     :editor/italics
-     {:desc    "Italics"
-      :binding "mod+i"
-      :fn      editor-handler/italics-format!}
-     :editor/highlight
-     {:desc    "Highlight"
-      :binding "mod+shift+h"
-      :fn      editor-handler/highlight-format!}
-     :editor/strike-through
-     {:desc    "Strikethrough"
-      :binding "mod+shift+s"
-      :fn      editor-handler/strike-through-format!}
-     :editor/clear-block
-     {:desc    "Delete entire block content"
-      :binding (if mac? "ctrl+l" "alt+l")
-      :fn      editor-handler/clear-block-content!}
-     :editor/kill-line-before
-     {:desc    "Delete line before cursor position"
-      :binding (if mac? "ctrl+u" "alt+u")
-      :fn      editor-handler/kill-line-before!}
-     :editor/kill-line-after
-     {:desc    "Delete line after cursor position"
-      :binding (if mac? false "alt+k")
-      :fn      editor-handler/kill-line-after!}
-     :editor/beginning-of-block
-     {:desc    "Move cursor to the beginning of a block"
-      :binding (if mac? false "alt+a")
-      :fn      editor-handler/beginning-of-block}
-     :editor/end-of-block
-     {:desc    "Move cursor to the end of a block"
-      :binding (if mac? false "alt+e")
-      :fn      editor-handler/end-of-block}
-     :editor/forward-word
-     {:desc    "Move cursor forward a word"
-      :binding (if mac? "ctrl+shift+f" "alt+f")
-      :fn      editor-handler/cursor-forward-word}
-     :editor/backward-word
-     {:desc    "Move cursor backward a word"
-      :binding (if mac? "ctrl+shift+b" "alt+b")
-      :fn      editor-handler/cursor-backward-word}
-     :editor/forward-kill-word
-     {:desc    "Delete a word forwards"
-      :binding (if mac? "ctrl+w" "alt+d")
-      :fn      editor-handler/forward-kill-word}
-     :editor/backward-kill-word
-     {:desc    "Delete a word backwards"
-      :binding (if mac? false "alt+w")
-      :fn      editor-handler/backward-kill-word}
-     :editor/replace-block-reference-at-point
-     {:desc    "Replace block reference with its content at point"
-      :binding "mod+shift+r"
-      :fn      editor-handler/replace-block-reference-with-content-at-point}
-     :editor/paste-text-in-one-block-at-point
-     {:desc    "Paste text into one block at point"
-      :binding "mod+shift+v"
-      :fn      editor-handler/paste-text-in-one-block-at-point}
-     :editor/insert-youtube-timestamp
-     {:desc    "Insert youtube timestamp"
-      :binding "mod+shift+y"
-      :fn      commands/insert-youtube-timestamp}}
+    (build-category-map [:editor/escape-editing
+                         :editor/backspace
+                         :editor/delete
+                         :editor/new-block
+                         :editor/new-line
+                         :editor/follow-link
+                         :editor/open-link-in-sidebar
+                         :editor/bold
+                         :editor/italics
+                         :editor/highlight
+                         :editor/strike-through
+                         :editor/clear-block
+                         :editor/kill-line-before
+                         :editor/kill-line-after
+                         :editor/beginning-of-block
+                         :editor/end-of-block
+                         :editor/forward-word
+                         :editor/backward-word
+                         :editor/forward-kill-word
+                         :editor/backward-kill-word
+                         :editor/replace-block-reference-at-point
+                         :editor/paste-text-in-one-block-at-point
+                         :editor/insert-youtube-timestamp])
 
     :shortcut.handler/editor-global
     ^{:before m/enable-when-not-component-editing!}
-    {:editor/cycle-todo
-     {:desc    "Rotate the TODO state of the current item"
-      :binding "mod+enter"
-      :fn      editor-handler/cycle-todo!}
-     :editor/up
-     {:desc    "Move cursor up / Select up"
-      :binding "up"
-      :fn      (editor-handler/shortcut-up-down :up)}
-     :editor/down
-     {:desc    "Move cursor down / Select down"
-      :binding "down"
-      :fn      (editor-handler/shortcut-up-down :down)}
-     :editor/left
-     {:desc    "Move cursor left / Open selected block at beginning"
-      :binding "left"
-      :fn      (editor-handler/shortcut-left-right :left)}
-     :editor/right
-     {:desc    "Move cursor right / Open selected block at end"
-      :binding "right"
-      :fn      (editor-handler/shortcut-left-right :right)}
-     :editor/move-block-up
-     {:desc    "Move block up"
-      :binding (if mac? "mod+shift+up" "alt+shift+up")
-      :fn      (editor-handler/move-up-down true)}
-     :editor/move-block-down
-     {:desc    "Move block down"
-      :binding (if mac? "mod+shift+down" "alt+shift+down")
-      :fn      (editor-handler/move-up-down false)}
-     ;; FIXME
-     ;; add open edit in non-selection mode
-     :editor/open-edit
-     {:desc    "Edit selected block"
-      :binding "enter"
-      :fn      (partial editor-handler/open-selected-block! :right)}
-     :editor/select-block-up
-     {:desc    "Select block above"
-      :binding "shift+up"
-      :fn      (editor-handler/on-select-block :up)}
-     :editor/select-block-down
-     {:desc    "Select block below"
-      :binding "shift+down"
-      :fn      (editor-handler/on-select-block :down)}
-     :editor/delete-selection
-     {:desc    "Delete selected blocks"
-      :binding ["backspace" "delete"]
-      :fn      editor-handler/delete-selection}
-     :editor/expand-block-children
-     {:desc    "Expand"
-      :binding "mod+down"
-      :fn      editor-handler/expand!}
-     :editor/collapse-block-children
-     {:desc    "Collapse"
-      :binding "mod+up"
-      :fn      editor-handler/collapse!}
-     :editor/indent
-     {:desc    "Indent block"
-      :binding "tab"
-      :fn      (editor-handler/keydown-tab-handler :right)}
-     :editor/outdent
-     {:desc    "Outdent block"
-      :binding "shift+tab"
-      :fn      (editor-handler/keydown-tab-handler :left)}
-     :editor/copy
-     {:desc    "Copy (copies either selection, or block reference)"
-      :binding "mod+c"
-      :fn      editor-handler/shortcut-copy}
-     :editor/cut
-     {:desc    "Cut"
-      :binding "mod+x"
-      :fn      editor-handler/shortcut-cut}
-     :editor/undo
-     {:desc    "Undo"
-      :binding "mod+z"
-      :fn      history/undo!}
-     :editor/redo
-     {:desc    "Redo"
-      :binding ["shift+mod+z" "mod+y"]
-      :fn      history/redo!}}
+    (build-category-map [:editor/cycle-todo
+                         :editor/up
+                         :editor/down
+                         :editor/left
+                         :editor/right
+                         :editor/move-block-up
+                         :editor/move-block-down
+                         :editor/open-edit
+                         :editor/select-block-up
+                         :editor/select-block-down
+                         :editor/delete-selection
+                         :editor/expand-block-children
+                         :editor/collapse-block-children
+                         :editor/indent
+                         :editor/outdent
+                         :editor/copy
+                         :editor/cut
+                         :editor/undo
+                         :editor/redo])
 
     :shortcut.handler/global-prevent-default
     ^{:before m/prevent-default-behavior}
-    {:editor/insert-link
-     {:desc    "HTML Link"
-      :binding "mod+l"
-      :fn      editor-handler/html-link-format!}
-     :editor/select-all-blocks
-     {:desc    "Select all blocks"
-      :binding "mod+shift+a"
-      :fn      editor-handler/select-all-blocks!}
-     :editor/zoom-in
-     {:desc    "Zoom in editing block / Forwards otherwise"
-      :binding (if mac? "mod+." "alt+right")
-      :fn      editor-handler/zoom-in!}
-     :editor/zoom-out
-     {:desc    "Zoom out editing block / Backwards otherwise"
-      :binding (if mac? "mod+," "alt+left")
-      :fn      editor-handler/zoom-out!}
-     :ui/toggle-brackets
-     {:desc    "Toggle whether to display brackets"
-      :binding "mod+c mod+b"
-      :fn      config-handler/toggle-ui-show-brackets!}
-     :go/search-in-page
-     {:desc    "Search in the current page"
-      :binding ["mod+shift+k" "mod+shift+u"]
-      :fn      #(route-handler/go-to-search! :page)}
-     :go/search
-     {:desc    "Full text search"
-      :binding ["mod+k" "mod+u"]
-      :fn      #(route-handler/go-to-search! :global)}
-     :go/journals
-     {:desc    "Jump to journals"
-      :binding (if mac? "mod+j" "alt+j")
-      :fn      route-handler/go-to-journals!}
-     :go/backward
-     {:desc    "Backwards"
-      :binding "mod+open-square-bracket"
-      :fn      (fn [_] (js/window.history.back))}
-     :go/forward
-     {:desc    "Forwards"
-      :binding "mod+close-square-bracket"
-      :fn      (fn [_] (js/window.history.forward))}
-     :search/re-index
-     {:desc    "Rebuild search index"
-      :binding "mod+c mod+s"
-      :fn      search-handler/rebuild-indices!}
-     :sidebar/open-today-page
-     {:desc    "Open today's page in the right sidebar"
-      :binding (if mac? "mod+shift+j" "alt+shift+j")
-      :fn      page-handler/open-today-in-sidebar}
-     :sidebar/clear
-     {:desc    "Clear all in the right sidebar"
-      :binding "mod+c mod+c"
-      :fn      #(do
-                  (state/clear-sidebar-blocks!)
-                  (state/hide-right-sidebar!))}}
+    (build-category-map [:editor/insert-link
+                         :editor/select-all-blocks
+                         :editor/zoom-in
+                         :editor/zoom-out
+                         :ui/toggle-brackets
+                         :go/search-in-page
+                         :go/search
+                         :go/journals
+                         :go/backward
+                         :go/forward
+                         :search/re-index
+                         :sidebar/open-today-page
+                         :sidebar/clear])
 
     :shortcut.handler/misc
     ;; always overrides the copy due to "mod+c mod+s"
-    {:misc/copy
-     {:binding "mod+c"
-      :fn      (fn [] (js/document.execCommand "copy"))}
-
-     :command-palette/toggle
-     {:desc    "Toggle command palette"
-      :binding "mod+shift+p"
-      :fn      (fn [] (state/toggle! :ui/command-palette-open?))}}
+    {:misc/copy              (:misc/copy              all-default-keyboard-shortcuts)
+     :command-palette/toggle (:command-palette/toggle all-default-keyboard-shortcuts)}
 
     :shortcut.handler/global-non-editing-only
     ^{:before m/enable-when-not-editing-mode!}
-    {:command/run
-     {:desc    "Run git command"
-      :binding "mod+shift+1"
-      :fn      #(state/pub-event! [:command/run])}
-     :go/home
-     {:desc    "Go to home"
-      :binding "g h"
-      :fn      #(route-handler/redirect-to-home!)}
-     :go/keyboard-shortcuts
-     {:desc    "Go to keyboard shortcuts"
-      :binding "g s"
-      :fn      #(route-handler/redirect! {:to :shortcut-setting})}
-     :go/tomorrow
-     {:desc    "Go to tomorrow"
-      :binding "g t"
-      :fn      journal-handler/go-to-tomorrow!}
-     :go/next-journal
-     {:desc    "Go to next journal"
-      :binding "g n"
-      :fn      journal-handler/go-to-next-journal!}
-     :go/prev-journal
-     {:desc    "Go to previous journal"
-      :binding "g p"
-      :fn      journal-handler/go-to-prev-journal!}
-     :ui/toggle-document-mode
-     {:desc    "Toggle document mode"
-      :binding "t d"
-      :fn      state/toggle-document-mode!}
-     :ui/toggle-settings
-     {:desc    "Toggle settings"
-      :binding (if mac? "t s" ["t s" "mod+,"])
-      :fn      ui-handler/toggle-settings-modal!}
-     :ui/toggle-right-sidebar
-     {:desc    "Toggle right sidebar"
-      :binding "t r"
-      :fn      ui-handler/toggle-right-sidebar!}
-     :ui/toggle-left-sidebar
-     {:desc    "Toggle left sidebar"
-      :binding "t l"
-      :fn      ui-handler/toggle-left-sidebar!}
-     :ui/toggle-help
-     {:desc    "Toggle help"
-      :binding "shift+/"
-      :fn      ui-handler/toggle-help!}
-     :ui/toggle-theme
-     {:desc    "Toggle between dark/light theme"
-      :binding "t t"
-      :fn      state/toggle-theme!}
-     :ui/toggle-contents
-     {:desc    "Toggle Favorites in sidebar"
-      :binding "t f"
-      :fn      ui-handler/toggle-contents!}
-     :editor/open-file-in-default-app
-     {:desc    "Open file in default app"
-      :binding "o f"
-      :fn      page-handler/open-file-in-default-app}
-     :editor/open-file-in-directory
-     {:desc    "Open file in parent directory"
-      :binding "o d"
-      :fn      page-handler/open-file-in-directory}
-     :ui/toggle-wide-mode
-     {:desc    "Toggle wide mode"
-      :binding "t w"
-      :fn      ui-handler/toggle-wide-mode!}
-     :ui/select-theme-color
-     {:desc    "Select available theme colors"
-      :binding "t i"
-      :fn      plugin-handler/show-themes-modal!}
-     :ui/goto-plugins
-     {:desc    "Go to plugins dashboard"
-      :binding "t p"
-      :fn      plugin-handler/goto-plugins-dashboard!}
-     :editor/toggle-open-blocks
-     {:desc    "Toggle open blocks (collapse or expand all blocks)"
-      :binding "t o"
-      :fn      editor-handler/toggle-open!}
-     :ui/toggle-cards
-     {:desc    "Toggle cards"
-      :binding "t c"
-      :fn      ui-handler/toggle-cards!}
-     ;; :ui/toggle-between-page-and-file route-handler/toggle-between-page-and-file!
-     :git/commit
-     {:desc    "Git commit message"
-      :binding "c"
-      :fn      commit/show-commit-modal!}}}))
+    (build-category-map [:command/run
+                         :go/home
+                         :go/keyboard-shortcuts
+                         :go/tomorrow
+                         :go/next-journal
+                         :go/prev-journal
+                         :ui/toggle-document-mode
+                         :ui/toggle-settings
+                         :ui/toggle-right-sidebar
+                         :ui/toggle-left-sidebar
+                         :ui/toggle-help
+                         :ui/toggle-theme
+                         :ui/toggle-contents
+                         :editor/open-file-in-default-app
+                         :editor/open-file-in-directory
+                         :ui/toggle-wide-mode
+                         :ui/select-theme-color
+                         :ui/goto-plugins
+                         :editor/toggle-open-blocks
+                         :ui/toggle-cards
+                         :git/commit])}))
 
 
 ;; Categories for docs purpose

--- a/src/main/frontend/modules/shortcut/data_helper.cljs
+++ b/src/main/frontend/modules/shortcut/data_helper.cljs
@@ -97,7 +97,8 @@
       (str/replace "shift+/" "?")
       (str/replace "open-square-bracket" "[")
       (str/replace "close-square-bracket" "]")
-      (str/lower-case)))
+      (str/lower-case)
+      (or binding "")))
 
 ;; if multiple bindings, gen seq for first binding only for now
 (defn gen-shortcut-seq [id]

--- a/src/main/frontend/modules/shortcut/data_helper.cljs
+++ b/src/main/frontend/modules/shortcut/data_helper.cljs
@@ -99,6 +99,7 @@
       (str/replace "shift+/" "?")
       (str/replace "left" "←")
       (str/replace "right" "→")
+      (str/replace "+" " ")
       (str/replace "open-square-bracket" "[")
       (str/replace "close-square-bracket" "]")
       (str/lower-case)))

--- a/src/main/frontend/modules/shortcut/data_helper.cljs
+++ b/src/main/frontend/modules/shortcut/data_helper.cljs
@@ -91,14 +91,17 @@
        (into {})))
 
 (defn decorate-binding [binding]
-  (-> binding
+  (-> (if (string? binding) binding (str/join "+"  binding))
       (str/replace "mod" (if util/mac? "cmd" "ctrl"))
+      (str/replace "ctrl" (if util/mac? "cmd" "ctrl"))
+      (str/replace "cmd" (if util/mac? "cmd" "ctrl"))
       (str/replace "alt" (if util/mac? "opt" "alt"))
       (str/replace "shift+/" "?")
+      (str/replace "left" "←")
+      (str/replace "right" "→")
       (str/replace "open-square-bracket" "[")
       (str/replace "close-square-bracket" "]")
-      (str/lower-case)
-      (or binding "")))
+      (str/lower-case)))
 
 ;; if multiple bindings, gen seq for first binding only for now
 (defn gen-shortcut-seq [id]
@@ -162,15 +165,15 @@
        (map key)
        (first)))
 
-(defn potential-confilct? [k]
+(defn potential-conflict? [k]
   (if-not (shortcut-binding k)
     false
     (let [handler-id    (get-group k)
           shortcut-m    (shortcut-map handler-id)
           bindings      (->> (shortcut-binding k)
-                            (map mod-key)
-                            (map KeyboardShortcutHandler/parseStringShortcut)
-                            (map js->clj))
+                             (map mod-key)
+                             (map KeyboardShortcutHandler/parseStringShortcut)
+                             (map js->clj))
           rest-bindings (->> (map key shortcut-m)
                              (remove #{k})
                              (map shortcut-binding)

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -465,7 +465,7 @@
   (let [default-binding (:binding (get shortcut-config/all-default-keyboard-shortcuts shortcut-name))
         custom-binding  (when (state/shortcuts) (get (state/shortcuts) shortcut-name))
         binding         (or custom-binding default-binding)]
-    (render-keyboard-shortcut (shortcut-helper/decorate-binding binding))))
+    (shortcut-helper/decorate-binding binding)))
 
 (defonce modal-show? (atom false))
 (rum/defc modal-overlay
@@ -721,7 +721,7 @@
                              (when-let [html (:html opts)]
                                (if (fn? html)
                                  (html)
-                                 [:div.px-2.py-2
+                                 [:div.px-2.py-1
                                   html]))
                              (catch js/Error e
                                (log/error :exception e)

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -13,6 +13,8 @@
             [frontend.handler.plugin :as plugin-handler]
             [cljs-bean.core :as bean]
             [goog.dom :as gdom]
+            [frontend.modules.shortcut.config :as shortcut-config]
+            [frontend.modules.shortcut.data-helper :as shortcut-helper]
             [promesa.core :as p]
             [goog.object :as gobj]
             [lambdaisland.glogi :as log]
@@ -441,9 +443,15 @@
       {:class       (if on? (if small? "translate-x-4" "translate-x-5") "translate-x-0")
        :aria-hidden "true"}]]]))
 
-;; `sequence` can be a list of symbols or strings
-(defn keyboard-shortcut [sequence]
-  [:span.keyboard-shortcut
+;; `sequence` can be a list of symbols, a list of strings, or a string
+(defn render-keyboard-shortcut [sequence]
+  (let [sequence (if (string? sequence)
+                   (-> sequence ;; turn string into sequence
+                       (str/trim)
+                       (str/lower-case)
+                       (str/split  #" |\+"))
+                   sequence)]
+    [:span.keyboard-shortcut
    (map-indexed (fn [i key]
                   [:code {:key i}
                    ;; Display "cmd" rather than "meta" to the user to describe the Mac
@@ -451,7 +459,13 @@
                    (if (or (= :meta key) (= "meta" key))
                      (util/meta-key-name)
                      (name key))])
-                sequence)])
+                sequence)]))
+
+(defn keyboard-shortcut-from-config [shortcut-name]
+  (let [default-binding (:binding (get shortcut-config/all-default-keyboard-shortcuts shortcut-name))
+        custom-binding  (when (state/shortcuts) (get (state/shortcuts) shortcut-name))
+        binding         (or custom-binding default-binding)]
+    (render-keyboard-shortcut (shortcut-helper/decorate-binding binding))))
 
 (defonce modal-show? (atom false))
 (rum/defc modal-overlay
@@ -707,7 +721,7 @@
                              (when-let [html (:html opts)]
                                (if (fn? html)
                                  (html)
-                                 [:div.pr-3.py-1
+                                 [:div.px-2.py-2
                                   html]))
                              (catch js/Error e
                                (log/error :exception e)

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -702,6 +702,7 @@
     (Tippy (->
             (merge {:arrow true
                     :sticky true
+                    :delay 600
                     :theme "customized"
                     :disabled (not (state/enable-tooltip?))
                     :unmountHTMLWhenHide true

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1130,11 +1130,14 @@
 
 (defn ->platform-shortcut
   [keyboard-shortcut]
-  (if mac?
-    (-> keyboard-shortcut
-        (string/replace "Ctrl" "Cmd")
-        (string/replace "Alt" "Opt"))
-    keyboard-shortcut))
+  (let [result (or keyboard-shortcut "")
+        result (string/replace result "left" "←")
+        result (string/replace result "right" "→")]
+    (if mac?
+      (-> result
+          (string/replace "Ctrl" "Cmd")
+          (string/replace "Alt" "Opt"))
+      result)))
 
 (defn remove-common-preceding
   [col1 col2]

--- a/yarn.lock
+++ b/yarn.lock
@@ -7862,6 +7862,11 @@ react-grid-layout@^0.16.6:
     react-draggable "3.x"
     react-resizable "1.x"
 
+react-icon-base@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-icon-base/-/react-icon-base-2.1.0.tgz#a196e33fdf1e7aaa1fda3aefbb68bdad9e82a79d"
+  integrity sha1-oZbjP98eeqof2jrvu2i9rZ6Cp50=
+
 react-icons@^2.2.7:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-2.2.7.tgz#d7860826b258557510dac10680abea5ca23cf650"


### PR DESCRIPTION
- Now pulls the keyboard shortcut binding from config if the user has defined it, otherwise pulls the default binding. (Previously, it was hard-coded and didn't talk to config at all, which meant that the tooltips were wrong if (a) you'd defined a custom tooltip or (b) the tooltip had the wrong binding hard-coded.)
- Tooltips have slightly higher contrast + `<kbd>` styles, making them easier to read.
- Creates a `monospace` theme for tooltips, meant for shortcut bindings
- Refactors `shortcuts.config` so that the default bindings are easier to read. 
  - Note: This part of the PR has a very large diff, but it's not actually a substantial change (i.e. functionality didn't change), it was just for readability.
  - By restructuring it in this way, it'll allow for more use in the future (e.g. adding a search filter on the Shortcuts page).
  - I probably should've made this change a separate PR to keep the diff smaller — I'm happy to break it out if that's helpful!
- Renames `ui/keyboard-shortcut` → `ui/render-keyboard-shortcut`
- Adds tooltips in a few more places in the header

---------

Visually, very little has actually changed. Now, it's just a bit more compact/concise + it pulls the custom keybinding:

| **before** | <img src="https://user-images.githubusercontent.com/6979755/142113186-712ccb55-6d8d-4213-aa16-e9b74e31e4eb.png" /> |
| -: | :- |
| **after** | <img src="https://user-images.githubusercontent.com/6979755/142118892-708a72c5-bbe6-4fc0-be52-19d43d3f6ca3.png" /> |