### PR TITLE
Optimize the language selection logic, fix the wrong highlight.js language selection

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2607,9 +2607,12 @@
         (highlight/html-export attr code)
 
         :else
-        (let [language (if (contains? #{"edn" "clj" "cljc" "cljs" "clojure"} language) "text/x-clojure" language)]
+        (let [language (if (contains? #{"edn" "clj" "cljc" "cljs"} language) "clojure" language)]
           (if (:slide? config)
-            (highlight/highlight (str (medley/random-uuid)) {:data-lang language} code)
+            (highlight/highlight (str (medley/random-uuid))
+                                 {:class (str "language-" language)
+                                  :data-lang language}
+                                 code)
             [:div
              (lazy-editor/editor config (str (dc/squuid)) attr code options)
              ;; FIXME: The following code seemed unreachable

--- a/src/main/frontend/components/file.cljs
+++ b/src/main/frontend/components/file.cljs
@@ -115,8 +115,7 @@
          (and format (contains? (config/text-formats) format))
          (when-let [file-content (db/get-file path)]
            (let [content (string/trim file-content)
-                 mode (util/get-file-ext path)
-                 mode (if (contains? #{"edn" "clj" "cljc" "cljs" "clojure"} mode) "text/x-clojure" mode)]
+                 mode (util/get-file-ext path)]
              (lazy-editor/editor {:file? true
                                   :file-path path} path {:data-lang mode} content {})))
 

--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -270,10 +270,7 @@
    (when-let [mode (:data-lang attr)]
      (when-not (= mode "calc")
        [:div.extensions__code-lang
-        (let [mode (string/lower-case mode)]
-          (if (= mode "text/x-clojure")
-            "clojure"
-            mode))]))
+        (string/lower-case mode)]))
    [:textarea (merge {:id id
                       ;; Expose the textarea associated with the CodeMirror instance via
                       ;; ref so that we can autofocus into the CodeMirror instance later.


### PR DESCRIPTION
- use `CodeMirror.findModeByName`
- remove redudent clojure mime type for CodeMirror
- fix wrong highlight.js language mode(since .language-* is not set, it was always a guess)