### PR TITLE
fix: All Pages view lists all of the images

### DIFF
--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -55,6 +55,7 @@
 
                   (and
                    (= typ "Search")
+                   (text/page-ref? (second (:url (second block))))
                    (text/page-ref-un-brackets! (second (:url (second block)))))
 
                   (and
@@ -84,10 +85,10 @@
 
                (and (vector? block)
                     (= "Macro" (first block)))
-               (let [{:keys [name arguments]} (second block)]
-                 (let [argument (string/join ", " arguments)]
+               (let [{:keys [name arguments]} (second block)
+                     argument (string/join ", " arguments)]
                    (when (= name "embed")
-                     (text/page-ref-un-brackets! argument))))
+                     (text/page-ref-un-brackets! argument)))
 
                (and (vector? block)
                     (= "Tag" (first block)))


### PR DESCRIPTION
**Issue to solve:**
https://github.com/logseq/logseq/issues/3224

**What's happening:**
* Refs are counted into pages.
* 538b0d8ad6c78c6e2d8ed51a151fc9bf9b186c94 removed the quote check (`[[]]`) when retrieving refs of "Links" with `:url` of "Search", and triggers the bug. (Haven't checked why the image file is categorized as this)
* Bug happens if a user has such links, and apply a re-index within the bad commits.

**The fix:**
* Add back the quote check

**For users suffered from the bug:**
* Refresh and re-index after the commit