### PR TITLE
fix(iOS): clicking unlinked reference blanks out

### DIFF
--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -1062,9 +1062,9 @@
                db-utils/group-by-page))))))
 
 (defn- pattern [name]
-  (re-pattern (str "(?i)(?!#)(?!\\[\\[)"
+  (re-pattern (str "(?i)(^|[^\\[#0-9a-zA-Z]|((^|[^\\[])\\[))"
                    (util/regex-escape name)
-                   "(?!\\]\\])")))
+                   "($|[^0-9a-zA-Z])")))
 
 (defn get-page-unlinked-references
   [page]

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -1062,14 +1062,14 @@
                db-utils/group-by-page))))))
 
 (defn- pattern [name]
-  (re-pattern (str "(?i)(?<!#)(?<!\\[\\[)"
+  (re-pattern (str "(?i)(?!#)(?!\\[\\[)"
                    (util/regex-escape name)
                    "(?!\\]\\])")))
 
 (defn get-page-unlinked-references
   [page]
   (when-let [repo (state/get-current-repo)]
-    (when-let [conn (conn/get-conn repo)]
+    (when (conn/get-conn repo)
       (let [page (util/safe-page-name-sanity-lc page)
             page-id     (:db/id (db-utils/entity [:block/name page]))
             alias-names (get-page-alias-names repo page)
@@ -1085,7 +1085,7 @@
                                               (map :e))
                                          result (d/pull-many db block-attrs ids)]
                                      (remove (fn [block] (= page-id (:db/id (:block/page block)))) result)))}
-               nil)
+                      nil)
              react
              (sort-by-left-recursive)
              db-utils/group-by-page)))))


### PR DESCRIPTION
Safari doesn't support lookbehind pattern `?<!`.
Reference: https://stackoverflow.com/questions/51568821/works-in-chrome-but-breaks-in-safari-invalid-regular-expression-invalid-group

Fix #3645 