### PR TITLE
Dev: Rewrite tests from #4382 to use with-redefs

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -62,6 +62,8 @@
          :output-to       "static/tests.js"
          :closure-defines {frontend.util/NODETEST true}
          :devtools        {:enabled false}
+         ;; disable :static-fns to allow for with-redefs and repl development
+         :compiler-options {:static-fns false}
          :main            frontend.node-test-runner/main}
 
   :publishing {:target        :browser

--- a/src/test/frontend/util/marker_test.cljs
+++ b/src/test/frontend/util/marker_test.cljs
@@ -1,7 +1,6 @@
 (ns frontend.util.marker-test
   (:require [cljs.test :refer [are deftest]]
-            [frontend.util.marker :as marker]
-            [clojure.string :as string]))
+            [frontend.util.marker :as marker]))
 
 (deftest add-or-update-marker-markdown
   (are [content marker expect] (= expect (marker/add-or-update-marker content :markdown marker))
@@ -23,32 +22,5 @@
     "todo" "TODO" "TODO todo"
     "TODO xxx" "DONE" "DONE xxx"
     "TODO" "DONE" "DONE "))
-
-(defn set-marker
-  [marker content format new-marker]
-  (let [old-header-marker (when (not= format :org)
-                            (re-find (marker/header-marker-pattern true marker) content))
-        new-header-marker (when old-header-marker
-                            (string/replace old-header-marker marker new-marker))
-        marker (or old-header-marker marker)
-        new-marker (or new-header-marker new-marker)
-        new-content (->
-                     (if marker
-                       (string/replace-first content (re-pattern (str "^" marker)) new-marker)
-                       (str new-marker " " content))
-                     (string/triml))]
-    new-content))
-
-(deftest set-marker-org
-  (are [marker content new-marker expect] (= expect (set-marker marker content :org new-marker))
-    "TODO" "TODO content" "DOING" "DOING content"
-    "TODO" "## TODO content" "DOING" "## TODO content"
-    "DONE" "DONE content" "" "content"))
-
-(deftest set-marker-markdown
-  (are [marker content new-marker expect] (= expect (set-marker marker content :markdown new-marker))
-    "TODO" "TODO content" "DOING" "DOING content"
-    "TODO" "## TODO content" "DOING" "## DOING content"
-    "DONE" "DONE content" "" "content"))
 
 #_(cljs.test/run-tests)


### PR DESCRIPTION
This follows up on https://github.com/logseq/logseq/pull/4382/files/c250ca7f4076280afce3ae7613a2754b4c26e04e#r815154731 to convert the tests to use `with-redefs` /cc @llcc. I also moved tests since the tested fn is in `editor-handler`.

In general, `with-redefs` is pretty useful for mocking and stubbing. If we have more complex testing scenarios, we can use something like https://github.com/circleci/bond . One caveat with `with-redefs` in cljs is that async is not supported - https://clojure.atlassian.net/browse/CLJS-884