### PR TITLE
feat: support Arweave URLs for links and images

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -262,6 +262,10 @@
     (when @src
       (resizable-image config title @src metadata full_text true))))
 
+(defn ar-url->http-url
+  [href]
+  (string/replace href #"^ar://" (str (state/get-arweave-gateway) "/")))
+
 ;; TODO: safe encoding asciis
 ;; TODO: image link to another link
 (defn image-link [config url href label metadata full_text]
@@ -279,6 +283,9 @@
              href (cond
                     (util/starts-with? href "http")
                     href
+
+                    (util/starts-with? href "ar")
+                    (ar-url->http-url href)
 
                     config/publishing?
                     (subs href 1)
@@ -990,6 +997,16 @@
                                (when-let [current (pdf-assets/inflate-asset href)]
                                  (state/set-state! :pdf/current current)))}
              (get-label-text label)]
+
+            (= protocol "ar")
+            (->elem
+              :a.external-link
+              (cond->
+                {:href (ar-url->http-url href)
+                 :target "_blank"}
+                title
+                (assoc :title title))
+              (map-inline config label))
 
             :else
             (->elem

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -236,6 +236,12 @@
   ([repo-url]
    (get-in @state [:config repo-url])))
 
+(def default-arweave-gateway "https://arweave.net")
+
+(defn get-arweave-gateway
+  []
+  (:arweave/gateway (get-config) default-arweave-gateway))
+
 (defonce built-in-macros
   {"img" "[:img.$4 {:src \"$1\" :style {:width $2 :height $3}}]"})
 


### PR DESCRIPTION
Adds ar://<tx> URL support for both links and images. The Arweave gateway used can be configured with the :arweave/gateway config key. It defaults to "https://arweave.net" if not configured.

I think this is reasonably tidy, but I'm happy to restructure it if desired (move code, rename functions, etc.). Also, it wasn't completely clear if or where I should add tests. Just let me know if you want any changes and I'll update the PR.