### PR TITLE
Enhance WYSIWYG experience of multiline heading

### DIFF
--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -274,48 +274,49 @@
 }
 
 .ls-block h1,
-.editor-inner .h1 {
+.editor-inner .h1.uniline-block {
   font-size: 2em;
   min-height: 1.5em;
 }
 
 .ls-block h2,
-.editor-inner .h2 {
+.editor-inner .h2.uniline-block {
   font-size: 1.5em;
   min-height: 1.5em;
 }
 
 .ls-block h3,
-.editor-inner .h3 {
+.editor-inner .h3.uniline-block {
   font-size: 1.17em;
   min-height: 1.17em;
 }
 
 .ls-block h4,
-.editor-inner .h4 {
+.editor-inner .h4.uniline-block {
   font-size: 1.12em;
   min-height: 1.12em;
 }
 
 .ls-block h5,
-.editor-inner .h5 {
+.editor-inner .h5.uniline-block {
   font-size: 0.83em;
   min-height: 0.83em;
 }
 
 .ls-block h6,
-.editor-inner .h6 {
+.editor-inner .h6.uniline-block {
   font-size: 0.75em;
   min-height: 0.75em;
 }
 
 .ls-block :is(h1, h2, h3, h4, h5, h6),
-.editor-inner :is(.h1, .h2, .h3, .h4, .h5, .h6) {
+.editor-inner .uniline-block:is(.h1, .h2, .h3, .h4, .h5, .h6),
+.editor-inner .multiline-block:is(.h1, .h2, .h3, .h4, .h5, .h6)::first-line {
   font-weight: 600;
 }
 
 .ls-block :is(h1, h2),
-.editor-inner :is(.h1, .h2) {
+.editor-inner .uniline-block:is(.h1, .h2) {
   border-bottom: 1px solid var(--ls-quaternary-background-color);
   margin: 0.4em 0 0;
 }

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -536,6 +536,10 @@
   []
   (get (:editor/content @state) (get-edit-input-id)))
 
+(defn sub-edit-content
+  []
+  (get (sub :editor/content) (get-edit-input-id)))
+
 (defn append-current-edit-content!
   [append-text]
   (when-not (string/blank? append-text)

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -538,7 +538,7 @@
 
 (defn sub-edit-content
   []
-  (get (sub :editor/content) (get-edit-input-id)))
+  (sub [:editor/content (get-edit-input-id)]))
 
 (defn append-current-edit-content!
   [append-text]

--- a/src/main/frontend/util/keycode.cljs
+++ b/src/main/frontend/util/keycode.cljs
@@ -2,6 +2,8 @@
 
 (def left-square-bracket 219)
 (def left-paren 57)
+(def enter 13)
 
 (def left-square-bracket-code "BracketLeft")
 (def left-paren-code "Digit9")
+(def enter-code "Enter")


### PR DESCRIPTION
**Motivation**:
* For users who write multiple lines in heading block, the current WYSIWYG is very annoying, as it enlarges the non-heading part of the block.
* The process of "typing '#'s then changing style" is laggy

**Improvements**:
* refactor: remove duplicated class-name
* enhance: remove change of style for multiline headings in editing
* enhance: to make heading css more responsive, bind editor's heading class to editor content
* fix: adapt textarea to changable font-size
* fix: remove the markdown style WYSIWYG headline in org-mode editing

**Trade-offs**:
* Every change of content would trigger the heading class check
* ~~Every typing would trigger the textarea's row-height measurement~~
  * Every pressing of `enter` would trigger textarea's row-height measurement
  * Since the measurement is relatively expensive

(The cost is tiny based on my profiling)
**Comparison**
[Check out the `.mov` version](https://junyidu.notion.site/LogSeq-WYSIWYG-improve-4d25acae2a034585861a4f1df06940e5)
![After](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/c6e6ef53-e4ae-4c1b-9b5d-341660759447/%E5%B1%8F%E5%B9%95%E5%BD%95%E5%88%B62021-11-26_%E4%B8%8B%E5%8D%8812.36.15.gif?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211126%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211126T045816Z&X-Amz-Expires=86400&X-Amz-Signature=e04f8ae3b271478a782d81aecb0e1411f1b0423fae02d3510c36c4d81b6c4b45&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22%25E5%25B1%258F%25E5%25B9%2595%25E5%25BD%2595%25E5%2588%25B62021-11-26%2520%25E4%25B8%258B%25E5%258D%258812.36.15.gif%22&x-id=GetObject)

![Before](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/c1f14677-0d04-40e1-ba4d-69b9e358dff0/%E5%B1%8F%E5%B9%95%E5%BD%95%E5%88%B62021-11-26_%E4%B8%8B%E5%8D%8812.42.53.gif?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20211126%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211126T050227Z&X-Amz-Expires=86400&X-Amz-Signature=229b0d50d755f3c71f71ff41c70e7cc90fcc33d14c597deeb699d6e88e2b12d7&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22%25E5%25B1%258F%25E5%25B9%2595%25E5%25BD%2595%25E5%2588%25B62021-11-26%2520%25E4%25B8%258B%25E5%258D%258812.42.53.gif%22&x-id=GetObject)