### PR TITLE
ci: refactor desktop app release workflow, add nightly build

### DIFF
--- a/.github/workflows/build-desktop-release.yml
+++ b/.github/workflows/build-desktop-release.yml
@@ -24,7 +24,7 @@ on:
         type: boolean
         required: true
         default: true
-  schedule: # Every weekday at the noon (UTC) we run a scheduled nightly build
+  schedule: # Every workday at the noon (UTC) we run a scheduled nightly build
     - cron: '0 12 * * MON-FRI'
 
 env:
@@ -75,14 +75,19 @@ jobs:
         with:
           cli: ${{ env.CLOJURE_VERSION }}
 
-      - name: Compile CLJS
-        run: yarn install && gulp build && yarn cljs:release-electron
-
       - name: Retrieve tag version
         id: ref
         run: |
           pkgver=$(node ./scripts/get-pkg-version.js "${{ github.event.inputs.build-target }}")
           echo ::set-output name=version::$pkgver
+
+      - name: Update Nightly APP Version
+        if: ${{ github.event.inputs.build-target == 'nightly' }}
+        run: |
+          sed -i 's/defonce version ".*"/defonce version "${{ steps.ref.outputs.version }}"/g' src/main/frontend/version.cljs
+
+      - name: Compile CLJS
+        run: yarn install && gulp build && yarn cljs:release-electron
 
       - name: Update APP Version
         run: |

--- a/.github/workflows/build-desktop-release.yml
+++ b/.github/workflows/build-desktop-release.yml
@@ -1,25 +1,35 @@
-# This is a basic workflow to help you get started with Actions
+# This is the main desktop application release workflow for both nightly and beta/stable releases.
 
 name: Build-Desktop-Release
 
 on:
   workflow_dispatch:
     inputs:
-      tag-version:
-        description: "Release Tag Version"
+      build-target:
+        description: 'Build Target ("nightly"/"beta")'
+        type: string
         required: true
+        default: "nightly"
       git-ref:
         description: "Release Git Ref"
         required: true
         default: "master"
       is-draft:
         description: 'Draft Release? '
+        type: boolean
         required: true
-        default: "true"
+        default: true
       is-pre-release:
         description: 'Pre Release?'
+        type: boolean
         required: true
-        default: "true"
+        default: true
+  schedule: # Every weekday at the noon (UTC) we run a scheduled nightly build
+    - cron: '0 12 * * MON-FRI'
+
+env:
+  CLOJURE_VERSION: '1.10.1.763'
+  NODE_VERSION: '16'
 
 jobs:
   compile-cljs:
@@ -31,67 +41,92 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache yarn cache directory
+        uses: actions/cache@v2
+        # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: Setup Java JDK
         uses: actions/setup-java@v1.4.3
         with:
           java-version: 1.8
 
-      - name: Cache local Maven repository
+      - name: Cache clojure deps
         uses: actions/cache@v2
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: ${{ runner.os }}-clojure-lib-${{ hashFiles('**/deps.edn') }}
 
-      - name: Install clojure
-        run: |
-          curl -O https://download.clojure.org/install/linux-install-1.10.1.763.sh
-          chmod +x linux-install-1.10.1.763.sh
-          sudo ./linux-install-1.10.1.763.sh
+      - name: Setup clojure
+        uses: DeLaGuardo/setup-clojure@3.5
+        with:
+          cli: ${{ env.CLOJURE_VERSION }}
 
       - name: Compile CLJS
         run: yarn install && gulp build && yarn cljs:release-electron
 
+      - name: Retrieve tag version
+        id: ref
+        run: |
+          pkgver=$(node ./scripts/get-pkg-version.js "${{ github.event.inputs.build-target }}")
+          echo ::set-output name=version::$pkgver
+
       - name: Update APP Version
         run: |
-          sed -i 's/"version": "0.0.1"/"version": "${{ github.event.inputs.tag-version }}"/g' ./package.json
+          sed -i 's/"version": "0.0.1"/"version": "${{ steps.ref.outputs.version }}"/g' ./package.json
         working-directory: ./static
 
       - name: Display Package.json
         run: cat ./package.json
         working-directory: ./static
 
+      - name: Save VERSION file
+        run: echo "${{ steps.ref.outputs.version }}" > ./VERSION
+        working-directory: ./static
+
       - name: List Files
         run: ls -al
         working-directory: ./static
 
