### PR TITLE
Tests for #4010

### DIFF
--- a/src/main/frontend/fs/capacitor_fs.cljs
+++ b/src/main/frontend/fs/capacitor_fs.cljs
@@ -159,13 +159,18 @@
                       (log/error :write-file-failed error)))))))))
 
 (defn get-file-path [dir path]
-  (let [[dir path'] (map #(some-> %
+  (let [[dir' path'] (map #(some-> %
                                   (string/replace "///" "/")
                                   js/decodeURI)
                          [dir path])
-        path (if (string/starts-with? path' dir)
-               path
-               (-> (str dir path)
+        path (cond (nil? path)
+               dir
+
+               (string/starts-with? path' dir')
+               path'
+
+               :else
+               (-> (str dir' path)
                    (string/replace "//" "/")))]
     (if (mobile-util/native-ios?)
       (js/encodeURI (js/decodeURI path))

--- a/src/main/frontend/fs/capacitor_fs.cljs
+++ b/src/main/frontend/fs/capacitor_fs.cljs
@@ -158,7 +158,7 @@
                       (error-handler error)
                       (log/error :write-file-failed error)))))))))
 
-(defn- get-file-path [dir path]
+(defn get-file-path [dir path]
   (let [[dir path'] (map #(some-> %
                                   (string/replace "///" "/")
                                   js/decodeURI)

--- a/src/test/frontend/fs/capacitor_fs_test.cljs
+++ b/src/test/frontend/fs/capacitor_fs_test.cljs
@@ -1,0 +1,24 @@
+(ns frontend.fs.capacitor-fs-test
+  (:require [frontend.fs.capacitor-fs :as capacitor-fs]
+            [clojure.test :refer [deftest is]]))
+
+(deftest get-file-path
+  (let [dir "file:///private/var/mobile/Library/Mobile%20Documents/iCloud~com~logseq~logseq/Documents/"
+        url-decoded-dir "file:/private/var/mobile/Library/Mobile Documents/iCloud~com~logseq~logseq/Documents/"]
+    (is (= (str url-decoded-dir "pages/pages-metadata.edn")
+           (capacitor-fs/get-file-path
+            dir
+            "file:///private/var/mobile/Library/Mobile Documents/iCloud~com~logseq~logseq/Documents/pages/pages-metadata.edn"))
+        "full path returns as url decoded full path")
+
+    (is (= (str url-decoded-dir "journals/2002_01_28.md")
+           (capacitor-fs/get-file-path
+            dir
+            "/journals/2002_01_28.md"))
+        "relative path returns as url decoded full path")
+
+    (is (= dir
+           (capacitor-fs/get-file-path
+            dir
+            nil))
+        "nil path returns url encoded dir")))


### PR DESCRIPTION
These are some tests for #4010 and thus are based off that branch. [The CI job](https://github.com/logseq/logseq/runs/5009975975?check_suite_focus=true) shows that the nil case failed unexpectedly and that the relative case returned url encoded path instead of url decoded path. Fixed these with the followup commit.

EDIT: The last commit doesn't trigger CI tests. I did confirm locally that `yarn test` runs. It looks like it's because of [this configuration](https://github.com/logseq/logseq/blob/86122245af90a793a39673e9e9283dd3a9ff1130/.github/workflows/build.yml#L9). I can change it to any branch if @tiensonqin is ok with it