### PR TITLE
fix(org): get right link href for file links

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -126,7 +126,9 @@
   [url]
   (match url
     ["File" s]
-    (string/replace s "file://" "")
+    (-> (string/replace s "file://" "")
+        ;; "file:/Users/ll/Downloads/test.pdf" is a normal org file link
+        (string/replace "file:" ""))
 
     ["Complex" m]
     (let [{:keys [link protocol]} m]


### PR DESCRIPTION
By fixing the href value, the following links should work well as external links in orgmode.
`[[file:/Users/ll/Downloads/test.pdf]]`
`[[file:/Users/ll/Downloads/test.pdf][a pdf]]`

