### PR TITLE
Fix sentry platform not showing up on issues

### DIFF
--- a/src/main/frontend/modules/instrumentation/sentry.cljs
+++ b/src/main/frontend/modules/instrumentation/sentry.cljs
@@ -18,7 +18,7 @@
    :initialScope {:tags
                   {:platform (cond
                                (util/electron?) "electron"
-                               (util/mobile?) "mobile"
+                               (mobile-util/is-native-platform?) "mobile"
                                :else "web")
                    :publishing cfg/publishing?}}
    :integrations [(new posthog/SentryIntegration posthog "logseq" 5311485)

--- a/src/main/frontend/modules/instrumentation/sentry.cljs
+++ b/src/main/frontend/modules/instrumentation/sentry.cljs
@@ -15,7 +15,12 @@
                                          :else "")
                          version)
    :environment (if cfg/dev? "development" "production")
-   :platform (if (util/electron?) "electron" "web")
+   :initialScope {:tags
+                  {:platform (cond
+                               (util/electron?) "electron"
+                               (util/mobile?) "mobile"
+                               :else "web")
+                   :publishing cfg/publishing?}}
    :integrations [(new posthog/SentryIntegration posthog "logseq" 5311485)
                   (new BrowserTracing)]
    :debug cfg/dev?


### PR DESCRIPTION
I was QAing #4618 and noticed that platform was not showing up as a sentry tag. Docs don't mention a platform option but they do mention an [initialScope](https://docs.sentry.io/platforms/javascript/guides/react/configuration/options/#initial-scope) option which sets [tags](https://docs.sentry.io/platforms/javascript/guides/react/enriching-events/tags/). Here are examples of the issues [before the PR](https://sentry.io/organizations/logseq/issues/3114529645/?environment=development&project=5311485&query=is%3Aunresolved+OOPS&statsPeriod=14d) and [after the PR](https://sentry.io/organizations/logseq/issues/3114531129/?environment=development&project=5311485&query=is%3Aunresolved+OOPS&statsPeriod=14d). I also added mobile to platform and added publishing as another tag to allow for more search indices