### PR TITLE
fix(build): sourcemap in release

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -98,7 +98,7 @@ jobs:
           curl -sL https://sentry.io/get-cli/ | bash
           release_name="logseq-android@${{ steps.ref.outputs.version }}"
           sentry-cli releases new "${release_name}"
-          sentry-cli releases files "${release_name}" upload-sourcemaps --ext map ./static/js --url-prefix '~/static/js'
+          sentry-cli releases files "${release_name}" upload-sourcemaps --ext map --ext js ./static/js --url-prefix '~/static/js'
           sentry-cli releases finalize "${release_name}"
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/build-desktop-release.yml
+++ b/.github/workflows/build-desktop-release.yml
@@ -113,7 +113,7 @@ jobs:
           curl -sL https://sentry.io/get-cli/ | bash
           release_name="logseq@${{ steps.ref.outputs.version }}"
           sentry-cli releases new "${release_name}"
-          sentry-cli releases files "${release_name}" upload-sourcemaps --ext map ./static/js --url-prefix '~/static/js'
+          sentry-cli releases files "${release_name}" upload-sourcemaps --ext map --ext js ./static/js --url-prefix '~/static/js'
           sentry-cli releases finalize "${release_name}"
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/src/main/frontend/modules/instrumentation/sentry.cljs
+++ b/src/main/frontend/modules/instrumentation/sentry.cljs
@@ -24,7 +24,20 @@
    :integrations [(new posthog/SentryIntegration posthog "logseq" 5311485)
                   (new BrowserTracing)]
    :debug cfg/dev?
-   :tracesSampleRate 1.0})
+   :tracesSampleRate 1.0
+   :beforeSend (fn [^js event]
+                 (when-let [[_ _ query-and-fragment]
+                            (re-matches #"file://.*?/(app/electron|static/index)\.html(.*)" (.. event -request -url))]
+                   (set! (.. event -request -url) (str "http://localhost/electron.html" query-and-fragment)))
+                 (doseq [value (.. event -exception -values)]
+                   (doseq [frame (.. value -stacktrace -frames)]
+                     (when (not-empty (.. frame -filename))
+                       (when-let [[_ filename]
+                                  (re-matches #"file://.*?/app/(js/.*\.js)" (.. frame -filename))]
+                         (set! (.. frame -filename) (str "/static/" filename))
+                         ;; NOTE: No idea of why there's a 2-line offset.
+                         (set! (.. frame -lineno) (- (.. frame -lineno) 2))))))
+                 event)})
 
 (defn init []
   (let [config (clj->js config)]


### PR DESCRIPTION
Fix #4613

- hijack sentry report, hide path, replace with mock URL
- fix sourcemap lineno offset(no idea of why there's a 2-line offset)

to review: https://sentry.io/organizations/logseq/issues/3127186378/?project=5311485&query=release%3Alogseq%400.6.4-local+platform%3Aelectron&statsPeriod=14d