### PR TITLE
Removing padding on mark

### DIFF
--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -1075,7 +1075,6 @@ a.navigation {
 mark {
   background: #fef3ac;
   color: #262626;
-  padding: 2px 4px;
   border-radius: 3px;
 }
 


### PR DESCRIPTION
Addresses #3659, fixes both the case of a two-word search string matching a one word string, and having the space inserted, as well as a two word search string leading to a space at the end when highlighting.

I feel it looks much more aesthetic now.
Before:
![image](https://user-images.githubusercontent.com/61575/147661661-7565bc10-75da-4968-892c-c0c531dc5111.png)
![image](https://user-images.githubusercontent.com/61575/147661664-cc265e1a-4ca0-4afa-b877-72dc6259f2bf.png)

Now:
![image](https://user-images.githubusercontent.com/61575/147661706-4582afe5-bf5d-46ca-8838-1e79e18c773c.png)
![image](https://user-images.githubusercontent.com/61575/147661709-562d2adc-39d5-4260-9a74-6042d569b3a8.png)
