### PR TITLE
fix(build): wrong vendor assets of excalidraw

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "@capacitor/filesystem": "1.0.6",
         "@capacitor/ios": "3.2.2",
         "@capacitor/splash-screen": "1.1.3",
-        "@excalidraw/excalidraw": "0.4.2",
+        "@excalidraw/excalidraw": "0.4.3",
         "@kanru/rage-wasm": "0.2.1",
         "@sentry/browser": "6.4.1",
         "@sentry/electron": "2.5.1",


### PR DESCRIPTION
Fixes #3421

~~Haven't got any idea of how this was introduced.~~

**EDIT:**

2e2e8f23aae62d0ae0f71c3b9f577dd5beba331b changes excalidraw semver from `^0.4.2` to `0.4.2`.
While in the codebase's `resources/js/excalidraw-assets/vendor-3525c448906ddcdcb701.js` is the asset file of `0.4.3`( semver rule matters).

So when building a release desktop app with no-cache, excalidraw vendor assets will be missing(wrong file path).
