### PR TITLE
fix: cloze selector

### DIFF
--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -544,11 +544,11 @@ a[data-ref="card"], .page-reference[data-ref="card"] {
     display: none;
 }
 
-span.cloze {
+a.cloze {
     color: var(--ls-cloze-text-color);
 }
 
-span.cloze-revealed {
+a.cloze-revealed {
     color: var(--ls-cloze-text-color);
     text-decoration: underline;
     text-underline-position: under;


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

During the development of the theme, I found that the selector of `cloze` didn't correspond to the actual tag.