### PR TITLE
fix: cycle marker will remove `#` unexpectedly

### DIFF
--- a/src/main/frontend/util/marker.cljs
+++ b/src/main/frontend/util/marker.cljs
@@ -4,7 +4,7 @@
 
 (defn marker-pattern [format]
   (re-pattern
-   (str "^" (when-not (= format :org) "(#*\\s*)?")
+   (str "^" (when-not (= format :org) "(#*\\s+)?")
         "(NOW|LATER|TODO|DOING|DONE|WAITING|WAIT|CANCELED|CANCELLED|STARTED|IN-PROGRESS)?\\s?")))
 
 (def bare-marker-pattern
@@ -30,13 +30,13 @@
 
 (defn header-marker-pattern
   [markdown? marker]
-  (re-pattern (str "^" (when markdown? "#*\\s*") marker)))
+  (re-pattern (str "^" (when markdown? "(#*\\s+)?") marker)))
 
 (defn replace-marker
   [content markdown? old-marker new-marker]
   (string/replace-first content (header-marker-pattern markdown? old-marker)
                         (fn [match]
-                          (if (and markdown? (= new-marker "")  (string/starts-with? match "#"))
+                          (if (and markdown? (= new-marker "") (string/starts-with? match "#"))
                             (string/replace match (str " " old-marker) "")
                             (string/replace match old-marker new-marker)))))
 

--- a/src/main/frontend/util/marker.cljs
+++ b/src/main/frontend/util/marker.cljs
@@ -30,7 +30,7 @@
 
 (defn header-marker-pattern
   [markdown? marker]
-  (re-pattern (str "^" (when markdown? "(#+\\s+)?") marker)))
+  (re-pattern (str "^" (when markdown? "#+\\s+") marker)))
 
 (defn replace-marker
   [content markdown? old-marker new-marker]

--- a/src/main/frontend/util/marker.cljs
+++ b/src/main/frontend/util/marker.cljs
@@ -4,7 +4,7 @@
 
 (defn marker-pattern [format]
   (re-pattern
-   (str "^" (when-not (= format :org) "(#*\\s+)?")
+   (str "^" (when-not (= format :org) "(#+\\s+)?")
         "(NOW|LATER|TODO|DOING|DONE|WAITING|WAIT|CANCELED|CANCELLED|STARTED|IN-PROGRESS)?\\s?")))
 
 (def bare-marker-pattern
@@ -30,7 +30,7 @@
 
 (defn header-marker-pattern
   [markdown? marker]
-  (re-pattern (str "^" (when markdown? "(#*\\s+)?") marker)))
+  (re-pattern (str "^" (when markdown? "(#+\\s+)?") marker)))
 
 (defn replace-marker
   [content markdown? old-marker new-marker]

--- a/src/test/frontend/util/marker_test.cljs
+++ b/src/test/frontend/util/marker_test.cljs
@@ -14,8 +14,7 @@
     "TODO" "DONE" "DONE "
     "## TODO [#A] xxx" "DONE" "## DONE [#A] xxx"
     "#test content" "TODO" "TODO #test content"
-    "TODO #test content" "DONE" "DONE #test content"
-    "DONE #test content" "" "#test content"))
+    "TODO #test content" "DONE" "DONE #test content"))
 
 (deftest add-or-update-marker-org
   (are [content marker expect] (= expect (marker/add-or-update-marker content :org marker))

--- a/src/test/frontend/util/marker_test.cljs
+++ b/src/test/frontend/util/marker_test.cljs
@@ -12,7 +12,10 @@
     "todo" "TODO" "TODO todo"
     "TODO xxx" "DONE" "DONE xxx"
     "TODO" "DONE" "DONE "
-    "## TODO [#A] xxx" "DONE" "## DONE [#A] xxx"))
+    "## TODO [#A] xxx" "DONE" "## DONE [#A] xxx"
+    "#test content" "TODO" "TODO #test content"
+    "TODO #test content" "DONE" "DONE #test content"
+    "DONE #test content" "" "#test content"))
 
 (deftest add-or-update-marker-org
   (are [content marker expect] (= expect (marker/add-or-update-marker content :org marker))


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

This PR changes the regex of a markdown header to `#+\s+`, it's more accurate than `#*\s*` because a markdown header should always have at least one `#` and one space.

So it can close #4588 due to `#xxx` won't being matched anymore.