### PR TITLE
enhance: move the editor into the center of the viewport

### DIFF
--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -903,7 +903,10 @@
              ;; it seems to me textarea autoresize is completely broken
              #_(set! (.-value input) (string/trim content)))
            (when move-cursor?
-             (cursor/move-cursor-to input pos))))))))
+             (cursor/move-cursor-to input pos))
+
+           (when (or (util/mobile?) (mobile-util/is-native-platform?))
+             (util/make-el-center-if-near-top input))))))))
 
 (defn clear-edit!
   []

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1489,6 +1489,12 @@
               false)))))
 
 #?(:cljs
+  (defn make-el-into-center-viewport
+    [^js/HTMLElement el]
+    (when el
+      (.scrollIntoView el #js {:block "center" :behavior "smooth"}))))
+
+#?(:cljs
    (defn make-el-into-viewport
      ([^js/HTMLElement el]
       (make-el-into-viewport el 60))
@@ -1500,11 +1506,20 @@
                           target-bottom (.-bottom (.getBoundingClientRect el))]
                       (when (> (+ target-bottom (or (safe-parse-int offset) 0))
                                viewport-height)
-                        (.scrollIntoView el #js {:block "center" :behavior "smooth"})))]
+                        (make-el-into-center-viewport el)))]
 
         (if async?
           (js/setTimeout #(handle) 64)
           (handle))))))
+
+#?(:cljs
+   (defn make-el-center-if-near-top
+     ([^js/HTMLElement el]
+      (make-el-center-if-near-top el 80))
+     ([^js/HTMLElement el offset]
+      (let [target-top (.-top (.getBoundingClientRect el))]
+        (when (<= target-top (or (safe-parse-int offset) 0))
+          (make-el-into-center-viewport el))))))
 
 #?(:cljs
    (defn sm-breakpoint?


### PR DESCRIPTION
Move the editor into the center of the viewport if it's near the top.

It can be triggered by deleting a block near the top.