### PR TITLE
Fix app stuck when pressing enter at empty page-ref

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2427,7 +2427,7 @@
               "admonition-block" (keydown-new-line)
               "source-block" (keydown-new-line)
               "block-ref" (open-block-in-sidebar! (:link thing-at-point))
-              "page-ref" (do
+              "page-ref" (when-not (string/blank? (:link thing-at-point))
                            (insert-first-page-block-if-not-exists! (:link thing-at-point))
                            (route-handler/redirect-to-page! (:link thing-at-point)))
               "list-item"


### PR DESCRIPTION
When pressing enter key at an empty page-ref `[[|]]` (`|` indicates text cursor), Logseq app will get stuck showing an empty page.

To reproduce:

- type `[[]]` in any block
- discard the search popup, and move text cursor to the middle of the square brackets
- type `Enter` on the keyboard
- App gets stunk, no responding