### PR TITLE
Sort 'Pages tagged with' list alphabetically

### DIFF
--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -166,7 +166,7 @@
         (ui/foldable
          [:h2.font-bold.opacity-50 (util/format "Pages tagged with \"%s\"" tag)]
          [:ul.mt-2
-          (for [[original-name name] pages]
+          (for [[original-name name] (sort pages)]
             [:li {:key (str "tagged-page-" name)}
              [:a {:href (rfe/href :page {:name name})}
               original-name]])]


### PR DESCRIPTION
This minimal change sorts the 'Pages tagged with' list on each tag page alphabetically. 