### PR TITLE
Refine file editing experience, fix file switching bug

### DIFF
--- a/src/main/frontend/components/file.cljs
+++ b/src/main/frontend/components/file.cljs
@@ -2,6 +2,7 @@
   (:require [cljs-time.coerce :as tc]
             [cljs-time.core :as t]
             [clojure.string :as string]
+            [datascript.core :as dc]
             [frontend.components.content :as content]
             [frontend.components.lazy-editor :as lazy-editor]
             [frontend.components.svg :as svg]
@@ -73,11 +74,12 @@
   (let [path (get-path state)
         format (format/get-format path)
         page (db/get-file-page path)
+        random-id (str (dc/squuid))
         config? (= path (config/get-config-path))]
     (rum/with-context [[tongue] i18n/*tongue-context*]
-      [:div.file {:id (str "file-" path)}
+      [:div.file {:id (str "file-edit-wrapper-" random-id)}
        [:h1.title
-        path]
+        [:bdi path]]
        (when page
          [:div.text-sm.mb-4.ml-1 "Page: "
           [:a.bg-base-2.p-1.ml-1 {:style {:border-radius 4}
@@ -118,7 +120,11 @@
                  mode (util/get-file-ext path)
                  mode (if (contains? #{"edn" "clj" "cljc" "cljs" "clojure"} mode) "text/x-clojure" mode)]
              (lazy-editor/editor {:file? true
-                                  :file-path path} path {:data-lang mode} content {})))
+                                  :file-path path}
+                                 (str "file-edit-" random-id)
+                                 {:data-lang mode}
+                                 content
+                                 {})))
 
          :else
          [:div (tongue :file/format-not-supported (name format))])])))

--- a/src/main/frontend/fs/nfs.cljs
+++ b/src/main/frontend/fs/nfs.cljs
@@ -173,7 +173,7 @@
                          (not (string/blank? db-content))
                          (not (:skip-compare? opts))
                          (not contents-matched?)
-                         (not (contains? #{"excalidraw" "edn"} ext))
+                         (not (contains? #{"excalidraw" "edn" "css"} ext))
                          (not (string/includes? path "/.recycle/"))
                          (zero? pending-writes))
                       (p/let [local-content (encrypt/decrypt local-content)]

--- a/src/main/frontend/fs/node.cljs
+++ b/src/main/frontend/fs/node.cljs
@@ -62,7 +62,7 @@
         (and
          (not= stat :not-found)         ; file on the disk was deleted
          (not contents-matched?)
-         (not (contains? #{"excalidraw" "edn"} ext))
+         (not (contains? #{"excalidraw" "edn" "css"} ext))
          (not (string/includes? path "/.recycle/"))
          (zero? pending-writes))
         (do


### PR DESCRIPTION
fix(editor): more stable file edit

- update element state when switching files #3415
- notification when saved
- minor style change
- refine editor element id gen, use UUID
- add trailing newline to the saved file

Fix #3415