### PR TITLE
fix: IME check refactor

### DIFF
--- a/src/main/frontend/components/search.cljs
+++ b/src/main/frontend/components/search.cljs
@@ -388,7 +388,7 @@
                              (when @search-timeout
                                (js/clearTimeout @search-timeout))
                              (let [value (util/evalue e)
-                                   is-composing? (util/onchange-event-is-composing? e)]
+                                   is-composing? (util/onchange-event-is-composing? e)] ;; #3199
                                (if (and (string/blank? value) (not is-composing?))
                                  (search-handler/clear-search! false)
                                  (let [search-mode (state/get-search-mode)

--- a/src/main/frontend/components/search.cljs
+++ b/src/main/frontend/components/search.cljs
@@ -388,7 +388,7 @@
                              (when @search-timeout
                                (js/clearTimeout @search-timeout))
                              (let [value (util/evalue e)
-                                   is-composing? (util/event-is-composing? e)]
+                                   is-composing? (util/onchange-event-is-composing? e)]
                                (if (and (string/blank? value) (not is-composing?))
                                  (search-handler/clear-search! false)
                                  (let [search-mode (state/get-search-mode)

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2790,7 +2790,8 @@
           shift? (.-shiftKey e)
           code (gobj/getValueByKeys e "event_" "code")]
       (cond
-        (util/event-is-composing? e)
+        (and (util/event-is-composing? e true)
+             (not (state/get-editor-show-page-search-hashtag?)))
         nil
 
         (or ctrlKey metaKey)

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2788,10 +2788,14 @@
           metaKey (gobj/get e "metaKey")
           pos (cursor/pos input)
           shift? (.-shiftKey e)
-          code (gobj/getValueByKeys e "event_" "code")]
+          code (gobj/getValueByKeys e "event_" "code")
+          hashtag? (or (surround-by? input "#" " ")
+                       (surround-by? input "#" :end)
+                       (= key "#"))]
       (cond
         (and (util/event-is-composing? e true) ;; #3218
-             (not (state/get-editor-show-page-search-hashtag?))) ;; #3283
+             (not hashtag?) ;; #3283 @Rime
+             (not (state/get-editor-show-page-search-hashtag?))) ;; #3283 @MacOS pinyin
         nil
 
         (or ctrlKey metaKey)
@@ -2836,10 +2840,7 @@
           (util/stop e)
           (autopair input-id key format nil))
 
-        (or
-         (surround-by? input "#" " ")
-         (surround-by? input "#" :end)
-         (= key "#"))
+        hashtag?
         (do
           (commands/handle-step [:editor/search-page-hashtag])
           (state/set-last-pos! (cursor/pos input))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2790,8 +2790,8 @@
           shift? (.-shiftKey e)
           code (gobj/getValueByKeys e "event_" "code")]
       (cond
-        (and (util/event-is-composing? e true)
-             (not (state/get-editor-show-page-search-hashtag?)))
+        (and (util/event-is-composing? e true) ;; #3218
+             (not (state/get-editor-show-page-search-hashtag?))) ;; #3283
         nil
 
         (or ctrlKey metaKey)
@@ -2880,8 +2880,11 @@
             c (util/nth-safe value (dec current-pos))
             last-key-code (state/get-last-key-code)
             blank-selected? (string/blank? (util/get-selected-text))
-            shift? (.-shiftKey e)]
-        (when-not (state/get-editor-show-input)
+            shift? (.-shiftKey e)
+            is-processed? (util/event-is-composing? e true) ;; #3440
+            non-enter-processed? (and is-processed? ;; #3251
+                                      (not= code "Enter"))] ;; #3459
+        (when-not (or (state/get-editor-show-input) non-enter-processed?)
           (cond
             (and (not (contains? #{"ArrowDown" "ArrowLeft" "ArrowRight" "ArrowUp"} k))
                  (not (:editor/show-page-search? @state/state))
@@ -2969,7 +2972,7 @@
 
             :else
             nil))
-        (when-not (= k "Shift")
+        (when-not (or (= k "Shift") is-processed?)
           (state/set-last-key-code! {:key-code key-code
                                      :code code
                                      :shift? (.-shiftKey e)}))))))

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1493,6 +1493,20 @@
 
 #?(:cljs
    (defn event-is-composing?
+     "Check if keydown event is a composing (IME) event. 
+      Ignore the IME finishing keycode by default."
+     ([e]
+      (event-is-composing? e true))
+     ([e ignore-finish?]
+      (let [event-composing? (gobj/getValueByKeys e "event_" "isComposing")
+            finish-keycode?  (= (.-keyCode e) 229)]
+       (if ignore-finish?
+         (and event-composing? (not finish-keycode?))
+         (or event-composing?  finish-keycode?))))))
+
+#?(:cljs
+   (defn onchange-event-is-composing?
+      "Check if onchange event of Input is a composing (IME) event.
+       Including IME finishing."
      [e]
-     (or (gobj/getValueByKeys e "event_" "isComposing")
-         (= (.-keyCode e) 229))))
+     (gobj/getValueByKeys e "nativeEvent" "isComposing"))) ;; No keycode available

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1496,12 +1496,14 @@
      "Check if keydown event is a composing (IME) event. 
       Ignore the IME process by default."
      ([e]
-      (event-is-composing? e true))
-     ([e ignore-process?]
+      (event-is-composing? e false))
+     ([e include-process?]
       (let [event-composing? (gobj/getValueByKeys e "event_" "isComposing")]
-        (if ignore-process?
-          event-composing?
-          (or event-composing? (= (gobj/get e "key") "Process")))))))
+        (if include-process?
+          (or event-composing? 
+              (= (gobj/get e "keyCode") 229)
+              (= (gobj/get e "key") "Process"))
+          event-composing?)))))
 
 #?(:cljs
    (defn onchange-event-is-composing?

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1494,19 +1494,18 @@
 #?(:cljs
    (defn event-is-composing?
      "Check if keydown event is a composing (IME) event. 
-      Ignore the IME finishing keycode by default."
+      Ignore the IME process by default."
      ([e]
       (event-is-composing? e true))
-     ([e ignore-finish?]
-      (let [event-composing? (gobj/getValueByKeys e "event_" "isComposing")
-            finish-keycode?  (= (.-keyCode e) 229)]
-       (if ignore-finish?
-         (and event-composing? (not finish-keycode?))
-         (or event-composing?  finish-keycode?))))))
+     ([e ignore-process?]
+      (let [event-composing? (gobj/getValueByKeys e "event_" "isComposing")]
+        (if ignore-process?
+          event-composing?
+          (or event-composing? (= (gobj/get e "key") "Process")))))))
 
 #?(:cljs
    (defn onchange-event-is-composing?
       "Check if onchange event of Input is a composing (IME) event.
-       Including IME finishing."
+       Always ignore the IME process."
      [e]
      (gobj/getValueByKeys e "nativeEvent" "isComposing"))) ;; No keycode available


### PR DESCRIPTION
Fix #3440

### Impacted IME issues
#3440 #3459  #3283 #3251 #3218 #3199

### Tests
- [x] MacOS: https://www.loom.com/share/46f9f6e96e594a53932f1515f538ba5d
- [x] Windows (MS Pinyin): https://www.loom.com/share/fddf68f4a8aa434cbb27b33ff2e24477
- [x] Windows (Rime): https://www.loom.com/share/5052061c10544d1f8421f206eb287b48

### Known minor issues
* Chinese IME would trigger markdown heading 1 style when type in `#中文标签`