### PR TITLE
Feature: Use query-dsl rules from advanced query

### DIFF
--- a/.carve/ignore
+++ b/.carve/ignore
@@ -65,4 +65,4 @@ frontend.util.pool/terminate-pool!
 ;; Repl fn
 frontend.util.property/add-page-properties
 ;; Used by shadow
-frontend.node-test-runner/main
+frontend.test.node-test-runner/main

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -14,7 +14,9 @@
              datascript.transit dt
              datascript.db ddb
              lambdaisland.glogi log
-             frontend.db.query-dsl query-dsl}}}
+             frontend.db.query-dsl query-dsl
+             frontend.db.react react
+             frontend.db.query-react query-react}}}
 
  :hooks {:analyze-call {rum.core/defc hooks.rum/defc
                          rum.core/defcs hooks.rum/defcs}}

--- a/scripts/src/logseq/tasks/dev.clj
+++ b/scripts/src/logseq/tasks/dev.clj
@@ -6,7 +6,7 @@
 (defn watch
   "Watches environment to reload cljs, css and other assets"
   []
-  (shell "yarn watch"))
+  (shell "yarn electron-watch"))
 
 (defn- file-modified-later-than?
   [file comparison-instant]

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -67,7 +67,7 @@
          :devtools        {:enabled false}
          ;; disable :static-fns to allow for with-redefs and repl development
          :compiler-options {:static-fns false}
-         :main            frontend.node-test-runner/main}
+         :main            frontend.test.node-test-runner/main}
 
   :publishing {:target        :browser
                :module-loader true

--- a/src/main/frontend/db/query_custom.cljs
+++ b/src/main/frontend/db/query_custom.cljs
@@ -1,11 +1,11 @@
 (ns frontend.db.query-custom
-  "Custom queries."
+  "Handles executing custom queries a.k.a. advanced queries"
   (:require [frontend.state :as state]
-            [clojure.string :as string]
-            [cljs.reader :as reader]
             [frontend.db.query-react :as react]
             [frontend.db.query-dsl :as query-dsl]
             [frontend.db.model :as model]
+            [frontend.db.rules :as rules]
+            [frontend.util.datalog :as datalog-util]
             [clojure.walk :as walk]))
 
 ;; FIXME: what if users want to query other attributes than block-attrs?
@@ -21,24 +21,30 @@
        f))
    l))
 
