### PR TITLE
chore: bump version 0.6.3

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "com.logseq.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 15
-        versionName "0.6.2"
+        versionCode 16
+        versionName "0.6.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/resources/package.json
+++ b/resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Logseq",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "main": "electron.js",
   "author": "Logseq",
   "license": "AGPL-3.0",

--- a/src/main/frontend/version.cljs
+++ b/src/main/frontend/version.cljs
@@ -1,3 +1,3 @@
 (ns frontend.version)
 
-(defonce version "0.6.2")
+(defonce version "0.6.3")


### PR DESCRIPTION
This is the preparation for the v0.6.3 release.

## Pending Fixes:

- [x] https://github.com/logseq/logseq/issues/4304
- [x] https://github.com/logseq/logseq/issues/4507
- [x] https://github.com/logseq/logseq/pull/4535