### PR TITLE
fix(build): deps for macos arm64 build

### DIFF
--- a/.github/workflows/build-desktop-release.yml
+++ b/.github/workflows/build-desktop-release.yml
@@ -343,8 +343,12 @@ jobs:
       #       **/node_modules
       #     key: ${{ runner.os }}-node-modules
 
+      - name: Fetch deps and fix dugit arch for arm64
+        run: yarn install --ignore-platform && cd node_modules/dugite && npm_config_arch=arm64 node script/download-git.js
+        working-directory: ./static
+
       - name: Build/Release Electron App for arm64
-        run: npx cross-env npm_config_arch=arm64 yarn install && yarn electron:make-macos-arm64
+        run: yarn electron:make-macos-arm64
         working-directory: ./static
         env:
           APPLE_ID: ${{ secrets.APPLE_ID_EMAIL }}


### PR DESCRIPTION
`npm_config_arch=arm64` also afffects electron-forge. so dugite should be fixed additionally.

`--ignore-platform` is added to allow future development on node napi.