### PR TITLE
feat: add {{namespace [[page]]}} macro which can be used as a toc

### DIFF
--- a/resources/icons.edn
+++ b/resources/icons.edn
@@ -1,3 +1,4 @@
+;; https://tabler-icons.io/
 ["Icon2fa"
  "Icon3dCubeSphere"
  "IconAB"

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -807,7 +807,10 @@
   [:ul
    (for [child children]
      [:li {:key (str "namespace-" namespace "-" (:db/id child))}
-      (page-cp config child)
+      (let [shorten-name (some-> (or (:block/original-name child) (:block/name child))
+                                 (string/split "/")
+                                 last)]
+        (page-cp {:label shorten-name} child))
       (when (seq (:namespace/children child))
         (namespace-hierarchy-aux config (:block/name child)
                                  (:namespace/children child)))])])

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -238,18 +238,18 @@
           [:a.delete.ml-1
            {:title    "maximize image"
             :on-click (fn [^js e] (let [images (js/document.querySelectorAll ".asset-container img")
-                                       images (to-array images)
-                                       images (if-not (= (count images) 1)
-                                                (let [^js _image (.closest (.-target e) ".asset-container")
-                                                      image (. _image querySelector "img")]
-                                                  (cons image (remove #(= image %) images)))
-                                                images)
-                                       images (for [^js it images] {:src (.-src it)
-                                                                    :w (.-naturalWidth it)
-                                                                    :h (.-naturalHeight it)})]
+                                        images (to-array images)
+                                        images (if-not (= (count images) 1)
+                                                 (let [^js _image (.closest (.-target e) ".asset-container")
+                                                       image (. _image querySelector "img")]
+                                                   (cons image (remove #(= image %) images)))
+                                                 images)
+                                        images (for [^js it images] {:src (.-src it)
+                                                                     :w (.-naturalWidth it)
+                                                                     :h (.-naturalHeight it)})]
 
-                                   (when (seq images)
-                                     (lightbox/preview-images! images))))}
+                                    (when (seq images)
+                                      (lightbox/preview-images! images))))}
 
            (svg/maximize)]]])))))
 
@@ -2404,7 +2404,7 @@
         states (filter #(not (string/starts-with? % "CLOCK:")) log)]
     (when (seq clocks)
       (let [tr (fn [elm cols] (->elem :tr
-                                     (mapv (fn [col] (->elem elm col)) cols)))
+                                      (mapv (fn [col] (->elem elm col)) cols)))
             head  [:thead.overflow-x-scroll (tr :th.py-0 ["Type" "Start" "End" "Span"])]
             clock-tbody (->elem
                          :tbody.overflow-scroll.sm:overflow-auto

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -238,18 +238,18 @@
           [:a.delete.ml-1
            {:title    "maximize image"
             :on-click (fn [^js e] (let [images (js/document.querySelectorAll ".asset-container img")
-                                        images (to-array images)
-                                        images (if-not (= (count images) 1)
-                                                 (let [^js _image (.closest (.-target e) ".asset-container")
-                                                       image (. _image querySelector "img")]
-                                                   (cons image (remove #(= image %) images)))
-                                                 images)
-                                        images (for [^js it images] {:src (.-src it)
-                                                                     :w (.-naturalWidth it)
-                                                                     :h (.-naturalHeight it)})]
+                                       images (to-array images)
+                                       images (if-not (= (count images) 1)
+                                                (let [^js _image (.closest (.-target e) ".asset-container")
+                                                      image (. _image querySelector "img")]
+                                                  (cons image (remove #(= image %) images)))
+                                                images)
+                                       images (for [^js it images] {:src (.-src it)
+                                                                    :w (.-naturalWidth it)
+                                                                    :h (.-naturalHeight it)})]
 
-                                    (when (seq images)
-                                      (lightbox/preview-images! images))))}
+                                   (when (seq images)
+                                     (lightbox/preview-images! images))))}
 
            (svg/maximize)]]])))))
 
@@ -802,6 +802,24 @@
         (join (config/get-repo-dir (state/get-current-repo))
               (config/get-local-asset-absolute-path path)))))
 
