### PR TITLE
don't collapse left sidebar when editing

### DIFF
--- a/src/main/frontend/mobile/core.cljs
+++ b/src/main/frontend/mobile/core.cljs
@@ -41,9 +41,9 @@
     ;; Keyboard watcher
     (.addListener Keyboard "keyboardWillShow"
                   #(state/pub-event! [:mobile/keyboard-will-show]))
-    (.addListener Keyboard "keyboardDidShow"
-                  #(state/pub-event! [:mobile/keyboard-did-show]))
-
+    ;; (.addListener Keyboard "keyboardDidShow"
+    ;;               #(state/pub-event! [:mobile/keyboard-did-show]))
+    
     (.addListener App "appStateChange"
                   (fn [^js state]
                     (when-let [repo (state/get-current-repo)]


### PR DESCRIPTION
Since left-sidebar layout mess-up when editing has been fixed, collapse is not needed anymore.