### PR TITLE
fix: unable to type with IME in search modal

### DIFF
--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -102,7 +102,6 @@
       (when input
         (let [current-pos (cursor/pos input)
               edit-content (or (state/sub [:editor/content id]) "")
-              edit-block (state/sub :editor/block)
               sidebar? (in-sidebar? input)
               q (or
                  @editor-handler/*selected-text

--- a/src/main/frontend/components/search.cljs
+++ b/src/main/frontend/components/search.cljs
@@ -15,7 +15,7 @@
             [frontend.config :as config]
             [frontend.search :as search]
             [clojure.string :as string]
-            [goog.dom :as gdom]
+            [goog.object :as gobj]
             [medley.core :as medley]
             [frontend.context.i18n :as i18n]
             [frontend.date :as date]
@@ -387,8 +387,9 @@
             :on-change     (fn [e]
                              (when @search-timeout
                                (js/clearTimeout @search-timeout))
-                             (let [value (util/evalue e)]
-                               (if (string/blank? value)
+                             (let [value (util/evalue e)
+                                   is-composing? (gobj/getValueByKeys e "nativeEvent" "isComposing")]
+                               (if (and (string/blank? value) (not is-composing?))
                                  (search-handler/clear-search! false)
                                  (let [search-mode (state/get-search-mode)
                                        opts (if (= :page search-mode)


### PR DESCRIPTION
Fix #3199 #3084 
Close #1561  (Seems it is fixed for a while)