### PR TITLE
enhance: block expand/collapse toggle

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1349,9 +1349,10 @@
 (defn- toggle-block-children
   [e children]
   (let [block-ids (map :block/uuid children)]
-    (if (some editor-handler/collapsable? block-ids)
-      (dorun (map editor-handler/collapse-block! block-ids))
-      (dorun (map editor-handler/expand-block! block-ids)))))
+    (dorun
+     (if (some editor-handler/collapsable? block-ids)
+       (map editor-handler/collapse-block! block-ids)
+       (map editor-handler/expand-block! block-ids)))))
 
 (rum/defc block-children < rum/reactive
   [config children collapsed? *ref-collapsed?]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -185,23 +185,23 @@
       (ui/resize-provider
        (ui/resize-consumer
         (cond->
-         {:className "resize image-resize"
-          :onSizeChanged (fn [value]
-                           (when (and (not @*resizing-image?)
-                                      (some? @size)
-                                      (not= value @size))
-                             (reset! *resizing-image? true))
-                           (reset! size value))
-          :onMouseUp (fn []
-                       (when (and @size @*resizing-image?)
-                         (when-let [block-id (:block/uuid config)]
-                           (let [size (bean/->clj @size)]
-                             (editor-handler/resize-image! block-id metadata full_text size))))
-                       (when @*resizing-image?
+          {:className "resize image-resize"
+           :onSizeChanged (fn [value]
+                            (when (and (not @*resizing-image?)
+                                       (some? @size)
+                                       (not= value @size))
+                              (reset! *resizing-image? true))
+                            (reset! size value))
+           :onMouseUp (fn []
+                        (when (and @size @*resizing-image?)
+                          (when-let [block-id (:block/uuid config)]
+                            (let [size (bean/->clj @size)]
+                              (editor-handler/resize-image! block-id metadata full_text size))))
+                        (when @*resizing-image?
                           ;; TODO: need a better way to prevent the clicking to edit current block
-                         (js/setTimeout #(reset! *resizing-image? false) 200)))
-          :onClick (fn [e]
-                     (when @*resizing-image? (util/stop e)))}
+                          (js/setTimeout #(reset! *resizing-image? false) 200)))
+           :onClick (fn [e]
+                      (when @*resizing-image? (util/stop e)))}
           (and (:width metadata) (not (util/mobile?)))
           (assoc :style {:width (:width metadata)}))
         [:div.asset-container
@@ -476,7 +476,7 @@
           redirect-page-name (or (and (= :org (state/get-preferred-format))
                                       (:org-mode/insert-file-link? (state/get-config))
                                       redirect-page-name)
-                              (model/get-redirect-page-name page-name (:block/alias? config)))
+                                 (model/get-redirect-page-name page-name (:block/alias? config)))
           inner (page-inner config
                             page-name-in-block
                             page-name
@@ -922,9 +922,9 @@
             (->elem
              :a
              (cond->
-              {:href      (str "file://" path)
-               :data-href path
-               :target    "_blank"}
+               {:href      (str "file://" path)
+                :data-href path
+                :target    "_blank"}
                title
                (assoc :title title))
              (map-inline config label)))
@@ -981,9 +981,9 @@
                     (->elem
                      :a
                      (cond->
-                      {:href      (str "file://" href*)
-                       :data-href href*
-                       :target    "_blank"}
+                       {:href      (str "file://" href*)
+                        :data-href href*
+                        :target    "_blank"}
                        title
                        (assoc :title title))
                      (map-inline config label))))))
@@ -1007,20 +1007,20 @@
 
             (= protocol "ar")
             (->elem
-              :a.external-link
-              (cond->
-                {:href (ar-url->http-url href)
-                 :target "_blank"}
-                title
-                (assoc :title title))
-              (map-inline config label))
+             :a.external-link
+             (cond->
+               {:href (ar-url->http-url href)
+                :target "_blank"}
+               title
+               (assoc :title title))
+             (map-inline config label))
 
             :else
             (->elem
              :a.external-link
              (cond->
-              {:href href
-               :target "_blank"}
+               {:href href
+                :target "_blank"}
                title
                (assoc :title title))
              (map-inline config label))))))
