### PR TITLE
chore: bump version 0.6.5

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "com.logseq.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 17
-        versionName "0.6.4"
+        versionCode 18
+        versionName "0.6.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/resources/package.json
+++ b/resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Logseq",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "main": "electron.js",
   "author": "Logseq",
   "license": "AGPL-3.0",

--- a/src/main/frontend/version.cljs
+++ b/src/main/frontend/version.cljs
@@ -1,3 +1,3 @@
 (ns frontend.version)
 
-(defonce version "0.6.4")
+(defonce version "0.6.5")


### PR DESCRIPTION
Prepare for 0.6.5 release. This will be a release focusing on bug fixes.

- [x] https://github.com/logseq/logseq/pull/4691
- [x] https://github.com/logseq/logseq/issues/4613