### PR TITLE
Enhance: Gracefully fail references component and other small error improvements

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1953,7 +1953,7 @@
     (if (and edit? editor-box)
       [:div.editor-wrapper {:id editor-id}
        (ui/catch-error
-        [:p.warning "Something wrong in the editor"]
+        (ui/block-error "Something wrong in the editor" {})
         (editor-box {:block block
                      :block-id uuid
                      :block-parent-id block-id
@@ -2478,7 +2478,7 @@
                      result-atom)]
     (assoc state :query-atom query-atom)))
 
-(rum/defcs ^:large-vars/cleanup-todo custom-query < rum/reactive
+(rum/defcs ^:large-vars/cleanup-todo custom-query* < rum/reactive
   {:will-mount trigger-custom-query!
    :did-mount (fn [state]
                 (when-let [query (last (:rum/args state))]
@@ -2492,119 +2492,121 @@
                      (db/remove-custom-query! (state/get-current-repo) query))
                    state)}
   [state config {:keys [title query view collapsed? children? breadcrumb-show?] :as q}]
+  (let [dsl-query? (:dsl-query? config)
+        query-atom (:query-atom state)
+        current-block-uuid (or (:block/uuid (:block config))
+                               (:block/uuid config))
+        current-block (db/entity [:block/uuid current-block-uuid])
+        ;; exclude the current one, otherwise it'll loop forever
+        remove-blocks (if current-block-uuid [current-block-uuid] nil)
+        query-result (and query-atom (rum/react query-atom))
+        table? (or (get-in current-block [:block/properties :query-table])
+                   (and (string? query) (string/ends-with? (string/trim query) "table")))
+        transformed-query-result (when query-result
+                                   (db/custom-query-result-transform query-result remove-blocks q))
+        not-grouped-by-page? (or table?
+                                 (boolean (:result-transform q))
+                                 (and (string? query) (string/includes? query "(by-page false)")))
+        result (if (and (:block/uuid (first transformed-query-result)) (not not-grouped-by-page?))
+                 (db-utils/group-by-page transformed-query-result)
+                 transformed-query-result)
+        _ (when-let [query-result (:query-result config)]
+            (let [result (remove (fn [b] (some? (get-in b [:block/properties :template]))) result)]
+              (reset! query-result result)))
+        view-f (and view (sci/eval-string (pr-str view)))
+        only-blocks? (:block/uuid (first result))
+        blocks-grouped-by-page? (and (seq result)
+                                     (not not-grouped-by-page?)
+                                     (coll? (first result))
+                                     (:block/name (ffirst result))
+                                     (:block/uuid (first (second (first result))))
+                                     true)
+        built-in? (built-in-custom-query? title)
+        page-list? (and (seq result)
+                        (:block/name (first result)))
+        nested-query? (:custom-query? config)]
+    (if nested-query?
+      [:code (if dsl-query?
+               (util/format "{{query %s}}" query)
+               "{{query hidden}}")]
+      [:div.custom-query.mt-4 (get config :attr {})
+       (when-not (and built-in? (empty? result))
+         (ui/foldable
+          [:div.custom-query-title
+           [:span.title-text title]
+           [:span.opacity-60.text-sm.ml-2.results-count
+            (str (count transformed-query-result) " results")]]
+          (fn []
+            [:div
+             (when current-block
+               [:div.flex.flex-row.align-items.mt-2 {:on-mouse-down (fn [e] (util/stop e))}
+                (when-not page-list?
+                  [:div.flex.flex-row
+                   [:div.mx-2 [:span.text-sm "Table view"]]
+                   [:div {:style {:margin-top 5}}
+                    (ui/toggle table?
+                               (fn []
+                                 (editor-handler/set-block-property! current-block-uuid
+                                                                     "query-table"
+                                                                     (not table?)))
+                               true)]])
+
+                [:a.mx-2.block.fade-link
+                 {:on-click (fn []
+                              (let [all-keys (query-table/get-keys result page-list?)]
+                                (state/pub-event! [:modal/set-query-properties current-block all-keys])))}
+                 [:span.table-query-properties
+                  [:span.text-sm.mr-1 "Set properties"]
+                  svg/settings-sm]]])
+             (cond
+               (and (seq result) view-f)
+               (let [result (try
+                              (sci/call-fn view-f result)
+                              (catch js/Error error
+                                (log/error :custom-view-failed {:error error
+                                                                :result result})
+                                [:div "Custom view failed: "
+                                 (str error)]))]
+                 (util/hiccup-keywordize result))
+
+               page-list?
+               (query-table/result-table config current-block result {:page? true} map-inline page-cp ->elem inline-text)
+
+               table?
+               (query-table/result-table config current-block result {:page? false} map-inline page-cp ->elem inline-text)
+
+               (and (seq result) (or only-blocks? blocks-grouped-by-page?))
+               (->hiccup result (cond-> (assoc config
+                                               :custom-query? true
+                                               :breadcrumb-show? (if (some? breadcrumb-show?)
+                                                                   breadcrumb-show?
+                                                                   true)
+                                               :group-by-page? blocks-grouped-by-page?
+                                               :ref? true)
+                                        children?
+                                        (assoc :ref? true))
+                         {:style {:margin-top "0.25rem"
+                                  :margin-left "0.25rem"}})
+
+               (seq result)
+               (let [result (->>
+                             (for [record result]
+                               (if (map? record)
+                                 (str (util/pp-str record) "\n")
+                                 record))
+                             (remove nil?))]
+                 [:pre result])
+
+               :else
+               [:div.text-sm.mt-2.ml-2.font-medium.opacity-50 "Empty"])])
+          {:default-collapsed? collapsed?
+           :title-trigger? true}))])))
+
+(rum/defc custom-query
+  [config q]
   (ui/catch-error
-   [:div.warning
-    [:p "Query failed: "]
-    [:pre (str q)]]
-   (let [dsl-query? (:dsl-query? config)
-         query-atom (:query-atom state)
-         current-block-uuid (or (:block/uuid (:block config))
-                                (:block/uuid config))
-         current-block (db/entity [:block/uuid current-block-uuid])
-         ;; exclude the current one, otherwise it'll loop forever
-         remove-blocks (if current-block-uuid [current-block-uuid] nil)
-         query-result (and query-atom (rum/react query-atom))
-         table? (or (get-in current-block [:block/properties :query-table])
-                    (and (string? query) (string/ends-with? (string/trim query) "table")))
-         transformed-query-result (when query-result
-                                    (db/custom-query-result-transform query-result remove-blocks q))
-         not-grouped-by-page? (or table?
-                                  (boolean (:result-transform q))
-                                  (and (string? query) (string/includes? query "(by-page false)")))
-         result (if (and (:block/uuid (first transformed-query-result)) (not not-grouped-by-page?))
-                  (db-utils/group-by-page transformed-query-result)
-                  transformed-query-result)
-         _ (when-let [query-result (:query-result config)]
-             (let [result (remove (fn [b] (some? (get-in b [:block/properties :template]))) result)]
-               (reset! query-result result)))
-         view-f (and view (sci/eval-string (pr-str view)))
-         only-blocks? (:block/uuid (first result))
-         blocks-grouped-by-page? (and (seq result)
-                                      (not not-grouped-by-page?)
-                                      (coll? (first result))
-                                      (:block/name (ffirst result))
-                                      (:block/uuid (first (second (first result))))
-                                      true)
-         built-in? (built-in-custom-query? title)
-         page-list? (and (seq result)
-                         (:block/name (first result)))
-         nested-query? (:custom-query? config)]
-     (if nested-query?
-       [:code (if dsl-query?
-                (util/format "{{query %s}}" query)
-                "{{query hidden}}")]
-       [:div.custom-query.mt-4 (get config :attr {})
-        (when-not (and built-in? (empty? result))
-          (ui/foldable
-           [:div.custom-query-title
-            [:span.title-text title]
-            [:span.opacity-60.text-sm.ml-2.results-count
-             (str (count transformed-query-result) " results")]]
-           (fn []
-             [:div
-              (when current-block
-                [:div.flex.flex-row.align-items.mt-2 {:on-mouse-down (fn [e] (util/stop e))}
-                 (when-not page-list?
-                   [:div.flex.flex-row
-                    [:div.mx-2 [:span.text-sm "Table view"]]
-                    [:div {:style {:margin-top 5}}
-                     (ui/toggle table?
-                                (fn []
-                                  (editor-handler/set-block-property! current-block-uuid
-                                                                      "query-table"
-                                                                      (not table?)))
-                                true)]])
-
-                 [:a.mx-2.block.fade-link
-                  {:on-click (fn []
-                               (let [all-keys (query-table/get-keys result page-list?)]
-                                 (state/pub-event! [:modal/set-query-properties current-block all-keys])))}
-                  [:span.table-query-properties
-                   [:span.text-sm.mr-1 "Set properties"]
-                   svg/settings-sm]]])
-              (cond
-                (and (seq result) view-f)
-                (let [result (try
-                               (sci/call-fn view-f result)
-                               (catch js/Error error
-                                 (log/error :custom-view-failed {:error error
-                                                                 :result result})
-                                 [:div "Custom view failed: "
-                                  (str error)]))]
-                  (util/hiccup-keywordize result))
-
-                page-list?
-                (query-table/result-table config current-block result {:page? true} map-inline page-cp ->elem inline-text)
-
-                table?
-                (query-table/result-table config current-block result {:page? false} map-inline page-cp ->elem inline-text)
-
-                (and (seq result) (or only-blocks? blocks-grouped-by-page?))
-                (->hiccup result (cond-> (assoc config
-                                                :custom-query? true
-                                                :breadcrumb-show? (if (some? breadcrumb-show?)
-                                                                    breadcrumb-show?
-                                                                    true)
-                                                :group-by-page? blocks-grouped-by-page?
-                                                :ref? true)
-                                   children?
-                                   (assoc :ref? true))
-                          {:style {:margin-top "0.25rem"
-                                   :margin-left "0.25rem"}})
-
-                (seq result)
-                (let [result (->>
-                              (for [record result]
-                                (if (map? record)
-                                  (str (util/pp-str record) "\n")
-                                  record))
-                              (remove nil?))]
-                  [:pre result])
-
-                :else
-                [:div.text-sm.mt-2.ml-2.font-medium.opacity-50 "Empty"])])
-           {:default-collapsed? collapsed?
-            :title-trigger? true}))]))))
+   (ui/block-error "Query Error:" {:content (:query q)})
+   (custom-query* config q)))
 
 (defn admonition
   [config type result]

--- a/src/main/frontend/components/journal.cljs
+++ b/src/main/frontend/components/journal.cljs
@@ -83,7 +83,7 @@
        (page/today-queries repo today? false)
 
        (rum/with-key
-         (reference/references title false)
+         (reference/references title)
          (str title "-refs"))
 
        (when intro? (onboarding/intro))])))

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -149,7 +149,7 @@
          (for [query queries]
            (ui/catch-error
             (rum/with-key
-              (ui/block-error "Failed default query:" {:content (pr-str query)})
+              (ui/component-error "Failed default query:" {:content (pr-str query)})
               (str repo "-custom-query-" (:query query)))
             (rum/with-key
               (block/custom-query {:attr {:class "mt-10"}
@@ -382,7 +382,7 @@
        ;; referenced blocks
        [:div {:key "page-references"}
         (rum/with-key
-          (reference/references route-page-name false)
+          (reference/references route-page-name)
           (str route-page-name "-refs"))]
 
        (when-not block?

--- a/src/main/frontend/components/reference.cljs
+++ b/src/main/frontend/components/reference.cljs
@@ -66,14 +66,14 @@
          [page (map #(block-with-ref-level % 1) blocks)])
     page-blocks))
 
-(rum/defcs references < rum/reactive db-mixins/query
+(rum/defcs references* < rum/reactive db-mixins/query
   (rum/local nil ::n-ref)
   {:init (fn [state]
            (let [page-name (first (:rum/args state))
                  filters (when page-name
                            (atom (page-handler/get-filters (string/lower-case page-name))))]
              (assoc state ::filters filters)))}
-  [state page-name _marker?]
+  [state page-name]
   (when page-name
     (let [page-name (string/lower-case page-name)
           repo (state/get-current-repo)
@@ -166,6 +166,12 @@
 
              {:default-collapsed? default-collapsed?
               :title-trigger? true}))]]))))
+
+(rum/defc references
+  [page-name]
+  (ui/catch-error
+   (ui/component-error "Linked References: Unexpected error")
+   (references* page-name)))
 
 (rum/defcs unlinked-references-aux
   < rum/reactive db-mixins/query

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -722,7 +722,7 @@
     view))
 
 (rum/defc block-error
-  "Well styled error for blocks that error unexpectedly during render"
+  "Well styled error message for blocks"
   [title {:keys [content section-attrs]}]
   [:section.border.mt-1.p-1.cursor-pointer.block-content-fallback-ui
    section-attrs
@@ -731,7 +731,12 @@
     [:a.text-xs.opacity-50.hover:opacity-80
      {:href "https://github.com/logseq/logseq/issues"
       :target "_blank"} "report issue"]]
-   [:pre.m-0.text-sm content]])
+   (when content [:pre.m-0.text-sm content])])
+
+(def component-error
+  "Well styled error message for higher level components. Currently same as
+  block-error but this could change"
+  block-error)
 
 (rum/defc select
   [options on-change class]


### PR DESCRIPTION
In #4576, a user's screen went blank due to the references component failing in irreproducible way and then went on to experience secondary and tertiary errors that were strange. A failing references component now looks like:

<img width="914" alt="Screen Shot 2022-03-18 at 3 03 43 PM" src="https://user-images.githubusercontent.com/97210743/159078985-4912b6d1-aee6-4870-b94b-576dd0585dae.png">

This PR adds a `ui/catch-error` to at least give the user a degraded but graceful error. We should consider using more of these for at least the journals/home view so that small errors result in blank startup experiences.

This PR also introduced component-error and fixed `custom-query` not catching its error