### PR TITLE
Fix wrong namespace if nested link exists in the graph

### DIFF
--- a/src/main/frontend/components/hierarchy.cljs
+++ b/src/main/frontend/components/hierarchy.cljs
@@ -11,13 +11,14 @@
 ;; FIXME: use block/namespace to get the relation
 (defn get-relation
   [page]
-  (when (text/namespace-page? page)
-    (->> (db/get-namespace-pages (state/get-current-repo) page)
-         (map (fn [page]
-                (or (:block/original-name page) (:block/name page))))
-         (map #(string/split % #"/"))
-         (remove #(= % [page]))
-         (sort))))
+  (when-let [page (or (text/get-nested-page-name page) page)]
+   (when (text/namespace-page? page)
+     (->> (db/get-namespace-pages (state/get-current-repo) page)
+          (map (fn [page]
+                 (or (:block/original-name page) (:block/name page))))
+          (map #(string/split % #"/"))
+          (remove #(= % [page]))
+          (sort)))))
 
 (rum/defc structures
   [page]

--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -262,6 +262,7 @@
     (let [original-page-name (util/remove-boundary-slashes original-page-name)
           [original-page-name page-name journal-day] (convert-page-if-journal original-page-name)
           namespace? (and (string/includes? original-page-name "/")
+                          (not (boolean (text/get-nested-page-name original-page-name)))
                           (text/namespace-page? original-page-name))
           m (merge
              {:block/name page-name
@@ -302,10 +303,12 @@
      (concat title body))
     (let [refs (remove string/blank? @refs)
           children-pages (->> (mapcat (fn [p]
-                                        (when (text/namespace-page? p)
-                                          (util/split-namespace-pages p)))
+                                        (let [p (or (text/get-nested-page-name p) p)]
+                                          (when (text/namespace-page? p)
+                                            (util/split-namespace-pages p))))
                                       refs)
-                              (remove string/blank?))
+                              (remove string/blank?)
+                              (distinct))
           refs (->> (distinct (concat refs children-pages))
                     (remove nil?))
           refs (map (fn [ref] (page-name->map ref with-id?)) refs)]

--- a/src/main/frontend/text.cljs
+++ b/src/main/frontend/text.cljs
@@ -83,6 +83,11 @@
         y (re-seq #"\]\]" s)]
     (and (> (count x) 0) (= (count x) (count y)))))
 
+(defn get-nested-page-name
+  [page-name]
+  (when-let [first-match (re-find page-ref-re-without-nested page-name)]
+    (second first-match)))
+
 (defn- concat-nested-pages
   [coll]
   (first


### PR DESCRIPTION
1. Fix: create wrong pages if nested_link exists in the graph.
If `[[[[A/B]] is page]] got referenced` exists as a link in the graph, a `[[A` page will be created. This PR fixes this issue.
2. Fix: create wrong namespace if nested_link exists in the graph.
Before:
<img width="583" alt="CleanShot 2021-11-22 at 10 12 01@2x" src="https://user-images.githubusercontent.com/3996879/142791000-2fc185a2-ffb9-48d5-a791-858a6e5900be.png">

After:
<img width="584" alt="CleanShot 2021-11-22 at 10 10 43@2x" src="https://user-images.githubusercontent.com/3996879/142790884-db39a200-eca7-44e5-affb-e491bc0903c5.png">
