### PR TITLE
WIP enhance (query) - page-refs matches multiple tags

### DIFF
--- a/src/main/frontend/db/rules.cljc
+++ b/src/main/frontend/db/rules.cljc
@@ -140,7 +140,7 @@
    '[(page-refs ?b ?page-name)
      [?b :block/path-refs ?r]
      [?r :block/name ?tag]
-     [(contains? ?page-name ?tag)]]   
+     [(contains? ?page-names ?tag)]]   
    
    :page-ref
    '[(page-ref ?b ?page-name)

--- a/src/main/frontend/db/rules.cljc
+++ b/src/main/frontend/db/rules.cljc
@@ -136,6 +136,12 @@
                [(str ?val) ?str-val]
                [(contains? ?v ?str-val)]))]
 
+   :page-refs
+   '[(page-refs ?b ?page-name)
+     [?b :block/path-refs ?r]
+     [?r :block/name ?tag]
+     [(contains? ?page-name ?tag)]]   
+   
    :page-ref
    '[(page-ref ?b ?page-name)
      [?b :block/path-refs [:block/name ?page-name]]]})


### PR DESCRIPTION
At the moment, to find multiple types of tasks, this will work:

`(task ?b #{"TODO" "DOING"})`

Which is very nice, and short. To find multiple tags, you need to do:

`(or (page-ref ?b "mytag") (page-ref ?b "othertag"))`

Which is kind of too long. The path enables:

`(page-refs ?b #{"mytag" "othertag"})`