### PR TITLE
enhance: backup files when there're differences between db and disk

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-grid-layout": "0.16.6",
+        "react-icon-base": "^2.1.2",
         "react-icons": "2.2.7",
         "react-resize-context": "3.0.0",
         "react-textarea-autosize": "8.3.3",

--- a/resources/package.json
+++ b/resources/package.json
@@ -32,6 +32,7 @@
     "semver": "7.3.5",
     "update-electron-app": "2.0.1",
     "extract-zip": "2.0.1",
+    "diff-match-patch": "1.0.5",
     "https-proxy-agent": "5.0.0"
   },
   "devDependencies": {

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -17,8 +17,7 @@
             [electron.search :as search]
             [electron.git :as git]
             [electron.plugin :as plugin]
-            [electron.window :as win]
-            [goog.object :as gobj]))
+            [electron.window :as win]))
 
 (defmulti handle (fn [_window args] (keyword (first args))))
 
@@ -76,7 +75,7 @@
       (fs-extra/removeSync (path/join dir file)))))
 
 (defn backup-file
-  [repo path content]
+  [_repo path content]
   (let [new-path (str path "." (string/replace (.toISOString (js/Date.)) ":" "_"))]
     (fs/writeFileSync new-path content)
     (fs/statSync new-path)

--- a/src/main/frontend/fs/watcher_handler.cljs
+++ b/src/main/frontend/fs/watcher_handler.cljs
@@ -32,8 +32,8 @@
 (defn- handle-add-and-change!
   [repo path content db-content mtime backup?]
   (p/let [
-          ;; save the previous content in a bak file to avoid data overwritten.
-          _ (when backup? (ipc/ipc "backupDbFile" (config/get-local-dir repo) path db-content))
+          ;; save the previous content in a versioned bak file to avoid data overwritten.
+          _ (when backup? (ipc/ipc "backupDbFile" (config/get-local-dir repo) path db-content content))
           _ (file-handler/alter-file repo path content {:re-render-root? true
                                                         :from-disk? true})]
     (set-missing-block-ids! content)

--- a/static/yarn.lock
+++ b/static/yarn.lock
@@ -1529,6 +1529,11 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
+diff-match-patch@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.5.tgz#abb584d5f10cd1196dfc55aa03701592ae3f7b37"
+  integrity sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==
+
 dir-compare@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/dir-compare/-/dir-compare-2.4.0.tgz#785c41dc5f645b34343a4eafc50b79bac7f11631"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6760,10 +6760,10 @@ react-grid-layout@0.16.6:
     react-draggable "3.x"
     react-resizable "1.x"
 
-react-icon-base@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/react-icon-base/-/react-icon-base-2.1.0.tgz#a196e33fdf1e7aaa1fda3aefbb68bdad9e82a79d"
-  integrity sha1-oZbjP98eeqof2jrvu2i9rZ6Cp50=
+react-icon-base@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/react-icon-base/-/react-icon-base-2.1.2.tgz#a17101dad9c1192652356096860a9ab43a0766c7"
+  integrity sha512-NRlRo0RPxWRMQT7osj8UCBSSXsGOxhF1pre84ildhuft5S2U382NOs7tg29osWSjbO90L2a3VTCqadA/LnAzHQ==
 
 react-icons@2.2.7:
   version "2.2.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5247,10 +5247,10 @@ mkdirp@^1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mldoc@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/mldoc/-/mldoc-1.3.1.tgz#50a8ad73d0489624883ad1414dd8a11ccff0ddf1"
-  integrity sha512-WlsK7fKQOV4t3YBVonHOOE+SOYkPn6/jb3Ob+Hn8dH/SMZ71OfhdKIxjqJrYn4M+10FfiQvKS9lXVHLAGqsl/A==
+mldoc@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/mldoc/-/mldoc-1.3.2.tgz#d08bb6bd7a6ea6ae27cb02f4d5b4c8f7c95d31ba"
+  integrity sha512-yK/IfRwLpNEyFyU61wISho3ik2en/VVtY4wxZFfyasOX5xBvxcI/FBAqXmO4hV7V6paH8Ko9APgAW3AcX+CiOQ==
   dependencies:
     yargs "^12.0.2"
 
@@ -6769,8 +6769,6 @@ react-icons@2.2.7:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-2.2.7.tgz#d7860826b258557510dac10680abea5ca23cf650"
   integrity sha512-0n4lcGqzJFcIQLoQytLdJCE0DKSA9dkwEZRYoGrIDJZFvIT6Hbajx5mv9geqhqFiNjUgtxg8kPyDfjlhymbGFg==
-  dependencies:
-    react-icon-base "2.1.0"
 
 react-is@^16.13.1, react-is@^16.3.1:
   version "16.13.1"


### PR DESCRIPTION
Previously, files are stored to logseq/bak when logseq detects
there're differences between the db and disk. But it has two problems:

1. Only a few users know `logseq/bak`, other users think that their
data has been lost.
2. Files in the logseq/bak folder are never truncated.

This PR backups old files in DB with timestamp suffixes instead of
logesq/bak, and only keep the latest 10 versions of any changed file.