### PR TITLE
fix(ios): nil timer in fs watcher

### DIFF
--- a/ios/App/App/FsWatcher.swift
+++ b/ios/App/App/FsWatcher.swift
@@ -195,10 +195,10 @@ public class PollingWatcher {
         print("debug ticker elapsed=\(elapsedInMs)ms")
         
         if #available(iOS 13.0, *) {
-            timer!.schedule(deadline: .now().advanced(by: .seconds(2)), leeway: .milliseconds(100))
+            timer?.schedule(deadline: .now().advanced(by: .seconds(2)), leeway: .milliseconds(100))
         } else {
             // Fallback on earlier versions
-            timer!.schedule(deadline: .now() + 2.0, leeway: .milliseconds(100))
+            timer?.schedule(deadline: .now() + 2.0, leeway: .milliseconds(100))
         }
     }
     


### PR DESCRIPTION
When loading large graphs, tick function might be running for a long time. Meanwhile, the timer is already deinited.