### PR TITLE
Fix: Query fixes related to use of lookup refs

### DIFF
--- a/src/main/frontend/db/query_dsl.cljs
+++ b/src/main/frontend/db/query_dsl.cljs
@@ -13,8 +13,7 @@
             [frontend.db.rules :as rules]
             [frontend.template :as template]
             [frontend.text :as text]
-            [frontend.util :as util]
-            [lambdaisland.glogi :as log]))
+            [frontend.util :as util]))
 
 
 ;; Query fields:
@@ -553,18 +552,12 @@ Some bindings in this fn:
                                  (take @sample (shuffle col)))
                                identity)
               transform-fn (comp sort-by random-samples)]
-          (try
-            (query-react/react-query repo
-                                     {:query query'
-                                      :query-string query-string
-                                      :rules rules}
-                                     {:use-cache? false
-                                      :transform-fn transform-fn})
-            (catch ExceptionInfo e
-              ;; Allow non-existent page queries to be ignored
-              (if (string/includes? (str (.-message e)) "Nothing found for entity")
-                (log/error :nothing-found-error e)
-                (throw e)))))))))
+          (query-react/react-query repo
+                                   {:query query'
+                                    :query-string query-string
+                                    :rules rules}
+                                   {:use-cache? false
+                                    :transform-fn transform-fn}))))))
 
 (defn custom-query
   "Runs a dsl query with query as a seq. Primary use is from advanced query"

--- a/src/main/frontend/db/rules.cljc
+++ b/src/main/frontend/db/rules.cljc
@@ -116,7 +116,8 @@
 
    :page
    '[(page ?b ?page-name)
-     [?b :block/page [:block/name ?page-name]]]
+     [?b :block/page ?bp]
+     [?bp :block/name ?page-name]]
 
    :namespace
    '[(namespace ?p ?namespace)

--- a/src/main/frontend/db/rules.cljc
+++ b/src/main/frontend/db/rules.cljc
@@ -139,4 +139,5 @@
 
    :page-ref
    '[(page-ref ?b ?page-name)
-     [?b :block/path-refs [:block/name ?page-name]]]})
+     [?b :block/path-refs ?bp]
+     [?bp :block/name ?page-name]]})

