### PR TITLE
fix(style): refine shift-in animation of left-sidebar

### DIFF
--- a/src/main/frontend/components/sidebar.css
+++ b/src/main/frontend/components/sidebar.css
@@ -223,8 +223,6 @@
   &:before {
     content: " ";
     height: 3rem;
-    width: calc(var(--ls-left-sidebar-sm-width) - var(--ls-scrollbar-width));
-    transition: width .3s;
     background-color: var(--ls-primary-background-color);
     position: fixed;
     left: 0;
@@ -244,10 +242,6 @@
 
     &.is-open {
       width: var(--ls-left-sidebar-width);
-
-      &:before {
-        width: calc(var(--ls-left-sidebar-width) - var(--ls-scrollbar-width));
-      }
     }
 
     > .shade-mask {


### PR DESCRIPTION

https://user-images.githubusercontent.com/72891/146886912-14ec75d1-1b71-4a33-b9ac-3a6457f2e337.mov

This left sidebar's animation is divided into header and body parts, which is not in sync.
Caused by `:before` pseudo-element.