### PR TITLE
fix: insert-link doesn't work

### DIFF
--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -255,7 +255,7 @@
 
    :editor/insert-link             {:desc    "HTML Link"
                                     :binding "mod+l"
-                                    :fn      editor-handler/html-link-format!}
+                                    :fn      #(editor-handler/html-link-format!)}
 
    :editor/select-all-blocks       {:desc    "Select all blocks"
                                     :binding "mod+shift+a"


### PR DESCRIPTION
Refers to https://github.com/logseq/logseq/issues/3278
Fix the cmd+l for inserting `[blablabla]()` ability.
To further improve the functionality, we could split it into an individual insert-link handler function in future.