### PR TITLE
fix: always trigger removing  file of separate git dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ strings.csv
 .calva
 resources/electron.js
 .clj-kondo/.cache
+.clj-kondo/babashka/sci
 .lsp/
 /libs/dist/
 charlie/

--- a/src/electron/electron/git.cljs
+++ b/src/electron/electron/git.cljs
@@ -51,7 +51,7 @@
           p (.join path graph-path ".git")]
       (when (and (fs/existsSync p)
                  (.isFile (fs/statSync p)))
-        (let [content (.toString (fs/readFileSync p))
+        (let [content (string/trim (.toString (fs/readFileSync p)))
               dir-path (string/replace content "gitdir: " "")]
           (when (and content
                      (string/starts-with? content "gitdir:")


### PR DESCRIPTION
Related to #4620, partially fixed (the `.git` file got removed every time)