### PR TITLE
fix: search input in All pages requires 2 chars

### DIFF
--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -748,8 +748,7 @@
 
         search-key (fn [key]
                      (when-let [key (and key (string/trim key))]
-                       (if (and (> (count key) 2)
-                                (not (string/blank? key))
+                       (if (and (not (string/blank? key))
                                 (seq @*results))
                          (reset! *search-key key)
                          (reset! *search-key nil))))


### PR DESCRIPTION
Fixes #3273

https://github.com/logseq/logseq/blob/5b2ae552ae171c75633f08a0af27fe55dbaea6a1/src/main/frontend/components/page.cljs#L749-L755

