### PR TITLE
fix: datascript error blocks file watching

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -425,7 +425,7 @@
                s (if (not= (util/safe-page-name-sanity-lc original-name) page-name-in-block)
                    page-name-in-block ;; page-name-in-block might be overrided (legacy)
                    original-name)
-               _ (when-not page-entity (js/console.error "page-inner's page-entity is nil, given page-name: " page-name
+               _ (when-not page-entity (js/console.warning "page-inner's page-entity is nil, given page-name: " page-name
                                                          " page-name-in-block: " page-name-in-block))]
            (if tag? (str "#" s) s))))]))
 

--- a/src/main/frontend/handler/extract.cljs
+++ b/src/main/frontend/handler/extract.cljs
@@ -204,7 +204,7 @@
          (map (partial apply merge))
          (with-block-uuid))))
 
-(defn- remove-illegal-refs
+(defn remove-illegal-refs
   [block block-ids-set refresh?]
   (let [aux-fn (fn [refs]
                  (let [block-refs (if refresh? (set refs)
@@ -216,6 +216,7 @@
         (update :block/refs aux-fn)
         (update :block/path-refs aux-fn))))
 
+;; TODO: refactor with reset-file!
 (defn extract-all-blocks-pages
   [repo-url files metadata refresh?]
   (when (seq files)


### PR DESCRIPTION
A temporary Fix #3804
Need discussion about how to refine this part of code.

Can locate the issue is caused by
https://github.com/logseq/logseq/blob/3ded9ee1ff9dc7c15ce8aaf072d8de7deeb2ba9e/src/main/frontend/handler/file.cljs#L163-L180

which requires the filtering logic from
https://github.com/logseq/logseq/blob/3ded9ee1ff9dc7c15ce8aaf072d8de7deeb2ba9e/src/main/frontend/handler/extract.cljs#L250-L255

Should we merge this two functions or at least extract some helper functions? As they have so many overlapping logics