### PR TITLE
fix: use simpler regexp to parse links in properties

### DIFF
--- a/src/main/frontend/handler/link.cljs
+++ b/src/main/frontend/handler/link.cljs
@@ -1,8 +1,7 @@
-(ns frontend.handler.link 
-  (:require
-    [frontend.util :as util]))
+(ns frontend.handler.link
+  (:require [frontend.util :as util]))
 
-(def plain-link "(?:http://www\\.|https://www\\.|http://|https://){1}[a-z0-9]+(?:[\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}(?:.*)*")
+(def plain-link "(\b(https?|file)://)?[-A-Za-z0-9+&@#/%?=~_|!:,.;]+[-A-Za-z0-9+&@#/%=~_|]")
 (def plain-link-re (re-pattern plain-link))
 (def org-link-re-1 (re-pattern (util/format "\\[\\[(%s)\\]\\[(.+)\\]\\]" plain-link)))
 (def org-link-re-2 (re-pattern (util/format "\\[\\[(%s)\\]\\]" plain-link)))
@@ -10,27 +9,24 @@
 
 (defn- plain-link?
   [link]
-  (let [matches (re-matches plain-link-re link)]
-    (when matches
-      {:type "plain-link"
-       :url matches})))
+  (when-let [matches (re-matches plain-link-re link)]
+    {:type "plain-link"
+     :url matches}))
 
 (defn- org-link?
   [link]
-  (let [matches (or (re-matches org-link-re-1 link)
-                    (re-matches org-link-re-2 link))]
-    (when matches
-      {:type "org-link"
-       :url (second matches)
-       :label (nth matches 2 nil)})))
+  (when-let [matches (or (re-matches org-link-re-1 link)
+                         (re-matches org-link-re-2 link))]
+    {:type "org-link"
+     :url (second matches)
+     :label (nth matches 2 nil)}))
 
 (defn- markdown-link?
   [link]
-  (let [matches (re-matches markdown-link-re link)]
-    (when matches
-      {:type "markdown-link"
-       :url (nth matches 2)
-       :label (second matches)})))
+  (when-let [matches (re-matches markdown-link-re link)]
+    {:type "markdown-link"
+     :url (nth matches 2)
+     :label (second matches)}))
 
 (defn link?
   [link]

--- a/src/main/frontend/handler/link.cljs
+++ b/src/main/frontend/handler/link.cljs
@@ -1,7 +1,7 @@
 (ns frontend.handler.link
   (:require [frontend.util :as util]))
 
-(def plain-link "(\b(https?|file)://)?[-A-Za-z0-9+&@#/%?=~_|!:,.;]+[-A-Za-z0-9+&@#/%=~_|]")
+(def plain-link "(\bhttps?://)?[-A-Za-z0-9+&@#/%?=~_|!:,.;]+[-A-Za-z0-9+&@#/%=~_|]")
 (def plain-link-re (re-pattern plain-link))
 (def org-link-re-1 (re-pattern (util/format "\\[\\[(%s)\\]\\[(.+)\\]\\]" plain-link)))
 (def org-link-re-2 (re-pattern (util/format "\\[\\[(%s)\\]\\]" plain-link)))


### PR DESCRIPTION
Fix #3519

**EDIT:**

Use a simpler regexp.