### PR TITLE
fix: Formatting keyboard shortcuts

### DIFF
--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -592,7 +592,16 @@
     :editor/expand-block-children
     :editor/toggle-open-blocks
     :go/backward
-    :go/forward]
+    :go/forward
+    :go/home
+    :go/journals
+    :go/all-pages
+    :go/graph-view
+    :go/flashcards
+    :go/tomorrow
+    :go/next-journal
+    :go/prev-journal
+    :go/keyboard-shortcuts]
 
    :shortcut.category/block-editing
    ^{:doc "Block editing general"}
@@ -650,15 +659,7 @@
 
    :shortcut.category/others
    ^{:doc "Others"}
-   [:go/home
-    :go/journals
-    :go/all-pages
-    :go/graph-view
-    :go/flashcards
-    :go/tomorrow
-    :go/next-journal
-    :go/prev-journal
-    :pdf/previous-page
+   [:pdf/previous-page
     :pdf/next-page
     :command/run
     :command-palette/toggle

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -84,7 +84,7 @@
                                   :binding "t"
                                   :fn      srs/recall}
 
-   :editor/escape-editing        {:desc    "Escape editing (remap to ctrl+open-square-bracket for example)"
+   :editor/escape-editing        {:desc    "Escape editing"
                                   :binding false
                                   :fn      (fn [_ _] (editor-handler/escape-editing))}
 


### PR DESCRIPTION
Changes:
- [x] Removed `Escape editing` keymap recommendation.
  - The recommended key for `Escape editing` is `Ctrl` + `[`. This is a default binding in Logseq for going `Backwards` and should not be recommended.
    ![image](https://user-images.githubusercontent.com/25513724/146615089-7fbddff3-4f5c-4669-996f-d32b79c20684.png)
    ![image](https://user-images.githubusercontent.com/25513724/146610718-89361690-8177-4ca3-8879-5376d159e374.png)
- [x] Moved `go` options from `Other` to `Navigation` category.
  - the goto shortcuts such as: `g` `h` are used for navigating logseq. 
- [x] Added missing `:go/keyboard-shortcuts` option to `Navigation`.
