### PR TITLE
fix(plugin): allow target attribution in provideUI

### DIFF
--- a/libs/src/helpers.ts
+++ b/libs/src/helpers.ts
@@ -269,7 +269,7 @@ export function setupInjectedUI (
       ui.template, {
         ADD_TAGS: ['iframe'],
         ALLOW_UNKNOWN_PROTOCOLS: true,
-        ADD_ATTR: ['allow', 'src', 'allowfullscreen', 'frameborder', 'scrolling']
+        ADD_ATTR: ['allow', 'src', 'allowfullscreen', 'frameborder', 'scrolling', 'target']
       })
   } else { // remove ui
     injectedUIEffects.get(id)?.call(null)


### PR DESCRIPTION
Without `target="_blank"` attribution, the plugin cannot render an external link (or this link will always be opened in current window).