### PR TITLE
Avoid annoying javascript alert window for error debug

### DIFF
--- a/src/main/frontend/fs/capacitor_fs.cljs
+++ b/src/main/frontend/fs/capacitor_fs.cljs
@@ -208,7 +208,7 @@
                                     :encoding (.-UTF8 Encoding)}))]
          content)
        (p/catch (fn [error]
-                  (js/alert error))))))
+                  (log/error :read-file-failed error))))))
   (delete-file! [_this repo dir path {:keys [ok-handler error-handler]}]
     (let [path (get-file-path dir path)]
       (p/catch


### PR DESCRIPTION
As reported in https://github.com/logseq/logseq/issues/4399, annoying `invalid path` alert window consistently popups. This PR changes `read-file` error-catch to `log` to avoid this popup.