### PR TITLE
Optimizing nested query rules for graph traversal

### DIFF
--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -611,7 +611,7 @@
             '[:find ?id
               :in $ ?p %
               :where
-              (parent ?p ?c)
+              (child ?p ?c)
               [?c :block/uuid ?id]]
             conn
             eid

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -1382,8 +1382,8 @@
                          {:block/file [:db/id :file/path]}]) ...]
         :in $ % ?namespace
         :where
-        (namespace ?p ?c)
-        [?p :block/name ?namespace]]
+        [?p :block/name ?namespace]
+        (namespace ?p ?c)]
       (conn/get-conn repo)
       rules
       namespace)))

--- a/src/main/frontend/db/rules.cljs
+++ b/src/main/frontend/db/rules.cljs
@@ -7,6 +7,12 @@
      [?c :block/parent ?t]
      (parent ?p ?t)]
 
+    [(child ?p ?c)
+     [?c :block/parent ?p]]
+    [(child ?p ?c)
+     [?t :block/parent ?p]
+     (child ?t ?c)]
+
     [(namespace ?p ?c)
      [?c :block/namespace ?p]]
     [(namespace ?p ?c)
@@ -29,4 +35,7 @@
     ;;            [(identity ?vs) [?v ...]]
     ;;            (not-join [?e ?v]
     ;;                      [?e ?a ?v]))]
+    ;; Recursive optimization
+    ;; https://stackoverflow.com/questions/42457136/recursive-datalog-queries-for-datomic-really-slow
+    ;; Should optimize for query the decendents of a block
     ])

--- a/src/main/frontend/db/rules.cljs
+++ b/src/main/frontend/db/rules.cljs
@@ -16,8 +16,8 @@
     [(namespace ?p ?c)
      [?c :block/namespace ?p]]
     [(namespace ?p ?c)
-     [?c :block/namespace ?t]
-     (namespace ?p ?t)]
+     [?t :block/namespace ?p]
+     (namespace ?t ?c)]
 
     ;; from https://stackoverflow.com/questions/43784258/find-entities-whose-ref-to-many-attribute-contains-all-elements-of-input
     ;; Quote:
@@ -35,7 +35,18 @@
     ;;            [(identity ?vs) [?v ...]]
     ;;            (not-join [?e ?v]
     ;;                      [?e ?a ?v]))]
+
     ;; Recursive optimization
     ;; https://stackoverflow.com/questions/42457136/recursive-datalog-queries-for-datomic-really-slow
     ;; Should optimize for query the decendents of a block
+    ;; Quote:
+    ;; My theory is that your rules are not written in a way that Datalog can optimize for this read pattern - probably resulting in a traversal of all the entities. I suggest to rewrite them as follows:
+    ;; [[(ubersymbol ?c ?p) 
+    ;;   (?c :ml/parent ?p)]
+    ;;  [(ubersymbol ?c ?p) 
+    ;;   ;; we bind a child of the ancestor, instead of a parent of the descendant
+    ;;   (?c1 :ml/parent ?p)
+    ;;   (ubersymbol ?c ?c1)]]
+    
+    ;; This way of writing the ruleset is optimized to find the descendants of some node. The way you originally wrote it is optimized to find the anscestors of some node.
     ])


### PR DESCRIPTION
Fix: https://github.com/logseq/logseq/issues/4362

According to [This Stackoverflow answer](https://stackoverflow.com/a/42470020), it's better to bind the child of the ancestor if we want to find the descendants of some node.
Intuitively, it's to avoid the case that both variables in a rule are unresolved. E.g, when `?p` is given, we should use `[?t :block/parent ?p]` instead of `[?c :block/parent ?t]`
[REFERENCE: Clause order](https://docs.datomic.com/on-prem/query/query-executing.html#clause-order)

Should double confirm the internal detail of datascript? Should overhaul and re-order all queries?