### PR TITLE
fix: missing normalized for file watcher ipc

### DIFF
--- a/src/main/frontend/fs/watcher_handler.cljs
+++ b/src/main/frontend/fs/watcher_handler.cljs
@@ -9,10 +9,13 @@
             [frontend.handler.file :as file-handler]
             [frontend.handler.page :as page-handler]
             [frontend.handler.ui :as ui-handler]
+            [frontend.util :as util]
             [lambdaisland.glogi :as log]
             [electron.ipc :as ipc]
             [promesa.core :as p]
             [frontend.state :as state]))
+
+;; all IPC paths must be normalized! (via util/path-normalize)
 
 (defn- set-missing-block-ids!
   [content]
@@ -39,7 +42,8 @@
 (defn handle-changed!
   [type {:keys [dir path content stat] :as payload}]
   (when dir
-    (let [repo (config/get-local-repo dir)
+    (let [path (util/path-normalize path)
+          repo (config/get-local-repo dir)
           {:keys [mtime]} stat
           db-content (or (db/get-file repo path) "")]
       (when (and (or content (= type "unlink"))


### PR DESCRIPTION
Fix #4277

For dev:
All paths should be normalized via `util/path-normalize` when read into main process