### PR TITLE
Removing nil orphans

### DIFF
--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -1522,7 +1522,8 @@
                                            (not (:block/journal? page))))
                                  page))))
                           pages)
-                        (remove false?))]
+                        (remove false?)
+                        (remove nil?))]
     orphaned-pages))
 
 (defn remove-orphaned-pages!


### PR DESCRIPTION
Fixes #3774. When printing the returned list of orphaned pages, turns out a lot of them are nil.
![image](https://user-images.githubusercontent.com/61575/148529897-48838ef2-e62f-4052-b071-7958619061d8.png)

Simply removing these seems to fix the problem on my side. However, I'm not exactly sure why these are nil, whether there is a deeper underlying problem (we're already filtering for false).