### PR TITLE
Fix oudated yarn.lock and add CI check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    # branches: [master]
+    branches: [master]
     paths-ignore:
       - '*.md'
   pull_request:
@@ -66,12 +66,11 @@ jobs:
         if: steps.clojure-deps.outputs.cache-hit != 'true'
         run: clojure -A:cljs -P
 
-      - run: git diff --exit-code
       - name: Fetch yarn deps
         run: yarn install
 
       # Exits with 0 if yarn.lock is up to date or 1 if we forgot to update it
-      - name: Ensure lockfile is up to date
+      - name: Ensure yarn.lock is up to date
         run: git diff --exit-code yarn.lock
 
       - name: Run ClojureScript test

--- a/yarn.lock
+++ b/yarn.lock
@@ -6760,6 +6760,11 @@ react-grid-layout@0.16.6:
     react-draggable "3.x"
     react-resizable "1.x"
 
+react-icon-base@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-icon-base/-/react-icon-base-2.1.0.tgz#a196e33fdf1e7aaa1fda3aefbb68bdad9e82a79d"
+  integrity sha1-oZbjP98eeqof2jrvu2i9rZ6Cp50=
+
 react-icons@2.2.7:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-2.2.7.tgz#d7860826b258557510dac10680abea5ca23cf650"


### PR DESCRIPTION
Also added a CI step which catches this error in the future - https://github.com/logseq/logseq/runs/5290530621?check_suite_focus=true . I could also add these checks to static/ and libs/ if we'd like but this lockfile is the one I see outdated the most