### PR TITLE
fix: remove assets/draws from All Pages

### DIFF
--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -46,35 +46,38 @@
   [block]
   (let [page (cond
                (and (vector? block) (= "Link" (first block)))
-               (let [typ (first (:url (second block)))]
+               (let [typ (first (:url (second block)))
+                     value (second (:url (second block)))]
                  ;; {:url ["File" "file:../pages/hello_world.org"], :label [["Plain" "hello world"]], :title nil}
                  (or
                   (and
                    (= typ "Page_ref")
-                   (string? (second (:url (second block))))
-                   (second (:url (second block))))
+                   (and (string? value)
+                        (not (or (config/local-asset? value)
+                                 (config/draw? value))))
+                   value)
 
                   (and
                    (= typ "Search")
-                   (text/page-ref? (second (:url (second block))))
-                   (text/page-ref-un-brackets! (second (:url (second block)))))
+                   (text/page-ref? value)
+                   (text/page-ref-un-brackets! value))
 
                   (and
                    (= typ "Search")
-                   (not (contains? #{\# \* \/ \[} (first (second (:url (second block))))))
-                   (let [page (second (:url (second block)))
-                         ext (some-> (util/get-file-ext page) keyword)]
-                     (when (and (not (util/starts-with? page "http:"))
-                                (not (util/starts-with? page "https:"))
-                                (not (util/starts-with? page "file:"))
+                   (not (contains? #{\# \* \/ \[} (first value)))
+                   (let [ext (some-> (util/get-file-ext value) keyword)]
+                     (when (and (not (util/starts-with? value "http:"))
+                                (not (util/starts-with? value "https:"))
+                                (not (util/starts-with? value "file:"))
+                                (not (config/local-asset? value))
                                 (or (= ext :excalidraw)
                                     (not (contains? (config/supported-formats) ext))))
-                       page)))
+                       value)))
 
                   (and
                    (= typ "Complex")
-                   (= (:protocol (second (:url (second block)))) "file")
-                   (:link (second (:url (second block)))))
+                   (= (:protocol value) "file")
+                   (:link value))
 
                   (and
                    (= typ "File")

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -611,6 +611,7 @@
        (remove (fn [p]
                  (let [name (:block/name p)]
                    (or (util/uuid-string? name)
+                       (config/draw? name)
                        (db/built-in-pages-names (string/upper-case name))))))
        (common-handler/fix-pages-timestamps)))
 


### PR DESCRIPTION
When creating a `demo` Excalidraw file from commands, two pages `Draws` and `Draws/demo.Excalidraw` are created unexpectedly. `Draws` page should not be created, and both of them should not appear in `All Pages` and `Graph View`.  Also, when uploading an PDF asset, similar problem exists. 

This PR fixed the above issue.