### PR TITLE
bump react-tweet-embed

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
         "react-textarea-autosize": "8.0.1",
         "react-tippy": "1.4.0",
         "react-transition-group": "4.3.0",
-        "react-tweet-embed": "1.2.2",
+        "react-tweet-embed": "1.3.1",
         "reakit": "0.11.1",
         "threads": "1.6.5",
         "url": "^0.11.0",


### PR DESCRIPTION
The current version 1.2.1 was released 3 years ago. Updating it to the latest version may solve some issues, typically unloading issue that iOS users keep reporting.