### PR TITLE
fix: renderer not rendering in page/block property properly

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -702,10 +702,12 @@
          (util/format "((%s))" id)]))))
 
 (defn inline-text
-  [format v]
-  (when (string? v)
-    (let [inline-list (mldoc/inline->edn v (mldoc/default-config format))]
-      [:div.inline.mr-1 (map-inline {} inline-list)])))
+  ([format v]
+   (inline-text {} format v))
+  ([config format v]
+   (when (string? v)
+     (let [inline-list (mldoc/inline->edn v (mldoc/default-config format))]
+       [:div.inline.mr-1 (map-inline config inline-list)]))))
 
 (defn- render-macro
   [config name arguments macro-content format]
@@ -1680,7 +1682,7 @@
        (util/unquote-string v)
 
        :else
-       (inline-text (:block/format block) (str v)))]))
+       (inline-text config (:block/format block) (str v)))]))
 
 (rum/defc properties-cp
   [config block]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1268,7 +1268,7 @@
             nil))
 
         (and plugin-handler/lsp-enabled? (= name "renderer"))
-        (when-let [block-uuid (str (:block/uuid config))]
+        (when-let [block-uuid (not-empty (str (:block/uuid config)))]
           (plugins/hook-ui-slot :macro-renderer-slotted (assoc options :uuid block-uuid)))
 
         (get @macro/macros name)

--- a/src/main/logseq/api.cljs
+++ b/src/main/logseq/api.cljs
@@ -20,7 +20,6 @@
             [frontend.handler.notification :as notification]
             [frontend.handler.page :as page-handler]
             [frontend.handler.plugin :as plugin-handler]
-            [frontend.handler.ui :as ui-handler]
             [frontend.modules.outliner.core :as outliner]
             [frontend.modules.outliner.tree :as outliner-tree]
             [frontend.handler.command-palette :as palette-handler]
@@ -641,7 +640,3 @@
         (get @state/state (keyword path))
         @state/state)
       (bean/->js)))
-
-(defn ^:export __re_render_root
-  []
-  (ui-handler/re-render-root!))

--- a/src/main/logseq/api.cljs
+++ b/src/main/logseq/api.cljs
@@ -20,6 +20,7 @@
             [frontend.handler.notification :as notification]
             [frontend.handler.page :as page-handler]
             [frontend.handler.plugin :as plugin-handler]
+            [frontend.handler.ui :as ui-handler]
             [frontend.modules.outliner.core :as outliner]
             [frontend.modules.outliner.tree :as outliner-tree]
             [frontend.handler.command-palette :as palette-handler]
@@ -640,3 +641,7 @@
         (get @state/state (keyword path))
         @state/state)
       (bean/->js)))
+
+(defn ^:export __re_render_root
+  []
+  (ui-handler/re-render-root!))


### PR DESCRIPTION
Should also pass in the `config`, which contains block/uuid context.

## Bug description
When rendering plugin-provided content (`{{renderer xxx}}` macros) via `onMacroRendererSlotted` API, there will be the arguments and the current blocks' `uuid` . i.e., the following is the type.

```ts
    onMacroRendererSlotted: IUserSlotHook<{
        payload: {
            arguments: Array<string>;
            uuid: string;
            [key: string]: any;
        };
    }>;
```

Internally, the `onMacroRendererSlotted` hook will register a render callback to let the core get the custom content provided by plugins. Reference: https://github.com/logseq/logseq/blob/1987d7dc79dcb78453cfcd49b1f9d8c7b3656001/src/main/frontend/components/block.cljs#L1269-L1270

For renderer macros, they will be rendered with `inline-text` fn:
https://github.com/logseq/logseq/blob/1987d7dc79dcb78453cfcd49b1f9d8c7b3656001/src/main/frontend/components/block.cljs#L2698-L2714

However, in the `inline-text` case, there is no block context provided. Thus the plugin could not know the `uuid` of the current rendering block.

---
As a result, https://github.com/pengx17/logseq-plugin-todo-master could not be rendered properly in block-properties because it does not know the UUID. 

e.g., 
<img width="689" alt="image" src="https://user-images.githubusercontent.com/584378/160087252-6264d84d-78b4-4321-a7ab-90b2b3c697f5.png">

will be rendered as
<img width="165" alt="image" src="https://user-images.githubusercontent.com/584378/160087400-6f7cc674-d768-47a9-90a3-0bcb461c617b.png">

After the fix, it will be rendered as
<img width="392" alt="image" src="https://user-images.githubusercontent.com/584378/160089834-e0374ff9-87a5-4756-81d6-0b7c58a8c482.png">
