### PR TITLE
Revert "fix: List properties out of order when contain more than 8 elements"

### DIFF
--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -184,9 +184,9 @@
                                        v (if (and
                                               (string? v)
                                               (contains? #{:alias :aliases :tags} k))
-                                           [v]
+                                           (set [v])
                                            v)
-                                       v (if (coll? v) (distinct v) v)]
+                                       v (if (coll? v) (set v) v)]
                                    [k v])))
                           (remove #(nil? (second %))))]
       {:properties (into {} properties)

--- a/src/main/frontend/text.cljs
+++ b/src/main/frontend/text.cljs
@@ -178,7 +178,7 @@
                     (string/starts-with? result "#")))
          (let [result (if coll? result [result])
                result (map (fn [s] (string/replace s #"^#+" "")) result)]
-           (distinct result))
+           (set result))
          (first result)))
 
      :else


### PR DESCRIPTION
Reverts logseq/logseq#4470

Since it breaks query test cases. Final changes will be included in https://github.com/logseq/logseq/pull/4477