### PR TITLE
fix(android): don't read files starting with #

### DIFF
--- a/src/main/frontend/fs/capacitor_fs.cljs
+++ b/src/main/frontend/fs/capacitor_fs.cljs
@@ -47,6 +47,7 @@
                              files (->> files
                                         (remove (fn [file]
                                                   (or (string/starts-with? file ".")
+                                                      (string/starts-with? file "#")
                                                       (= file "bak")))))
                              files (->> files
                                         (map (fn [file]


### PR DESCRIPTION
`(.stat Filesystem (clj->js {:path file}))` returns its parent directory
if the file starting with a #, which leads to reading the directory endlessly.