### PR TITLE
fix(ci): enable e2e test on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,6 @@ jobs:
           node static/tests.js
 
       - name: Run Playwright test
-        if: github.event_name == 'pull_request'
         run: |
           yarn release
           (cd static && yarn install && yarn rebuild:better-sqlite3)


### PR DESCRIPTION
It seemed that 32eba7ab7a1e500033be6f7c039be7574e1b01d0 breaks e2e tests.

Since this repo doesn't reject push to master.
e2e tests should be enabled in any case.

Related #3433