### PR TITLE
enhance: add warning for clear cache

### DIFF
--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -635,6 +635,10 @@
             (developer-mode-row t developer-mode?)
             (clear-cache-row t)
 
+            (ui/admonition
+             :warning
+             [:p "Clear cache will discard open graphs. You will lose unsaved changes."])
+
             (when logged?
               [:div
                [:div.mt-6.sm:mt-5.sm:grid.sm:grid-cols-3.sm:gap-4.sm:items-center.sm:pt-5


### PR DESCRIPTION
Added a warning under "Clear cache" in advanced settings. I noticed that some users like in (#3309) might not realize that clearing the cache will discard open graphs. 

<table><tbody><tr><td>Before</td><td>After</td></tr><tr><td><figure class="image"><img src="https://user-images.githubusercontent.com/25513724/143990370-33d8d725-df9c-4839-b955-ba6336fc4a23.png"></figure></td><td><figure class="image"><img src="https://user-images.githubusercontent.com/25513724/143990932-e8fe268e-7578-4d04-9182-839bc33b41a2.png"></figure></td></tr></tbody></table>

The warning is based on the warnings for "Refreshing" and "Re-Indexing" the graph  
 

<table><tbody><tr><td>Refresh</td><td>Re-index</td></tr><tr><td><figure class="image"><img src="https://user-images.githubusercontent.com/25513724/143916911-8dc243ad-f301-402b-b70c-4b30e00d525b.png" alt="https://user-images.githubusercontent.com/25513724/143916911-8dc243ad-f301-402b-b70c-4b30e00d525b.png"></figure></td><td><figure class="image"><img src="https://user-images.githubusercontent.com/25513724/143917171-439c82af-4df6-45f6-ba4a-76c8418b6261.png" alt="https://user-images.githubusercontent.com/25513724/143917171-439c82af-4df6-45f6-ba4a-76c8418b6261.png"></figure></td></tr></tbody></table>

A better solution would be prompting the user to confirm by pressing "yes." I couldn't figure out how to get another pop-up window open while the settings page is also open