### PR TITLE
feat: remember right sidebar width after resizing

### DIFF
--- a/src/main/frontend/components/right_sidebar.cljs
+++ b/src/main/frontend/components/right_sidebar.cljs
@@ -13,6 +13,7 @@
             [frontend.extensions.slide :as slide]
             [frontend.state :as state]
             [frontend.ui :as ui]
+            [frontend.handler.ui :as ui-handler]
             [frontend.util :as util]
             [goog.object :as gobj]
             [medley.core :as medley]
@@ -24,7 +25,7 @@
   (when-not (util/mobile?)
     (ui/with-shortcut :ui/toggle-right-sidebar "left"
       [:a.button.fade-link.toggle
-       {:on-click state/toggle-sidebar-open?!}
+       {:on-click ui-handler/toggle-right-sidebar!}
        (ui/icon "layout-sidebar-right" {:style {:fontSize "20px"}})])))
 
 (rum/defc block-cp < rum/reactive

--- a/src/main/frontend/components/right_sidebar.cljs
+++ b/src/main/frontend/components/right_sidebar.cljs
@@ -186,7 +186,8 @@
                          right-el (js/document.getElementById "right-sidebar")]
                      (when right-el
                        (let [width (str (* right-el-ratio 100) "%")]
-                         (.setProperty (.-style right-el) "width" width)))))}}))
+                         (.setProperty (.-style right-el) "width" width)
+                         (ui-handler/persist-right-sidebar-width!)))))}}))
              (.styleCursor false)
              (.on "dragstart" #(.. js/document.documentElement -classList (add "is-resizing-buf")))
              (.on "dragend" #(.. js/document.documentElement -classList (remove "is-resizing-buf")))))

--- a/src/main/frontend/handler/ui.cljs
+++ b/src/main/frontend/handler/ui.cljs
@@ -16,14 +16,36 @@
             [frontend.mobile.util :as mobile]
             [electron.ipc :as ipc]))
 
+(defn- get-css-var-value
+  [var-name]
+  (.getPropertyValue (js/getComputedStyle (.-documentElement js/document)) var-name))
+
 ;; sidebars
+(defn- get-right-sidebar-width
+  []
+  (or (.. (js/document.getElementById "right-sidebar") -style -width)
+      (get-css-var-value "--right-sidebar-width")))
+
+(defn- persist-right-sidebar-width!
+  []
+  (storage/set "ls-right-sidebar-width" (get-right-sidebar-width)))
+
+(defn- restore-right-sidebar-width!
+  []
+  (when-let [width (storage/get "ls-right-sidebar-width")]
+    (.setProperty (.-style (js/document.getElementById "right-sidebar")) "width" width)))
+
 (defn close-left-sidebar!
   []
   (when-let [elem (gdom/getElement "close-left-bar")]
+    (persist-right-sidebar-width!)
     (.click elem)))
 
 (defn toggle-right-sidebar!
   []
+  (if (:ui/sidebar-open? @state/state) 
+    (persist-right-sidebar-width!) 
+    (restore-right-sidebar-width!))
   (state/toggle-sidebar-open?!))
 
 (defn persist-right-sidebar-state!

--- a/src/main/frontend/handler/ui.cljs
+++ b/src/main/frontend/handler/ui.cljs
@@ -26,11 +26,11 @@
   (or (.. (js/document.getElementById "right-sidebar") -style -width)
       (get-css-var-value "--right-sidebar-width")))
 
-(defn- persist-right-sidebar-width!
+(defn persist-right-sidebar-width!
   []
   (storage/set "ls-right-sidebar-width" (get-right-sidebar-width)))
 
-(defn- restore-right-sidebar-width!
+(defn restore-right-sidebar-width!
   []
   (when-let [width (storage/get "ls-right-sidebar-width")]
     (.setProperty (.-style (js/document.getElementById "right-sidebar")) "width" width)))
@@ -38,14 +38,11 @@
 (defn close-left-sidebar!
   []
   (when-let [elem (gdom/getElement "close-left-bar")]
-    (persist-right-sidebar-width!)
     (.click elem)))
 
 (defn toggle-right-sidebar!
   []
-  (if (:ui/sidebar-open? @state/state) 
-    (persist-right-sidebar-width!) 
-    (restore-right-sidebar-width!))
+  (when-not (:ui/sidebar-open? @state/state) (restore-right-sidebar-width!))
   (state/toggle-sidebar-open?!))
 
 (defn persist-right-sidebar-state!
@@ -63,7 +60,8 @@
       (when open?
         (state/set-state! :ui/sidebar-open? open?)
         (state/set-state! :sidebar/blocks blocks)
-        (state/set-state! :ui/sidebar-collapsed-blocks collapsed)))))
+        (state/set-state! :ui/sidebar-collapsed-blocks collapsed)
+        (restore-right-sidebar-width!)))))
 
 (defn toggle-contents!
   []


### PR DESCRIPTION
Persist right sidebar width into store just before sidebar is closed;
Restore right sidebar width from local store when sidebar is about to open