### PR TITLE
Add datalog console extension in dev

### DIFF
--- a/src/main/frontend/handler.cljs
+++ b/src/main/frontend/handler.cljs
@@ -7,6 +7,7 @@
             [frontend.config :as config]
             [frontend.db :as db]
             [frontend.db-schema :as db-schema]
+            [frontend.db.conn :as conn]
             [frontend.error :as error]
             [frontend.handler.command-palette :as command-palette]
             [frontend.handler.common :as common-handler]
@@ -28,6 +29,7 @@
             [frontend.ui :as ui]
             [frontend.util :as util]
             [frontend.util.pool :as pool]
+            [cljs.reader :refer [read-string]]
             [goog.object :as gobj]
             [lambdaisland.glogi :as log]
             [promesa.core :as p]))
@@ -149,6 +151,21 @@
   (js/window.addEventListener "online" handle-connection-change)
   (js/window.addEventListener "offline" handle-connection-change))
 
+(defn enable-datalog-console
+  "Enables datalog console in browser provided by https://github.com/homebaseio/datalog-console"
+  []
+  (js/document.documentElement.setAttribute "__datalog-console-remote-installed__" true)
+  (.addEventListener js/window "message"
+                     (fn [event]
+                       (let [conn (conn/get-conn)]
+                         (when-let [devtool-message (gobj/getValueByKeys event "data" ":datalog-console.client/devtool-message")]
+                           (let [msg-type (:type (read-string devtool-message))]
+                             (case msg-type
+
+                               :datalog-console.client/request-whole-database-as-string
+                               (.postMessage js/window #js {":datalog-console.remote/remote-message" (pr-str conn)} "*")
+
+                               nil)))))))
 (defn- get-repos
   []
   (let [logged? (state/logged?)
@@ -217,6 +234,8 @@
     (db/run-batch-txs!)
     (file-handler/run-writes-chan!)
     (pool/init-parser-pool!)
+    (when config/dev?
+      (enable-datalog-console))
     (when (util/electron?)
       (el/listen!))))
 


### PR DESCRIPTION
Hi logseq team.
  I thought it'd be fun if logseq had support for https://github.com/homebaseio/datalog-console like athens does. Here's what it looks like: 
<img width="1435" alt="Screen Shot 2021-11-23 at 2 09 56 AM" src="https://user-images.githubusercontent.com/11994/142983573-815995a3-1960-4638-afd5-3ae9e32defe5.png">

I've confirmed this works in Chrome. This may work in electron but that will require more investigation. I've only enabled this in dev but perhaps it could be useful in prod at some point. I could add transact support from their [example integration](https://github.com/homebaseio/datalog-console/blob/main/src/main/datalog_console/integrations/datascript.cljs) if you'd like. To try this extension, follow steps 2-5 from https://github.com/homebaseio/datalog-console . For step 3, `yarn watch` and open logseq in Chrome.

Thanks for your hard work. Cheers

