### PR TITLE
fix rename issues if special chars like (), + exists in page name

### DIFF
--- a/src/main/frontend/db.cljs
+++ b/src/main/frontend/db.cljs
@@ -49,7 +49,7 @@
   get-all-pages get-pages get-pages-relation get-pages-that-mentioned-page get-public-pages get-tag-pages
   journal-page? local-native-fs? mark-repo-as-cloned! page-alias-set page-blocks-transform pull-block
   set-file-last-modified-at! transact-files-db! page-empty? page-empty-or-dummy? get-alias-source-page
-  set-file-content! has-children? get-namespace-pages get-all-namespace-relation get-nested-pages]
+  set-file-content! has-children? get-namespace-pages get-all-namespace-relation get-pages-by-name-partition]
 
  [frontend.db.react
   get-current-marker get-current-page get-current-priority set-key-value

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -572,18 +572,20 @@
   (when-let [block (db-utils/entity repo [:block/uuid block-id])]
     (db-utils/entity repo (:db/id (:block/page block)))))
 
-(defn get-nested-pages
-  [repo page-name]
+(defn get-pages-by-name-partition
+  [repo partition]
   (when-let [conn (conn/get-conn repo)]
-    (let [nested-page-name (->> (string/trim page-name)
-                                (util/format "[[%s]]"))]
-      (d/q '[:find ?e ?n
-             :in $ ?x
-             :where
-             [?e :block/name ?n]
-             [(clojure.string/includes? ?n ?x)]]
-           conn
-           nested-page-name))))
+    (when-not (string/blank? partition)
+      (let [partition (string/lower-case (string/trim partition))
+            ids (->> (d/datoms conn :aevt :block/name)
+                     (filter (fn [datom]
+                               (let [page (:v datom)]
+                                 (string/includes? page partition))))
+                     (map :e))]
+        (when (seq ids)
+          (db-utils/pull-many repo
+                              '[:db/id :block/name :block/original-name]
+                              ids))))))
 
 (defn block-and-children-transform
   [result repo-url block-uuid]

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -415,23 +415,42 @@
 
 (defn- rename-nested-pages
   [old-ns-name new-ns-name]
-  (when-let [nested-pages (db/get-nested-pages
-                           (state/get-current-repo)
-                           (string/lower-case old-ns-name))]
-    (doseq [page nested-pages]
-      (let [[_page-id old-page-name] page
-            new-page-name (util/replace-ignore-case
-                           old-page-name
-                           (util/format "\\[\\[%s\\]\\]" old-ns-name)
-                           (util/format "[[%s]]" new-ns-name))]
-        (rename-page-aux old-page-name new-page-name)))))
+  (let [repo            (state/get-current-repo)
+        nested-page-str (util/format "[[%s]]" (string/lower-case old-ns-name))
+        ns-prefix       (util/format "[[%s/" (string/lower-case old-ns-name))
+        nested-pages    (db/get-pages-by-name-partition repo nested-page-str)
+        nested-pages-ns (db/get-pages-by-name-partition repo ns-prefix)]
+    (when nested-pages
+      ;; rename page "[[obsidian]] is a tool" to "[[logseq]] is a tool"
+      (doseq [{:block/keys [name original-name]} nested-pages]
+        (let [old-page-title (or original-name name)
+              new-page-title (string/replace
+                             old-page-title
+                             (util/format "[[%s]]" old-ns-name)
+                             (util/format "[[%s]]" new-ns-name))]
+          (when (and old-page-title new-page-title)
+            (p/do!
+             (rename-page-aux old-page-title new-page-title)
+             (println "Renamed " old-page-title " to " new-page-title))))))
+    (when nested-pages-ns
+      ;; rename page "[[obsidian/page1]] is a tool" to "[[logseq/page1]] is a tool"
+      (doseq [{:block/keys [name original-name]} nested-pages-ns]
+        (let [old-page-title (or original-name name)
+              new-page-title (string/replace
+                              old-page-title
+                             (util/format "[[%s/" old-ns-name)
+                             (util/format "[[%s/" new-ns-name))]
+          (when (and old-page-title new-page-title)
+            (p/do!
+             (rename-page-aux old-page-title new-page-title)
+             (println "Renamed " old-page-title " to " new-page-title))))))))
 
 (defn- rename-namespace-pages!
   [repo old-name new-name]
   (let [pages (db/get-namespace-pages repo old-name)]
-    (doseq [{:block/keys [name original-name] :as page} pages]
+    (doseq [{:block/keys [name original-name]} pages]
       (let [old-page-title (or original-name name)
-            new-page-title (util/replace-first-ignore-case old-page-title old-name new-name)]
+            new-page-title (string/replace old-page-title old-name new-name)]
         (when (and old-page-title new-page-title)
           (p/let [_ (rename-page-aux old-page-title new-page-title)]
             (println "Renamed " old-page-title " to " new-page-title)))))))
@@ -480,19 +499,13 @@
                            (or (:block/original-name to-page)
                                (:block/name to-page))))
 