+(rum/defc namespace-hierarchy-aux
+  [config namespace children]
+  [:ul
+   (for [child children]
+     [:li {:key (str "namespace-" namespace "-" (:db/id child))}
+      (page-cp config child)
+      (when (seq (:namespace/children child))
+        (namespace-hierarchy-aux config (:block/name child)
+                                 (:namespace/children child)))])])
+
+(rum/defc namespace-hierarchy
+  [config namespace children]
+  [:div.namespace
+   [:div.font-medium.flex.flex-row.items-center.pb-2
+    [:span.text-sm.mr-1 "Namespace "]
+    (page-cp config {:block/name namespace})]
+   (namespace-hierarchy-aux config namespace children)])
+
 (defn inline
   [{:keys [html-export?] :as config} item]
   (match item
@@ -1130,6 +1148,13 @@
          [:span.warning
           (util/format "{{function %s}}" (first arguments))])
 
+        (= name "namespace")
+        (let [namespace (first arguments)]
+          (when-not (string/blank? namespace)
+            (let [namespace (string/lower-case (text/page-ref-un-brackets! namespace))
+                  children (model/get-namespace-hierarchy (state/get-current-repo) namespace)]
+              (namespace-hierarchy config namespace children))))
+
         (= name "youtube")
         (when-let [url (first arguments)]
           (let [YouTube-regex #"^((?:https?:)?//)?((?:www|m).)?((?:youtube.com|youtu.be))(/(?:[\w-]+\?v=|embed/|v/)?)([\w-]+)(\S+)?$"]
@@ -1376,9 +1401,9 @@
             (when (map? child)
               (let [child (dissoc child :block/meta)
                     config (cond->
-                            (-> config
-                                (assoc :block/uuid (:block/uuid child))
-                                (dissoc :breadcrumb-show? :embed-parent))
+                             (-> config
+                                 (assoc :block/uuid (:block/uuid child))
+                                 (dissoc :breadcrumb-show? :embed-parent))
                              ref?
                              (assoc :ref-child? true))]
                 (rum/with-key (block-container config child)
@@ -2376,7 +2401,7 @@
         states (filter #(not (string/starts-with? % "CLOCK:")) log)]
     (when (seq clocks)
       (let [tr (fn [elm cols] (->elem :tr
-                                      (mapv (fn [col] (->elem elm col)) cols)))
+                                     (mapv (fn [col] (->elem elm col)) cols)))
             head  [:thead.overflow-x-scroll (tr :th.py-0 ["Type" "Start" "End" "Span"])]
             clock-tbody (->elem
                          :tbody.overflow-scroll.sm:overflow-auto

--- a/src/main/frontend/components/hierarchy.cljs
+++ b/src/main/frontend/components/hierarchy.cljs
@@ -2,31 +2,43 @@
   (:require [clojure.string :as string]
             [frontend.components.block :as block]
             [frontend.db :as db]
+            [frontend.db.model :as db-model]
             [frontend.state :as state]
             [frontend.text :as text]
             [frontend.ui :as ui]
             [medley.core :as medley]
-            [rum.core :as rum]))
+            [rum.core :as rum]
+            [frontend.util :as util]))
 
-;; FIXME: use block/namespace to get the relation
 (defn get-relation
   [page]
   (when-let [page (or (text/get-nested-page-name page) page)]
    (when (text/namespace-page? page)
-     (->> (db/get-namespace-pages (state/get-current-repo) page)
-          (map (fn [page]
-                 (or (:block/original-name page) (:block/name page))))
-          (map #(string/split % #"/"))
-          (sort)))))
+     (let [repo (state/get-current-repo)
+           namespace-pages (db/get-namespace-pages repo page)
+           parent-routes (db-model/get-page-namespace-routes repo page)
+           pages (->> (concat namespace-pages parent-routes)
+                      (distinct)
+                      (map (fn [page]
+                             (or (:block/original-name page) (:block/name page))))
+                      (map #(string/split % "/"))
+                      (sort))
+           page-namespace (db-model/get-page-namespace repo page)
+           page-namespace (util/get-page-original-name page-namespace)]
+       (cond
+         (seq pages)
+         pages
+
+         page-namespace
+         [(string/split page-namespace "/")]
+
+         :else
+         nil)))))
 
 (rum/defc structures
   [page]
   (let [namespaces (get-relation page)]
-    (when (and (seq namespaces)
-               (not (and (= 1
-                            (count namespaces)
-                            (count (first namespaces)))
-                         (not (string/includes? (ffirst namespaces) "/")))))
+    (when (seq namespaces)
       [:div.page-hierachy.mt-6
        (ui/foldable
         [:h2.font-bold.opacity-30 "Hierarchy"]

--- a/src/main/frontend/components/hierarchy.cljs
+++ b/src/main/frontend/components/hierarchy.cljs
@@ -17,7 +17,6 @@
           (map (fn [page]
                  (or (:block/original-name page) (:block/name page))))
           (map #(string/split % #"/"))
-          (remove #(= % [page]))
           (sort)))))
 
 (rum/defc structures

--- a/src/main/frontend/components/hierarchy.cljs
+++ b/src/main/frontend/components/hierarchy.cljs
@@ -19,10 +19,10 @@
            parent-routes (db-model/get-page-namespace-routes repo page)
            pages (->> (concat namespace-pages parent-routes)
                       (distinct)
+                      (sort-by :block/name)
                       (map (fn [page]
                              (or (:block/original-name page) (:block/name page))))
-                      (map #(string/split % "/"))
-                      (sort))
+                      (map #(string/split % "/")))
            page-namespace (db-model/get-page-namespace repo page)
            page-namespace (util/get-page-original-name page-namespace)]
        (cond
@@ -55,5 +55,5 @@
                                          {}
                                          page))))
              (interpose [:span.mx-2.opacity-30 "/"]))])]
-        {:default-collapsed? true
+        {:default-collapsed? false
          :title-trigger? true})])))

--- a/src/main/frontend/handler/file.cljs
+++ b/src/main/frontend/handler/file.cljs
@@ -118,8 +118,8 @@
                                        (let [id (second ref)]
                                          (or (contains? block-ids id)
                                              (db/entity [:block/uuid id])))
-                                       (and (map? ref) (contains? ref :block/journal?))
-                                       (db/entity [:block/name (ref :block/name)]))) refs))]
+                                       :else
+                                       true)) refs))]
     (map (fn [item]
            (update item :block/refs keep-block-ref-f))
       data)))

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -481,10 +481,8 @@
       (outliner-file/sync-to-file {:db/id to-id})
 
       (rename-update-refs! from-page
-                           (or (:block/original-name from-page)
-                               (:block/name from-page))
-                           (or (:block/original-name to-page)
-                               (:block/name to-page))))
+                           (util/get-page-original-name from-page)
+                           (util/get-page-original-name to-page)))
 
     (delete! from nil)
 