@@ -1355,9 +1355,9 @@
        (map editor-handler/expand-block! block-ids)))))
 
 (rum/defc block-children < rum/reactive
-  [config children collapsed? *ref-collapsed?]
+  [config children collapsed? *default-collapsed?]
   (let [ref? (:ref? config)
-        collapsed? (if ref? (rum/react *ref-collapsed?) collapsed?)
+        collapsed? (if ref? (rum/react *default-collapsed?) collapsed?)
         children (and (coll? children) (filter map? children))]
     (when (and (coll? children)
                (seq children)
@@ -1394,7 +1394,7 @@
    (every? #(= % ["Horizontal_Rule"]) body)))
 
 (rum/defcs block-control < rum/reactive
-  [state config block uuid block-id body children collapsed? *ref-collapsed? *control-show? edit?]
+  [state config block uuid block-id body children collapsed? *control-show? edit?]
   (let [doc-mode? (state/sub :document/mode?)
         has-children-blocks? (and (coll? children) (seq children))
         has-child? (and
@@ -1406,9 +1406,7 @@
                                 (seq body))
                            has-children-blocks?)
                        (util/react *control-show?))
-        ref-collapsed? (util/react *ref-collapsed?)
         ref? (:ref? config)
-        collapsed? (if ref? ref-collapsed? collapsed?)
         empty-content? (block-content-empty? block)]
     [:div.mr-1.flex.flex-row.items-center.sm:mr-2
      {:style {:height 24
@@ -1420,11 +1418,9 @@
        :on-click (fn [event]
                    (util/stop event)
                    (when-not (and (not collapsed?) (not has-child?))
-                     (if ref?
-                       (swap! *ref-collapsed? not)
-                       (if collapsed?
-                         (editor-handler/expand-block! uuid)
-                         (editor-handler/collapse-block! uuid)))))}
+                     (if collapsed?
+                       (editor-handler/expand-block! uuid)
+                       (editor-handler/collapse-block! uuid))))}
       [:span {:class (if control-show? "control-show" "control-hide")}
        (ui/rotating-arrow collapsed?)]]
      (let [bullet [:a {:on-click (fn [event]
@@ -1568,7 +1564,7 @@
 
 (defn build-block-title
   [config {:block/keys [title marker pre-block? properties level heading-level]
-                                :as t}]
+           :as t}]
   (let [config (assoc config :block t)
         slide? (boolean (:slide? config))
         block-ref? (:block-ref? config)
@@ -1620,7 +1616,7 @@
           (when (and (util/electron?) (not= block-type :default))
             [:a.prefix-link
              {:on-click #(case block-type
-                            ;; pdf annotation
+                           ;; pdf annotation
                            :annotation (pdf-assets/open-block-ref! t)
                            (.preventDefault %))}
 
@@ -1793,12 +1789,12 @@
            (not (:block/pre-block? block)))
       (let [move-to (rum/react *move-to)]
         (when-not
-         (or (and top? (not= move-to :top))
-             (and (not top?) (= move-to :top))
-             (and block-content? (not= move-to :nested))
-             (and (not block-content?)
-                  (seq (:block/children block))
-                  (= move-to :nested)))
+            (or (and top? (not= move-to :top))
+                (and (not top?) (= move-to :top))
+                (and block-content? (not= move-to :nested))
+                (and (not block-content?)
+                     (seq (:block/children block))
+                     (= move-to :nested)))
           (dnd-separator move-to block-content?))))))
 
 (defn clock-summary-cp
@@ -1841,12 +1837,12 @@
                          :on-mouse-down ; TODO: it seems that Safari doesn't work well with on-mouse-down
                          )
         attrs (cond->
-                  {:blockid       (str uuid)
-                   :data-type (name block-type)
-                   :style {:width "100%"}}
-                  (not block-ref?)
-                  (assoc mouse-down-key (fn [e]
-                                          (block-content-on-mouse-down e block block-id content edit-input-id))))]
+                {:blockid       (str uuid)
+                 :data-type (name block-type)
+                 :style {:width "100%"}}
+                (not block-ref?)
+                (assoc mouse-down-key (fn [e]
+                                        (block-content-on-mouse-down e block block-id content edit-input-id))))]
     [:div.block-content.inline
      (cond-> {:id (str "block-content-" uuid)
               :on-mouse-up (fn [_e]
@@ -2021,16 +2017,16 @@
                                                                  (:block/pre-block? block)
                                                                  content)]
                                  [block
-                                 (if (seq title)
-                                   (->elem :span (map-inline config title))
-                                   (->elem :div (markup-elements-cp config body)))]))))
+                                  (if (seq title)
+                                    (->elem :span (map-inline config title))
+                                    (->elem :div (markup-elements-cp config body)))]))))
             breadcrumb (->> (into [] parents-props)
                             (concat [page-name-props] (when more? [:more]))
                             (filterv identity)
                             (map (fn [x] (if (vector? x)
-                                          (let [[block label] x]
-                                            (breadcrumb-fragment config block label))
-                                          [:span.opacity-70 "⋯"])))
+                                           (let [[block label] x]
+                                             (breadcrumb-fragment config block label))
+                                           [:span.opacity-70 "⋯"])))
                             (interpose (breadcrumb-separator)))]
         [:div.block-parents.flex-row.flex-1
          {:class (when (seq breadcrumb)
@@ -2142,31 +2138,13 @@
      children)
     (distinct @refs)))
 
