### PR TITLE
fix(editor): handle code block with non-latin1 chars

### DIFF
--- a/e2e-tests/code-editing.spec.ts
+++ b/e2e-tests/code-editing.spec.ts
@@ -142,7 +142,7 @@ test('multiple code block', async ({ page }) => {
   await createRandomPage(page)
 
   // NOTE: the two code blocks are of the same content
-  await page.fill('.block-editor textarea', 'Heading\n```clojure\n```\nMiddle\n```clojure\n```\nFooter')
+  await page.fill('.block-editor textarea', '中文 Heading\n```clojure\n```\nMiddle 🚀\n```clojure\n```\nFooter')
   await page.waitForTimeout(500)
 
   await page.press('.block-editor textarea', 'Escape')
@@ -159,7 +159,7 @@ test('multiple code block', async ({ page }) => {
   await page.press('.CodeMirror textarea >> nth=0', 'Escape')
   await page.waitForTimeout(500)
   expect(await page.inputValue('.block-editor textarea'))
-    .toBe('Heading\n```clojure\n:key-test\n\n```\nMiddle\n```clojure\n```\nFooter')
+    .toBe('中文 Heading\n```clojure\n:key-test\n\n```\nMiddle 🚀\n```clojure\n```\nFooter')
 
   // second
   await page.press('.block-editor textarea', 'Escape')
@@ -169,11 +169,11 @@ test('multiple code block', async ({ page }) => {
   await page.click('.CodeMirror pre >> nth=1')
   await page.waitForTimeout(500)
 
-  await page.type('.CodeMirror textarea >> nth=1', '\n  :key-test\n', { strict: true })
+  await page.type('.CodeMirror textarea >> nth=1', '\n  :key-test 日本語\n', { strict: true })
   await page.waitForTimeout(500)
 
   await page.press('.CodeMirror textarea >> nth=1', 'Escape')
   await page.waitForTimeout(500)
   expect(await page.inputValue('.block-editor textarea'))
-    .toBe('Heading\n```clojure\n:key-test\n\n```\nMiddle\n```clojure\n\n  :key-test\n\n```\nFooter')
+    .toBe('中文 Heading\n```clojure\n:key-test\n\n```\nMiddle 🚀\n```clojure\n\n  :key-test 日本語\n\n```\nFooter')
 })

--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -45,6 +45,7 @@
             [frontend.handler.editor :as editor-handler]
             [frontend.handler.file :as file-handler]
             [frontend.state :as state]
+            [frontend.utf8 :as utf8]
             [frontend.util :as util]
             [goog.dom :as gdom]
             [goog.object :as gobj]
@@ -69,8 +70,9 @@
         (let [block (db/pull [:block/uuid (:block/uuid config)])
               content (:block/content block)
               {:keys [start_pos end_pos]} (:pos_meta (last (:rum/args state)))
-              prefix (subs content 0 (- start_pos 2))
-              surfix (subs content (- end_pos 2))
+              raw-content (utf8/encode content) ;; NOTE: :pos_meta is based on byte position
+              prefix (utf8/decode (.slice raw-content 0 (- start_pos 2)))
+              surfix (utf8/decode (.slice raw-content (- end_pos 2)))
               new-content (if (string/blank? value)
                             (str prefix surfix)
                             (str prefix value "\n" surfix))]


### PR DESCRIPTION
Affects code block with non-latin1 chars in the heading line.