### PR TITLE
Enhance full text search index

### DIFF
--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -18,6 +18,7 @@
             [frontend.mixins :as mixins]
             [frontend.modules.shortcut.core :as shortcut]
             [frontend.state :as state]
+            [frontend.search.db :as search-db]
             [frontend.ui :as ui]
             [frontend.util :as util]
             [frontend.util.cursor :as cursor]
@@ -170,7 +171,8 @@
                                       (:block/name page))
                              repo (state/sub :git/current-repo)
                              format (db/get-page-format page)
-                             content (:block/content (db-model/query-block-by-uuid uuid))]
+                             block (db-model/query-block-by-uuid uuid)
+                             content (search-db/block->content block)]
 
                          [:.py-2 (search/block-search-result-item repo uuid format content q :block)]))
         :class       "black"}))))

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -10,6 +10,7 @@
             [frontend.mobile.util :as mobile-util]
             [frontend.config :as config]
             [frontend.db :as db]
+            [frontend.db.model :as db-model]
             [frontend.extensions.zotero :as zotero]
             [frontend.handler.editor :as editor-handler :refer [get-state]]
             [frontend.handler.editor.lifecycle :as lifecycle]
@@ -164,11 +165,12 @@
        {:on-chosen   chosen-handler
         :on-enter    non-exist-block-handler
         :empty-div   [:div.text-gray-500.pl-4.pr-4 "Search for a block"]
-        :item-render (fn [{:block/keys [content page uuid]}]
+        :item-render (fn [{:block/keys [page uuid]}]  ;; content returned from search engine is normalized
                        (let [page (or (:block/original-name page)
                                       (:block/name page))
                              repo (state/sub :git/current-repo)
-                             format (db/get-page-format page)]
+                             format (db/get-page-format page)
+                             content (:block/content (db-model/query-block-by-uuid uuid))]
 
                          [:.py-2 (search/block-search-result-item repo uuid format content q :block)]))
         :class       "black"}))))

--- a/src/main/frontend/components/search.cljs
+++ b/src/main/frontend/components/search.cljs
@@ -11,6 +11,7 @@
             [frontend.extensions.pdf.assets :as pdf-assets]
             [frontend.ui :as ui]
             [frontend.state :as state]
+            [frontend.search.db :as search-db]
             [frontend.mixins :as mixins]
             [frontend.config :as config]
             [clojure.string :as string]
@@ -202,7 +203,8 @@
                                                         page (util/get-page-original-name page)
                                                         repo (state/sub :git/current-repo)
                                                         format (db/get-page-format page)
-                                                        content (:block/content (model/query-block-by-uuid uuid))]
+                                                        block (model/query-block-by-uuid uuid)
+                                                        content (search-db/block->content block)]
                                                     [:span {:data-block-ref uuid}
                                                       (search-result-item "Block"
                                                         (block-search-result-item repo uuid format content search-q search-mode))])

--- a/src/main/frontend/components/search.cljs
+++ b/src/main/frontend/components/search.cljs
@@ -198,10 +198,11 @@
                                                   (search-result-item "File" (highlight-exact-query data search-q))
 
                                                   :block
