### PR TITLE
Introduce clj-kondo for linting

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,10 +1,20 @@
-{:linters {:unresolved-symbol {:exclude [goog.DEBUG]}}
+{:linters {:unresolved-symbol {:exclude [goog.DEBUG 
+                                         goog.string.unescapeEntities]}}
  :hooks {:analyze-call {rum.core/defc hooks.rum/defc
                         rum.core/defcs hooks.rum/defcs}}
  :lint-as {promesa.core/let clojure.core/let
+           promesa.core/loop clojure.core/loop
            garden.def/defstyles clojure.core/def
            garden.def/defkeyframes clojure.core/def
            rum.core/defcc rum.core/defc
+           rum.core/with-context clojure.core/doseq
+           rum.core/defcontext clojure.core/def
            clojure.test.check.clojure-test/defspec clojure.core/def
            clojure.test.check.properties/for-all clojure.core/for
-           frontend.modules.outliner.datascript/auto-transact! clojure.core/let}}
+           nubank.workspaces.core/defcard clojure.core/def
+           ;; src/main
+           frontend.modules.outliner.datascript/auto-transact! clojure.core/let
+           frontend.namespaces/import-vars potemkin/import-vars
+           ;; src/test
+           frontend.react/defc clojure.core/defn}
+ :skip-comments true}

--- a/deps.edn
+++ b/deps.edn
@@ -58,4 +58,8 @@
             {com.cognitect/test-runner
              {:git/url "https://github.com/cognitect-labs/test-runner",
               :sha "76568540e7f40268ad2b646110f237a60295fa3c"}},
-            :main-opts ["-m" "cognitect.test-runner" "-d" "src/test"]}}}
+            :main-opts ["-m" "cognitect.test-runner" "-d" "src/test"]}
+           
+           :clj-kondo
+           {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.10.19"}}
+            :main-opts ["-m" "clj-kondo.main"]}}}

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
         "cljs:dev-release-app": "clojure -M:cljs release app --config-merge '{:closure-defines {frontend.config/DEV-RELEASE true}}'",
         "cljs:debug": "clojure -M:cljs release parser-worker app --debug",
         "cljs:report": "clojure -M:cljs run shadow.cljs.build-report parser-worker app report.html",
-        "cljs:build-electron": "clojure -A:cljs compile parser-worker app electron"
+        "cljs:build-electron": "clojure -A:cljs compile parser-worker app electron",
+        "cljs:lint": "clojure -M:clj-kondo --parallel --lint src"
     },
     "dependencies": {
         "@capacitor/android": "^3.2.2",

--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -2,7 +2,6 @@
   (:require [clojure.string :as string]
             ["fs-extra" :as fs]
             ["path" :as path]
-            [clojure.string :as string]
             [cljs-bean.core :as bean]
             ["electron" :refer [app BrowserWindow]]))
 

