### PR TITLE
fix(build): electron-rebuild version

### DIFF
--- a/resources/package.json
+++ b/resources/package.json
@@ -11,7 +11,7 @@
     "electron:make": "electron-forge make",
     "electron:make-macos-arm64": "electron-forge make --platform=darwin --arch=arm64",
     "electron:publish:github": "electron-forge publish",
-    "rebuild:better-sqlite3": "electron-rebuild -v 15 -f -w better-sqlite3",
+    "rebuild:better-sqlite3": "electron-rebuild -v 15.1.2 -f -w better-sqlite3",
     "postinstall": "install-app-deps"
   },
   "config": {


### PR DESCRIPTION
Fixes:

`cd static && DEBUG=electron-rebuild yarn rebuild:better-sqlite3`

```
✖ Rebuild Failed

An unhandled error occurred inside electron-rebuild
node-gyp failed to rebuild '***/Repos/logseq/static/node_modules/better-sqlite3'.
For more information, rerun with the DEBUG environment variable set to "electron-rebuild".

Error: Invalid version number: 15
```