### PR TITLE
fix: typo in warning for clear cache

### DIFF
--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -637,7 +637,7 @@
 
             (ui/admonition
              :warning
-             [:p "Clear cache will discard open graphs. You will lose unsaved changes."])
+             [:p "Clearing the cache will discard open graphs. You will lose unsaved changes."])
 
             (when logged?
               [:div


### PR DESCRIPTION
There is a grammatical error (663c86d#commitcomment-61122338) in my last pull request (#3316)

<table><tbody><tr><td>Current</td><td>Fix</td></tr><tr><td><figure class="image"><img src="https://user-images.githubusercontent.com/25513724/144099330-9d98b427-c51a-4c41-8beb-c90f7caf92de.png"></figure></td><td><figure class="image"><img src="https://user-images.githubusercontent.com/25513724/143990932-e8fe268e-7578-4d04-9182-839bc33b41a2.png" alt="https://user-images.githubusercontent.com/25513724/143990932-e8fe268e-7578-4d04-9182-839bc33b41a2.png"></figure></td></tr></tbody></table>

Any feedback on the warning phrasing would be appreciated