### PR TITLE
fix: apply page-name sanitity to sidebar

### DIFF
--- a/src/main/frontend/components/page_menu.cljs
+++ b/src/main/frontend/components/page_menu.cljs
@@ -57,21 +57,21 @@
   [page-name]
   (when-let [page-name (or
                         page-name
-                        (and (state/get-current-page)
-                             (string/lower-case (state/get-current-page))))]
+                        (state/get-current-page))]
     (let [t i18n/t
+          page-name (util/page-name-sanity-lc page-name)
           repo (state/sub :git/current-repo)
-          page (and page-name (db/entity repo [:block/name page-name]))
+          page (db/entity repo [:block/name page-name])
           page-original-name (:block/original-name page)
           journal? (db/journal-page? page-name)
           block? (and page (util/uuid-string? page-name))
-          contents? (= (string/lower-case (str page-name)) "contents")
+          contents? (= page-name "contents")
           {:keys [title] :as properties} (:block/properties page)
           title (or title page-original-name page-name)
           public? (true? (:public properties))
           favorites (:favorites (state/sub-graph-config))
-          favorited? (contains? (set (map string/lower-case favorites))
-                                (string/lower-case page-name))
+          favorited? (contains? (set (map util/page-name-sanity-lc favorites))
+                                page-name)
           developer-mode? (state/sub [:ui/developer-mode?])]
       (when (and page (not block?))
         (->>

--- a/src/main/frontend/components/sidebar.cljs
+++ b/src/main/frontend/components/sidebar.cljs
@@ -80,7 +80,7 @@
   [name icon]
   (let [original-name (db-model/get-page-original-name name)]
     [:a {:on-click (fn [e]
-                     (let [name (util/safe-lower-case name)]
+                     (let [name (util/safe-page-name-sanity-lc name)]
                        (if (gobj/get e "shiftKey")
                          (when-let [page-entity (db/entity [:block/name name])]
                            (state/sidebar-add-block!
@@ -149,7 +149,7 @@
        [:ul.favorites.text-sm
         (for [name favorites]
           (when-not (string/blank? name)
-            (when-let [entity (db/entity [:block/name (util/safe-lower-case name)])]
+            (when-let [entity (db/entity [:block/name (util/safe-page-name-sanity-lc name)])]
               (let [icon (get-page-icon entity)]
                 (favorite-item t name icon)))))]))))
 
@@ -173,7 +173,7 @@
                     (map :page))]
      [:ul.text-sm
       (for [name pages]
-        (when-let [entity (db/entity [:block/name (util/safe-lower-case name)])]
+        (when-let [entity (db/entity [:block/name (util/safe-page-name-sanity-lc name)])]
           [:li.recent-item {:key name}
            (page-name name (get-page-icon entity))]))])))
 
@@ -200,7 +200,7 @@
     (let [page (:page default-home)
           page (when (and (string? page)
                           (not (string/blank? page)))
-                 (db/entity [:block/name (util/safe-lower-case page)]))]
+                 (db/entity [:block/name (util/safe-page-name-sanity-lc page)]))]
       (if page
         default-home
         (dissoc default-home :page)))))

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -769,7 +769,7 @@
 (defn get-page-original-name
   [page-name]
   (when (string? page-name)
-    (let [page (db-utils/pull [:block/name (string/lower-case page-name)])]
+    (let [page (db-utils/pull [:block/name (util/page-name-sanity-lc page-name)])]
       (or (:block/original-name page)
           (:block/name page)))))
 

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1142,6 +1142,11 @@
   [s]
   (.normalize s "NFKC"))
 
+(defn query-normalize
+  [s]
+  (normalize (string/lower-case s))
+)
+
 (defn page-name-sanity
   "Sanitize the page-name for file name"
   ([page-name]
@@ -1159,9 +1164,14 @@
        page))))
 
 (defn page-name-sanity-lc
-  "Sanitize the query string for a page"
+  "Sanitize the query string for a page name (mandate for :block/name)"
   [s]
   (page-name-sanity (string/lower-case s)))
+
+(defn safe-page-name-sanity-lc
+  [s]
+  (if (string? s)
+    (page-name-sanity-lc s) s))
 
 (defn get-page-original-name
   [page]


### PR DESCRIPTION
Fix https://github.com/logseq/logseq/issues/3790

The fix was a part of the incoming page-name sanity fix up.
AFAIK, the issue is not introduced by the recent page-name sanity enhancement. It can also be reproduced in older releases.