### PR TITLE
Include isPageBlock property in insertBlock

### DIFF
--- a/libs/src/LSPlugin.ts
+++ b/libs/src/LSPlugin.ts
@@ -346,7 +346,7 @@ export interface IEditorProxy extends Record<string, any> {
   insertBlock: (
     srcBlock: BlockIdentity,
     content: string,
-    opts?: Partial<{ before: boolean; sibling: boolean; properties: {} }>
+    opts?: Partial<{ before: boolean; sibling: boolean; isPageBlock: boolean; properties: {} }>
   ) => Promise<BlockEntity | null>
 
   insertBatchBlock: (


### PR DESCRIPTION
Currently, using the isPageBlock property when using insertBlock allows you to insert a block on an empty page. However, there will be a TS error as shown below:
```
Argument of type '{ isPageBlock: boolean; }' is not assignable to parameter of type 'Partial<{ before: boolean; sibling: boolean; properties: {}; }>'.
  Object literal may only specify known properties, and 'isPageBlock' does not exist in type 'Partial<{ before: boolean; sibling: boolean; properties: {}; }>'.
```
This PR attempts to remove this lint error.