### PR TITLE
enhance: improve long page loading performance

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -88,7 +88,6 @@
 (def *move-to (atom nil))
 
 ;; TODO: dynamic
-(defonce max-blocks-per-page 200)
 (defonce max-depth-of-links 5)
 (defonce *blocks-container-id (atom 0))
 
@@ -2877,37 +2876,58 @@
         (str (:block/uuid item))))))
 
 (defonce ignore-scroll? (atom false))
+
+(defn- custom-query-or-ref?
+  [config]
+  (let [ref? (:ref? config)
+        custom-query? (:custom-query? config)]
+    (or custom-query? ref?)))
+
+
+;; TODO: virtual tree for better UX and memory usage reduce
+(def initial-blocks-length 200)
+(def step-loading-blocks 50)
+
+(defn- flat-blocks-tree
+  [vec-tree]
+  (->> (mapcat (fn [x] (tree-seq map? :block/children x)) vec-tree)
+       (map #(dissoc % :block/children))))
+
+(defn- get-segment
+  [config flat-blocks idx blocks->vec-tree]
+  (let [new-idx (if-not (zero? idx)
+                  (+ idx step-loading-blocks)
+                  initial-blocks-length)
+        max-idx (count flat-blocks)
+        idx (min max-idx new-idx)
+        blocks (util/safe-subvec flat-blocks 0 idx)]
+    [(blocks->vec-tree blocks)
+     idx]))
+
 (rum/defcs lazy-blocks <
-  (rum/local 1 ::page)
-  [state config blocks]
-  (let [*page (get state ::page)
-        segment (->> blocks
-                     (drop (* (dec @*page) max-blocks-per-page))
-                     (take max-blocks-per-page))
+  {:did-remount (fn [old-state new-state]
+                  ;; Loading more when pressing Enter or paste
+                  (let [args (:rum/args new-state)]
+                    ;; FIXME: what if users paste too many blocks?
+                    ;; or, a template with a lot of blocks?
+                    (swap! (::last-idx new-state) + 100))
+                  new-state)}
+  (rum/local 0 ::last-idx)
+  [state config flat-blocks blocks->vec-tree]
+  (let [*last-idx (::last-idx state)
+        [segment idx] (get-segment config
+                                   flat-blocks
+                                   @*last-idx
+                                   blocks->vec-tree)
         bottom-reached (fn []
-                         (when (and (= (count segment) max-blocks-per-page)
-                                    (> (count blocks) (* @*page max-blocks-per-page))
-                                    (not @ignore-scroll?))
-                           (swap! *page inc)
-                           (util/scroll-to-top))
-                         (reset! ignore-scroll? false))
-        top-reached (fn []
-                      (when (> @*page 1)
-                        (swap! *page dec)
-                        (reset! ignore-scroll? true)
-                        (js/setTimeout #(util/scroll-to
-                                         (.-scrollHeight (js/document.getElementById "lazy-blocks"))) 100)))]
+                         (reset! *last-idx idx)
+                         (reset! ignore-scroll? false))]
     [:div#lazy-blocks
-     (when (> @*page 1)
-       [:div.ml-4.mb-4 [:a#prev.opacity-60.opacity-100.text-sm.font-medium {:on-click top-reached}
-                        "Prev"]])
      (ui/infinite-list
       "main-container"
       (block-list config segment)
-      {:on-load bottom-reached})
-     (when (> (count blocks) (* @*page max-blocks-per-page))
-       [:div.ml-4.mt-4 [:a#more.opacity-60.opacity-100.text-sm.font-medium {:on-click bottom-reached}
-                        "More"]])]))
+      {:on-load bottom-reached
+       :threhold 400})]))
 
 (rum/defcs blocks-container <
   {:init (fn [state]
@@ -2919,20 +2939,19 @@
                               (let [id' (swap! *blocks-container-id inc)]
                                 (reset! *init-blocks-container-id id')
                                 id'))
-        sidebar? (:sidebar? config)
-        ref? (:ref? config)
-        custom-query? (:custom-query? config)
-        blocks->vec-tree #(if (or custom-query? ref?) % (tree/blocks->vec-tree % (:id config)))
-        blocks' (blocks->vec-tree blocks)
-        blocks (if (seq blocks') blocks' blocks)
         config (assoc config :blocks-container-id blocks-container-id)
         doc-mode? (:document/mode? config)]
     (when (seq blocks)
-      [:div.blocks-container.flex-1
-       {:class (when doc-mode? "document-mode")
-        ;; :style {:margin-left (if sidebar? 0 -10)}
-        }
-       (lazy-blocks config blocks)])))
+      (let [blocks->vec-tree #(if (custom-query-or-ref? config) % (tree/blocks->vec-tree % (:id config)))
+            blocks-tree (blocks->vec-tree blocks)
+            blocks-tree (if (seq blocks-tree) blocks-tree blocks)
+            flat-blocks (if (custom-query-or-ref? config)
+                          blocks-tree
+                          (flat-blocks-tree blocks-tree))
+            flat-blocks (vec flat-blocks)]
+        [:div.blocks-container.flex-1
+         {:class (when doc-mode? "document-mode")}
+         (lazy-blocks config flat-blocks blocks->vec-tree)]))))
 
 ;; headers to hiccup
 (defn ->hiccup

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2921,13 +2921,16 @@
                                    blocks->vec-tree)
         bottom-reached (fn []
                          (reset! *last-idx idx)
-                         (reset! ignore-scroll? false))]
+                         (reset! ignore-scroll? false))
+        has-more? (>= (count flat-blocks) (inc idx))]
     [:div#lazy-blocks
      (ui/infinite-list
       "main-content-container"
       (block-list config segment)
       {:on-load bottom-reached
-       :threhold 1000})]))
+       :threhold 1000
+       :has-more has-more?
+       :more-text "More"})]))
 
 (rum/defcs blocks-container <
   {:init (fn [state]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2930,7 +2930,7 @@
       {:on-load bottom-reached
        :threhold 1000
        :has-more has-more?
-       :more-text "More"})]))
+       :more (if (:preview? config) "More" (ui/loading "Loading"))})]))
 
 (rum/defcs blocks-container <
   {:init (fn [state]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2924,10 +2924,10 @@
                          (reset! ignore-scroll? false))]
     [:div#lazy-blocks
      (ui/infinite-list
-      "main-container"
+      "main-content-container"
       (block-list config segment)
       {:on-load bottom-reached
-       :threhold 400})]))
+       :threhold 1000})]))
 
 (rum/defcs blocks-container <
   {:init (fn [state]

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -474,7 +474,7 @@
         _ (rum/use-effect! (fn []
                              (when-let [^js/HTMLElement cnt
                                         (and right-sidebar? editing-key
-                                             (js/document.querySelector "#main-container"))]
+                                             (js/document.querySelector "#main-content-container"))]
                                (when (.contains cnt (js/document.querySelector (str "#" editing-key)))
                                  (let [el  (rum/deref *el)
                                        ofx (- (.-scrollWidth cnt) (.-clientWidth cnt))]

--- a/src/main/frontend/components/journal.cljs
+++ b/src/main/frontend/components/journal.cljs
@@ -92,7 +92,7 @@
 (rum/defc journals < rum/reactive
   [latest-journals]
   [:div#journals
-   (ui/infinite-list "main-container"
+   (ui/infinite-list "main-content-container"
                      (for [[journal-name format] latest-journals]
                        [:div.journal-item.content {:key journal-name}
                         (journal-cp [journal-name format])])

--- a/src/main/frontend/components/journal.cljs
+++ b/src/main/frontend/components/journal.cljs
@@ -97,7 +97,7 @@
                        [:div.journal-item.content {:key journal-name}
                         (journal-cp [journal-name format])])
                      {:has-more (page-handler/has-more-journals?)
-                      :more-text-class "text-4xl"
+                      :more-class "text-4xl"
                       :on-top-reached page-handler/create-today-journal!
                       :on-load (fn []
                                  (page-handler/load-more-journals!))})])

--- a/src/main/frontend/components/journal.cljs
+++ b/src/main/frontend/components/journal.cljs
@@ -97,6 +97,7 @@
                        [:div.journal-item.content {:key journal-name}
                         (journal-cp [journal-name format])])
                      {:has-more (page-handler/has-more-journals?)
+                      :more-text-class "text-4xl"
                       :on-top-reached page-handler/create-today-journal!
                       :on-load (fn []
                                  (page-handler/load-more-journals!))})])

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -47,9 +47,9 @@
     (get-in route-match [:parameters :path :name])))
 
 (defn- get-blocks
-  [repo page-name page-original-name block? block-id]
+  [repo page-name block-id]
   (when page-name
-    (if block?
+    (if block-id
       (db/get-block-and-children repo block-id)
       (db/get-page-blocks repo page-name))))
 
@@ -130,7 +130,7 @@
           page-e (if (and page-e (:db/id page-e))
                    {:db/id (:db/id page-e)}
                    page-e)
-          page-blocks (get-blocks repo page-name page-original-name block? block-id)]
+          page-blocks (get-blocks repo page-name block-id)]
       (if (empty? page-blocks)
         (dummy-block page-name)
         (let [document-mode? (state/sub :document/mode?)

--- a/src/main/frontend/components/sidebar.cljs
+++ b/src/main/frontend/components/sidebar.cljs
@@ -305,14 +305,14 @@
 
   (let [left-sidebar-open? (state/sub :ui/left-sidebar-open?)]
     (rum/with-context [[t] i18n/*tongue-context*]
-      [:div#main-content.cp__sidebar-main-layout.flex-1.flex
+      [:div#main-container.cp__sidebar-main-layout.flex-1.flex
        {:class (util/classnames [{:is-left-sidebar-open left-sidebar-open?}])}
 
        ;; desktop left sidebar layout
        (left-sidebar {:left-sidebar-open? left-sidebar-open?
                       :route-match route-match})
 
-       [:div#main-content-container.w-full.flex.justify-center
+       [:div#main-content-container.scrollbar-spacing.w-full.flex.justify-center
         [:div.cp__sidebar-main-content
          {:data-is-global-graph-pages global-graph-pages?
           :data-is-full-width         (or global-graph-pages?
@@ -535,16 +535,15 @@
                           :default-home   default-home
                           :new-block-mode new-block-mode})
 
-          [:div#main-container.scrollbar-spacing
-           (main {:route-match         route-match
-                  :global-graph-pages? global-graph-pages?
-                  :logged?             logged?
-                  :home?               home?
-                  :route-name          route-name
-                  :indexeddb-support?  indexeddb-support?
-                  :white?              white?
-                  :db-restoring?       db-restoring?
-                  :main-content        main-content})]
+          (main {:route-match         route-match
+                 :global-graph-pages? global-graph-pages?
+                 :logged?             logged?
+                 :home?               home?
+                 :route-name          route-name
+                 :indexeddb-support?  indexeddb-support?
+                 :white?              white?
+                 :db-restoring?       db-restoring?
+                 :main-content        main-content})
 
           (footer)]
          (right-sidebar/sidebar)

--- a/src/main/frontend/components/sidebar.css
+++ b/src/main/frontend/components/sidebar.css
@@ -31,10 +31,7 @@
 
 #main-container {
   position: relative;
-  height: 100%;
-}
-
-#main-content {
+  height: calc(100vh - var(--ls-headbar-height));
   transition: padding-left .3s;
 
   &.is-left-sidebar-open {
@@ -464,4 +461,8 @@ html[data-theme='dark'] {
 
 .favorites li.dragging-target {
   border-left: 5px solid green;
+}
+
+#main-content-container {
+    height: calc(100vh - var(--ls-headbar-height));
 }

--- a/src/main/frontend/components/sidebar.css
+++ b/src/main/frontend/components/sidebar.css
@@ -30,17 +30,22 @@
 }
 
 #main-container {
+    position: relative;
+    height: 100%;
+    transition: padding-left .3s;
+
+    &.is-left-sidebar-open {
+        padding-left: 0;
+
+        @screen sm {
+            padding-left: var(--ls-left-sidebar-width);
+        }
+    }
+}
+
+#main-content {
   position: relative;
   height: calc(100vh - var(--ls-headbar-height));
-  transition: padding-left .3s;
-
-  &.is-left-sidebar-open {
-    padding-left: 0;
-
-    @screen sm {
-      padding-left: var(--ls-left-sidebar-width);
-    }
-  }
 
   &-container {
     @apply p-4 sm:px-8;
@@ -461,8 +466,4 @@ html[data-theme='dark'] {
 
 .favorites li.dragging-target {
   border-left: 5px solid green;
-}
-
-#main-content-container {
-    height: calc(100vh - var(--ls-headbar-height));
 }

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -261,7 +261,7 @@
 
 (defn main-node
   []
-  (gdom/getElement "main-container"))
+  (gdom/getElement "main-content-container"))
 
 (defn get-scroll-top []
   (.-scrollTop (main-node)))
@@ -375,7 +375,7 @@
 
 (defn on-scroll
   [node {:keys [on-load on-top-reached threhold]
-         :or {threhold 100}}]
+         :or {threhold 500}}]
   (let [full-height (gobj/get node "scrollHeight")
         scroll-top (gobj/get node "scrollTop")
         client-height (gobj/get node "clientHeight")

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -402,16 +402,17 @@
   (mixins/event-mixin attach-listeners)
   "Render an infinite list."
   [state list-element-id body {:keys [on-load on-top-reached threhold
-                                      has-more more-text more-text-class]
-                               :or {more-text-class "text-sm"}}]
+                                      has-more more more-class]
+                               :or {more-class "text-sm"}}]
   (rum/with-context [[t] i18n/*tongue-context*]
     [:div
      body
      (when has-more
-       [:a.fade-link.text-link.font-bold
-        {:on-click on-load
-         :class more-text-class}
-        (or more-text (t :page/earlier))])]))
+       [:div.w-full.p-4
+        [:a.fade-link.text-link.font-bold
+         {:on-click on-load
+          :class more-class}
+         (or more (t :page/earlier))]])]))
 
 (rum/defcs auto-complete <
   (rum/local 0 ::current-idx)

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -35,7 +35,7 @@
 
 #?(:cljs (defonce ^js node-path utils/nodePath))
 #?(:cljs (defn app-scroll-container-node []
-           (gdom/getElement "main-container")))
+           (gdom/getElement "main-content-container")))
 
 #?(:cljs
    (defn ios?


### PR DESCRIPTION
This PR addresses the bad performance when loading long pages, 20k blocks will make logseq stuck and not respond at all.

Previously, there's already pagination and lazy loading but it's only for the top-level blocks, this PR enabled the lazy loading for blocks in nested levels too.

In the future, we should investigate virtual trees to improve both UX and reduce memory usage.

https://www.loom.com/share/296118d8a50e4fba90d5c4398f9cae30