### PR TITLE
fix: custom macro click issue

### DIFF
--- a/src/main/frontend/components/plugins.cljs
+++ b/src/main/frontend/components/plugins.cljs
@@ -402,7 +402,8 @@
          #())
        [id])
      [:div.lsp-hook-ui-slot
-      (merge opts {:id id})])))
+      (merge opts {:id id
+                   :on-mouse-down (fn [e] (util/stop e))})])))
 
 (rum/defc ui-item-renderer
   [pid type {:keys [key template]}]


### PR DESCRIPTION
Clicking a custom macro may invoke the block content itself's `mouse-down` handler. https://github.com/logseq/logseq/blob/master/src/main/frontend/components/block.cljs#L1794

Alternatively, we can stop event propagation here: https://github.com/logseq/logseq/blob/master/libs/src/helpers.ts#L358. Not sure which one is the desired solution?