### PR TITLE
Fix invalid boolean props

### DIFF
--- a/e2e-tests/basic.spec.ts
+++ b/e2e-tests/basic.spec.ts
@@ -289,3 +289,13 @@ test.skip('open directory', async ({ page }) => {
 
   await page.click('#left-sidebar >> text=Journals')
 })
+
+test('invalid page props #3944', async ({ page }) => {
+  await createRandomPage(page)
+
+  await page.fill(':nth-match(textarea, 1)', 'public:: true\nsize:: 65535')
+  await page.press(':nth-match(textarea, 1)', 'Enter')
+  await page.press(':nth-match(textarea, 1)', 'Enter')
+
+  await page.waitForTimeout(1000)
+})

--- a/src/main/frontend/format/mldoc.cljs
+++ b/src/main/frontend/format/mldoc.cljs
@@ -154,7 +154,7 @@
           properties (assoc properties :tags tags :alias alias)
           properties (-> properties
                          (update :filetags (constantly filetags)))
-          properties (medley/filter-kv (fn [_k v] (seq v)) properties)]
+          properties (medley/remove-kv (fn [_k v] (or (nil? v) (and (coll? v) (empty? v)))) properties)]
       (if (seq properties)
         (cons [["Properties" properties] nil] other-ast)
         original-ast))


### PR DESCRIPTION
Introduced in 2401ce9. it might change some processing orders. A commit just before it works.

Fixes #3944 