### PR TITLE
fix: e2e tests for new left sidebar

### DIFF
--- a/e2e-tests/basic.spec.ts
+++ b/e2e-tests/basic.spec.ts
@@ -12,11 +12,25 @@ test('render app', async ({ page }) => {
   expect(await page.title()).toMatch(/^Logseq.*?/)
 })
 
-test('open sidebar', async ({ page }) => {
-  await openSidebar(page)
+test('toggle sidebar', async ({ page }) => {
+  let sidebar = page.locator('#left-sidebar')
 
+  // Left sidebar is toggled by `is-open` class
+  if (/is-open/.test(await sidebar.getAttribute('class'))) {
+    await page.click('#left-menu.button')
+    expect(await sidebar.getAttribute('class')).not.toMatch(/is-open/)
+  } else {
+    await page.click('#left-menu.button')
+    expect(await sidebar.getAttribute('class')).toMatch(/is-open/)
+    await page.click('#left-menu.button')
+    expect(await sidebar.getAttribute('class')).not.toMatch(/is-open/)
+  }
+
+  await page.click('#left-menu.button')
+
+  expect(await sidebar.getAttribute('class')).toMatch(/is-open/)
+  await page.waitForSelector('#left-sidebar .left-sidebar-inner', { state: 'visible' })
   await page.waitForSelector('#left-sidebar a:has-text("New page")', { state: 'visible' })
-  await page.waitForSelector('#left-sidebar >> text=Journals', { state: 'visible' })
 })
 
 test('search', async ({ page }) => {

--- a/e2e-tests/utils.ts
+++ b/e2e-tests/utils.ts
@@ -22,18 +22,10 @@ export async function appFirstLoaded(page: Page) {
     await page.waitForSelector('text=This is a demo graph, changes will not be saved until you open a local folder')
 }
 
-export async function openSidebar(page: Page) {
-    let sidebarVisible = await page.isVisible('#left-sidebar .left-sidebar-inner')
-    if (!sidebarVisible) {
-        await page.click('#left-menu.button')
-    }
-    await page.waitForSelector('#left-sidebar .left-sidebar-inner', { state: 'visible' })
-}
-
 export async function createRandomPage(page: Page) {
     const randomTitle = randomString(20)
 
-    // Click #left-sidebar a:has-text("New page")
+    // Click #search-button
     await page.click('#search-button')
     // Fill [placeholder="Search or create page"]
     await page.fill('[placeholder="Search or create page"]', randomTitle)


### PR DESCRIPTION
New left sidebar is handled by `is-open` class.