--- a/src/main/frontend/extensions/srs.cljs
+++ b/src/main/frontend/extensions/srs.cljs
@@ -254,7 +254,7 @@
    (when (string? query-string)
      (let [query-string (template/resolve-dynamic-template! query-string)
            {:keys [query sort-by rules]} (query-dsl/parse query-string)
-           query* (concat [['?b :block/refs [:block/name card-hash-tag]]]
+           query* (concat [['?b :block/refs '?bp] ['?bp :block/name card-hash-tag]]
                           (if (coll? (first query))
                             query
                             [query]))]

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -714,13 +714,11 @@
 (rum/defcs catch-error
   < {:did-catch
      (fn [state error _info]
-       (js/console.dir error)
+       (log/error :exception error)
        (assoc state ::error error))}
   [{error ::error, c :rum/react-component} error-view view]
   (if (some? error)
-    (do
-      (log/error :exception error)
-      error-view)
+    error-view
     view))
 
 (rum/defc block-error

--- a/src/test/frontend/db/query_custom_test.cljs
+++ b/src/test/frontend/db/query_custom_test.cljs
@@ -1,5 +1,5 @@
 (ns frontend.db.query-custom-test
-  (:require [cljs.test :refer [deftest is use-fixtures]]
+  (:require [cljs.test :refer [deftest is use-fixtures testing]]
             [frontend.test.helper :as test-helper :refer [load-test-files]]
             [frontend.db.query-custom :as query-custom]
             [frontend.db.react :as react]))
@@ -21,23 +21,33 @@
 - LATER b3
 - b3"}])
 
-  (is (= ["LATER b3"]
-         (map :block/content
-              (custom-query {:query '[:find (pull ?b [*])
-                                      :where
-                                      (block-content ?b "b")
-                                      (task ?b #{"LATER"})]})))
-      "datalog query returns correct results")
+  (testing "advanced datalog queries"
+    (is (= ["LATER b3"]
+           (map :block/content
+                (custom-query {:query '[:find (pull ?b [*])
+                                        :where
+                                        (block-content ?b "b")
+                                        (task ?b #{"LATER"})]})))
+        "basic advanced query works")
 
-  (is (= ["LATER b3"]
-         (map :block/content
-              (custom-query {:query '[:find (pull ?b [*])
-                                      :in $
-                                      :where
-                                      (block-content ?b "b")
-                                      (task ?b #{"LATER"})]})))
-      "datalog query with :in returns correct results")
+    (is (= ["LATER b3"]
+           (map :block/content
+                (custom-query {:query '[:find (pull ?b [*])
+                                        :in $
+                                        :where
+                                        (block-content ?b "b")
+                                        (task ?b #{"LATER"})]})))
+        "advanced query with an :in works")
 
+    (is (= #{"page1"}
+           (set
+            (map #(get-in % [:block/page :block/name])
+                 (custom-query {:query '[:find (pull ?b [*])
+                                         :in $ ?page
+                                         :where
+                                         (page ?b ?page)]
+                                :inputs ["page1"]}))))
+        "advanced query with bound :in argument works"))
 
   (is (= ["LATER b3"]
          (map :block/content

--- a/src/test/frontend/db/query_dsl_test.cljs
+++ b/src/test/frontend/db/query_dsl_test.cljs
@@ -355,12 +355,7 @@ tags: other
          nil
          ""
          " "
-         "\"\""))
-
-  (testing "Non exists page should be ignored"
-    (are [x] (nil? (dsl-query x))
-         "[[page-not-exist]]"
-         "[[another-page-not-exist]]")))
+         "\"\"")))
 
 (deftest page-ref-and-boolean-queries
   (load-test-files [{:file/path "pages/page1.md"
@@ -380,8 +375,8 @@ tags: other
         "Tag arg")
 
     (is (= []
-           (map :block/content (dsl-query "[[blarg]]")))
-        "Correctly returns no results"))
+           (dsl-query "[[blarg]]"))
+        "Nonexistent page returns no results"))
 
   (testing "basic boolean queries"
     (is (= ["b2 [[page 2]] #tag1"]
@@ -393,6 +388,11 @@ tags: other
            (map :block/content
                 (dsl-query "(or [[tag2]] [[page 2]])")))
         "OR query")
+
+    (is (= ["b1 [[page 1]] #tag2"]
+           (map :block/content
+                (dsl-query "(or [[tag2]] [[page 3]])")))
+        "OR query with nonexistent page should return meaningful results")
 
     (is (= ["foo:: bar\n" "b1 [[page 1]] #tag2" "b3"]
            (->> (dsl-query "(not [[page 2]])")


### PR DESCRIPTION
This PR fixes a couple bugs caused by our use of lookup refs in queries and rules which is [not recommended by datomic](https://docs.datomic.com/on-prem/schema/identity.html#:~:text=You%20can%20use%20lookup%20refs%20to%20retrieve%20entities%20using%20the%20entity%20and%20datoms%20using%20the%20datoms%20and%20seek%2Ddatoms%20APIs.%20You%20cannot%20use%20them%20in%20the%20body%20of%20a%20query%2C%20use%20datalog%20clauses%20instead.):
- page-ref (and page) rules were unable to bind to args as reported in https://github.com/logseq/logseq/pull/4518#issuecomment-1068743086
- For nonexistent lookups, queries failed hard of instead gracefully returning empty. This caused the following issues
  - srs query reported `"Nothing found for entity id [:block/name \"card\"]"` as can be seen in #4576 
  - Queries with nonexistent blocks returned empty instead of meaningful results like https://github.com/logseq/logseq/blob/04534648b5e3f3ebdd6a0da97ea60d8b2d3528ca/src/test/frontend/db/query_dsl_test.cljs#L392-L395

I did a regex search of `[:block/name` lookups and didn't find other uses of it in queries or rules