### PR TITLE
fix(logbook): logbook disappears when block got embedded

### DIFF
--- a/src/main/frontend/util/drawer.cljs
+++ b/src/main/frontend/util/drawer.cljs
@@ -61,7 +61,7 @@
 
                             :else
                             (let [properties-count (count (second (first (second ast))))
-                                  properties (subvec body-without-timestamps 0 (inc properties-count))
+                                  properties (subvec body-without-timestamps 0 properties-count)
                                   after (rest body-without-timestamps)]
                               (string/join "\n" (concat [title] scheduled deadline properties [drawer] after))))
                           (string/join "\n" (concat [title] scheduled deadline [drawer] body-without-timestamps))))


### PR DESCRIPTION
Once a Task Block got embedded, its logbook drawer disappears when toggling the state from TODO to DOING.  This PR fixed this issue.

https://www.loom.com/share/fbe905f794294c6eb3088252e473530f