### PR TITLE
fix page rename on mobile

### DIFF
--- a/src/main/frontend/fs.cljs
+++ b/src/main/frontend/fs.cljs
@@ -113,7 +113,12 @@
     (p/resolved nil)
 
     :else
-    (protocol/rename! (get-fs old-path) repo old-path new-path)))
+    (let [[old-path new-path]
+        (map #(if (or (util/electron?) (mobile-util/is-native-platform?))
+                %
+                (str (config/get-repo-dir repo) "/" %))
+             [old-path new-path])]
+     (protocol/rename! (get-fs old-path) repo old-path new-path))))
 
 (defn stat
   [dir path]

--- a/src/main/frontend/fs/capacitor_fs.cljs
+++ b/src/main/frontend/fs/capacitor_fs.cljs
@@ -239,7 +239,7 @@
           (fn [error]
             (log/error :rename-file-failed error)))))
   (stat [_this dir path]
-    (let [path (str dir path)]
+    (let [path (get-file-path dir path)]
       (p/let [result (.stat Filesystem (clj->js
                                         {:path path
                                          ;; :directory (.-ExternalStorage Directory)

--- a/src/main/frontend/fs/capacitor_fs.cljs
+++ b/src/main/frontend/fs/capacitor_fs.cljs
@@ -2,7 +2,6 @@
   (:require ["@capacitor/filesystem" :refer [Encoding Filesystem]]
             [cljs-bean.core :as bean]
             [clojure.string :as string]
-            [frontend.config :as config]
             [frontend.fs.protocol :as protocol]
             [frontend.mobile.util :as mobile-util]
             [frontend.util :as util]
@@ -159,6 +158,19 @@
                       (error-handler error)
                       (log/error :write-file-failed error)))))))))
 
+(defn- get-file-path [dir path]
+  (let [[dir path'] (map #(-> (when %
+                                (string/replace % "///" "/"))
+                              js/decodeURI)
+                         [dir path])
+        path (if (string/starts-with? path' dir)
+               path
+               (-> (str dir path)
+                   (string/replace "//" "/")))]
+    (if (mobile-util/native-ios?)
+      (js/encodeURI (js/decodeURI path))
+      path)))
+
 (defrecord Capacitorfs []
   protocol/Fs
   (mkdir! [_this dir]
@@ -177,7 +189,7 @@
                              :recursive true}))]
       (js/console.log result)
       result))
-  (readdir [_this dir]                   ; recursive
+  (readdir [_this dir]                  ; recursive
     (readdir dir))
   (unlink! [_this _repo _path _opts]
     nil)
@@ -200,16 +212,7 @@
        (p/catch (fn [error]
                   (js/alert error))))))
   (delete-file! [_this repo dir path {:keys [ok-handler error-handler]}]
-    (let [path (cond
-                 (= (mobile-util/platform) "ios")
-                 (js/encodeURI (js/decodeURI path))
-
-                 (string/starts-with? path (config/get-repo-dir repo))
-                 path
-
-                 :else
-                 (-> (str dir "/" path)
-                     (string/replace "//" "/")))]
+    (let [path (get-file-path dir path)]
       (p/catch
           (p/let [result (.deleteFile Filesystem
                                       (clj->js
@@ -221,16 +224,7 @@
               (error-handler error)
               (log/error :delete-file-failed error))))))
   (write-file! [this repo dir path content opts]
-    (let [path (cond
-                 (= (mobile-util/platform) "ios")
-                 (js/encodeURI (js/decodeURI path))
-
-                 (string/starts-with? path (config/get-repo-dir repo))
-                 path
-
-                 :else
-                 (-> (str dir "/" path)
-                     (string/replace "//" "/")))]
+    (let [path (get-file-path dir path)]
       (p/let [stat (p/catch
                        (.stat Filesystem (clj->js {:path path}))
                        (fn [_e] :not-found))]

--- a/src/main/frontend/fs/capacitor_fs.cljs
+++ b/src/main/frontend/fs/capacitor_fs.cljs
@@ -229,8 +229,15 @@
                        (.stat Filesystem (clj->js {:path path}))
                        (fn [_e] :not-found))]
         (write-file-impl! this repo dir path content opts stat))))
-  (rename! [_this _repo _old-path _new-path]
-    nil)
+  (rename! [_this _repo old-path new-path]
+    (let [[old-path new-path] (map #(get-file-path "" %) [old-path new-path])]
+      (p/catch
+          (p/let [_ (.rename Filesystem
+                             (clj->js
+                              {:from old-path
+                               :to new-path}))])
+          (fn [error]
+            (log/error :rename-file-failed error)))))
   (stat [_this dir path]
     (let [path (str dir path)]
       (p/let [result (.stat Filesystem (clj->js

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -153,16 +153,6 @@
         parts (concat (butlast result) [new-file])]
     (string/join "/" parts)))
 
-(defn- rename-file-aux!
-  [repo old-path new-path]
-  (fs/rename! repo
-              (if (util/electron?)
-                old-path
-                (str (config/get-repo-dir repo) "/" old-path))
-              (if (util/electron?)
-                new-path
-                (str (config/get-repo-dir repo) "/" new-path))))
-
 (defn rename-file!
   [file new-name ok-handler]
   (let [repo (state/get-current-repo)
@@ -173,7 +163,7 @@
     (db/transact! repo [{:db/id (:db/id file)
                          :file/path new-path}])
     (->
-     (p/let [_ (rename-file-aux! repo old-path new-path)
+     (p/let [_ (fs/rename! repo old-path new-path)
              _ (when-not (config/local-db? repo)
                  (git/rename repo old-path new-path))]
        (common-handler/check-changed-files-status)


### PR DESCRIPTION
The PR fixes page rename issue on mobile.

* Reuse new function from PR https://github.com/logseq/logseq/pull/4010.