### PR TITLE
Enhance block toggle feature

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1334,17 +1334,20 @@
 
 (defn- bullet-on-click
   [e block uuid]
-  (if (-> block :block/properties :collapsed)
-    (editor-handler/expand-all! uuid (:block/level block)))
-  (if (gobj/get e "shiftKey")
-    (do
-      (state/sidebar-add-block!
-       (state/get-current-repo)
-       (:db/id block)
-       :block
-       block)
-      (util/stop e))
-    (route-handler/redirect-to-page! uuid)))
+  (let [block (if (-> block :block/properties :collapsed)
+                (do (editor-handler/expand-block! uuid)
+                    (update-in block [:block/properties] dissoc :collapsed))
+               block)]
+    (if (gobj/get e "shiftKey")
+      (do
+        (state/sidebar-add-block!
+          (state/get-current-repo)
+          (:db/id block)
+          :block
+          block)
+        (util/stop e))
+      (route-handler/redirect-to-page! uuid))
+    ))
 
 (defn- block-left-border-on-click
   [e children]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1336,20 +1336,15 @@
 
 (defn- bullet-on-click
   [e block uuid]
-  (let [block (if (-> block :block/properties :collapsed)
-                (do (editor-handler/expand-block! uuid)
-                    (update-in block [:block/properties] dissoc :collapsed))
-               block)]
-    (if (gobj/get e "shiftKey")
-      (do
-        (state/sidebar-add-block!
-          (state/get-current-repo)
-          (:db/id block)
-          :block
-          block)
-        (util/stop e))
-      (route-handler/redirect-to-page! uuid))
-    ))
+  (if (gobj/get e "shiftKey")
+    (do
+      (state/sidebar-add-block!
+       (state/get-current-repo)
+       (:db/id block)
+       :block
+       block)
+      (util/stop e))
+    (route-handler/redirect-to-page! uuid)))
 
 (defn- block-left-border-on-click
   [e children]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1334,6 +1334,8 @@
 
 (defn- bullet-on-click
   [e block uuid]
+  (if (-> block :block/properties :collapsed)
+    (editor-handler/expand-all! uuid (:block/level block)))
   (if (gobj/get e "shiftKey")
     (do
       (state/sidebar-add-block!
@@ -1344,6 +1346,14 @@
       (util/stop e))
     (route-handler/redirect-to-page! uuid)))
 
+(defn- block-left-border-on-click
+  [e children]
+  (if (< (.-offsetX (.-nativeEvent e)) 10)
+    (let [block-ids (map :block/uuid children)]
+      (if (some editor-handler/collapsable? block-ids)
+        (dorun (map editor-handler/collapse-block! block-ids))
+        (dorun (map editor-handler/expand-block! block-ids))))))
+
 (rum/defc block-children < rum/reactive
   [config children collapsed? *ref-collapsed?]
   (let [ref? (:ref? config)
@@ -1353,12 +1363,13 @@
                (seq children)
                (not collapsed?))
       (let [doc-mode? (state/sub :document/mode?)]
-        [:div.block-children {:style {:margin-left (if doc-mode? 18
-                                                       (if (or (mobile-util/native-android?)
-                                                               (mobile-util/native-iphone?))
-                                                         22
-                                                         29))
-                                      :display (if collapsed? "none" "")}}
+        [:div.block-children {:style    {:margin-left (if doc-mode? 18
+                                                                    (if (or (mobile-util/native-android?)
+                                                                            (mobile-util/native-iphone?))
+                                                                      22
+                                                                      29))
+                                         :display     (if collapsed? "none" "")}
+                              :on-click (fn [event] (block-left-border-on-click event children))}
          (for [child children]
            (when (map? child)
              (let [child (dissoc child :block/meta)

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -133,10 +133,15 @@
   }
 }
 
-.block-children {
-  border-left: 1px solid;
-  border-left-color: var(--ls-guideline-color, #ddd);
+.block-children-left-border {
+  width: 3px;
+  padding-right: 2px;
+  cursor: pointer;
+  background-clip: content-box;
+  background-color: var(--ls-guideline-color, #ddd);
+}
 
+.block-children {
   padding-top: 2px;
   padding-bottom: 3px;
 
@@ -451,8 +456,8 @@ a:hover > .bullet-container {
 .doc-mode {
   margin-left: -16px;
 
-  .block-children {
-    border-left: none;
+  .block-children-left-border {
+    display: none;
   }
 
   .hide-inner-bullet .bullet {

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -234,6 +234,18 @@
                           (editor-handler/cut-block! block-id))}
              "Cut")
 
+            (ui/menu-link
+              {:key      "Expand all"
+               :on-click (fn [_e]
+                           (editor-handler/expand-all! block-id))}
+              "Expand all")
+
+            (ui/menu-link
+              {:key      "Collapse all"
+               :on-click (fn [_e]
+                           (editor-handler/collapse-all! block-id))}
+              "Collapse all")
+
             (when (state/sub [:plugin/simple-commands])
               (when-let [cmds (state/get-plugins-commands-with-type :block-context-menu-item)]
                 (for [[_ {:keys [key label] :as cmd} action pid] cmds]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3439,9 +3439,9 @@
                (doseq [{:block/keys [uuid]} blocks-to-collapse]
                  (collapse-block! uuid))))))))))
 
-(defn- collapse-all!
+(defn collapse-all!
   ([]
-   (collapse-all! nil))
+   (collapse-all! nil nil))
   ([block-id]
    (collapse-all! block-id nil))
   ([block-id max-level]
@@ -3450,9 +3450,9 @@
        (doseq [{:block/keys [uuid]} blocks-to-collapse]
          (collapse-block! uuid))))))
 
-(defn- expand-all!
+(defn expand-all!
   ([]
-   (expand-all! nil))
+   (expand-all! nil nil))
   ([block-id]
    (expand-all! block-id nil))
   ([block-id max-level]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3317,7 +3317,6 @@
 (defn all-blocks-with-level
   "Return all blocks associated with correct level
    if :root-block is not nil, only return root block with its children
-   if :max-level is not nil, only return blocks that level <= :max-level
    if :expanded? true, return expanded children
    if :collapse? true, return without any collapsed children
    for example:
@@ -3331,7 +3330,7 @@
     [{:block a :level 1}
      {:block b :level 2}
      {:block e :level 2}]"
-  [{:keys [collapse? expanded? root-block max-level] :or {collapse? false expanded? false root-block nil max-level nil}}]
+  [{:keys [collapse? expanded? root-block] :or {collapse? false expanded? false root-block nil}}]
   (when-let [page (or (state/get-current-page)
                       (date/today))]
     (->>
@@ -3355,9 +3354,6 @@
 
      (#(cond->> %
          expanded? (filter (fn [b] (collapsable? (:block/uuid b))))))
-
-     (#(cond->> %
-         max-level (filter (fn [b] (>= max-level (:block/level b))))))
 
      (map (fn [x] (dissoc x :block/children))))))
 
@@ -3441,22 +3437,18 @@
 
 (defn collapse-all!
   ([]
-   (collapse-all! nil nil))
+   (collapse-all! nil))
   ([block-id]
-   (collapse-all! block-id nil))
-  ([block-id max-level]
-   (let [blocks-to-collapse (all-blocks-with-level {:expanded? true :root-block block-id :max-level max-level})]
+   (let [blocks-to-collapse (all-blocks-with-level {:expanded? true :root-block block-id})]
      (when (seq blocks-to-collapse)
        (doseq [{:block/keys [uuid]} blocks-to-collapse]
          (collapse-block! uuid))))))
 
 (defn expand-all!
   ([]
-   (expand-all! nil nil))
+   (expand-all! nil))
   ([block-id]
-   (expand-all! block-id nil))
-  ([block-id max-level]
-   (->> (all-blocks-with-level {:root-block block-id :max-level max-level})
+   (->> (all-blocks-with-level {:root-block block-id})
         (filter (fn [b] (-> b :block/properties :collapsed)))
         (map (comp expand-block! :block/uuid))
         doall)))


### PR DESCRIPTION
There are several improvements list below:
* fix `t o` doesn't collapse all blocks 
* add `Exppand all` and `Collapse all` menu item for toggling block 
*  auto expand children of the top block if collapse(fix #3222) 
* basic support for toggling by clicking the left bar of the block (see https://discuss.logseq.com/t/collapse-all-child-bullets-by-clicking-the-alignment-line/1937/3)

### Fix `t o` doesn't collapse all blocks 
For the structure below:
![image](https://user-images.githubusercontent.com/5035364/147238813-718fff71-004c-483d-bd30-1e648f8990e9.png)

if we collapse `b` block
![image](https://user-images.githubusercontent.com/5035364/147238990-bfe90357-b3cf-4ee6-8019-823437edf6a8.png)

and use `t o` to collpase all block, and manually expand `b` block again, we will find `c` is not collapsed.

**wrong behavior after expand b block**
![image](https://user-images.githubusercontent.com/5035364/147239158-6f9a1ba4-eb4e-49e6-bac9-ee4549fad24e.png)

**expected behavior**
![image](https://user-images.githubusercontent.com/5035364/147239229-60aacae3-d924-4a87-8f50-1d2d9b7ac672.png)

### `Exppand all` and `Collapse all`
Now we can toggle in the block level.
![image](https://user-images.githubusercontent.com/5035364/147239358-6c48620e-d5c5-4153-a8c3-35cf69556390.png)

### auto expand children of the top block if collapse
When we jump to the block page, if the top block is collapse, expand its next level children.
fix #3222


### basic support for toggling by clicking the left bar of the block 
see  https://discuss.logseq.com/t/collapse-all-child-bullets-by-clicking-the-alignment-line/1937/3 for detail.
But for some css issues, sometimes we will click on the trigger area of the children and don't trigger the right behavior.