--- a/src/main/frontend/components/repo.cljs
+++ b/src/main/frontend/components/repo.cljs
@@ -173,7 +173,7 @@
                (t :git/version) (str " " version/version)]]])))])))
 
 (rum/defc repos-dropdown < rum/reactive
-  [toggle-dropdown-f]
+  []
   (when-let [current-repo (state/sub :git/current-repo)]
     (rum/with-context [[t] i18n/*tongue-context*]
       (let [get-repo-name (fn [repo]

--- a/src/main/frontend/components/sidebar.cljs
+++ b/src/main/frontend/components/sidebar.cljs
@@ -30,8 +30,7 @@
             [goog.object :as gobj]
             [rum.core :as rum]
             [frontend.extensions.srs :as srs]
-            [frontend.extensions.pdf.assets :as pdf-assets]
-            [frontend.components.widgets :as widgets]))
+            [frontend.extensions.pdf.assets :as pdf-assets]))
 
 (defn nav-item
   [title href svg-d active? close-modal-fn]

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -418,7 +418,7 @@
          (recur next (conj result next))
          (vec result))))))
 
-(defn- sort-by-left-recursive
+(defn sort-by-left-recursive
   [form]
   (walk/postwalk (fn [f]
                    (if (and (map? f)

--- a/src/main/frontend/debug.cljs
+++ b/src/main/frontend/debug.cljs
@@ -2,7 +2,6 @@
   (:require [cljs.pprint :as pprint]
             [frontend.state :as state]
             [frontend.util :as util]
-            [frontend.state :as state]
             [frontend.handler.notification :as notification]))
 
 (defn pprint

--- a/src/main/frontend/extensions/graph.cljs
+++ b/src/main/frontend/extensions/graph.cljs
@@ -1,6 +1,5 @@
 (ns frontend.extensions.graph
   (:require [cljs-bean.core :as bean]
-            [cljs-bean.core :as bean]
             [clojure.string :as string]
             [frontend.extensions.graph.pixi :as pixi]
             [frontend.handler.route :as route-handler]

--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -684,7 +684,7 @@
                   [others parents' block result'])))]
         (recur blocks parents sibling result)))))
 
-(defn- parse-block
+(defn parse-block
   ([block]
    (parse-block block nil))
   ([{:block/keys [uuid content page format] :as block} {:keys [with-id?]

--- a/src/main/frontend/fs/protocol.cljs
+++ b/src/main/frontend/fs/protocol.cljs
@@ -1,4 +1,6 @@
-(ns frontend.fs.protocol)
+(ns frontend.fs.protocol
+  ;; namespace local config to suppress 'new-path' of 'rename!'. clj-kondo's bug?
+  {:clj-kondo/config {:linters {:private-call {:level :off}}}})
 
 (defprotocol Fs
   (mkdir! [this dir])

--- a/src/main/frontend/handler/git.cljs
+++ b/src/main/frontend/handler/git.cljs
@@ -12,17 +12,17 @@
             [lambdaisland.glogi :as log]
             [promesa.core :as p]))
 
-(defn- set-git-status!
+(defn set-git-status!
   [repo-url value]
   (db/set-key-value repo-url :git/status value)
   (state/set-git-status! repo-url value))
 
-(defn- set-git-last-pulled-at!
+(defn set-git-last-pulled-at!
   [repo-url]
   (db/set-key-value repo-url :git/last-pulled-at
                     (date/get-date-time-string (tl/local-now))))
 
-(defn- set-git-error!
+(defn set-git-error!
   [repo-url value]
   (db/set-key-value repo-url :git/error (when value (str value))))
 

--- a/src/main/frontend/handler/plugin.cljs
+++ b/src/main/frontend/handler/plugin.cljs
@@ -370,7 +370,7 @@
                                         ;; plugins
                                         (swap! state/state md/dissoc-in [:plugin/installed-plugins pid])
                                         ;; commands
-                                        (clear-commands!))))
+                                        (clear-commands! pid))))
 
                 (.on "unlink-plugin" (fn [pid]
                                        (let [pid (keyword pid)]

--- a/src/main/frontend/handler/ui.cljs
+++ b/src/main/frontend/handler/ui.cljs
@@ -12,7 +12,6 @@
             [goog.dom :as gdom]
             [goog.object :as gobj]
             [clojure.string :as string]
-            [frontend.storage :as storage]
             [rum.core :as rum]
             [clojure.edn :as edn]))
 

--- a/src/main/frontend/spec.cljs
+++ b/src/main/frontend/spec.cljs
@@ -15,7 +15,7 @@
   (when config/dev?
     (if (s/explain-data spec value)
      (let [error-message (expound/expound-str spec value)
-           ex (ex-info "Error in validate" nil)]
+           ex (ex-info "Error in validate" {})]
        (log/error :exception ex :spec/validate-failed error-message)
        false)
      true)))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -16,7 +16,7 @@
             [promesa.core :as p]
             [rum.core :as rum]))
 
-(defonce ^:private state
+(defonce state
   (let [document-mode? (or (storage/get :document/mode?) false)
         current-graph (let [graph (storage/get :git/current-repo)]
                         (when graph (ipc/ipc "setCurrentGraph" graph))

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -992,7 +992,7 @@
     (url-encode s)))
 
 #?(:cljs
-   (defn- get-clipboard-as-html
+   (defn get-clipboard-as-html
      [event]
      (if-let [c (gobj/get event "clipboardData")]
        [(.getData c "text/html") (.getData c "text")]

--- a/src/main/frontend/util/property.cljs
+++ b/src/main/frontend/util/property.cljs
@@ -5,7 +5,6 @@
             [frontend.config :as config]
             [medley.core :as medley]
             [frontend.format.mldoc :as mldoc]
-            [frontend.handler.link :as link]
             [frontend.text :as text]
             [frontend.util.cursor :as cursor]
             [frontend.handler.link :as link]))

--- a/src/test/frontend/handler/export_test.cljs
+++ b/src/test/frontend/handler/export_test.cljs
@@ -1,4 +1,6 @@
 (ns frontend.handler.export-test
+  ;; namespace local config for private function tests
+  {:clj-kondo/config {:linters {:private-call {:level :off}}}}
   (:require [cljs.test :refer [async deftest is testing use-fixtures are]]
             [frontend.handler.export :as export]
             [frontend.db.config :refer [test-db] :as config]

--- a/src/test/frontend/handler/page_test.cljs
+++ b/src/test/frontend/handler/page_test.cljs
@@ -1,4 +1,6 @@
 (ns frontend.handler.page-test
+  ;; namespace local config for private function tests
+  {:clj-kondo/config {:linters {:private-call {:level :off}}}}
   (:require [cljs.test :refer [deftest are]]
             [clojure.string :as string]
             [frontend.util :as util]

--- a/src/test/frontend/react_test.cljs
+++ b/src/test/frontend/react_test.cljs
@@ -1,4 +1,6 @@
 (ns frontend.react-test
+  ;; namespace local config for r/defc tests
+  {:clj-kondo/config {:linters {:inline-def {:level :off}}}}
   (:require [frontend.react :as r]
             [cljs.test :refer [deftest is are testing use-fixtures run-tests]]
             [frontend.fixtures :as fixtures]))


### PR DESCRIPTION
### Changes
* Can lint via `yarn cljs:lint` (not included in any other script yet)
* Resolved some macros for clj-kondo to work
* Fix some simple errors in 426a93a (e.g. duplicated `require`, private call)
### Limitations
* 10+ error and 700+ warnings to fix (or suppress)
* Suppress some linting using [namespace local config](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#introduction) (most cases are in `/src/test/`)