### PR TITLE
Increase iCloud background sync interval

### DIFF
--- a/src/main/frontend/handler.cljs
+++ b/src/main/frontend/handler.cljs
@@ -58,6 +58,14 @@
     (f)
     (js/setInterval f 5000)))
 
+(defn- icloud-sync!
+  []
+  (let [f (fn []
+            (when (state/get-current-repo)
+              (.downloadFilesFromiCloud mobile-util/download-icloud-files)))]
+    (f)
+    (js/setInterval f 300000)))
+
 (defn- instrument!
   []
   (let [total (srs/get-srs-cards-total)]
@@ -130,6 +138,8 @@
                                  (js/console.error "Failed to request GitHub app tokens."))))
 
                             (watch-for-date!)
+                            (when (mobile-util/native-ios?)
+                              (icloud-sync!))
                             (file-handler/watch-for-current-graph-dir!)))
                          (p/catch (fn [error]
                                     (log/error :exception error))))))

--- a/src/main/frontend/handler.cljs
+++ b/src/main/frontend/handler.cljs
@@ -58,14 +58,6 @@
     (f)
     (js/setInterval f 5000)))
 
-(defn- icloud-sync!
-  []
-  (let [f (fn []
-            (when (state/get-current-repo)
-              (.downloadFilesFromiCloud mobile-util/download-icloud-files)))]
-    (f)
-    (js/setInterval f 300000)))
-
 (defn- instrument!
   []
   (let [total (srs/get-srs-cards-total)]
@@ -138,8 +130,9 @@
                                  (js/console.error "Failed to request GitHub app tokens."))))
 
                             (watch-for-date!)
-                            (when (mobile-util/native-ios?)
-                              (icloud-sync!))
+                            (when (and (state/get-current-repo)
+                                       (mobile-util/native-ios?))
+                              (mobile-util/icloud-sync!))
                             (file-handler/watch-for-current-graph-dir!)))
                          (p/catch (fn [error]
                                     (log/error :exception error))))))

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -721,9 +721,7 @@
                         (config/get-file-extension format))
               file-path (str "/" path)
               repo-dir (config/get-repo-dir repo)]
-          (p/let [_ (when (mobile-util/native-ios?)
-                      (.downloadFilesFromiCloud mobile-util/download-icloud-files))
-                  file-exists? (fs/file-exists? repo-dir file-path)
+          (p/let [file-exists? (fs/file-exists? repo-dir file-path)
                   file-content (when file-exists?
                                  (fs/read-file repo-dir file-path))]
             (when (and (db/page-empty? repo today-page)

--- a/src/main/frontend/mobile/util.cljs
+++ b/src/main/frontend/mobile/util.cljs
@@ -122,3 +122,10 @@
     (if (and model landscape?)
       20
       (:statusbar (model @idevice-info)))))
+
+(defn icloud-sync!
+  []
+  (let [f (fn []
+            (.downloadFilesFromiCloud download-icloud-files))]
+    (f)
+    (js/setInterval f 300000)))


### PR DESCRIPTION
Logseq iOS app now fully downloads iCloud files every 5 seconds (called in `create-today-journal`),  which is too frequent and may leads to some performance issues (The device gets hot slightly).

This PR increases the interval to 5 minutes. 