### PR TITLE
Add comments near plugin event listeners to make events more searchable

### DIFF
--- a/libs/src/LSPlugin.core.ts
+++ b/libs/src/LSPlugin.core.ts
@@ -7,38 +7,29 @@ import {
   setupInjectedUI,
   deferred,
   invokeHostExportedApi,
-  isObject,
-  withFileProtocol,
+  isObject, withFileProtocol,
   getSDKPathRoot,
-  PROTOCOL_FILE,
-  URL_LSP,
+  PROTOCOL_FILE, URL_LSP,
   safetyPathJoin,
-  path,
-  safetyPathNormalize,
-  mergeSettingsWithSchema,
-  IS_DEV,
+  path, safetyPathNormalize,
+  mergeSettingsWithSchema, IS_DEV
 } from './helpers'
 import * as pluginHelpers from './helpers'
 import Debug from 'debug'
 import {
   LSPluginCaller,
-  LSPMSG_READY,
-  LSPMSG_SYNC,
-  LSPMSG,
-  LSPMSG_SETTINGS,
-  LSPMSG_ERROR_TAG,
-  LSPMSG_BEFORE_UNLOAD,
-  AWAIT_LSPMSGFn,
+  LSPMSG_READY, LSPMSG_SYNC,
+  LSPMSG, LSPMSG_SETTINGS,
+  LSPMSG_ERROR_TAG, LSPMSG_BEFORE_UNLOAD,
+  AWAIT_LSPMSGFn
 } from './LSPlugin.caller'
 import {
   ILSPluginThemeManager,
-  LSPluginPkgConfig,
-  SettingSchemaDesc,
+  LSPluginPkgConfig, SettingSchemaDesc,
   StyleOptions,
   StyleString,
-  ThemeOptions,
-  UIContainerAttrs,
-  UIOptions,
+  ThemeOptions, UIContainerAttrs,
+  UIOptions
 } from './LSPlugin'
 import { snakeCase } from 'snake-case'
 
