### PR TITLE
feat(debug): add debug func `defn`

### DIFF
--- a/src/main/frontend/debug.clj
+++ b/src/main/frontend/debug.clj
@@ -1,0 +1,26 @@
+(ns frontend.debug
+  (:refer-clojure :rename {defn core-defn}))
+
+(defmacro defn [name & fdecl]
+  (let [fdecl (if (string? (first fdecl))
+                (next fdecl)
+                fdecl)
+        fdecl (if (map? (first fdecl))
+                (next fdecl)
+                fdecl)
+        fdecl (if (vector? (first fdecl))
+                (list fdecl)
+                fdecl)
+        fdecl (if (map? (last fdecl))
+                (butlast fdecl)
+                fdecl)
+        fdecl (map (fn [decl]
+                     (let [params (first decl)
+                           body (next decl)]
+                       `(~params
+                         (let [start# (cljs.core/system-time)
+                               ret# (do ~@body)
+                               elapsed# (.toFixed (- (cljs.core/system-time) start#) 6)]
+                           (println (str "[" '~name "] " elapsed# " msecs"))
+                           ret#)))) fdecl)]
+    `(core-defn ~@(cons name fdecl))))

--- a/src/main/frontend/debug.cljs
+++ b/src/main/frontend/debug.cljs
@@ -1,4 +1,5 @@
 (ns frontend.debug
+  (:require-macros [frontend.debug])
   (:refer-clojure :exclude [print])
   (:require [cljs.pprint :as pprint]
             [frontend.state :as state]


### PR DESCRIPTION
we can replace `clojure.core/defn` with `frontend.debug/defn` when profiling , this `defn` will print elapsed time of all funcs