### PR TITLE
fix: block ref id in block-reference

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -879,7 +879,11 @@
               link-depth (or link-depth 0)]
           (if (> link-depth max-depth-of-links)
             [:p.warning.text-sm "Block ref nesting is too deep"]
-            (block-reference (assoc config :reference? true :link-depth (inc link-depth)) id label*)))
+            (block-reference (assoc config
+                                    :reference? true
+                                    :link-depth (inc link-depth) 
+                                    :block/uuid id)
+                             id label*)))
 
         ["Page_ref" page]
         (let [format (get-in config [:block :block/format])]


### PR DESCRIPTION
block-ref should use the target block id instead of the original block id.
This PR tries to fix a renderer rendering issue of plugins like https://github.com/pengx17/logseq-plugin-todo-master. I.e., if a renderer is rendered within a block-ref, the UUID in `logseq.App.onMacroRendererSlotted(async ({ payload, slot })` should be the nested block-ref instead of the outer one.

<img width="476" alt="image" src="https://user-images.githubusercontent.com/584378/155286708-81eafeec-10b8-4541-b58f-f20f086781ce.png">
