### PR TITLE
fix: rm space when showing template popup

### DIFF
--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -377,6 +377,9 @@
           postfix (subs edit-content current-pos)
           postfix (if postfix-fn (postfix-fn postfix) postfix)
           new-value (cond
+                      (string/blank? postfix)
+                      prefix
+
                       space?
                       (util/concat-without-spaces prefix postfix)
 


### PR DESCRIPTION
When using `\` to open `Template` popup, extra space will be inserted after `\`.

Rationale: A `\` is not like other prefix+postfix style inserting commands, it is only the first stage of the template command.

To reproduce the behavior:

- `\Tem`
- Click Template or press Enter
- A popup will appear, and the current line becomes `\ |` (`|` indicates text cursor)

Triggering template popup:
![image](https://user-images.githubusercontent.com/72891/143161729-9d76761f-5060-4175-b505-19a4a182b989.png)

Original
![image](https://user-images.githubusercontent.com/72891/143161875-3fea5c3c-d651-4f0d-8e14-2c6aa9efc666.png)

This fix:
![image](https://user-images.githubusercontent.com/72891/143161987-a105d6cf-5914-45e3-ac05-530d062859f6.png)