--- a/src/main/frontend/handler/route.cljs
+++ b/src/main/frontend/handler/route.cljs
@@ -86,8 +86,7 @@
               content))
           "Page no longer exists!!")
         (let [page (db/pull [:block/name (string/lower-case name)])]
-          (or (:block/original-name page)
-              (:block/name page)
+          (or (util/get-page-original-name page)
               "Logseq"))))
     :tag
     (str "#"  (:name path-params))

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1141,6 +1141,11 @@
       ;; for android filesystem compatiblity
       (string/replace #"[\\#|%]+" "_")))
 
+(defn get-page-original-name
+  [page]
+  (or (:block/original-name page)
+      (:block/name page)))
+
 (defn lowercase-first
   [s]
   (when s


### PR DESCRIPTION
`{{namespace [[Book 1]]}}` can be rendered as:
![CleanShot 2021-12-28 at 15 10 46](https://user-images.githubusercontent.com/479169/147538715-c0874a12-5418-4855-85f7-c1b97f2062a8.png)

- [x] Cut namespace prefix
- [x] Fixed #3620
- [x] Display namespace routes for the last sub page in Hierarchy
![CleanShot 2021-12-28 at 15 12 29](https://user-images.githubusercontent.com/479169/147538865-824eaf92-dcf9-4ca3-9deb-ad05c52cffd2.png)
