### PR TITLE
Add command to save graph to disk

### DIFF
--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -101,6 +101,9 @@
 (defmethod handle :graph/migrated [[_ _repo]]
   (js/alert "Graph migrated."))
 
+(defmethod handle :graph/save [_]
+  (db/persist! (state/get-current-repo)))
+
 (defn get-local-repo
   []
   (when-let [repo (state/get-current-repo)]

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -315,16 +315,20 @@
                                     :binding "mod+shift+p"
                                     :fn      (fn [] (state/toggle! :ui/command-palette-open?))}
 
-   :graph/open              {:desc    "Select graph to open"
+   :graph/open                     {:desc    "Select graph to open"
                                     :fn      (fn [] (state/set-state! :ui/open-select :graph-open))
                                     :binding "mod+shift+g"}
 
-   :graph/remove            {:desc    "Remove a graph"
+   :graph/remove                   {:desc    "Remove a graph"
                                     :fn      (fn [] (state/set-state! :ui/open-select :graph-remove))
                                     :binding false}
 
    :graph/add                      {:desc "Add a graph"
                                     :fn (fn [] (route-handler/redirect! {:to :repo-add}))
+                                    :binding false}
+
+   :graph/save                     {:desc "Save current graph to disk"
+                                    :fn #(state/pub-event! [:graph/save])
                                     :binding false}
 
    :command/run                    (when (util/electron?)
@@ -511,6 +515,7 @@
                           :graph/open
                           :graph/remove
                           :graph/add
+                          :graph/save
                           :editor/cycle-todo
                           :editor/up
                           :editor/down
@@ -695,6 +700,7 @@
     :graph/open
     :graph/remove
     :graph/add
+    :graph/save
     :sidebar/clear
     :sidebar/open-today-page
     :search/re-index


### PR DESCRIPTION
This PR adds a command to save the current graph to `~/.logseq/graphs`. This is useful for power users as it allows them to develop and use applications directly against the datascript db. I'm writing a personal CLI to use an updated datascript db. I added this command because the only other way I saw to persist the db was to quit the app which isn't user friendly