-;; (rum/defc block-immediate-children < rum/reactive
-;;   [repo config uuid ref? collapsed?]
-;;   (when (and ref? (not collapsed?))
-;;     (let [children (db/get-block-immediate-children repo uuid)
-;;           children (block-handler/filter-blocks repo children (:filters config) false)]
-;;       (when (seq children)
-;;         [:div.ref-children {:style {:margin-left "1.8rem"}}
-;;          (blocks-container children (assoc config
-;;                                            :breadcrumb-show? false
-;;                                            :ref? true
-;;                                            :ref-child? true))]))))
-
 (rum/defcs block-container < rum/reactive
   {:init (fn [state]
-           (let [[config block] (:rum/args state)
-                 ref-collpased? (boolean
-                                 (and
-                                  (seq (:block/children block))
-                                  (or (:custom-query? config)
-                                      (and (:ref? config)
-                                           (>= (:ref/level block)
-                                               (state/get-ref-open-blocks-level))))))]
+           (let [[config block] (:rum/args state)]
              (assoc state
+                    ::init-collapsed? (get-in block [:block/properties :collapsed])
                     ::control-show? (atom false)
-                    ::ref-collapsed? (atom ref-collpased?))))
+                    ::default-collapsed? (atom (editor-handler/block-default-collapsed? block config)))))
    :should-update (fn [old-state new-state]
                     (let [compare-keys [:block/uuid :block/properties
                                         :block/parent :block/left
@@ -2179,7 +2157,8 @@
                        (not= (select-keys (first (:rum/args old-state)) config-compare-keys)
                              (select-keys (first (:rum/args new-state)) config-compare-keys)))))}
   [state config {:block/keys [uuid repo children pre-block? top? properties refs heading-level level type format content] :as block}]
