### PR TITLE
fix: nested and query issues and full-text search in nested queries

### DIFF
--- a/src/test/frontend/db/query_dsl_test.cljs
+++ b/src/test/frontend/db/query_dsl_test.cljs
@@ -150,9 +150,10 @@ last-modified-at:: 1609084800002"}]]
        :count 1}
 
       "(or (property prop-c \"page c\") (property prop-b val-b))"
-      {:query '[or
-                (and [?b :block/properties ?prop] [(missing? $ ?b :block/name)] [(get ?prop :prop-c) ?v] (or [(= ?v "page c")] [(contains? ?v "page c")]))
-                (and [?b :block/properties ?prop] [(missing? $ ?b :block/name)] [(get ?prop :prop-b) ?v] (or [(= ?v "val-b")] [(contains? ?v "val-b")]))]
+      {:query '[[?b :block/content ?content]
+                (or
+                 (and [?b :block/properties ?prop] [(missing? $ ?b :block/name)] [(get ?prop :prop-c) ?v] (or [(= ?v "page c")] [(contains? ?v "page c")]))
+                 (and [?b :block/properties ?prop] [(missing? $ ?b :block/name)] [(get ?prop :prop-b) ?v] (or [(= ?v "val-b")] [(contains? ?v "val-b")])))]
        :count 2}))
 
   (testing "task queries"


### PR DESCRIPTION
Related to #3630.

Full text search example in a nested query:
`(and [[page]] "query")`

![CleanShot 2021-12-29 at 21 31 16](https://user-images.githubusercontent.com/479169/147667458-45d3b413-bc5f-42b9-973a-357457672254.png)
