### PR TITLE
feat(editor): add elixir language mode to code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
         "chokidar": "3.5.1",
         "chrono-node": "2.2.4",
         "codemirror": "5.58.1",
+        "codemirror-mode-elixir": "1.1.2",
         "d3-force": "3.0.0",
         "diff": "5.0.0",
         "dompurify": "2.4.0",

--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -126,6 +126,7 @@
             ["codemirror/mode/yaml-frontmatter/yaml-frontmatter"]
             ["codemirror/mode/yaml/yaml"]
             ["codemirror/mode/z80/z80"]
+            ["codemirror-mode-elixir/dist/codemirror-mode-elixir"]
             [frontend.commands :as commands]
             [frontend.db :as db]
             [frontend.extensions.calc :as calc]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1841,6 +1841,11 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==
 
+codemirror-mode-elixir@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/codemirror-mode-elixir/-/codemirror-mode-elixir-1.1.2.tgz#61227208d2684d928500af6934e4b9c995fb0960"
+  integrity sha512-1oIuRVHyUhLv0Za9sEIsI7urAj06EohwO/yVj10bg7aHnimHQ964Wk3uuoPH0Yn8L38EkOd+SwULYpDiCQtoTA==
+
 codemirror@5.58.1:
   version "5.58.1"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.58.1.tgz#ec6bf38ad2a17f74c61bd00cc6dc5a69bd167854"


### PR DESCRIPTION
Hello! First of all, thank you for this amazing application! I've been using it for the past week and it already has had a huge impact on how I organize myself and it has already increased my productivity :rocket:

https://github.com/logseq/logseq/pull/3496 added support for all the language modes available for CodeMirror. However, elixir (and many others), are not included among those modes.

CodeMirror stopped supporting other languages in their own code base and they're encouraging developers to create separate repositories for the unsupported languages.

- https://github.com/codemirror/CodeMirror/issues/6583 is an example of the previous statement.
- https://github.com/ianwalter/codemirror-mode-elixir is the recommended repository to use for Elixir language mode by the CodeMirror developers (see [previous issue](https://github.com/codemirror/CodeMirror/issues/6583)).

This PR adds elixir language mode to code blocks using the recommended elixir language mode from CodeMirror developers.

> **To give a bit more context**: I'm using logseq at the moment for my personal and work private journals, but I'd like to extend its use to build an _organization brain_ at work. Our stack consists mainly of Typescript and Elixir, so that's why I wanted to have support for Elixir :rocket:

![](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)