### PR TITLE
enhance iCloud sync

### DIFF
--- a/ios/App/App/DownloadiCloudFiles.m
+++ b/ios/App/App/DownloadiCloudFiles.m
@@ -9,5 +9,6 @@
 #import <Capacitor/Capacitor.h>
 
 CAP_PLUGIN(DownloadiCloudFiles, "DownloadiCloudFiles",
-           CAP_PLUGIN_METHOD(downloadFilesFromiCloud, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(iCloudSync, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(syncGraph, CAPPluginReturnPromise);
            )

--- a/src/main/frontend/fs/capacitor_fs.cljs
+++ b/src/main/frontend/fs/capacitor_fs.cljs
@@ -250,7 +250,7 @@
                   (.pickFolder mobile-util/folder-picker)
                   #(js->clj % :keywordize-keys true)
                   :path)
-            _ (when (mobile-util/native-ios?) (.downloadFilesFromiCloud mobile-util/download-icloud-files))
+            _ (when (mobile-util/native-ios?) (mobile-util/sync-icloud-repo path))
             files (readdir path)
             files (js->clj files :keywordize-keys true)]
       (into [] (concat [{:path path}] files))))

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -721,9 +721,7 @@
                         (config/get-file-extension format))
               file-path (str "/" path)
               repo-dir (config/get-repo-dir repo)]
-          (p/let [_ (when (mobile-util/native-ios?)
-                      (.downloadFilesFromiCloud mobile-util/download-icloud-files))
-                  file-exists? (fs/file-exists? repo-dir file-path)
+          (p/let [file-exists? (fs/file-exists? repo-dir file-path)
                   file-content (when file-exists?
                                  (fs/read-file repo-dir file-path))]
             (when (and (db/page-empty? repo today-page)

--- a/src/main/frontend/handler/repo.cljs
+++ b/src/main/frontend/handler/repo.cljs
@@ -29,7 +29,7 @@
             [promesa.core :as p]
             [shadow.resource :as rc]
             [clojure.set :as set]
-            [frontend.mobile.util :as mobile]
+            [frontend.mobile.util :as mobile-util]
             [frontend.db.persist :as db-persist]
             [electron.ipc :as ipc]))
 
@@ -632,10 +632,11 @@
   [nfs-rebuild-index! ok-handler]
   (route-handler/redirect-to-home!)
   (when-let [repo (state/get-current-repo)]
-    (let [local? (config/local-db? repo)]
+    (let [local? (config/local-db? repo)
+          repo-dir (config/get-repo-dir repo)]
       (if local?
-        (p/let [_ (when (mobile/native-ios?)
-                    (.downloadFilesFromiCloud mobile/download-icloud-files))
+        (p/let [_ (when (mobile-util/native-ios?)
+                    (mobile-util/sync-icloud-repo repo-dir))
                 _ (metadata-handler/set-pages-metadata! repo)]
           (nfs-rebuild-index! repo ok-handler))
         (rebuild-index! repo))

--- a/src/main/frontend/mobile/util.cljs
+++ b/src/main/frontend/mobile/util.cljs
@@ -1,7 +1,7 @@
 (ns frontend.mobile.util
   (:require ["@capacitor/core" :refer [Capacitor registerPlugin]]
             ["@capacitor/splash-screen" :refer [SplashScreen]]
-            [clojure.string :as str]))
+            [clojure.string :as string]))
 
 (defn platform []
   (.getPlatform Capacitor))
@@ -28,6 +28,14 @@
  (defonce download-icloud-files (registerPlugin "DownloadiCloudFiles")))
 (when (native-ios?)
   (defonce ios-file-container (registerPlugin "FileContainer")))
+
+(defn sync-icloud-repo [repo-dir]
+  (let [repo-name (-> (string/split repo-dir "Documents/")
+                      last
+                      string/trim
+                      js/decodeURI)]
+    (.syncGraph download-icloud-files
+                       (clj->js {:graph repo-name}))))
 
 (defn hide-splash []
   (.hide SplashScreen))
@@ -101,18 +109,18 @@
 (defn native-iphone-without-notch?
   []
   (when-let [model (get-idevice-model)]
-    (str/starts-with? (first model) "iPhone8")))
+    (string/starts-with? (first model) "iPhone8")))
 
 (defn native-iphone?
   []
   (when-let [model (get-idevice-model)]
-    (and (str/starts-with? (first model) "iPhone")
-         (not (str/starts-with? (first model) "iPhone8")))))
+    (and (string/starts-with? (first model) "iPhone")
+         (not (string/starts-with? (first model) "iPhone8")))))
 
 (defn native-ipad?
   []
   (when-let [model (get-idevice-model)]
-    (str/starts-with? (first model) "iPad")))
+    (string/starts-with? (first model) "iPad")))
 
 (defn get-idevice-statusbar-height
   []


### PR DESCRIPTION
- Rename `downloadFilesFromiCloud` to `iCloudSync` (swift)
- Add a new function `syncGraph` which takes a graph url parameter (swift)

`iCloudSync` syncs all unsynchronized files in all graphs, including files in `bak`, `.git`, `.Trash`, `.recycle`, while `syncGraph` only syncs a single graph with those auxiliary folders excluded to reduce downloading time.

Now iOS app syncs iCloud files as follows:
- Sync selected graph only when adding a new graph
- Sync current graph only when re-indexing
- Sync current graph only when switching from other apps
- Fully sync all graphs every 5 minutes in background (implemented in PR https://github.com/logseq/logseq/pull/4014) to avoid any potential sync issues, eg. sync block.