### PR TITLE
Fix filename encode and special chars

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -10,9 +10,10 @@ android {
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-app')
-    implementation project(':capacitor-filesystem')
-    implementation project(':capacitor-splash-screen')
     implementation project(':capacitor-camera')
+    implementation project(':capacitor-filesystem')
+    implementation project(':capacitor-keyboard')
+    implementation project(':capacitor-splash-screen')
 
 }
 

--- a/android/app/src/main/assets/capacitor.plugins.json
+++ b/android/app/src/main/assets/capacitor.plugins.json
@@ -4,15 +4,19 @@
 		"classpath": "com.capacitorjs.plugins.app.AppPlugin"
 	},
 	{
+		"pkg": "@capacitor/camera",
+		"classpath": "com.capacitorjs.plugins.camera.CameraPlugin"
+	},
+	{
 		"pkg": "@capacitor/filesystem",
 		"classpath": "com.capacitorjs.plugins.filesystem.FilesystemPlugin"
 	},
 	{
-		"pkg": "@capacitor/splash-screen",
-		"classpath": "com.capacitorjs.plugins.splashscreen.SplashScreenPlugin"
+		"pkg": "@capacitor/keyboard",
+		"classpath": "com.capacitorjs.plugins.keyboard.KeyboardPlugin"
 	},
 	{
-		"pkg": "@capacitor/camera",
-		"classpath": "com.capacitorjs.plugins.camera.CameraPlugin"
+		"pkg": "@capacitor/splash-screen",
+		"classpath": "com.capacitorjs.plugins.splashscreen.SplashScreenPlugin"
 	}
 ]

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -5,11 +5,14 @@ project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/
 include ':capacitor-app'
 project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
 
+include ':capacitor-camera'
+project(':capacitor-camera').projectDir = new File('../node_modules/@capacitor/camera/android')
+
 include ':capacitor-filesystem'
 project(':capacitor-filesystem').projectDir = new File('../node_modules/@capacitor/filesystem/android')
 
+include ':capacitor-keyboard'
+project(':capacitor-keyboard').projectDir = new File('../node_modules/@capacitor/keyboard/android')
+
 include ':capacitor-splash-screen'
 project(':capacitor-splash-screen').projectDir = new File('../node_modules/@capacitor/splash-screen/android')
-
-include ':capacitor-camera'
-project(':capacitor-camera').projectDir = new File('../node_modules/@capacitor/camera/android')

--- a/src/main/frontend/fs/capacitor_fs.cljs
+++ b/src/main/frontend/fs/capacitor_fs.cljs
@@ -9,7 +9,8 @@
             ["@capacitor/filesystem" :refer [Filesystem Directory Encoding]]
             [frontend.mobile.util :as util]
             [promesa.core :as p]
-            [clojure.string :as string]))
+            [clojure.string :as string]
+            [frontend.mobile.util :as mobile-util]))
 
 (when (util/native-ios?)
   (defn iOS-ensure-documents!
@@ -52,7 +53,11 @@
                                                       (= file "bak")))))
                              files (->> files
                                         (map (fn [file]
-                                               (futil/node-path.join d (futil/url-encode file)))))
+                                               (futil/node-path.join
+                                                d
+                                                (if (mobile-util/native-ios?)
+                                                  (futil/url-encode file)
+                                                  file)))))
                              files-with-stats (p/all
                                                (mapv
                                                 (fn [file]

--- a/src/main/frontend/fs/capacitor_fs.cljs
+++ b/src/main/frontend/fs/capacitor_fs.cljs
@@ -48,8 +48,9 @@
                              files (->> files
                                         (remove (fn [file]
                                                   (or (string/starts-with? file ".")
-                                                      (string/includes? file "#")
-                                                      (string/includes? file "%")
+                                                      (and (mobile-util/native-android?)
+                                                           (or (string/includes? file "#")
+                                                               (string/includes? file "%")))
                                                       (= file "bak")))))
                              files (->> files
                                         (map (fn [file]


### PR DESCRIPTION
- Don't encode path on android
- Allow reading and parsing file with # and % in its filename. 
   fix https://github.com/logseq/logseq/issues/3707 