### PR TITLE
feat(editor): support agda syntax highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
         "chokidar": "3.5.1",
         "chrono-node": "2.2.4",
         "codemirror": "5.58.1",
+        "@codewars/codemirror-agda": "0.2.0",
         "d3-force": "3.0.0",
         "diff": "5.0.0",
         "electron": "15.1.2",

--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -4,6 +4,7 @@
             ["codemirror/addon/edit/closebrackets"]
             ["codemirror/addon/edit/matchbrackets"]
             ["codemirror/addon/selection/active-line"]
+            ["@codewars/codemirror-agda" :as cm-agda]
             ["codemirror/mode/apl/apl"]
             ["codemirror/mode/asciiarmor/asciiarmor"]
             ["codemirror/mode/asn.1/asn.1"]
@@ -271,6 +272,8 @@
 
 (rum/defcs editor < rum/reactive
   {:init (fn [state]
+           (let [agda-define-mode (gobj/get cm-agda "defineMode")]
+             (agda-define-mode cm))
            (let [[_ _ _ code _] (:rum/args state)]
              (assoc state :editor-atom (atom nil) :calc-atom (atom (calc/eval-lines code)))))
    :did-mount (fn [state]

--- a/yarn.lock
+++ b/yarn.lock
@@ -512,6 +512,11 @@
   resolved "https://registry.npmmirror.com/@capacitor/status-bar/download/@capacitor/status-bar-1.0.6.tgz#d58c9087cfc7c7377e8009bea86152e4fdd2939e"
   integrity sha1-1YyQh8/Hxzd+gAm+qGFS5P3Sk54=
 
+"@codewars/codemirror-agda@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@codewars/codemirror-agda/-/codemirror-agda-0.2.0.tgz#a877cc6f68337f13069745754eea121dd4a333d1"
+  integrity sha512-qMXOdBTM9iVN0AhSxNDr5SE6ZJxbZmnyJf78eebyI3e4FveUJhZz/ON4ubCEJGmuqsxkuoU7nQ9EOpktchvLUA==
+
 "@electron/get@^1.13.0":
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.13.1.tgz#42a0aa62fd1189638bd966e23effaebb16108368"


### PR DESCRIPTION
Add support for Agda syntax highlight via `@codewars/codemirror-agda`.

<img width="1157" alt="image" src="https://user-images.githubusercontent.com/23358293/158050976-40368ef9-678a-4e42-b3f7-91d3baf6a760.png">
