### PR TITLE
Fix: Ignoring keydown during IME composition

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2753,15 +2753,19 @@
 
 (defn keydown-not-matched-handler
   [format]
-  (fn [e _key-code]
+  (fn [e key-code]
     (let [input-id (state/get-edit-input-id)
           input (state/get-input)
           key (gobj/get e "key")
           value (gobj/get input "value")
           ctrlKey (gobj/get e "ctrlKey")
           metaKey (gobj/get e "metaKey")
+          is-composing? (gobj/getValueByKeys e "event_" "isComposing")
           pos (cursor/pos input)]
       (cond
+        (or is-composing? (= key-code 229))
+        nil
+
         (or ctrlKey metaKey)
         nil
 


### PR DESCRIPTION
See-also: https://developer.mozilla.org/en-US/docs/Web/API/Document/keydown_event#ignoring_keydown_during_ime_composition

Fixes #1821

Reproduce this bug on macOS:
- add system Japanese Hiragana Input Method, switch to it
- press `[` key
- the IME begins composition,  and Logseq shows `[「]` with an underline, which is annoying

![image](https://user-images.githubusercontent.com/72891/142660096-ff3902a9-b295-4260-aa53-7185db5b11d7.png)

