### PR TITLE
Feat/open file backups directory

### DIFF
--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -1,5 +1,5 @@
 (ns electron.handler
-  (:require ["electron" :refer [ipcMain dialog app autoUpdater]]
+  (:require ["electron" :refer [ipcMain dialog app autoUpdater shell]]
             [cljs-bean.core :as bean]
             ["fs" :as fs]
             ["buffer" :as buffer]
@@ -64,27 +64,33 @@
     (some (fn [a] (= -1 (first a))) result)))
 
 (defn- truncate-old-versioned-files!
-  [file-path]
-  (let [dir (path/dirname file-path)
-        files (fs/readdirSync dir (clj->js {:withFileTypes true}))
+  [dir]
+  (let [files (fs/readdirSync dir (clj->js {:withFileTypes true}))
         files (map #(.-name %) files)
-        prefix (str (path/basename file-path) ".")
-        versioned-files (filter #(string/starts-with? % prefix) files)
-        old-versioned-files (drop 3 (reverse (sort versioned-files)))]
+        old-versioned-files (drop 3 (reverse (sort files)))]
     (doseq [file old-versioned-files]
       (fs-extra/removeSync (path/join dir file)))))
 
-(defn backup-file
-  [repo path content]
+(defn- get-backup-dir
+  [repo path]
   (let [path (string/replace path repo "")
         bak-dir (str repo "/logseq/bak")
         path (str bak-dir path)
-        new-path (str path "." (string/replace (.toISOString (js/Date.)) ":" "_"))
-        dir (path/dirname new-path)]
-    (fs-extra/ensureDirSync dir)
+        parsed-path (path/parse path)]
+    (path/join (.-dir parsed-path)
+               (.-name parsed-path))))
+
+(defn backup-file
+  [repo path content]
+  (let [path-dir (get-backup-dir repo path)
+        ext (path/extname path)
+        new-path (path/join path-dir
+                            (str (string/replace (.toISOString (js/Date.)) ":" "_")
+                                 ext))]
+    (fs-extra/ensureDirSync path-dir)
     (fs/writeFileSync new-path content)
     (fs/statSync new-path)
-    (truncate-old-versioned-files! path)
+    (truncate-old-versioned-files! path-dir)
     new-path))
 
 (defmethod handle :backupDbFile [_window [_ repo path db-content new-content]]
@@ -92,6 +98,11 @@
              (string? new-content)
              (string-some-deleted? db-content new-content))
     (backup-file repo path db-content)))
+
+(defmethod handle :openFileBackupDir [_window [_ repo path]]
+  (when (string? path)
+    (let [dir (get-backup-dir repo path)]
+      (.openPath shell dir))))
 
 (defmethod handle :readFile [_window [_ path]]
   (utils/read-file path))

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -70,13 +70,18 @@
         files (map #(.-name %) files)
         prefix (str (path/basename file-path) ".")
         versioned-files (filter #(string/starts-with? % prefix) files)
-        old-versioned-files (drop 10 (reverse (sort versioned-files)))]
+        old-versioned-files (drop 3 (reverse (sort versioned-files)))]
     (doseq [file old-versioned-files]
       (fs-extra/removeSync (path/join dir file)))))
 
 (defn backup-file
-  [_repo path content]
-  (let [new-path (str path "." (string/replace (.toISOString (js/Date.)) ":" "_"))]
+  [repo path content]
+  (let [path (string/replace path repo "")
+        bak-dir (str repo "/logseq/bak")
+        path (str bak-dir path)
+        new-path (str path "." (string/replace (.toISOString (js/Date.)) ":" "_"))
+        dir (path/dirname new-path)]
+    (fs-extra/ensureDirSync dir)
     (fs/writeFileSync new-path content)
     (fs/statSync new-path)
     (truncate-old-versioned-files! path)

--- a/src/main/frontend/db.cljs
+++ b/src/main/frontend/db.cljs
@@ -146,7 +146,7 @@
                    (when-let [f @*sync-search-indice-f]
                      (f datoms)))))))
 
-(defn- listen-and-persist!
+(defn listen-and-persist!
   [repo]
   (when-let [conn (get-conn repo false)]
     (repo-listen-to-tx! repo conn)))

--- a/src/main/frontend/dicts.cljs
+++ b/src/main/frontend/dicts.cljs
@@ -167,6 +167,7 @@
         :page/action-publish "Publish"
         :page/make-public "Make it public for publishing"
         :page/version-history "Check page history"
+        :page/open-backup-directory "Open page backups directory"
         :page/make-private "Make it private"
         :page/delete "Delete page"
         :page/publish "Publish this page on Logseq"
@@ -1066,6 +1067,7 @@
            :page/action-publish "发布"
            :page/make-public "导出 HTML 时发布本页面"
            :page/version-history "查看页面历史记录"
+           :page/open-backup-directory "打开页面备份文件夹"
            :page/make-private "导出 HTML 时取消发布本页面"
            :page/delete "删除本页"
            :page/publish "将本页发布至 Logseq"
@@ -3209,7 +3211,7 @@
         :plugin/marketplace-tips "Se o plugin não funcionar corretamente quando instalado pela 1ª vez, tente reiniciar o Logseq."
         :plugin/up-to-date "Está atualizado"
         :plugin/custom-js-alert "Ficheiro custom.js encontrado, quer executá-lo? (Se não compreender o conteúdo do ficheiro, é melhor não executá-lo, pois há certos riscos de segurança ao fazê-lo.)"
-        
+
         :pdf/copy-ref "Copiar referência"
         :pdf/copy-text "Copiar texto"
         :pdf/linked-ref "Referências ligadas"


### PR DESCRIPTION
This PR enables users to open a specific page's corresponding backups directory located in `logseq/bak/...related-page-dir`.
https://www.loom.com/share/33c3fb431cd844aa82687f1819a34361