### PR TITLE
fix(electron): multi window check in re-index

### DIFF
--- a/src/main/frontend/components/repo.cljs
+++ b/src/main/frontend/components/repo.cljs
@@ -196,8 +196,7 @@
   [state]
   (when (util/electron?)
     (p/let [multiple-windows? (ipc/ipc "graphHasMultipleWindows" (state/get-current-repo))]
-      (when multiple-windows?
-        (reset! (::electron-multiple-windows? state) true)))))
+      (reset! (::electron-multiple-windows? state) multiple-windows?))))
 
 (rum/defcs repos-dropdown < rum/reactive
   (rum/local false ::electron-multiple-windows?)


### PR DESCRIPTION
Fixes the following BUG:

`multiple-windows?` will always be true if set.

To reproduce:
- Open Window A with Graph A
- Open Window B(will also be Graph A)
- Click re-index(then cancel)
- Close Window B
- Now you cannot re-index Graph A

