### PR TITLE
Upgrade SCI

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -17,7 +17,7 @@
                                          :sha     "5704fbf48d3478eedcf24d458c8964b3c2fd59a9"}
   cljs-drag-n-drop/cljs-drag-n-drop     {:mvn/version "0.1.0"}
   cljs-http/cljs-http                   {:mvn/version "0.1.46"}
-  borkdude/sci                          {:mvn/version "0.1.1-alpha.6"}
+  org.babashka/sci                      {:mvn/version "0.3.2"}
   hickory/hickory                       {:git/url "https://github.com/logseq/hickory"
                                          :sha     "9c2c2f1fc2c45efaad906e0faabc3201278deeaa"}
   hiccups/hiccups                       {:mvn/version "0.3.0"}


### PR DESCRIPTION
SCI has moved to a new organization: `org.babashka/sci {:mvn/version "0.3.2"}`.

Having both `borkdude/sci` and `org.babashka/sci` on the classpath can cause problems.