### PR TITLE
test(e2e): add keyboard event simulation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,6 +181,10 @@ jobs:
       - name: Ensure static yarn.lock is up to date
         run: git diff --exit-code static/yarn.lock
 
+      # If not building, the `event_` of `goog.event.KeyboardEvent` would be missing
+      - name: Build app
+        run: clojure -M:cljs compile app
+
       - name: Run Playwright test
         run: xvfb-run -- yarn e2e-test
         env:

--- a/e2e-tests/editor.spec.ts
+++ b/e2e-tests/editor.spec.ts
@@ -9,33 +9,33 @@ test(
   "but dont trigger RIME #3440 ",
   // cases should trigger [[]] #3251
   async ({ page }) => {
-    for (let [idx, left_full_bracket] of [
-      kb_events.win10_pinyin_left_full_bracket,
-      kb_events.macos_pinyin_left_full_bracket
+    for (let [idx, events] of [
+      kb_events.win10_pinyin_left_full_square_bracket,
+      kb_events.macos_pinyin_left_full_square_bracket
       // TODO: support #3741
-      // kb_events.win10_legacy_pinyin_left_full_bracket,
+      // kb_events.win10_legacy_pinyin_left_full_square_bracket,
     ].entries()) {
       await createRandomPage(page)
       let check_text = "#3251 test " + idx
       await page.fill(':nth-match(textarea, 1)', check_text + "【")
-      await dispatch_kb_events(page, ':nth-match(textarea, 1)', left_full_bracket)
+      await dispatch_kb_events(page, ':nth-match(textarea, 1)', events)
       expect(await page.inputValue(':nth-match(textarea, 1)')).toBe(check_text + '【')
       await page.fill(':nth-match(textarea, 1)', check_text + "【【")
-      await dispatch_kb_events(page, ':nth-match(textarea, 1)', left_full_bracket)
+      await dispatch_kb_events(page, ':nth-match(textarea, 1)', events)
       expect(await page.inputValue(':nth-match(textarea, 1)')).toBe(check_text + '[[]]')
     };
 
     // dont trigger RIME #3440
-    for (let [idx, selecting_candidate_left_bracket] of [
-      kb_events.macos_pinyin_selecting_candidate_double_left_bracket,
-      kb_events.win10_RIME_selecting_candidate_double_left_bracket
+    for (let [idx, events] of [
+      kb_events.macos_pinyin_selecting_candidate_double_left_square_bracket,
+      kb_events.win10_RIME_selecting_candidate_double_left_square_bracket
     ].entries()) {
       await createRandomPage(page)
       let check_text = "#3440 test " + idx
       await page.fill(':nth-match(textarea, 1)', check_text)
-      await dispatch_kb_events(page, ':nth-match(textarea, 1)', selecting_candidate_left_bracket)
+      await dispatch_kb_events(page, ':nth-match(textarea, 1)', events)
       expect(await page.inputValue(':nth-match(textarea, 1)')).toBe(check_text)
-      await dispatch_kb_events(page, ':nth-match(textarea, 1)', selecting_candidate_left_bracket)
+      await dispatch_kb_events(page, ':nth-match(textarea, 1)', events)
       expect(await page.inputValue(':nth-match(textarea, 1)')).toBe(check_text)
     }
   })

--- a/e2e-tests/editor.spec.ts
+++ b/e2e-tests/editor.spec.ts
@@ -9,19 +9,20 @@ test(
   "but dont trigger RIME #3440 ",
   // cases should trigger [[]] #3251
   async ({ page }) => {
-    for (let left_full_bracket of [
-      kb_events.macos_pinyin_left_full_bracket,
+    for (let [idx, left_full_bracket] of [
       kb_events.win10_pinyin_left_full_bracket,
+      kb_events.macos_pinyin_left_full_bracket
       // TODO: support #3741
       // kb_events.win10_legacy_pinyin_left_full_bracket,
-    ]) {
+    ].entries()) {
       await createRandomPage(page)
-      await page.type(':nth-match(textarea, 1)', "【")
+      let check_text = "#3251 test " + idx
+      await page.fill(':nth-match(textarea, 1)', check_text + "【")
       await dispatch_kb_events(page, ':nth-match(textarea, 1)', left_full_bracket)
-      expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('【')
-      await page.type(':nth-match(textarea, 1)', "【")
+      expect(await page.inputValue(':nth-match(textarea, 1)')).toBe(check_text + '【')
+      await page.fill(':nth-match(textarea, 1)', check_text + "【【")
       await dispatch_kb_events(page, ':nth-match(textarea, 1)', left_full_bracket)
-      expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('[[]]')
+      expect(await page.inputValue(':nth-match(textarea, 1)')).toBe(check_text + '[[]]')
     };
 
     // dont trigger RIME #3440
@@ -31,7 +32,7 @@ test(
     ].entries()) {
       await createRandomPage(page)
       let check_text = "#3440 test " + idx
-      await page.type(':nth-match(textarea, 1)', check_text)
+      await page.fill(':nth-match(textarea, 1)', check_text)
       await dispatch_kb_events(page, ':nth-match(textarea, 1)', selecting_candidate_left_bracket)
       expect(await page.inputValue(':nth-match(textarea, 1)')).toBe(check_text)
       await dispatch_kb_events(page, ':nth-match(textarea, 1)', selecting_candidate_left_bracket)

--- a/e2e-tests/editor.spec.ts
+++ b/e2e-tests/editor.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test'
 import { test } from './fixtures'
-import { createRandomPage, IsMac } from './utils'
-import { dispatch_kb_events, press_with_events, macos_pinyin_left_full_bracket } from './util/keyboard-events'
+import { createRandomPage } from './utils'
+import { dispatch_kb_events } from './util/keyboard-events'
 import * as kb_events from './util/keyboard-events'
 
 test(

--- a/e2e-tests/editor.spec.ts
+++ b/e2e-tests/editor.spec.ts
@@ -7,7 +7,7 @@ import * as kb_events from './util/keyboard-events'
 test(
   "press Chinese parenthesis 【 by 2 times #3251 should trigger [[]], " +
   "but dont trigger RIME #3440 ",
-  // cases should trigger [[]]
+  // cases should trigger [[]] #3251
   async ({ page }) => {
     for (let left_full_bracket of [
       kb_events.macos_pinyin_left_full_bracket,
@@ -22,16 +22,22 @@ test(
       await page.type(':nth-match(textarea, 1)', "【")
       await dispatch_kb_events(page, ':nth-match(textarea, 1)', left_full_bracket)
       expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('[[]]')
-    }
+    };
 
-    // cases should NOT trigger [[]]
-    await createRandomPage(page)
-    await page.type(':nth-match(textarea, 1)', "【")
-    await dispatch_kb_events(page, ':nth-match(textarea, 1)', kb_events.win10_RIME_left_full_bracket)
-    expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('【')
-    await page.type(':nth-match(textarea, 1)', "【")
-    await dispatch_kb_events(page, ':nth-match(textarea, 1)', kb_events.win10_RIME_left_full_bracket)
-    expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('【【')
+    // dont trigger RIME #3440
+    for (let [idx, selecting_candidate_left_bracket] of [
+      kb_events.macos_pinyin_selecting_candidate_left_bracket,
+      kb_events.win10_RIME_selecting_candidate_left_bracket
+    ].entries()) {
+      await createRandomPage(page)
+      let prefix = "#3440 test " + idx + ": "
+      await page.type(':nth-match(textarea, 1)', prefix + "【")
+      await dispatch_kb_events(page, ':nth-match(textarea, 1)', selecting_candidate_left_bracket)
+      expect(await page.inputValue(':nth-match(textarea, 1)')).toBe(prefix + '【')
+      await page.type(':nth-match(textarea, 1)', "【")
+      await dispatch_kb_events(page, ':nth-match(textarea, 1)', selecting_candidate_left_bracket)
+      expect(await page.inputValue(':nth-match(textarea, 1)')).toBe(prefix + '【【')
+    }
   })
 
 test('hashtag and quare brackets in same line #4178', async ({ page }) => {

--- a/e2e-tests/editor.spec.ts
+++ b/e2e-tests/editor.spec.ts
@@ -1,6 +1,19 @@
 import { expect } from '@playwright/test'
 import { test } from './fixtures'
 import { createRandomPage, IsMac } from './utils'
+import { press_with_events, macos_pinyin_left_full_bracket } from './util/keyboard-events'
+
+test('keyboard related issues', async ({ page }) => {
+  await createRandomPage(page)
+  await page.type(':nth-match(textarea, 1)', 'without events: ')
+  await page.type(':nth-match(textarea, 1)', "【")
+  await page.type(':nth-match(textarea, 1)', "【")
+
+  await page.type(':nth-match(textarea, 1)', ' | with events: ')
+  await press_with_events(page, ':nth-match(textarea, 1)', macos_pinyin_left_full_bracket)
+  await press_with_events(page, ':nth-match(textarea, 1)', macos_pinyin_left_full_bracket)
+  await page.pause()
+})
 
 test('hashtag and quare brackets in same line #4178', async ({ page }) => {
   await createRandomPage(page)
@@ -67,3 +80,4 @@ test('hashtag and quare brackets in same line #4178', async ({ page }) => {
 //     await page.keyboard.press('Control+Shift+v')
 //   }  
 // })
+  

--- a/e2e-tests/editor.spec.ts
+++ b/e2e-tests/editor.spec.ts
@@ -10,9 +10,10 @@ test('keyboard related issues', async ({ page }) => {
   await page.type(':nth-match(textarea, 1)', "【")
 
   await page.type(':nth-match(textarea, 1)', ' | with events: ')
+  await page.type(':nth-match(textarea, 1)', "【")
   await press_with_events(page, ':nth-match(textarea, 1)', macos_pinyin_left_full_bracket)
+  await page.type(':nth-match(textarea, 1)', "【")
   await press_with_events(page, ':nth-match(textarea, 1)', macos_pinyin_left_full_bracket)
-  await page.pause()
 })
 
 test('hashtag and quare brackets in same line #4178', async ({ page }) => {

--- a/e2e-tests/editor.spec.ts
+++ b/e2e-tests/editor.spec.ts
@@ -26,17 +26,16 @@ test(
 
     // dont trigger RIME #3440
     for (let [idx, selecting_candidate_left_bracket] of [
-      kb_events.macos_pinyin_selecting_candidate_left_bracket,
-      kb_events.win10_RIME_selecting_candidate_left_bracket
+      kb_events.macos_pinyin_selecting_candidate_double_left_bracket,
+      kb_events.win10_RIME_selecting_candidate_double_left_bracket
     ].entries()) {
       await createRandomPage(page)
-      let prefix = "#3440 test " + idx + ": "
-      await page.type(':nth-match(textarea, 1)', prefix + "【")
+      let check_text = "#3440 test " + idx
+      await page.type(':nth-match(textarea, 1)', check_text)
       await dispatch_kb_events(page, ':nth-match(textarea, 1)', selecting_candidate_left_bracket)
-      expect(await page.inputValue(':nth-match(textarea, 1)')).toBe(prefix + '【')
-      await page.type(':nth-match(textarea, 1)', "【")
+      expect(await page.inputValue(':nth-match(textarea, 1)')).toBe(check_text)
       await dispatch_kb_events(page, ':nth-match(textarea, 1)', selecting_candidate_left_bracket)
-      expect(await page.inputValue(':nth-match(textarea, 1)')).toBe(prefix + '【【')
+      expect(await page.inputValue(':nth-match(textarea, 1)')).toBe(check_text)
     }
   })
 

--- a/e2e-tests/util/keyboard-event-cap.html
+++ b/e2e-tests/util/keyboard-event-cap.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <script>
+    'use strict';
+
+    const keys = [
+      // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
+      // without deprecated / non-standard
+      "altKey", "code", "ctrlKey", "isComposing", "key", "locale", "location", "metaKey",
+      "repeat", "shiftKey",
+      // empiricial
+      "composed"
+    ]
+
+    let output_list = [];
+
+    function select_keys(obj, keys) {
+      let new_obj = {}
+      for (let k in event)
+        if (keys.indexOf(k) != -1)
+          new_obj[k] = event[k]
+      return new_obj
+    }
+
+    let key_handler_builder = (event_type) => (event) => {
+      if (event["target"].id != "input")
+        return;
+      let output = {
+        "event_type": event_type,
+        "event": select_keys(event, keys)
+      }
+      output_list.push(output);
+      let to_print = JSON.stringify(
+        output_list,
+        undefined,
+        2);
+      document.getElementById("outputs").innerText = to_print;
+    }
+
+    document.addEventListener('keydown', key_handler_builder('keydown'), false);
+    document.addEventListener('keyup', key_handler_builder('keyup'), false);
+
+    window.onload = (e) => {
+      document.getElementById("input").focus();
+    }
+
+  </script>
+</head>
+
+<body>
+  <input id="input" />
+  <h2>Key Down</h2>
+  <p id="outputs" style="white-space: pre;" />
+</body>
+
+</html>

--- a/e2e-tests/util/keyboard-event-cap.html
+++ b/e2e-tests/util/keyboard-event-cap.html
@@ -9,28 +9,30 @@
       // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
       // without deprecated / non-standard
       "altKey", "code", "ctrlKey", "isComposing", "key", "locale", "location", "metaKey",
-      "repeat", "shiftKey",
-      // empiricial
-      "composed"
+      "repeat", "shiftKey"
     ]
 
     let output_list = [];
+    let last_timestamp = Date.now();
 
     function select_keys(obj, keys) {
       let new_obj = {}
       for (let k in event)
         if (keys.indexOf(k) != -1)
-          new_obj[k] = event[k]
+          new_obj[k] = event[k];
       return new_obj
     }
 
     let key_handler_builder = (event_type) => (event) => {
       if (event["target"].id != "input")
         return;
+      let cur_timestamp = Date.now();
       let output = {
         "event_type": event_type,
-        "event": select_keys(event, keys)
+        "event": select_keys(event, keys),
+        "latency": cur_timestamp - last_timestamp // Time to wait before firing event
       }
+      last_timestamp = cur_timestamp;
       output_list.push(output);
       let to_print = JSON.stringify(
         output_list,
@@ -41,6 +43,10 @@
 
     document.addEventListener('keydown', key_handler_builder('keydown'), false);
     document.addEventListener('keyup', key_handler_builder('keyup'), false);
+    document.addEventListener('keypress', key_handler_builder('keypress'), false);
+    document.addEventListener('compositionstart', key_handler_builder('compositionstart'), false);
+    document.addEventListener('compositionend', key_handler_builder('compositionend'), false);
+    document.addEventListener('compositionupdate', key_handler_builder('compositionupdate'), false);
 
     window.onload = (e) => {
       document.getElementById("input").focus();

--- a/e2e-tests/util/keyboard-events.ts
+++ b/e2e-tests/util/keyboard-events.ts
@@ -1,7 +1,7 @@
 
 
 // typing 【
-export let press_with_events = async function (page, selector, keyboard_events ){
+export let dispatch_kb_events = async function (page, selector, keyboard_events ){
     for (let idx in keyboard_events){
       let { event_type, event } = keyboard_events[idx]
       await page.dispatchEvent(selector, event_type, event)
@@ -30,6 +30,225 @@ export let macos_pinyin_left_full_bracket = [
     "event": {
       "key": "【",
       "code": "BracketLeft",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": false,
+      "composed": true
+    }
+  }
+]
+
+export let win10_pinyin_left_full_bracket = [
+  {
+    "event_type": "keydown",
+    "event": {
+      "key": "Process",
+      "code": "BracketLeft",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": false,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keyup",
+    "event": {
+      "key": "Process",
+      "code": "BracketLeft",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": false,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keyup",
+    "event": {
+      "key": "[",
+      "code": "BracketLeft",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": false,
+      "composed": true
+    }
+  }
+]
+
+export let win10_legacy_pinyin_left_full_bracket = [
+  {
+    "event_type": "keydown",
+    "event": {
+      "key": "Process",
+      "code": "BracketLeft",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": false,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keyup",
+    "event": {
+      "key": "Process",
+      "code": "BracketLeft",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": false,
+      "composed": true
+    }
+  }
+]
+
+export let win10_RIME_left_full_bracket = [
+  {
+    "event_type": "keydown",
+    "event": {
+      "key": "Process",
+      "code": "BracketLeft",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": false,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keyup",
+    "event": {
+      "key": "Process",
+      "code": "BracketLeft",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keyup",
+    "event": {
+      "key": "[",
+      "code": "BracketLeft",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keydown",
+    "event": {
+      "key": "Process",
+      "code": "BracketLeft",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keyup",
+    "event": {
+      "key": "Process",
+      "code": "BracketLeft",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keyup",
+    "event": {
+      "key": "[",
+      "code": "BracketLeft",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keydown",
+    "event": {
+      "key": "Process",
+      "code": "Space",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keyup",
+    "event": {
+      "key": "Process",
+      "code": "Space",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": false,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keyup",
+    "event": {
+      "key": " ",
+      "code": "Space",
       "location": 0,
       "ctrlKey": false,
       "shiftKey": false,

--- a/e2e-tests/util/keyboard-events.ts
+++ b/e2e-tests/util/keyboard-events.ts
@@ -1,11 +1,14 @@
+/*** 
+ * Author: Junyi Du <junyi@logseq.com>
+ * References:
+ * https://stackoverflow.com/questions/8892238/detect-keyboard-layout-with-javascript
+ * ***/
 
-
-// typing 【
 export let dispatch_kb_events = async function (page, selector, keyboard_events ){
     for (let idx in keyboard_events){
-      let { event_type, event } = keyboard_events[idx]
+      let { event_type, event, latency } = keyboard_events[idx]
+      await page.waitForTimeout(latency)
       await page.dispatchEvent(selector, event_type, event)
-      await page.waitForTimeout(100)
     }
 }
 
@@ -21,9 +24,24 @@ export let macos_pinyin_left_full_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": false,
-      "composed": true
-    }
+      "isComposing": false
+    },
+    "latency": 0
+  },
+  {
+    "event_type": "keypress",
+    "event": {
+      "key": "【",
+      "code": "BracketLeft",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": false
+    },
+    "latency": 1
   },
   {
     "event_type": "keyup",
@@ -36,9 +54,9 @@ export let macos_pinyin_left_full_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": false,
-      "composed": true
-    }
+      "isComposing": false
+    },
+    "latency": 17
   }
 ]
 
@@ -54,9 +72,29 @@ export let win10_pinyin_left_full_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": false,
-      "composed": true
-    }
+      "isComposing": false
+    },
+    "latency": 0
+  },
+  {
+    "event_type": "compositionstart",
+    "event": {},
+    "latency": 4
+  },
+  {
+    "event_type": "compositionupdate",
+    "event": {},
+    "latency": 0
+  },
+  {
+    "event_type": "compositionupdate",
+    "event": {},
+    "latency": 12
+  },
+  {
+    "event_type": "compositionend",
+    "event": {},
+    "latency": 1
   },
   {
     "event_type": "keyup",
@@ -69,9 +107,9 @@ export let win10_pinyin_left_full_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": false,
-      "composed": true
-    }
+      "isComposing": false
+    },
+    "latency": 61
   },
   {
     "event_type": "keyup",
@@ -84,9 +122,9 @@ export let win10_pinyin_left_full_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": false,
-      "composed": true
-    }
+      "isComposing": false
+    },
+    "latency": 1
   }
 ]
 
@@ -102,9 +140,29 @@ export let win10_legacy_pinyin_left_full_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": false,
-      "composed": true
-    }
+      "isComposing": false
+    },
+    "latency": 0
+  },
+  {
+    "event_type": "compositionstart",
+    "event": {},
+    "latency": 1
+  },
+  {
+    "event_type": "compositionupdate",
+    "event": {},
+    "latency": 0
+  },
+  {
+    "event_type": "compositionupdate",
+    "event": {},
+    "latency": 0
+  },
+  {
+    "event_type": "compositionend",
+    "event": {},
+    "latency": 1
   },
   {
     "event_type": "keyup",
@@ -117,9 +175,9 @@ export let win10_legacy_pinyin_left_full_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": false,
-      "composed": true
-    }
+      "isComposing": false
+    },
+    "latency": 93
   }
 ]
 
@@ -135,9 +193,19 @@ export let macos_pinyin_selecting_candidate_double_left_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": false,
-      "composed": true
-    }
+      "isComposing": false
+    },
+    "latency": 0
+  },
+  {
+    "event_type": "compositionstart",
+    "event": {},
+    "latency": 1
+  },
+  {
+    "event_type": "compositionupdate",
+    "event": {},
+    "latency": 0
   },
   {
     "event_type": "keyup",
@@ -150,9 +218,9 @@ export let macos_pinyin_selecting_candidate_double_left_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
+      "isComposing": true
+    },
+    "latency": 48
   },
   {
     "event_type": "keydown",
@@ -165,9 +233,9 @@ export let macos_pinyin_selecting_candidate_double_left_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
+      "isComposing": true
+    },
+    "latency": 627
   },
   {
     "event_type": "keyup",
@@ -180,9 +248,9 @@ export let macos_pinyin_selecting_candidate_double_left_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
+      "isComposing": true
+    },
+    "latency": 59
   },
   {
     "event_type": "keydown",
@@ -195,9 +263,9 @@ export let macos_pinyin_selecting_candidate_double_left_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
+      "isComposing": true
+    },
+    "latency": 289
   },
   {
     "event_type": "keyup",
@@ -210,9 +278,9 @@ export let macos_pinyin_selecting_candidate_double_left_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
+      "isComposing": true
+    },
+    "latency": 73
   },
   {
     "event_type": "keydown",
@@ -225,9 +293,9 @@ export let macos_pinyin_selecting_candidate_double_left_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
+      "isComposing": true
+    },
+    "latency": 443
   },
   {
     "event_type": "keyup",
@@ -240,9 +308,9 @@ export let macos_pinyin_selecting_candidate_double_left_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
+      "isComposing": true
+    },
+    "latency": 79
   },
   {
     "event_type": "keydown",
@@ -255,9 +323,9 @@ export let macos_pinyin_selecting_candidate_double_left_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
+      "isComposing": true
+    },
+    "latency": 155
   },
   {
     "event_type": "keyup",
@@ -270,9 +338,14 @@ export let macos_pinyin_selecting_candidate_double_left_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
+      "isComposing": true
+    },
+    "latency": 44
+  },
+  {
+    "event_type": "compositionend",
+    "event": {},
+    "latency": 968
   }
 ]
 
@@ -281,51 +354,6 @@ export let win10_RIME_selecting_candidate_double_left_bracket = [
     "event_type": "keydown",
     "event": {
       "key": "Process",
-      "code": "KeyA",
-      "location": 0,
-      "ctrlKey": false,
-      "shiftKey": false,
-      "altKey": false,
-      "metaKey": false,
-      "repeat": false,
-      "isComposing": false,
-      "composed": true
-    }
-  },
-  {
-    "event_type": "keyup",
-    "event": {
-      "key": "Process",
-      "code": "KeyA",
-      "location": 0,
-      "ctrlKey": false,
-      "shiftKey": false,
-      "altKey": false,
-      "metaKey": false,
-      "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
-  },
-  {
-    "event_type": "keyup",
-    "event": {
-      "key": "a",
-      "code": "KeyA",
-      "location": 0,
-      "ctrlKey": false,
-      "shiftKey": false,
-      "altKey": false,
-      "metaKey": false,
-      "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
-  },
-  {
-    "event_type": "keydown",
-    "event": {
-      "key": "Process",
       "code": "BracketRight",
       "location": 0,
       "ctrlKey": false,
@@ -333,9 +361,19 @@ export let win10_RIME_selecting_candidate_double_left_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
+      "isComposing": false
+    },
+    "latency": 0
+  },
+  {
+    "event_type": "compositionstart",
+    "event": {},
+    "latency": 0
+  },
+  {
+    "event_type": "compositionupdate",
+    "event": {},
+    "latency": 0
   },
   {
     "event_type": "keyup",
@@ -348,9 +386,9 @@ export let win10_RIME_selecting_candidate_double_left_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
+      "isComposing": true
+    },
+    "latency": 79
   },
   {
     "event_type": "keyup",
@@ -363,98 +401,58 @@ export let win10_RIME_selecting_candidate_double_left_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
+      "isComposing": true
+    },
+    "latency": 3
   },
   {
     "event_type": "keydown",
     "event": {
       "key": "Process",
-      "code": "BracketLeft",
+      "code": "BracketRight",
       "location": 0,
       "ctrlKey": false,
       "shiftKey": false,
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
+      "isComposing": true
+    },
+    "latency": 237
   },
   {
     "event_type": "keyup",
     "event": {
       "key": "Process",
-      "code": "BracketLeft",
+      "code": "BracketRight",
       "location": 0,
       "ctrlKey": false,
       "shiftKey": false,
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
+      "isComposing": true
+    },
+    "latency": 96
   },
   {
     "event_type": "keyup",
     "event": {
-      "key": "[",
-      "code": "BracketLeft",
+      "key": "]",
+      "code": "BracketRight",
       "location": 0,
       "ctrlKey": false,
       "shiftKey": false,
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
+      "isComposing": true
+    },
+    "latency": 3
   },
   {
-    "event_type": "keydown",
-    "event": {
-      "key": "Process",
-      "code": "BracketLeft",
-      "location": 0,
-      "ctrlKey": false,
-      "shiftKey": false,
-      "altKey": false,
-      "metaKey": false,
-      "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
-  },
-  {
-    "event_type": "keyup",
-    "event": {
-      "key": "Process",
-      "code": "BracketLeft",
-      "location": 0,
-      "ctrlKey": false,
-      "shiftKey": false,
-      "altKey": false,
-      "metaKey": false,
-      "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
-  },
-  {
-    "event_type": "keyup",
-    "event": {
-      "key": "[",
-      "code": "BracketLeft",
-      "location": 0,
-      "ctrlKey": false,
-      "shiftKey": false,
-      "altKey": false,
-      "metaKey": false,
-      "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
+    "event_type": "compositionend",
+    "event": {},
+    "latency": 1479
   }
 ]

--- a/e2e-tests/util/keyboard-events.ts
+++ b/e2e-tests/util/keyboard-events.ts
@@ -1,55 +1,43 @@
 
 
 // typing 【
-export let press_with_events = async function (page, selector, { typedown, keyboard_events }){
-    await page.type(selector, typedown)
+export let press_with_events = async function (page, selector, keyboard_events ){
     for (let idx in keyboard_events){
-      let ev = keyboard_events[idx]
-      await page.dispatchEvent(selector, ev["type"], ev)
+      let { event_type, event } = keyboard_events[idx]
+      await page.dispatchEvent(selector, event_type, event)
       await page.waitForTimeout(100)
     }
 }
 
-export let macos_pinyin_left_full_bracket = {
-    "typedown": "【",
-    "keyboard_events": [{
-        "altKey": false,
-        "charCode": 0,
-        "ctrlKey": false,
-        "code": "BracketLeft",
-        "composed": true,
-        "detail": 0,
-        "event_": {
-            "code": "BracketLeft",
-            "isComposing": false,
-            "composed": true
-        },
-        "isComposing": false,
-        "isTrusted": true,
-        "key": "【",
-        "keyCode": 219,
-        "metaKey": false,
-        "repeat": false,
-        "returnValue": true,
-        "shiftKey": false,
-        "type": "keydown",
-        "which": 219,
-        "platformModifierKey": false
-    }, {
-        "altKey": false,
-        "charCode": 0,
-        "ctrlKey": false,
-        "event_": {
-            "code": "BracketLeft",
-            "isComposing": false,
-            "composed": true
-        },
-        "key": "【",
-        "keyCode": 219,
-        "metaKey": false,
-        "repeat": false,
-        "shiftKey": false,
-        "type": "keyup",
-        "platformModifierKey": false
+export let macos_pinyin_left_full_bracket = [
+  {
+    "event_type": "keydown",
+    "event": {
+      "key": "【",
+      "code": "BracketLeft",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": false,
+      "composed": true
     }
-]}
+  },
+  {
+    "event_type": "keyup",
+    "event": {
+      "key": "【",
+      "code": "BracketLeft",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": false,
+      "composed": true
+    }
+  }
+]

--- a/e2e-tests/util/keyboard-events.ts
+++ b/e2e-tests/util/keyboard-events.ts
@@ -4,15 +4,23 @@
  * https://stackoverflow.com/questions/8892238/detect-keyboard-layout-with-javascript
  * ***/
 
-export let dispatch_kb_events = async function (page, selector, keyboard_events ){
-    for (let idx in keyboard_events){
-      let { event_type, event, latency } = keyboard_events[idx]
-      await page.waitForTimeout(latency)
-      await page.dispatchEvent(selector, event_type, event)
-    }
+import { Page } from '@playwright/test'
+
+interface RecordedEvent {
+  event_type: string;
+  event: any; // KeyboardEvent is too heavy
+  latency: number;
 }
 
-export let macos_pinyin_left_full_bracket = [
+export let dispatch_kb_events = async function (page: Page, selector: string, keyboard_events: RecordedEvent[] ){
+  for (let kbev of keyboard_events){
+    let { event_type, event, latency } = kbev
+    await page.waitForTimeout(latency)
+    await page.dispatchEvent(selector, event_type, event)
+  }
+}
+
+export let macos_pinyin_left_full_bracket: RecordedEvent[] = [
   {
     "event_type": "keydown",
     "event": {
@@ -60,7 +68,7 @@ export let macos_pinyin_left_full_bracket = [
   }
 ]
 
-export let win10_pinyin_left_full_bracket = [
+export let win10_pinyin_left_full_bracket: RecordedEvent[] = [
   {
     "event_type": "keydown",
     "event": {
@@ -128,7 +136,7 @@ export let win10_pinyin_left_full_bracket = [
   }
 ]
 
-export let win10_legacy_pinyin_left_full_bracket = [
+export let win10_legacy_pinyin_left_full_bracket: RecordedEvent[] = [
   {
     "event_type": "keydown",
     "event": {
@@ -181,7 +189,7 @@ export let win10_legacy_pinyin_left_full_bracket = [
   }
 ]
 
-export let macos_pinyin_selecting_candidate_double_left_bracket = [
+export let macos_pinyin_selecting_candidate_double_left_bracket: RecordedEvent[] = [
   {
     "event_type": "keydown",
     "event": {
@@ -349,7 +357,7 @@ export let macos_pinyin_selecting_candidate_double_left_bracket = [
   }
 ]
 
-export let win10_RIME_selecting_candidate_double_left_bracket = [
+export let win10_RIME_selecting_candidate_double_left_bracket: RecordedEvent[] = [
   {
     "event_type": "keydown",
     "event": {

--- a/e2e-tests/util/keyboard-events.ts
+++ b/e2e-tests/util/keyboard-events.ts
@@ -123,7 +123,115 @@ export let win10_legacy_pinyin_left_full_bracket = [
   }
 ]
 
-export let win10_RIME_left_full_bracket = [
+export let macos_pinyin_selecting_candidate_left_bracket = [
+  {
+    "event_type": "keydown",
+    "event": {
+      "key": "a",
+      "code": "KeyA",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": false,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keyup",
+    "event": {
+      "key": "a",
+      "code": "KeyA",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keydown",
+    "event": {
+      "key": "【",
+      "code": "BracketLeft",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keyup",
+    "event": {
+      "key": "【",
+      "code": "BracketLeft",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  }
+]
+
+export let win10_RIME_selecting_candidate_left_bracket = [
+  {
+    "event_type": "keydown",
+    "event": {
+      "key": "Process",
+      "code": "KeyA",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": false,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keyup",
+    "event": {
+      "key": "Process",
+      "code": "KeyA",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keyup",
+    "event": {
+      "key": "a",
+      "code": "KeyA",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  },
   {
     "event_type": "keydown",
     "event": {
@@ -135,7 +243,7 @@ export let win10_RIME_left_full_bracket = [
       "altKey": false,
       "metaKey": false,
       "repeat": false,
-      "isComposing": false,
+      "isComposing": true,
       "composed": true
     }
   },
@@ -211,51 +319,6 @@ export let win10_RIME_left_full_bracket = [
       "metaKey": false,
       "repeat": false,
       "isComposing": true,
-      "composed": true
-    }
-  },
-  {
-    "event_type": "keydown",
-    "event": {
-      "key": "Process",
-      "code": "Space",
-      "location": 0,
-      "ctrlKey": false,
-      "shiftKey": false,
-      "altKey": false,
-      "metaKey": false,
-      "repeat": false,
-      "isComposing": true,
-      "composed": true
-    }
-  },
-  {
-    "event_type": "keyup",
-    "event": {
-      "key": "Process",
-      "code": "Space",
-      "location": 0,
-      "ctrlKey": false,
-      "shiftKey": false,
-      "altKey": false,
-      "metaKey": false,
-      "repeat": false,
-      "isComposing": false,
-      "composed": true
-    }
-  },
-  {
-    "event_type": "keyup",
-    "event": {
-      "key": " ",
-      "code": "Space",
-      "location": 0,
-      "ctrlKey": false,
-      "shiftKey": false,
-      "altKey": false,
-      "metaKey": false,
-      "repeat": false,
-      "isComposing": false,
       "composed": true
     }
   }

--- a/e2e-tests/util/keyboard-events.ts
+++ b/e2e-tests/util/keyboard-events.ts
@@ -123,12 +123,12 @@ export let win10_legacy_pinyin_left_full_bracket = [
   }
 ]
 
-export let macos_pinyin_selecting_candidate_left_bracket = [
+export let macos_pinyin_selecting_candidate_double_left_bracket = [
   {
     "event_type": "keydown",
     "event": {
-      "key": "a",
-      "code": "KeyA",
+      "key": "b",
+      "code": "KeyB",
       "location": 0,
       "ctrlKey": false,
       "shiftKey": false,
@@ -142,8 +142,98 @@ export let macos_pinyin_selecting_candidate_left_bracket = [
   {
     "event_type": "keyup",
     "event": {
-      "key": "a",
-      "code": "KeyA",
+      "key": "b",
+      "code": "KeyB",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keydown",
+    "event": {
+      "key": "】",
+      "code": "BracketRight",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keyup",
+    "event": {
+      "key": "】",
+      "code": "BracketRight",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keydown",
+    "event": {
+      "key": "】",
+      "code": "BracketRight",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keyup",
+    "event": {
+      "key": "】",
+      "code": "BracketRight",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keydown",
+    "event": {
+      "key": "【",
+      "code": "BracketLeft",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keyup",
+    "event": {
+      "key": "【",
+      "code": "BracketLeft",
       "location": 0,
       "ctrlKey": false,
       "shiftKey": false,
@@ -186,7 +276,7 @@ export let macos_pinyin_selecting_candidate_left_bracket = [
   }
 ]
 
-export let win10_RIME_selecting_candidate_left_bracket = [
+export let win10_RIME_selecting_candidate_double_left_bracket = [
   {
     "event_type": "keydown",
     "event": {
@@ -222,6 +312,51 @@ export let win10_RIME_selecting_candidate_left_bracket = [
     "event": {
       "key": "a",
       "code": "KeyA",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keydown",
+    "event": {
+      "key": "Process",
+      "code": "BracketRight",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keyup",
+    "event": {
+      "key": "Process",
+      "code": "BracketRight",
+      "location": 0,
+      "ctrlKey": false,
+      "shiftKey": false,
+      "altKey": false,
+      "metaKey": false,
+      "repeat": false,
+      "isComposing": true,
+      "composed": true
+    }
+  },
+  {
+    "event_type": "keyup",
+    "event": {
+      "key": "]",
+      "code": "BracketRight",
       "location": 0,
       "ctrlKey": false,
       "shiftKey": false,

--- a/e2e-tests/util/keyboard-events.ts
+++ b/e2e-tests/util/keyboard-events.ts
@@ -20,7 +20,7 @@ export let dispatch_kb_events = async function (page: Page, selector: string, ke
   }
 }
 
-export let macos_pinyin_left_full_bracket: RecordedEvent[] = [
+export let macos_pinyin_left_full_square_bracket: RecordedEvent[] = [
   {
     "event_type": "keydown",
     "event": {
@@ -68,7 +68,7 @@ export let macos_pinyin_left_full_bracket: RecordedEvent[] = [
   }
 ]
 
-export let win10_pinyin_left_full_bracket: RecordedEvent[] = [
+export let win10_pinyin_left_full_square_bracket: RecordedEvent[] = [
   {
     "event_type": "keydown",
     "event": {
@@ -136,7 +136,7 @@ export let win10_pinyin_left_full_bracket: RecordedEvent[] = [
   }
 ]
 
-export let win10_legacy_pinyin_left_full_bracket: RecordedEvent[] = [
+export let win10_legacy_pinyin_left_full_square_bracket: RecordedEvent[] = [
   {
     "event_type": "keydown",
     "event": {
@@ -189,7 +189,7 @@ export let win10_legacy_pinyin_left_full_bracket: RecordedEvent[] = [
   }
 ]
 
-export let macos_pinyin_selecting_candidate_double_left_bracket: RecordedEvent[] = [
+export let macos_pinyin_selecting_candidate_double_left_square_bracket: RecordedEvent[] = [
   {
     "event_type": "keydown",
     "event": {
@@ -357,7 +357,7 @@ export let macos_pinyin_selecting_candidate_double_left_bracket: RecordedEvent[]
   }
 ]
 
-export let win10_RIME_selecting_candidate_double_left_bracket: RecordedEvent[] = [
+export let win10_RIME_selecting_candidate_double_left_square_bracket: RecordedEvent[] = [
   {
     "event_type": "keydown",
     "event": {

--- a/e2e-tests/util/keyboard-events.ts
+++ b/e2e-tests/util/keyboard-events.ts
@@ -1,0 +1,55 @@
+
+
+// typing 【
+export let press_with_events = async function (page, selector, { typedown, keyboard_events }){
+    await page.type(selector, typedown)
+    for (let idx in keyboard_events){
+      let ev = keyboard_events[idx]
+      await page.dispatchEvent(selector, ev["type"], ev)
+      await page.waitForTimeout(100)
+    }
+}
+
+export let macos_pinyin_left_full_bracket = {
+    "typedown": "【",
+    "keyboard_events": [{
+        "altKey": false,
+        "charCode": 0,
+        "ctrlKey": false,
+        "code": "BracketLeft",
+        "composed": true,
+        "detail": 0,
+        "event_": {
+            "code": "BracketLeft",
+            "isComposing": false,
+            "composed": true
+        },
+        "isComposing": false,
+        "isTrusted": true,
+        "key": "【",
+        "keyCode": 219,
+        "metaKey": false,
+        "repeat": false,
+        "returnValue": true,
+        "shiftKey": false,
+        "type": "keydown",
+        "which": 219,
+        "platformModifierKey": false
+    }, {
+        "altKey": false,
+        "charCode": 0,
+        "ctrlKey": false,
+        "event_": {
+            "code": "BracketLeft",
+            "isComposing": false,
+            "composed": true
+        },
+        "key": "【",
+        "keyCode": 219,
+        "metaKey": false,
+        "repeat": false,
+        "shiftKey": false,
+        "type": "keyup",
+        "platformModifierKey": false
+    }
+]}


### PR DESCRIPTION
Addressing complicated IME / locale / layout related issues like #3741 #3760
Previous PR addressing such cases: https://github.com/logseq/logseq/pull/3478
- [x] e2e keyboard event simulating mechanism
- [x] collect samples on different OS & IME & layouts & Issues
  - [x] **Press Chinese parenthesis `【` by 2 times** [#3251](https://github.com/logseq/logseq/issues/3251)
	- Expect: Show `【` at first then autocomplete to `[[]]` at the second type-in
  - [x] **Type `[` `]` during IME composition** [#3440](https://github.com/logseq/logseq/issues/3440) #Rime #[[MacOS Pinyin]]
- [x] e2e CI doesn't work for IME + Keyboard testing cases
  - [x] property `isComposing` of `KeyboardEvent` of Google Closure Library is missing
    * `clojure -M:cljs compile app`
    
    
 ### TODO in next PR
 - [ ] - **Type Chinese words in `cmd k`** [#3199](https://github.com/logseq/logseq/issues/3199)
	- Expect: Can type and search Chinese
  - [ ] **Trigger hashtag `#` search with Chinese** [#3283](https://github.com/logseq/logseq/issues/3283)
	- Expect: Can search pages
  - [ ] **Trigger slash `/` command using IME** [#3459](https://github.com/logseq/logseq/issues/3459)
	- Expect: Can search commands
	- Expect: No autocomplete happens
  - [ ] **Press `[` key with Japanese Romaji** [#3218](https://github.com/logseq/logseq/pull/3218) #MacOS
	- Expect: Show `「` only, instead of `[「]`
  - [ ] **Press `Shift + 9` twice with French Layout** [#3444](https://github.com/logseq/logseq/issues/3444) #MacOS
	- Expect: Show `99`