### PR TITLE
enhance(ui): add data-ref for items in left sidebar

### DIFF
--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -250,7 +250,8 @@
                                          {:page page}))
                                       (when (and (not hls-file?) (not fmt-journal?))
                                         (reset! *edit? true))))}
-         [:h1.title {:style {:margin-left -2}}
+         [:h1.title {:data-ref page-name
+                     :style {:margin-left -2}}
           (when (not= icon "") [:span.page-icon icon])
           title]]))))
 

--- a/src/main/frontend/components/sidebar.cljs
+++ b/src/main/frontend/components/sidebar.cljs
@@ -93,6 +93,7 @@
         target (state/sub :favorites/dragging)]
     [:li.favorite-item
      {:key name
+      :data-ref name
       :class (if (and target @dragging-over (not= target @dragging-over))
                "dragging-target"
                "")
@@ -158,7 +159,9 @@
      [:ul.text-sm
       (for [name pages]
         (when-let [entity (db/entity [:block/name (util/safe-page-name-sanity-lc name)])]
-          [:li.recent-item {:key name}
+          [:li.recent-item
+           {:key name
+            :data-ref name}
            (page-name name (get-page-icon entity))]))])))
 
 (rum/defcs flashcards < db-mixins/query rum/reactive


### PR DESCRIPTION
Adding data-ref for items in the left sidebar and page titles, so we can target it with custom CSS.

My specific use case is making a few pages look extra pretty with emoji, without needing to include the emoji in the actual name. Pictured here is my seedling styling (any pages that start with `S: `)
<img width="445" alt="image" src="https://user-images.githubusercontent.com/573204/154780950-744a6423-84f8-47ae-9eea-835ab5d946f1.png">
