### PR TITLE
fix: List properties out of order when contain more than 8 elements

### DIFF
--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -184,9 +184,9 @@
                                        v (if (and
                                               (string? v)
                                               (contains? #{:alias :aliases :tags} k))
-                                           (set [v])
+                                           [v]
                                            v)
-                                       v (if (coll? v) (set v) v)]
+                                       v (if (coll? v) (distinct v) v)]
                                    [k v])))
                           (remove #(nil? (second %))))]
       {:properties (into {} properties)

--- a/src/main/frontend/text.cljs
+++ b/src/main/frontend/text.cljs
@@ -178,7 +178,7 @@
                     (string/starts-with? result "#")))
          (let [result (if coll? result [result])
                result (map (fn [s] (string/replace s #"^#+" "")) result)]
-           (set result))
+           (distinct result))
          (first result)))
 
      :else


### PR DESCRIPTION
As described by @w1ndy in https://github.com/logseq/logseq/issues/4462, using `set` for properties causes the parsed pages out of order, so I removed the set function and used `instinct` to remove duplicates.

Close https://github.com/logseq/logseq/issues/4462

- [ ] fix tests