### PR TITLE
Chore: bump version 0.6.4

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "com.logseq.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 16
-        versionName "0.6.3"
+        versionCode 17
+        versionName "0.6.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/resources/package.json
+++ b/resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Logseq",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "main": "electron.js",
   "author": "Logseq",
   "license": "AGPL-3.0",

--- a/src/main/frontend/version.cljs
+++ b/src/main/frontend/version.cljs
@@ -1,3 +1,3 @@
 (ns frontend.version)
 
-(defonce version "0.6.3")
+(defonce version "0.6.4")


### PR DESCRIPTION
Prepare for the v0.6.4 release.

## Pending PRs and Fixes

- ~~[ ] https://github.com/logseq/logseq/pull/4580~~
- [x] https://github.com/logseq/logseq/issues/4614
- [x] https://github.com/logseq/logseq/issues/4613
- [x] https://github.com/logseq/logseq/issues/4612

**UPDATE**
#4580 will be excluded from 0.6.4.
