### PR TITLE
Feature: Open links in search with keybinding

### DIFF
--- a/src/main/frontend/handler/ui.cljs
+++ b/src/main/frontend/handler/ui.cljs
@@ -231,6 +231,16 @@
       ((or on-shift-chosen on-chosen) (nth matched @current-idx) false)
       (and on-enter (on-enter state)))))
 
+(defn auto-complete-open-link
+  [state e]
+  (let [[matched {:keys [on-chosen-open-link]}] (:rum/args state)
+        current-idx (get state :frontend.ui/current-idx)]
+    (util/stop e)
+    (when (and (seq matched)
+             (> (count matched)
+                @current-idx))
+      (on-chosen-open-link (nth matched @current-idx) false))))
+
 ;; date-picker
 ;; TODO: find a better way
 (def *internal-model (rum/cursor state/state :date-picker/date))

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -64,6 +64,10 @@
                                   :binding "shift+enter"
                                   :fn      ui-handler/auto-complete-shift-complete}
 
+   :auto-complete/open-link      {:desc    "Auto-complete: Open selected item in browser"
+                                  :binding "mod+o"
+                                  :fn      ui-handler/auto-complete-open-link}
+
    :cards/toggle-answers         {:desc    "Cards: show/hide answers/clozes"
                                   :binding "s"
                                   :fn      srs/toggle-answers}
@@ -482,7 +486,8 @@
     (build-category-map [:auto-complete/complete
                          :auto-complete/prev
                          :auto-complete/next
-                         :auto-complete/shift-complete])
+                         :auto-complete/shift-complete
+                         :auto-complete/open-link])
 
     :shortcut.handler/cards
     (-> (build-category-map [:cards/toggle-answers
@@ -719,6 +724,7 @@
     :auto-complete/next
     :auto-complete/complete
     :auto-complete/shift-complete
+    :auto-complete/open-link
     :date-picker/prev-day
     :date-picker/next-day
     :date-picker/prev-week


### PR DESCRIPTION
Most of us have a number of links in our notes. It would be helpful to quickly visit them. This PR adds a keystroke `mod+o` (same keybinding for same functionality when we're editing) to open urls from the current search item. It also does some minor cleanup of the search component in the 2nd commit. I QAed refactored changes

[Demo of opening links for block and page](https://www.loom.com/share/4d89fdd1cf79409cb108e6ec092e84ac)