### PR TITLE
fix(editor): reorder auto-complete items

### DIFF
--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -122,13 +122,17 @@
                               (empty? matched-pages)
                               matched-pages
 
+                              ;; reorder, shortest and starts-with first.
                               :else
-                              (->>
-                               (cons (first matched-pages)
-                                     (cons
-                                      (str "New page: " q)
-                                      (rest matched-pages)))
-                               (remove nil?)))]
+                              (let [matched-pages (remove nil? matched-pages)
+                                    matched-pages (sort-by
+                                                   (fn [m]
+                                                     [(not (string/starts-with? m q)) (count m)])
+                                                   matched-pages)]
+                                (cons (first matched-pages)
+                                      (cons
+                                       (str "New page: " q)
+                                       (rest matched-pages)))))]
           (ui/auto-complete
            matched-pages
            {:on-chosen   (page-handler/on-chosen-handler input id q pos format)


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/72891/150177545-5fe54c82-4722-4265-930b-f8d95ef1e497.png)


Now:
![image](https://user-images.githubusercontent.com/72891/150177359-651ca20e-7e17-4f29-9e46-0936426ab0ea.png)
