### PR TITLE
Use standard datascript

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -7,7 +7,12 @@
   :unresolved-var {:exclude [frontend.util/node-path.basename
                              frontend.util/node-path.dirname
                              frontend.util/node-path.join
-                             frontend.util/node-path.name]}}
+                             frontend.util/node-path.name]}
+
+  :consistent-alias
+  {:aliases {datascript.core d
+             datascript.transit dt
+             datascript.db ddb}}}
 
  :hooks {:analyze-call {rum.core/defc hooks.rum/defc
                          rum.core/defcs hooks.rum/defcs}}

--- a/deps.edn
+++ b/deps.edn
@@ -3,12 +3,8 @@
  {org.clojure/clojure                   {:mvn/version "1.10.0"}
   cheshire/cheshire                     {:mvn/version "5.10.0"}
   rum/rum                               {:mvn/version "0.12.3"}
-  ;; rum                         {:local/root "/home/tienson/codes/source/clj/rum"}
-  ;; persistent-sorted-set       {:mvn/version "0.1.2"}
-  datascript/datascript                 {:git/url "https://github.com/logseq/datascript"
-                                         :sha     "de8df66e69ecd847c048f548fa0d5de0d4378bd0"}
-  datascript-transit/datascript-transit {:mvn/version "0.3.0"
-                                         :exclusions  [datascript/datascript]}
+  datascript/datascript                 {:mvn/version "1.3.8"}
+  datascript-transit/datascript-transit {:mvn/version "0.3.0"}
   borkdude/rewrite-edn                  {:git/url "https://github.com/borkdude/rewrite-edn"
                                          :sha     "edd87dc7f045f28d7afcbfc44bc0f0a2683dde62"}
   funcool/promesa                       {:mvn/version "4.0.2"}

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -6,8 +6,8 @@
             [cljs.reader :as reader]
             [clojure.string :as string]
             [clojure.walk :as walk]
-            [datascript.core :as dc]
-            [dommy.core :as d]
+            [datascript.core :as d]
+            [dommy.core :as dom]
             [frontend.commands :as commands]
             [frontend.components.datetime :as datetime-comp]
             [frontend.components.lazy-editor :as lazy-editor]
@@ -848,12 +848,12 @@
     ["Latex_Fragment" ["Displayed" s]]
     (if html-export?
       (latex/html-export s false true)
-      (latex/latex (str (dc/squuid)) s false true))
+      (latex/latex (str (d/squuid)) s false true))
 
     ["Latex_Fragment" ["Inline" s]]
     (if html-export?
       (latex/html-export s false true)
-      (latex/latex (str (dc/squuid)) s false false))
+      (latex/latex (str (d/squuid)) s false false))
 
     ["Target" s]
     [:a {:id s} s]
@@ -1761,16 +1761,16 @@
 (defn- target-forbidden-edit?
   [target]
   (or
-   (d/has-class? target "forbid-edit")
-   (d/has-class? target "bullet")
-   (d/has-class? target "logbook")
+   (dom/has-class? target "forbid-edit")
+   (dom/has-class? target "bullet")
+   (dom/has-class? target "logbook")
    (util/link? target)
    (util/time? target)
    (util/input? target)
    (util/details-or-summary? target)
    (and (util/sup? target)
-        (d/has-class? target "fn"))
-   (d/has-class? target "image-resize")))
+        (dom/has-class? target "fn"))
+   (dom/has-class? target "image-resize")))
 
 (defn- block-content-on-mouse-down
   [e block block-id _content edit-input-id]
@@ -1995,8 +1995,8 @@
 (defn non-dragging?
   [e]
   (and (= (gobj/get e "buttons") 1)
-       (not (d/has-class? (gobj/get e "target") "bullet-container"))
-       (not (d/has-class? (gobj/get e "target") "bullet"))
+       (not (dom/has-class? (gobj/get e "target") "bullet-container"))
+       (not (dom/has-class? (gobj/get e "target") "bullet"))
        (not @*dragging?)))
 
 (rum/defc breadcrumb-fragment
@@ -2123,7 +2123,7 @@
   (when-let [parent (gdom/getElement block-id)]
     (let [node (.querySelector parent ".bullet-container")]
       (when doc-mode?
-        (d/remove-class! node "hide-inner-bullet"))))
+        (dom/remove-class! node "hide-inner-bullet"))))
   (when (and
          (state/in-selection-mode?)
          (non-dragging? e))
@@ -2137,7 +2137,7 @@
   (when doc-mode?
     (when-let [parent (gdom/getElement block-id)]
       (when-let [node (.querySelector parent ".bullet-container")]
-        (d/add-class! node "hide-inner-bullet"))))
+        (dom/add-class! node "hide-inner-bullet"))))
   (when (and (non-dragging? e)
              (not @*resizing-image?))
     (state/into-selection-mode!)))
