### PR TITLE
fix: do not ignore patterns in parent dir

### DIFF
--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -47,8 +47,9 @@
            ["." ".recycle" "assets" "node_modules"])
      (string/ends-with? path ".DS_Store")
      ;; hidden directory or file
-     (re-find #"/\.[^.]+" path)
-     (re-find #"^\.[^.]+" path)
+     (let [relpath (path/relative dir path)]
+       (or (re-find #"/\.[^.]+" relpath)
+           (re-find #"^\.[^.]+" relpath)))
      (let [path (string/lower-case path)]
        (and
         (not (string/blank? (path/extname path)))


### PR DESCRIPTION
Fixes #3310

TODO:

- [x] Confirm this does not break the Windows platform

**EDIT**:
Tested on Windows. 