### PR TITLE
Fix page search autocompletion

### DIFF
--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -1,5 +1,6 @@
 (ns frontend.components.editor
   (:require [clojure.string :as string]
+            [goog.string :as gstring]
             [frontend.commands :as commands
              :refer [*angle-bracket-caret-pos *first-command-group *matched-block-commands *matched-commands *show-block-commands *show-commands *slash-caret-pos]]
             [frontend.components.block :as block]
@@ -97,7 +98,7 @@
 
 (rum/defc page-search < rum/reactive
   {:will-unmount (fn [state] (reset! editor-handler/*selected-text nil) state)}
-  "Editor embedded page searching"
+  "Embedded page searching popup"
   [id format]
   (when (state/sub :editor/show-page-search?)
     (let [pos (:editor/last-saved-cursor @state/state)
@@ -119,20 +120,23 @@
                               (contains? (set (map util/page-name-sanity-lc matched-pages)) (util/page-name-sanity-lc (string/trim q)))  ;; if there's a page name fully matched
                               matched-pages
 
+                              (string/blank? q)
+                              nil
+
                               (empty? matched-pages)
-                              matched-pages
+                              (cons (str "New page: " q) matched-pages)
 
                               ;; reorder, shortest and starts-with first.
                               :else
                               (let [matched-pages (remove nil? matched-pages)
                                     matched-pages (sort-by
                                                    (fn [m]
-                                                     [(not (string/starts-with? m q)) (count m)])
+                                                     [(not (gstring/caseInsensitiveStartsWith m q)) (count m)])
                                                    matched-pages)]
-                                (cons (first matched-pages)
-                                      (cons
-                                       (str "New page: " q)
-                                       (rest matched-pages)))))]
+                                (if (gstring/caseInsensitiveStartsWith (first matched-pages) q)
+                                  (cons (first matched-pages)
+                                        (cons  (str "New page: " q) (rest matched-pages)))
+                                  (cons (str "New page: " q) matched-pages))))]
           (ui/auto-complete
            matched-pages
            {:on-chosen   (page-handler/on-chosen-handler input id q pos format)

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2977,7 +2977,9 @@
         hashtag?
         (do
           (commands/handle-step [:editor/search-page-hashtag])
-          (state/set-last-pos! (cursor/pos input))
+          (if (= key "#")
+            (state/set-last-pos! (inc (cursor/pos input))) ;; In keydown handler, the `#` is not inserted yet.
+            (state/set-last-pos! (cursor/pos input)))
           (reset! commands/*slash-caret-pos (cursor/get-caret-pos input)))
 
         (let [sym "$"]

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -660,7 +660,7 @@
       (fn [chosen _click?]
         (state/set-editor-show-page-search! false)
         (let [wrapped? (= "[[" (util/safe-subs edit-content (- pos 2) pos))
-              chosen (if (string/starts-with? chosen "New page: ")
+              chosen (if (string/starts-with? chosen "New page: ") ;; FIXME: What if a page named "New page: XXX"?
                        (subs chosen 10)
                        chosen)
               chosen (if (and (util/safe-re-find #"\s+" chosen) (not wrapped?))
@@ -677,7 +677,7 @@
                                           (str "#" (when wrapped? "[[") chosen)
                                           format
                                           {:last-pattern last-pattern
-                                           :end-pattern "]]"
+                                           :end-pattern (when wrapped? "]]")
                                            :forward-pos forward-pos})))
       (fn [chosen _click?]
         (state/set-editor-show-page-search! false)


### PR DESCRIPTION
- Fix #4178, handle `[[]]` with `#` in the same line
- Refine page search item order
  - blank input -> placeholder for search or type
  - matches -> case insensitive match
  - no match -> New Page: ...
- wrong `set-last-pos!` in keydown handler