### PR TITLE
Fix blank screen on home page

### DIFF
--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -140,6 +140,16 @@
   (when-let [repo (state/get-current-repo)]
     (page-blocks-cp repo page {:sidebar? true})))
 
+(rum/defc failed-query-fallback
+  [query]
+  [:section.border.mt-1.p-1.block-content-fallback-ui
+   [:div.flex.justify-between.items-center.px-1
+    [:h5.text-red-600.pb-1 "Failed default query:"]
+    [:a.text-xs.opacity-50.hover:opacity-80
+     {:href "https://github.com/logseq/logseq/issues"
+      :target "_blank"} "report issue"]]
+   [:pre.m-0.text-sm (pr-str query)]])
+
 (rum/defc today-queries < rum/reactive
   [repo today? sidebar?]
   (when (and today? (not sidebar?))
@@ -147,11 +157,15 @@
       (when (seq queries)
         [:div#today-queries.mt-10
          (for [query queries]
-           (rum/with-key
-             (block/custom-query {:attr {:class "mt-10"}
-                                  :editor-box editor/box
-                                  :page page} query)
-             (str repo "-custom-query-" (:query query))))]))))
+           (ui/catch-error
+            (rum/with-key
+              (failed-query-fallback query)
+              (str repo "-custom-query-" (:query query)))
+            (rum/with-key
+              (block/custom-query {:attr {:class "mt-10"}
+                                   :editor-box editor/box
+                                   :page page} query)
+              (str repo "-custom-query-" (:query query)))))]))))
 
 (defn tagged-pages
   [repo tag]

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -140,16 +140,6 @@
   (when-let [repo (state/get-current-repo)]
     (page-blocks-cp repo page {:sidebar? true})))
 
-(rum/defc failed-query-fallback
-  [query]
-  [:section.border.mt-1.p-1.block-content-fallback-ui
-   [:div.flex.justify-between.items-center.px-1
-    [:h5.text-red-600.pb-1 "Failed default query:"]
-    [:a.text-xs.opacity-50.hover:opacity-80
-     {:href "https://github.com/logseq/logseq/issues"
-      :target "_blank"} "report issue"]]
-   [:pre.m-0.text-sm (pr-str query)]])
-
 (rum/defc today-queries < rum/reactive
   [repo today? sidebar?]
   (when (and today? (not sidebar?))
@@ -159,7 +149,7 @@
          (for [query queries]
            (ui/catch-error
             (rum/with-key
-              (failed-query-fallback query)
+              (ui/block-error "Failed default query:" {:content (pr-str query)})
               (str repo "-custom-query-" (:query query)))
             (rum/with-key
               (block/custom-query {:attr {:class "mt-10"}

--- a/src/main/frontend/db/query_react.cljs
+++ b/src/main/frontend/db/query_react.cljs
@@ -28,7 +28,8 @@
     (= :tomorrow input)
     (date->int (t/plus (t/today) (t/days 1)))
     (= :current-page input)
-    (string/lower-case (state/get-current-page))
+    ;; This sometimes runs when there isn't a current page e.g. :home route
+    (some-> (state/get-current-page) string/lower-case)
     (and (keyword? input)
          (util/safe-re-find #"^\d+d(-before)?$" (name input)))
     (let [input (name input)

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -723,6 +723,18 @@
       error-view)
     view))
 
+(rum/defc block-error
+  "Well styled error for blocks that error unexpectedly during render"
+  [title {:keys [content section-attrs]}]
+  [:section.border.mt-1.p-1.cursor-pointer.block-content-fallback-ui
+   section-attrs
+   [:div.flex.justify-between.items-center.px-1
+    [:h5.text-red-600.pb-1 title]
+    [:a.text-xs.opacity-50.hover:opacity-80
+     {:href "https://github.com/logseq/logseq/issues"
+      :target "_blank"} "report issue"]]
+   [:pre.m-0.text-sm content]])
+
 (rum/defc select
   [options on-change class]
   [:select.mt-1.block.text-base.leading-6.border-gray-300.focus:outline-none.focus:shadow-outline-blue.focus:border-blue-300.sm:text-sm.sm:leading-5.ml-1.sm:ml-4.w-12.sm:w-20


### PR DESCRIPTION
This fixes #4539 where two users had shared default-queries that were causing their home screen to crash. This PR also improves the error handling of default-queries so that any future errors render an inline error instead of blanking the screen like:
<img width="879" alt="Screen Shot 2022-03-14 at 12 32 33 PM" src="https://user-images.githubusercontent.com/97210743/158262975-e96ec69e-7d8e-4c6f-ae9a-0a3e616e2944.png">

This PR also introduces a reusable block-error component and uses it when advanced queries fail to parse correctly. Before it looked like:

<img width="774" alt="Screen Shot 2022-03-14 at 4 27 46 PM" src="https://user-images.githubusercontent.com/97210743/158263247-4f9f627d-2f2c-4523-bb16-e2a4a35993b8.png">

and now the error looks like:
<img width="777" alt="Screen Shot 2022-03-14 at 4 37 21 PM" src="https://user-images.githubusercontent.com/97210743/158263270-d1230c99-bacf-49c8-b1b6-7761b0dbddc0.png">

If we like this block-error component, I could use it in a couple more places where we render blocks errors with `div.warning ...`