### PR TITLE
Dev: Move mobile startup code to avoid shadow warning

### DIFF
--- a/src/main/frontend/fs/capacitor_fs.cljs
+++ b/src/main/frontend/fs/capacitor_fs.cljs
@@ -16,20 +16,6 @@
     []
     (.ensureDocuments mobile-util/ios-file-container)))
 
-(when (mobile-util/native-ios?)
-  ;; NOTE: avoid circular dependency
-  #_:clj-kondo/ignore
-  (def handle-changed! (delay frontend.fs.watcher-handler/handle-changed!))
-
-  (p/do!
-   (.addListener mobile-util/fs-watcher "watcher"
-                 (fn [^js event]
-                   (@handle-changed!
-                    (.-event event)
-                    (update (js->clj event :keywordize-keys true)
-                            :path
-                            js/decodeURI))))))
-
 (defn check-permission-android []
   (p/let [permission (.checkPermissions Filesystem)
           permission (-> permission


### PR DESCRIPTION
This PR fixes an issue that is making desktop development more difficult lately. I've noticed recently every file save results in this shadow warning:
<img width="957" alt="Screen Shot 2022-03-07 at 2 16 25 PM" src="https://user-images.githubusercontent.com/11994/157106500-10331145-95cf-41b8-a1ee-09516886f91b.png">

This PR moves the code to mobile.core/init which avoids the warning and is a more appropriate place for this code anyway. I haven't tested this code in iOS as I don't have logseq setup on it yet so I'd appreciate if someone could confirm the behavior 

I noticed this behavior was introduced in #4371 which is mobile specific. Thinking on this more, we are making it harder on ourselves by having desktop and mobile development this coupled. Behavior in mobile startup shouldn't be effecting desktop startup this easily. I'll start a separate discussion on this
