### PR TITLE
feat: support block-embed alias in OrgMode

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -912,6 +912,10 @@
                (not= \* (last s)))
           (->elem :a {:on-click #(route-handler/jump-to-anchor! (mldoc/anchorLink (subs s 1)))} (subs s 1))
 
+          (text/block-ref? s)
+          (let [id (text/get-block-ref s)]
+            (block-reference config id label))
+
           (not (string/includes? s "."))
           (page-reference (:html-export? config) s config label)
 


### PR DESCRIPTION
This PR implements block-embed alias in OrgMode, which is already supported in markdown format.
The syntax is `[[((6225c04c-1d8f-47a2-9a5c-76be21fe8fd2))][label]]`.

Close https://github.com/logseq/logseq/issues/4111