### PR TITLE
fix: text goes beneath toolbar in large block on iOS

### DIFF
--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -714,6 +714,7 @@
        :on-click          (editor-handler/editor-on-click! id)
        :on-change         (editor-handler/editor-on-change! block id search-timeout)
        :on-paste          (editor-handler/editor-on-paste! id)
+       :on-height-change  (editor-handler/editor-on-height-change! id)
        :auto-focus        false
        :class             heading-class})
 

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3116,6 +3116,18 @@
     (let [input (gdom/getElement id)]
       (close-autocomplete-if-outside input))))
 
+(defn editor-on-height-change!
+  [id]
+  (fn [row-height]
+    (let [input (gdom/getElement id)
+          top (gobj/get (.getBoundingClientRect input) "top")
+          cursor-y (+ top row-height)
+          vw-height (.-height js/window.visualViewport)]
+      (when (<  vw-height (+ cursor-y 40))
+        (let [main-node (gdom/getElement "main-content-container")
+              scroll-top (.-scrollTop main-node)]
+          (set! (.-scrollTop main-node) (+ scroll-top 24)))))))
+
 (defn editor-on-change!
   [block id search-timeout]
   (fn [e]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3123,9 +3123,11 @@
           top (gobj/get (.getBoundingClientRect input) "top")
           cursor-y (+ top row-height)
           vw-height (.-height js/window.visualViewport)]
+      ;; 40 is mobile toolbar height
       (when (<  vw-height (+ cursor-y 40))
         (let [main-node (gdom/getElement "main-content-container")
               scroll-top (.-scrollTop main-node)]
+          ;; 24 is default line height
           (set! (.-scrollTop main-node) (+ scroll-top 24)))))))
 
 (defn editor-on-change!


### PR DESCRIPTION
Demo: https://www.loom.com/share/59251a285045480e8dd50d4f02e40015

close https://github.com/logseq/logseq/issues/378