### PR TITLE
fix: failed to insert a new timestamp in a block

### DIFF
--- a/src/main/frontend/components/datetime.cljs
+++ b/src/main/frontend/components/datetime.cljs
@@ -108,10 +108,10 @@
                                      block-id (or (:block/uuid (state/get-edit-block))
                                                   (:block/uuid block))
                                      typ (or @commands/*current-command typ)]
-                                 (state/clear-edit!)
                                  (editor-handler/set-block-timestamp! block-id
                                                                       typ
                                                                       text)
+                                 (state/clear-edit!)
                                  (when show?
                                    (reset! show? false))))
                              (clear-timestamp!)


### PR DESCRIPTION
revert https://github.com/logseq/logseq/pull/3481, it broke the workflow that insert a new timestamp in a block.