### PR TITLE
enhancement: only run custom queries when not typing

### DIFF
--- a/src/main/frontend/db/react.cljs
+++ b/src/main/frontend/db/react.cljs
@@ -336,7 +336,7 @@
                 (= (first k) repo-url)
                 (or (get affected-keys (vec (rest k)))
                     custom?))
-           (let [{:keys [query inputs transform-fn query-fn inputs-fn result]} cache]
+           (let [{:keys [query query-fn result]} cache]
              (when (or query query-fn)
                (try
                  (let [db' (when (and (vector? k) (not= (second k) :kv))

--- a/src/main/frontend/handler.cljs
+++ b/src/main/frontend/handler.cljs
@@ -7,6 +7,7 @@
             [frontend.db :as db]
             [frontend.db-schema :as db-schema]
             [frontend.db.conn :as conn]
+            [frontend.db.react :as db-react]
             [frontend.error :as error]
             [frontend.handler.command-palette :as command-palette]
             [frontend.handler.common :as common-handler]
@@ -218,6 +219,8 @@
      (fn [_error]
        (notification/show! "Sorry, it seems that your browser doesn't support IndexedDB, we recommend to use latest Chrome(Chromium) or Firefox(Non-private mode)." :error false)
        (state/set-indexedb-support! false)))
+
+    (db-react/run-custom-queries-when-idle!)
 
     (events/run!)
 

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -28,6 +28,7 @@
      :system/events                         (async/chan 100)
      :db/batch-txs                          (async/chan 100)
      :file/writes                           (async/chan 100)
+     :reactive/custom-queries               (async/chan 100)
      :notification/show?                    false
      :notification/content                  nil
      :repo/cloning?                         false
@@ -1144,6 +1145,10 @@
 (defn get-file-write-chan
   []
   (:file/writes @state))
+
+(defn get-reactive-custom-queries-chan
+  []
+  (:reactive/custom-queries @state))
 
 (defn get-write-chan-length
   []


### PR DESCRIPTION
Previously, all the custom queries including both queries and advanced queries will be executed synchronously when there's any editor update, which can hurt the editing experience a lot if there were too many blocks. 