-      - name: Compress Static Files
-        run: zip -r static.zip ./static
-
       - name: Cache Static File
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
-          name: static.zip
-          path: static.zip
+          name: static
+          path: static
 
   build-linux:
     runs-on: ubuntu-18.04
     needs: [ compile-cljs ]
     steps:
       - name: Download The Static Asset
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v2
         with:
-          name: static.zip
-          path: ./
+          name: static
+          path: static
 
-      - name: Uncompress Static FIles
-        run: unzip static.zip
+      - name: Retrieve tag version
+        id: ref
+        run: |
+          pkgver=$(cat ./static/VERSION)
+          echo ::set-output name=version::$pkgver
 
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
 
       # - name: Cache Node Modules
       #   uses: actions/cache@v2
@@ -101,44 +136,43 @@ jobs:
       #     key: ${{ runner.os }}-node-modules
 
       - name: Build/Release Electron App
-        run: yarn install  && yarn electron:make
+        run: yarn install && yarn electron:make
         working-directory: ./static
 
-      - name: Change Artifact Name For ZIP File
-        run: mv static/out/make/zip/linux/x64/*-linux-x64-*.zip  static/out/make/zip/linux/x64/Logseq-linux.zip
+      - name: Save artifacts
+        run: |
+          mkdir -p builds
+          # NOTE: save VERSION file to builds directory
+          cp static/VERSION ./builds/VERSION
+          mv static/out/make/*-*.AppImage ./builds/Logseq-linux-x64-${{ steps.ref.outputs.version }}.AppImage
+          mv static/out/make/zip/linux/x64/*-linux-x64-*.zip ./builds/Logseq-linux-x64-${{ steps.ref.outputs.version }}.zip
 
-      - name: Change Artifact Name For AppImage File
-        run: mv static/out/make/*-*.AppImage  static/out/make/Logseq-linux.AppImage
-
-      - name: Cache Artifact With ZIP format
-        uses: actions/upload-artifact@v1
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
         with:
-          name: Logseq-linux.zip
-          path: static/out/make/zip/linux/x64/Logseq-linux.zip
-
-      - name: Cache Artifact With AppImage format
-        uses: actions/upload-artifact@v1
-        with:
-          name: Logseq-linux.AppImage
-          path: static/out/make/Logseq-linux.AppImage
+          name: logseq-linux-builds
+          path: builds
 
   build-windows:
     runs-on: windows-latest
     needs: [ compile-cljs ]
     steps:
       - name: Download The Static Asset
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v2
         with:
-          name: static.zip
-          path: ./
+          name: static
+          path: static
 
-      - name: Uncompress Static FIles
-        run: unzip static.zip
+      - name: Retrieve tag version
+        id: ref
+        run: |
+          $env:PkgVer=$(cat ./static/VERSION)
+          echo "::set-output name=version::$env:PkgVer"
 
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
 
       # - name: Cache Node Modules
       #   uses: actions/cache@v2
@@ -162,18 +196,16 @@ jobs:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
 
-      - name: Change Artifact Name
-        run: Get-ChildItem  static\out\make\squirrel.windows\x64\*.exe | Rename-Item -NewName Logseq-win64.exe
+      - name: Save Artifact
+        run: |
+          mkdir builds
+          mv static\out\make\squirrel.windows\x64\*.exe builds\Logseq-win-x64-${{ steps.ref.outputs.version }}.exe
 
-      - name: List Directory
-        run: dir
-        working-directory: static/out/make/squirrel.windows/x64/
-
-      - name: Cache Artifact
-        uses: actions/upload-artifact@v1
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
         with:
-          name: Logseq-win64.exe
-          path: static/out/make/squirrel.windows/x64/Logseq-win64.exe
+          name: logseq-win64-builds
+          path: builds
 
   build-macos:
     needs: [ compile-cljs ]
@@ -181,13 +213,16 @@ jobs:
 
     steps:
       - name: Download The Static Asset
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v2
         with:
-          name: static.zip
-          path: ./
+          name: static
+          path: static
 
-      - name: Uncompress Static Files
-        run: unzip ./static.zip
+      - name: Retrieve tag version
+        id: ref
+        run: |
+          pkgver=$(cat ./static/VERSION)
+          echo ::set-output name=version::$pkgver
 
       - name: List Static Files
         run: ls -al ./static
@@ -195,7 +230,19 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Cache yarn cache directory
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: Signing By Apple Developer ID
         uses: apple-actions/import-codesign-certs@v1
@@ -210,244 +257,92 @@ jobs:
       #       **/node_modules
       #     key: ${{ runner.os }}-node-modules
 
