### PR TITLE
Add --exclude to node test runner and fix testing staleness issue

### DIFF
--- a/.carve/ignore
+++ b/.carve/ignore
@@ -65,5 +65,4 @@ frontend.util.pool/terminate-pool!
 ;; Repl fn
 frontend.util.property/add-page-properties
 ;; Used by shadow
-frontend.test-runner/main
-
+frontend.node-test-runner/main

--- a/deps.edn
+++ b/deps.edn
@@ -23,9 +23,9 @@
   hiccups/hiccups                       {:mvn/version "0.3.0"}
   tongue/tongue                         {:mvn/version "0.2.9"}
   org.clojure/core.async                {:mvn/version "1.3.610"}
-  thheller/shadow-cljs                  {:mvn/version "2.15.3"}
+  thheller/shadow-cljs                  {:mvn/version "2.17.5"}
   expound/expound                       {:mvn/version "0.8.6"}
-  com.lambdaisland/glogi                {:mvn/version "1.0.116"}
+  com.lambdaisland/glogi                {:mvn/version "1.1.144"}
   binaryage/devtools                    {:mvn/version "1.0.2"}
   camel-snake-kebab/camel-snake-kebab   {:mvn/version "0.4.2"}
   instaparse/instaparse                 {:mvn/version "1.4.10"}
