### PR TITLE
fix(timestamp): clear editing state before setting timestamp

### DIFF
--- a/src/main/frontend/components/datetime.cljs
+++ b/src/main/frontend/components/datetime.cljs
@@ -108,10 +108,10 @@
                                      block-id (or (:block/uuid (state/get-edit-block))
                                                   (:block/uuid block))
                                      typ (or @commands/*current-command typ)]
+                                 (state/clear-edit!)
                                  (editor-handler/set-block-timestamp! block-id
                                                                       typ
                                                                       text)
-                                 (state/clear-edit!)
                                  (when show?
                                    (reset! show? false))))
                              (clear-timestamp!)


### PR DESCRIPTION
If editing state is on in other block, submitting the timestamp to current block will also add a timestamp to that block.