### PR TITLE
Improve issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -15,7 +15,7 @@ body:
       label: Reproduce the Bug
       description: |
         Please tell us the steps to reproduce the bug.
-      value: |
+      placeholder: |
         1. Go to '...'
         2. Click on '....'
         3. Scroll down to '....'

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -44,10 +44,7 @@ body:
       label: Desktop Platform Information
       description: |
         Would you mind to tell us the system information about your desktop platform?
-      value: |
-        - OS: [e.g. iOS]
-        - Browser [e.g. chrome, safari]
-        - Version [e.g. 22]
+      placeholder: "example: MacOS 12.2 Logseq Desktop v0.5.9"
     validations:
       required: false
   - type: textarea
@@ -56,11 +53,7 @@ body:
       label: Mobile Platform Information
       description: |
         Would you mind to tell us the system information about your mobile platform?
-      value: |
-        - Device: [e.g. iPhone6]
-        - OS: [e.g. iOS8.1]
-        - Browser [e.g. stock browser, safari]
-        - Version [e.g. 22]
+      placeholder: "example: Android App v0.5.9"
     validations:
       required: false
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -55,7 +55,9 @@ body:
       label: Mobile Platform Information
       description: |
         Would you mind to tell us the system information about your mobile platform?
-      placeholder: "example: Android App v0.5.9"
+      placeholder: |
+        Device, OS version, Browser or App, Logseq App version
+        example: iPhone6, iOS8.1, App, v0.5.9
     validations:
       required: false
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -44,7 +44,9 @@ body:
       label: Desktop Platform Information
       description: |
         Would you mind to tell us the system information about your desktop platform?
-      placeholder: "example: MacOS 12.2 Logseq Desktop v0.5.9"
+      placeholder: |
+        OS version, Browser or App, Logseq App version
+        example: MacOS 12.2, App, v0.5.9
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
Replace `value` with `placeholder` for reproduce step and platform information, because this can leave **less interference information** for unfilled fields like: 
![image](https://user-images.githubusercontent.com/37948597/152825557-ca18ebc4-2cf9-4400-9168-060b26f23344.png)

Also simplified platform information 
```
- OS: [e.g. iOS]
- Browser [e.g. chrome, safari]
- Version [e.g. 22]
```
into a single `MacOS 12.2 Logseq Desktop v0.5.9`, because the old version doesn't include desktop version and thus may make users confused.

By the way, another choice is something like this (move example into description and keep empty value fields):
```
      description: |
        Would you mind to tell us the system information about your desktop platform?
        example:
        - OS: MacOS 12.2
        - Browser: Chrome 22 (leave it empty if you are using desktop app)
        - Desktop App: v0.5.9 (leave it empty if you are using browser)
      value: |
        - OS:
        - Browser:
        - Version:
```
I personally prefer the simpler style.

Feel free to commit directly if you have different preferences or better ideas!