### PR TITLE
fix: #4311 collapsed state not persisted for blocks with properties

### DIFF
--- a/src/main/frontend/modules/file/core.cljs
+++ b/src/main/frontend/modules/file/core.cljs
@@ -16,6 +16,7 @@
     (string/join (str "\n" spaces-tabs) lines)))
 
 (defn- content-with-collapsed-state
+  "Only accept nake content (without any indentation)"
   [format content collapsed? properties]
   (cond
     collapsed?
@@ -67,13 +68,14 @@
                                   (-> (string/replace content #"^\s?#+\s+" "")
                                       (string/replace #"^\s?#+\s?$" ""))
                                   content)
+                        content (content-with-collapsed-state format content collapsed? properties)
                         new-content (indented-block-content (string/trim content) spaces-tabs)
                         sep (if (or markdown-top-heading?
                                     (string/blank? new-content))
                               ""
                               " ")]
                     (str prefix sep new-content)))]
-    (content-with-collapsed-state format content collapsed? properties)))
+    content))
 
 
 (defn- tree->file-content-aux

--- a/src/main/frontend/util/property.cljs
+++ b/src/main/frontend/util/property.cljs
@@ -227,6 +227,7 @@
   (string/starts-with? s "---\n"))
 
 (defn insert-property
+  "Only accept nake content (without any indentation)"
   ([format content key value]
    (insert-property format content key value false))
   ([format content key value front-matter?]


### PR DESCRIPTION
Fix: #4311

Move `content-with-collapsed-state` before applying indentation to content