### PR TITLE
fix(editor): wrong indent removal fn

### DIFF
--- a/src/main/frontend/text.cljs
+++ b/src/main/frontend/text.cljs
@@ -350,10 +350,8 @@
 (defn remove-indentations
   [text]
   (when (string? text)
-    (let [lines (string/split-lines text)
-          spaces (re-find #"^[\s\t]+" (first lines))
-          spaces-count (count spaces)]
-      (string/join "\n" (map (fn [line]
-                               (let [spaces (re-find #"^[\s\t]+" line)
-                                     spaces-count (min (count spaces) spaces-count)]
-                                 (util/safe-subs line spaces-count))) lines)))))
+    (let [lines (string/split text #"\r?\n" -1)
+          spaces-count (apply min (map #(count (re-find #"^[\s\t]+" %)) lines))]
+      (if (zero? spaces-count)
+        text
+        (string/join "\n" (map #(util/safe-subs % spaces-count) lines))))))


### PR DESCRIPTION
This PR fixes:
- Indention is wrongly calculated from the first line of code, causing #3130 
- `string/split-lines` returns empty vec, following `re-find` call will fail
    ![image](https://user-images.githubusercontent.com/72891/145562777-12beb4a6-f815-469c-8deb-f8210b7958b1.png)

FYI:

`clojure.string/split-lines` is not empty-line friendly:

```clojure
user=> (clojure.string/split-lines "\n\n\n\n \n\n\n\n")
["" "" "" "" " "]
user=> (clojure.string/split-lines "\n\n")
[]
```

`(string/split text #"\r?\n" -1)` is OK.
