### PR TITLE
Fix: Display error if dsl query fails hard

### DIFF
--- a/src/main/frontend/db/query_dsl.cljs
+++ b/src/main/frontend/db/query_dsl.cljs
@@ -517,11 +517,18 @@
                                         (take @sample (shuffle col)))
                                       identity)
                      transform-fn (comp sort-by random-samples)]
-                 (react/react-query repo
-                                    {:query query
-                                     :query-string query-string}
-                                    {:use-cache? false
-                                     :transform-fn transform-fn}))))))))))
+                 (try
+                   (react/react-query repo
+                                      {:query query
+                                       :query-string query-string
+                                       :throw-exception true}
+                                      {:use-cache? false
+                                       :transform-fn transform-fn})
+                   (catch ExceptionInfo e
+                     ;; Allow non-existent page queries to be ignored
+                     (if (string/includes? (str (.-message e)) "Nothing found for entity")
+                       (log/error :query-dsl-error e)
+                       (throw e)))))))))))))
 
 (defn custom-query
   [repo query-m query-opts]

--- a/src/main/frontend/db/query_react.cljs
+++ b/src/main/frontend/db/query_react.cljs
@@ -112,7 +112,7 @@
          f)) query)))
 
 (defn react-query
-  [repo {:keys [query inputs] :as query'} query-opts]
+  [repo {:keys [query inputs throw-exception] :as query'} query-opts]
   (let [pprint (if config/dev? (fn [_] nil) debug/pprint)]
     (pprint "================")
     (pprint "Use the following to debug your datalog queries:")
@@ -126,5 +126,7 @@
         (pprint "query-opts:" query-opts)
         (apply react/q repo k query-opts query inputs))
       (catch js/Error e
+        (when throw-exception
+          (throw (ex-info (.-message e) {})))
         (pprint "Custom query failed: " {:query query'})
         (js/console.dir e)))))


### PR DESCRIPTION
While investigating #4101, I found that the generated query is invalid and causes datascript to throw an exception. I was surprised to see that the user saw a blank table, as if nothing was wrong. This PR makes dsl query failures more explicit by displaying the "Block render error" e.g.
<img width="638" alt="Screen Shot 2022-03-02 at 9 30 14 PM" src="https://user-images.githubusercontent.com/97210743/156485549-a9b1bacb-3e6f-4d20-ba52-95103cf6d23f.png">

I think this is an improvement as the user is aware something went wrong. When they report the issue, we are able to fix the bug quicker because we know it's an unexpected failure
