### PR TITLE
dev: fix watcher fsevent error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,12 @@ const sourcePath = path.join(__dirname, 'src/main/frontend')
 const resourceFilePath = path.join(resourcesPath, '**')
 const outputFilePath = path.join(outputPath, '**')
 
+const gulpOptions = { 
+  ignoreInitial: true,
+  usePolling: true,  // fsevents watcher throws error for large amount of files
+  interval: 1000  // reduce polling cpu pressure
+}
+
 const css = {
   watchCSS () {
     return cp.spawn(`yarn css:watch`, {
@@ -46,10 +52,7 @@ const common = {
   },
 
   keepSyncResourceFile () {
-    return gulp.watch(resourceFilePath, { 
-      ignoreInitial: true,
-      usePolling: false  // Don't know why but have to set explicitly, or high cpu usage
-     }, common.syncResourceFile)
+    return gulp.watch(resourceFilePath, gulpOptions, common.syncResourceFile)
   },
 
   syncAllStatic () {
@@ -70,10 +73,7 @@ const common = {
     return gulp.watch([
       path.join(outputPath, 'js/**'),
       path.join(outputPath, 'css/**')
-    ], { 
-      ignoreInitial: true,
-      usePolling: false  // Don't know why but have to set explicitly, or high cpu usage
-    }, common.syncJS_CSSinRt)
+    ], gulpOptions, common.syncJS_CSSinRt)
   }
 }
 


### PR DESCRIPTION
Revert #3899, as fsevent error reported:
>[13:33:25] 'keepSyncResourceFile' errored after 1.3 s
>[13:33:25] Error: EMFILE: too many open files, watch '/Users/mono/Repos/logseq/resources/node_modules/node-abi/node_modules/.bin/semver'
>    at FSWatcher.<computed> (node:internal/fs/watchers:244:19)

Now enlarge polling interval. Current CPU usage:
<img width="962" alt="image" src="https://user-images.githubusercontent.com/9862022/149459137-3e4c996b-8ab6-4074-9fd9-a5f6eb62033f.png">
