### PR TITLE
fix: use the correct variable in (seq coll)

### DIFF
--- a/src/main/frontend/components/repo.cljs
+++ b/src/main/frontend/components/repo.cljs
@@ -257,7 +257,7 @@
                            :options {:on-click ui-handler/open-new-window!}})]
     (->>
      (concat repo-links
-             [(when (seq repos) {:hr true})
+             [(when (seq repo-links) {:hr true})
               {:title (t :new-graph) :options {:href (rfe/href :repo-add)}}
               {:title (t :all-graphs) :options {:href (rfe/href :repos)}}
               refresh-link


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

Replace `repos` with `repo-links`.

After the change, the `<hr />` will not be displayed if there is only one repo.