### PR TITLE
fix(mobile): weird header padding on mobile

### DIFF
--- a/src/main/frontend/components/header.css
+++ b/src/main/frontend/components/header.css
@@ -1,8 +1,7 @@
 .cp__header {
   @apply shadow z-10;
   -webkit-app-region: drag;
-
-  padding-right: 0.5rem;
+  
   padding-top: var(--ls-headbar-inner-top-padding);
   height: calc(var(--ls-headbar-height) + var(--ls-headbar-inner-top-padding));
   display: flex;
@@ -27,6 +26,7 @@
 
   > .r {
     align-items: center;
+    padding-right: 0.5rem;
   }
 
   /* To prevent header glitch on Safari */


### PR DESCRIPTION
Fix the right padding of header:
![image](https://user-images.githubusercontent.com/3996879/147634511-6e7417b5-0baa-42bf-ac43-63e10655e946.png)