### PR TITLE
ci: add android apk build

### DIFF
--- a/.github/workflows/build-mobile-release.yml
+++ b/.github/workflows/build-mobile-release.yml
@@ -1,0 +1,110 @@
+# This is the main mobile application release workflow for both nightly and beta/stable releases.
+
+name: Build-Mobile-Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      build-target:
+        description: 'Build Target ("nightly"/"beta")'
+        type: string
+        required: true
+        default: "beta"
+
+env:
+  CLOJURE_VERSION: '1.10.1.763'
+  NODE_VERSION: '16'
+
+jobs:
+  compile-android:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache yarn cache directory
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 1.8
+
+      - name: Cache clojure deps
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: ${{ runner.os }}-clojure-lib-${{ hashFiles('**/deps.edn') }}
+
+      - name: Setup clojure
+        uses: DeLaGuardo/setup-clojure@3.5
+        with:
+          cli: ${{ env.CLOJURE_VERSION }}
+
+      - name: Retrieve tag version
+        id: ref
+        run: |
+          pkgver=$(node ./scripts/get-pkg-version.js "${{ github.event.inputs.build-target }}")
+          echo ::set-output name=version::$pkgver
+
+      - name: Update Nightly APP Version
+        if: ${{ github.event.inputs.build-target == 'nightly' || github.event_name == 'schedule' }}
+        run: |
+          sed -i 's/defonce version ".*"/defonce version "${{ steps.ref.outputs.version }}"/g' src/main/frontend/version.cljs
+
+      - name: Compile CLJS
+        run: yarn install && yarn release
+
+      - name: Prepare public Directory
+        run: |
+          cp -r static public/
+          rm -rvf public/static/js/publishing
+          rm -rvf public/workspaces
+          rm -rvf public/static/js/*.js.map || true
+          rm -rvf public/static/*.*
+          rm -rvf public/static/ios
+          rm -rvf android/app/src/main/assets/public || true
+
+      - name: Sync public to Android Project
+        run: npx cap sync
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+
+      - name: Build Android
+        run: |
+          ./gradlew clean
+          ./gradlew zipApksForRelease
+        working-directory: android
+
+      - name: Sign Android APK
+        run: |
+          echo ${{ secrets.ANDROID_KEYSTORE }} | base64 -d > keystore.jks
+          /usr/local/lib/android/sdk/build-tools/30.0.3/apksigner sign \
+            --ks keystore.jks --ks-pass "pass:${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" \
+            --in app/build/outputs/apk/release/app-release-unsigned.apk \
+            --out app-signed.apk
+        working-directory: android
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: logseq-android-apk
+          path: android/app-signed.apk


### PR DESCRIPTION
NOTE: Because the release process for the mobile version of the application has not yet been determined, no release operations are currently being performed. The apk can be downloaded from the Github Actions page.

This workflow requires two secrets for signing apk:

- ANDROID_KEYSTORE: base64 encoded of keystore.jks
- ANDROID_KEYSTORE_PASSWORD: the password of keystore.jks, with no special chars for now