### PR TITLE
fix(electron): do not save cache for demo graph

### DIFF
--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -201,7 +201,8 @@
   (get-serialized-graph graph-name))
 
 (defmethod handle :saveGraph [_window [_ graph-name value-str]]
-  (when (and graph-name value-str)
+  ;; NOTE: graph-name is a plain "local" for demo graph.
+  (when (and graph-name value-str (not (= "local" graph-name)))
     (when-let [file-path (get-graph-path graph-name)]
       (fs/writeFileSync file-path value-str))))
 


### PR DESCRIPTION
Clear cache then close the app will save a `local.transit` in `~/.logseq/graphs`.

![image](https://user-images.githubusercontent.com/72891/149347005-def735c3-2b98-4c7d-ad56-b9a625e98bc1.png)

Next time opening logseq, there will be a "path empty" error in the main thread.

Fix #3850