### PR TITLE
enhance(marketplace): plugin readme page ui position

### DIFF
--- a/resources/marketplace.html
+++ b/resources/marketplace.html
@@ -17,9 +17,30 @@
       box-sizing: border-box;
       font-family: sans-serif;
       width: 100%;
-      height: 100%;
+      min-height: 100%;
     }
+ 
+      html::-webkit-scrollbar-thumb {
+        background-color: rgba(0, 0, 0, 0.1);
+      }
 
+      html::-webkit-scrollbar {
+        background-color: rgba(0, 0, 0, 0.05);
+      }
+
+      html::-webkit-scrollbar-thumb:active {
+        background-color: rgba(0, 0, 0, 0.2);
+      }
+
+      html::-webkit-scrollbar {
+        width: 6px;
+        height: 8px;
+      }
+
+      html::-webkit-scrollbar-corner {
+        background: transparent;
+      }
+    
     body {
       display: flex;
     }


### PR DESCRIPTION
### fix marketplace: plugin readme page ui position

The marketplace page, in the readme page of plugin,the close button has a wrong position ,Also,the end of this page has no padding.

### repoduce
windows 10  
0.5.8 nightly 20220113
marketplace: link preview plugin 

### before:
![1642168618(1)](https://user-images.githubusercontent.com/46164858/149526849-ff95c9ac-f956-40ce-a328-27bb328e2cc3.jpg)

### after:
![1642168664(1)](https://user-images.githubusercontent.com/46164858/149526936-3d4a0ed6-e013-4f8b-bab7-2078ed37785d.png)
