### PR TITLE
Fix: code save when blur

### DIFF
--- a/e2e-tests/code-editing.spec.ts
+++ b/e2e-tests/code-editing.spec.ts
@@ -177,3 +177,32 @@ test('multiple code block', async ({ page }) => {
   expect(await page.inputValue('.block-editor textarea'))
     .toBe('中文 Heading\n```clojure\n:key-test\n\n```\nMiddle 🚀\n```clojure\n\n  :key-test 日本語\n\n```\nFooter')
 })
+
+test('click outside to exit', async ({ page }) => {
+  await createRandomPage(page)
+
+  await page.fill('.block-editor textarea', 'Header ``Click``\n```\n  ABC\n```')
+  await page.waitForTimeout(500) // wait for fill
+  await escapeToCodeEditor(page)
+  await page.type('.CodeMirror textarea', '  DEF\nGHI')
+
+  await page.waitForTimeout(500)
+  await page.click('text=Click')
+  await page.waitForTimeout(500)
+  // NOTE: auto-indent is on
+  expect(await page.inputValue('.block-editor textarea')).toBe('Header ``Click``\n```\n  ABC  DEF\n  GHI\n```')
+})
+
+test('click lanuage label to exit #3463', async ({ page }) => {
+  await createRandomPage(page)
+
+  await page.fill('.block-editor textarea', '```cpp\n```')
+  await page.waitForTimeout(500)
+  await escapeToCodeEditor(page)
+  await page.type('.CodeMirror textarea', '#include<iostream>')
+
+  await page.waitForTimeout(500)
+  await page.click('text=cpp') // the language label
+  await page.waitForTimeout(500)
+  expect(await page.inputValue('.block-editor textarea')).toBe('```cpp\n#include<iostream>\n```')
+})

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1742,18 +1742,18 @@
                  (d/has-class? target "image-resize"))
         (editor-handler/clear-selection!)
         (editor-handler/unhighlight-blocks!)
-        (let [block (or (db/pull [:block/uuid (:block/uuid block)]) block)
-              f #(let [cursor-range (util/caret-range (gdom/getElement block-id))
+        (let [f #(let [block (or (db/pull [:block/uuid (:block/uuid block)]) block)
+                       cursor-range (util/caret-range (gdom/getElement block-id))
+                       new-content (:block/content block)
                        content (-> (property/remove-built-in-properties (:block/format block)
                                                                         content)
                                    (drawer/remove-logbook))]
                    ;; save current editing block
                    (let [{:keys [value] :as state} (editor-handler/get-state)]
                      (editor-handler/save-block! state value))
-
                    (state/set-editing!
                     edit-input-id
-                    content
+                    new-content
                     block
                     cursor-range
                     false))]
@@ -1934,8 +1934,8 @@
       [:div.flex.flex-row.block-content-wrapper
        [:div.flex-1.w-full {:style {:display (if (:slide? config) "block" "flex")}}
         (ui/catch-error
-          (block-content-fallback edit-input-id block)
-          (block-content config block edit-input-id block-id slide?))]
+         (block-content-fallback edit-input-id block)
+         (block-content config block edit-input-id block-id slide?))]
        [:div.flex.flex-row
         (when (and (:embed? config)
                    (:embed-parent config))
@@ -2612,6 +2612,8 @@
             (highlight/highlight (str (medley/random-uuid)) {:data-lang language} code)
             [:div
              (lazy-editor/editor config (str (dc/squuid)) attr code options)
+             ;; FIXME: The following code seemed unreachable
+             ;; options has key: :lines, :language, :full_content, :pos_meta
              (let [options (:options options)]
                (when (and (= language "text/x-clojure") (contains? (set options) ":results"))
                  (sci/eval-result code)))]))))))


### PR DESCRIPTION
- use new-content when entering edit mode
- add e2e test cases for #3463 