### PR TITLE
fix(test): update cypress tests according to new ui

### DIFF
--- a/cypress/integration/app/basic.cljs
+++ b/cypress/integration/app/basic.cljs
@@ -11,12 +11,17 @@
   (beforeEach []
               (.clearIndexedDB cy))
   (before []
-          (.visit cy "http://localhost:3001"))
+          (.. cy
+              (visit "http://localhost:3001")
+              (get "#main-content-container" #js {:timeout 10000})
+              (should (fn [result]
+                        (expect result :not.to.contain "Loading")))))
 
   (it "Search" []
     (.. cy
         (get "#search-button")
         (click)
+        (get "input.cp__palette-input")
         (type "welcome to Logseq"))
     (.. cy (get "#ui__ac-inner")
         (should (fn [result]
@@ -27,14 +32,11 @@
     (.. cy
         (get "#search-button")
         (click)
-        (type "new page"))
-
-    (.wait cy 1000)
-
-    (.. cy
-        (get "#search-button")
+        (get "input.cp__palette-input")
+        (type "new page")
+        (wait 500)
         (type "{enter}"))
-
+      
     ;; edit bullet
     (util/edit-block "this is my first bullet {enter}")
     (util/edit-block "this is my second bullet {enter}")

--- a/cypress/integration/app/template.cljs
+++ b/cypress/integration/app/template.cljs
@@ -12,18 +12,23 @@
                       (.clearIndexedDB cy)
                       (cy.wait 1000))
           (before []
-                  (.visit cy "http://localhost:3001"))
+                  (.. cy
+                      (visit "http://localhost:3001")
+                      (get "#main-content-container" #js {:timeout 10000})
+                      (should (fn [result]
+                                (expect result :not.to.contain "Loading")))))
           (it "template-basic" []
               (.. cy
                   (get "#search-button")
                   (click)
+                  (get "input.cp__palette-input")
                   (type "template test page")
                   (wait 1000)
                   (type "{enter}"))
               (util/edit-block "template")
               (.. cy
                   (realPress #js ["Shift" "Enter"]))
-              (util/edit-block "template:: template-name{enter}")
+              (util/edit-block "template:: template-name{enter}{enter}")
               (util/tab)
               (util/edit-block "line1{enter}")
               (util/edit-block "line2{enter}")

--- a/cypress/integration/app/util.cljs
+++ b/cypress/integration/app/util.cljs
@@ -5,7 +5,7 @@
 
 (defn back-to-home
   []
-  (.. cy (get ".cp__header-logo")
+  (.. cy (get ".ui__modal")
       (first)
       (click)))
 


### PR DESCRIPTION
- wait for loading before starts
- no header logo now, click the modal overlay to go home
- multiline block requires `{enter}` twice to finish editing?