### PR TITLE
chore: add release.yml config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - test
+      - chore
+      - ci
+      - :type/dev
+  categories:
+    - title: Exciting New Features 🎉
+      labels:
+        - :type/feature-request
+        - :type/feature
+    - title: Bug Fixes 🐛
+      labels:
+        - :type/bug
+        - :type/bug-fix
+        - :type/regression
+    - title: Enhancements 🔧
+      labels:
+        - :type/enhancement
+        - :type/performance
+    - title: Other Changes 🚧
+      labels:
+        - "*"


### PR DESCRIPTION
- Can be used for auto-generated release notes
- Ref: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes