### PR TITLE
enhance(iOS): add Excalidraw file for force download

### DIFF
--- a/ios/App/App/DownloadiCloudFiles.swift
+++ b/ios/App/App/DownloadiCloudFiles.swift
@@ -19,7 +19,8 @@ public class DownloadiCloudFiles: CAPPlugin,  UIDocumentPickerDelegate  {
         "md",
         "org",
         "css",
-        "edn"
+        "edn",
+        "excalidraw"
     ]
     
     var containerUrl: URL? {


### PR DESCRIPTION
Force downloading Excalidraw file from iCloud.

Excalidraw will be supported on mobile in the next release. Force syncing  its file resolves the invalid file error alert.