### PR TITLE
Adding block/page unification in query

### DIFF
--- a/src/main/frontend/db/query_dsl.cljs
+++ b/src/main/frontend/db/query_dsl.cljs
@@ -343,7 +343,9 @@
               (list
                'or
                [(list '= sym v)]
-               [(list 'contains? sym v)])])
+               [(list 'contains? sym v)])
+               ['?b :block/page '?p] 
+              ])
            [['?p :block/name]
             ['?p :block/properties '?prop]
             [(list 'get '?prop (keyword k)) '?prop-v]


### PR DESCRIPTION
In the query_dsl.cljs file at the bottom, there is an example of a query that currently gives the wrong result.

```(query "(and (page-property foo bar) [[hello]])"))```

Currently asking for blocks on pages matching a certain query, like page-property, results in all eligible blocks being listed, whether or not they are on pages with that page property.

The problem seems to be that in the generated datalog query, there are conditions on the page `?p` and the block `?b`, but there is no link between the two - no condition that `?b` be on a page `?p`. When adding that condition to the query (` ['?b :block/page '?p]`), we get the desired results.

However, it is not clear to me exactly where to add this string in the code. On one hand, it does not seem to do any harm to add this link whether or not there are actual block conditions (ie. a pure page query with this where clause added still works). However, this does not take into account cases like `(or (page-property a) [[a]])`, nested and/ors etc. Therefore I am submitting this PR merely as an illustration, and I hope someone who understands the query parser logic better than me can help implement this properly.

I'd love to see this addressed, since this to me is a major improvement over Roam, and potentially incredibly useful in many use cases (show me all writings on "method" only from papers about biology - based on a page-property science-field biology for example).

Tweeted a little walkthrough video (more for people interested in Logseq development, not necessary to understand this PR)
https://www.loom.com/share/a849904da94043c69e09a1a95d8e7e1a