### PR TITLE
fix empty block children is not clickable issue

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1362,25 +1362,24 @@
                (seq children)
                (not collapsed?))
       (let [doc-mode? (state/sub :document/mode?)]
-        [:div.block-children-container {:style {:display "flex"
-                                                :margin-left (if doc-mode? 18
-                                                                           (if (or (mobile-util/native-android?)
-                                                                                   (mobile-util/native-iphone?))
-                                                                             22
-                                                                             29))}}
+        [:div.block-children-container.flex {:style {:margin-left (if doc-mode? 18
+                                                                      (if (or (mobile-util/native-android?)
+                                                                              (mobile-util/native-iphone?))
+                                                                        22
+                                                                        29))}}
          [:div.block-children-left-border {:on-click (fn [event] (toggle-block-children event children))}]
-         [:div.block-children {:style    {:display     (if collapsed? "none" "")}}
+         [:div.block-children.w-full {:style    {:display     (if collapsed? "none" "")}}
           (for [child children]
             (when (map? child)
               (let [child (dissoc child :block/meta)
                     config (cond->
-                             (-> config
-                                 (assoc :block/uuid (:block/uuid child))
-                                 (dissoc :breadcrumb-show? :embed-parent))
+                            (-> config
+                                (assoc :block/uuid (:block/uuid child))
+                                (dissoc :breadcrumb-show? :embed-parent))
                              ref?
                              (assoc :ref-child? true))]
                 (rum/with-key (block-container config child)
-                              (:block/uuid child)))))]]))))
+                  (:block/uuid child)))))]]))))
 
 (defn- block-content-empty?
   [{:block/keys [properties title body]}]

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -153,7 +153,6 @@
 }
 
 .block-control, .block-control:hover {
-  @apply: opacity-50.hover:opacity-100;
   text-decoration: none;
   cursor: pointer;
   font-size: 14px;
@@ -264,7 +263,6 @@ html.is-native-android {
 }
 
 .ls-block {
-  @apply: .flex.flex-col.rounded-sm;
   position: relative;
   min-height: 24px;
   padding: 2px 0;


### PR DESCRIPTION
In https://github.com/logseq/logseq/pull/3559, block children are wrapped into a `flex` container, but it previously took all available width, after the change it only takes its children width. This issue will make the width of block children smaller. For empty block children, they are not clickable.
![image](https://user-images.githubusercontent.com/584378/147415072-aacbe424-1364-456c-9d95-9bd77ca2fd53.png)
