### PR TITLE
fix: nightly build with draft=false

### DIFF
--- a/.github/workflows/build-desktop-release.yml
+++ b/.github/workflows/build-desktop-release.yml
@@ -389,7 +389,7 @@ jobs:
         with:
           tag_name: nightly
           name: 'Desktop App Nightly Relase $$'
-          draft: true
+          draft: false
           prerelease: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.is-pre-release) || (github.event_name == 'schedule')}}
           body: "This is a nightly release of the Logseq desktop app."
           files: |


### PR DESCRIPTION
Nightly build must be a non-draft. It is due to the nightly tag is already existed, a draft release can not create a tag.