### PR TITLE
Fix: code offset is wrong when code and multi properties in the same block

### DIFF
--- a/e2e-tests/code-editing.spec.ts
+++ b/e2e-tests/code-editing.spec.ts
@@ -196,6 +196,9 @@ test('click outside to exit', async ({ page }) => {
 test('click lanuage label to exit #3463', async ({ page }) => {
   await createRandomPage(page)
 
+  await page.press('.block-editor textarea', 'Enter')
+  await page.waitForTimeout(200)
+
   await page.fill('.block-editor textarea', '```cpp\n```')
   await page.waitForTimeout(500)
   await escapeToCodeEditor(page)
@@ -205,4 +208,39 @@ test('click lanuage label to exit #3463', async ({ page }) => {
   await page.click('text=cpp') // the language label
   await page.waitForTimeout(500)
   expect(await page.inputValue('.block-editor textarea')).toBe('```cpp\n#include<iostream>\n```')
+})
+
+test('multi properties with code', async ({ page }) => {
+  await createRandomPage(page)
+
+  await page.fill('.block-editor textarea',
+    'type:: code\n' +
+    '类型:: 代码\n' +
+    '```go\n' +
+    'if err != nil {\n' +
+    '\treturn err\n' +
+    '}\n' +
+    '```'
+  )
+  await page.waitForTimeout(500)
+  await escapeToCodeEditor(page)
+
+  // first character of code
+  await page.click('.CodeMirror pre', { position: { x: 1, y: 5 } })
+  await page.waitForTimeout(500)
+  await page.type('.CodeMirror textarea', '// Returns nil\n')
+
+  await page.waitForTimeout(500)
+  await page.press('.CodeMirror textarea', 'Escape')
+  await page.waitForTimeout(500)
+  expect(await page.inputValue('.block-editor textarea')).toBe(
+    'type:: code\n' +
+    '类型:: 代码\n' +
+    '```go\n' +
+    '// Returns nil\n' +
+    'if err != nil {\n' +
+    '\treturn err\n' +
+    '}\n' +
+    '```'
+  )
 })

--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -158,9 +158,10 @@
         (let [block (db/pull [:block/uuid (:block/uuid config)])
               content (:block/content block)
               {:keys [start_pos end_pos]} (:pos_meta (last (:rum/args state)))
+              offset (if (:block/pre-block? block) 0 2)
               raw-content (utf8/encode content) ;; NOTE: :pos_meta is based on byte position
-              prefix (utf8/decode (.slice raw-content 0 (- start_pos 2)))
-              surfix (utf8/decode (.slice raw-content (- end_pos 2)))
+              prefix (utf8/decode (.slice raw-content 0 (- start_pos offset)))
+              surfix (utf8/decode (.slice raw-content (- end_pos offset)))
               new-content (if (string/blank? value)
                             (str prefix surfix)
                             (str prefix value "\n" surfix))]

--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -738,8 +738,7 @@
   ([block-uuid format pre-block? content]
    (when-not (string/blank? content)
      (let [content (if pre-block? content
-                       (str (config/get-block-pattern format) " " (string/triml content)))
-           content (property/remove-properties format content)]
+                       (str (config/get-block-pattern format) " " (string/triml content)))]
        (if-let [result (state/get-block-ast block-uuid content)]
          result
          (let [ast (->> (format/to-edn content format (mldoc/default-config format))


### PR DESCRIPTION
When properties and code snippets are in the same block, offset calculation will interfere with property-stripped content.

- Fix pre-block offset
- Fix multiple properties with code snippet
- Fix #3472 
- Add e2e test case