### PR TITLE
Fix clj test invocation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,9 @@ jobs:
       - name: Fetch yarn deps
         run: yarn cache clean && yarn install
 
-      - name: Run Clojure test
+      - name: Run ClojureScript test
         run: |
           yarn cljs:test
           node static/tests.js
+      - name: Run Clojure test
+        run: clj -Mtest-clj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,5 +79,3 @@ jobs:
         run: |
           yarn cljs:test
           node static/tests.js
-      - name: Run Clojure test
-        run: clojure -Mtest-clj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,4 +80,4 @@ jobs:
           yarn cljs:test
           node static/tests.js
       - name: Run Clojure test
-        run: clj -Mtest-clj
+        run: clojure -Mtest-clj

--- a/README.md
+++ b/README.md
@@ -118,12 +118,6 @@ Run Cypress tests
 yarn e2e-test
 ```
 
-Run Clojure tests. (Note: `.cljc` files may be tested both by ClojureScript, and Clojure.)
-
-```bash
-clj -Mtest-clj
-```
-
 ## Desktop app development
 
 ### 1. Compile to JavaScript

--- a/deps.edn
+++ b/deps.edn
@@ -52,14 +52,6 @@
                           org.clojars.knubie/cljs-run-test {:mvn/version "1.0.1"}}
             :main-opts   ["-m" "shadow.cljs.devtools.cli"]}
 
-           :test-clj
-           {:extra-paths ["src/test/"]
-            :extra-deps
-            {com.cognitect/test-runner
-             {:git/url "https://github.com/cognitect-labs/test-runner",
-              :sha "76568540e7f40268ad2b646110f237a60295fa3c"}},
-            :main-opts ["-m" "cognitect.test-runner" "-d" "src/test"]}
-           
            :clj-kondo
            {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.10.19"}}
             :main-opts ["-m" "clj-kondo.main"]}}}

--- a/src/test/frontend/external/roam_test.cljs
+++ b/src/test/frontend/external/roam_test.cljs
@@ -1,6 +1,5 @@
 (ns frontend.external.roam-test
-  (:require #?(:clj  [clojure.test :refer :all]
-               :cljs [cljs.test :refer [is deftest]])
+  (:require [cljs.test :refer [is deftest]]
             [frontend.external.roam :as roam]
             [frontend.external :refer [to-markdown-files]]))
 


### PR DESCRIPTION
Hi logseq team. I noticed the clj tests run with `clj -Mtest-clj` fail with `Exception in thread "main" Syntax error compiling at (frontend/external/roam.cljc:1:1)`. It seems that roam.clj is no longer clj compatible so I moved the roam test to be cljs. I also added the clj tests to CI so they continue to pass going forward. I could make roam.clj to be cljs specific as well or take this PR in a different direction e.g. remove clj testing.

Thanks for this amazing editor :) Cheers.