### PR TITLE
fix: alias is not considered from shortcut / graph / press enter visit

### DIFF
--- a/e2e-tests/page-alias.spec.ts
+++ b/e2e-tests/page-alias.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 import { test } from './fixtures'
-import { IsMac, createRandomPage, newBlock, lastBlock } from './utils'
+import { IsMac, createRandomPage, newBlock, newInnerBlock, lastBlock, lastInnerBlock } from './utils'
 
 
 test('page alias', async ({ page }) => {
@@ -30,27 +30,27 @@ test('page alias', async ({ page }) => {
   await page.keyboard.press(hotkeyOpenLink)
 
   // shortcut opening test
-  await lastBlock(page, true)
+  await lastInnerBlock(page)
   expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('page alias test content')
-  await newBlock(page, true)
+  await newInnerBlock(page)
   await page.type(':nth-match(textarea, 1)', 'yet another page alias test content')
   await page.keyboard.press(hotkeyBack)
 
   // pressing enter opening test
-  await lastBlock(page, true)
+  await lastInnerBlock(page)
   await page.press(':nth-match(textarea, 1)', 'ArrowLeft')
   await page.press(':nth-match(textarea, 1)', 'ArrowLeft')
   await page.press(':nth-match(textarea, 1)', 'ArrowLeft')
   await page.press(':nth-match(textarea, 1)', 'Enter')
-  await lastBlock(page, true)
+  await lastInnerBlock(page)
   expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('yet another page alias test content')
-  await newBlock(page, true)
+  await newInnerBlock(page)
   await page.type(':nth-match(textarea, 1)', 'still another page alias test content')
   await page.keyboard.press(hotkeyBack)
 
   // clicking opening test
   await page.click('.page-blocks-inner .ls-block .page-ref >> nth=-1')
-  await lastBlock(page, true)
+  await lastInnerBlock(page)
   expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('still another page alias test content')
 
   // TODO: test alias from graph clicking

--- a/e2e-tests/page-alias.spec.ts
+++ b/e2e-tests/page-alias.spec.ts
@@ -1,0 +1,58 @@
+import { expect } from '@playwright/test'
+import { test } from './fixtures'
+import { IsMac, createRandomPage, newBlock, lastBlock } from './utils'
+
+
+test('page alias', async ({ page }) => {
+  let hotkeyOpenLink = 'Control+o'
+  let hotkeyBack = 'Control+['
+  if (IsMac) {
+    hotkeyOpenLink = 'Meta+o'
+    hotkeyBack = 'Meta+['
+  }
+
+  // shortcut opening test
+  await createRandomPage(page)
+
+  await page.fill(':nth-match(textarea, 1)', '[[page alias test target page]]')
+  await page.keyboard.press(hotkeyOpenLink)
+
+  // build target Page with alias
+  await page.type(':nth-match(textarea, 1)', 'alias:: [[page alias test alias page]]')
+  await page.press(':nth-match(textarea, 1)', 'Enter') // double Enter for exit property editing
+  await page.press(':nth-match(textarea, 1)', 'Enter')
+  await page.type(':nth-match(textarea, 1)', 'page alias test content')
+  await page.keyboard.press(hotkeyBack)
+
+  // create alias ref in origin Page
+  await newBlock(page)
+  await page.type(':nth-match(textarea, 1)', '[[page alias test alias page]]')
+  await page.keyboard.press(hotkeyOpenLink)
+
+  // shortcut opening test
+  await lastBlock(page, true)
+  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('page alias test content')
+  await newBlock(page, true)
+  await page.type(':nth-match(textarea, 1)', 'yet another page alias test content')
+  await page.keyboard.press(hotkeyBack)
+
+  // pressing enter opening test
+  await lastBlock(page, true)
+  await page.press(':nth-match(textarea, 1)', 'ArrowLeft')
+  await page.press(':nth-match(textarea, 1)', 'ArrowLeft')
+  await page.press(':nth-match(textarea, 1)', 'ArrowLeft')
+  await page.press(':nth-match(textarea, 1)', 'Enter')
+  await lastBlock(page, true)
+  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('yet another page alias test content')
+  await newBlock(page, true)
+  await page.type(':nth-match(textarea, 1)', 'still another page alias test content')
+  await page.keyboard.press(hotkeyBack)
+
+  // clicking opening test
+  await page.click('.page-blocks-inner .ls-block .page-ref >> nth=-1')
+  await lastBlock(page, true)
+  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('still another page alias test content')
+
+  // TODO: test alias from graph clicking
+  // TODO: test alias from search clicking
+})

--- a/e2e-tests/utils.ts
+++ b/e2e-tests/utils.ts
@@ -36,20 +36,26 @@ export async function createRandomPage(page: Page) {
 }
 
 /**
-* Locate the last block in the editor
+* Locate the last block in the inner editor
 * @param page The Playwright Page object.
-* @param inner_only If true, only return the .page-inner-block which has no 
-extra blocks like linked references included. Defaults to false.
 * @returns The locator of the last block.
 */
-export async function lastBlock(page: Page, inner_only: Boolean = false): Promise<Locator> {
+export async function lastInnerBlock(page: Page): Promise<Locator> {
     // discard any popups
     await page.keyboard.press('Escape')
     // click last block
-    if (inner_only) 
-        await page.click('.page-blocks-inner .ls-block >> nth=-1')
-    else
-        await page.click('.ls-block >> nth=-1')
+    await page.click('.page-blocks-inner .ls-block >> nth=-1')
+    // wait for textarea
+    await page.waitForSelector(':nth-match(textarea, 1)', { state: 'visible' })
+
+    return page.locator(':nth-match(textarea, 1)')
+}
+
+export async function lastBlock(page: Page): Promise<Locator> {
+    // discard any popups
+    await page.keyboard.press('Escape')
+    // click last block
+    await page.click('.ls-block >> nth=-1')
     // wait for textarea
     await page.waitForSelector(':nth-match(textarea, 1)', { state: 'visible' })
 
@@ -57,14 +63,19 @@ export async function lastBlock(page: Page, inner_only: Boolean = false): Promis
 }
 
 /**
-* Create and locate a new block at the end of the editor
+* Create and locate a new block at the end of the inner editor
 * @param page The Playwright Page object 
-* @param inner_only If true, only consider the .page-inner-block that no extra 
-blocks like linked references considered. Defaults to false.
 * @returns The locator of the last block
 */
-export async function newBlock(page: Page, inner_only: Boolean = false): Promise<Locator> {
-    await lastBlock(page, inner_only)
+export async function newInnerBlock(page: Page): Promise<Locator> {
+    await lastInnerBlock(page)
+    await page.press(':nth-match(textarea, 1)', 'Enter')
+
+    return page.locator(':nth-match(textarea, 1)')
+}
+
+export async function newBlock(page: Page): Promise<Locator> {
+    await lastBlock(page)
     await page.press(':nth-match(textarea, 1)', 'Enter')
 
     return page.locator(':nth-match(textarea, 1)')

--- a/e2e-tests/utils.ts
+++ b/e2e-tests/utils.ts
@@ -35,19 +35,36 @@ export async function createRandomPage(page: Page) {
     await page.waitForSelector(':nth-match(textarea, 1)', { state: 'visible' })
 }
 
-export async function lastBlock(page: Page): Promise<Locator> {
+/**
+* Locate the last block in the editor
+* @param page The Playwright Page object.
+* @param inner_only If true, only return the .page-inner-block which has no 
+extra blocks like linked references included. Defaults to false.
+* @returns The locator of the last block.
+*/
+export async function lastBlock(page: Page, inner_only: Boolean = false): Promise<Locator> {
     // discard any popups
     await page.keyboard.press('Escape')
     // click last block
-    await page.click('.ls-block >> nth=-1')
+    if (inner_only) 
+        await page.click('.page-blocks-inner .ls-block >> nth=-1')
+    else
+        await page.click('.ls-block >> nth=-1')
     // wait for textarea
     await page.waitForSelector(':nth-match(textarea, 1)', { state: 'visible' })
 
     return page.locator(':nth-match(textarea, 1)')
 }
 
-export async function newBlock(page: Page): Promise<Locator> {
-    await lastBlock(page)
+/**
+* Create and locate a new block at the end of the editor
+* @param page The Playwright Page object 
+* @param inner_only If true, only consider the .page-inner-block that no extra 
+blocks like linked references considered. Defaults to false.
+* @returns The locator of the last block
+*/
+export async function newBlock(page: Page, inner_only: Boolean = false): Promise<Locator> {
+    await lastBlock(page, inner_only)
     await page.press(':nth-match(textarea, 1)', 'Enter')
 
     return page.locator(':nth-match(textarea, 1)')

--- a/src/main/frontend/extensions/graph.cljs
+++ b/src/main/frontend/extensions/graph.cljs
@@ -1,6 +1,7 @@
 (ns frontend.extensions.graph
   (:require [cljs-bean.core :as bean]
             [clojure.string :as string]
+            [frontend.db.model :as model]
             [frontend.extensions.graph.pixi :as pixi]
             [frontend.handler.route :as route-handler]
             [goog.object :as gobj]
@@ -30,20 +31,17 @@
 (defn on-click-handler [graph node event *focus-nodes *n-hops drag? dark?]
   ;; shift+click to select the page
   (if (or (gobj/get event "shiftKey") drag?)
-    (let [page-name (string/lower-case node)]
-      (when-not @*n-hops
+    ((when-not @*n-hops
         ;; Don't trigger re-render
-        (swap! *focus-nodes
-               (fn [v]
-                 (vec (distinct (conj v node))))))
+       (swap! *focus-nodes
+              (fn [v]
+                (vec (distinct (conj v node))))))
       ;; highlight current node
-      (let [node-attributes (-> (.getNodeAttributes (.-graph graph) node)
-                                (bean/->clj))]
-        (.setNodeAttribute (.-graph graph) node "parent" "ls-selected-nodes"))
-      (highlight-neighbours! graph node (set @*focus-nodes) dark?)
-      (highlight-edges! graph node dark?))
+     (.setNodeAttribute (.-graph graph) node "parent" "ls-selected-nodes")
+     (highlight-neighbours! graph node (set @*focus-nodes) dark?)
+     (highlight-edges! graph node dark?))
     (when-not drag?
-      (let [page-name (string/lower-case node)]
+      (let [page-name (model/get-redirect-page-name node)]
         (.unhoverNode ^js graph node)
         (route-handler/redirect-to-page! page-name)))))
 

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1281,6 +1281,7 @@
           (delete-blocks! repo blocks))))))
 
 (defn- get-nearest-page
+  "Return the nearset page-name (not dereferenced, may be an alias)"
   []
   (when-let [block (state/get-edit-block)]
     (when (:block/uuid block)
@@ -1315,7 +1316,7 @@
   []
   (when-let [page (get-nearest-page)]
     (when-not (string/blank? page)
-      (let [page-name (string/lower-case page)]
+      (let [page-name (db-model/get-redirect-page-name page)]
         (state/clear-edit!)
         (insert-first-page-block-if-not-exists! page-name)
         (route-handler/redirect-to-page! page-name)))))
@@ -2493,8 +2494,10 @@
                                  nil))
               "block-ref" (open-block-in-sidebar! (:link thing-at-point))
               "page-ref" (when-not (string/blank? (:link thing-at-point))
-                           (insert-first-page-block-if-not-exists! (:link thing-at-point))
-                           (route-handler/redirect-to-page! (:link thing-at-point)))
+                           (let [page (:link thing-at-point)
+                                 page-name (db-model/get-redirect-page-name page)]
+                             (insert-first-page-block-if-not-exists! page-name)
+                             (route-handler/redirect-to-page! page-name)))
               "list-item" (dwim-in-list state)
               "properties-drawer" (dwim-in-properties state))
 

--- a/src/main/frontend/handler/route.cljs
+++ b/src/main/frontend/handler/route.cljs
@@ -36,6 +36,7 @@
   (redirect! {:to :graph}))
 
 (defn redirect-to-page!
+  "Must ensure `page-name` is dereferenced (not an alias), or it will create a wrong new page with that name (#3511)."
   ([page-name]
    (recent-handler/add-page-to-recent! (state/get-current-repo) page-name)
    (redirect! {:to :page


### PR DESCRIPTION
- Should call `get-redirect-page-name` to check if a `page-name` is an alias of another page before redirect
- Partly related to #3511

**Fixed `redirect-to-page` invokes that alias is NOT working**
- [x]  On click shortcut `mod + o`: `follow-link-under-cursor!`
- [x]  On pressing `Enter` in page-ref: `keydown-new-block`
- [x]  On graph node clicking: `on-click-handler` in `src/main/frontend/extensions/graph.cljs`

Checked `redirect-to-page` invokes that alias is working
- On click `shift + mod + o`:  (db name only)
- On mouse click:  `page-cp` (calling `get-redirect-page-name`)
- On create page: `create!` if `re-direction` is `true` (happens when create new page in search modal)
- On zoom-in: `zoom-in!` (uuid only)
- On zoom-out: `zoom-out!` (db name only)
- On opening `default-home`: `main-content` (db name only)
- On search (db name only)

**E2E Tests**
- [x] Test alias functionality (mouse click, shortcut, pressing enter)
- Add argument `inner_only` to functions `lastBlock` and `newBlock` (see comments)