### PR TITLE
fix: graph view hang due to node / edge duplication

### DIFF
--- a/src/main/frontend/extensions/graph/pixi.cljs
+++ b/src/main/frontend/extensions/graph/pixi.cljs
@@ -176,7 +176,9 @@
           links-js                                                                  (bean/->js links)]
       (let [simulation (layout! nodes-js links-js)]
         (doseq [node nodes-js]
-          (.addNode graph (.-id node) node))
+          (try (.addNode graph (.-id node) node)
+               (catch js/Error e
+                 (js/console.error e))))
         (doseq [link links-js]
           (let [source (.-id (.-source link))
                 target (.-id (.-target link))]


### PR DESCRIPTION
Fix #3755
Further fix #3498

- [x] Error catching
- [x] Investigate the cause of duplication
  - I think it's better to merge the error catching first.