-                                                  (let [{:block/keys [page content uuid]} data
+                                                  (let [{:block/keys [page uuid]} data  ;; content here is normalized
                                                         page (util/get-page-original-name page)
                                                         repo (state/sub :git/current-repo)
-                                                        format (db/get-page-format page)]
+                                                        format (db/get-page-format page)
+                                                        content (:block/content (model/query-block-by-uuid uuid))]
                                                     [:span {:data-block-ref uuid}
                                                       (search-result-item "Block"
                                                         (block-search-result-item repo uuid format content search-q search-mode))])

--- a/src/main/frontend/components/sidebar.cljs
+++ b/src/main/frontend/components/sidebar.cljs
@@ -350,7 +350,7 @@
                (when-let [pages (->> (seq sidebar)
                                      (remove string/blank?))]
                  (doseq [page pages]
-                   (let [page (util/safe-lower-case page)
+                   (let [page (util/safe-page-name-sanity-lc page)
                          [db-id block-type] (if (= page "contents")
                                               ["contents" :contents]
                                               [page :page])]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -419,13 +419,13 @@
                      :data [block]}]
            (db/refresh! repo opts)))
 
-       ;; page title changed
+       ;; sanitized page name changed
        (when-let [title (get-in block [:block/properties :title])]
-         (when-let [old-title (:block/name (db/entity (:db/id (:block/page block))))]
+         (when-let [old-page-name (:block/name (db/entity (:db/id (:block/page block))))]
            (when (and (:block/pre-block? block)
                       (not (string/blank? title))
-                      (not= (string/lower-case title) old-title))
-             (state/pub-event! [:page/title-property-changed old-title title]))))))
+                      (not= (util/page-name-sanity-lc title) old-page-name))
+             (state/pub-event! [:page/title-property-changed old-page-name title]))))))
 
     (repo-handler/push-if-auto-enabled! repo)))
 

--- a/src/main/frontend/search.cljs
+++ b/src/main/frontend/search.cljs
@@ -185,8 +185,8 @@
                        (doseq [page-name pages-to-remove-set]
                          (.remove indice
                                   (fn [page]
-                                    (= (util/safe-lower-case page-name)
-                                       (util/safe-lower-case (gobj/get page "name"))))))
+                                    (= (util/safe-page-name-sanity-lc page-name)
+                                       (util/safe-page-name-sanity-lc (gobj/get page "name"))))))
                        (when (seq pages-to-add)
                          (doseq [page pages-to-add]
                            (.add indice (bean/->js page)))))

--- a/src/main/frontend/search/db.cljs
+++ b/src/main/frontend/search/db.cljs
@@ -16,12 +16,17 @@
   [repo]
   (nil? (get @indices repo)))
 
+(defn block->content
+  "Convert a block to the display contents for searching"
+  [{:block/keys [content format]}]
+  (->> (text/remove-level-spaces content format)
+       (drawer/remove-logbook)
+       (property/remove-built-in-properties format)))
+
 (defn block->index
-  "Convert a block to the contents for searching (will be displayed in the search results)"
-  [{:block/keys [uuid content format page] :as block}]
-  (when-let [result (->> (text/remove-level-spaces content format)
-                         (drawer/remove-logbook)
-                         (property/remove-built-in-properties format)
+  "Convert a block to the index for searching"
+  [{:block/keys [uuid page] :as block}]
+  (when-let [result (->> (block->content block)
                          (util/search-normalize))]
     {:id (:db/id block)
      :uuid (str uuid)

--- a/src/main/frontend/search/db.cljs
+++ b/src/main/frontend/search/db.cljs
@@ -22,7 +22,7 @@
   (when-let [result (->> (text/remove-level-spaces content format)
                          (drawer/remove-logbook)
                          (property/remove-built-in-properties format)
-                         (util/search-normalize-content))]
+                         (util/search-normalize))]
     {:id (:db/id block)
      :uuid (str uuid)
      :page page

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1170,7 +1170,6 @@
         (subs s 0 (dec (count s)))
         s))))
 
-
 (defn normalize
   [s]
   (.normalize s "NFC"))


### PR DESCRIPTION
Make search index normalized & case-insensitive.

**Motivations**
* `fuse.js` and `SQLite3 + fst5` have different behaviors toward tokenization, especially the default tokenizers in `fst5` handles Cyrillic upper case characters badly (Fix #3352);
* It's confusing that index text is case-sensitive, while query text is case-insensitive;

- [x] Make index lower-cased
- [x] FST display block content pulled from db, instead of content returned by search engine
- [x] Sanitize search block display

**To activate the update**
* `mod+c mod+s` to rebuild search index