### PR TITLE
fix(ios): unhide logseq folder in iCloud Drive

### DIFF
--- a/ios/App/App/FileContainer.swift
+++ b/ios/App/App/FileContainer.swift
@@ -32,6 +32,19 @@ public class FileContainer: CAPPlugin, UIDocumentPickerDelegate {
             }
         }
 
+        let str = ""
+        guard let filename = self.containerUrl?.appendingPathComponent(".logseq") else {
+            return
+        }
+        
+        if !FileManager.default.fileExists(atPath: filename.path) {
+            do {
+                try str.write(to: filename, atomically: true, encoding:  String.Encoding.utf8)
+            }
+            catch {
+                // failed to write file – bad permissions, bad filename, missing permissions, or more likely it can't be converted to the encoding
+            }
+        }
         self._call?.resolve([
             "path": self.containerUrl?.path
                             ])


### PR DESCRIPTION
add an empty .logseq file at the container root to reveal the logseq folder.