### PR TITLE
Refactor: refine saving process of code editing, with e2e test cases

### DIFF
--- a/e2e-tests/basic.spec.ts
+++ b/e2e-tests/basic.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 import { test } from './fixtures'
-import { randomString, createRandomPage, openSidebar, newBlock, lastBlock } from './utils'
+import { randomString, createRandomPage, newBlock } from './utils'
 
 
 test('render app', async ({ page }) => {

--- a/e2e-tests/code-editing.spec.ts
+++ b/e2e-tests/code-editing.spec.ts
@@ -1,0 +1,179 @@
+import { expect } from '@playwright/test'
+import { test } from './fixtures'
+import { createRandomPage, newBlock, lastBlock, appFirstLoaded, IsMac, IsLinux, escapeToCodeEditor, escapeToBlockEditor } from './utils'
+
+/**
+ * NOTE: CodeMirror is a complex library that requires a lot of setup to work.
+ * This test suite is designed to test the basic functionality of the editor.
+ * It is not intended to test the full functionality of CodeMirror.
+ * For more information, see: https://codemirror.net/doc/manual.html
+ */
+
+test('switch code editing mode', async ({ page }) => {
+  await createRandomPage(page)
+
+  // NOTE: ` will trigger auto-pairing in Logseq
+  // NOTE: ( will trigger auto-pairing in CodeMirror
+  // NOTE: waitForTimeout is needed to ensure that the hotkey handler is finished (shift+enter)
+  // NOTE: waitForTimeout is needed to ensure that the CodeMirror editor is fully loaded and unloaded
+  // NOTE: multiple textarea elements are existed in the editor, be careful to select the right one
+
+  // code block with 0 line
+  await page.type(':nth-match(textarea, 1)', '```clojure\n')
+  // line number: 1
+  await page.waitForSelector('.CodeMirror pre', { state: 'visible' })
+  expect(await page.locator('.CodeMirror-gutter-wrapper .CodeMirror-linenumber').innerText()).toBe('1')
+  // lang label: clojure
+  expect(await page.innerText('.block-body .extensions__code-lang')).toBe('clojure')
+
+  await page.press('.CodeMirror textarea', 'Escape')
+  await page.waitForSelector('.CodeMirror pre', { state: 'hidden' })
+  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('```clojure\n```')
+
+  await page.waitForTimeout(500)
+  await page.press(':nth-match(textarea, 1)', 'Escape')
+  await page.waitForSelector('.CodeMirror pre', { state: 'visible' })
+
+  // NOTE: must wait here, await loading of CodeMirror editor
+  await page.waitForTimeout(500)
+  await page.click('.CodeMirror pre')
+  await page.waitForTimeout(500)
+
+  await page.type('.CodeMirror textarea', '(+ 1 1')
+  await page.press('.CodeMirror textarea', 'Escape')
+  await page.waitForSelector('.CodeMirror pre', { state: 'hidden' })
+  expect(await page.inputValue('.block-editor textarea')).toBe('```clojure\n(+ 1 1)\n```')
+
+  await page.waitForTimeout(500) // editor unloading
+  await page.press('.block-editor textarea', 'Escape')
+  await page.waitForTimeout(500) // editor loading
+  // click position is estimated to be at the begining of the first line
+  await page.click('.CodeMirror pre', { position: { x: 1, y: 5 } })
+  await page.waitForTimeout(500)
+
+  await page.type('.CodeMirror textarea', ';; comment\n\n  \n')
+
+  await page.press('.CodeMirror textarea', 'Escape')
+  await page.waitForSelector('.CodeMirror pre', { state: 'hidden' })
+  expect(await page.inputValue('.block-editor textarea')).toBe('```clojure\n;; comment\n\n  \n(+ 1 1)\n```')
+
+  await page.waitForTimeout(500)
+})
+
+
+test('convert from block content to code', async ({ page }) => {
+  await createRandomPage(page)
+
+  await page.type('.block-editor textarea', '```')
+  await page.press('.block-editor textarea', 'Shift+Enter')
+  await page.waitForTimeout(100) // wait for hotkey handler
+  await page.press('.block-editor textarea', 'Escape')
+  await page.waitForSelector('.CodeMirror pre', { state: 'visible' })
+
+  await page.waitForTimeout(500)
+  await page.click('.CodeMirror pre')
+  await page.waitForTimeout(500)
+  expect(await page.locator('.CodeMirror-gutter-wrapper .CodeMirror-linenumber >> nth=-1').innerText()).toBe('1')
+
+  await page.press('.CodeMirror textarea', 'Escape')
+  await page.waitForTimeout(500)
+
+  expect(await page.inputValue('.block-editor textarea')).toBe('```\n```')
+
+  // reset block, code block with 1 line
+  await page.fill('.block-editor textarea', '```\n\n```')
+  await page.waitForTimeout(500) // wait for fill
+  await escapeToCodeEditor(page)
+  expect(await page.locator('.CodeMirror-gutter-wrapper .CodeMirror-linenumber >> nth=-1').innerText()).toBe('1')
+  await escapeToBlockEditor(page)
+  expect(await page.inputValue('.block-editor textarea')).toBe('```\n\n```')
+
+  // reset block, code block with 2 line
+  await page.fill('.block-editor textarea', '```\n\n\n```')
+  await page.waitForTimeout(500)
+  await escapeToCodeEditor(page)
+  expect(await page.locator('.CodeMirror-gutter-wrapper .CodeMirror-linenumber >> nth=-1').innerText()).toBe('2')
+  await escapeToBlockEditor(page)
+  expect(await page.inputValue('.block-editor textarea')).toBe('```\n\n\n```')
+
+  await page.fill('.block-editor textarea', '```\n  indented\nsecond line\n\n```')
+  await page.waitForTimeout(500)
+  await escapeToCodeEditor(page)
+  await escapeToBlockEditor(page)
+  expect(await page.inputValue('.block-editor textarea')).toBe('```\n  indented\nsecond line\n\n```')
+
+  await page.fill('.block-editor textarea', '```\n  indented\n  indented\n```')
+  await page.waitForTimeout(500)
+  await escapeToCodeEditor(page)
+  await escapeToBlockEditor(page)
+  expect(await page.inputValue('.block-editor textarea')).toBe('```\n  indented\n  indented\n```')
+})
+
+test('code block mixed input source', async ({ page }) => {
+  await createRandomPage(page)
+
+  await page.fill('.block-editor textarea', '```\n  ABC\n```')
+  await page.waitForTimeout(500) // wait for fill
+  await escapeToCodeEditor(page)
+  await page.type('.CodeMirror textarea', '  DEF\nGHI')
+
+  await page.waitForTimeout(500)
+  await page.press('.CodeMirror textarea', 'Escape')
+  await page.waitForTimeout(500)
+  // NOTE: auto-indent is on
+  expect(await page.inputValue('.block-editor textarea')).toBe('```\n  ABC  DEF\n  GHI\n```')
+})
+
+test('code block with text around', async ({ page }) => {
+  await createRandomPage(page)
+
+  await page.fill('.block-editor textarea', 'Heading\n```\n```\nFooter')
+  await page.waitForTimeout(500)
+  await escapeToCodeEditor(page)
+  await page.type('.CodeMirror textarea', 'first\n  second')
+
+  await page.waitForTimeout(500)
+  await page.press('.CodeMirror textarea', 'Escape')
+  await page.waitForTimeout(500)
+  expect(await page.inputValue('.block-editor textarea')).toBe('Heading\n```\nfirst\n  second\n```\nFooter')
+})
+
+test('multiple code block', async ({ page }) => {
+  await createRandomPage(page)
+
+  // NOTE: the two code blocks are of the same content
+  await page.fill('.block-editor textarea', 'Heading\n```clojure\n```\nMiddle\n```clojure\n```\nFooter')
+  await page.waitForTimeout(500)
+
+  await page.press('.block-editor textarea', 'Escape')
+  await page.waitForSelector('.CodeMirror pre', { state: 'visible' })
+
+  // first
+  await page.waitForTimeout(500)
+  await page.click('.CodeMirror pre >> nth=0')
+  await page.waitForTimeout(500)
+
+  await page.type('.CodeMirror textarea >> nth=0', ':key-test\n', { strict: true })
+  await page.waitForTimeout(500)
+
+  await page.press('.CodeMirror textarea >> nth=0', 'Escape')
+  await page.waitForTimeout(500)
+  expect(await page.inputValue('.block-editor textarea'))
+    .toBe('Heading\n```clojure\n:key-test\n\n```\nMiddle\n```clojure\n```\nFooter')
+
+  // second
+  await page.press('.block-editor textarea', 'Escape')
+  await page.waitForSelector('.CodeMirror pre', { state: 'visible' })
+
+  await page.waitForTimeout(500)
+  await page.click('.CodeMirror pre >> nth=1')
+  await page.waitForTimeout(500)
+
+  await page.type('.CodeMirror textarea >> nth=1', '\n  :key-test\n', { strict: true })
+  await page.waitForTimeout(500)
+
+  await page.press('.CodeMirror textarea >> nth=1', 'Escape')
+  await page.waitForTimeout(500)
+  expect(await page.inputValue('.block-editor textarea'))
+    .toBe('Heading\n```clojure\n:key-test\n\n```\nMiddle\n```clojure\n\n  :key-test\n\n```\nFooter')
+})

--- a/e2e-tests/code-editing.spec.ts
+++ b/e2e-tests/code-editing.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 import { test } from './fixtures'
-import { createRandomPage, newBlock, lastBlock, appFirstLoaded, IsMac, IsLinux, escapeToCodeEditor, escapeToBlockEditor } from './utils'
+import { createRandomPage, escapeToCodeEditor, escapeToBlockEditor } from './utils'
 
 /**
  * NOTE: CodeMirror is a complex library that requires a lot of setup to work.

--- a/e2e-tests/hotkey.spec.ts
+++ b/e2e-tests/hotkey.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 import { test } from './fixtures'
-import { createRandomPage, newBlock, lastBlock, appFirstLoaded, IsMac, IsLinux } from './utils'
+import { createRandomPage, newBlock, lastBlock, IsMac, IsLinux } from './utils'
 
 test('open search dialog', async ({ page }) => {
   if (IsMac) {

--- a/e2e-tests/utils.ts
+++ b/e2e-tests/utils.ts
@@ -52,3 +52,23 @@ export async function newBlock(page: Page): Promise<Locator> {
 
     return page.locator(':nth-match(textarea, 1)')
 }
+
+export async function escapeToCodeEditor(page: Page): Promise<void> {
+    await page.press('.block-editor textarea', 'Escape')
+    await page.waitForSelector('.CodeMirror pre', { state: 'visible' })
+
+    await page.waitForTimeout(500)
+    await page.click('.CodeMirror pre')
+    await page.waitForTimeout(500)
+
+    await page.waitForSelector('.CodeMirror textarea', { state: 'visible' })
+}
+
+export async function escapeToBlockEditor(page: Page): Promise<void> {
+    await page.waitForTimeout(500)
+    await page.click('.CodeMirror pre')
+    await page.waitForTimeout(500)
+
+    await page.press('.CodeMirror textarea', 'Escape')
+    await page.waitForTimeout(500)
+}

--- a/src/main/frontend/components/lazy_editor.cljs
+++ b/src/main/frontend/components/lazy_editor.cljs
@@ -3,8 +3,7 @@
             [rum.core :as rum]
             [shadow.lazy :as lazy]
             [frontend.ui :as ui]
-            [frontend.state :as state]
-            [frontend.text :as text]))
+            [frontend.state :as state]))
 
 (def lazy-editor (lazy/loadable frontend.extensions.code/editor))
 
@@ -20,7 +19,6 @@
   (let [loaded? (rum/react loaded?)
         theme (state/sub :ui/theme)
         code (or code "")
-        code (text/remove-indentations code)
         code (string/replace-first code #"\n$" "")] ;; See-also: #3410
     (if loaded?
       (@lazy-editor config id attr code theme options)

--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -46,7 +46,6 @@
             [frontend.handler.file :as file-handler]
             [frontend.state :as state]
             [frontend.util :as util]
-            [frontend.text :as text]
             [goog.dom :as gdom]
             [goog.object :as gobj]
             [rum.core :as rum]))
@@ -68,29 +67,14 @@
       (cond
         (:block/uuid config)
         (let [block (db/pull [:block/uuid (:block/uuid config)])
-              format (:block/format block)
               content (:block/content block)
-              {:keys [lines]} (last (:rum/args state))
-              full-content (:full_content (last (:rum/args state)))
-              value (text/remove-indentations value)]
-          (when full-content
-            (let [lines (string/split-lines full-content)
-                  fl (first lines)
-                  ll (last lines)]
-              (when (and fl ll)
-                (let [src (->> (subvec (vec lines) 1 (dec (count lines)))
-                               (string/join "\n"))
-                      src (text/remove-indentations src)
-                      full-content (str (string/trim fl)
-                                        (if (seq src)
-                                          (str "\n" src "\n")
-                                          "\n")
-                                        (string/trim ll))]
-                  (when (string/includes? content full-content)
-                    (let [value' (str (string/trim fl) "\n" value "\n" (string/trim ll))
-                          ;; FIXME: What if there're multiple code blocks with the same value?
-                          content' (string/replace-first content full-content value')]
-                      (editor-handler/save-block-if-changed! block content'))))))))
+              {:keys [start_pos end_pos]} (:pos_meta (last (:rum/args state)))
+              prefix (subs content 0 (- start_pos 2))
+              surfix (subs content (- end_pos 2))
+              new-content (if (string/blank? value)
+                            (str prefix surfix)
+                            (str prefix value "\n" surfix))]
+          (editor-handler/save-block-if-changed! block new-content))
 
         (:file-path config)
         (let [path (:file-path config)
@@ -137,9 +121,8 @@
                               (get-in config [:block :block/uuid])))
         _ (state/set-state! :editor/code-mode? false)
         original-mode (get attr :data-lang)
-        mode original-mode
-        clojure? (contains? #{"clojure" "clj" "text/x-clojure" "cljs" "cljc"} mode)
-        mode (if clojure? "clojure" (text->cm-mode mode))
+        clojure? (contains? #{"clojure" "clj" "text/x-clojure" "cljs" "cljc"} original-mode)
+        mode (if clojure? "clojure" (text->cm-mode original-mode))
         lisp? (or clojure?
                   (contains? #{"scheme" "racket" "lisp"} mode))
         textarea (gdom/getElement id)
@@ -152,14 +135,12 @@
                                      :lineNumbers true
                                      :styleActiveLine true
                                      :extraKeys #js {"Esc" (fn [cm]
+                                                             (reset! esc-pressed? true)
                                                              (save-file-or-block-when-blur-or-esc! cm textarea config state)
                                                              (when-let [block-id (:block/uuid config)]
-                                                               (let [block (db/pull [:block/uuid block-id])
-                                                                     value (.getValue cm)
-                                                                     textarea-value (gobj/get textarea "value")]
+                                                               (let [block (db/pull [:block/uuid block-id])]
                                                                  (editor-handler/edit-block! block :max block-id)))
                                                              ;; TODO: return "handled" or false doesn't always prevent event bubbles
-                                                             (reset! esc-pressed? true)
                                                              (js/setTimeout #(reset! esc-pressed? false) 10))}}))]
     (when editor
       (let [textarea-ref (rum/ref-node state textarea-ref-name)]

--- a/src/main/frontend/text.cljs
+++ b/src/main/frontend/text.cljs
@@ -1,9 +1,7 @@
 (ns frontend.text
   (:require [frontend.config :as config]
             [frontend.util :as util]
-            [clojure.string :as string]
-            [clojure.set :as set]
-            [medley.core :as medley]))
+            [clojure.string :as string]))
 
 (def page-ref-re-0 #"\[\[(.*)\]\]")
 (def org-page-ref-re #"\[\[(file:.*)\]\[.+?\]\]")
@@ -346,12 +344,3 @@
       (if (not= (first parts) "0")
         (string/join "/" parts)
         (last parts)))))
-
-(defn remove-indentations
-  [text]
-  (when (string? text)
-    (let [lines (string/split text #"\r?\n" -1)
-          spaces-count (apply min (map #(count (re-find #"^[\s\t]+" %)) lines))]
-      (if (zero? spaces-count)
-        text
-        (string/join "\n" (map #(util/safe-subs % spaces-count) lines))))))


### PR DESCRIPTION
- won't `remove-indentations` before and after code editor
  - underlying CodeMirror status is buggy, the original implementation forgets to modify block just before entering code editor,
  - I can confirm this is the main cause of failing to save code to block
  - empty spaces matter, what if a user write code in [whitespace](https://en.wikipedia.org/wiki/Whitespace_(programming_language)) 🤣 
- rewrite saving handler of code editor
  - use pos-meta to handle block updates(both markdown and org-mode)
    - Now multiple code snippets can be in the same block
  - debounce ESC event against blur
    - original debounce logic is lagging
- Add e2e test cases
  - simple edit, switch between code editor and raw editor
  - indentations, whitespaces
  - code snippets surrounded by texts
  - multiple code snippets in the same block

