### PR TITLE
enhance: sort by block name before save page metadata

### DIFF
--- a/src/main/frontend/handler/metadata.cljs
+++ b/src/main/frontend/handler/metadata.cljs
@@ -45,6 +45,7 @@
         all-pages (->> (db/get-all-pages repo)
                        (common-handler/fix-pages-timestamps)
                        (map #(select-keys % [:block/name :block/created-at :block/updated-at]))
+                       (sort-by :block/name)
                        (vec))]
     (p/let [_ (-> (file-handler/create-pages-metadata-file repo)
                   (p/catch (fn [] nil)))]


### PR DESCRIPTION
This avoids diff caused by hashmap order rearrangement, also minimizing diff when new pages are added.
