### PR TITLE
fix: don't watch-for-date! if enable-journals? nils

### DIFF
--- a/src/main/frontend/handler.cljs
+++ b/src/main/frontend/handler.cljs
@@ -119,7 +119,7 @@
                             (state/pub-event! [:modal/nfs-ask-permission])
 
                             (page-handler/init-commands!)
-
+                            
                             (when (seq (:repos me))
                               ;; FIXME: handle error
                               (common-handler/request-app-tokens!
@@ -128,10 +128,13 @@
                                (fn []
                                  (js/console.error "Failed to request GitHub app tokens."))))
 
-                            (watch-for-date!)
+                            (when (state/enable-journals? (state/get-current-repo))
+                              (watch-for-date!))
+                            
                             (when (and (state/get-current-repo)
                                        (mobile-util/native-ios?))
                               (mobile-util/icloud-sync!))
+                            
                             (file-handler/watch-for-current-graph-dir!)))
                          (p/then (state/pub-event! [:graph/ready (state/get-current-repo)]))
                          (p/catch (fn [error]


### PR DESCRIPTION
This PR disables `watch-for-date!` to check whether today's journal exists if users set the enable-journals? to false. 