-      - name: Build/Release Electron App
+      - name: Build/Release Electron App for x64
         run: yarn install && yarn electron:make
         working-directory: ./static
         env:
           APPLE_ID: ${{ secrets.APPLE_ID_EMAIL }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
 
-      - name: Change DMG Name
-        run: mv static/out/make/*.dmg static/out/make/logseq-darwin-x64-${{ github.event.inputs.tag-version }}.dmg
-
-      - name: Cache Artifact DMG
-        uses: actions/upload-artifact@v1
-        with:
-          name: Logseq-x64.dmg
-          path: static/out/make/logseq-darwin-x64-${{ github.event.inputs.tag-version }}.dmg
-
-      - name: ls files
-        run: du -a static/out/
-
-      - name: Change zip Name
-        run: mv static/out/make/zip/darwin/x64/*.zip static/out/make/zip/darwin/x64/logseq-darwin-x64-${{ github.event.inputs.tag-version }}.zip
-
-      - name: Cache Artifact ZIP
-        uses: actions/upload-artifact@v1
-        with:
-          name: Logseq-x64.zip
-          path: static/out/make/zip/darwin/x64/logseq-darwin-x64-${{ github.event.inputs.tag-version }}.zip
-
-  build-macos-arm64:
-    needs: [ compile-cljs ]
-    runs-on: macos-latest
-
-    steps:
-      # this is only needed temporarily
-      # wait until macos-11 GA https://github.com/actions/virtual-environments/issues/2486
-      # or m1 hardware https://github.com/actions/virtual-environments/issues/2187
-      - name: hack osx sdk
+      - name: Save x64 artifacts
         run: |
-          if [ "$(sw_vers -productVersion | cut -d'.' -f1)" = 10 ]; then
-            pushd /Library/Developer/CommandLineTools/SDKs
-            sudo rm MacOSX.sdk
-            sudo ln -s MacOSX11.1.sdk MacOSX.sdk
-            sudo rm -rf MacOSX10.15.sdk
-            ls -l
-            popd
-          fi
-      - name: Download The Static Asset
-        uses: actions/download-artifact@v1
-        with:
-          name: static.zip
-          path: ./
+          mkdir -p builds
+          mv static/out/make/Logseq.dmg ./builds/Logseq-darwin-x64-${{ steps.ref.outputs.version }}.dmg
+          mv static/out/make/zip/darwin/x64/*.zip ./builds/Logseq-darwin-x64-${{ steps.ref.outputs.version }}.zip
 
-      - name: Uncompress Static Files
-        run: unzip ./static.zip
-
-      - name: List Static Files
-        run: ls -al ./static
-
-      - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16
-
-      - name: Signing By Apple Developer ID
-        uses: apple-actions/import-codesign-certs@v1
-        with:
-          p12-file-base64: ${{ secrets.APPLE_CERTIFICATES_P12 }}
-          p12-password: ${{ secrets.APPLE_CERTIFICATES_P12_PASSWORD }}
-
-      # - name: Cache Node Modules
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       **/node_modules
-      #     key: ${{ runner.os }}-node-modules
-
-      - name: Build/Release Electron App
+      - name: Build/Release Electron App for arm64
         run: yarn install && yarn electron:make-macos-arm64
         working-directory: ./static
         env:
           APPLE_ID: ${{ secrets.APPLE_ID_EMAIL }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
 
-      - name: Change DMG Name
-        run: mv static/out/make/*.dmg static/out/make/logseq-darwin-arm64-${{ github.event.inputs.tag-version }}.dmg
+      - name: Save arm64 artifacts
+        run: |
+          mv static/out/make/Logseq.dmg ./builds/Logseq-darwin-arm64-${{ steps.ref.outputs.version }}.dmg
+          mv static/out/make/zip/darwin/arm64/*.zip ./builds/Logseq-darwin-arm64-${{ steps.ref.outputs.version }}.zip
 
-      - name: Cache Artifact DMG
-        uses: actions/upload-artifact@v1
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
         with:
-          name: Logseq-arm64.dmg
-          path: static/out/make/logseq-darwin-arm64-${{ github.event.inputs.tag-version }}.dmg
-
-      - name: ls files
-        run: du -a static/out/
-
-      - name: Change zip Name
-        run: mv static/out/make/zip/darwin/arm64/*.zip static/out/make/zip/darwin/arm64/logseq-darwin-arm64-${{ github.event.inputs.tag-version }}.zip
-
-      - name: Cache Artifact ZIP
-        uses: actions/upload-artifact@v1
-        with:
-          name: Logseq-arm64.zip
-          path: static/out/make/zip/darwin/arm64/logseq-darwin-arm64-${{ github.event.inputs.tag-version }}.zip
+          name: logseq-darwin-builds
+          path: builds
 
   release:
-    needs: [ build-macos, build-linux, build-windows, build-macos-arm64 ]
+    # NOTE: For now, we only have beta channel to be released on Github
+    if: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.build-target == 'beta') }}
+    needs: [ build-macos, build-linux, build-windows ]
     runs-on: ubuntu-18.04
-
     steps:
-      - name: Download The MacOS X64 DMG Artifact
-        uses: actions/download-artifact@v1
+      - name: Download MacOS Artifacts
+        uses: actions/download-artifact@v2
         with:
-          name: Logseq-x64.dmg
+          name: logseq-darwin-builds
           path: ./
 
-      - name: Download The MacOS X64 ZIP Artifact
-        uses: actions/download-artifact@v1
+      - name: Download The Linux Artifacts
+        uses: actions/download-artifact@v2
         with:
-          name: Logseq-x64.zip
-          path: ./
-
-      - name: Download The MacOS ARM64 DMG Artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: Logseq-arm64.dmg
-          path: ./
-
-      - name: Download The MacOS ARM64 ZIP Artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: Logseq-arm64.zip
-          path: ./
-
-      - name: Download The Linux Artifact In Zip format
-        uses: actions/download-artifact@v1
-        with:
-          name: Logseq-linux.zip
-          path: ./
-
-      - name: Download The Linux Artifact In AppImage format
-        uses: actions/download-artifact@v1
-        with:
-          name: Logseq-linux.AppImage
+          name: logseq-linux-builds
           path: ./
 
       - name: Download The Windows Artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v2
         with:
-          name: Logseq-win64.exe
+          name: logseq-win64-builds
           path: ./
 
       - name: List files
         run: ls -rl
 
+      - name: Retrieve tag version
+        id: ref
+        run: |
+          pkgver=$(cat VERSION)
+          echo ::set-output name=version::$pkgver
+
+      - name: Generate SHA256 checksums
+        run: |
+          sha256sum *-darwin-* > SHA256SUMS.txt
+          sha256sum *-win-* >> SHA256SUMS.txt
+          sha256sum *-linux-* >> SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
       - name: Create Release Draft
-        id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.event.inputs.tag-version }}
-          release_name: Desktop APP ${{ github.event.inputs.tag-version }} (Beta Testing)
+          tag_name: ${{ steps.ref.outputs.version }}
+          name: Desktop APP ${{ steps.ref.outputs.version }} (Beta Testing)
+          body: "TODO: Fill this changelog. Sorry for the inconvenience!"
           draft: ${{ github.event.inputs.is-draft }}
           prerelease: ${{ github.event.inputs.is-pre-release }}
+          files: |
+            ./VERSION
+            ./SHA256SUMS.txt
+            ./*.zip
+            ./*.dmg
+            ./*.exe
+            ./*.AppImage
 
-      - name: Upload MacOS X64 ZIP Artifact
-        id: upload-macos-x64-zip-artifact
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./logseq-darwin-x64-${{ github.event.inputs.tag-version }}.zip
-          asset_name: logseq-darwin-x64-${{ github.event.inputs.tag-version }}.zip
-          asset_content_type: application/zip
-
-      - name: Upload MacOS X64 DMG Artifact
-        id: upload-macos-x64-dmg-artifact
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./logseq-darwin-x64-${{ github.event.inputs.tag-version }}.dmg
-          asset_name: logseq-darwin-x64-${{ github.event.inputs.tag-version }}.dmg
-          asset_content_type: application/x-apple-diskimage
-
-      - name: Upload MacOS ARM64 ZIP Artifact
-        id: upload-macos-arm64-zip-artifact
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./logseq-darwin-arm64-${{ github.event.inputs.tag-version }}.zip
-          asset_name: logseq-darwin-arm64-${{ github.event.inputs.tag-version }}.zip
-          asset_content_type: application/zip
-
-      - name: Upload MacOS ARM64 DMG Artifact
-        id: upload-macos-arm64-dmg-artifact
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./logseq-darwin-arm64-${{ github.event.inputs.tag-version }}.dmg
-          asset_name: logseq-darwin-arm64-${{ github.event.inputs.tag-version }}.dmg
-          asset_content_type: application/x-apple-diskimage
-
-      - name: Upload Linux Artifact With Zip format
-        id: upload-linux-artifact-with-zip-format
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./Logseq-linux.zip
-          asset_name: logseq-linux-x64-${{ github.event.inputs.tag-version }}.zip
-          asset_content_type: application/zip
-
-      - name: Upload Linux Artifact With AppImage format
-        id: upload-linux-artifact-with-appimage-format
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./Logseq-linux.AppImage
-          asset_name: logseq-linux-x64-${{ github.event.inputs.tag-version }}.AppImage
-          asset_content_type: application/octet-stream
-
-      - name: Upload Windows Artifact
-        id: upload-win-artifact
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./Logseq-win64.exe
-          asset_name: logseq-win-x64-${{ github.event.inputs.tag-version }}.exe
-          asset_content_type: application/octet-stream

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "logseq",
-    "version": "0.0.1",
+    "version": "0.5.1",
     "private": true,
     "main": "static/electron.js",
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "logseq",
-    "version": "0.5.1",
+    "version": "0.0.1",
     "private": true,
     "main": "static/electron.js",
     "devDependencies": {

--- a/scripts/get-pkg-version.js
+++ b/scripts/get-pkg-version.js
@@ -1,0 +1,17 @@
+// This script file outputs the version in the package.json of project dir,
+// and optionally add nightly postfix.
+//
+// It is used as a helper by the continuous integration.
+const path = require('path')
+const process = require('process')
+
+const ver = require(path.join(__dirname, '../package.json')).version
+
+if (process.argv[2] === 'nightly') {
+  const today = new Date()
+  console.log(
+    ver + '+nightly.' + today.toISOString().split('T')[0].replaceAll('-', '')
+  )
+} else {
+  console.log(ver)
+}

--- a/scripts/get-pkg-version.js
+++ b/scripts/get-pkg-version.js
@@ -1,11 +1,22 @@
-// This script file outputs the version in the package.json of project dir,
-// and optionally add nightly postfix.
-//
-// It is used as a helper by the continuous integration.
+// This script file simply outputs the version in the package.json.
+// It is used as a helper by the continuous integration
 const path = require('path')
 const process = require('process')
+const fs = require('fs')
 
-const ver = require(path.join(__dirname, '../package.json')).version
+const content = fs.readFileSync(
+  path.join(__dirname, '../src/main/frontend/version.cljs')
+)
+const pattern = /\(defonce version "(.*?)"\)/g
+
+const match = pattern.exec(content)
+let ver = '0.0.1'
+if (match) {
+  ver = match[1]
+} else {
+  console.error('Could not find version in version.cljs')
+  process.exit(1)
+}
 
 if (process.argv[2] === 'nightly') {
   const today = new Date()


### PR DESCRIPTION
- Reduce build steps
- Add nightly build
  - [ ] Simply use Github Actions' artifacts for now?
- Merge macOS x64 and arm64 build into one job
- To trigger a beta release:
  - Bump `version` config in `src/main/frontend/version.cljs`
  - In Github Actions page, choose Build-Desktop-Release workflow
  - Make build target a `beta`
  - Run the workflow
  - Go to the Release page and fill the release notes
  - Publish the Release🚀
  
**Update:**
- [x] should address version string in `src/main/frontend/version.cljs` too.

**Edit**
Use version in `src/main/frontend/version.cljs`.
Fix #3128, now the version in Release Page will always match App version in Settings menu
