### PR TITLE
Dev: Document logging setup and bump to latest devtools

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -26,7 +26,7 @@
   thheller/shadow-cljs                  {:mvn/version "2.17.5"}
   expound/expound                       {:mvn/version "0.8.6"}
   com.lambdaisland/glogi                {:mvn/version "1.1.144"}
-  binaryage/devtools                    {:mvn/version "1.0.2"}
+  binaryage/devtools                    {:mvn/version "1.0.5"}
   camel-snake-kebab/camel-snake-kebab   {:mvn/version "0.4.2"}
   instaparse/instaparse                 {:mvn/version "1.4.10"}
   nubank/workspaces                     {:mvn/version "1.1.1"}

--- a/docs/dev-practices.md
+++ b/docs/dev-practices.md
@@ -99,3 +99,11 @@ appear where shadow-cljs was first invoked e.g. where `yarn watch` is running.
 Specific namespace(s) can be auto run with the `:ns-regexp` option e.g. `npx
 shadow-cljs watch test --config-merge '{:autorun true :ns-regexp
 "frontend.text-test"}'`.
+
+## Logging
+
+For logging, we use https://github.com/lambdaisland/glogi. When in development,
+be sure to have [enabled custom
+formatters](https://github.com/binaryage/cljs-devtools/blob/master/docs/installation.md#enable-custom-formatters-in-chrome)
+in the desktop app and browser. Without this enabled, most of the log messages
+aren't readable.


### PR DESCRIPTION
Most of my desktop log messages weren't readable e.g.
<img width="932" alt="Screen Shot 2022-03-03 at 11 47 54 AM" src="https://user-images.githubusercontent.com/97210743/156621025-cfac551c-4e15-42f5-98c7-8be78c26a001.png">

Documented this to prevent others from running into same issue