### PR TITLE
Fix/system chan loop broken

### DIFF
--- a/src/main/frontend/fs/node.cljs
+++ b/src/main/frontend/fs/node.cljs
@@ -69,7 +69,7 @@
           (when (util/electron?)
             (debug/set-ack-step! path :saved-successfully)
             (debug/ack-file-write! path))
-          (let [disk-content (encrypt/decrypt disk-content)]
+          (p/let [disk-content (encrypt/decrypt disk-content)]
             (state/pub-event! [:file/not-matched-from-disk path disk-content content])))
 
         :else

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -231,7 +231,8 @@
           (catch js/Error error
             (let [type :handle-system-events/failed]
               (js/console.error (str type) (clj->js payload) "\n" error)
-              (state/pub-event! [:instrument {:type type
-                                              :payload {:payload payload :error error}}])))))
+              (state/pub-event! [:instrument {:type    type
+                                              :payload payload
+                                              :error error}])))))
       (recur))
     chan))

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -173,7 +173,7 @@
   (state/clear-edit!)
   (when-let [repo (state/get-current-repo)]
     (when (and disk-content db-content
-               (not= (string/trim disk-content) (string/trim db-content)))
+               (not= (util/trim-safe disk-content) (util/trim-safe db-content)))
       (state/set-modal! #(diff/local-file repo path disk-content db-content)))))
 
 (defmethod handle :modal/display-file-version [[_ path content hash]]
@@ -226,6 +226,9 @@
   (let [chan (state/get-events-chan)]
     (async/go-loop []
       (let [payload (async/<! chan)]
-        (handle payload))
+        (try
+          (handle payload)
+          (catch js/Error e
+            (js/console.error "[System/events]" (clj->js payload) "\n" e))))
       (recur))
     chan))

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -228,7 +228,10 @@
       (let [payload (async/<! chan)]
         (try
           (handle payload)
-          (catch js/Error e
-            (js/console.error "[System/events]" (clj->js payload) "\n" e))))
+          (catch js/Error error
+            (let [type :handle-system-events/failed]
+              (js/console.error (str type) (clj->js payload) "\n" error)
+              (state/pub-event! [:instrument {:type type
+                                              :payload {:payload payload :error error}}])))))
       (recur))
     chan))


### PR DESCRIPTION
This affects all consumption events in the `:system/events` channel. 
Such as Search(ctrl+k) not working unexpectedly ...