+(defn- add-rules-to-query
+  "Searches query's :where for rules and adds them to query if used"
+  [{:keys [query] :as query-m}]
+  (let [{:keys [where]} (datalog-util/query-vec->map query)
+        rules-found (datalog-util/find-rules-in-where where (-> rules/query-dsl-rules keys set))]
+    (if (seq rules-found)
+      (-> query-m
+          (update :query (fn [q]
+                           (if (contains? (set q) :in)
+                             (datalog-util/add-to-end-of-query-section q :in ['%])
+                             (into q [:in '$ '%]))))
+          (assoc :rules (mapv rules/query-dsl-rules rules-found)))
+      query-m)))
+
 (defn custom-query
+  "Executes a datalog query through query-react, given either a regular datalog
+  query or a simple query"
   ([query]
    (custom-query query {}))
   ([query query-opts]
-   #_:clj-kondo/ignore
-   (when-let [query' (cond
-                       (and (string? query)
-                            (not (string/blank? query)))
-                       (reader/read-string query)
-
-                       (map? query)
-                       query
-
-                       :else
-                       nil)]
-     (let [repo (state/get-current-repo)
-           query' (replace-star-with-block-attrs! query)]
-       (if (or (list? (:query query'))
-               (not= :find (first (:query query')))) ; dsl query
-         (query-dsl/custom-query repo query' query-opts)
-         (react/react-query repo query' query-opts))))))
+   (custom-query (state/get-current-repo) query query-opts))
+  ([repo query query-opts]
+   (let [query' (replace-star-with-block-attrs! query)]
+     (if (or (list? (:query query'))
+             (not= :find (first (:query query')))) ; dsl query
+       (query-dsl/custom-query repo query' query-opts)
+       (react/react-query repo (add-rules-to-query query') query-opts)))))

--- a/src/main/frontend/db/query_custom.cljs
+++ b/src/main/frontend/db/query_custom.cljs
@@ -1,7 +1,7 @@
 (ns frontend.db.query-custom
   "Handles executing custom queries a.k.a. advanced queries"
   (:require [frontend.state :as state]
-            [frontend.db.query-react :as react]
+            [frontend.db.query-react :as query-react]
             [frontend.db.query-dsl :as query-dsl]
             [frontend.db.model :as model]
             [frontend.db.rules :as rules]
@@ -47,4 +47,4 @@
      (if (or (list? (:query query'))
              (not= :find (first (:query query')))) ; dsl query
        (query-dsl/custom-query repo query' query-opts)
-       (react/react-query repo (add-rules-to-query query') query-opts)))))
+       (query-react/react-query repo (add-rules-to-query query') query-opts)))))

--- a/src/main/frontend/db/query_dsl.cljs
+++ b/src/main/frontend/db/query_dsl.cljs
@@ -8,7 +8,7 @@
             [clojure.walk :as walk]
             [frontend.date :as date]
             [frontend.db.model :as model]
-            [frontend.db.query-react :as react]
+            [frontend.db.query-react :as query-react]
             [frontend.db.utils :as db-utils]
             [frontend.db.rules :as rules]
             [frontend.template :as template]
@@ -586,7 +586,7 @@ Some bindings in this fn:
                                      identity)
                     transform-fn (comp sort-by random-samples)]
                 (try
-                  (react/react-query repo
+                  (query-react/react-query repo
                                      {:query query
                                       :query-string query-string
                                       :rules rules}
@@ -605,7 +605,7 @@ Some bindings in this fn:
     (let [query-string (template/resolve-dynamic-template! (pr-str (:query query-m)))
           {:keys [query sort-by blocks? rules]} (parse query-string)]
       (when-let [query (query-wrapper query blocks?)]
-        (react/react-query repo
+        (query-react/react-query repo
                            (merge
                             query-m
                             {:query query

--- a/src/main/frontend/db/query_dsl.cljs
+++ b/src/main/frontend/db/query_dsl.cljs
@@ -1,4 +1,5 @@
 (ns frontend.db.query-dsl
+  "Handles executing dsl queries a.k.a. simple queries"
   (:require [cljs-time.coerce :as tc]
             [cljs-time.core :as t]
             [cljs.reader :as reader]

--- a/src/main/frontend/db_mixins.cljs
+++ b/src/main/frontend/db_mixins.cljs
@@ -1,13 +1,13 @@
 (ns frontend.db-mixins
-  (:require [frontend.db.react :as db]))
+  (:require [frontend.db.react :as react]))
 
 (def query
   {:wrap-render
    (fn [render-fn]
      (fn [state]
-       (binding [db/*query-component* (:rum/react-component state)]
+       (binding [react/*query-component* (:rum/react-component state)]
          (render-fn state))))
    :will-unmount
    (fn [state]
-     (db/remove-query-component! (:rum/react-component state))
+     (react/remove-query-component! (:rum/react-component state))
      state)})

--- a/src/main/frontend/extensions/srs.cljs
+++ b/src/main/frontend/extensions/srs.cljs
@@ -1,7 +1,7 @@
 (ns frontend.extensions.srs
   (:require [frontend.template :as template]
             [frontend.db.query-dsl :as query-dsl]
-            [frontend.db.query-react :as react]
+            [frontend.db.query-react :as query-react]
             [frontend.util :as util]
             [frontend.util.property :as property]
             [frontend.util.drawer :as drawer]
@@ -259,7 +259,7 @@
                             query
                             [query]))]
        (when-let [query (query-dsl/query-wrapper query* true)]
-         (let [result (react/react-query repo
+         (let [result (query-react/react-query repo
                                          {:query query
                                           :rules (or rules [])}
                                          (merge

--- a/src/main/frontend/handler.cljs
+++ b/src/main/frontend/handler.cljs
@@ -7,7 +7,7 @@
             [frontend.db :as db]
             [frontend.db-schema :as db-schema]
             [frontend.db.conn :as conn]
-            [frontend.db.react :as db-react]
+            [frontend.db.react :as react]
             [frontend.error :as error]
             [frontend.handler.command-palette :as command-palette]
             [frontend.handler.common :as common-handler]
@@ -221,7 +221,7 @@
        (notification/show! "Sorry, it seems that your browser doesn't support IndexedDB, we recommend to use latest Chrome(Chromium) or Firefox(Non-private mode)." :error false)
        (state/set-indexedb-support! false)))
 
-    (db-react/run-custom-queries-when-idle!)
+    (react/run-custom-queries-when-idle!)
 
     (events/run!)
 

--- a/src/main/frontend/util/datalog.cljc
+++ b/src/main/frontend/util/datalog.cljc
@@ -1,0 +1,34 @@
+(ns frontend.util.datalog
+  "Utility fns related to datalog queries and rules")
+
+(defn find-rules-in-where
+  "Given where clauses and a set of valid rules, returns rules found in where
+  clause as keywords. A more advanced version of this would use a datalog parser
+and not require valid-rules"
+  [where valid-rules]
+  (->> where
+       flatten
+       (filter #(and (symbol? %) (contains? valid-rules (keyword %))))
+       (map keyword)))
+
+(defn query-vec->map
+  "Converts query vec to query map. Modified version of
+  datascript.parser/query->map which preserves insertion order in case map is
+  converted back to vec"
+  [query-vec]
+  (loop [parsed (array-map) key nil qs query-vec]
+    (if-let [q (first qs)]
+      (if (keyword? q)
+        (recur parsed q (next qs))
+        (recur (update-in parsed [key] (fnil conj []) q) key (next qs)))
+      parsed)))
+
+(defn add-to-end-of-query-section
+  "Adds vec of elements to end of a query section e.g. :find or :in"
+  [query-vec query-kw elems]
+  (let [query-map (query-vec->map query-vec)]
+    (vec
+     (reduce (fn [acc [k v]]
+               (concat acc [k] v (when (= k query-kw) elems)))
+             '()
+             query-map))))

--- a/src/test/frontend/db/config.cljs
+++ b/src/test/frontend/db/config.cljs
@@ -3,16 +3,6 @@
             [frontend.state :as state]
             [frontend.db.persist :as db-persist]))
 
-(defonce test-db "test-db")
-
-(defn start-test-db!
-  []
-  (conn/start! nil test-db))
-
-(defn destroy-test-db!
-  []
-  (conn/destroy-all!))
-
 (defn destroy-db! [] (conn/destroy-all!))
 
 (defn clear-current-repo []

--- a/src/test/frontend/db/model_test.cljs
+++ b/src/test/frontend/db/model_test.cljs
@@ -1,11 +1,10 @@
 (ns frontend.db.model-test
   (:require [cljs.test :refer [use-fixtures deftest is]]
             [frontend.db.model :as model]
-            [frontend.db.config :as config]
-            [frontend.handler.repo :as repo-handler]))
+            [frontend.test.helper :as test-helper :refer [load-test-files]]))
 
-(defn- load-test-files [files]
-  (repo-handler/parse-files-and-load-to-db! config/test-db files {:re-render? false}))
+(use-fixtures :each {:before test-helper/start-test-db!
+                     :after test-helper/destroy-test-db!})
 
 (deftest get-page-namespace-routes
   (load-test-files [{:file/path "pages/a.b.c.md"
@@ -16,7 +15,7 @@
                      :file/content "baz"}])
 
   (is (= '()
-         (map :block/name (model/get-page-namespace-routes config/test-db "b/c")))
+         (map :block/name (model/get-page-namespace-routes test-helper/test-db "b/c")))
       "Empty if page exists"))
 
 ;; (deftest test-page-alias-with-multiple-alias
@@ -82,9 +81,5 @@
 ;;       1 (count b-ref-blocks)
 ;;       1 (count a-ref-blocks)
 ;;       (set ["b" "c"]) (set alias-names))))
-
-(use-fixtures :each
-  {:before config/start-test-db!
-   :after config/destroy-test-db!})
 
 #_(cljs.test/test-ns 'frontend.db.model-test)

--- a/src/test/frontend/db/outliner_test.cljs
+++ b/src/test/frontend/db/outliner_test.cljs
@@ -3,7 +3,7 @@
             [datascript.core :as d]
             [frontend.core-test :as core-test]
             [frontend.db.outliner :as outliner]
-            [frontend.fixtures :as fixtures]))
+            [frontend.test.fixtures :as fixtures]))
 
 (use-fixtures :each fixtures/reset-db)
 

--- a/src/test/frontend/db/query_custom_test.cljs
+++ b/src/test/frontend/db/query_custom_test.cljs
@@ -2,14 +2,14 @@
   (:require [cljs.test :refer [deftest is use-fixtures]]
             [frontend.test.helper :as test-helper :refer [load-test-files]]
             [frontend.db.query-custom :as query-custom]
-            [frontend.db.react :as db-react]))
+            [frontend.db.react :as react]))
 
 (use-fixtures :each {:before test-helper/start-test-db!
                      :after test-helper/destroy-test-db!})
 
 (defn- custom-query
   [query]
-  (db-react/clear-query-state!)
+  (react/clear-query-state!)
   (when-let [result (query-custom/custom-query test-helper/test-db query {})]
     (map first (deref result))))
 

--- a/src/test/frontend/db/query_custom_test.cljs
+++ b/src/test/frontend/db/query_custom_test.cljs
@@ -1,0 +1,45 @@
+(ns frontend.db.query-custom-test
+  (:require [cljs.test :refer [deftest is use-fixtures]]
+            [frontend.test.helper :as test-helper :refer [load-test-files]]
+            [frontend.db.query-custom :as query-custom]
+            [frontend.db.react :as db-react]))
+
+(use-fixtures :each {:before test-helper/start-test-db!
+                     :after test-helper/destroy-test-db!})
+
+(defn- custom-query
+  [query]
+  (db-react/clear-query-state!)
+  (when-let [result (query-custom/custom-query test-helper/test-db query {})]
+    (map first (deref result))))
+
+(deftest custom-query-test
+  (load-test-files [{:file/path "pages/page1.md"
+                     :file/content "foo:: bar
+- NOW b1
+- TODO b2
+- LATER b3
+- b3"}])
+
+  (is (= ["LATER b3"]
+         (map :block/content
+              (custom-query {:query '[:find (pull ?b [*])
+                                      :where
+                                      (block-content ?b "b")
+                                      (task ?b #{"LATER"})]})))
+      "datalog query returns correct results")
+
+  (is (= ["LATER b3"]
+         (map :block/content
+              (custom-query {:query '[:find (pull ?b [*])
+                                      :in $
+                                      :where
+                                      (block-content ?b "b")
+                                      (task ?b #{"LATER"})]})))
+      "datalog query with :in returns correct results")
+
+
+  (is (= ["LATER b3"]
+         (map :block/content
+              (custom-query {:query (list 'and '(task later) "b")})))
+      "Simple query returns correct results"))

--- a/src/test/frontend/db/query_dsl_test.cljs
+++ b/src/test/frontend/db/query_dsl_test.cljs
@@ -15,10 +15,25 @@
 
 ;; Test helpers
 ;; ============
+
+(def dsl-query*
+  "When $EXAMPLE set, prints query result of build query. Useful for
+   documenting examples and debugging"
+  (if (some? js/process.env.EXAMPLE)
+    (fn dsl-query-star [& args]
+      (let [old-build-query query-dsl/build-query]
+       (with-redefs [query-dsl/build-query
+                     (fn [& args']
+                       (let [res (apply old-build-query args')]
+                         (println "EXAMPLE:" (pr-str (:query res)))
+                         res))]
+         (apply query-dsl/query args))))
+    query-dsl/query))
+
 (defn- dsl-query
   [s]
   (db/clear-query-state!)
-  (when-let [result (query-dsl/query test-helper/test-db s)]
+  (when-let [result (dsl-query* test-helper/test-db s)]
     (map first (deref result))))
 
 (defn- custom-query

--- a/src/test/frontend/db/query_dsl_test.cljs
+++ b/src/test/frontend/db/query_dsl_test.cljs
@@ -2,30 +2,29 @@
   (:require [cljs.test :refer [are deftest testing use-fixtures is]]
             [clojure.string :as str]
             [frontend.db :as db]
-            [frontend.db.config :refer [test-db] :as config]
             [frontend.db.query-dsl :as query-dsl]
-            [frontend.handler.repo :as repo-handler]))
+            [frontend.test.helper :as test-helper :refer [load-test-files]]))
 
 ;; TODO: quickcheck
 ;; 1. generate query filters
 ;; 2. find illegal queries which can't be executed by datascript
 ;; 3. find filters combinations which might break the current query implementation
 
+(use-fixtures :each {:before test-helper/start-test-db!
+                     :after test-helper/destroy-test-db!})
+
 ;; Test helpers
 ;; ============
-(defn- load-test-files [files]
-  (repo-handler/parse-files-and-load-to-db! test-db files {:re-render? false}))
-
 (defn- dsl-query
   [s]
   (db/clear-query-state!)
-  (when-let [result (query-dsl/query test-db s)]
+  (when-let [result (query-dsl/query test-helper/test-db s)]
     (map first (deref result))))
 
 (defn- custom-query
   [query]
   (db/clear-query-state!)
-  (when-let [result (query-dsl/custom-query test-db query {})]
+  (when-let [result (query-dsl/custom-query test-helper/test-db query {})]
     (map first (deref result))))
 
 (defn- q
@@ -34,7 +33,7 @@
   (let [parse-result (query-dsl/parse s)
         query (:query parse-result)]
     {:query (if (seq query) (vec query) query)
-     :result (query-dsl/query test-db s)}))
+     :result (query-dsl/query test-helper/test-db s)}))
 
 ;; Tests
 ;; =====
@@ -519,15 +518,11 @@ last-modified-at:: 1609084800002"}]]
     ;;            '(1608968448113 1608968448115 1608968448120 1609052958714 1609052974285)))))
     )
 
-(use-fixtures :each
-              {:before config/start-test-db!
-               :after config/destroy-test-db!})
-
 #_(cljs.test/run-tests)
 
 (comment
  (require '[clojure.pprint :as pprint])
- (config/start-test-db!)
+ (test-helper/start-test-db!)
  (load-test-files-with-timestamps)
 
  (query-dsl/query test-db "(task done)")

--- a/src/test/frontend/modules/outliner/core_test.cljs
+++ b/src/test/frontend/modules/outliner/core_test.cljs
@@ -1,6 +1,6 @@
 (ns frontend.modules.outliner.core-test
   (:require [cljs.test :refer [deftest is use-fixtures testing] :as test]
-            [frontend.fixtures :as fixtures]
+            [frontend.test.fixtures :as fixtures]
             [frontend.modules.outliner.core :as outliner-core]
             [frontend.modules.outliner.datascript :as outliner-ds]
             [frontend.modules.outliner.tree :as tree]

--- a/src/test/frontend/modules/outliner/ds_test.cljs
+++ b/src/test/frontend/modules/outliner/ds_test.cljs
@@ -1,6 +1,6 @@
 (ns frontend.modules.outliner.ds-test
   (:require [cljs.test :refer [deftest is use-fixtures] :as test]
-            [frontend.fixtures :as fixtures]
+            [frontend.test.fixtures :as fixtures]
             [frontend.modules.outliner.datascript :as ds]))
 
 (use-fixtures :each

--- a/src/test/frontend/react_test.cljs
+++ b/src/test/frontend/react_test.cljs
@@ -3,7 +3,7 @@
   {:clj-kondo/config {:linters {:inline-def {:level :off}}}}
   (:require [frontend.react :as r]
             [cljs.test :refer [deftest is use-fixtures]]
-            [frontend.fixtures :as fixtures]))
+            [frontend.test.fixtures :as fixtures]))
 
 (use-fixtures :each
   fixtures/react-components)

--- a/src/test/frontend/test/fixtures.cljs
+++ b/src/test/frontend/test/fixtures.cljs
@@ -3,7 +3,7 @@
             [frontend.config :as config]
             [frontend.db-schema :as db-schema]
             [frontend.db.conn :as conn]
-            [frontend.db.react :as db-react]
+            [frontend.db.react :as react]
             [frontend.state :as state]))
 
 (defn load-test-env
@@ -12,9 +12,9 @@
 
 (defn react-components
   [f]
-  (reset! db-react/query-state {})
+  (reset! react/query-state {})
   (let [r (f)]
-    (reset! db-react/query-state {})
+    (reset! react/query-state {})
     r))
 
 (defn- reset-datascript

--- a/src/test/frontend/test/fixtures.cljs
+++ b/src/test/frontend/test/fixtures.cljs
@@ -1,4 +1,4 @@
-(ns frontend.fixtures
+(ns frontend.test.fixtures
   (:require [datascript.core :as d]
             [frontend.config :as config]
             [frontend.db-schema :as db-schema]

--- a/src/test/frontend/test/helper.cljs
+++ b/src/test/frontend/test/helper.cljs
@@ -1,0 +1,17 @@
+(ns frontend.test.helper
+  "Common helper fns for tests"
+  (:require [frontend.handler.repo :as repo-handler]
+            [frontend.db.conn :as conn]))
+
+(defonce test-db "test-db")
+
+(defn start-test-db!
+  []
+  (conn/start! nil test-db))
+
+(defn destroy-test-db!
+  []
+  (conn/destroy-all!))
+
+(defn load-test-files [files]
+  (repo-handler/parse-files-and-load-to-db! test-db files {:re-render? false}))

--- a/src/test/frontend/test/node_test_runner.cljs
+++ b/src/test/frontend/test/node_test_runner.cljs
@@ -1,4 +1,4 @@
-(ns frontend.node-test-runner
+(ns frontend.test.node-test-runner
   "shadow-cljs test runner for :node-test that provides the same test selection
   options as
   https://github.com/cognitect-labs/test-runner#invoke-with-clojure--m-clojuremain.

--- a/src/test/frontend/util/datalog_test.cljs
+++ b/src/test/frontend/util/datalog_test.cljs
@@ -1,0 +1,30 @@
+(ns frontend.util.datalog-test
+  (:require [cljs.test :refer [deftest is]]
+            [frontend.util.datalog :as datalog-util]))
+
+(deftest add-to-end-of-query-in
+  (is (= '[:find ?b
+           :in $ ?query %
+           :where
+           (block-content ?b ?query)]
+         (datalog-util/add-to-end-of-query-section
+          '[:find ?b
+            :in $ ?query
+            :where
+            (block-content ?b ?query)]
+          :in
+          ['%]))
+      "Add to :in in middle of query")
+
+  (is (= '[:find ?b
+           :where
+           (block-content ?b ?query)
+           :in $ ?query %]
+         (datalog-util/add-to-end-of-query-section
+          '[:find ?b
+            :where
+            (block-content ?b ?query)
+            :in $ ?query]
+          :in
+          ['%]))
+      "Add to :in at end of query"))


### PR DESCRIPTION
Following up on https://github.com/logseq/logseq/pull/4420#discussion_r817182905, this PR allows a user to use any of the [query-dsl-rules](https://github.com/logseq/logseq/blob/d8bc074be17d3e4c1b780f9ce08e15f2f45193a6/src/main/frontend/db/rules.cljc#L61) in advanced queries and it will seamlessly work e.g. https://github.com/logseq/logseq/blob/ed6a02c6921f6605d6c2482ca013f81de9c16b01/src/test/frontend/db/query_custom_test.cljs#L26-L29 . The ability to pull in rules dynamically will make advanced queries much easier to read and should allow for interesting and powerful query composition. There are other powerful features we could enable with this ability e.g. allow users to define rules in their config and pull them in as they would like. I'll see if I can get some feedback from users. This PR also organizes our test namespaces and makes our react* aliases consistent