### PR TITLE
fix(document-mode): bullet lines not fully hidden

### DIFF
--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -386,6 +386,10 @@ html.is-native-android {
   margin: 1.67em 0;
 }
 
+.document-mode .block-children {
+    border-left: 0px solid;
+}
+
 .document-mode .ls-block {
     margin-bottom: 1rem;
 }


### PR DESCRIPTION
First PR! 🎉

Fix issue with bullet lines not being shown, closes #3663 

### Before
<img width="1440" alt="Screen Shot 2022-02-06 at 11 33 46 AM" src="https://user-images.githubusercontent.com/80150109/152671643-ceb3811c-9df8-4d40-ab8e-d2c8a02b06ee.png">

### After
<img width="1440" alt="Screen Shot 2022-02-06 at 11 33 12 AM" src="https://user-images.githubusercontent.com/80150109/152671627-e70eb379-b043-47d3-a11d-b1100c41ec26.png">
