### PR TITLE
fix: auto save on editing properties

### DIFF
--- a/e2e-tests/page-rename.spec.ts
+++ b/e2e-tests/page-rename.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 import { test } from './fixtures'
-import { IsMac, createPage, newBlock, newInnerBlock, randomString, lastBlock } from './utils'
+import { IsMac, createPage, randomLowerString, newBlock, newInnerBlock, randomString, lastBlock } from './utils'
 
 /***
  * Test rename feature
@@ -35,4 +35,29 @@ async function page_rename_test(page, original_page_name: string, new_page_name:
 test('page rename test', async ({ page }) => {
   await page_rename_test(page, "abcd", "a.b.c.d")
   await page_rename_test(page, "abcd", "a/b/c/d")
+})
+
+// TODO introduce more samples when #4722 is fixed
+test('page title property test', async ({ page }) => {
+  // Edit Title Property and Double Enter (ETPDE)
+  // exit editing via insert new block
+  let rand = randomLowerString(10)
+  let original_name = "etpde old" + rand
+  let new_name = "etpde new" + rand
+  await createPage(page, original_name)
+   // add some spaces to test if it is trimmed
+  await page.type(':nth-match(textarea, 1)', 'title:: ' + new_name + "     ")
+  await page.press(':nth-match(textarea, 1)', 'Enter') // DWIM property mode creates new line
+  await page.press(':nth-match(textarea, 1)', 'Enter')
+  expect(await page.innerText('.page-title .title')).toBe(new_name)
+
+  // Edit Title Property and Esc (ETPE)
+  // exit editing via moving out focus
+  rand = randomLowerString(10)
+  original_name = "etpe old " + rand
+  new_name = "etpe new " + rand
+  await createPage(page, original_name)
+  await page.type(':nth-match(textarea, 1)', 'title:: ' + new_name)
+  await page.press(':nth-match(textarea, 1)', 'Escape')
+  expect(await page.innerText('.page-title .title')).toBe(new_name)
 })

--- a/e2e-tests/utils.ts
+++ b/e2e-tests/utils.ts
@@ -19,6 +19,18 @@ export function randomString(length: number) {
   return result;
 }
 
+export function randomLowerString(length: number) {
+  const characters = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+  let result = '';
+  const charactersLength = characters.length;
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+  }
+
+  return result;
+}
+
 export async function createRandomPage(page: Page) {
   const randomTitle = randomString(20)
 

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -453,6 +453,11 @@
      (when-let [block (d/entity db [:block/uuid block-id])]
        (:block/parent block)))))
 
+(defn top-block?
+  [block]
+  (= (:db/id (:block/parent block))
+     (:db/id (:block/page block))))
+
 ;; non recursive query
 (defn get-block-parents
   ([repo block-id]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -552,6 +552,7 @@
          :pos pos}))))
 
 (defn insert-new-block!
+  "Won't save previous block content - remember to save!"
   ([state]
    (insert-new-block! state nil))
   ([_state block-value]
@@ -1268,6 +1269,7 @@
      (save-block-aux! block value {}))))
 
 (defn save-current-block!
+  "skip-properties? if set true, when editing block is likely be properties, skip saving"
   ([]
    (save-current-block! {}))
   ([{:keys [force? skip-properties?] :as opts}]
@@ -2053,6 +2055,7 @@
                 "END"
                 (do
                   (cursor/move-cursor-to-end input)
+                  (save-current-block!)
                   (insert-new-block! state))
                 ;; cursor in other positions of :ke|y: or ke|y::, move to line end for inserting value.
                 (if (property/property-key-exist? format content property-key)
@@ -2289,7 +2292,8 @@
             :else
             (profile
              "Insert block"
-             (insert-new-block! state))))))))
+             (do (save-current-block!)
+                 (insert-new-block! state)))))))))
 
 (defn keydown-new-block-handler [state e]
   (if (state/doc-mode-enter-for-new-line?)

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1801,23 +1801,22 @@
 
 (defonce *auto-save-timeout (atom nil))
 (defn edit-box-on-change!
-  [e block id]
+  [e _block id]
   (let [value (util/evalue e)
         repo (state/get-current-repo)]
     (state/set-edit-content! id value false)
     (when @*auto-save-timeout
       (js/clearTimeout @*auto-save-timeout))
     (mark-last-input-time! repo)
-    (when-not (and (db-model/top-block? block)            ; don't auto-save for page's properties block
-                   (not-empty (:block/properties block)))
-      (reset! *auto-save-timeout
-              (js/setTimeout
-               (fn []
-                 (when (state/input-idle? repo)
-                   (state/set-editor-op! :auto-save)
-                   (save-current-block! {:skip-properties? true})
-                   (state/set-editor-op! nil)))
-               500)))))
+    (reset! *auto-save-timeout
+            (js/setTimeout
+             (fn []
+               (when (state/input-idle? repo)
+                 (state/set-editor-op! :auto-save)
+                 ; don't auto-save for page's properties block
+                 (save-current-block! {:skip-properties? true})
+                 (state/set-editor-op! nil)))
+             500))))
 
 (defn handle-last-input []
   (let [input           (state/get-input)

--- a/src/main/frontend/util/thingatpt.cljs
+++ b/src/main/frontend/util/thingatpt.cljs
@@ -63,9 +63,11 @@
   (when-let [macro (thing-at-point ["{{embed" "}}"] input)]
     (assoc macro :type "macro")))
 
+;; TODO support markdown YAML front matter
+;; TODO support using org style properties in markdown
 (defn properties-at-point [& [input]]
   (when-let [properties
-             (case (state/get-preferred-format)
+             (case (state/get-preferred-format) ;; TODO fix me to block's format
                :org (thing-at-point
                      [property-util/properties-start
                       property-util/properties-end]
@@ -75,10 +77,12 @@
                    line)))]
     (assoc properties :type "properties-drawer")))
 
+;; TODO support markdown YAML front matter
+;; TODO support using org style properties in markdown
 (defn property-key-at-point [& [input]]
   (when (properties-at-point input)
     (let [property
-          (case (state/get-preferred-format)
+          (case (state/get-preferred-format) ;; TODO fix me to block's format
             :org (thing-at-point ":" input "\n")
             (when-let [line (:raw-content (line-at-point input))]
               (let [key (first (string/split line "::"))
@@ -109,7 +113,7 @@
                :ordered (int? bullet))))))
 
 (defn- get-markup-at-point [& [input]]
-  (let [format (state/get-preferred-format)]
+  (let [format (state/get-preferred-format)] ;; TODO fix me to block's format
    (or (thing-at-point (config/get-hr format) input)
        (thing-at-point (config/get-bold format) input)
        (thing-at-point (config/get-italic format) input)


### PR DESCRIPTION
Fix https://github.com/logseq/logseq/issues/4695
- [x] Don't auto-save current block when property value is under editing (by calling `thingatpt/properties-at-point`)
- [x] Don't trigger auto-saving block when editing a page-property block (by checking (not-empty :block/properties))
- [x] Save block before `insert-new-block!` (via calling `save-current-block!`)
- [x] Add E2E test cases (and found #4722)

Known issue: doesn't support front-matter or using org style properties in markdown