### PR TITLE
fix: replace-block-reference-with-content-at-point not working

### DIFF
--- a/e2e-tests/editor.spec.ts
+++ b/e2e-tests/editor.spec.ts
@@ -1,26 +1,69 @@
 import { expect } from '@playwright/test'
 import { test } from './fixtures'
-import { createRandomPage } from './utils'
+import { createRandomPage, IsMac } from './utils'
 
 test('hashtag and quare brackets in same line #4178', async ({ page }) => {
-    await createRandomPage(page)
-  
-    await page.type(':nth-match(textarea, 1)', '#foo bar')
-    await page.press(':nth-match(textarea, 1)', 'Enter')
-    await page.type(':nth-match(textarea, 1)', 'bar [[blah]]')
-    for (let i = 0; i < 12; i++) {
-      await page.press(':nth-match(textarea, 1)', 'ArrowLeft')
-    }
-    await page.type(':nth-match(textarea, 1)', ' ')
+  await createRandomPage(page)
+
+  await page.type(':nth-match(textarea, 1)', '#foo bar')
+  await page.press(':nth-match(textarea, 1)', 'Enter')
+  await page.type(':nth-match(textarea, 1)', 'bar [[blah]]')
+  for (let i = 0; i < 12; i++) {
     await page.press(':nth-match(textarea, 1)', 'ArrowLeft')
-  
-    await page.type(':nth-match(textarea, 1)', '#')
-    await page.waitForSelector('text="Search for a page"', { 'state': 'visible' })
-  
-    await page.type(':nth-match(textarea, 1)', 'fo')
-  
-    await page.click('.absolute >> text=' + 'foo')
-  
-    expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('#foo bar [[blah]]')
-  })
-  
+  }
+  await page.type(':nth-match(textarea, 1)', ' ')
+  await page.press(':nth-match(textarea, 1)', 'ArrowLeft')
+
+  await page.type(':nth-match(textarea, 1)', '#')
+  await page.waitForSelector('text="Search for a page"', { state: 'visible' })
+
+  await page.type(':nth-match(textarea, 1)', 'fo')
+
+  await page.click('.absolute >> text=' + 'foo')
+
+  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe(
+    '#foo bar [[blah]]'
+  )
+})
+
+// FIXME: ClipboardItem is not defined when running with this test
+// test('copy & paste block ref and replace its content', async ({ page }) => {
+//   await createRandomPage(page)
+
+//   await page.type(':nth-match(textarea, 1)', 'Some random text')
+//   if (IsMac) {
+//     await page.keyboard.press('Meta+c')
+//   } else {
+//     await page.keyboard.press('Control+c')
+//   }
+
+//   await page.pause()
+
+//   await page.press(':nth-match(textarea, 1)', 'Enter')
+//   if (IsMac) {
+//     await page.keyboard.press('Meta+v')
+//   } else {
+//     await page.keyboard.press('Control+v')
+//   }
+//   await page.keyboard.press('Escape')
+
+//   const blockRef$ = page.locator('.block-ref >> text="Some random text"');
+
+//   // Check if the newly created block-ref has the same referenced content
+//   await expect(blockRef$).toHaveCount(1);
+
+//   // Edit the last block
+//   await blockRef$.press('Enter')
+
+//   // Move cursor into the block ref
+//   for (let i = 0; i < 4; i++) {
+//     await page.press(':nth-match(textarea, 1)', 'ArrowLeft')
+//   }
+
+//   // Trigger replace-block-reference-with-content-at-point
+//   if (IsMac) {
+//     await page.keyboard.press('Meta+Shift+r')
+//   } else {
+//     await page.keyboard.press('Control+Shift+v')
+//   }  
+// })

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3601,19 +3601,18 @@
 
 (defn replace-block-reference-with-content-at-point
   []
-  (when-let [{:keys [content start end]} (thingatpt/block-ref-at-point)]
-    (let [block-ref-id (subs content 2 (- (count content) 2))]
-      (when-let [block (db/pull [:block/uuid (uuid block-ref-id)])]
-        (let [block-content (:block/content block)
-              format (or (:block/format block) :markdown)
-              block-content-without-prop (-> (property/remove-properties format block-content)
-                                             (drawer/remove-logbook))]
-          (when-let [input (state/get-input)]
-            (when-let [current-block-content (gobj/get input "value")]
-              (let [block-content* (str (subs current-block-content 0 start)
-                                        block-content-without-prop
-                                        (subs current-block-content end))]
-                (state/set-block-content-and-last-pos! input block-content* 1)))))))))
+  (when-let [{:keys [start end link]} (thingatpt/block-ref-at-point)]
+    (when-let [block (db/pull [:block/uuid link])]
+      (let [block-content (:block/content block)
+            format (or (:block/format block) :markdown)
+            block-content-without-prop (-> (property/remove-properties format block-content)
+                                           (drawer/remove-logbook))]
+        (when-let [input (state/get-input)]
+          (when-let [current-block-content (gobj/get input "value")]
+            (let [block-content* (str (subs current-block-content 0 start)
+                                      block-content-without-prop
+                                      (subs current-block-content end))]
+              (state/set-block-content-and-last-pos! input block-content* 1))))))))
 
 (defn copy-current-ref
   [block-id]


### PR DESCRIPTION
The shortcut for "mod+shitf+c" no longer works after https://github.com/logseq/logseq/pull/2889.

Also tried to add a test for this case, but failed to find out the reason why ClipboardItem is not defined when running with playwright 😅