### PR TITLE
Fix ci(build): rename job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,12 @@ env:
 
 jobs:
 
-  cljs-test:
-    runs-on: ubuntu-latest
+  test:
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+
+    runs-on: ${{ matrix.operating-system }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/72891/149350802-5d2e6c9b-0124-43a0-ad56-430c0da089b6.png)

The `test(ubuntu-latest)` is renamed. No clue why it says "wait for status to be reported".