@@ -61,10 +52,10 @@ type LSPluginCoreOptions = {
  */
 class PluginSettings extends EventEmitter<'change' | 'reset'> {
   private _settings: Record<string, any> = {
-    disabled: false,
+    disabled: false
   }
 
-  constructor(
+  constructor (
     private _userPluginSettings: any,
     private _schema?: Array<SettingSchemaDesc>
   ) {
@@ -73,11 +64,11 @@ class PluginSettings extends EventEmitter<'change' | 'reset'> {
     Object.assign(this._settings, _userPluginSettings)
   }
 
-  get<T = any>(k: string): T {
+  get<T = any> (k: string): T {
     return this._settings[k]
   }
 
-  set(k: string | Record<string, any>, v?: any) {
+  set (k: string | Record<string, any>, v?: any) {
     const o = deepMerge({}, this._settings)
 
     if (typeof k === 'string') {
@@ -89,18 +80,19 @@ class PluginSettings extends EventEmitter<'change' | 'reset'> {
       return
     }
 
-    this.emit('change', Object.assign({}, this._settings), o)
+    this.emit('change',
+      Object.assign({}, this._settings), o)
   }
 
-  set settings(value: Record<string, any>) {
+  set settings (value: Record<string, any>) {
     this._settings = value
   }
 
-  get settings(): Record<string, any> {
+  get settings (): Record<string, any> {
     return this._settings
   }
 
-  setSchema(schema: Array<SettingSchemaDesc>, syncSettings?: boolean) {
+  setSchema (schema: Array<SettingSchemaDesc>, syncSettings?: boolean) {
     this._schema = schema
 
     if (syncSettings) {
@@ -110,7 +102,7 @@ class PluginSettings extends EventEmitter<'change' | 'reset'> {
     }
   }
 
-  reset() {
+  reset () {
     const o = this.settings
     const val = {}
 
@@ -122,7 +114,7 @@ class PluginSettings extends EventEmitter<'change' | 'reset'> {
     this.emit('reset', val, o)
   }
 
-  toJSON() {
+  toJSON () {
     return this._settings
   }
 }
@@ -130,11 +122,11 @@ class PluginSettings extends EventEmitter<'change' | 'reset'> {
 class PluginLogger extends EventEmitter<'change'> {
   private _logs: Array<[type: string, payload: any]> = []
 
-  constructor(private _tag: string) {
+  constructor (private _tag: string) {
     super()
   }
 
-  write(type: string, payload: any[]) {
+  write (type: string, payload: any[]) {
     let msg = payload.reduce((ac, it) => {
       if (it && it instanceof Error) {
         ac += `${it.message} ${it.stack}`
@@ -148,24 +140,24 @@ class PluginLogger extends EventEmitter<'change'> {
     this.emit('change')
   }
 
-  clear() {
+  clear () {
     this._logs = []
     this.emit('change')
   }
 
-  info(...args: any[]) {
+  info (...args: any[]) {
     this.write('INFO', args)
   }
 
-  error(...args: any[]) {
+  error (...args: any[]) {
     this.write('ERROR', args)
   }
 
-  warn(...args: any[]) {
+  warn (...args: any[]) {
     this.write('WARN', args)
   }
 
-  toJSON() {
+  toJSON () {
     return this._logs
   }
 }
@@ -203,26 +195,17 @@ enum PluginLocalLoadStatus {
   UNLOADING = 'unloading',
   LOADED = 'loaded',
   UNLOADED = 'unload',
-  ERROR = 'error',
+  ERROR = 'error'
 }
 
-function initUserSettingsHandlers(pluginLocal: PluginLocal) {
+function initUserSettingsHandlers (pluginLocal: PluginLocal) {
   const _ = (label: string): any => `settings:${label}`
 
   // settings:schema
-  pluginLocal.on(
-    _('schema'),
-    ({
-      schema,
-      isSync,
-    }: {
-      schema: Array<SettingSchemaDesc>
-      isSync?: boolean
-    }) => {
-      pluginLocal.settingsSchema = schema
-      pluginLocal.settings?.setSchema(schema, isSync)
-    }
-  )
+  pluginLocal.on(_('schema'), ({ schema, isSync }: { schema: Array<SettingSchemaDesc>, isSync?: boolean }) => {
+    pluginLocal.settingsSchema = schema
+    pluginLocal.settings?.setSchema(schema, isSync)
+  })
 
   // settings:update
   pluginLocal.on(_('update'), (attrs) => {
@@ -233,27 +216,23 @@ function initUserSettingsHandlers(pluginLocal: PluginLocal) {
   // settings:visible:changed
   pluginLocal.on(_('visible:changed'), (payload) => {
     const visible = payload?.visible
-    invokeHostExportedApi(
-      'set_focused_settings',
-      visible ? pluginLocal.id : null
-    )
+    invokeHostExportedApi('set_focused_settings',
+      visible ? pluginLocal.id : null)
   })
 }
 
-function initMainUIHandlers(pluginLocal: PluginLocal) {
+function initMainUIHandlers (pluginLocal: PluginLocal) {
   const _ = (label: string): any => `main-ui:${label}`
 
   // main-ui:visible
   pluginLocal.on(_('visible'), ({ visible, toggle, cursor, autoFocus }) => {
     const el = pluginLocal.getMainUIContainer()
-    el?.classList[toggle ? 'toggle' : visible ? 'add' : 'remove']('visible')
+    el?.classList[toggle ? 'toggle' : (visible ? 'add' : 'remove')]('visible')
     // pluginLocal.caller!.callUserModel(LSPMSG, { type: _('visible'), payload: visible })
     // auto focus frame
     if (visible) {
-      if (!pluginLocal.shadow && el && autoFocus !== false) {
-        ;(
-          el.querySelector('iframe') as HTMLIFrameElement
-        )?.contentWindow?.focus()
+      if (!pluginLocal.shadow && el && (autoFocus !== false)) {
+        (el.querySelector('iframe') as HTMLIFrameElement)?.contentWindow?.focus()
       }
     }
 
@@ -273,13 +252,13 @@ function initMainUIHandlers(pluginLocal: PluginLocal) {
             title: pluginLocal.options.name,
             close: () => {
               pluginLocal.caller.call('sys:ui:visible', { toggle: true })
-            },
-          })
-        )
+            }
+          }))
       }
 
       if (k === 'resizable' && v) {
-        pluginLocal._dispose(pluginLocal._setupResizableContainer(el))
+        pluginLocal._dispose(
+          pluginLocal._setupResizableContainer(el))
       }
     })
   })
@@ -290,10 +269,9 @@ function initMainUIHandlers(pluginLocal: PluginLocal) {
     const isInitedLayout = !!el.dataset.inited_layout
 
     Object.entries(style).forEach(([k, v]) => {
-      if (
-        isInitedLayout &&
-        ['left', 'top', 'bottom', 'right', 'width', 'height'].includes(k)
-      ) {
+      if (isInitedLayout && [
+        'left', 'top', 'bottom', 'right', 'width', 'height'
+      ].includes(k)) {
         return
       }
 
@@ -302,13 +280,16 @@ function initMainUIHandlers(pluginLocal: PluginLocal) {
   })
 }
 
-function initProviderHandlers(pluginLocal: PluginLocal) {
+function initProviderHandlers (pluginLocal: PluginLocal) {
   let _ = (label: string): any => `provider:${label}`
   let themed = false
 
   // provider:theme
   pluginLocal.on(_('theme'), (theme: ThemeOptions) => {
-    pluginLocal.themeMgr.registerTheme(pluginLocal.id, theme)
+    pluginLocal.themeMgr.registerTheme(
+      pluginLocal.id,
+      theme
+    )
 
     if (!themed) {
       pluginLocal._dispose(() => {
@@ -333,7 +314,7 @@ function initProviderHandlers(pluginLocal: PluginLocal) {
     pluginLocal._dispose(
       setupInjectedStyle(style, {
         'data-injected-style': key ? `${key}-${pluginLocal.id}` : '',
-        'data-ref': pluginLocal.id,
+        'data-ref': pluginLocal.id
       })
     )
   })
@@ -341,28 +322,22 @@ function initProviderHandlers(pluginLocal: PluginLocal) {
   // provider:ui
   pluginLocal.on(_('ui'), (ui: UIOptions) => {
     pluginLocal._onHostMounted(() => {
+
       pluginLocal._dispose(
-        setupInjectedUI.call(
-          pluginLocal,
-          ui,
-          Object.assign(
-            {
-              'data-ref': pluginLocal.id,
-            },
-            ui.attrs || {}
-          ),
+        setupInjectedUI.call(pluginLocal,
+          ui, Object.assign({
+            'data-ref': pluginLocal.id
+          }, ui.attrs || {}),
           ({ el, float }) => {
             if (!float) return
             const identity = el.dataset.identity
             pluginLocal.layoutCore.move_container_to_top(identity)
-          }
-        )
-      )
+          }))
     })
   })
 }
 
-function initApiProxyHandlers(pluginLocal: PluginLocal) {
+function initApiProxyHandlers (pluginLocal: PluginLocal) {
   let _ = (label: string): any => `api:${label}`
 
   pluginLocal.on(_('call'), async (payload) => {
@@ -388,8 +363,7 @@ function initApiProxyHandlers(pluginLocal: PluginLocal) {
     if (_sync != null) {
       const reply = (result: any) => {
         pluginLocal.caller?.callUserModel(LSPMSG_SYNC, {
-          result,
-          _sync,
+          result, _sync
         })
       }
 
@@ -398,25 +372,26 @@ function initApiProxyHandlers(pluginLocal: PluginLocal) {
   })
 }
 
-function convertToLSPResource(fullUrl: string, dotPluginRoot: string) {
-  if (dotPluginRoot && fullUrl.startsWith(PROTOCOL_FILE + dotPluginRoot)) {
+function convertToLSPResource (fullUrl: string, dotPluginRoot: string) {
+  if (
+    dotPluginRoot &&
+    fullUrl.startsWith(PROTOCOL_FILE + dotPluginRoot)
+  ) {
     fullUrl = safetyPathJoin(
-      URL_LSP,
-      fullUrl.substr(PROTOCOL_FILE.length + dotPluginRoot.length)
-    )
+      URL_LSP, fullUrl.substr(PROTOCOL_FILE.length + dotPluginRoot.length))
   }
   return fullUrl
 }
 
 class IllegalPluginPackageError extends Error {
-  constructor(message: string) {
+  constructor (message: string) {
     super(message)
     this.name = IllegalPluginPackageError.name
   }
 }
 
 class ExistedImportedPluginPackageError extends Error {
-  constructor(message: string) {
+  constructor (message: string) {
     super(message)
     this.name = ExistedImportedPluginPackageError.name
   }
@@ -425,9 +400,9 @@ class ExistedImportedPluginPackageError extends Error {
 /**
  * Host plugin for local
  */
-class PluginLocal extends EventEmitter<
-  'loaded' | 'unloaded' | 'beforeunload' | 'error'
-> {
+class PluginLocal
+  extends EventEmitter<'loaded' | 'unloaded' | 'beforeunload' | 'error'> {
+
   private _disposes: Array<() => Promise<any>> = []
   private _id: PluginLocalIdentity
   private _status: PluginLocalLoadStatus = PluginLocalLoadStatus.UNLOADED
@@ -441,7 +416,7 @@ class PluginLocal extends EventEmitter<
    * @param _themeMgr
    * @param _ctx
    */
-  constructor(
+  constructor (
     private _options: PluginLocalOptions,
     private _themeMgr: ILSPluginThemeManager,
     private _ctx: LSPluginCore
@@ -456,17 +431,18 @@ class PluginLocal extends EventEmitter<
     initApiProxyHandlers(this)
   }
 
-  async _setupUserSettings(reload?: boolean) {
+  async _setupUserSettings (
+    reload?: boolean
+  ) {
     const { _options } = this
-    const logger = (_options.logger = new PluginLogger('Loader'))
+    const logger = _options.logger = new PluginLogger('Loader')
 
     if (_options.settings && !reload) {
       return
     }
 
     try {
-      const loadFreshSettings = () =>
-        invokeHostExportedApi('load_plugin_user_settings', this.id)
+      const loadFreshSettings = () => invokeHostExportedApi('load_plugin_user_settings', this.id)
       const [userSettingsFilePath, userSettings] = await loadFreshSettings()
       this._dotSettingsFile = userSettingsFilePath
 
@@ -516,7 +492,7 @@ class PluginLocal extends EventEmitter<
     }
   }
 
-  getMainUIContainer(): HTMLElement | undefined {
+  getMainUIContainer (): HTMLElement | undefined {
     if (this.shadow) {
       return this.caller?._getSandboxShadowContainer()
     }
@@ -524,20 +500,19 @@ class PluginLocal extends EventEmitter<
     return this.caller?._getSandboxIframeContainer()
   }
 
-  _resolveResourceFullUrl(filePath: string, localRoot?: string) {
+  _resolveResourceFullUrl (filePath: string, localRoot?: string) {
     if (!filePath?.trim()) return
     localRoot = localRoot || this._localRoot
     const reg = /^(http|file)/
     if (!reg.test(filePath)) {
       const url = path.join(localRoot, filePath)
-      filePath = reg.test(url) ? url : PROTOCOL_FILE + url
+      filePath = reg.test(url) ? url : (PROTOCOL_FILE + url)
     }
-    return !this.options.effect && this.isInstalledInDotRoot
-      ? convertToLSPResource(filePath, this.dotPluginsRoot)
-      : filePath
+    return (!this.options.effect && this.isInstalledInDotRoot) ?
+      convertToLSPResource(filePath, this.dotPluginsRoot) : filePath
   }
 
-  async _preparePackageConfigs() {
+  async _preparePackageConfigs () {
     const { url } = this._options
     let pkg: any
 
@@ -550,39 +525,28 @@ class PluginLocal extends EventEmitter<
 
       pkg = await invokeHostExportedApi('load_plugin_config', url)
 
-      if (!pkg || ((pkg = JSON.parse(pkg)), !pkg)) {
+      if (!pkg || (pkg = JSON.parse(pkg), !pkg)) {
         throw new Error(`Parse package config error #${url}/package.json`)
       }
     } catch (e) {
       throw new IllegalPluginPackageError(e.message)
     }
 
-    const localRoot = (this._localRoot = safetyPathNormalize(url))
+    const localRoot = this._localRoot = safetyPathNormalize(url)
     const logseq: Partial<LSPluginPkgConfig> = pkg.logseq || {}
 
-    // Pick legal attrs
-    ;[
-      'name',
-      'author',
-      'repository',
-      'version',
-      'description',
-      'repo',
-      'title',
-      'effect',
-      'sponsors',
-    ]
-      .concat(!this.isInstalledInDotRoot ? ['devEntry'] : [])
-      .forEach((k) => {
-        this._options[k] = pkg[k]
-      })
+      // Pick legal attrs
+    ;['name', 'author', 'repository', 'version',
+      'description', 'repo', 'title', 'effect', 'sponsors'
+    ].concat(!this.isInstalledInDotRoot ? ['devEntry'] : []).forEach(k => {
+      this._options[k] = pkg[k]
+    })
 
     const validateEntry = (main) => main && /\.(js|html)$/.test(main)
 
     // Entry from main
     const entry = logseq.entry || logseq.main || pkg.main
-    if (validateEntry(entry)) {
-      // Theme has no main
+    if (validateEntry(entry)) { // Theme has no main
       this._options.entry = this._resolveResourceFullUrl(entry, localRoot)
       this._options.devEntry = logseq.devEntry
 
@@ -595,7 +559,8 @@ class PluginLocal extends EventEmitter<
     const icon = logseq.icon || pkg.icon
 
     this._options.title = title
-    this._options.icon = icon && this._resolveResourceFullUrl(icon)
+    this._options.icon = icon &&
+      this._resolveResourceFullUrl(icon)
     this._options.theme = Boolean(logseq.theme || !!logseq.themes)
 
     // TODO: strategy for Logseq plugins center
@@ -607,10 +572,7 @@ class PluginLocal extends EventEmitter<
       } else {
         logseq.id = this.id
         try {
-          await invokeHostExportedApi('save_plugin_config', url, {
-            ...pkg,
-            logseq,
-          })
+          await invokeHostExportedApi('save_plugin_config', url, { ...pkg, logseq })
         } catch (e) {
           debug('[save plugin ID Error] ', e)
         }
@@ -639,7 +601,7 @@ class PluginLocal extends EventEmitter<
     }
   }
 
-  async _tryToNormalizeEntry() {
+  async _tryToNormalizeEntry () {
     let { entry, settings, devEntry } = this.options
     devEntry = devEntry || settings?.get('_devEntry')
 
@@ -657,7 +619,7 @@ class PluginLocal extends EventEmitter<
       dirPathInstalled = this._localRoot.replace(this.dotPluginsRoot, '')
       dirPathInstalled = path.join(DIR_PLUGINS, dirPathInstalled)
     }
-    let tag = new Date().getDay()
+    let tag = (new Date()).getDay()
     let sdkPathRoot = await getSDKPathRoot()
     let entryPath = await invokeHostExportedApi(
       tmp_file_method,
@@ -667,20 +629,16 @@ class PluginLocal extends EventEmitter<
   <head>
     <meta charset="UTF-8">
     <title>logseq plugin entry</title>
-    ${
-      IS_DEV
-        ? `<script src="${sdkPathRoot}/lsplugin.user.js?v=${tag}"></script>`
-        : `<script src="https://cdn.jsdelivr.net/npm/@logseq/libs/dist/lsplugin.user.min.js?v=${tag}"></script>`
-    }
+    ${IS_DEV ?
+        `<script src="${sdkPathRoot}/lsplugin.user.js?v=${tag}"></script>` :
+        `<script src="https://cdn.jsdelivr.net/npm/@logseq/libs/dist/lsplugin.user.min.js?v=${tag}"></script>`}
     
   </head>
   <body>
   <div id="app"></div>
   <script src="${entry}"></script>
   </body>
-</html>`,
-      dirPathInstalled
-    )
+</html>`, dirPathInstalled)
 
     entry = convertToLSPResource(
       withFileProtocol(path.normalize(entryPath)),
@@ -690,7 +648,7 @@ class PluginLocal extends EventEmitter<
     this._options.entry = entry
   }
 
-  async _loadConfigThemes(themes: Array<ThemeOptions>) {
+  async _loadConfigThemes (themes: Array<ThemeOptions>) {
     themes.forEach((options) => {
       if (!options.url) return
 
@@ -707,35 +665,26 @@ class PluginLocal extends EventEmitter<
     })
   }
 
-  async _loadLayoutsData(): Promise<Record<string, any>> {
+  async _loadLayoutsData (): Promise<Record<string, any>> {
     const key = this.id + '_layouts'
-    const [, layouts] = await invokeHostExportedApi(
-      'load_plugin_user_settings',
-      key
-    )
+    const [, layouts] = await invokeHostExportedApi('load_plugin_user_settings', key)
     return layouts || {}
   }
 
-  async _saveLayoutsData(data) {
+  async _saveLayoutsData (data) {
     const key = this.id + '_layouts'
     await invokeHostExportedApi('save_plugin_user_settings', key, data)
   }
 
-  async _persistMainUILayoutData(e: {
-    width: number
-    height: number
-    left: number
-    top: number
-  }) {
+  async _persistMainUILayoutData (e: { width: number, height: number, left: number, top: number }) {
     const layouts = await this._loadLayoutsData()
     layouts.$$0 = e
     await this._saveLayoutsData(layouts)
   }
 
-  _setupDraggableContainer(
+  _setupDraggableContainer (
     el: HTMLElement,
-    opts: Partial<{ key: string; title: string; close: () => void }> = {}
-  ): () => void {
+    opts: Partial<{ key: string, title: string, close: () => void }> = {}): () => void {
     const ds = el.dataset
     if (ds.inited_draggable) return
     if (!ds.identity) {
@@ -754,46 +703,33 @@ class PluginLocal extends EventEmitter<
       </div>
     `
 
-    handle.querySelector('.x').addEventListener(
-      'click',
-      (e) => {
+    handle.querySelector('.x')
+      .addEventListener('click', (e) => {
         opts?.close?.()
         e.stopPropagation()
-      },
-      false
-    )
+      }, false)
 
-    handle.addEventListener(
-      'mousedown',
-      (e) => {
-        const target = e.target as HTMLElement
-        if (target?.closest('.r')) {
-          e.stopPropagation()
-          e.preventDefault()
-          return
-        }
-      },
-      false
-    )
+    handle.addEventListener('mousedown', (e) => {
+      const target = e.target as HTMLElement
+      if (target?.closest('.r')) {
+        e.stopPropagation()
+        e.preventDefault()
+        return
+      }
+    }, false)
 
     el.prepend(handle)
 
     // move to top
-    el.addEventListener(
-      'mousedown',
-      (e) => {
-        this.layoutCore.move_container_to_top(ds.identity)
-      },
-      true
-    )
+    el.addEventListener('mousedown', (e) => {
+      this.layoutCore.move_container_to_top(ds.identity)
+    }, true)
 
     const setTitle = (title) => {
       handle.querySelector('h3').textContent = title
     }
-    const dispose = this.layoutCore.setup_draggable_container_BANG_(
-      el,
-      !isInjectedUI ? this._persistMainUILayoutData.bind(this) : () => {}
-    )
+    const dispose = this.layoutCore.setup_draggable_container_BANG_(el,
+      !isInjectedUI ? this._persistMainUILayoutData.bind(this) : () => {})
 
     ds.inited_draggable = 'true'
 
@@ -823,7 +759,7 @@ class PluginLocal extends EventEmitter<
     }
   }
 
-  _setupResizableContainer(el: HTMLElement, key?: string): () => void {
+  _setupResizableContainer (el: HTMLElement, key?: string): () => void {
     const ds = el.dataset
     if (ds.inited_resizable) return
     if (!ds.identity) {
@@ -835,18 +771,16 @@ class PluginLocal extends EventEmitter<
 
     // @ts-ignore
     const layoutCore = window.frontend.modules.layout.core
-    const dispose = layoutCore.setup_resizable_container_BANG_(
-      el,
-      !key ? this._persistMainUILayoutData.bind(this) : () => {}
-    )
+    const dispose = layoutCore.setup_resizable_container_BANG_(el,
+      !key ? this._persistMainUILayoutData.bind(this) : () => {})
 
     ds.inited_resizable = 'true'
     return dispose
   }
 
-  async load(
+  async load (
     opts?: Partial<{
-      indicator: DeferredActor
+      indicator: DeferredActor,
       reload: boolean
     }>
   ) {
@@ -863,7 +797,9 @@ class PluginLocal extends EventEmitter<
 
       let installPackageThemes = await this._preparePackageConfigs()
 
-      this._dispose(await this._setupUserSettings(opts?.reload))
+      this._dispose(
+        await this._setupUserSettings(opts?.reload)
+      )
 
       if (!this.disabled) {
         await installPackageThemes.call(null)
@@ -908,7 +844,7 @@ class PluginLocal extends EventEmitter<
     }
   }
 
-  async reload() {
+  async reload () {
     if (this.pending) {
       return
     }
@@ -922,7 +858,7 @@ class PluginLocal extends EventEmitter<
   /**
    * @param unregister If true delete plugin files
    */
-  async unload(unregister: boolean = false) {
+  async unload (unregister: boolean = false) {
     if (this.pending) {
       return
     }
@@ -944,10 +880,7 @@ class PluginLocal extends EventEmitter<
 
       // sync call
       try {
-        await this._caller?.callUserModel(
-          AWAIT_LSPMSGFn(LSPMSG_BEFORE_UNLOAD),
-          eventBeforeUnload
-        )
+        await this._caller?.callUserModel(AWAIT_LSPMSGFn(LSPMSG_BEFORE_UNLOAD), eventBeforeUnload)
         this.emit('beforeunload', eventBeforeUnload)
       } catch (e) {
         console.error('[beforeunload Error]', e)
@@ -964,7 +897,7 @@ class PluginLocal extends EventEmitter<
     }
   }
 
-  private async dispose() {
+  private async dispose () {
     for (const fn of this._disposes) {
       try {
         fn && (await fn())
@@ -977,12 +910,12 @@ class PluginLocal extends EventEmitter<
     this._disposes = []
   }
 
-  _dispose(fn: any) {
+  _dispose (fn: any) {
     if (!fn) return
     this._disposes.push(fn)
   }
 
-  _onHostMounted(callback: () => void) {
+  _onHostMounted (callback: () => void) {
     const actor = this._ctx.hostMountedActor
 
     if (!actor || actor.settled) {
@@ -992,98 +925,96 @@ class PluginLocal extends EventEmitter<
     }
   }
 
-  get layoutCore(): any {
+  get layoutCore (): any {
     // @ts-ignore
     return window.frontend.modules.layout.core
   }
 
-  get isInstalledInDotRoot() {
+  get isInstalledInDotRoot () {
     const dotRoot = this.dotConfigRoot
     const plgRoot = this.localRoot
     return dotRoot && plgRoot && plgRoot.startsWith(dotRoot)
   }
 
-  get loaded() {
+  get loaded () {
     return this._status === PluginLocalLoadStatus.LOADED
   }
 
-  get pending() {
-    return [
-      PluginLocalLoadStatus.LOADING,
-      PluginLocalLoadStatus.UNLOADING,
-    ].includes(this._status)
+  get pending () {
+    return [PluginLocalLoadStatus.LOADING, PluginLocalLoadStatus.UNLOADING]
+      .includes(this._status)
   }
 
-  get status(): PluginLocalLoadStatus {
+  get status (): PluginLocalLoadStatus {
     return this._status
   }
 
-  get settings() {
+  get settings () {
     return this.options.settings
   }
 
-  set settingsSchema(schema: Array<SettingSchemaDesc>) {
+  set settingsSchema (schema: Array<SettingSchemaDesc>) {
     this.options.settingsSchema = schema
   }
 
-  get settingsSchema() {
+  get settingsSchema () {
     return this.options.settingsSchema
   }
 
-  get logger() {
+  get logger () {
     return this.options.logger
   }
 
-  get disabled() {
+  get disabled () {
     return this.settings?.get('disabled')
   }
 
-  get caller() {
+  get caller () {
     return this._caller
   }
 
-  get id(): string {
+  get id (): string {
     return this._id
   }
 
-  get shadow(): boolean {
+  get shadow (): boolean {
     return this.options.mode === 'shadow'
   }
 
-  get options(): PluginLocalOptions {
+  get options (): PluginLocalOptions {
     return this._options
   }
 
-  get themeMgr(): ILSPluginThemeManager {
+  get themeMgr (): ILSPluginThemeManager {
     return this._themeMgr
   }
 
-  get debugTag() {
+  get debugTag () {
     const name = this._options?.name
     return `#${this._id} ${name ?? ''}`
   }
 
-  get localRoot(): string {
+  get localRoot (): string {
     return this._localRoot || this._options.url
   }
 
-  get loadErr(): Error | undefined {
+  get loadErr (): Error | undefined {
     return this._loadErr
   }
 
-  get dotConfigRoot() {
+  get dotConfigRoot () {
     return path.normalize(this._ctx.options.dotConfigRoot)
   }
 
-  get dotSettingsFile(): string | undefined {
+  get dotSettingsFile (): string | undefined {
     return this._dotSettingsFile
   }
 
-  get dotPluginsRoot() {
+  get dotPluginsRoot () {
     return path.join(this.dotConfigRoot, DIR_PLUGINS)
   }
 
-  toJSON() {
+  toJSON () {
     const json = { ...this.options } as any
     json.id = this.id
     json.err = this.loadErr
@@ -1098,46 +1029,26 @@ class PluginLocal extends EventEmitter<
  * Host plugin core
  */
 class LSPluginCore
-  extends EventEmitter<
-    | 'beforeenable'
-    | 'enabled'
-    | 'beforedisable'
-    | 'disabled'
-    | 'registered'
-    | 'error'
-    | 'unregistered'
-    | 'theme-changed'
-    | 'theme-selected'
-    | 'settings-changed'
-    | 'unlink-plugin'
-    | 'beforereload'
-    | 'reloaded'
-  >
-  implements ILSPluginThemeManager
-{
+  extends EventEmitter<'beforeenable' | 'enabled' | 'beforedisable' | 'disabled' | 'registered' | 'error' | 'unregistered' |
+    'theme-changed' | 'theme-selected' | 'settings-changed' | 'unlink-plugin' | 'beforereload' | 'reloaded'>
+  implements ILSPluginThemeManager {
+
   private _isRegistering = false
   private _readyIndicator?: DeferredActor
   private _hostMountedActor: DeferredActor = deferred()
   private _userPreferences: Partial<UserPreferences> = {}
-  private _registeredThemes = new Map<
-    PluginLocalIdentity,
-    Array<ThemeOptions>
-  >()
+  private _registeredThemes = new Map<PluginLocalIdentity, Array<ThemeOptions>>()
   private _registeredPlugins = new Map<PluginLocalIdentity, PluginLocal>()
-  private _currentTheme: {
-    dis: () => void
-    pid: PluginLocalIdentity
-    opt: ThemeOptions
-  }
+  private _currentTheme: { dis: () => void, pid: PluginLocalIdentity, opt: ThemeOptions }
 
   /**
    * @param _options
    */
-  constructor(private _options: Partial<LSPluginCoreOptions>) {
+  constructor (private _options: Partial<LSPluginCoreOptions>) {
     super()
   }
 
-  async loadUserPreferences() {
+  async loadUserPreferences () {
     try {
       const settings = await invokeHostExportedApi(`load_user_preferences`)
 
@@ -1149,22 +1060,19 @@ class LSPluginCore
     }
   }
 
-  async saveUserPreferences(settings: Partial<UserPreferences>) {
+  async saveUserPreferences (settings: Partial<UserPreferences>) {
     try {
       if (settings) {
         Object.assign(this._userPreferences, settings)
       }
 
-      await invokeHostExportedApi(
-        `save_user_preferences`,
-        this._userPreferences
-      )
+      await invokeHostExportedApi(`save_user_preferences`, this._userPreferences)
     } catch (e) {
       debug('[save user preferences Error]', e)
     }
   }
 
-  async activateUserPreferences() {
+  async activateUserPreferences () {
     const { theme } = this._userPreferences
 
     // 0. theme
@@ -1177,7 +1085,7 @@ class LSPluginCore
    * @param plugins
    * @param initial
    */
-  async register(
+  async register (
     plugins: Array<RegisterPluginOpts> | RegisterPluginOpts,
     initial = false
   ) {
@@ -1186,10 +1094,7 @@ class LSPluginCore
       return
     }
 
-    const perfTable = new Map<
-      string,
-      { o: PluginLocal; s: number; e: number }
-    >()
+    const perfTable = new Map<string, { o: PluginLocal, s: number, e: number }>()
     const debugPerfInfo = () => {
       const data = Array.from(perfTable.values()).reduce((ac, it) => {
         const { options, status, disabled } = it.o
@@ -1198,9 +1103,8 @@ class LSPluginCore
           name: options.name,
           entry: options.entry,
           status: status,
-          enabled:
-            typeof disabled === 'boolean' ? (!disabled ? '🟢' : '⚫️') : '🔴',
-          perf: !it.e ? it.o.loadErr : `${(it.e - it.s).toFixed(2)}ms`,
+          enabled: typeof disabled === 'boolean' ? (!disabled ? '🟢' : '⚫️') : '🔴',
+          perf: !it.e ? it.o.loadErr : `${(it.e - it.s).toFixed(2)}ms`
         }
 
         return ac
@@ -1216,34 +1120,21 @@ class LSPluginCore
       this._isRegistering = true
 
       const userConfigRoot = this._options.dotConfigRoot
-      const readyIndicator = (this._readyIndicator = deferred())
+      const readyIndicator = this._readyIndicator = deferred()
 
       await this.loadUserPreferences()
 
       const externals = new Set(this._userPreferences.externals || [])
 
       if (initial) {
-        plugins = plugins.concat(
-          [...externals]
-            .filter((url) => {
-              return (
-                !plugins.length ||
-                (plugins as RegisterPluginOpts[]).every(
-                  (p) => !p.entry && p.url !== url
-                )
-              )
-            })
-            .map((url) => ({ url }))
-        )
+        plugins = plugins.concat([...externals].filter(url => {
+          return !plugins.length || (plugins as RegisterPluginOpts[]).every((p) => !p.entry && (p.url !== url))
+        }).map(url => ({ url })))
       }
 
       for (const pluginOptions of plugins) {
         const { url } = pluginOptions as PluginLocalOptions
-        const pluginLocal = new PluginLocal(
-          pluginOptions as PluginLocalOptions,
-          this,
-          this
-        )
+        const pluginLocal = new PluginLocal(pluginOptions as PluginLocalOptions, this, this)
 
         const perfInfo = { o: pluginLocal, s: performance.now(), e: 0 }
         perfTable.set(pluginLocal.id, perfInfo)
@@ -1259,8 +1150,7 @@ class LSPluginCore
 
           if (
             loadErr instanceof IllegalPluginPackageError ||
-            loadErr instanceof ExistedImportedPluginPackageError
-          ) {
+            loadErr instanceof ExistedImportedPluginPackageError) {
             // TODO: notify global log system?
             continue
           }
@@ -1294,7 +1184,7 @@ class LSPluginCore
     }
   }
 
-  async reload(plugins: Array<PluginLocalIdentity> | PluginLocalIdentity) {
+  async reload (plugins: Array<PluginLocalIdentity> | PluginLocalIdentity) {
     if (!Array.isArray(plugins)) {
       await this.reload([plugins])
       return
@@ -1310,7 +1200,7 @@ class LSPluginCore
     }
   }
 
-  async unregister(plugins: Array<PluginLocalIdentity> | PluginLocalIdentity) {
+  async unregister (plugins: Array<PluginLocalIdentity> | PluginLocalIdentity) {
     if (!Array.isArray(plugins)) {
       await this.unregister([plugins])
       return
@@ -1336,12 +1226,12 @@ class LSPluginCore
       await this.saveUserPreferences({
         externals: externals.filter((it) => {
           return !unregisteredExternals.includes(it)
-        }),
+        })
       })
     }
   }
 
-  async enable(plugin: PluginLocalIdentity) {
+  async enable (plugin: PluginLocalIdentity) {
     const p = this.ensurePlugin(plugin)
     if (p.pending) return
 
@@ -1350,7 +1240,7 @@ class LSPluginCore
     this.emit('enabled', p.id)
   }
 
-  async disable(plugin: PluginLocalIdentity) {
+  async disable (plugin: PluginLocalIdentity) {
     const p = this.ensurePlugin(plugin)
     if (p.pending) return
 
@@ -1359,29 +1249,29 @@ class LSPluginCore
     this.emit('disabled', p.id)
   }
 
-  async _hook(ns: string, type: string, payload?: any, pid?: string) {
+  async _hook (ns: string, type: string, payload?: any, pid?: string) {
     for (const [_, p] of this._registeredPlugins) {
       if (!pid || pid === p.id) {
         p.caller?.callUserModel(LSPMSG, {
-          ns,
-          type: snakeCase(type),
-          payload,
+          ns, type: snakeCase(type), payload
         })
       }
     }
   }
 
-  hookApp(type: string, payload?: any, pid?: string) {
+  hookApp (type: string, payload?: any, pid?: string) {
     this._hook(`hook:app`, type, payload, pid)
   }
 
-  hookEditor(type: string, payload?: any, pid?: string) {
+  hookEditor (type: string, payload?: any, pid?: string) {
     this._hook(`hook:editor`, type, payload, pid)
   }
 
-  _execDirective(tag: string, ...params: any[]) {}
+  _execDirective (tag: string, ...params: any[]) {
 
-  ensurePlugin(plugin: PluginLocalIdentity | PluginLocal) {
+  }
+
+  ensurePlugin (plugin: PluginLocalIdentity | PluginLocal) {
     if (plugin instanceof PluginLocal) {
       return plugin
     }
@@ -1395,51 +1285,48 @@ class LSPluginCore
     return p
   }
 
-  hostMounted() {
+  hostMounted () {
     this._hostMountedActor.resolve()
   }
 
-  get registeredPlugins(): Map<PluginLocalIdentity, PluginLocal> {
+  get registeredPlugins (): Map<PluginLocalIdentity, PluginLocal> {
     return this._registeredPlugins
   }
 
-  get options() {
+  get options () {
     return this._options
   }
 
-  get readyIndicator(): DeferredActor | undefined {
+  get readyIndicator (): DeferredActor | undefined {
     return this._readyIndicator
   }
 
-  get hostMountedActor(): DeferredActor {
+  get hostMountedActor (): DeferredActor {
     return this._hostMountedActor
   }
 
-  get isRegistering(): boolean {
+  get isRegistering (): boolean {
     return this._isRegistering
   }
 
-  get themes(): Map<PluginLocalIdentity, Array<ThemeOptions>> {
+  get themes (): Map<PluginLocalIdentity, Array<ThemeOptions>> {
     return this._registeredThemes
   }
 
-  async registerTheme(
-    id: PluginLocalIdentity,
-    opt: ThemeOptions
-  ): Promise<void> {
+  async registerTheme (id: PluginLocalIdentity, opt: ThemeOptions): Promise<void> {
     debug('registered Theme #', id, opt)
 
     if (!id) return
     let themes: Array<ThemeOptions> = this._registeredThemes.get(id)!
     if (!themes) {
-      this._registeredThemes.set(id, (themes = []))
+      this._registeredThemes.set(id, themes = [])
     }
 
     themes.push(opt)
     this.emit('theme-changed', this.themes, { id, ...opt })
   }
 
-  async selectTheme(opt?: ThemeOptions, effect = true): Promise<void> {
+  async selectTheme (opt?: ThemeOptions, effect = true): Promise<void> {
     // clear current
     if (this._currentTheme) {
       this._currentTheme.dis?.()
@@ -1447,23 +1334,18 @@ class LSPluginCore
 
     const disInjectedTheme = setupInjectedTheme(opt?.url)
     this.emit('theme-selected', opt)
-    effect && (await this.saveUserPreferences({ theme: opt?.url ? opt : null }))
+    effect && await this.saveUserPreferences({ theme: opt?.url ? opt : null })
     if (opt?.url) {
       this._currentTheme = {
         dis: () => {
           disInjectedTheme()
           effect && this.saveUserPreferences({ theme: null })
-        },
-        opt,
-        pid: opt.pid,
+        }, opt, pid: opt.pid
       }
     }
   }
 
-  async unregisterTheme(
-    id: PluginLocalIdentity,
-    effect: boolean = true
-  ): Promise<void> {
+  async unregisterTheme (id: PluginLocalIdentity, effect: boolean = true): Promise<void> {
     debug('unregistered Theme #', id)
 
     if (!this._registeredThemes.has(id)) return
@@ -1478,7 +1360,7 @@ class LSPluginCore
   }
 }
 
-function setupPluginCore(options: any) {
+function setupPluginCore (options: any) {
   const pluginCore = new LSPluginCore(options)
 
   debug('=== 🔗 Setup Logseq Plugin System 🔗 ===')
@@ -1486,4 +1368,8 @@ function setupPluginCore(options: any) {
   window.LSPluginCore = pluginCore
 }
 
-export { PluginLocal, pluginHelpers, setupPluginCore }
+export {
+  PluginLocal,
+  pluginHelpers,
+  setupPluginCore
+}

--- a/libs/src/LSPlugin.core.ts
+++ b/libs/src/LSPlugin.core.ts
@@ -201,16 +201,19 @@ enum PluginLocalLoadStatus {
 function initUserSettingsHandlers (pluginLocal: PluginLocal) {
   const _ = (label: string): any => `settings:${label}`
 
+  // settings:schema
   pluginLocal.on(_('schema'), ({ schema, isSync }: { schema: Array<SettingSchemaDesc>, isSync?: boolean }) => {
     pluginLocal.settingsSchema = schema
     pluginLocal.settings?.setSchema(schema, isSync)
   })
 
+  // settings:update
   pluginLocal.on(_('update'), (attrs) => {
     if (!attrs) return
     pluginLocal.settings?.set(attrs)
   })
 
+  // settings:visible:changed
   pluginLocal.on(_('visible:changed'), (payload) => {
     const visible = payload?.visible
     invokeHostExportedApi('set_focused_settings',
@@ -221,6 +224,8 @@ function initUserSettingsHandlers (pluginLocal: PluginLocal) {
 function initMainUIHandlers (pluginLocal: PluginLocal) {
   const _ = (label: string): any => `main-ui:${label}`
 
+
+  // main-ui:visible
   pluginLocal.on(_('visible'), ({ visible, toggle, cursor, autoFocus }) => {
     const el = pluginLocal.getMainUIContainer()
     el?.classList[toggle ? 'toggle' : (visible ? 'add' : 'remove')]('visible')
@@ -237,6 +242,7 @@ function initMainUIHandlers (pluginLocal: PluginLocal) {
     }
   })
 
+  // main-ui:attrs
   pluginLocal.on(_('attrs'), (attrs: Partial<UIContainerAttrs>) => {
     const el = pluginLocal.getMainUIContainer()
     Object.entries(attrs).forEach(([k, v]) => {
@@ -258,6 +264,7 @@ function initMainUIHandlers (pluginLocal: PluginLocal) {
     })
   })
 
+  // main-ui:style
   pluginLocal.on(_('style'), (style: Record<string, any>) => {
     const el = pluginLocal.getMainUIContainer()
     const isInitedLayout = !!el.dataset.inited_layout
@@ -278,6 +285,7 @@ function initProviderHandlers (pluginLocal: PluginLocal) {
   let _ = (label: string): any => `provider:${label}`
   let themed = false
 
+  // provider:theme
   pluginLocal.on(_('theme'), (theme: ThemeOptions) => {
     pluginLocal.themeMgr.registerTheme(
       pluginLocal.id,
@@ -293,6 +301,7 @@ function initProviderHandlers (pluginLocal: PluginLocal) {
     }
   })
 
+  // provider:style
   pluginLocal.on(_('style'), (style: StyleString | StyleOptions) => {
     let key: string | undefined
 
@@ -311,6 +320,7 @@ function initProviderHandlers (pluginLocal: PluginLocal) {
     )
   })
 
+  // provider:ui
   pluginLocal.on(_('ui'), (ui: UIOptions) => {
     pluginLocal._onHostMounted(() => {
 

--- a/libs/src/LSPlugin.core.ts
+++ b/libs/src/LSPlugin.core.ts
@@ -7,29 +7,38 @@ import {
   setupInjectedUI,
   deferred,
   invokeHostExportedApi,
-  isObject, withFileProtocol,
+  isObject,
+  withFileProtocol,
   getSDKPathRoot,
-  PROTOCOL_FILE, URL_LSP,
+  PROTOCOL_FILE,
+  URL_LSP,
   safetyPathJoin,
-  path, safetyPathNormalize,
-  mergeSettingsWithSchema, IS_DEV
+  path,
+  safetyPathNormalize,
+  mergeSettingsWithSchema,
+  IS_DEV,
 } from './helpers'
 import * as pluginHelpers from './helpers'
 import Debug from 'debug'
 import {
   LSPluginCaller,
-  LSPMSG_READY, LSPMSG_SYNC,
-  LSPMSG, LSPMSG_SETTINGS,
-  LSPMSG_ERROR_TAG, LSPMSG_BEFORE_UNLOAD,
-  AWAIT_LSPMSGFn
+  LSPMSG_READY,
+  LSPMSG_SYNC,
+  LSPMSG,
+  LSPMSG_SETTINGS,
+  LSPMSG_ERROR_TAG,
+  LSPMSG_BEFORE_UNLOAD,
+  AWAIT_LSPMSGFn,
 } from './LSPlugin.caller'
 import {
   ILSPluginThemeManager,
-  LSPluginPkgConfig, SettingSchemaDesc,
+  LSPluginPkgConfig,
+  SettingSchemaDesc,
   StyleOptions,
   StyleString,
-  ThemeOptions, UIContainerAttrs,
-  UIOptions
+  ThemeOptions,
+  UIContainerAttrs,
+  UIOptions,
 } from './LSPlugin'
 import { snakeCase } from 'snake-case'
 
@@ -52,10 +61,10 @@ type LSPluginCoreOptions = {
  */
 class PluginSettings extends EventEmitter<'change' | 'reset'> {
   private _settings: Record<string, any> = {
-    disabled: false
+    disabled: false,
   }
 
-  constructor (
+  constructor(
     private _userPluginSettings: any,
     private _schema?: Array<SettingSchemaDesc>
   ) {
@@ -64,11 +73,11 @@ class PluginSettings extends EventEmitter<'change' | 'reset'> {
     Object.assign(this._settings, _userPluginSettings)
   }
 
-  get<T = any> (k: string): T {
+  get<T = any>(k: string): T {
     return this._settings[k]
   }
 
-  set (k: string | Record<string, any>, v?: any) {
+  set(k: string | Record<string, any>, v?: any) {
     const o = deepMerge({}, this._settings)
 
     if (typeof k === 'string') {
@@ -80,19 +89,18 @@ class PluginSettings extends EventEmitter<'change' | 'reset'> {
       return
     }
 
-    this.emit('change',
-      Object.assign({}, this._settings), o)
+    this.emit('change', Object.assign({}, this._settings), o)
   }
 
-  set settings (value: Record<string, any>) {
+  set settings(value: Record<string, any>) {
     this._settings = value
   }
 
-  get settings (): Record<string, any> {
+  get settings(): Record<string, any> {
     return this._settings
   }
 
-  setSchema (schema: Array<SettingSchemaDesc>, syncSettings?: boolean) {
+  setSchema(schema: Array<SettingSchemaDesc>, syncSettings?: boolean) {
     this._schema = schema
 
     if (syncSettings) {
@@ -102,7 +110,7 @@ class PluginSettings extends EventEmitter<'change' | 'reset'> {
     }
   }
 
-  reset () {
+  reset() {
     const o = this.settings
     const val = {}
 
@@ -114,7 +122,7 @@ class PluginSettings extends EventEmitter<'change' | 'reset'> {
     this.emit('reset', val, o)
   }
 
-  toJSON () {
+  toJSON() {
     return this._settings
   }
 }
@@ -122,11 +130,11 @@ class PluginSettings extends EventEmitter<'change' | 'reset'> {
 class PluginLogger extends EventEmitter<'change'> {
   private _logs: Array<[type: string, payload: any]> = []
 
-  constructor (private _tag: string) {
+  constructor(private _tag: string) {
     super()
   }
 
-  write (type: string, payload: any[]) {
+  write(type: string, payload: any[]) {
     let msg = payload.reduce((ac, it) => {
       if (it && it instanceof Error) {
         ac += `${it.message} ${it.stack}`
@@ -140,24 +148,24 @@ class PluginLogger extends EventEmitter<'change'> {
     this.emit('change')
   }
 
-  clear () {
+  clear() {
     this._logs = []
     this.emit('change')
   }
 
-  info (...args: any[]) {
+  info(...args: any[]) {
     this.write('INFO', args)
   }
 
-  error (...args: any[]) {
+  error(...args: any[]) {
     this.write('ERROR', args)
   }
 
-  warn (...args: any[]) {
+  warn(...args: any[]) {
     this.write('WARN', args)
   }
 
-  toJSON () {
+  toJSON() {
     return this._logs
   }
 }
@@ -195,17 +203,26 @@ enum PluginLocalLoadStatus {
   UNLOADING = 'unloading',
   LOADED = 'loaded',
   UNLOADED = 'unload',
-  ERROR = 'error'
+  ERROR = 'error',
 }
 
-function initUserSettingsHandlers (pluginLocal: PluginLocal) {
+function initUserSettingsHandlers(pluginLocal: PluginLocal) {
   const _ = (label: string): any => `settings:${label}`
 
   // settings:schema
-  pluginLocal.on(_('schema'), ({ schema, isSync }: { schema: Array<SettingSchemaDesc>, isSync?: boolean }) => {
-    pluginLocal.settingsSchema = schema
-    pluginLocal.settings?.setSchema(schema, isSync)
-  })
+  pluginLocal.on(
+    _('schema'),
+    ({
+      schema,
+      isSync,
+    }: {
+      schema: Array<SettingSchemaDesc>
+      isSync?: boolean
+    }) => {
+      pluginLocal.settingsSchema = schema
+      pluginLocal.settings?.setSchema(schema, isSync)
+    }
+  )
 
   // settings:update
   pluginLocal.on(_('update'), (attrs) => {
@@ -216,24 +233,27 @@ function initUserSettingsHandlers (pluginLocal: PluginLocal) {
   // settings:visible:changed
   pluginLocal.on(_('visible:changed'), (payload) => {
     const visible = payload?.visible
-    invokeHostExportedApi('set_focused_settings',
-      visible ? pluginLocal.id : null)
+    invokeHostExportedApi(
+      'set_focused_settings',
+      visible ? pluginLocal.id : null
+    )
   })
 }
 
-function initMainUIHandlers (pluginLocal: PluginLocal) {
+function initMainUIHandlers(pluginLocal: PluginLocal) {
   const _ = (label: string): any => `main-ui:${label}`
-
 
   // main-ui:visible
   pluginLocal.on(_('visible'), ({ visible, toggle, cursor, autoFocus }) => {
     const el = pluginLocal.getMainUIContainer()
-    el?.classList[toggle ? 'toggle' : (visible ? 'add' : 'remove')]('visible')
+    el?.classList[toggle ? 'toggle' : visible ? 'add' : 'remove']('visible')
     // pluginLocal.caller!.callUserModel(LSPMSG, { type: _('visible'), payload: visible })
     // auto focus frame
     if (visible) {
-      if (!pluginLocal.shadow && el && (autoFocus !== false)) {
-        (el.querySelector('iframe') as HTMLIFrameElement)?.contentWindow?.focus()
+      if (!pluginLocal.shadow && el && autoFocus !== false) {
+        ;(
+          el.querySelector('iframe') as HTMLIFrameElement
+        )?.contentWindow?.focus()
       }
     }
 
@@ -253,13 +273,13 @@ function initMainUIHandlers (pluginLocal: PluginLocal) {
             title: pluginLocal.options.name,
             close: () => {
               pluginLocal.caller.call('sys:ui:visible', { toggle: true })
-            }
-          }))
+            },
+          })
+        )
       }
 
       if (k === 'resizable' && v) {
-        pluginLocal._dispose(
-          pluginLocal._setupResizableContainer(el))
+        pluginLocal._dispose(pluginLocal._setupResizableContainer(el))
       }
     })
   })
@@ -270,9 +290,10 @@ function initMainUIHandlers (pluginLocal: PluginLocal) {
     const isInitedLayout = !!el.dataset.inited_layout
 
     Object.entries(style).forEach(([k, v]) => {
-      if (isInitedLayout && [
-        'left', 'top', 'bottom', 'right', 'width', 'height'
-      ].includes(k)) {
+      if (
+        isInitedLayout &&
+        ['left', 'top', 'bottom', 'right', 'width', 'height'].includes(k)
+      ) {
         return
       }
 
@@ -281,16 +302,13 @@ function initMainUIHandlers (pluginLocal: PluginLocal) {
   })
 }
 
-function initProviderHandlers (pluginLocal: PluginLocal) {
+function initProviderHandlers(pluginLocal: PluginLocal) {
   let _ = (label: string): any => `provider:${label}`
   let themed = false
 
   // provider:theme
   pluginLocal.on(_('theme'), (theme: ThemeOptions) => {
-    pluginLocal.themeMgr.registerTheme(
-      pluginLocal.id,
-      theme
-    )
+    pluginLocal.themeMgr.registerTheme(pluginLocal.id, theme)
 
     if (!themed) {
       pluginLocal._dispose(() => {
@@ -315,7 +333,7 @@ function initProviderHandlers (pluginLocal: PluginLocal) {
     pluginLocal._dispose(
       setupInjectedStyle(style, {
         'data-injected-style': key ? `${key}-${pluginLocal.id}` : '',
-        'data-ref': pluginLocal.id
+        'data-ref': pluginLocal.id,
       })
     )
   })
@@ -323,22 +341,28 @@ function initProviderHandlers (pluginLocal: PluginLocal) {
   // provider:ui
   pluginLocal.on(_('ui'), (ui: UIOptions) => {
     pluginLocal._onHostMounted(() => {
-
       pluginLocal._dispose(
-        setupInjectedUI.call(pluginLocal,
-          ui, Object.assign({
-            'data-ref': pluginLocal.id
-          }, ui.attrs || {}),
+        setupInjectedUI.call(
+          pluginLocal,
+          ui,
+          Object.assign(
+            {
+              'data-ref': pluginLocal.id,
+            },
+            ui.attrs || {}
+          ),
           ({ el, float }) => {
             if (!float) return
             const identity = el.dataset.identity
             pluginLocal.layoutCore.move_container_to_top(identity)
-          }))
+          }
+        )
+      )
     })
   })
 }
 
-function initApiProxyHandlers (pluginLocal: PluginLocal) {
+function initApiProxyHandlers(pluginLocal: PluginLocal) {
   let _ = (label: string): any => `api:${label}`
 
   pluginLocal.on(_('call'), async (payload) => {
@@ -364,7 +388,8 @@ function initApiProxyHandlers (pluginLocal: PluginLocal) {
     if (_sync != null) {
       const reply = (result: any) => {
         pluginLocal.caller?.callUserModel(LSPMSG_SYNC, {
-          result, _sync
+          result,
+          _sync,
         })
       }
 
@@ -373,26 +398,25 @@ function initApiProxyHandlers (pluginLocal: PluginLocal) {
   })
 }
 
-function convertToLSPResource (fullUrl: string, dotPluginRoot: string) {
-  if (
-    dotPluginRoot &&
-    fullUrl.startsWith(PROTOCOL_FILE + dotPluginRoot)
-  ) {
+function convertToLSPResource(fullUrl: string, dotPluginRoot: string) {
+  if (dotPluginRoot && fullUrl.startsWith(PROTOCOL_FILE + dotPluginRoot)) {
     fullUrl = safetyPathJoin(
-      URL_LSP, fullUrl.substr(PROTOCOL_FILE.length + dotPluginRoot.length))
+      URL_LSP,
+      fullUrl.substr(PROTOCOL_FILE.length + dotPluginRoot.length)
+    )
   }
   return fullUrl
 }
 
 class IllegalPluginPackageError extends Error {
-  constructor (message: string) {
+  constructor(message: string) {
     super(message)
     this.name = IllegalPluginPackageError.name
   }
 }
 
 class ExistedImportedPluginPackageError extends Error {
-  constructor (message: string) {
+  constructor(message: string) {
     super(message)
     this.name = ExistedImportedPluginPackageError.name
   }
@@ -401,9 +425,9 @@ class ExistedImportedPluginPackageError extends Error {
 /**
  * Host plugin for local
  */
-class PluginLocal
-  extends EventEmitter<'loaded' | 'unloaded' | 'beforeunload' | 'error'> {
-
+class PluginLocal extends EventEmitter<
+  'loaded' | 'unloaded' | 'beforeunload' | 'error'
+> {
   private _disposes: Array<() => Promise<any>> = []
   private _id: PluginLocalIdentity
   private _status: PluginLocalLoadStatus = PluginLocalLoadStatus.UNLOADED
@@ -417,7 +441,7 @@ class PluginLocal
    * @param _themeMgr
    * @param _ctx
    */
-  constructor (
+  constructor(
     private _options: PluginLocalOptions,
     private _themeMgr: ILSPluginThemeManager,
     private _ctx: LSPluginCore
@@ -432,18 +456,17 @@ class PluginLocal
     initApiProxyHandlers(this)
   }
 
-  async _setupUserSettings (
-    reload?: boolean
-  ) {
+  async _setupUserSettings(reload?: boolean) {
     const { _options } = this
-    const logger = _options.logger = new PluginLogger('Loader')
+    const logger = (_options.logger = new PluginLogger('Loader'))
 
     if (_options.settings && !reload) {
       return
     }
 
     try {
-      const loadFreshSettings = () => invokeHostExportedApi('load_plugin_user_settings', this.id)
+      const loadFreshSettings = () =>
+        invokeHostExportedApi('load_plugin_user_settings', this.id)
       const [userSettingsFilePath, userSettings] = await loadFreshSettings()
       this._dotSettingsFile = userSettingsFilePath
 
@@ -493,7 +516,7 @@ class PluginLocal
     }
   }
 
-  getMainUIContainer (): HTMLElement | undefined {
+  getMainUIContainer(): HTMLElement | undefined {
     if (this.shadow) {
       return this.caller?._getSandboxShadowContainer()
     }
@@ -501,19 +524,20 @@ class PluginLocal
     return this.caller?._getSandboxIframeContainer()
   }
 
-  _resolveResourceFullUrl (filePath: string, localRoot?: string) {
+  _resolveResourceFullUrl(filePath: string, localRoot?: string) {
     if (!filePath?.trim()) return
     localRoot = localRoot || this._localRoot
     const reg = /^(http|file)/
     if (!reg.test(filePath)) {
       const url = path.join(localRoot, filePath)
-      filePath = reg.test(url) ? url : (PROTOCOL_FILE + url)
+      filePath = reg.test(url) ? url : PROTOCOL_FILE + url
     }
-    return (!this.options.effect && this.isInstalledInDotRoot) ?
-      convertToLSPResource(filePath, this.dotPluginsRoot) : filePath
+    return !this.options.effect && this.isInstalledInDotRoot
+      ? convertToLSPResource(filePath, this.dotPluginsRoot)
+      : filePath
   }
 
-  async _preparePackageConfigs () {
+  async _preparePackageConfigs() {
     const { url } = this._options
     let pkg: any
 
@@ -526,28 +550,39 @@ class PluginLocal
 
       pkg = await invokeHostExportedApi('load_plugin_config', url)
 
-      if (!pkg || (pkg = JSON.parse(pkg), !pkg)) {
+      if (!pkg || ((pkg = JSON.parse(pkg)), !pkg)) {
         throw new Error(`Parse package config error #${url}/package.json`)
       }
     } catch (e) {
       throw new IllegalPluginPackageError(e.message)
     }
 
-    const localRoot = this._localRoot = safetyPathNormalize(url)
+    const localRoot = (this._localRoot = safetyPathNormalize(url))
     const logseq: Partial<LSPluginPkgConfig> = pkg.logseq || {}
 
-      // Pick legal attrs
-    ;['name', 'author', 'repository', 'version',
-      'description', 'repo', 'title', 'effect', 'sponsors'
-    ].concat(!this.isInstalledInDotRoot ? ['devEntry'] : []).forEach(k => {
-      this._options[k] = pkg[k]
-    })
+    // Pick legal attrs
+    ;[
+      'name',
+      'author',
+      'repository',
+      'version',
+      'description',
+      'repo',
+      'title',
+      'effect',
+      'sponsors',
+    ]
+      .concat(!this.isInstalledInDotRoot ? ['devEntry'] : [])
+      .forEach((k) => {
+        this._options[k] = pkg[k]
+      })
 
     const validateEntry = (main) => main && /\.(js|html)$/.test(main)
 
     // Entry from main
     const entry = logseq.entry || logseq.main || pkg.main
-    if (validateEntry(entry)) { // Theme has no main
+    if (validateEntry(entry)) {
+      // Theme has no main
       this._options.entry = this._resolveResourceFullUrl(entry, localRoot)
       this._options.devEntry = logseq.devEntry
 
@@ -560,8 +595,7 @@ class PluginLocal
     const icon = logseq.icon || pkg.icon
 
     this._options.title = title
-    this._options.icon = icon &&
-      this._resolveResourceFullUrl(icon)
+    this._options.icon = icon && this._resolveResourceFullUrl(icon)
     this._options.theme = Boolean(logseq.theme || !!logseq.themes)
 
     // TODO: strategy for Logseq plugins center
@@ -573,7 +607,10 @@ class PluginLocal
       } else {
         logseq.id = this.id
         try {
-          await invokeHostExportedApi('save_plugin_config', url, { ...pkg, logseq })
+          await invokeHostExportedApi('save_plugin_config', url, {
+            ...pkg,
+            logseq,
+          })
         } catch (e) {
           debug('[save plugin ID Error] ', e)
         }
@@ -602,7 +639,7 @@ class PluginLocal
     }
   }
 
-  async _tryToNormalizeEntry () {
+  async _tryToNormalizeEntry() {
     let { entry, settings, devEntry } = this.options
     devEntry = devEntry || settings?.get('_devEntry')
 
@@ -620,7 +657,7 @@ class PluginLocal
       dirPathInstalled = this._localRoot.replace(this.dotPluginsRoot, '')
       dirPathInstalled = path.join(DIR_PLUGINS, dirPathInstalled)
     }
-    let tag = (new Date()).getDay()
+    let tag = new Date().getDay()
     let sdkPathRoot = await getSDKPathRoot()
     let entryPath = await invokeHostExportedApi(
       tmp_file_method,
@@ -630,16 +667,20 @@ class PluginLocal
   <head>
     <meta charset="UTF-8">
     <title>logseq plugin entry</title>
-    ${IS_DEV ?
-        `<script src="${sdkPathRoot}/lsplugin.user.js?v=${tag}"></script>` :
-        `<script src="https://cdn.jsdelivr.net/npm/@logseq/libs/dist/lsplugin.user.min.js?v=${tag}"></script>`}
+    ${
+      IS_DEV
+        ? `<script src="${sdkPathRoot}/lsplugin.user.js?v=${tag}"></script>`
+        : `<script src="https://cdn.jsdelivr.net/npm/@logseq/libs/dist/lsplugin.user.min.js?v=${tag}"></script>`
+    }
     
   </head>
   <body>
   <div id="app"></div>
   <script src="${entry}"></script>
   </body>
-</html>`, dirPathInstalled)
+</html>`,
+      dirPathInstalled
+    )
 
     entry = convertToLSPResource(
       withFileProtocol(path.normalize(entryPath)),
@@ -649,7 +690,7 @@ class PluginLocal
     this._options.entry = entry
   }
 
-  async _loadConfigThemes (themes: Array<ThemeOptions>) {
+  async _loadConfigThemes(themes: Array<ThemeOptions>) {
     themes.forEach((options) => {
       if (!options.url) return
 
@@ -666,26 +707,35 @@ class PluginLocal
     })
   }
 
-  async _loadLayoutsData (): Promise<Record<string, any>> {
+  async _loadLayoutsData(): Promise<Record<string, any>> {
     const key = this.id + '_layouts'
-    const [, layouts] = await invokeHostExportedApi('load_plugin_user_settings', key)
+    const [, layouts] = await invokeHostExportedApi(
+      'load_plugin_user_settings',
+      key
+    )
     return layouts || {}
   }
 
-  async _saveLayoutsData (data) {
+  async _saveLayoutsData(data) {
     const key = this.id + '_layouts'
     await invokeHostExportedApi('save_plugin_user_settings', key, data)
   }
 
-  async _persistMainUILayoutData (e: { width: number, height: number, left: number, top: number }) {
+  async _persistMainUILayoutData(e: {
+    width: number
+    height: number
+    left: number
+    top: number
+  }) {
     const layouts = await this._loadLayoutsData()
     layouts.$$0 = e
     await this._saveLayoutsData(layouts)
   }
 
-  _setupDraggableContainer (
+  _setupDraggableContainer(
     el: HTMLElement,
-    opts: Partial<{ key: string, title: string, close: () => void }> = {}): () => void {
+    opts: Partial<{ key: string; title: string; close: () => void }> = {}
+  ): () => void {
     const ds = el.dataset
     if (ds.inited_draggable) return
     if (!ds.identity) {
@@ -704,33 +754,46 @@ class PluginLocal
       </div>
     `
 
-    handle.querySelector('.x')
-      .addEventListener('click', (e) => {
+    handle.querySelector('.x').addEventListener(
+      'click',
+      (e) => {
         opts?.close?.()
         e.stopPropagation()
-      }, false)
+      },
+      false
+    )
 
-    handle.addEventListener('mousedown', (e) => {
-      const target = e.target as HTMLElement
-      if (target?.closest('.r')) {
-        e.stopPropagation()
-        e.preventDefault()
-        return
-      }
-    }, false)
+    handle.addEventListener(
+      'mousedown',
+      (e) => {
+        const target = e.target as HTMLElement
+        if (target?.closest('.r')) {
+          e.stopPropagation()
+          e.preventDefault()
+          return
+        }
+      },
+      false
+    )
 
     el.prepend(handle)
 
     // move to top
-    el.addEventListener('mousedown', (e) => {
-      this.layoutCore.move_container_to_top(ds.identity)
-    }, true)
+    el.addEventListener(
+      'mousedown',
+      (e) => {
+        this.layoutCore.move_container_to_top(ds.identity)
+      },
+      true
+    )
 
     const setTitle = (title) => {
       handle.querySelector('h3').textContent = title
     }
-    const dispose = this.layoutCore.setup_draggable_container_BANG_(el,
-      !isInjectedUI ? this._persistMainUILayoutData.bind(this) : () => {})
+    const dispose = this.layoutCore.setup_draggable_container_BANG_(
+      el,
+      !isInjectedUI ? this._persistMainUILayoutData.bind(this) : () => {}
+    )
 
     ds.inited_draggable = 'true'
 
@@ -760,7 +823,7 @@ class PluginLocal
     }
   }
 
-  _setupResizableContainer (el: HTMLElement, key?: string): () => void {
+  _setupResizableContainer(el: HTMLElement, key?: string): () => void {
     const ds = el.dataset
     if (ds.inited_resizable) return
     if (!ds.identity) {
@@ -772,16 +835,18 @@ class PluginLocal
 
     // @ts-ignore
     const layoutCore = window.frontend.modules.layout.core
-    const dispose = layoutCore.setup_resizable_container_BANG_(el,
-      !key ? this._persistMainUILayoutData.bind(this) : () => {})
+    const dispose = layoutCore.setup_resizable_container_BANG_(
+      el,
+      !key ? this._persistMainUILayoutData.bind(this) : () => {}
+    )
 
     ds.inited_resizable = 'true'
     return dispose
   }
 
-  async load (
+  async load(
     opts?: Partial<{
-      indicator: DeferredActor,
+      indicator: DeferredActor
       reload: boolean
     }>
   ) {
@@ -798,9 +863,7 @@ class PluginLocal
 
       let installPackageThemes = await this._preparePackageConfigs()
 
-      this._dispose(
-        await this._setupUserSettings(opts?.reload)
-      )
+      this._dispose(await this._setupUserSettings(opts?.reload))
 
       if (!this.disabled) {
         await installPackageThemes.call(null)
@@ -845,7 +908,7 @@ class PluginLocal
     }
   }
 
-  async reload () {
+  async reload() {
     if (this.pending) {
       return
     }
@@ -859,7 +922,7 @@ class PluginLocal
   /**
    * @param unregister If true delete plugin files
    */
-  async unload (unregister: boolean = false) {
+  async unload(unregister: boolean = false) {
     if (this.pending) {
       return
     }
@@ -881,7 +944,10 @@ class PluginLocal
 
       // sync call
       try {
-        await this._caller?.callUserModel(AWAIT_LSPMSGFn(LSPMSG_BEFORE_UNLOAD), eventBeforeUnload)
+        await this._caller?.callUserModel(
+          AWAIT_LSPMSGFn(LSPMSG_BEFORE_UNLOAD),
+          eventBeforeUnload
+        )
         this.emit('beforeunload', eventBeforeUnload)
       } catch (e) {
         console.error('[beforeunload Error]', e)
@@ -898,7 +964,7 @@ class PluginLocal
     }
   }
 
-  private async dispose () {
+  private async dispose() {
     for (const fn of this._disposes) {
       try {
         fn && (await fn())
@@ -911,12 +977,12 @@ class PluginLocal
     this._disposes = []
   }
 
-  _dispose (fn: any) {
+  _dispose(fn: any) {
     if (!fn) return
     this._disposes.push(fn)
   }
 
-  _onHostMounted (callback: () => void) {
+  _onHostMounted(callback: () => void) {
     const actor = this._ctx.hostMountedActor
 
     if (!actor || actor.settled) {
@@ -926,96 +992,98 @@ class PluginLocal
     }
   }
 
-  get layoutCore (): any {
+  get layoutCore(): any {
     // @ts-ignore
     return window.frontend.modules.layout.core
   }
 
-  get isInstalledInDotRoot () {
+  get isInstalledInDotRoot() {
     const dotRoot = this.dotConfigRoot
     const plgRoot = this.localRoot
     return dotRoot && plgRoot && plgRoot.startsWith(dotRoot)
   }
 
-  get loaded () {
+  get loaded() {
     return this._status === PluginLocalLoadStatus.LOADED
   }
 
-  get pending () {
-    return [PluginLocalLoadStatus.LOADING, PluginLocalLoadStatus.UNLOADING]
-      .includes(this._status)
+  get pending() {
+    return [
+      PluginLocalLoadStatus.LOADING,
+      PluginLocalLoadStatus.UNLOADING,
+    ].includes(this._status)
   }
 
-  get status (): PluginLocalLoadStatus {
+  get status(): PluginLocalLoadStatus {
     return this._status
   }
 
-  get settings () {
+  get settings() {
     return this.options.settings
   }
 
-  set settingsSchema (schema: Array<SettingSchemaDesc>) {
+  set settingsSchema(schema: Array<SettingSchemaDesc>) {
     this.options.settingsSchema = schema
   }
 
-  get settingsSchema () {
+  get settingsSchema() {
     return this.options.settingsSchema
   }
 
-  get logger () {
+  get logger() {
     return this.options.logger
   }
 
-  get disabled () {
+  get disabled() {
     return this.settings?.get('disabled')
   }
 
-  get caller () {
+  get caller() {
     return this._caller
   }
 
-  get id (): string {
+  get id(): string {
     return this._id
   }
 
-  get shadow (): boolean {
+  get shadow(): boolean {
     return this.options.mode === 'shadow'
   }
 
-  get options (): PluginLocalOptions {
+  get options(): PluginLocalOptions {
     return this._options
   }
 
-  get themeMgr (): ILSPluginThemeManager {
+  get themeMgr(): ILSPluginThemeManager {
     return this._themeMgr
   }
 
-  get debugTag () {
+  get debugTag() {
     const name = this._options?.name
     return `#${this._id} ${name ?? ''}`
   }
 
-  get localRoot (): string {
+  get localRoot(): string {
     return this._localRoot || this._options.url
   }
 
-  get loadErr (): Error | undefined {
+  get loadErr(): Error | undefined {
     return this._loadErr
   }
 
-  get dotConfigRoot () {
+  get dotConfigRoot() {
     return path.normalize(this._ctx.options.dotConfigRoot)
   }
 
-  get dotSettingsFile (): string | undefined {
+  get dotSettingsFile(): string | undefined {
     return this._dotSettingsFile
   }
 
-  get dotPluginsRoot () {
+  get dotPluginsRoot() {
     return path.join(this.dotConfigRoot, DIR_PLUGINS)
   }
 
-  toJSON () {
+  toJSON() {
     const json = { ...this.options } as any
     json.id = this.id
     json.err = this.loadErr
@@ -1030,26 +1098,46 @@ class PluginLocal
  * Host plugin core
  */
 class LSPluginCore
-  extends EventEmitter<'beforeenable' | 'enabled' | 'beforedisable' | 'disabled' | 'registered' | 'error' | 'unregistered' |
-    'theme-changed' | 'theme-selected' | 'settings-changed' | 'unlink-plugin' | 'beforereload' | 'reloaded'>
-  implements ILSPluginThemeManager {
-
+  extends EventEmitter<
+    | 'beforeenable'
+    | 'enabled'
+    | 'beforedisable'
+    | 'disabled'
+    | 'registered'
+    | 'error'
+    | 'unregistered'
+    | 'theme-changed'
+    | 'theme-selected'
+    | 'settings-changed'
+    | 'unlink-plugin'
+    | 'beforereload'
+    | 'reloaded'
+  >
+  implements ILSPluginThemeManager
+{
   private _isRegistering = false
   private _readyIndicator?: DeferredActor
   private _hostMountedActor: DeferredActor = deferred()
   private _userPreferences: Partial<UserPreferences> = {}
-  private _registeredThemes = new Map<PluginLocalIdentity, Array<ThemeOptions>>()
+  private _registeredThemes = new Map<
+    PluginLocalIdentity,
+    Array<ThemeOptions>
+  >()
   private _registeredPlugins = new Map<PluginLocalIdentity, PluginLocal>()
-  private _currentTheme: { dis: () => void, pid: PluginLocalIdentity, opt: ThemeOptions }
+  private _currentTheme: {
+    dis: () => void
+    pid: PluginLocalIdentity
+    opt: ThemeOptions
+  }
 
   /**
    * @param _options
    */
-  constructor (private _options: Partial<LSPluginCoreOptions>) {
+  constructor(private _options: Partial<LSPluginCoreOptions>) {
     super()
   }
 
-  async loadUserPreferences () {
+  async loadUserPreferences() {
     try {
       const settings = await invokeHostExportedApi(`load_user_preferences`)
 
@@ -1061,19 +1149,22 @@ class LSPluginCore
     }
   }
 
-  async saveUserPreferences (settings: Partial<UserPreferences>) {
+  async saveUserPreferences(settings: Partial<UserPreferences>) {
     try {
       if (settings) {
         Object.assign(this._userPreferences, settings)
       }
 
-      await invokeHostExportedApi(`save_user_preferences`, this._userPreferences)
+      await invokeHostExportedApi(
+        `save_user_preferences`,
+        this._userPreferences
+      )
     } catch (e) {
       debug('[save user preferences Error]', e)
     }
   }
 
-  async activateUserPreferences () {
+  async activateUserPreferences() {
     const { theme } = this._userPreferences
 
     // 0. theme
@@ -1086,7 +1177,7 @@ class LSPluginCore
    * @param plugins
    * @param initial
    */
-  async register (
+  async register(
     plugins: Array<RegisterPluginOpts> | RegisterPluginOpts,
     initial = false
   ) {
@@ -1095,7 +1186,10 @@ class LSPluginCore
       return
     }
 
-    const perfTable = new Map<string, { o: PluginLocal, s: number, e: number }>()
+    const perfTable = new Map<
+      string,
+      { o: PluginLocal; s: number; e: number }
+    >()
     const debugPerfInfo = () => {
       const data = Array.from(perfTable.values()).reduce((ac, it) => {
         const { options, status, disabled } = it.o
@@ -1104,8 +1198,9 @@ class LSPluginCore
           name: options.name,
           entry: options.entry,
           status: status,
-          enabled: typeof disabled === 'boolean' ? (!disabled ? '🟢' : '⚫️') : '🔴',
-          perf: !it.e ? it.o.loadErr : `${(it.e - it.s).toFixed(2)}ms`
+          enabled:
+            typeof disabled === 'boolean' ? (!disabled ? '🟢' : '⚫️') : '🔴',
+          perf: !it.e ? it.o.loadErr : `${(it.e - it.s).toFixed(2)}ms`,
         }
 
         return ac
@@ -1121,21 +1216,34 @@ class LSPluginCore
       this._isRegistering = true
 
       const userConfigRoot = this._options.dotConfigRoot
-      const readyIndicator = this._readyIndicator = deferred()
+      const readyIndicator = (this._readyIndicator = deferred())
 
       await this.loadUserPreferences()
 
       const externals = new Set(this._userPreferences.externals || [])
 
       if (initial) {
-        plugins = plugins.concat([...externals].filter(url => {
-          return !plugins.length || (plugins as RegisterPluginOpts[]).every((p) => !p.entry && (p.url !== url))
-        }).map(url => ({ url })))
+        plugins = plugins.concat(
+          [...externals]
+            .filter((url) => {
+              return (
+                !plugins.length ||
+                (plugins as RegisterPluginOpts[]).every(
+                  (p) => !p.entry && p.url !== url
+                )
+              )
+            })
+            .map((url) => ({ url }))
+        )
       }
 
       for (const pluginOptions of plugins) {
         const { url } = pluginOptions as PluginLocalOptions
-        const pluginLocal = new PluginLocal(pluginOptions as PluginLocalOptions, this, this)
+        const pluginLocal = new PluginLocal(
+          pluginOptions as PluginLocalOptions,
+          this,
+          this
+        )
 
         const perfInfo = { o: pluginLocal, s: performance.now(), e: 0 }
         perfTable.set(pluginLocal.id, perfInfo)
@@ -1151,7 +1259,8 @@ class LSPluginCore
 
           if (
             loadErr instanceof IllegalPluginPackageError ||
-            loadErr instanceof ExistedImportedPluginPackageError) {
+            loadErr instanceof ExistedImportedPluginPackageError
+          ) {
             // TODO: notify global log system?
             continue
           }
@@ -1185,7 +1294,7 @@ class LSPluginCore
     }
   }
 
-  async reload (plugins: Array<PluginLocalIdentity> | PluginLocalIdentity) {
+  async reload(plugins: Array<PluginLocalIdentity> | PluginLocalIdentity) {
     if (!Array.isArray(plugins)) {
       await this.reload([plugins])
       return
@@ -1201,7 +1310,7 @@ class LSPluginCore
     }
   }
 
-  async unregister (plugins: Array<PluginLocalIdentity> | PluginLocalIdentity) {
+  async unregister(plugins: Array<PluginLocalIdentity> | PluginLocalIdentity) {
     if (!Array.isArray(plugins)) {
       await this.unregister([plugins])
       return
@@ -1227,12 +1336,12 @@ class LSPluginCore
       await this.saveUserPreferences({
         externals: externals.filter((it) => {
           return !unregisteredExternals.includes(it)
-        })
+        }),
       })
     }
   }
 
-  async enable (plugin: PluginLocalIdentity) {
+  async enable(plugin: PluginLocalIdentity) {
     const p = this.ensurePlugin(plugin)
     if (p.pending) return
 
@@ -1241,7 +1350,7 @@ class LSPluginCore
     this.emit('enabled', p.id)
   }
 
-  async disable (plugin: PluginLocalIdentity) {
+  async disable(plugin: PluginLocalIdentity) {
     const p = this.ensurePlugin(plugin)
     if (p.pending) return
 
@@ -1250,29 +1359,29 @@ class LSPluginCore
     this.emit('disabled', p.id)
   }
 
-  async _hook (ns: string, type: string, payload?: any, pid?: string) {
+  async _hook(ns: string, type: string, payload?: any, pid?: string) {
     for (const [_, p] of this._registeredPlugins) {
       if (!pid || pid === p.id) {
         p.caller?.callUserModel(LSPMSG, {
-          ns, type: snakeCase(type), payload
+          ns,
+          type: snakeCase(type),
+          payload,
         })
       }
     }
   }
 
-  hookApp (type: string, payload?: any, pid?: string) {
+  hookApp(type: string, payload?: any, pid?: string) {
     this._hook(`hook:app`, type, payload, pid)
   }
 
-  hookEditor (type: string, payload?: any, pid?: string) {
+  hookEditor(type: string, payload?: any, pid?: string) {
     this._hook(`hook:editor`, type, payload, pid)
   }
 
-  _execDirective (tag: string, ...params: any[]) {
+  _execDirective(tag: string, ...params: any[]) {}
 
-  }
-
-  ensurePlugin (plugin: PluginLocalIdentity | PluginLocal) {
+  ensurePlugin(plugin: PluginLocalIdentity | PluginLocal) {
     if (plugin instanceof PluginLocal) {
       return plugin
     }
@@ -1286,48 +1395,51 @@ class LSPluginCore
     return p
   }
 
-  hostMounted () {
+  hostMounted() {
     this._hostMountedActor.resolve()
   }
 
-  get registeredPlugins (): Map<PluginLocalIdentity, PluginLocal> {
+  get registeredPlugins(): Map<PluginLocalIdentity, PluginLocal> {
     return this._registeredPlugins
   }
 
-  get options () {
+  get options() {
     return this._options
   }
 
-  get readyIndicator (): DeferredActor | undefined {
+  get readyIndicator(): DeferredActor | undefined {
     return this._readyIndicator
   }
 
-  get hostMountedActor (): DeferredActor {
+  get hostMountedActor(): DeferredActor {
     return this._hostMountedActor
   }
 
-  get isRegistering (): boolean {
+  get isRegistering(): boolean {
     return this._isRegistering
   }
 
-  get themes (): Map<PluginLocalIdentity, Array<ThemeOptions>> {
+  get themes(): Map<PluginLocalIdentity, Array<ThemeOptions>> {
     return this._registeredThemes
   }
 
-  async registerTheme (id: PluginLocalIdentity, opt: ThemeOptions): Promise<void> {
+  async registerTheme(
+    id: PluginLocalIdentity,
+    opt: ThemeOptions
+  ): Promise<void> {
     debug('registered Theme #', id, opt)
 
     if (!id) return
     let themes: Array<ThemeOptions> = this._registeredThemes.get(id)!
     if (!themes) {
-      this._registeredThemes.set(id, themes = [])
+      this._registeredThemes.set(id, (themes = []))
     }
 
     themes.push(opt)
     this.emit('theme-changed', this.themes, { id, ...opt })
   }
 
-  async selectTheme (opt?: ThemeOptions, effect = true): Promise<void> {
+  async selectTheme(opt?: ThemeOptions, effect = true): Promise<void> {
     // clear current
     if (this._currentTheme) {
       this._currentTheme.dis?.()
@@ -1335,18 +1447,23 @@ class LSPluginCore
 
     const disInjectedTheme = setupInjectedTheme(opt?.url)
     this.emit('theme-selected', opt)
-    effect && await this.saveUserPreferences({ theme: opt?.url ? opt : null })
+    effect && (await this.saveUserPreferences({ theme: opt?.url ? opt : null }))
     if (opt?.url) {
       this._currentTheme = {
         dis: () => {
           disInjectedTheme()
           effect && this.saveUserPreferences({ theme: null })
-        }, opt, pid: opt.pid
+        },
+        opt,
+        pid: opt.pid,
       }
     }
   }
 
-  async unregisterTheme (id: PluginLocalIdentity, effect: boolean = true): Promise<void> {
+  async unregisterTheme(
+    id: PluginLocalIdentity,
+    effect: boolean = true
+  ): Promise<void> {
     debug('unregistered Theme #', id)
 
     if (!this._registeredThemes.has(id)) return
@@ -1361,7 +1478,7 @@ class LSPluginCore
   }
 }
 
-function setupPluginCore (options: any) {
+function setupPluginCore(options: any) {
   const pluginCore = new LSPluginCore(options)
 
   debug('=== 🔗 Setup Logseq Plugin System 🔗 ===')
@@ -1369,8 +1486,4 @@ function setupPluginCore (options: any) {
   window.LSPluginCore = pluginCore
 }
 
-export {
-  PluginLocal,
-  pluginHelpers,
-  setupPluginCore
-}
+export { PluginLocal, pluginHelpers, setupPluginCore }


### PR DESCRIPTION
I spent a good amount of time trying to trace functions things like `provideStyle()`, and I didn't figure out how to trace the event until today, since its listener is added using string concatenation. This PR adds a few comments with the full event name, so it's easier to trace in the code for future programmers.

Until we have comprehensive documentation for plugin developers, this will help out the people who don't mind looking at the code itself.