### PR TITLE
enhance(mobile): editing in large block

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "react-grid-layout": "0.16.6",
         "react-icons": "2.2.7",
         "react-resize-context": "3.0.0",
-        "react-textarea-autosize": "8.0.1",
+        "react-textarea-autosize": "8.3.3",
         "react-tippy": "1.4.0",
         "react-transition-group": "4.3.0",
         "react-tweet-embed": "1.3.1",

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -235,7 +235,7 @@
         vw-pending? (state/sub :ui/visual-viewport-pending?)
         ;; TODO: should we add this focus step to `simple-insert!`?
         viewport-fn (fn [] (when-let [input (gdom/getElement parent-id)]
-                             (util/make-el-into-center-viewport input)
+                             (util/make-el-cursor-position-into-center-viewport input)
                              (.focus input)))]
     [:div#mobile-editor-toolbar.bg-base-2
      {:style {:bottom (if vw-state
@@ -278,7 +278,6 @@
       [:button.bottom-action
        {:on-mouse-down (fn [e]
                          (util/stop e)
-                         (viewport-fn)
                          (commands/simple-insert! parent-id "\n" {}))}
        (ui/icon "arrow-back"
                 {:style {:fontSize ui/icon-size}})]]

--- a/src/main/frontend/handler/editor/lifecycle.cljs
+++ b/src/main/frontend/handler/editor/lifecycle.cljs
@@ -23,7 +23,7 @@
       (.focus element)
       (when (or (mobile-util/is-native-platform?)
                 (util/mobile?))
-        (util/make-el-into-viewport element))))
+        (util/make-el-cursor-position-into-center-viewport element))))
   state)
 
 (defn did-remount!

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -268,7 +268,7 @@
 
 (defmethod handle :mobile/keyboard-did-show [[_]]
   (when-let [input (state/get-input)]
-    (util/make-el-into-viewport input)))
+    (util/make-el-cursor-position-into-center-viewport input)))
 
 (defmethod handle :plugin/consume-updates [[_ id pending? updated?]]
   (let [downloading? (:plugin/updates-downloading? @state/state)]

--- a/src/main/frontend/handler/ui.cljs
+++ b/src/main/frontend/handler/ui.cljs
@@ -273,10 +273,3 @@
 (defn open-new-window!
   []
   (ipc/ipc "openNewWindow"))
-
-(defn try-to-editing-input-into-viewport!
-  []
-  (when-let [input (state/get-input)]
-    (when (or (mobile/is-native-platform?)
-            (util/mobile?))
-      (util/make-el-into-viewport input))))

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1378,28 +1378,32 @@
               false)))))
 
 #?(:cljs
-  (defn make-el-into-center-viewport
-    [^js/HTMLElement el]
-    (when el
-      (.scrollIntoView el #js {:block "center" :behavior "smooth"}))))
+   (defn make-el-into-center-viewport
+     [^js/HTMLElement el]
+     (when el
+       (.scrollIntoView el #js {:block "center" :behavior "smooth"}))))
 
 #?(:cljs
-   (defn make-el-into-viewport
-     ([^js/HTMLElement el]
-      (make-el-into-viewport el 60))
-     ([^js/HTMLElement el offset]
-      (make-el-into-viewport el offset true))
-     ([^js/HTMLElement el offset async?]
-      (let [handle #(let [viewport-height (or (.-height js/window.visualViewport)
-                                              (.-clientHeight js/document.documentElement))
-                          target-bottom (.-bottom (.getBoundingClientRect el))]
-                      (when (> (+ target-bottom (or (safe-parse-int offset) 0))
-                               viewport-height)
-                        (make-el-into-center-viewport el)))]
-
-        (if async?
-          (js/setTimeout #(handle) 64)
-          (handle))))))
+   (defn make-el-cursor-position-into-center-viewport
+     [^js/HTMLElement el]
+     (when el
+       (let [main-node (gdom/getElement "main-content-container")
+             pos (get-selection-start el)
+             cursor-top (some-> (gdom/getElement "mock-text")
+                                gdom/getChildren
+                                array-seq
+                                (nth-safe pos)
+                                .-offsetTop)
+             box-caret (.getBoundingClientRect el)
+             box-top (.-top box-caret)
+             box-bottom (.-bottom box-caret)
+             vw-height (or (.-height js/window.visualViewport)
+                           (.-clientHeight js/document.documentElement))
+             scroll-top (.-scrollTop main-node)
+             cursor-y (if cursor-top (+ cursor-top box-top) box-bottom)
+             scroll (- cursor-y (/ vw-height 2))]
+         (when (> scroll 0)
+           (set! (.-scrollTop main-node) (+ scroll-top scroll)))))))
 
 #?(:cljs
    (defn make-el-center-if-near-top


### PR DESCRIPTION
This PR improves various editing operations in large block.
- Cursor row goes to center of screen when texts overflow the viewport no matter inputting in the middle or at the end of block.
- Cursor position goes to center of screen when clicking to edit a block
- Calling commands/page reference/block references, etc. will move the autocomplete window to center of screen

Additionally, l updated `react-textarea-autosize` since it added { rowHeight: number } as a second parameter to the onHeightChange callback from [8.2.0](https://github.com/Andarist/react-textarea-autosize/blob/main/CHANGELOG.md#820), which is used in this PR.
