### PR TITLE
Enhance DWIM feature of list item

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2421,7 +2421,8 @@
                   (when (thingatpt/get-setting :properties?)
                     (thingatpt/properties-at-point input))
                   (when (thingatpt/get-setting :list?)
-                    (thingatpt/list-item-at-point input)))]
+                    (and (cursor/end-of-line? input) ;; only apply DWIM when cursor at EOL 
+                         (thingatpt/list-item-at-point input))))]
           (cond
             thing-at-point
             (case (:type thing-at-point)

--- a/src/main/frontend/util/cursor.cljs
+++ b/src/main/frontend/util/cursor.cljs
@@ -91,7 +91,9 @@
   [input]
   (let [[content pos] (get-input-content&pos input)]
     (if (zero? pos) 0
-        (inc (string/last-index-of content \newline (dec pos))))))
+        (let [last-newline-pos (string/last-index-of content \newline (dec pos))]
+          (if (= nil last-newline-pos) 0 ;; no newline found (first line)
+              (inc last-newline-pos))))))
 
 (defn line-end-pos
   [input]


### PR DESCRIPTION
* Fix the bug that some DWIM features don't work on the first line of block
* https://github.com/logseq/logseq/issues/3294 Limit the list item's DWIM to the case that user press `enter` at the end of line