### PR TITLE
fix: do not triml while saving block

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -354,7 +354,6 @@
         content (if (and (seq properties) real-content (not= real-content content))
                   (property/with-built-in-properties properties content format)
                   content)
-        content (text/remove-lines-level-spaces content format)
         content (drawer/with-logbook block content)
         content (with-timetracking block content)
         first-block? (= left page)


### PR DESCRIPTION
Fixes #3178

Introduced in https://github.com/logseq/logseq/commit/8323d0a2d2da8764bdd995bc0c076e0d0cf2f6f3 #2357

Does this break #2357 fix?