### PR TITLE
fix(ui): wrong precondition for open button

### DIFF
--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -160,9 +160,10 @@
                    (remove #(= (:url %) config/local-repo)))
         electron-mac? (and util/mac? (util/electron?))
         vw-state (state/sub :ui/visual-viewport-state)
-        show-open-folder? (and (or (nfs/supported?)
-                                   (mobile-util/is-native-platform?))
-                               (empty? repos)
+        show-open-folder? (and (nfs/supported?)
+                               (or (empty? repos)
+                                   (nil? (state/sub :git/current-repo)))
+                               (not (mobile-util/is-native-platform?))
                                (not config/publishing?))
         refreshing? (state/sub :nfs/refreshing?)]
     (rum/with-context [[t] i18n/*tongue-context*]
@@ -230,9 +231,7 @@
 
         (repo/sync-status current-repo)
 
-        (when (and
-               show-open-folder?
-               (not (mobile-util/is-native-platform?)))
+        (when show-open-folder?
           [:a.text-sm.font-medium.button
            {:on-click #(page-handler/ls-dir-files! shortcut/refresh!)}
            [:div.flex.flex-row.text-center.open-button__inner.items-center


### PR DESCRIPTION
This fixes the wrong precondition for top-right `+ Open` button.

Avoid buggy UI conditions like:( neither repo-switch nor open button is shown. CANNOT open new graphs)

![image](https://user-images.githubusercontent.com/72891/149869076-b84fd187-2a71-4907-8fd4-2394fff327b7.png)

The button's shown condition should be coordinated with repo-switch of left-sidebar.

https://github.com/logseq/logseq/blob/557b67925fc2025facd039ed184be063f5110b27/src/main/frontend/components/repo.cljs#L215

https://github.com/logseq/logseq/blob/557b67925fc2025facd039ed184be063f5110b27/src/main/frontend/components/repo.cljs#L296-L305

Fix #3781
Fix #3637
