### PR TITLE
Fix logbook disappearing when embedding the block

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2638,7 +2638,9 @@
               [:div.opacity-50.font-medium
                (util/format ":%s:" (string/upper-case name))]
               [:div.opacity-50.font-medium
-               (logbook-cp lines)
+               (if (= name "logbook")
+                 (logbook-cp lines)
+                 (apply str lines))
                [:div ":END:"]]
               {:default-collapsed? true
                :title-trigger? true})]]])

--- a/src/main/frontend/util/drawer.cljs
+++ b/src/main/frontend/util/drawer.cljs
@@ -61,7 +61,7 @@
 
                             :else
                             (let [properties-count (count (second (first (second ast))))
-                                  properties (subvec body-without-timestamps 0 (inc properties-count))
+                                  properties (subvec body-without-timestamps 0 properties-count)
                                   after (rest body-without-timestamps)]
                               (string/join "\n" (concat [title] scheduled deadline properties [drawer] after))))
                           (string/join "\n" (concat [title] scheduled deadline [drawer] body-without-timestamps))))


### PR DESCRIPTION
Once a Task Block got embedded, its logbook drawer disappears when toggling the state from TODO to DOING. 
This PR fixed this issue.