### PR TITLE
Revert "fix: title prop with double quotes"

### DIFF
--- a/src/main/frontend/text.cljs
+++ b/src/main/frontend/text.cljs
@@ -369,7 +369,7 @@
         v (string/trim v)]
     (cond
       (contains? #{"title" "filters"} k)
-      (util/unquote-string-if-wrapped v)
+      v
 
       (= v "true")
       true


### PR DESCRIPTION
Reverts logseq/logseq#3975

![image](https://user-images.githubusercontent.com/72891/151542634-5275d145-71d3-442a-b09b-533e21911baf.png)
