### PR TITLE
fix: shortcut warning at startup

### DIFF
--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -398,12 +398,12 @@
 
    :editor/open-file-in-default-app (when (util/electron?)
                                       {:desc    "Open file in default app"
-                                       :binding nil
+                                       :binding false
                                        :fn      page-handler/open-file-in-default-app})
 
    :editor/open-file-in-directory   (when (util/electron?)
                                       {:desc    "Open file in parent directory"
-                                       :binding nil
+                                       :binding false
                                        :fn      page-handler/open-file-in-directory})
 
    :ui/toggle-wide-mode             {:desc    "Toggle wide mode"


### PR DESCRIPTION
- set to false to disable silently

![image](https://user-images.githubusercontent.com/72891/147019694-68e1a1a0-937b-4bdd-a5c1-c43ab5960bb0.png)

