### PR TITLE
Ci: add android build to nightly

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,6 +1,7 @@
-# This is the main mobile application release workflow for both nightly and beta/stable releases.
+# This is the main Android apk build workflow for both nightly and beta releases.
+# This is also configured to run as a workflow_call.
 
-name: Build-Mobile-Release
+name: Build-Android
 
 on:
   workflow_dispatch:
@@ -10,14 +11,24 @@ on:
         type: string
         required: true
         default: "beta"
+  workflow_call:
+    inputs:
+      build-target:
+        type: string
+        required: true
+    secrets:
+      ANDROID_KEYSTORE:
+        required: true
+      ANDROID_KEYSTORE_PASSWORD:
+        required: true
 
 env:
   CLOJURE_VERSION: '1.10.1.763'
   NODE_VERSION: '16'
 
 jobs:
-  compile-android:
-    runs-on: ubuntu-20.04
+  build-apk:
+    runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v2
@@ -61,13 +72,14 @@ jobs:
       - name: Retrieve tag version
         id: ref
         run: |
-          pkgver=$(node ./scripts/get-pkg-version.js "${{ github.event.inputs.build-target }}")
+          pkgver=$(node ./scripts/get-pkg-version.js "${{ inputs.build-target || github.event.inputs.build-target }}")
           echo ::set-output name=version::$pkgver
 
       - name: Update Nightly APP Version
-        if: ${{ github.event.inputs.build-target == 'nightly' || github.event_name == 'schedule' }}
+        if: ${{ inputs.build-target == 'nightly' || github.event.inputs.build-target == 'nightly' }}
         run: |
           sed -i 's/defonce version ".*"/defonce version "${{ steps.ref.outputs.version }}"/g' src/main/frontend/version.cljs
+          sed -i 's/versionName ".*"/versionName "${{ steps.ref.outputs.version }}"/g' android/app/build.gradle
 
       - name: Compile CLJS
         run: yarn install && yarn release
@@ -103,8 +115,13 @@ jobs:
             --out app-signed.apk
         working-directory: android
 
+      - name: Rename Apk
+        run: |
+          mkdir builds
+          mv android/app-signed.apk ./builds/Logseq-android-${{ steps.ref.outputs.version }}.apk
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: logseq-android-apk
-          path: android/app-signed.apk
+          name: logseq-android-builds
+          path: builds

--- a/.github/workflows/build-desktop-release.yml
+++ b/.github/workflows/build-desktop-release.yml
@@ -350,9 +350,18 @@ jobs:
           name: logseq-darwin-arm64-builds
           path: builds
 
+  # reuse workflow via workflow_call
+  build-android:
+    uses: logseq/logseq/.github/workflows/build-android.yml@master
+    with:
+      build-target: "${{ github.event.inputs.build-target }}"
+    secrets:
+      ANDROID_KEYSTORE: "${{ secrets.ANDROID_KEYSTORE }}"
+      ANDROID_KEYSTORE_PASSWORD: "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}"
+
   nightly-release:
     if: ${{ github.event_name == 'schedule' || github.event.inputs.build-target == 'nightly' }}
-    needs: [ build-macos-x64, build-macos-arm64, build-linux, build-windows ]
+    needs: [ build-macos-x64, build-macos-arm64, build-linux, build-windows, build-android ]
     runs-on: ubuntu-18.04
     steps:
       - name: Download MacOS x64 Artifacts
@@ -379,11 +388,18 @@ jobs:
           name: logseq-win64-builds
           path: ./
 
+      - name: Download Android Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: logseq-android-builds
+          path: ./
+
       - name: Generate SHA256 checksums
         run: |
           sha256sum *-darwin-* > SHA256SUMS.txt
           sha256sum *-win-* >> SHA256SUMS.txt
           sha256sum *-linux-* >> SHA256SUMS.txt
+          sha256sum *.apk >> SHA256SUMS.txt
           cat SHA256SUMS.txt
 
       - name: List files
@@ -395,7 +411,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: nightly
-          name: 'Desktop APP Nightly Release $$'
+          name: 'Desktop/Mobile APP Nightly Release $$'
           draft: false
           prerelease: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.is-pre-release) || (github.event_name == 'schedule')}}
           body: |
@@ -407,11 +423,12 @@ jobs:
             ./*.dmg
             ./*.exe
             ./*.AppImage
+            ./*.apk
 
   release:
     # NOTE: For now, we only have beta channel to be released on Github
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build-target != 'nightly' }}
-    needs: [ build-macos-x64, build-macos-arm64, build-linux, build-windows ]
+    needs: [ build-macos-x64, build-macos-arm64, build-linux, build-windows, build-android ]
     runs-on: ubuntu-18.04
     steps:
       - name: Download MacOS x64 Artifacts
@@ -436,6 +453,12 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: logseq-win64-builds
+          path: ./
+
+      - name: Download Android Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: logseq-android-builds
           path: ./
 
       - name: List files
@@ -452,6 +475,7 @@ jobs:
           sha256sum *-darwin-* > SHA256SUMS.txt
           sha256sum *-win-* >> SHA256SUMS.txt
           sha256sum *-linux-* >> SHA256SUMS.txt
+          sha256sum *.apk >> SHA256SUMS.txt
           cat SHA256SUMS.txt
 
       - name: Create Release Draft
@@ -471,3 +495,4 @@ jobs:
             ./*.dmg
             ./*.exe
             ./*.AppImage
+            ./*.apk

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,7 +7,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 11
-        versionName "0.5.1"
+        versionName "0.5.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.


### PR DESCRIPTION
- reuse build-android.yml in nightly/beta release workflow
- bump Android app version to 0.5.4

#3541 will add Android version to bump-version script later.