### PR TITLE
chore: Update README E2E Testing Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,14 @@ Run ClojureScript tests
 yarn test
 ```
 
-Run Cypress tests
+Run E2E tests
 
 ``` bash
-yarn e2e-test
+yarn electron-watch
+# in another shell
+yarn e2e-test # or npx playwright test
 ```
+
 
 ## Desktop app development
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ yarn electron-watch
 yarn e2e-test # or npx playwright test
 ```
 
-
 ## Desktop app development
 
 ### 1. Compile to JavaScript


### PR DESCRIPTION
Updated the instructions for E2E testing

- Cypress was removed and replaced with playwright (https://github.com/logseq/logseq/pull/3241)
- Instructions are based on @andelf comment (https://github.com/logseq/logseq/pull/3241#issuecomment-976201958)