-    (delete! from nil)
-
-    (route-handler/redirect! {:to          :page
-                              :push        false
-                              :path-params {:name (string/lower-case to)}})))
+    (delete! from nil)))
 
 (defn rename!
   [old-name new-name]
   (let [repo          (state/get-current-repo)
         old-name      (string/trim old-name)
         new-name      (string/trim new-name)
-        namespace     (or (string/includes? old-name "/")
-                          (db/get-namespace-pages repo old-name))
         name-changed? (not= old-name new-name)]
     (if (and old-name
              new-name
@@ -505,12 +518,9 @@
 
           (db/pull [:block/name (string/lower-case new-name)])
           (merge-pages! old-name new-name)
-
-          namespace
-          (rename-namespace-pages! repo old-name new-name)
-
+          
           :else
-          (rename-page-aux old-name new-name))
+          (rename-namespace-pages! repo old-name new-name))
         (rename-nested-pages old-name new-name))
       (when (string/blank? new-name)
         (notification/show! "Please use a valid name, empty name is not allowed!" :error)))))

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -215,7 +215,7 @@
                          (re-find
                           (re-pattern
                            (util/format
-                            "\\[\\[file:\\./.*%s\\.org\\]\\[(.*?)\\]\\]" old-name))
+                            "\\[\\[file:\\.*/.*%s\\.org\\]\\[(.*?)\\]\\]" old-name))
                           content))]
     (-> (if old-org-ref
             (let [[old-full-ref old-label] old-org-ref

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -499,7 +499,11 @@
                            (or (:block/original-name to-page)
                                (:block/name to-page))))
 
-    (delete! from nil)))
+    (delete! from nil)
+    
+    (route-handler/redirect! {:to          :page
+                              :push        false
+                              :path-params {:name (string/lower-case to)}})))
 
 (defn rename!
   [old-name new-name]

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -621,11 +621,25 @@
          (str prefix new-value)))
      s)))
 
-(defn replace-ignore-case [s old-value new-value]
-  (string/replace s (re-pattern (str "(?i)" old-value)) new-value))
+(defn replace-ignore-case
+  [s old-value new-value & [escape-chars]]
+  (let [escape-chars (or escape-chars "[]{}().+*?")
+        old-value (if (string? escape-chars)
+                    (reduce (fn [acc escape-char]
+                              (string/replace acc escape-char (str "\\" escape-char)))
+                            old-value escape-chars)
+                    old-value)]
+    (string/replace s (re-pattern (str "(?i)" old-value)) new-value)))
 
-(defn replace-first-ignore-case [s old-value new-value]
-  (string/replace-first s (re-pattern (str "(?i)" old-value)) new-value))
+(defn replace-first-ignore-case
+  [s old-value new-value & [escape-chars]]
+  (let [escape-chars (or escape-chars "[]{}().+*?")
+        old-value (if (string? escape-chars)
+                    (reduce (fn [acc escape-char]
+                              (string/replace acc escape-char (str "\\" escape-char)))
+                            old-value escape-chars)
+                    old-value)]
+    (string/replace-first s (re-pattern (str "(?i)" old-value)) new-value)))
 
 ;; copy from https://stackoverflow.com/questions/18735665/how-can-i-get-the-positions-of-regex-matches-in-clojurescript
 #?(:cljs

--- a/src/main/frontend/util/page_property.cljs
+++ b/src/main/frontend/util/page_property.cljs
@@ -24,13 +24,8 @@
                                                (string/join ", " v)
                                                v))))
           before (remove nil? (map #(build-property-fn %) [:title :alias :aliases]))
-          other (reduce (fn [content elem]
-                          (string/replace
-                           content
-                           (re-pattern (case format
-                                         :org (str "#\\+" (subs elem 2) "\n*")
-                                         (str elem "\n*")))
-                           ""))
+          other (reduce (fn [acc elem]
+                          (util/replace-ignore-case acc (str elem "\n*") "" "[]{}().+"))
                         content before)]
       (string/join "\n" (remove #(= "" %)
                                 (concat before [other]))))))

--- a/src/test/frontend/handler/page_test.cljs
+++ b/src/test/frontend/handler/page_test.cljs
@@ -17,7 +17,7 @@
         old-org-ref (re-find
                      (re-pattern
                       (util/format
-                       "\\[\\[file:\\./.*%s\\.org\\]\\[(.*?)\\]\\]" old-name))
+                       "\\[\\[file:\\.*/.*%s\\.org\\]\\[(.*?)\\]\\]" old-name))
                      content)]
     (-> (if old-org-ref
           (let [[old-full-ref old-label] old-org-ref
@@ -51,6 +51,9 @@
     
     ["bla [[file:./logseq.foo.org][logseq/foo]] bla" "logseq/foo" "logseq/bar"]
     "bla [[file:./logseq.bar.org][logseq/bar]] bla"
+
+    ["bla [[file:../pages/logseq.foo.org][logseq/foo]] bla" "logseq/foo" "logseq/bar"]
+    "bla [[file:../pages/logseq.bar.org][logseq/bar]] bla"
 
     ["bla [[file:./pages/logseq.foo.org][logseq/foo]] bla" "logseq/foo" "logseq/bar"]
     "bla [[file:./pages/logseq.bar.org][logseq/bar]] bla"


### PR DESCRIPTION
- fix #3221.
- The nested_page will also be updated if the namespace in the name got renamed.  

Renaming a page will be more stable after this PR and PR https://github.com/logseq/logseq/pull/3228 got merged.
Demo: https://www.loom.com/share/8f78a816257449c5b42a888ef44a7621