### PR TITLE
fix: local graph should popup encryption dialog when re-index

### DIFF
--- a/src/main/frontend/handler/web/nfs.cljs
+++ b/src/main/frontend/handler/web/nfs.cljs
@@ -258,9 +258,12 @@
                                (rename-f "modify" modified))]
                     (when (or (and (seq diffs) (seq modified-files))
                               (seq diffs))
+                      (comment "re-index a local graph is handled here")
                       (repo-handler/load-repo-to-db! repo
                                                      {:diffs     diffs
                                                       :nfs-files modified-files
+                                                      ;; re-ask encryption
+                                                      :first-clone? re-index?
                                                       :refresh? (not re-index?)}))
                     (when (and (util/electron?) (not re-index?))
                       (db/transact! repo new-files))))))))


### PR DESCRIPTION
BUG:

You cannot enable encryption on a local graph with the Encryption setting on.
[The doc](https://logseq.github.io/#/page/Encryption) says `re-index` the graph should work, but actually nothing happens when re-indexing.

Fix:

![image](https://user-images.githubusercontent.com/72891/144572511-1d5eac53-274c-409c-9b8a-f9a6457bcd97.png)

![image](https://user-images.githubusercontent.com/72891/144572677-214782a9-a347-4149-a31a-c34f05fe8428.png)

