### PR TITLE
Fix property page links in #4088

### DIFF
--- a/src/main/frontend/db/query_dsl.cljs
+++ b/src/main/frontend/db/query_dsl.cljs
@@ -141,6 +141,7 @@
      l)
     @vars))
 
+;; TODO: Convert -> fns to rules
 (defn ->property-query
   ([k v]
    (->property-query k v '?v))
@@ -154,6 +155,16 @@
      [(list 'contains? sym v)]
      ;; For integer pages that aren't strings
      [(list 'contains? sym (str v))])]))
+
+(defn ->page-property-query
+  [k v]
+  [['?p :block/name]
+   ['?p :block/properties '?prop]
+   [(list 'get '?prop (keyword k)) '?v]
+   (list
+    'or
+    [(list '= '?v v)]
+    [(list 'contains? '?v v)])])
 
 (defn build-query
   ([repo e env]
@@ -354,15 +365,8 @@
              k (string/replace (name k) "_" "-")]
          (if-not (nil? v)
            (let [v (text/parse-property k v)
-                 v (if (coll? v) (first v) v)
-                 sym '?v]
-             [['?p :block/name]
-              ['?p :block/properties '?prop]
-              [(list 'get '?prop (keyword k)) sym]
-              (list
-               'or
-               [(list '= sym v)]
-               [(list 'contains? sym v)])])
+                 v (if (coll? v) (first v) v)]
+             (->page-property-query k v))
            [['?p :block/name]
             ['?p :block/properties '?prop]
             [(list 'get '?prop (keyword k)) '?prop-v]

--- a/src/main/frontend/db/query_dsl.cljs
+++ b/src/main/frontend/db/query_dsl.cljs
@@ -141,6 +141,20 @@
      l)
     @vars))
 
+(defn ->property-query
+  ([k v]
+   (->property-query k v '?v))
+  ([k v sym]
+   [['?b :block/properties '?prop]
+    [(list 'missing? '$ '?b :block/name)]
+    [(list 'get '?prop (keyword k)) sym]
+    (list
+     'or
+     [(list '= sym v)]
+     [(list 'contains? sym v)]
+     ;; For integer pages that aren't strings
+     [(list 'contains? sym (str v))])]))
+
 (defn build-query
   ([repo e env]
    (build-query repo e (assoc env :vars (atom {})) 0))
@@ -269,13 +283,7 @@
              sym (if (= current-filter 'or)
                    '?v
                    (uniq-symbol counter "?v"))]
-         [['?b :block/properties '?prop]
-          [(list 'missing? '$ '?b :block/name)]
-          [(list 'get '?prop (keyword k)) sym]
-          (list
-           'or
-           [(list '= sym v)]
-           [(list 'contains? sym v)])])
+         (->property-query k v sym))
 
        (and (= 'property fe)
             (= 2 (count e)))

--- a/src/main/frontend/handler/link.cljs
+++ b/src/main/frontend/handler/link.cljs
@@ -1,13 +1,14 @@
 (ns frontend.handler.link
   (:require [frontend.util :as util]))
 
-(def plain-link "(?:http://www\\.|https://www\\.|http://|https://){1}[a-z0-9]+(?:[\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}(?:.*)*")
+(def plain-link-re-string
+  "(?:http://www\\.|https://www\\.|http://|https://){1}[a-z0-9]+(?:[\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}(?:.*)*")
 ;; Based on https://orgmode.org/manual/Link-Format.html#Link-Format
-(def org-link-re-1 (re-pattern (util/format "\\[\\[(%s)\\]\\[(.+)\\]\\]" plain-link)))
-(def org-link-re-2 (re-pattern (util/format "\\[\\[(%s)\\]\\]" plain-link)))
-(def markdown-link-re (re-pattern (util/format "^\\[(.+)\\]\\((%s)\\)" plain-link)))
+(def org-link-re-1 (re-pattern (util/format "\\[\\[(%s)\\]\\[(.+)\\]\\]" plain-link-re-string)))
+(def org-link-re-2 (re-pattern (util/format "\\[\\[(%s)\\]\\]" plain-link-re-string)))
+(def markdown-link-re (re-pattern (util/format "^\\[(.+)\\]\\((%s)\\)" plain-link-re-string)))
 
-(defn- org-link?
+(defn- org-link
   [link]
   (when-let [matches (or (re-matches org-link-re-1 link)
                          (re-matches org-link-re-2 link))]
@@ -15,21 +16,23 @@
      :url (second matches)
      :label (nth matches 2 nil)}))
 
-(defn- markdown-link?
+(defn- markdown-link
   [link]
   (when-let [matches (re-matches markdown-link-re link)]
     {:type "markdown-link"
      :url (nth matches 2)
      :label (second matches)}))
 
-(defn- plain-link?
+(defn- plain-link
   [link]
   (when (util/url? link)
     {:type "plain-link"
      :url link}))
 
-(defn link?
+(defn link
+  "If the given string is an org, markdown or plain url, return a map indicating
+  the url type, url itself and the optional label."
   [link]
-  (or (plain-link? link)
-      (org-link? link)
-      (markdown-link? link)))
+  (or (plain-link link)
+      (org-link link)
+      (markdown-link link)))

--- a/src/main/frontend/handler/link.cljs
+++ b/src/main/frontend/handler/link.cljs
@@ -1,7 +1,8 @@
 (ns frontend.handler.link
   (:require [frontend.util :as util]))
 
-(def plain-link "(\bhttps?://)?[-A-Za-z0-9+&@#/%?=~_|!:,.;]+[-A-Za-z0-9+&@#/%=~_|]")
+(def plain-link "(?:http://www\\.|https://www\\.|http://|https://){1}[a-z0-9]+(?:[\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}(?:.*)*")
+;; Based on https://orgmode.org/manual/Link-Format.html#Link-Format
 (def org-link-re-1 (re-pattern (util/format "\\[\\[(%s)\\]\\[(.+)\\]\\]" plain-link)))
 (def org-link-re-2 (re-pattern (util/format "\\[\\[(%s)\\]\\]" plain-link)))
 (def markdown-link-re (re-pattern (util/format "^\\[(.+)\\]\\((%s)\\)" plain-link)))
@@ -21,8 +22,14 @@
      :url (nth matches 2)
      :label (second matches)}))
 
+(defn- plain-link?
+  [link]
+  (when (util/url? link)
+    {:type "plain-link"
+     :url link}))
+
 (defn link?
   [link]
-  (or (util/url? link)
+  (or (plain-link? link)
       (org-link? link)
       (markdown-link? link)))

--- a/src/main/frontend/text.cljs
+++ b/src/main/frontend/text.cljs
@@ -379,7 +379,7 @@
       (contains? @non-parsing-properties (string/lower-case k))
       v
 
-      (link/link? v)
+      (link/link v)
       v
 
       :else

--- a/src/test/frontend/db/query_dsl_test.cljs
+++ b/src/test/frontend/db/query_dsl_test.cljs
@@ -17,7 +17,7 @@
                 :file/content "---
 title: Dec 26th, 2020
 tags: [[page-tag-1]], page-tag-2
-parent: [[child page 1]]
+parent: [[child page 1]], [[child-no-space]]
 ---
 - DONE 26-b1 [[page 1]]
 created-at:: 1608968448113
@@ -26,6 +26,7 @@ prop-a:: val-a
 prop-c:: [[page a]], [[page b]], [[page c]]
 prop-num:: 2000
 prop-linked-num:: [[3000]]
+prop-d:: [[no-space-link]]
 - LATER 26-b2-modified-later [[page 2]] #tag1
 created-at:: 1608968448114
 last-modified-at:: 1608968448120
@@ -84,9 +85,6 @@ last-modified-at:: 1609084800002"}]]
 
 (defn q-count
   [s]
-  #_(let [db (frontend.db.conn/get-conn test-db)]
-    (prn :DB (d/q '[:find (pull ?b [*]) :where [?b :block/properties ?prop] [(get ?prop :prop-num)]]
-                db)))
   (let [{:keys [query result]} (q s)]
     {:query query
      :count (if result
@@ -143,7 +141,52 @@ last-modified-at:: 1609084800002"}]]
 
        "(property prop-linked-num 3000)"
        {:query (dsl/->property-query "prop-linked-num" 3000)
+        :count 1}
+
+       "(property prop-d no-space-link)"
+       {:query (dsl/->property-query "prop-d" "no-space-link")
         :count 1}))
+
+(deftest page-property-queries
+  (are [x y] (= (q-count x) y)
+       "(page-property parent)"
+       {:query '[[?p :block/name]
+                 [?p :block/properties ?prop]
+                 [(get ?prop :parent) ?prop-v]
+                 [true]], :count 3}
+
+       "(page-property parent [[child page 1]])"
+       {:query (dsl/->page-property-query "parent" "child page 1")
+        :count 2}
+
+       "(page-property parent [[child-no-space]])"
+       {:query (dsl/->page-property-query "parent" "child-no-space")
+        :count 1}
+
+       "(page-property parent \"child page 1\")"
+       {:query (dsl/->page-property-query "parent" "child page 1") 
+        :count 2}
+
+       "(and (page-property parent [[child page 1]]) (page-property parent [[child page 2]]))"
+       {:query '([?p :block/name]
+                 [?p :block/properties ?prop]
+                 [(get ?prop :parent) ?v]
+                 (or [(= ?v "child page 1")] [(contains? ?v "child page 1")])
+                 (or [(= ?v "child page 2")] [(contains? ?v "child page 2")]))
+        :count 1}
+
+       "(or (page-property parent [[child page 1]]) (page-property parent [[child page 2]]))"
+       {:query '(or (and
+                     [?p :block/name]
+                     [?p :block/properties ?prop]
+                     [(get ?prop :parent) ?v]
+                     (or [(= ?v "child page 1")] [(contains? ?v "child page 1")]))
+                    (and
+                     [?p :block/name]
+                     [?p :block/properties ?prop]
+                     [(get ?prop :parent) ?v]
+                     (or [(= ?v "child page 2")] [(contains? ?v "child page 2")])))
+        :count 3}))
 
 (deftest test-parse
   []
@@ -262,50 +305,7 @@ last-modified-at:: 1609084800002"}]]
                 [(contains? #{"page-tag-1" "page-tag-2"} ?tag1)]]
        :count 2}))
 
-  (testing "page-property queries"
-    (are [x y] (= (q-count x) y)
-      "(page-property parent)"
-      {:query '[[?p :block/name]
-                [?p :block/properties ?prop]
-                [(get ?prop :parent) ?prop-v]
-                [true]], :count 3}
 
-      "(page-property parent [[child page 1]])"
-      {:query '[[?p :block/name]
-                [?p :block/properties ?prop]
-                [(get ?prop :parent) ?v]
-                (or [(= ?v "child page 1")] [(contains? ?v "child page 1")])]
-       :count 2}
-
-      "(page-property parent \"child page 1\")"
-      {:query '[[?p :block/name]
-                [?p :block/properties ?prop]
-                [(get ?prop :parent) ?v]
-                (or
-                 [(= ?v "child page 1")]
-                 [(contains? ?v "child page 1")])]
-       :count 2}
-
-      "(and (page-property parent [[child page 1]]) (page-property parent [[child page 2]]))"
-      {:query '([?p :block/name]
-                [?p :block/properties ?prop]
-                [(get ?prop :parent) ?v]
-                (or [(= ?v "child page 1")] [(contains? ?v "child page 1")])
-                (or [(= ?v "child page 2")] [(contains? ?v "child page 2")]))
-       :count 1}
-
-      "(or (page-property parent [[child page 1]]) (page-property parent [[child page 2]]))"
-      {:query '(or (and
-                    [?p :block/name]
-                    [?p :block/properties ?prop]
-                    [(get ?prop :parent) ?v]
-                    (or [(= ?v "child page 1")] [(contains? ?v "child page 1")]))
-                   (and
-                    [?p :block/name]
-                    [?p :block/properties ?prop]
-                    [(get ?prop :parent) ?v]
-                    (or [(= ?v "child page 2")] [(contains? ?v "child page 2")])))
-       :count 3}))
 
   ;; boolean queries
   (testing "AND queries"
@@ -334,7 +334,7 @@ last-modified-at:: 1609084800002"}]]
       "(not [[page 1]])"
       {:query '([?b :block/uuid]
                 (not [?b :block/path-refs [:block/name "page 1"]]))
-       :count 37}))
+       :count 39}))
 
   (testing "Between query"
     (are [x y] (= (count-only x) y)
@@ -382,7 +382,7 @@ last-modified-at:: 1609084800002"}]]
                   (and [?b :block/path-refs [:block/name "page 1"]])
                   (and [?b :block/path-refs [:block/name "page 2"]])
                   [?b])))
-       :count 40})
+       :count 42})
 
     ;; FIXME: not working
     ;; (are [x y] (= (q-count x) y)

--- a/src/test/frontend/handler/link_test.cljs
+++ b/src/test/frontend/handler/link_test.cljs
@@ -1,4 +1,4 @@
-(ns frontend.handler.test-link
+(ns frontend.handler.link-test
   (:require [cljs.test :refer [are deftest testing]]
             [frontend.handler.link :as link]))
 
@@ -9,7 +9,7 @@
       "[[google.com][google]]" nil
       "[[google.com]]" nil
       "[google](google.com)" nil))
-  
+
   (testing "plain links"
     (are [x y] (= (link/link? x) y)
       "http://www.google.com"
@@ -18,7 +18,7 @@
       "http://google.com"
       {:type "plain-link" :url "http://google.com"}))
 
-  (testing "org links"
+  (testing "org links with labels"
     (are [x y] (= (link/link? x) y)
       "[[http://www.google.com][google]]"
       {:type "org-link" :url "http://www.google.com" :label "google"}
@@ -32,7 +32,7 @@
       "[[https://google.com][google]]"
       {:type "org-link" :url "https://google.com" :label "google"}))
 
-  (testing "org links"
+  (testing "org links without labels"
     (are [x y] (= (link/link? x) y)
       "[[http://www.google.com]]"
       {:type "org-link" :url "http://www.google.com" :label nil}
@@ -47,5 +47,3 @@
 
       "[google](https://www.google.com)"
       {:type "markdown-link" :url "https://www.google.com" :label "google"})))
-
-#_(cljs.test/test-ns 'frontend.test-link)

--- a/src/test/frontend/handler/link_test.cljs
+++ b/src/test/frontend/handler/link_test.cljs
@@ -2,16 +2,16 @@
   (:require [cljs.test :refer [are deftest testing]]
             [frontend.handler.link :as link]))
 
-(deftest test-link?
+(deftest test-link
   (testing "non-link"
-    (are [x y] (= (link/link? x) y)
+    (are [x y] (= (link/link x) y)
       "google.com" nil
       "[[google.com][google]]" nil
       "[[google.com]]" nil
       "[google](google.com)" nil))
 
   (testing "plain links"
-    (are [x y] (= (link/link? x) y)
+    (are [x y] (= (link/link x) y)
       "http://www.google.com"
       {:type "plain-link" :url "http://www.google.com"}
 
@@ -19,7 +19,7 @@
       {:type "plain-link" :url "http://google.com"}))
 
   (testing "org links with labels"
-    (are [x y] (= (link/link? x) y)
+    (are [x y] (= (link/link x) y)
       "[[http://www.google.com][google]]"
       {:type "org-link" :url "http://www.google.com" :label "google"}
 
@@ -33,7 +33,7 @@
       {:type "org-link" :url "https://google.com" :label "google"}))
 
   (testing "org links without labels"
-    (are [x y] (= (link/link? x) y)
+    (are [x y] (= (link/link x) y)
       "[[http://www.google.com]]"
       {:type "org-link" :url "http://www.google.com" :label nil}
 
@@ -41,7 +41,7 @@
       {:type "org-link" :url "https://www.google.com" :label nil}))
 
   (testing "markdown links"
-    (are [x y] (= (link/link? x) y)
+    (are [x y] (= (link/link x) y)
       "[google](http://www.google.com)"
       {:type "markdown-link" :url "http://www.google.com" :label "google"}
 

--- a/src/test/frontend/text_test.cljs
+++ b/src/test/frontend/text_test.cljs
@@ -143,7 +143,7 @@
       :tags "foo" "foo"
       :tags "foo, bar" #{"foo" "bar"}
       :tags "foo,bar" #{"foo" "bar"}
-      :tags "[[foo]]" "[[foo]]"
+      :tags "[[foo]]" #{"foo"}
       :tags "[[foo]] [[bar]]" #{"foo" "bar"}
       :tags "[[foo]], [[bar]]" #{"foo" "bar"}
       :tags "[[foo]], [[bar]], #baz" #{"foo" "bar" "baz"}


### PR DESCRIPTION
This PR fixes three bugs:
- It starts running the `link-test` ns which wasn't running because it was named `test-link`. Most clj(s) test runners look for namespaces ending in `-test`.
- It fixes #4088 as evidenced by the text-test assertion change. Bug was introduced in #3520 but we didn't catch it because the link tests weren't running . This bug was also effecting querying as described in https://github.com/logseq/logseq/issues/4007#issuecomment-1021245310 and the [visual look of the link](https://github.com/logseq/logseq/issues/4007#issuecomment-1021245310)
- It fixes #4007 which was due to integers needing to match as strings or integers depending on whether they are links in a property value. I made the smallest change possible

While fixing this bug, I observed that the plain urls are the only ones that are formatted nicely as shown in #3103