### PR TITLE
More fluid Graph scaling on lower-end

### DIFF
--- a/src/main/frontend/handler/graph.cljs
+++ b/src/main/frontend/handler/graph.cljs
@@ -24,32 +24,30 @@
   [dark? current-page page-links tags nodes namespaces]
   (let [parents (set (map last namespaces))
         current-page (or current-page "")
-        pages (->> (set (flatten nodes))
-                   (remove nil?))]
+        pages (set (flatten nodes))]
     (->>
+     pages
+     (remove nil?)
      (mapv (fn [p]
-             (when p
-               (let [p (str p)
-                     current-page? (= p current-page)
-                     color (case [dark? current-page?] ; FIXME: Put it into CSS
-                             [false false] "#999"
-                             [false true]  "#045591"
-                             [true false]  "#93a1a1"
-                             [true true]   "#ffffff")
-                     color (if (contains? tags p)
-                             (if dark? "orange" "green")
-                             color)]
-                 (let [n (get page-links p 1)
-                       size (int (* 8 (max 1.0 (js/Math.cbrt n))))]
-                   (cond->
-                     {:id p
-                      :label p
-                      :size size
-                      :color color}
-                     (contains? parents p)
-                     (assoc :parent true))))))
-           pages)
-     (remove nil?))))
+             (let [p (str p)
+                   current-page? (= p current-page)
+                   color (case [dark? current-page?] ; FIXME: Put it into CSS
+                           [false false] "#999"
+                           [false true]  "#045591"
+                           [true false]  "#93a1a1"
+                           [true true]   "#ffffff")
+                   color (if (contains? tags p)
+                           (if dark? "orange" "green")
+                           color)]
+               (let [n (get page-links p 1)
+                     size (int (* 8 (max 1.0 (js/Math.cbrt n))))]
+                 (cond->
+                   {:id p
+                    :label p
+                    :size size
+                    :color color}
+                   (contains? parents p)
+                   (assoc :parent true)))))))))
 
 ;; slow
 (defn- uuid-or-asset?

--- a/src/main/frontend/handler/graph.cljs
+++ b/src/main/frontend/handler/graph.cljs
@@ -40,13 +40,7 @@
                              (if dark? "orange" "green")
                              color)]
                  (let [n (get page-links p 1)
-                       size-v (if (> n 2)
-                                (js/Math.cbrt n)
-                                n)
-                       size-v (if (< size-v 1)
-                                1
-                                (int size-v))
-                       size (* size-v 8)]
+                       size (int (* 8 (max 1.0 (js/Math.cbrt n))))]
                    (cond->
                      {:id p
                       :label p

--- a/src/main/frontend/handler/graph.cljs
+++ b/src/main/frontend/handler/graph.cljs
@@ -38,18 +38,18 @@
                            [true true]   "#ffffff")
                    color (if (contains? tags p)
                            (if dark? "orange" "green")
-                           color)]
-               (let [n (get page-links p 1)
-                     size (int (* 8 (max 1.0 (js/Math.cbrt n))))]
-                 (cond->
-                   {:id p
-                    :label p
-                    :size size
-                    :color color}
-                   (contains? parents p)
-                   (assoc :parent true)))))))))
+                           color)
+                   n (get page-links p 1)
+                   size (int (* 8 (max 1.0 (js/Math.cbrt n))))]
+                (cond->
+                  {:id p
+                   :label p
+                   :size size
+                   :color color}
+                  (contains? parents p)
+                  (assoc :parent true))))))))
 
-;; slow
+                  ;; slow
 (defn- uuid-or-asset?
   [id]
   (or (util/uuid-string? id)


### PR DESCRIPTION
This slightly improves the cubic-root-based node-size scaling in the graph view. 

Diff looks bigger than it is (only functional change is b2fff04887a48396ba9d2ef571773dabdd34afae) because I also removed some redundant code. That may (slightly) improve performance on large graphs. 