@@ -2647,7 +2647,7 @@
                                   :data-lang language}
                                  code)
             [:div
-             (lazy-editor/editor config (str (dc/squuid)) attr code options)
+             (lazy-editor/editor config (str (d/squuid)) attr code options)
              (let [options (:options options)]
                (when (and (= language "clojure") (contains? (set options) ":results"))
                  (sci/eval-result code)))]))))))
@@ -2728,7 +2728,7 @@
         ["Math" s]
         (if html-export?
           (latex/html-export s true true)
-          (latex/latex (str (dc/squuid)) s true true))
+          (latex/latex (str (d/squuid)) s true true))
         ["Example" l]
         [:pre.pre-wrap-white-space
          (join-lines l)]
@@ -2754,7 +2754,7 @@
         ["Export" "latex" _options content]
         (if html-export?
           (latex/html-export content true false)
-          (latex/latex (str (dc/squuid)) content true false))
+          (latex/latex (str (d/squuid)) content true false))
 
         ["Custom" "query" _options _result content]
         (try
@@ -2806,12 +2806,12 @@
         (let [content (latex-environment-content name option content)]
           (if html-export?
             (latex/html-export content true true)
-            (latex/latex (str (dc/squuid)) content true true)))
+            (latex/latex (str (d/squuid)) content true true)))
 
         ["Displayed_Math" content]
         (if html-export?
           (latex/html-export content true true)
-          (latex/latex (str (dc/squuid)) content true true))
+          (latex/latex (str (d/squuid)) content true true))
 
         ["Footnote_Definition" name definition]
         (let [id (util/url-encode name)]

--- a/src/main/frontend/components/file.cljs
+++ b/src/main/frontend/components/file.cljs
@@ -2,7 +2,7 @@
   (:require [cljs-time.coerce :as tc]
             [cljs-time.core :as t]
             [clojure.string :as string]
-            [datascript.core :as dc]
+            [datascript.core :as d]
             [frontend.components.lazy-editor :as lazy-editor]
             [frontend.components.svg :as svg]
             [frontend.config :as config]
@@ -73,7 +73,7 @@
   (let [path (get-path state)
         format (format/get-format path)
         original-name (db/get-file-page path)
-        random-id (str (dc/squuid))]
+        random-id (str (d/squuid))]
     (rum/with-context [[tongue] i18n/*tongue-context*]
       [:div.file {:id (str "file-edit-wrapper-" random-id)}
        [:h1.title


### PR DESCRIPTION
In preparation for being able to automate [clj(s) dependency checks](https://quire.io/w/Logseq-_team_dedicated_to_sport_of_knowledge/107/Upgrade_clj_cljs_dependencies?filter=all), I noticed we use a forked version of datascript. I looked into the [built-ins we added](https://github.com/tiensonqin/datascript/commits/fork) and the only we use is `get`. I [contributed this back to datascript](https://github.com/tonsky/datascript/pull/423) so we can now depend on the latest datascript. I looked at [the changelog](https://github.com/tonsky/datascript/blob/master/CHANGELOG.md) and didn't see any breaking changes since 1.3.2. Another advantage to being on standard datascript is that we'll be able to use a datascript version of bb. This could be _very_ useful for scripting, both for us logseq developers and for end users