### PR TITLE
fix(ui): missing span in repo-name dropdown

### DIFF
--- a/src/main/frontend/components/repo.cljs
+++ b/src/main/frontend/components/repo.cljs
@@ -276,7 +276,7 @@
                 (ui/icon "database mr-3" {:style {:font-size 20} :id "database-icon"})
                 [:div.graphs
                  [:span#repo-switch.block.pr-2.whitespace-nowrap
-                  [:span#repo-name.font-medium short-repo-name]
+                  [:span [:span#repo-name.font-medium short-repo-name]]
                   [:span.dropdown-caret.ml-2 {:style {:border-top-color "#6b7280"}}]]]]))
            links
            (cond->


### PR DESCRIPTION
Introduced in #3297

![](https://user-images.githubusercontent.com/72891/144959594-5b2b2cec-8566-4f9a-83e6-a829adb812cf.png)