### PR TITLE
fix(electron): only show add to dictionary when misspelling

### DIFF
--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -115,7 +115,7 @@
                                          :click
                                          (fn [] (. web-contents replaceMisspelling suggestion))}))))
 
-               (when-let [misspelled-word (.-misspelledWord ^js params)]
+               (when-let [misspelled-word (not-empty (.-misspelledWord ^js params))]
                  (. menu append
                     (MenuItem. (clj->js {:label
                                          "Add to dictionary"


### PR DESCRIPTION
- `Add to dictionary` is used for spelling check
- The condition in `when-let` of menu item is wrong, since `""` is considered boolean true in Clojure


Fix #3657
