### PR TITLE
fix: Chinese IMEs doesn't trigger slash command

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1257,7 +1257,7 @@
                ;; expand collapsed blocks
                (mapv (fn [b] (if (:collapsed (:block/properties b))
                                (vec (tree/sort-blocks (db/get-block-children repo (:block/uuid b)) b))
-                               [b])) )
+                               [b])))
                (flatten))
           block-ids* (mapv :block/uuid blocks*)
           level-blocks (blocks-with-level blocks*)
@@ -1698,9 +1698,9 @@
    "^" "^"
    "=" "="
    "/" "/"
-   "+" "+"
+   "+" "+"})
    ;; ":" ":"                              ; TODO: only properties editing and org mode tag
-   })
+   
 
 (def reversed-autopair-map
   (zipmap (vals autopair-map)
@@ -2874,107 +2874,107 @@
   [state input input-id search-timeout]
   (fn [e key-code]
     (let [k (gobj/get e "key")]
-      (when-not (= k "Process")
-        (let [code (gobj/getValueByKeys e "event_" "code")
-              format (:format (get-state))
-              current-pos (cursor/pos input)
-              value (gobj/get input "value")
-              c (util/nth-safe value (dec current-pos))
-              last-key-code (state/get-last-key-code)
-              blank-selected? (string/blank? (util/get-selected-text))
-              shift? (.-shiftKey e)]
-          (when-not (state/get-editor-show-input)
-            (cond
-              (and (not (contains? #{"ArrowDown" "ArrowLeft" "ArrowRight" "ArrowUp"} k))
-                   (not (:editor/show-page-search? @state/state))
-                   (not (:editor/show-page-search-hashtag? @state/state))
-                   (wrapped-by? input "[[" "]]"))
-              (let [orig-pos (cursor/get-caret-pos input)
-                    value (gobj/get input "value")
-                    square-pos (string/last-index-of (subs value 0 (:pos orig-pos)) "[[")
-                    pos (+ square-pos 2)
-                    _ (state/set-last-pos! pos)
-                    pos (assoc orig-pos :pos pos)
-                    command-step (if (= \# (util/nth-safe value (dec square-pos)))
-                                   :editor/search-page-hashtag
-                                   :editor/search-page)]
-                (commands/handle-step [command-step])
-                (reset! commands/*slash-caret-pos pos))
+      (let [code (gobj/getValueByKeys e "event_" "code")
+            format (:format (get-state))
+            current-pos (cursor/pos input)
+            value (gobj/get input "value")
+            c (util/nth-safe value (dec current-pos))
+            last-key-code (state/get-last-key-code)
+            blank-selected? (string/blank? (util/get-selected-text))
+            shift? (.-shiftKey e)]
+        (when-not (state/get-editor-show-input)
+          (cond
+            (and (not (contains? #{"ArrowDown" "ArrowLeft" "ArrowRight" "ArrowUp"} k))
+                 (not (:editor/show-page-search? @state/state))
+                 (not (:editor/show-page-search-hashtag? @state/state))
+                 (wrapped-by? input "[[" "]]"))
+            (let [orig-pos (cursor/get-caret-pos input)
+                  value (gobj/get input "value")
+                  square-pos (string/last-index-of (subs value 0 (:pos orig-pos)) "[[")
+                  pos (+ square-pos 2)
+                  _ (state/set-last-pos! pos)
+                  pos (assoc orig-pos :pos pos)
+                  command-step (if (= \# (util/nth-safe value (dec square-pos)))
+                                 :editor/search-page-hashtag
+                                 :editor/search-page)]
+              (commands/handle-step [command-step])
+              (reset! commands/*slash-caret-pos pos))
 
-              (and blank-selected?
-                   (or (= keycode/left-square-bracket key-code (:key-code last-key-code))
-                       (= keycode/left-square-bracket-code code (:code last-key-code)))
-                   (not shift?)
-                   (> current-pos 0)
-                   (not (wrapped-by? input "[[" "]]")))
-              (do
-                (commands/handle-step [:editor/input "[[]]" {:backward-truncate-number 2
-                                                             :backward-pos 2}])
-                (commands/handle-step [:editor/search-page])
-                (reset! commands/*slash-caret-pos (cursor/get-caret-pos input)))
+            (and blank-selected?
+                 (or (= keycode/left-square-bracket key-code (:key-code last-key-code))
+                     (= keycode/left-square-bracket-code code (:code last-key-code)))
+                 (not shift?)
+                 (> current-pos 0)
+                 (not (wrapped-by? input "[[" "]]")))
+            (do
+              (commands/handle-step [:editor/input "[[]]" {:backward-truncate-number 2
+                                                           :backward-pos 2}])
+              (commands/handle-step [:editor/search-page])
+              (reset! commands/*slash-caret-pos (cursor/get-caret-pos input)))
 
-              (and blank-selected?
-                   (or (= keycode/left-paren key-code (:key-code last-key-code))
-                       (= keycode/left-paren-code code (:code last-key-code)))
-                   (:shift? last-key-code)
-                   shift?
-                   (> current-pos 0)
-                   (not (wrapped-by? input "((" "))")))
-              (do
-                (commands/handle-step [:editor/input "(())" {:backward-truncate-number 2
-                                                             :backward-pos 2}])
-                (commands/handle-step [:editor/search-block :reference])
-                (reset! commands/*slash-caret-pos (cursor/get-caret-pos input)))
+            (and blank-selected?
+                 (or (= keycode/left-paren key-code (:key-code last-key-code))
+                     (= keycode/left-paren-code code (:code last-key-code)))
+                 (:shift? last-key-code)
+                 shift?
+                 (> current-pos 0)
+                 (not (wrapped-by? input "((" "))")))
+            (do
+              (commands/handle-step [:editor/input "(())" {:backward-truncate-number 2
+                                                           :backward-pos 2}])
+              (commands/handle-step [:editor/search-block :reference])
+              (reset! commands/*slash-caret-pos (cursor/get-caret-pos input)))
 
-              (and (= "〈" c)
-                   (= "《" (util/nth-safe value (dec (dec current-pos))))
-                   (> current-pos 0))
-              (do
-                (commands/handle-step [:editor/input commands/angle-bracket {:last-pattern "《〈"
-                                                                             :backward-pos 0}])
-                (reset! commands/*angle-bracket-caret-pos (cursor/get-caret-pos input))
-                (reset! commands/*show-block-commands true))
+            (and (= "〈" c)
+                 (= "《" (util/nth-safe value (dec (dec current-pos))))
+                 (> current-pos 0))
+            (do
+              (commands/handle-step [:editor/input commands/angle-bracket {:last-pattern "《〈"
+                                                                           :backward-pos 0}])
+              (reset! commands/*angle-bracket-caret-pos (cursor/get-caret-pos input))
+              (reset! commands/*show-block-commands true))
 
-              (and (= c " ")
-                   (or (= (util/nth-safe value (dec (dec current-pos))) "#")
-                       (not (state/get-editor-show-page-search?))
-                       (and (state/get-editor-show-page-search?)
-                            (not= (util/nth-safe value current-pos) "]"))))
-              (state/set-editor-show-page-search-hashtag! false)
+            (and (= c " ")
+                 (or (= (util/nth-safe value (dec (dec current-pos))) "#")
+                     (not (state/get-editor-show-page-search?))
+                     (and (state/get-editor-show-page-search?)
+                          (not= (util/nth-safe value current-pos) "]"))))
+            (state/set-editor-show-page-search-hashtag! false)
 
-              (and @*show-commands (not= k (state/get-editor-command-trigger)))
-              (let [matched-commands (get-matched-commands input)]
-                (if (seq matched-commands)
-                  (do
-                    (reset! *show-commands true)
-                    (reset! commands/*matched-commands matched-commands))
-                  (reset! *show-commands false)))
+            (and @*show-commands (not= k (state/get-editor-command-trigger)))
+            (let [matched-commands (get-matched-commands input)]
+              (if (seq matched-commands)
+                (do
+                  (reset! *show-commands true)
+                  (reset! commands/*matched-commands matched-commands))
+                (reset! *show-commands false)))
 
-              (and @*show-block-commands (not= key-code 188)) ; not <
-              (let [matched-block-commands (get-matched-block-commands input)]
-                (if (seq matched-block-commands)
-                  (cond
-                    (= key-code 9)       ;tab
-                    (when @*show-block-commands
-                      (util/stop e)
-                      (insert-command! input-id
-                                       (last (first matched-block-commands))
-                                       format
-                                       {:last-pattern commands/angle-bracket}))
+            (and @*show-block-commands (not= key-code 188)) ; not <
+            (let [matched-block-commands (get-matched-block-commands input)]
+              (if (seq matched-block-commands)
+                (cond
+                  (= key-code 9)       ;tab
+                  (when @*show-block-commands
+                    (util/stop e)
+                    (insert-command! input-id
+                                     (last (first matched-block-commands))
+                                     format
+                                     {:last-pattern commands/angle-bracket}))
 
-                    :else
-                    (reset! commands/*matched-block-commands matched-block-commands))
-                  (reset! *show-block-commands false)))
+                  :else
+                  (reset! commands/*matched-block-commands matched-block-commands))
+                (reset! *show-block-commands false)))
 
-              (nil? @search-timeout)
-              (close-autocomplete-if-outside input)
+            (nil? @search-timeout)
+            (close-autocomplete-if-outside input)
 
-              :else
-              nil))
-          (when-not (= k "Shift")
-            (state/set-last-key-code! {:key-code key-code
-                                       :code code
-                                       :shift? (.-shiftKey e)})))))))
+            :else
+            nil))
+        (when-not (= k "Shift")
+          (state/set-last-key-code! {:key-code key-code
+                                     :code code
+                                     :shift? (.-shiftKey e)}))))))
+                                       
 
 (defn editor-on-click!
   [id]


### PR DESCRIPTION
Close #3459

Note: the key change is to remove this Enter key checking:
https://github.com/logseq/logseq/blob/d7b1ce51e368a8ea7ae2020070144b7e0441abcf/src/main/frontend/handler/editor.cljs#L2877
I read the whole logic and didn't find it's usage. But I'm still concerning if it breaks any other case.
The Enter key checking is introduced in https://github.com/logseq/logseq/commit/efbcb792997a11af67d0a5b1cee51e833aaa11eb (to solve https://github.com/logseq/logseq/issues/3251). I tested MS pinyin and the `【【` completion works correctly.