### PR TITLE
dev: fix gulp-watch cpu usage

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,7 +46,10 @@ const common = {
   },
 
   keepSyncResourceFile () {
-    return gulp.watch(resourceFilePath, { ignoreInitial: true }, common.syncResourceFile)
+    return gulp.watch(resourceFilePath, { 
+      ignoreInitial: true,
+      usePolling: false  // Don't know why but have to set explicitly, or high cpu usage
+     }, common.syncResourceFile)
   },
 
   syncAllStatic () {
@@ -67,7 +70,10 @@ const common = {
     return gulp.watch([
       path.join(outputPath, 'js/**'),
       path.join(outputPath, 'css/**')
-    ], { ignoreInitial: true }, common.syncJS_CSSinRt)
+    ], { 
+      ignoreInitial: true,
+      usePolling: false  // Don't know why but have to set explicitly, or high cpu usage
+    }, common.syncJS_CSSinRt)
   }
 }
 


### PR DESCRIPTION
Solve gulp high cpu usage by explicitly setting `usePolling`
Before:
<img width="985" alt="Screen Shot 2022-01-14 at 12 43 54" src="https://user-images.githubusercontent.com/9862022/149454964-c0c2405a-cf85-41c4-997f-dc4a7fb71f37.png">
After:
<img width="978" alt="image" src="https://user-images.githubusercontent.com/9862022/149455016-0cbcef2a-ca66-4e03-95cf-cda17278c9f1.png">

An internal bug of Gulp / chokidar ? The default value for `usePolling` was `false`.
https://gulpjs.com/docs/en/api/watch/