### PR TITLE
fix: detect the first block in a page

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -795,12 +795,12 @@
   ([blocks]
    (let [blocks (doall
                  (map
-                   (fn [block]
-                     (when-let [id (gobj/get block "id")]
-                       (when-let [block (gdom/getElement id)]
-                         (dom/add-class! block "selected noselect")
-                         block)))
-                   blocks))]
+                  (fn [block]
+                    (when-let [id (gobj/get block "id")]
+                      (when-let [block (gdom/getElement id)]
+                        (dom/add-class! block "selected noselect")
+                        block)))
+                  blocks))]
      (state/set-selection-blocks! blocks))))
 
 (defn- get-selected-blocks-with-children
@@ -816,10 +816,10 @@
   "The set-marker will set a new marker on the selected block.
   if the `new-marker` is nil, it will generate it automatically."
   ([block]
-    (set-marker block nil))
+   (set-marker block nil))
   ([{:block/keys [marker content format] :as block} new-marker]
-    (let [[new-content _] (marker/cycle-marker content marker new-marker format (state/get-preferred-workflow))]
-      (save-block-if-changed! block new-content))))
+   (let [[new-content _] (marker/cycle-marker content marker new-marker format (state/get-preferred-workflow))]
+     (save-block-if-changed! block new-content))))
 
 (defn cycle-todos!
   []
@@ -1062,7 +1062,7 @@
                    (let [block (db/entity [:block/uuid block-id])]
                      (when-not (:block/pre-block? block)
                        [block-id :id (str block-id)])))
-              block-ids)]
+                 block-ids)]
     (batch-set-block-property! col)))
 
 (defn copy-block-ref!
@@ -1159,7 +1159,7 @@
                                         (let [level (dom/attr % "level")]
                                           {:id (uuid id)
                                            :level (int level)}))
-                                  selected-blocks))
+                                     selected-blocks))
                       (remove nil?))
           first-block (first blocks)
           first-root-level-index (ffirst
@@ -1974,10 +1974,10 @@
       (js/clearTimeout @*auto-save-timeout))
     (mark-last-input-time! repo)
     (when-not
-        (and
-         (= (:db/id (:block/parent block))
-            (:db/id (:block/page block)))            ; don't auto-save for page's properties block
-         (get-in block [:block/properties :title]))
+     (and
+      (= (:db/id (:block/parent block))
+         (:db/id (:block/page block)))            ; don't auto-save for page's properties block
+      (get-in block [:block/properties :title]))
       (reset! *auto-save-timeout
               (js/setTimeout
                (fn []
@@ -2109,8 +2109,8 @@
                      :block/page (select-keys page [:db/id])
                      :block/format format
                      :block/properties (apply dissoc (:block/properties block)
-                                         (concat [:id :custom_id :custom-id]
-                                                 exclude-properties))
+                                              (concat [:id :custom_id :custom-id]
+                                                      exclude-properties))
                      :block/meta (dissoc (:block/meta block) :start-pos :end-pos)
                      :block/content new-content
                      :block/path-refs (->> (cons (:db/id page) (:block/path-refs block))
@@ -2734,17 +2734,14 @@
           (js/document.execCommand "copy"))
         (delete-and-update input selected-start selected-end))
 
-      ;; not the top block in a page
-      (and page
-           (let [left-id (:db/id (:block/left block))
-                 page-id (:db/id (:block/page block))]
-             (= left-id page-id)))
-      (util/stop e)
-
       (zero? current-pos)
       (do
         (util/stop e)
-        (delete-block! repo false))
+        (when-not (and page
+                       (let [left-id (:db/id (:block/left block))
+                             page-id (:db/id (:block/page block))]
+                         (= left-id page-id)))
+          (delete-block! repo false)))
 
       (and (> current-pos 1)
            (= (util/nth-safe value (dec current-pos)) (state/get-editor-command-trigger)))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2723,7 +2723,6 @@
         selected-start (util/get-selection-start input)
         selected-end (util/get-selection-end input)
         block (state/get-edit-block)
-        page (state/get-current-page)
         repo (state/get-current-repo)]
     (mark-last-input-time! repo)
     (cond
@@ -2737,10 +2736,11 @@
       (zero? current-pos)
       (do
         (util/stop e)
-        (when-not (and page
-                       (let [left-id (:db/id (:block/left block))
-                             page-id (:db/id (:block/page block))]
-                         (= left-id page-id)))
+        ;; not the top block in a page or journal
+        (when-not
+         (let [left-id (:db/id (:block/left block))
+               page-id (:db/id (:block/page block))]
+           (= left-id page-id))
           (delete-block! repo false)))
 
       (and (> current-pos 1)

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -58,7 +58,6 @@
 
 ;; FIXME: should support multiple images concurrently uploading
 
-
 (defonce *asset-uploading? (atom false))
 (defonce *asset-uploading-process (atom 0))
 (defonce *selected-text (atom nil))
@@ -182,7 +181,6 @@
               pos (or pos (diff/find-position markup range))]
           (cursor/move-cursor-to node pos)
           (state/set-state! :editor/pos nil))))))
-
 
 (defn highlight-block!
   [block-uuid]
@@ -1678,7 +1676,6 @@
    "+" "+"})
 ;; ":" ":"                              ; TODO: only properties editing and org mode tag
 
-
 (def reversed-autopair-map
   (zipmap (vals autopair-map)
           (keys autopair-map)))
@@ -2737,10 +2734,7 @@
       (do
         (util/stop e)
         ;; not the top block in a page or journal
-        (when-not
-         (let [left-id (:db/id (:block/left block))
-               page-id (:db/id (:block/page block))]
-           (= left-id page-id))
+        (when-not (= (:block/left block) (:block/page block))
           (delete-block! repo false)))
 
       (and (> current-pos 1)
@@ -3029,7 +3023,6 @@
                                      :code code
                                      :key k
                                      :shift? (.-shiftKey e)}))))))
-
 
 (defn editor-on-click!
   [id]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2722,7 +2722,7 @@
                      (util/nth-safe value (dec current-pos)))
         selected-start (util/get-selection-start input)
         selected-end (util/get-selection-end input)
-        block-id (:block/uuid (state/get-edit-block))
+        block (state/get-edit-block)
         page (state/get-current-page)
         repo (state/get-current-repo)]
     (mark-last-input-time! repo)
@@ -2734,11 +2734,14 @@
           (js/document.execCommand "copy"))
         (delete-and-update input selected-start selected-end))
 
-      (and (zero? current-pos)
-           ;; not the top block in a block page
-           (not (and page
-                     (util/uuid-string? page)
-                     (= (medley/uuid page) block-id))))
+      ;; not the top block in a page
+      (and page
+           (let [left-id (:db/id (:block/left block))
+                 page-id (:db/id (:block/page block))]
+             (= left-id page-id)))
+      (util/stop e)
+
+      (zero? current-pos)
       (do
         (util/stop e)
         (delete-block! repo false))


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

Resolve #4688.

The old implementation has a condition `(util/uuid-string? page)`, which will always return `nil` because `page` is the name of a page.

But I'm not sure if I need to change anything else, if so please let me know. 😃