### PR TITLE
Fix block collapse state not being saved

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3572,11 +3572,13 @@
 (defn collapse-block! [block-id]
   (when (collapsable? block-id)
     (when-not (skip-collapsing-in-db?)
+      (set-block-property! block-id :collapsed true)
       (set-blocks-collapsed! [block-id] true)))
   (state/set-collapsed-block! block-id true))
 
 (defn expand-block! [block-id]
   (when-not (skip-collapsing-in-db?)
+    (set-block-property! block-id :collapsed false)
     (set-blocks-collapsed! [block-id] false))
   (state/set-collapsed-block! block-id false))
 


### PR DESCRIPTION
This is a fix for #4045. As noted in the first comment, this bug effects all collapse/expand actions. I found that this bug was introduced in https://github.com/logseq/logseq/pull/3855#discussion_r792101354. The fix just adds back the behavior before of saving the collapse state to the file. Calling `set-block-property!` directly is maybe a little inefficient since now two calls to `db/refresh!` and `outliner-core/save-node` occur. I didn't know if I should refactor more but at least this fixes the issue