### PR TITLE
fix: unexpected behaviour caused by abuse of keycode

### DIFF
--- a/e2e-tests/basic.spec.ts
+++ b/e2e-tests/basic.spec.ts
@@ -223,17 +223,34 @@ test('auto completion and auto pair', async ({ page }) => {
   await page.fill(':nth-match(textarea, 1)', 'Auto-completion test')
   await page.press(':nth-match(textarea, 1)', 'Enter')
 
-  // {}
+  // {{
   await page.type(':nth-match(textarea, 1)', 'type {{')
   expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('type {{}}')
 
-  // (()
+  // ((
   await newBlock(page)
 
   await page.type(':nth-match(textarea, 1)', 'type (')
   expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('type ()')
   await page.type(':nth-match(textarea, 1)', '(')
   expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('type (())')
+
+  // 99  #3444
+  // TODO: Test under different keyboard layout when Playwright supports it
+  // await newBlock(page)
+
+  // await page.type(':nth-match(textarea, 1)', 'type 9')
+  // expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('type 9')
+  // await page.type(':nth-match(textarea, 1)', '9')
+  // expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('type 99')
+
+  // [[  #3251
+  await newBlock(page)
+
+  await page.type(':nth-match(textarea, 1)', 'type [')
+  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('type []')
+  await page.type(':nth-match(textarea, 1)', '[')
+  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('type [[]]')
 
   // ``
   await newBlock(page)

--- a/e2e-tests/basic.spec.ts
+++ b/e2e-tests/basic.spec.ts
@@ -225,8 +225,7 @@ test('auto completion and auto pair', async ({ page }) => {
 
   // {}
   await page.type(':nth-match(textarea, 1)', 'type {{')
-  // FIXME: keycode seq is wrong
-  // expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('type {{}}')
+  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('type {{}}')
 
   // (()
   await newBlock(page)

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2904,9 +2904,6 @@
             non-enter-processed? (and is-processed? ;; #3251
                                       (not= code keycode/enter-code))] ;; #3459
         (when-not (or (state/get-editor-show-input) non-enter-processed?)
-          (js/console.log "---")
-          (js/console.log e)
-          (js/console.log last-key-code)
           (cond
             (and (not (contains? #{"ArrowDown" "ArrowLeft" "ArrowRight" "ArrowUp"} k))
                  (not (:editor/show-page-search? @state/state))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2842,17 +2842,13 @@
         nil
 
         (and (not (string/blank? (util/get-selected-text)))
-             (or (= key-code keycode/left-square-bracket)
-                 (= keycode/left-square-bracket-code code))
-             (not shift?))
+             (contains? keycode/left-square-brackets-keys key))
         (do
           (autopair input-id "[" format nil)
           (util/stop e))
 
         (and (not (string/blank? (util/get-selected-text)))
-             (or (= key-code keycode/left-paren)
-                 (= keycode/left-paren-code code))
-             shift?)
+             (contains? keycode/left-paren-keys key))
         (do
           (util/stop e)
           (autopair input-id "(" format nil))
@@ -2906,8 +2902,11 @@
             shift? (.-shiftKey e)
             is-processed? (util/event-is-composing? e true) ;; #3440
             non-enter-processed? (and is-processed? ;; #3251
-                                      (not= code "Enter"))] ;; #3459
+                                      (not= code keycode/enter-code))] ;; #3459
         (when-not (or (state/get-editor-show-input) non-enter-processed?)
+          (js/console.log "---")
+          (js/console.log e)
+          (js/console.log last-key-code)
           (cond
             (and (not (contains? #{"ArrowDown" "ArrowLeft" "ArrowRight" "ArrowUp"} k))
                  (not (:editor/show-page-search? @state/state))
@@ -2926,9 +2925,8 @@
               (reset! commands/*slash-caret-pos pos))
 
             (and blank-selected?
-                 (or (= keycode/left-square-bracket key-code (:key-code last-key-code))
-                     (= keycode/left-square-bracket-code code (:code last-key-code)))
-                 (not shift?)
+                 (contains? keycode/left-square-brackets-keys k)
+                 (= (:key last-key-code) k)
                  (> current-pos 0)
                  (not (wrapped-by? input "[[" "]]")))
             (do
@@ -2938,10 +2936,8 @@
               (reset! commands/*slash-caret-pos (cursor/get-caret-pos input)))
 
             (and blank-selected?
-                 (or (= keycode/left-paren key-code (:key-code last-key-code))
-                     (= keycode/left-paren-code code (:code last-key-code)))
-                 (:shift? last-key-code)
-                 shift?
+                 (contains? keycode/left-paren-keys k)
+                 (= (:key last-key-code) k)
                  (> current-pos 0)
                  (not (wrapped-by? input "((" "))")))
             (do
@@ -2998,6 +2994,7 @@
         (when-not (or (= k "Shift") is-processed?)
           (state/set-last-key-code! {:key-code key-code
                                      :code code
+                                     :key k
                                      :shift? (.-shiftKey e)}))))))
 
 

--- a/src/main/frontend/util/keycode.cljs
+++ b/src/main/frontend/util/keycode.cljs
@@ -1,9 +1,13 @@
 (ns frontend.util.keycode)
 
-(def left-square-bracket 219)
-(def left-paren 57)
+;; code / keycode should all be deprecated for non funcional keys
+;; (def left-square-bracket 219) ;; deprecated
+;; (def left-paren 57) ;; deprecated
 (def enter 13)
 
-(def left-square-bracket-code "BracketLeft")
-(def left-paren-code "Digit9")
+;; (def left-square-bracket-code "BracketLeft") ;; deprecated
+;; (def left-paren-code "Digit9") ;; deprecated
 (def enter-code "Enter")
+
+(def left-square-brackets-keys #{"[" "【"})
+(def left-paren-keys #{"(" "（"})

--- a/src/main/frontend/util/keycode.cljs
+++ b/src/main/frontend/util/keycode.cljs
@@ -9,5 +9,5 @@
 ;; (def left-paren-code "Digit9") ;; deprecated
 (def enter-code "Enter")
 
-(def left-square-brackets-keys #{"[" "【"})
+(def left-square-brackets-keys #{"[" "【" "「"})
 (def left-paren-keys #{"(" "（"})

--- a/src/main/frontend/util/keycode.cljs
+++ b/src/main/frontend/util/keycode.cljs
@@ -9,5 +9,5 @@
 ;; (def left-paren-code "Digit9") ;; deprecated
 (def enter-code "Enter")
 
-(def left-square-brackets-keys #{"[" "【" "「"})
+(def left-square-brackets-keys #{"[" "【"})
 (def left-paren-keys #{"(" "（"})


### PR DESCRIPTION
Fix #3444
Close #3292 

**Observations**
* Same KeyCode represents different Keys on different keyboard layouts;
* Should avoid checking `:keyCode` or `:code` of Events for non-functional keys;
* Assuming the `:keyCode` check is introduced for recognizing full-width chars like `【` `（` (Mainly caused by CJK IMEs)

**Actions**
- [x] Hard-code full-width char mappings in `src/main/frontend/util/keycode.cljs`
- [x] Use `:key` check instead
- [x] Expand E2E test cases
- [x] Manual test (following protocol)
    - [x] Windows (MS pinyin)
    - [x] Windows (Rime)
    - [x] MacOS

**Notes**
* Playwright's IME / Keyboard support is non-exist. 
* Playwright's typing of non-US keys are not sending keyup / keydown event.