### PR TITLE
bump mldoc to 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "ignore": "5.1.8",
         "is-svg": "4.3.0",
         "jszip": "3.5.0",
-        "mldoc": "1.3.0",
+        "mldoc": "1.3.1",
         "path": "0.12.7",
         "pixi-graph-fork": "0.2.0",
         "pixi.js": "6.2.0",


### PR DESCRIPTION
Latest logseq release doesn't include the fix of https://github.com/logseq/logseq/issues/3343

Current version of `mldoc` is 1.3.0, which does not include the fix (8 days ago)... Btw, the tags of `mldoc` are not pushed to github.


https://github.com/logseq/logseq/blame/5111d59f7a6d71421f7b985d3f702c92603bee4b/package.json#L99
![image](https://user-images.githubusercontent.com/37948597/154793935-54cf4a4c-4675-411a-8cf3-1d0f7fe70626.png)
