### PR TITLE
Fix: task and priority query bug

### DIFF
--- a/src/main/frontend/db/query_dsl.cljs
+++ b/src/main/frontend/db/query_dsl.cljs
@@ -196,7 +196,9 @@
 
       (or (= current-filter 'or)
           nested-and?)
-      (apply concat clauses)
+      (if (list? (first clauses))
+          (cons 'and clauses)
+          (apply concat clauses))
 
       :else
       (->> (map (fn [result]
@@ -277,8 +279,8 @@
                   (rest e))]
     (when (seq markers)
       (let [markers (set (map (comp string/upper-case name) markers))]
-        [['?b :block/marker '?marker]
-         [(list 'contains? markers '?marker)]]))))
+        {:query (list 'task '?b markers)
+         :rules [:task]}))))
 
 (defn- build-query-priority
   [e]
@@ -287,8 +289,8 @@
                      (rest e))]
     (when (seq priorities)
       (let [priorities (set (map (comp string/upper-case name) priorities))]
-        [['?b :block/priority '?priority]
-         [(list 'contains? priorities '?priority)]]))))
+        {:query (list 'priority '?b priorities)
+         :rules [:priority]}))))
 
 (defn- build-page-property
   [e]
@@ -378,10 +380,10 @@
        {:query (build-query-property-one-arg e)}
 
        (or (= 'todo fe) (= 'task fe))
-       {:query (build-query-todo e)}
+       (build-query-todo e)
 
        (= 'priority fe)
-       {:query (build-query-priority e)}
+       (build-query-priority e)
 
        (= 'sort-by fe)
        (let [[k order] (rest e)

--- a/src/main/frontend/db/rules.cljs
+++ b/src/main/frontend/db/rules.cljs
@@ -32,7 +32,9 @@
     ])
 
 (def query-dsl-rules
-  "Rules used by frontend.db.query-dsl"
+  "Rules used by frontend.db.query-dsl. The symbols ?b and ?p respectively refer
+  to block and page. Do not alter them as they are programatically built by the
+  query-dsl ns"
   {:page-property
    '[(page-property ?p ?key ?val)
      [?p :block/name]
@@ -64,4 +66,32 @@
 
    :all-page-tags
    '[(all-page-tags ?p)
-     [?e :block/tags ?p]]})
+     [?e :block/tags ?p]]
+
+   :between
+   '[(between ?b ?start ?end)
+     [?b :block/page ?p]
+     [?p :block/journal? true]
+     [?p :block/journal-day ?d]
+     [(>= ?d ?start)]
+     [(<= ?d ?end)]]
+
+   :has-property
+   '[(has-property ?b ?prop)
+     [?b :block/properties ?bp]
+     [(missing? $ ?b :block/name)]
+     [(get ?bp ?prop)]]
+
+   :block-content
+   '[(block-content ?b ?query)
+     [?b :block/content ?content]
+     [(clojure.string/includes? ?content ?query)]]
+
+   :page
+   '[(page ?b ?page-name)
+     [?b :block/page [:block/name ?page-name]]]
+
+   :namespace
+   '[(namespace ?p ?namespace)
+     [?p :block/namespace ?parent]
+     [?parent :block/name ?namespace]]})

--- a/src/main/frontend/db/rules.cljs
+++ b/src/main/frontend/db/rules.cljs
@@ -44,4 +44,14 @@
    '[(has-page-property ?p ?key)
      [?p :block/name]
      [?p :block/properties ?prop]
-     [(get ?prop ?key)]]})
+     [(get ?prop ?key)]]
+
+   :task
+   '[(task ?b ?markers)
+     [?b :block/marker ?marker]
+     [(contains? ?markers ?marker)]]
+
+   :priority
+   '[(priority ?b ?priorities)
+     [?b :block/priority ?priority]
+     [(contains? ?priorities ?priority)]]})

--- a/src/main/frontend/db/rules.cljs
+++ b/src/main/frontend/db/rules.cljs
@@ -94,4 +94,21 @@
    :namespace
    '[(namespace ?p ?namespace)
      [?p :block/namespace ?parent]
-     [?parent :block/name ?namespace]]})
+     [?parent :block/name ?namespace]]
+
+   :property
+   '[(property ?b ?key ?val)
+     [?b :block/properties ?prop]
+     [(missing? $ ?b :block/name)]
+     [(get ?prop ?key) ?v]
+     (or-join [?v]
+              [(= ?v ?val)]
+              [(contains? ?v ?val)]
+              ;; For integer pages that aren't strings
+              (and
+               [(str ?val) ?str-val]
+               [(contains? ?v ?str-val)]))]
+
+   :page-ref
+   '[(page-ref ?b ?page-name)
+     [?b :block/path-refs [:block/name ?page-name]]]})

--- a/src/main/frontend/db/rules.cljs
+++ b/src/main/frontend/db/rules.cljs
@@ -54,4 +54,14 @@
    :priority
    '[(priority ?b ?priorities)
      [?b :block/priority ?priority]
-     [(contains? ?priorities ?priority)]]})
+     [(contains? ?priorities ?priority)]]
+
+   :page-tags
+   '[(page-tags ?p ?tags)
+     [?p :block/tags ?t]
+     [?t :block/name ?tag]
+     [(contains? ?tags ?tag)]]
+
+   :all-page-tags
+   '[(all-page-tags ?p)
+     [?e :block/tags ?p]]})


### PR DESCRIPTION
This PR is a follow up to https://github.com/logseq/logseq/pull/4420 that fixes https://github.com/logseq/logseq/issues/4101. This PR also converts all search operators to use rules, tests were added for 5+ operators that weren't tested before and the query dsl namespace and tests are easier to read and maintain as they are split into smaller logical chunks. Unless I've noted otherwise, I strived to not change any logic that would effect existing behavior