### PR TITLE
feat: ✨ notifications-content support \n

### DIFF
--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -214,7 +214,7 @@
            [:div.flex-shrink-0
             svg]
            [:div.ml-3.w-0.flex-1
-            [:div.text-sm.leading-5.font-medium {:style {:margin 0 :white-space "pre-line"}
+            [:div.text-sm.leading-5.font-medium.whitespace-pre-line {:style {:margin 0}
                                                  :class color-class}
              content]]
            [:div.ml-4.flex-shrink-0.flex

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -214,7 +214,7 @@
            [:div.flex-shrink-0
             svg]
            [:div.ml-3.w-0.flex-1
-            [:div.text-sm.leading-5.font-medium {:style {:margin 0}
+            [:div.text-sm.leading-5.font-medium {:style {:margin 0 :white-space "pre-line"}
                                                  :class color-class}
              content]]
            [:div.ml-4.flex-shrink-0.flex


### PR DESCRIPTION
`logseq.App.showMsg`notifications-content support `\n`

before:
<img width="409" alt="image" src="https://user-images.githubusercontent.com/17695989/156755151-c1f501d1-3e64-4bc5-ad57-da4cdb21d513.png">

after:
<img width="403" alt="image" src="https://user-images.githubusercontent.com/17695989/156754962-d5206f45-e35a-40a5-921b-1279ed1956f5.png">
