### PR TITLE
Fix some UI warnings

### DIFF
--- a/src/main/frontend/components/sidebar.cljs
+++ b/src/main/frontend/components/sidebar.cljs
@@ -45,7 +45,7 @@
                        ^js parent (.closest target ".nav-content-item")]
                    (.toggle (.-classList parent) "is-expand")))}
 
-    [:a.font-medium.fade-link name]
+    [:div.font-medium.fade-link name]
     [:span
      [:a.more svg/arrow-down-v2]]]
    [:div.bd child]])

--- a/src/main/frontend/modules/shortcut/data_helper.cljs
+++ b/src/main/frontend/modules/shortcut/data_helper.cljs
@@ -190,7 +190,9 @@
 
 (defn shortcuts->commands [handler-id]
   (let [m (get @config/config handler-id)]
+    ;; NOTE: remove nil vals, since some commands are conditional
     (->> m
+         (filter (comp some? val))
          (map (fn [[id _]] (-> (shortcut-data-by-id id)
                                (assoc :id id :handler-id handler-id)
                                (rename-keys {:binding :shortcut


### PR DESCRIPTION
Fix some UI warnings

- `Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.`
- Command register validation under mobile & browser platforms(nil vals of commands)