### PR TITLE
feature to encrypt/decrypt a whole block

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1917,7 +1917,7 @@
         [:span
          (cond
            (seq title)
-           (if encrypted? (map-inline config title) (build-block-title config block)
+           (if encrypted? (map-inline config title) (build-block-title config block))
 
            :else
            nil)]

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -7,6 +7,7 @@
             [frontend.components.page-menu :as page-menu]
             [frontend.components.export :as export]
             [frontend.config :as config]
+            [frontend.components.block :as block]
             [frontend.context.i18n :as i18n]
             [frontend.db :as db]
             [frontend.extensions.srs :as srs]
@@ -217,6 +218,11 @@
               :on-click (fn [_]
                           (state/set-modal! #(export/export-blocks [block-id])))}
              "Copy as")
+
+            (ui/menu-link
+             {:key     "Encrypt block"
+              :on-click (fn [_e] (state/set-modal! #(block/decrypt-block block block-id (:block/content block))))}
+             (if (:encrypted properties) "Decrypt block" "Encrypt block"))
 
             (if (srs/card-block? block)
               (ui/menu-link

--- a/src/main/frontend/util/property.cljs
+++ b/src/main/frontend/util/property.cljs
@@ -22,7 +22,7 @@
 (defn built-in-properties
   []
   (set/union
-   #{:id :custom-id :background-color :heading :collapsed :created-at :updated-at :last-modified-at :created_at :last_modified_at :query-table :query-properties :query-sort-by :query-sort-desc
+   #{:id :custom-id :background-color :heading :collapsed :created-at :updated-at :last-modified-at :created_at :last_modified_at :query-table :query-properties :query-sort-by :query-sort-desc :encrypted
      :ls-type :hl-type :hl-page :hl-stamp}
    (set (map keyword config/markers))
    (set (config/get-block-hidden-properties))


### PR DESCRIPTION
- encryt block by block context menu link, using AGE encryption algo.
- encrypted block displayed with its title(in clear text) and an anchor link click to decrypt.
- encrypt/decrypt in a modal dialog component, edit the encrypted block in the modal dialog as well.
- well considered to forbid any editing onto the encrypted block otherwise than in the modal dialog.

<img width="636" alt="image" src="https://user-images.githubusercontent.com/62730465/144236411-3c4e0ece-c1d0-48d6-ae5f-ea61659ed9a9.png">
<img width="1077" alt="image" src="https://user-images.githubusercontent.com/62730465/144236608-7444b160-dd82-4ca9-be96-cb7bb3aae9f0.png">
<img width="1008" alt="image" src="https://user-images.githubusercontent.com/62730465/144236663-b9c56b44-932c-4935-b5b7-776193fcb65f.png">
<img width="1113" alt="image" src="https://user-images.githubusercontent.com/62730465/144236713-bad19f36-36ea-4364-97be-27c9d21a7dfc.png">