-  (let [block (merge block (block/parse-title-and-body uuid format pre-block? content))
+  (let [init-collapsed? (::init-collapsed? state)
+        block (merge block (block/parse-title-and-body uuid format pre-block? content))
         body (:block/body block)
         blocks-container-id (:blocks-container-id config)
         config (update config :block merge block)
@@ -2189,9 +2168,10 @@
                  config)
         heading? (and (= type :heading) heading-level (<= heading-level 6))
         *control-show? (get state ::control-show?)
-        *ref-collapsed? (get state ::ref-collapsed?)
-        collapsed? (or @*ref-collapsed?
-                       (get properties :collapsed))
+        *default-collapsed? (get state ::default-collapsed?)
+        collapsed? (if (not= init-collapsed? (:collapsed properties))
+                     (:collapsed properties)
+                     @*default-collapsed?)
         ref? (boolean (:ref? config))
         breadcrumb-show? (:breadcrumb-show? config)
         slide? (boolean (:slide? config))
@@ -2215,15 +2195,15 @@
         review-cards? (:review-cards? config)]
     [:div.ls-block
      (cond->
-      {:id block-id
-       :data-refs data-refs
-       :data-refs-self data-refs-self
-       :data-collapsed (and collapsed? has-child?)
-       :class (str uuid
-                   (when pre-block? " pre-block")
-                   (when (and card? (not review-cards?)) " shadow-xl"))
-       :blockid (str uuid)
-       :haschild (str has-child?)}
+       {:id block-id
+        :data-refs data-refs
+        :data-refs-self data-refs-self
+        :data-collapsed (and collapsed? has-child?)
+        :class (str uuid
+                    (when pre-block? " pre-block")
+                    (when (and card? (not review-cards?)) " shadow-xl"))
+        :blockid (str uuid)
+        :haschild (str has-child?)}
 
        level
        (assoc :level level)
@@ -2255,11 +2235,11 @@
        :on-mouse-leave (fn [e]
                          (block-mouse-leave e *control-show? block-id doc-mode?))}
       (when (not slide?)
-        (block-control config block uuid block-id body children collapsed? *ref-collapsed? *control-show? edit?))
+        (block-control config block uuid block-id body children collapsed? *control-show? edit?))
 
       (block-content-or-editor config block edit-input-id block-id heading-level edit?)]
 
-     (block-children config children collapsed? *ref-collapsed?)
+     (block-children config children collapsed? *default-collapsed?)
 
      (dnd-separator-wrapper block block-id slide? false false)]))
 
@@ -2326,7 +2306,7 @@
         (->elem
          :li
          (cond->
-          {:checked checked?}
+           {:checked checked?}
            number
            (assoc :value number))
          (vec-cat

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -141,6 +141,11 @@
   background-color: var(--ls-guideline-color, #ddd);
 }
 
+.block-children-left-border:hover {
+  padding-right: 0px;
+  background-color: var(--ls-primary-text-color);
+}
+
 .block-children {
   padding-top: 2px;
   padding-bottom: 3px;

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -234,17 +234,20 @@
                           (editor-handler/cut-block! block-id))}
              "Cut")
 
-            (ui/menu-link
-              {:key      "Expand all"
-               :on-click (fn [_e]
-                           (editor-handler/expand-all! block-id))}
-              "Expand all")
+            (when (editor-handler/expand-all? block-id)
+              (ui/menu-link
+               {:key      "Expand all"
+                :on-click (fn [_e]
+                            (editor-handler/expand-all! block-id))}
+               "Expand all"))
 
-            (ui/menu-link
-              {:key      "Collapse all"
-               :on-click (fn [_e]
-                           (editor-handler/collapse-all! block-id))}
-              "Collapse all")
+            (when (editor-handler/collapse-all? block-id)
+
+              (ui/menu-link
+               {:key      "Collapse all"
+                :on-click (fn [_e]
+                            (editor-handler/collapse-all! block-id))}
+               "Collapse all"))
 
             (when (state/sub [:plugin/simple-commands])
               (when-let [cmds (state/get-plugins-commands-with-type :block-context-menu-item)]

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -67,16 +67,8 @@
           (editor-handler/edit-block! block :max (:block/uuid block))))))
   state)
 