@@ -34,14 +34,14 @@
   org.clojars.mmb90/cljs-cache          {:mvn/version "0.1.4"}}
 
  :aliases {:cljs {:extra-paths ["src/dev-cljs/" "src/test/" "src/electron/"]
-                  :extra-deps  {org.clojure/clojurescript        {:mvn/version "1.10.879"}
+                  :extra-deps  {org.clojure/clojurescript        {:mvn/version "1.10.891"}
                                 org.clojure/tools.namespace      {:mvn/version "0.2.11"}
                                 cider/cider-nrepl                {:mvn/version "0.26.0"}
                                 org.clojars.knubie/cljs-run-test {:mvn/version "1.0.1"}}
                   :main-opts   ["-m" "shadow.cljs.devtools.cli"]}
 
            :test {:extra-paths ["src/test/"]
-                  :extra-deps  {org.clojure/clojurescript        {:mvn/version "1.10.879"}
+                  :extra-deps  {org.clojure/clojurescript        {:mvn/version "1.10.891"}
                                 org.clojure/test.check           {:mvn/version "1.1.1"}
                                 org.clojars.knubie/cljs-run-test {:mvn/version "1.0.1"}}
                   :main-opts   ["-m" "shadow.cljs.devtools.cli"]}

--- a/docs/dev-practices.md
+++ b/docs/dev-practices.md
@@ -75,24 +75,27 @@ yarn test
 
 There are a couple different ways to develop with tests:
 
+#### Focus Tests
+
+Tests can be selectively run on the commandline using our own test runner which
+provides the same test selection options as [cognitect-labs/test
+runner](https://github.com/cognitect-labs/test-runner#invoke-with-clojure--m-clojuremain).
+For this workflow:
+
+1. Run `clj -M:test watch test` in one shell
+2. Focus tests:
+  1. Add `^:focus` metadata flags to tests e.g. `(deftest ^:focus test-name ...)`.
+  2. In another shell, run `node static/tests.js -i focus` to only run those
+  tests. To run all tests except those tests run `node static/tests.js -e focus`.
+3. Or focus namespaces: Using the regex option `-r`, run tests for `frontend.text-test` with `node static/tests.js -r text`.
+
+For help on more options, run `node static/tests.js -h`.
+
 #### Autorun Tests
+
 To run tests automatically on file save, run `yarn
 shadow-cljs watch test --config-merge '{:autorun true}'`. The test output may
 appear where shadow-cljs was first invoked e.g. where `yarn watch` is running.
 Specific namespace(s) can be auto run with the `:ns-regexp` option e.g. `npx
 shadow-cljs watch test --config-merge '{:autorun true :ns-regexp
 "frontend.text-test"}'`.
-
-#### Focus Tests
-
-Tests can be automatically compiled and then selectively run on the commandline
-using our own test runner which emulates most of the options of [cognitect-labs/test
-runner](https://github.com/cognitect-labs/test-runner#invoke-with-clojure--m-clojuremain).
-For this workflow:
-
-1. Run `clj -M:test watch test` in one shell
-2. Focus tests or namespaces:
-  1. To focus test(s), add `^:focus` metadata flags. In another shell, run `node static/tests.js -i focus`
-  2. Alternatively, focus namespaces by using the regex option e.g. `node static/tests.js -r text` which runs tests for `frontend.text-test`.
-
-For help on more focusing options, run `node static/tests.js -h`

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "postcss-import-ext-glob": "^2.0.1",
         "postcss-nested": "5.0.5",
         "purgecss": "4.0.2",
-        "shadow-cljs": "2.15.3",
+        "shadow-cljs": "2.17.5",
         "stylelint": "^13.8.0",
         "stylelint-config-standard": "^20.0.0",
         "tailwindcss": "2.2.4",

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -62,7 +62,7 @@
          :output-to       "static/tests.js"
          :closure-defines {frontend.util/NODETEST true}
          :devtools        {:enabled false}
-         :main            frontend.test-runner/main}
+         :main            frontend.node-test-runner/main}
 
   :publishing {:target        :browser
                :module-loader true

--- a/src/test/frontend/test_runner.cljs
+++ b/src/test/frontend/test_runner.cljs
@@ -5,6 +5,7 @@
   This gives the user a fair amount of control over which tests and namespaces
   to call from the commandline. Once this test runner is stable enough we should
   contribute it upstream"
+  {:dev/always true} ;; necessary for test-data freshness
   (:require [shadow.test.env :as env]
             [clojure.tools.cli :as cli]
             [shadow.test.node :as node]
@@ -72,9 +73,15 @@ returns run options for selected tests to run"
    ["-r" "--namespace-regex REGEX"
     :parse-fn re-pattern :desc "Regex for namespaces to test"]])
 
+;; Necessary to have test-data in this ns for freshness. Relying on
+;; node/reset-test-data! was buggy
+(defn ^:dev/after-load reset-test-data! []
+  (-> (env/get-test-data)
+      (env/reset-test-data!)))
+
 (defn main [& args]
   ;; Load test data as is done with shadow.test.node/main
-  (node/reset-test-data!)
+  (reset-test-data!)
 
   (let [{:keys [options summary]} (parse-options args cli-options)]
     (if (:help options)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7303,10 +7303,10 @@ shadow-cljs-jar@1.3.2:
   resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz#97273afe1747b6a2311917c1c88d9e243c81957b"
   integrity sha512-XmeffAZHv8z7451kzeq9oKh8fh278Ak+UIOGGrapyqrFBB773xN8vMQ3O7J7TYLnb9BUwcqadKkmgaq7q6fhZg==
 
-shadow-cljs@2.15.3:
-  version "2.15.3"
-  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.15.3.tgz#11a0a04f1c31d9277838a5f649457edbb06baafb"
-  integrity sha512-KK7G9kSc0dwrOkN74o5yrxhrpsJ3BJCL11nGHBakzHLodc7pdiCLDeq2ChXyKl2yu9aJIzfSz8Hum38wpLQ1DA==
+shadow-cljs@2.17.5:
+  version "2.17.5"
+  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.17.5.tgz#ed2fa8b06ea62cb310f069b70314e555f5bf9d50"
+  integrity sha512-Xvev4OLxGkjxC5mT5jHZDpJuAKzSHn7bGa4RPBm+Jp2gBz4iNkNDNPDvkyqt0r9RD0SWaYJF8zGyxi5c18yJBw==
   dependencies:
     node-libs-browser "^2.2.1"
     readline-sync "^1.4.7"


### PR DESCRIPTION
This is a followup to #4364 to provide `--exclude` and fixes a bug which is currently effecting some tests from being run on master. We can now start writing tests like performance tests that only run at certain times :) This PR also bumps shadow-cljs. I did not see any breaking changes with [shadow's changelog](https://github.com/thheller/shadow-cljs/blob/master/CHANGELOG.md) and there are a number of bug fixes. There is a new Runtime tab under shadow builds which allow for some namespace exploration