### PR TITLE
Add a configuration option to support the previous collapse behavior

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1418,7 +1418,7 @@
    (every? #(= % ["Horizontal_Rule"]) body)))
 
 (rum/defcs block-control < rum/reactive
-  [state config block uuid block-id children collapsed? *control-show? edit?]
+  [state config block uuid block-id _children collapsed? *control-show? edit?]
   (let [doc-mode? (state/sub :document/mode?)
         control-show? (util/react *control-show?)
         ref? (:ref? config)

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1420,10 +1420,6 @@
 (rum/defcs block-control < rum/reactive
   [state config block uuid block-id children collapsed? *control-show? edit?]
   (let [doc-mode? (state/sub :document/mode?)
-        has-children-blocks? (and (coll? children) (seq children))
-        has-child? (and
-                    (not (:pre-block? block))
-                    has-children-blocks?)
         control-show? (util/react *control-show?)
         ref? (:ref? config)
         empty-content? (block-content-empty? block)]
@@ -1436,12 +1432,11 @@
       {:id (str "control-" uuid)
        :on-click (fn [event]
                    (util/stop event)
-                   (when-not (and (not collapsed?) (not has-child?))
-                     (if ref?
-                       (state/toggle-collapsed-block! uuid)
-                       (if collapsed?
-                         (editor-handler/expand-block! uuid)
-                         (editor-handler/collapse-block! uuid)))))}
+                   (if ref?
+                     (state/toggle-collapsed-block! uuid)
+                     (if collapsed?
+                       (editor-handler/expand-block! uuid)
+                       (editor-handler/collapse-block! uuid))))}
       [:span {:class (if control-show? "control-show cursor-pointer" "control-hide")}
        (ui/rotating-arrow collapsed?)]]
      (let [bullet [:a {:on-click (fn [event]
@@ -2116,7 +2111,7 @@
   (util/stop e)
   (when (or
          (model/block-collapsed? uuid)
-         (editor-handler/collapsable? uuid))
+         (editor-handler/collapsable? uuid true))
     (reset! *control-show? true))
   (when-let [parent (gdom/getElement block-id)]
     (let [node (.querySelector parent ".bullet-container")]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1418,7 +1418,7 @@
    (every? #(= % ["Horizontal_Rule"]) body)))
 
 (rum/defcs block-control < rum/reactive
-  [state config block uuid block-id _children collapsed? *control-show? edit?]
+  [state config block uuid block-id collapsed? *control-show? edit?]
   (let [doc-mode? (state/sub :document/mode?)
         control-show? (util/react *control-show?)
         ref? (:ref? config)
@@ -2111,7 +2111,7 @@
   (util/stop e)
   (when (or
          (model/block-collapsed? uuid)
-         (editor-handler/collapsable? uuid true))
+         (editor-handler/collapsable? uuid {:semantic? true}))
     (reset! *control-show? true))
   (when-let [parent (gdom/getElement block-id)]
     (let [node (.querySelector parent ".bullet-container")]
@@ -2279,7 +2279,7 @@
        :on-mouse-leave (fn [e]
                          (block-mouse-leave e *control-show? block-id doc-mode?))}
       (when (not slide?)
-        (block-control config block uuid block-id children collapsed? *control-show? edit?))
+        (block-control config block uuid block-id collapsed? *control-show? edit?))
 
       (block-content-or-editor config block edit-input-id block-id heading-level edit?)]
 

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -424,12 +424,8 @@
               next-sibling (get ids->blocks [(:db/id (:block/parent node)) id])
               next-siblings (if (and next-sibling child-block)
                               (cons next-sibling next-siblings)
-                              next-siblings)
-              collapsed? (:block/collapsed? node)]
-          (if-let [node (and
-                         (or (not collapsed?)
-                             (= (:db/id node) (:db/id parent)))
-                         (or child-block next-sibling))]
+                              next-siblings)]
+          (if-let [node (or child-block next-sibling)]
             (recur node next-siblings (conj result node))
             (if-let [sibling (first next-siblings)]
               (recur sibling (rest next-siblings) (conj result sibling))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3378,8 +3378,9 @@
 
 (defn collapsable?
   ([block-id]
-   (collapsable? block-id false))
-  ([block-id semantic?]
+   (collapsable? block-id {}))
+  ([block-id {:keys [semantic?]
+              :or {semantic? false}}]
    (when block-id
      (if-let [block (db-model/query-block-by-uuid block-id)]
        (and

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3385,9 +3385,11 @@
        (and
         (not (util/collapsed? block))
         (or (db-model/has-children? block-id)
-            (block-with-title? (:block/format block)
-                               (:block/content block)
-                               semantic?)))
+            (and
+             (:outliner/block-title-collapse-enabled? (state/get-config))
+             (block-with-title? (:block/format block)
+                                (:block/content block)
+                                semantic?))))
        false))))
 
 (defn all-blocks-with-level

--- a/templates/config.edn
+++ b/templates/config.edn
@@ -1,5 +1,5 @@
 {:meta/version 1
- 
+
  ;; Currently, we support either "Markdown" or "Org".
  ;; This can overwrite your global preference so that
  ;; maybe your personal preferred format is Org but you'd
@@ -143,6 +143,13 @@
  ;; E.g. [["js" "Javascript"]]
  :commands
  []
+
+ ;; By default, a block can only be collapsed if it has some children.
+ ;; `:outliner/block-title-collapse-enabled? true` enables a block with a title
+ ;; (multiple lines) can be collapsed too. For example:
+ ;; - block title
+ ;;   block content
+ :outliner/block-title-collapse-enabled? false
 
  ;; Macros replace texts and will make you more productive.
  ;; For example:


### PR DESCRIPTION
This PR introduces a new option `:outliner/block-title-collapse-enabled?` to bring back the old collapse behavior.
**Notice**: it's disabled by default.

Fix https://github.com/logseq/logseq/issues/4583

https://www.loom.com/share/eea40ca4853142e9b95050c83aa64db4