-(defn- expand-top-block!
-  [state]
-  (when-let [block-id (last (:rum/args state))]
-    (when-let [block (db/get-block-by-uuid block-id)]
-      (when (get-in block [:block/properties :collapsed])
-        (editor-handler/expand-block! block-id))))
-  state)
-
 (rum/defc page-blocks-inner <
-  {:did-mount  #(-> % open-first-block! expand-top-block!)
+  {:did-mount  open-first-block!
    :did-update open-first-block!}
   [page-name page-blocks hiccup sidebar? preview? block-uuid]
   [:div.page-blocks-inner {:style {:margin-left (if sidebar? 0 -20)}}

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -69,27 +69,16 @@
 
 (defn- expand-top-block!
   [state]
-  (let [[_ blocks _ _ _] (:rum/args state)]
-    (letfn [(one-top-block? [blocks]
-              (= 1 (->> blocks
-                        (mapcat (juxt :db/id #(-> % :block/parent :db/id)))
-                        (apply hash-map)
-                        (#(remove (reduce
-                                    (fn [acc [id parent]] (if (contains? % parent) (conj acc id) acc))
-                                    #{}
-                                    %)
-                                  (keys %)))
-                        count
-                        )))]
-      (if (and (one-top-block? blocks)
-               (-> blocks first :block/properties :collapsed))
-        (editor-handler/expand-block! (-> blocks first :block/uuid)))))
+  (when-let [block-id (last (:rum/args state))]
+    (when-let [block (db/get-block-by-uuid block-id)]
+      (when (get-in block [:block/properties :collapsed])
+        (editor-handler/expand-block! block-id))))
   state)
 
 (rum/defc page-blocks-inner <
   {:did-mount  #(-> % open-first-block! expand-top-block!)
    :did-update open-first-block!}
-  [page-name page-blocks hiccup sidebar? preview?]
+  [page-name page-blocks hiccup sidebar? preview? block-uuid]
   [:div.page-blocks-inner {:style {:margin-left (if sidebar? 0 -20)}}
    (rum/with-key
      (content/content page-name
@@ -163,7 +152,7 @@
               hiccup-config (common-handler/config-with-document-mode hiccup-config)
               hiccup (block/->hiccup page-blocks hiccup-config {})]
           [:div
-           (page-blocks-inner page-name page-blocks hiccup sidebar? preview?)
+           (page-blocks-inner page-name page-blocks hiccup sidebar? preview? block-id)
            (when-not config/publishing?
              (let [args (if block-id
                           {:block-uuid block-id}
@@ -444,7 +433,7 @@
                       s1 (if (> c1 1) "s" "")
                       ;; c2 (count (:links graph))
                       ;; s2 (if (> c2 1) "s" "")
-]
+                      ]
                   ;; (util/format "%d page%s, %d link%s" c1 s1 c2 s2)
                   (util/format "%d page%s" c1 s1))]
                [:div.p-6
@@ -704,18 +693,18 @@
 
         [:span.pr-2
          (ui/button
-          (t :cancel)
-          :intent "logseq"
-          :on-click close-fn)]
+           (t :cancel)
+           :intent "logseq"
+           :on-click close-fn)]
 
         (ui/button
-         (t :yes)
-         :on-click (fn []
-                     (close-fn)
-                     (doseq [page-name (map :block/name pages)]
-                       (page-handler/delete! page-name #()))
-                     (notification/show! (str (t :tips/all-done) "!") :success)
-                     (js/setTimeout #(refresh-fn) 200)))]])))
+          (t :yes)
+          :on-click (fn []
+                      (close-fn)
+                      (doseq [page-name (map :block/name pages)]
+                        (page-handler/delete! page-name #()))
+                      (notification/show! (str (t :tips/all-done) "!") :success)
+                      (js/setTimeout #(refresh-fn) 200)))]])))
 
 (rum/defcs all-pages < rum/reactive
   (rum/local nil ::pages)
@@ -748,11 +737,11 @@
         *search-input (rum/create-ref)
 
         *indeterminate (rum/derived-atom
-                        [*checks] ::indeterminate
-                        (fn [checks]
-                          (when-let [checks (vals checks)]
-                            (if (every? true? checks)
-                              1 (if (some true? checks) -1 0)))))
+                           [*checks] ::indeterminate
+                         (fn [checks]
+                           (when-let [checks (vals checks)]
+                             (if (every? true? checks)
+                               1 (if (some true? checks) -1 0)))))
 
         mobile? (util/mobile?)
         total-pages (if-not @*results-all 0
@@ -821,16 +810,16 @@
            [:div.l.flex.items-center
             [:div.actions-wrap
              (ui/button
-              [(ui/icon "trash") (t :delete)]
-              :on-click (fn []
-                          (let [selected (filter (fn [[_ v]] v) @*checks)
-                                selected (and (seq selected)
-                                              (into #{} (for [[k _] selected] k)))]
-                            (when-let [pages (and selected (filter #(contains? selected (:block/idx %)) @*results))]
-                              (state/set-modal! (batch-delete-dialog pages false #(do
-                                                                                    (reset! *checks nil)
-                                                                                    (refresh-pages)))))))
-              :small? true)]
+               [(ui/icon "trash") (t :delete)]
+               :on-click (fn []
+                           (let [selected (filter (fn [[_ v]] v) @*checks)
+                                 selected (and (seq selected)
+                                               (into #{} (for [[k _] selected] k)))]
+                             (when-let [pages (and selected (filter #(contains? selected (:block/idx %)) @*results))]
+                               (state/set-modal! (batch-delete-dialog pages false #(do
+                                                                                     (reset! *checks nil)
+                                                                                     (refresh-pages)))))))
+               :small? true)]
 
             [:div.search-wrap.flex.items-center.pl-2
              (let [search-fn (fn []
@@ -843,8 +832,8 @@
                                 (reset! *search-key nil)))]
 
                [(ui/button (ui/icon "search")
-                           :on-click search-fn
-                           :small? true)
+                  :on-click search-fn
+                  :small? true)
                 [:input.form-input {:placeholder   (t :search/page-names)
                                     :on-key-up     (fn [^js e]
                                                      (let [^js target (.-target e)]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3566,3 +3566,31 @@
       (save-block! (state/get-current-repo)
                    (:block/uuid block)
                    content))))
+
+(defn block-default-collapsed?
+  "Whether a block should be collapsed by default.
+  Currently, this handles several cases:
+  1. Zoom in mode, it will open the current block if it's collapsed.
+  2. Queries.
+  3. References."
+  [block config]
+  (let [collapsed? (cond
+                     (and (:block? config)
+                          (= (:id config) (str (:block/uuid block))))
+                     false
+
+                     (and (:block? config)
+                          (get-in block [:block/properties :collapsed]))
+                     true
+
+                     :else
+                     (boolean
+                      (and
+                       (seq (:block/children block))
+                       (or (:custom-query? config)
+                           (and (:ref? config)
+                                (>= (:ref/level block)
+                                    (state/get-ref-open-blocks-level)))))))]
+    (if (or (:ref? config) (:block? config))
+      collapsed?
+      (get-in block [:block/properties :collapsed]))))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3306,13 +3306,14 @@
     (state/set-edit-content! (state/get-edit-input-id) (.-value input))))
 
 (defn collapsable? [block-id]
-  (if-let [block (db-model/query-block-by-uuid block-id)]
-    (let [block (block/parse-title-and-body block)]
-      (and
-        (nil? (-> block :block/properties :collapsed))
-        (or (not-empty (:block/body block))
-            (db-model/has-children? block-id))))
-    false))
+  (when block-id
+    (if-let [block (db-model/query-block-by-uuid block-id)]
+      (let [block (block/parse-title-and-body block)]
+        (and
+         (nil? (-> block :block/properties :collapsed))
+         (or (not-empty (:block/body block))
+             (db-model/has-children? block-id))))
+      false)))
 
 (defn all-blocks-with-level
   "Return all blocks associated with correct level
@@ -3333,29 +3334,30 @@
   [{:keys [collapse? expanded? root-block] :or {collapse? false expanded? false root-block nil}}]
   (when-let [page (or (state/get-current-page)
                       (date/today))]
-    (->>
-     (-> page
-         (db/get-page-blocks-no-cache)
-         (tree/blocks->vec-tree page))
+    (let [blocks (-> page
+                     (db/get-page-blocks-no-cache)
+                     (tree/blocks->vec-tree page))]
+      (cond->> blocks
+        root-block
+        (map (fn find [root]
+               (if (= root-block (:block/uuid root))
+                 root
+                 (first (filter find (:block/children root []))))))
 
-     (#(cond->> %
-         root-block (map (fn find [root]
-                       (if (= root-block (:block/uuid root))
-                         root
-                         (first (filter find (:block/children root []))))))))
+        collapse?
+        (w/postwalk
+         (fn [b]
+           (if (and (map? b) (-> b :block/properties :collapsed))
+             (assoc b :block/children []) b)))
 
-     (#(cond->> %
-         collapse? (w/postwalk
-                     (fn [x]
-                      (if (and (map? x) (-> x :block/properties :collapsed))
-                        (assoc x :block/children []) x)))))
+        true
+        (mapcat (fn [x] (tree-seq map? :block/children x)))
 
-     (mapcat (fn [x] (tree-seq map? :block/children x)))
+        expanded?
+        (filter (fn [b] (collapsable? (:block/uuid b))))
 
-     (#(cond->> %
-         expanded? (filter (fn [b] (collapsable? (:block/uuid b))))))
-
-     (map (fn [x] (dissoc x :block/children))))))
+        true
+        (map (fn [x] (dissoc x :block/children)))))))
 
 (defn collapse-block! [block-id]
   (when (collapsable? block-id)
@@ -3440,9 +3442,8 @@
    (collapse-all! nil))
   ([block-id]
    (let [blocks-to-collapse (all-blocks-with-level {:expanded? true :root-block block-id})]
-     (when (seq blocks-to-collapse)
-       (doseq [{:block/keys [uuid]} blocks-to-collapse]
-         (collapse-block! uuid))))))
+     (doseq [{:block/keys [uuid]} blocks-to-collapse]
+       (collapse-block! uuid)))))
 
 (defn expand-all!
   ([]
@@ -3451,7 +3452,24 @@
    (->> (all-blocks-with-level {:root-block block-id})
         (filter (fn [b] (-> b :block/properties :collapsed)))
         (map (comp expand-block! :block/uuid))
-        doall)))
+        dorun)))
+
+(defn- get-block-with-its-children
+  [block-uuid]
+  (let [repo (state/get-current-repo)
+        children (db/get-block-children repo block-uuid)
+        block (db/pull [:block/uuid block-uuid])]
+    (cons block (seq children))))
+
+(defn expand-all?
+  [block-uuid]
+  (let [blocks (get-block-with-its-children block-uuid)]
+    (some #(get-in % [:block/properties :collapsed]) blocks)))
+
+(defn collapse-all?
+  [block-uuid]
+  (let [blocks (get-block-with-its-children block-uuid)]
+    (some #(collapsable? (:block/uuid %)) blocks)))
 
 (defn toggle-open! []
   (let [all-collapsed?


### PR DESCRIPTION
Some improvements based on #3559
1. Display `Expand all` where there're already collapsed blocks. This applies to `Collapse all` too.
2. Make the guideline bold when hovering on it.
3. Simplify some logic

It also resolves #2190