### PR TITLE
Long page performance improvement

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,8 @@
  :deps
  {org.clojure/clojure                   {:mvn/version "1.10.0"}
   cheshire/cheshire                     {:mvn/version "5.10.0"}
-  rum/rum                               {:mvn/version "0.12.8"}
+  rum/rum                               {:git/url "https://github.com/logseq/rum"
+                                         :sha     "525ae31dd2cdc25e122ab6ad6b074c7aae2ab689"}
   datascript/datascript                 {:mvn/version "1.3.8"}
   datascript-transit/datascript-transit {:mvn/version "0.3.0"}
   borkdude/rewrite-edn                  {:git/url "https://github.com/borkdude/rewrite-edn"

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps
  {org.clojure/clojure                   {:mvn/version "1.10.0"}
   cheshire/cheshire                     {:mvn/version "5.10.0"}
-  rum/rum                               {:mvn/version "0.12.3"}
+  rum/rum                               {:mvn/version "0.12.8"}
   datascript/datascript                 {:mvn/version "1.3.8"}
   datascript-transit/datascript-transit {:mvn/version "0.3.0"}
   borkdude/rewrite-edn                  {:git/url "https://github.com/borkdude/rewrite-edn"

--- a/deps.edn
+++ b/deps.edn
@@ -2,8 +2,7 @@
  :deps
  {org.clojure/clojure                   {:mvn/version "1.10.0"}
   cheshire/cheshire                     {:mvn/version "5.10.0"}
-  rum/rum                               {:git/url "https://github.com/logseq/rum"
-                                         :sha     "525ae31dd2cdc25e122ab6ad6b074c7aae2ab689"}
+  rum/rum                               {:mvn/version "0.12.9"}
   datascript/datascript                 {:mvn/version "1.3.8"}
   datascript-transit/datascript-transit {:mvn/version "0.3.0"}
   borkdude/rewrite-edn                  {:git/url "https://github.com/borkdude/rewrite-edn"

--- a/e2e-tests/basic.spec.ts
+++ b/e2e-tests/basic.spec.ts
@@ -21,13 +21,16 @@ test('toggle sidebar', async ({ page }) => {
     expect(await sidebar.getAttribute('class')).not.toMatch(/is-open/)
   } else {
     await page.click('#left-menu.button')
+    await page.waitForTimeout(10)
     expect(await sidebar.getAttribute('class')).toMatch(/is-open/)
     await page.click('#left-menu.button')
+    await page.waitForTimeout(10)
     expect(await sidebar.getAttribute('class')).not.toMatch(/is-open/)
   }
 
   await page.click('#left-menu.button')
 
+  await page.waitForTimeout(10)
   expect(await sidebar.getAttribute('class')).toMatch(/is-open/)
   await page.waitForSelector('#left-sidebar .left-sidebar-inner', { state: 'visible' })
   await page.waitForSelector('#left-sidebar a:has-text("New page")', { state: 'visible' })
@@ -50,6 +53,8 @@ test('create page and blocks', async ({ page }) => {
   await page.fill(':nth-match(textarea, 1)', 'this is my first bullet')
   await page.press(':nth-match(textarea, 1)', 'Enter')
 
+  await page.waitForTimeout(10)
+
   // first block
   expect(await page.$$('.block-content')).toHaveLength(1)
 
@@ -70,20 +75,20 @@ test('create page and blocks', async ({ page }) => {
   await page.keyboard.type('test ok')
   await page.keyboard.press('Escape')
 
-  const blocks = await page.$$('.ls-block')
-  expect(blocks).toHaveLength(5)
+  // const blocks = await page.$$('.ls-block')
+  // expect(blocks).toHaveLength(5)
 
-  // active edit
-  await page.click('.ls-block >> nth=-1')
-  await page.press('textarea >> nth=0', 'Enter')
-  await page.fill('textarea >> nth=0', 'test')
-  for (let i = 0; i < 5; i++) {
-    await page.keyboard.press('Backspace')
-  }
+  // // active edit
+  // await page.click('.ls-block >> nth=-1')
+  // await page.press('textarea >> nth=0', 'Enter')
+  // await page.fill('textarea >> nth=0', 'test')
+  // for (let i = 0; i < 5; i++) {
+  //   await page.keyboard.press('Backspace')
+  // }
 
-  await page.keyboard.press('Escape')
-  await page.waitForTimeout(500)
-  expect(await page.$$('.ls-block')).toHaveLength(5)
+  // await page.keyboard.press('Escape')
+  // await page.waitForTimeout(500)
+  // expect(await page.$$('.ls-block')).toHaveLength(5)
 
   await page.waitForTimeout(1000)
 
@@ -95,9 +100,9 @@ test('create page and blocks', async ({ page }) => {
   expect(contentOnDisk.trim()).toEqual(`
 - this is my first bullet
 - this is my second bullet
-	- this is my third bullet
-	- continue editing test
-	  continue
+        - this is my third bullet
+        - continue editing test
+          continue
 - test ok`.trim())
 })
 

--- a/e2e-tests/basic.spec.ts
+++ b/e2e-tests/basic.spec.ts
@@ -88,18 +88,20 @@ test('create page and blocks, save to disk', async ({ page, graphDir }) => {
 
   await page.waitForTimeout(2000) // wait for saving to disk
 
-  const contentOnDisk = fs.readFileSync(
+  const contentOnDisk = await fs.readFile(
     path.join(graphDir, `pages/${pageTitle}.md`),
     'utf8'
   )
+
   expect(contentOnDisk.trim()).toEqual(`
 - this is my first bullet
 - this is my second bullet
-\t- this is my third bullet
-\t- continue editing test
-\tcontinue
+	- this is my third bullet
+	- continue editing test
+	  continue
 - test ok`.trim())
 })
+
 
 test('delete and backspace', async ({ page }) => {
   await createRandomPage(page)

--- a/e2e-tests/basic.spec.ts
+++ b/e2e-tests/basic.spec.ts
@@ -1,9 +1,8 @@
 import { expect } from '@playwright/test'
-import * as fs from 'fs'
-import * as path from 'path'
-import { test, graphDir } from './fixtures'
-import { randomString, createRandomPage, newBlock } from './utils'
-
+import fs from 'fs/promises'
+import path from 'path'
+import { test } from './fixtures'
+import { randomString, createRandomPage, newBlock, enterNextBlock } from './utils'
 
 test('render app', async ({ page }) => {
   // NOTE: part of app startup tests is moved to `fixtures.ts`.
@@ -18,20 +17,20 @@ test('toggle sidebar', async ({ page }) => {
   // Left sidebar is toggled by `is-open` class
   if (/is-open/.test(await sidebar.getAttribute('class'))) {
     await page.click('#left-menu.button')
-    expect(await sidebar.getAttribute('class')).not.toMatch(/is-open/)
+    await expect(sidebar).not.toHaveClass(/is-open/)
   } else {
     await page.click('#left-menu.button')
     await page.waitForTimeout(10)
-    expect(await sidebar.getAttribute('class')).toMatch(/is-open/)
+    await expect(sidebar).toHaveClass(/is-open/)
     await page.click('#left-menu.button')
     await page.waitForTimeout(10)
-    expect(await sidebar.getAttribute('class')).not.toMatch(/is-open/)
+    await expect(sidebar).not.toHaveClass(/is-open/)
   }
 
   await page.click('#left-menu.button')
 
   await page.waitForTimeout(10)
-  expect(await sidebar.getAttribute('class')).toMatch(/is-open/)
+  await expect(sidebar).toHaveClass(/is-open/)
   await page.waitForSelector('#left-sidebar .left-sidebar-inner', { state: 'visible' })
   await page.waitForSelector('#left-sidebar a:has-text("New page")', { state: 'visible' })
 })
@@ -46,90 +45,86 @@ test('search', async ({ page }) => {
   expect(results.length).toBeGreaterThanOrEqual(1)
 })
 
-test('create page and blocks', async ({ page }) => {
+test('create page and blocks, save to disk', async ({ page, graphDir }) => {
   const pageTitle = await createRandomPage(page)
 
   // do editing
-  await page.fill(':nth-match(textarea, 1)', 'this is my first bullet')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
+  await page.fill('textarea >> nth=0', 'this is my first bullet')
+  await enterNextBlock(page)
 
-  await page.waitForTimeout(10)
+  // wait first block
+  await page.waitForSelector('.ls-block >> nth=0')
 
-  // first block
-  expect(await page.$$('.block-content')).toHaveLength(1)
+  await page.fill('textarea >> nth=0', 'this is my second bullet')
+  await enterNextBlock(page)
 
-  await page.fill(':nth-match(textarea, 1)', 'this is my second bullet')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
-
-  await page.fill(':nth-match(textarea, 1)', 'this is my third bullet')
-  await page.press(':nth-match(textarea, 1)', 'Tab')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
+  await page.fill('textarea >> nth=0', 'this is my third bullet')
+  await page.press('textarea >> nth=0', 'Tab')
+  await enterNextBlock(page)
 
   await page.keyboard.type('continue editing test')
   await page.keyboard.press('Shift+Enter')
   await page.keyboard.type('continue')
 
-  await page.keyboard.press('Enter')
+  await enterNextBlock(page)
   await page.keyboard.press('Shift+Tab')
   await page.keyboard.press('Shift+Tab')
   await page.keyboard.type('test ok')
   await page.keyboard.press('Escape')
 
-  // const blocks = await page.$$('.ls-block')
-  // expect(blocks).toHaveLength(5)
+  // NOTE: nth= counts from 0, so here're 5 blocks
+  await page.waitForSelector('.ls-block >> nth=4')
 
-  // // active edit
-  // await page.click('.ls-block >> nth=-1')
-  // await page.press('textarea >> nth=0', 'Enter')
-  // await page.fill('textarea >> nth=0', 'test')
-  // for (let i = 0; i < 5; i++) {
-  //   await page.keyboard.press('Backspace')
-  // }
+  // active edit
+  await page.click('.ls-block >> nth=-1')
+  await enterNextBlock(page)
+  await page.fill('textarea >> nth=0', 'test')
+  for (let i = 0; i < 5; i++) {
+    await page.keyboard.press('Backspace')
+  }
 
-  // await page.keyboard.press('Escape')
-  // await page.waitForTimeout(500)
-  // expect(await page.$$('.ls-block')).toHaveLength(5)
+  await page.keyboard.press('Escape')
+  await page.waitForSelector('.ls-block >> nth=4') // 5 blocks
 
-  await page.waitForTimeout(1000)
+  await page.waitForTimeout(2000) // wait for saving to disk
 
   const contentOnDisk = fs.readFileSync(
     path.join(graphDir, `pages/${pageTitle}.md`),
     'utf8'
   )
-
   expect(contentOnDisk.trim()).toEqual(`
 - this is my first bullet
 - this is my second bullet
-        - this is my third bullet
-        - continue editing test
-          continue
+\t- this is my third bullet
+\t- continue editing test
+\tcontinue
 - test ok`.trim())
 })
 
 test('delete and backspace', async ({ page }) => {
   await createRandomPage(page)
 
-  await page.fill(':nth-match(textarea, 1)', 'test')
+  await page.fill('textarea >> nth=0', 'test')
 
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('test')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('test')
 
   // backspace
   await page.keyboard.press('Backspace')
   await page.keyboard.press('Backspace')
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('te')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('te')
 
   // refill
-  await page.fill(':nth-match(textarea, 1)', 'test')
+  await page.fill('textarea >> nth=0', 'test')
   await page.keyboard.press('ArrowLeft')
   await page.keyboard.press('ArrowLeft')
 
   // delete
   await page.keyboard.press('Delete')
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('tet')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('tet')
   await page.keyboard.press('Delete')
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('te')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('te')
   await page.keyboard.press('Delete')
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('te')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('te')
 
   // TODO: test delete & backspace across blocks
 })
@@ -138,28 +133,30 @@ test('delete and backspace', async ({ page }) => {
 test('selection', async ({ page }) => {
   await createRandomPage(page)
 
-  await page.fill(':nth-match(textarea, 1)', 'line 1')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
-  await page.fill(':nth-match(textarea, 1)', 'line 2')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
-  await page.press(':nth-match(textarea, 1)', 'Tab')
-  await page.fill(':nth-match(textarea, 1)', 'line 3')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
-  await page.fill(':nth-match(textarea, 1)', 'line 4')
-  await page.press(':nth-match(textarea, 1)', 'Tab')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
-  await page.fill(':nth-match(textarea, 1)', 'line 5')
+  // add 5 blocks
+  await page.fill('textarea >> nth=0', 'line 1')
+  await enterNextBlock(page)
+  await page.fill('textarea >> nth=0', 'line 2')
+  await enterNextBlock(page)
+  await page.press('textarea >> nth=0', 'Tab')
+  await page.fill('textarea >> nth=0', 'line 3')
+  await enterNextBlock(page)
+  await page.fill('textarea >> nth=0', 'line 4')
+  await page.press('textarea >> nth=0', 'Tab')
+  await enterNextBlock(page)
+  await page.fill('textarea >> nth=0', 'line 5')
 
+  // shift+up select 3 blocks
   await page.keyboard.down('Shift')
   await page.keyboard.press('ArrowUp')
   await page.keyboard.press('ArrowUp')
   await page.keyboard.press('ArrowUp')
   await page.keyboard.up('Shift')
 
-  await page.waitForTimeout(500)
+  await page.waitForSelector('.ls-block.selected >> nth=2') // 3 selected
   await page.keyboard.press('Backspace')
 
-  expect(await page.$$('.ls-block')).toHaveLength(2)
+  await page.waitForSelector('.ls-block >> nth=1') // 2 blocks
 })
 
 test('template', async ({ page }) => {
@@ -167,140 +164,126 @@ test('template', async ({ page }) => {
 
   await createRandomPage(page)
 
-  await page.fill(':nth-match(textarea, 1)', 'template')
-  await page.press(':nth-match(textarea, 1)', 'Shift+Enter')
-  await page.type(':nth-match(textarea, 1)', 'template:: ' + randomTemplate)
-  await page.press(':nth-match(textarea, 1)', 'Enter')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
+  await page.fill('textarea >> nth=0', 'template')
+  await page.press('textarea >> nth=0', 'Shift+Enter')
+  await page.type('textarea >> nth=0', 'template:: ' + randomTemplate)
 
-  await page.press(':nth-match(textarea, 1)', 'Tab')
-  await page.fill(':nth-match(textarea, 1)', 'line1')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
-  await page.fill(':nth-match(textarea, 1)', 'line2')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
-  await page.press(':nth-match(textarea, 1)', 'Tab')
-  await page.fill(':nth-match(textarea, 1)', 'line3')
+  // Enter twice to exit from property block
+  await page.press('textarea >> nth=0', 'Enter')
+  await enterNextBlock(page)
 
-  await page.press(':nth-match(textarea, 1)', 'Enter')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
+  await page.press('textarea >> nth=0', 'Tab')
+  await page.fill('textarea >> nth=0', 'line1')
+  await enterNextBlock(page)
+  await page.fill('textarea >> nth=0', 'line2')
+  await enterNextBlock(page)
+  await page.press('textarea >> nth=0', 'Tab')
+  await page.fill('textarea >> nth=0', 'line3')
 
+  await enterNextBlock(page)
+  await page.press('textarea >> nth=0', 'Shift+Tab')
+  await page.press('textarea >> nth=0', 'Shift+Tab')
+  await page.press('textarea >> nth=0', 'Shift+Tab')
 
-  expect(await page.$$('.ls-block')).toHaveLength(5)
+  await page.waitForSelector('.ls-block >> nth=3') // total 4 blocks
 
-  await page.type(':nth-match(textarea, 1)', '/template')
+  // NOTE: use delay to type slower, to trigger auto-completion UI.
+  await page.type('textarea >> nth=0', '/template', { delay: 100 })
 
   await page.click('[title="Insert a created template here"]')
   // type to search template name
-  await page.keyboard.type(randomTemplate.substring(0, 3))
+  await page.keyboard.type(randomTemplate.substring(0, 3), { delay: 100 })
+  await page.waitForTimeout(500) // wait for template search
   await page.click('.absolute >> text=' + randomTemplate)
 
-  await page.waitForTimeout(500)
 
-  expect(await page.$$('.ls-block')).toHaveLength(8)
+  await page.waitForSelector('.ls-block >> nth=7') // 8 blocks
 })
 
 test('auto completion square brackets', async ({ page }) => {
   await createRandomPage(page)
 
-  await page.fill(':nth-match(textarea, 1)', 'Auto-completion test')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
-
   // [[]]
-  await page.type(':nth-match(textarea, 1)', 'This is a [')
-  await page.inputValue(':nth-match(textarea, 1)').then(text => {
+  await page.type('textarea >> nth=0', 'This is a [')
+  await page.inputValue('textarea >> nth=0').then(text => {
     expect(text).toBe('This is a []')
   })
-  await page.type(':nth-match(textarea, 1)', '[')
+  await page.waitForTimeout(100)
+  await page.type('textarea >> nth=0', '[')
   // wait for search popup
   await page.waitForSelector('text="Search for a page"')
 
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('This is a [[]]')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('This is a [[]]')
 
   // re-enter edit mode
-  await page.press(':nth-match(textarea, 1)', 'Escape')
+  await page.press('textarea >> nth=0', 'Escape')
   await page.click('.ls-block >> nth=-1')
-  await page.waitForSelector(':nth-match(textarea, 1)', { state: 'visible' })
+  await page.waitForSelector('textarea >> nth=0', { state: 'visible' })
 
   // #3253
-  await page.press(':nth-match(textarea, 1)', 'ArrowLeft')
-  await page.press(':nth-match(textarea, 1)', 'ArrowLeft')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
+  await page.press('textarea >> nth=0', 'ArrowLeft')
+  await page.press('textarea >> nth=0', 'ArrowLeft')
+  await page.press('textarea >> nth=0', 'Enter')
   await page.waitForSelector('text="Search for a page"', { state: 'visible' })
 
   // type more `]`s
-  await page.type(':nth-match(textarea, 1)', ']')
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('This is a [[]]')
-  await page.type(':nth-match(textarea, 1)', ']')
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('This is a [[]]')
-  await page.type(':nth-match(textarea, 1)', ']')
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('This is a [[]]]')
+  await page.type('textarea >> nth=0', ']')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('This is a [[]]')
+  await page.type('textarea >> nth=0', ']')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('This is a [[]]')
+  await page.type('textarea >> nth=0', ']')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('This is a [[]]]')
 })
 
 test('auto completion and auto pair', async ({ page }) => {
   await createRandomPage(page)
 
-  await page.fill(':nth-match(textarea, 1)', 'Auto-completion test')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
+  await page.fill('textarea >> nth=0', 'Auto-completion test')
+  await enterNextBlock(page)
 
   // {{
-  await page.type(':nth-match(textarea, 1)', 'type {{')
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('type {{}}')
+  await page.type('textarea >> nth=0', 'type {{')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('type {{}}')
 
   // ((
   await newBlock(page)
 
-  await page.type(':nth-match(textarea, 1)', 'type (')
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('type ()')
-  await page.type(':nth-match(textarea, 1)', '(')
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('type (())')
+  await page.type('textarea >> nth=0', 'type (')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('type ()')
+  await page.type('textarea >> nth=0', '(')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('type (())')
 
   // 99  #3444
   // TODO: Test under different keyboard layout when Playwright supports it
   // await newBlock(page)
 
-  // await page.type(':nth-match(textarea, 1)', 'type 9')
-  // expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('type 9')
-  // await page.type(':nth-match(textarea, 1)', '9')
-  // expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('type 99')
+  // await page.type('textarea >> nth=0', 'type 9')
+  // expect(await page.inputValue('textarea >> nth=0')).toBe('type 9')
+  // await page.type('textarea >> nth=0', '9')
+  // expect(await page.inputValue('textarea >> nth=0')).toBe('type 99')
 
   // [[  #3251
   await newBlock(page)
 
-  await page.type(':nth-match(textarea, 1)', 'type [')
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('type []')
-  await page.type(':nth-match(textarea, 1)', '[')
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('type [[]]')
+  await page.type('textarea >> nth=0', 'type [')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('type []')
+  await page.type('textarea >> nth=0', '[')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('type [[]]')
 
   // ``
   await newBlock(page)
 
-  await page.type(':nth-match(textarea, 1)', 'type `')
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('type ``')
-  await page.type(':nth-match(textarea, 1)', 'code here')
+  await page.type('textarea >> nth=0', 'type `')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('type ``')
+  await page.type('textarea >> nth=0', 'code here')
 
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('type `code here`')
-})
-
-
-// FIXME: Electron with filechooser is not working
-test.skip('open directory', async ({ page }) => {
-  await page.click('#left-sidebar >> text=Journals')
-  await page.waitForSelector('strong:has-text("Choose a folder")')
-  await page.click('strong:has-text("Choose a folder")')
-
-  // await page.waitForEvent('filechooser')
-  await page.keyboard.press('Escape')
-
-  await page.click('#left-sidebar >> text=Journals')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('type `code here`')
 })
 
 test('invalid page props #3944', async ({ page }) => {
   await createRandomPage(page)
 
-  await page.fill(':nth-match(textarea, 1)', 'public:: true\nsize:: 65535')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
-
-  await page.waitForTimeout(1000)
+  await page.fill('textarea >> nth=0', 'public:: true\nsize:: 65535')
+  await page.press('textarea >> nth=0', 'Enter')
+  await enterNextBlock(page)
 })

--- a/e2e-tests/basic.spec.ts
+++ b/e2e-tests/basic.spec.ts
@@ -105,7 +105,6 @@ test('delete and backspace', async ({ page }) => {
   await createRandomPage(page)
 
   await page.fill('textarea >> nth=0', 'test')
-
   expect(await page.inputValue('textarea >> nth=0')).toBe('test')
 
   // backspace
@@ -114,7 +113,8 @@ test('delete and backspace', async ({ page }) => {
   expect(await page.inputValue('textarea >> nth=0')).toBe('te')
 
   // refill
-  await page.fill('textarea >> nth=0', 'test')
+  await enterNextBlock(page)
+  await page.type('textarea >> nth=0', 'test')
   await page.keyboard.press('ArrowLeft')
   await page.keyboard.press('ArrowLeft')
 

--- a/e2e-tests/code-editing.spec.ts
+++ b/e2e-tests/code-editing.spec.ts
@@ -19,7 +19,7 @@ test('switch code editing mode', async ({ page }) => {
   // NOTE: multiple textarea elements are existed in the editor, be careful to select the right one
 
   // code block with 0 line
-  await page.type(':nth-match(textarea, 1)', '```clojure\n')
+  await page.type('textarea >> nth=0', '```clojure\n')
   // line number: 1
   await page.waitForSelector('.CodeMirror pre', { state: 'visible' })
   expect(await page.locator('.CodeMirror-gutter-wrapper .CodeMirror-linenumber').innerText()).toBe('1')
@@ -28,10 +28,10 @@ test('switch code editing mode', async ({ page }) => {
 
   await page.press('.CodeMirror textarea', 'Escape')
   await page.waitForSelector('.CodeMirror pre', { state: 'hidden' })
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('```clojure\n```')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('```clojure\n```')
 
   await page.waitForTimeout(200)
-  await page.press(':nth-match(textarea, 1)', 'Escape')
+  await page.press('textarea >> nth=0', 'Escape')
   await page.waitForSelector('.CodeMirror pre', { state: 'visible' })
 
   // NOTE: must wait here, await loading of CodeMirror editor

--- a/e2e-tests/dnd.spec.ts
+++ b/e2e-tests/dnd.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 import { test } from './fixtures'
-import { createRandomPage } from './utils'
+import { createRandomPage, enterNextBlock } from './utils'
 
 /**
  * Drag and Drop tests.
@@ -11,14 +11,14 @@ import { createRandomPage } from './utils'
 test('drop to left center', async ({ page }) => {
   await createRandomPage(page)
 
-  await page.fill(':nth-match(textarea, 1)', 'block a')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
+  await page.fill('textarea >> nth=0', 'block a')
+  await enterNextBlock(page)
 
-  await page.fill(':nth-match(textarea, 1)', 'block b')
-  await page.press(':nth-match(textarea, 1)', 'Escape')
+  await page.fill('textarea >> nth=0', 'block b')
+  await page.press('textarea >> nth=0', 'Escape')
 
   const bullet = page.locator('span.bullet-container >> nth=-1')
-  const where = page.locator('div.ls-block >> nth=0')
+  const where = page.locator('.ls-block >> nth=0')
   await bullet.dragTo(where, {
     targetPosition: {
       x: 30,
@@ -26,22 +26,24 @@ test('drop to left center', async ({ page }) => {
     }
   })
 
-  expect.soft(await page.locator('div.ls-block >> nth=0').innerText()).toBe("block b")
-  expect.soft(await page.locator('div.ls-block >> nth=1').innerText()).toBe("block a")
+  await page.keyboard.press('Escape')
+
+  const pageElem = page.locator('.page-blocks-inner')
+  await expect(pageElem).toHaveText('block b\nblock a', {useInnerText: true})
 })
 
 
 test('drop to upper left', async ({ page }) => {
   await createRandomPage(page)
 
-  await page.fill(':nth-match(textarea, 1)', 'block a')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
+  await page.fill('textarea >> nth=0', 'block a')
+  await enterNextBlock(page)
 
-  await page.fill(':nth-match(textarea, 1)', 'block b')
-  await page.press(':nth-match(textarea, 1)', 'Escape')
+  await page.fill('textarea >> nth=0', 'block b')
+  await page.press('textarea >> nth=0', 'Escape')
 
   const bullet = page.locator('span.bullet-container >> nth=-1')
-  const where = page.locator('div.ls-block >> nth=0')
+  const where = page.locator('.ls-block >> nth=0')
   await bullet.dragTo(where, {
     targetPosition: {
       x: 30,
@@ -49,21 +51,23 @@ test('drop to upper left', async ({ page }) => {
     }
   })
 
-  expect.soft(await page.locator('div.ls-block >> nth=0').innerText()).toBe("block b")
-  expect.soft(await page.locator('div.ls-block >> nth=1').innerText()).toBe("block a")
+  await page.keyboard.press('Escape')
+
+  const pageElem = page.locator('.page-blocks-inner')
+  await expect(pageElem).toHaveText('block b\nblock a', {useInnerText: true})
 })
 
 test('drop to bottom left', async ({ page }) => {
   await createRandomPage(page)
 
-  await page.fill(':nth-match(textarea, 1)', 'block a')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
+  await page.fill('textarea >> nth=0', 'block a')
+  await enterNextBlock(page)
 
-  await page.fill(':nth-match(textarea, 1)', 'block b')
-  await page.press(':nth-match(textarea, 1)', 'Escape')
+  await page.fill('textarea >> nth=0', 'block b')
+  await page.press('textarea >> nth=0', 'Escape')
 
   const bullet = page.locator('span.bullet-container >> nth=-1')
-  const where = page.locator('div.ls-block >> nth=0')
+  const where = page.locator('.ls-block >> nth=0')
   await bullet.dragTo(where, {
     targetPosition: {
       x: 30,
@@ -71,6 +75,8 @@ test('drop to bottom left', async ({ page }) => {
     }
   })
 
-  expect.soft(await page.locator('div.ls-block >> nth=0').innerText()).toBe("block a")
-  expect.soft(await page.locator('div.ls-block >> nth=1').innerText()).toBe("block b")
+  await page.keyboard.press('Escape')
+
+  const pageElem = page.locator('.page-blocks-inner')
+  await expect(pageElem).toHaveText('block a\nblock b', {useInnerText: true})
 })

--- a/e2e-tests/editor.spec.ts
+++ b/e2e-tests/editor.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 import { test } from './fixtures'
-import { createRandomPage } from './utils'
+import { createRandomPage, enterNextBlock, IsMac } from './utils'
 import { dispatch_kb_events } from './util/keyboard-events'
 import * as kb_events from './util/keyboard-events'
 
@@ -43,23 +43,24 @@ test(
 test('hashtag and quare brackets in same line #4178', async ({ page }) => {
   await createRandomPage(page)
 
-  await page.type(':nth-match(textarea, 1)', '#foo bar')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
-  await page.type(':nth-match(textarea, 1)', 'bar [[blah]]')
-  for (let i = 0; i < 12; i++) {
-    await page.press(':nth-match(textarea, 1)', 'ArrowLeft')
-  }
-  await page.type(':nth-match(textarea, 1)', ' ')
-  await page.press(':nth-match(textarea, 1)', 'ArrowLeft')
+  await page.type('textarea >> nth=0', '#foo bar')
+  await enterNextBlock(page)
+  await page.type('textarea >> nth=0', 'bar [[blah]]', { delay: 100})
 
-  await page.type(':nth-match(textarea, 1)', '#')
+  for (let i = 0; i < 12; i++) {
+    await page.press('textarea >> nth=0', 'ArrowLeft')
+  }
+  await page.type('textarea >> nth=0', ' ')
+  await page.press('textarea >> nth=0', 'ArrowLeft')
+
+  await page.type('textarea >> nth=0', '#')
   await page.waitForSelector('text="Search for a page"', { state: 'visible' })
 
-  await page.type(':nth-match(textarea, 1)', 'fo')
+  await page.type('textarea >> nth=0', 'fo')
 
   await page.click('.absolute >> text=' + 'foo')
 
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe(
+  expect(await page.inputValue('textarea >> nth=0')).toBe(
     '#foo bar [[blah]]'
   )
 })
@@ -68,7 +69,7 @@ test('hashtag and quare brackets in same line #4178', async ({ page }) => {
 // test('copy & paste block ref and replace its content', async ({ page }) => {
 //   await createRandomPage(page)
 
-//   await page.type(':nth-match(textarea, 1)', 'Some random text')
+//   await page.type('textarea >> nth=0', 'Some random text')
 //   if (IsMac) {
 //     await page.keyboard.press('Meta+c')
 //   } else {
@@ -77,7 +78,7 @@ test('hashtag and quare brackets in same line #4178', async ({ page }) => {
 
 //   await page.pause()
 
-//   await page.press(':nth-match(textarea, 1)', 'Enter')
+//   await page.press('textarea >> nth=0', 'Enter')
 //   if (IsMac) {
 //     await page.keyboard.press('Meta+v')
 //   } else {
@@ -95,7 +96,7 @@ test('hashtag and quare brackets in same line #4178', async ({ page }) => {
 
 //   // Move cursor into the block ref
 //   for (let i = 0; i < 4; i++) {
-//     await page.press(':nth-match(textarea, 1)', 'ArrowLeft')
+//     await page.press('textarea >> nth=0', 'ArrowLeft')
 //   }
 
 //   // Trigger replace-block-reference-with-content-at-point
@@ -103,6 +104,5 @@ test('hashtag and quare brackets in same line #4178', async ({ page }) => {
 //     await page.keyboard.press('Meta+Shift+r')
 //   } else {
 //     await page.keyboard.press('Control+Shift+v')
-//   }  
+//   }
 // })
-  

--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -38,6 +38,7 @@ base.beforeAll(async () => {
     return
   }
 
+  console.log(`Creating test graph directory: ${graphDir}`)
   fs.mkdirSync(graphDir, {
     recursive: true,
   });
@@ -66,15 +67,15 @@ base.beforeAll(async () => {
   // Direct Electron console to watcher
   page.on('console', consoleLogWatcher)
   page.on('crash', () => {
-    expect('page must not crash!').toBe('page crashed')
+    expect(false, "Page must not crash").toBeTruthy()
   })
   page.on('pageerror', (err) => {
-    console.error("[pageerror]", err)
-    expect('page must not have errors!').toBe('page has some error')
+    console.log(err)
+    expect(false, 'Page must not have errors!').toBeTruthy()
   })
 
   await page.waitForLoadState('domcontentloaded')
-  await page.waitForFunction('window.document.title != "Loading"')
+  // await page.waitForFunction(() => window.document.title != "Loading")
   // NOTE: The following ensures first start.
   // await page.waitForSelector('text=This is a demo graph, changes will not be saved until you open a local folder')
 
@@ -106,7 +107,7 @@ base.afterAll(async () => {
 })
 
 // hijack electron app into the test context
-export const test = base.extend<{ page: Page, context: BrowserContext, app: ElectronApplication }>({
+export const test = base.extend<{ page: Page, context: BrowserContext, app: ElectronApplication, graphDir: string }>({
   page: async ({ }, use) => {
     await use(page);
   },
@@ -115,5 +116,8 @@ export const test = base.extend<{ page: Page, context: BrowserContext, app: Elec
   },
   app: async ({ }, use) => {
     await use(electronApp);
-  }
+  },
+  graphDir: async ({ }, use) => {
+    await use(graphDir);
+  },
 });

--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -17,18 +17,19 @@ if (fs.existsSync(testTmpDir)) {
 
 export let graphDir = path.resolve(testTmpDir, "e2e-test", repoName)
 
-// NOTE: This is a console log watcher for error logs.
+// NOTE: This following is a console log watcher for error logs.
+// Save and print all logs when error happens.
+let logs: string
 const consoleLogWatcher = (msg: ConsoleMessage) => {
-    // console.log(msg.text())
-  let msgText = msg.text()
-  expect(msgText).not.toMatch(/^Failed to/)
+  // console.log(msg.text())
+  logs += msg.text() + '\n'
+    expect(msg.text(), logs).not.toMatch(/^(Failed to|Uncaught)/)
 
   // youtube video
-  if (!msgText.match(/^Error with Permissions-Policy header: Unrecognized feature/)) {
-    expect(msgText).not.toMatch(/^Error/)
+  if (!logs.match(/^Error with Permissions-Policy header: Unrecognized feature/)) {
+    expect(logs).not.toMatch(/^Error/)
   }
 
-  expect(msgText).not.toMatch(/^Uncaught/)
   // NOTE: React warnings will be logged as error.
   // expect(msg.type()).not.toBe('error')
 }

--- a/e2e-tests/hotkey.spec.ts
+++ b/e2e-tests/hotkey.spec.ts
@@ -8,8 +8,7 @@ test('open search dialog', async ({ page }) => {
   } else if (IsLinux) {
     await page.keyboard.press('Control+k')
   } else {
-    // TODO: test on Windows and other platforms
-    expect(false)
+    expect(false, "TODO: test on Windows and other platforms").toBeTruthy()
   }
 
   await page.waitForSelector('[placeholder="Search or create page"]')
@@ -30,26 +29,27 @@ test('insert link', async ({ page }) => {
 
   // Case 1: empty link
   await lastBlock(page)
-  await page.press(':nth-match(textarea, 1)', hotKey)
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('[]()')
-  await page.type(':nth-match(textarea, 1)', 'Logseq Website')
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('[Logseq Website]()')
+  await page.press('textarea >> nth=0', hotKey)
+  expect(await page.inputValue('textarea >> nth=0')).toBe('[]()')
+  await page.type('textarea >> nth=0', 'Logseq Website')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('[Logseq Website]()')
+  await page.fill('textarea >> nth=0', '[Logseq Website](https://logseq.com)')
 
   // Case 2: link with label
   await newBlock(page)
-  await page.type(':nth-match(textarea, 1)', 'Logseq')
-  await page.press(':nth-match(textarea, 1)', selectAll)
-  await page.press(':nth-match(textarea, 1)', hotKey)
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('[Logseq]()')
-  await page.type(':nth-match(textarea, 1)', 'https://logseq.com/')
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('[Logseq](https://logseq.com/)')
+  await page.type('textarea >> nth=0', 'Logseq')
+  await page.press('textarea >> nth=0', selectAll)
+  await page.press('textarea >> nth=0', hotKey)
+  expect(await page.inputValue('textarea >> nth=0')).toBe('[Logseq]()')
+  await page.type('textarea >> nth=0', 'https://logseq.com/')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('[Logseq](https://logseq.com/)')
 
   // Case 3: link with URL
   await newBlock(page)
-  await page.type(':nth-match(textarea, 1)', 'https://logseq.com/')
-  await page.press(':nth-match(textarea, 1)', selectAll)
-  await page.press(':nth-match(textarea, 1)', hotKey)
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('[](https://logseq.com/)')
-  await page.type(':nth-match(textarea, 1)', 'Logseq')
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe('[Logseq](https://logseq.com/)')
+  await page.type('textarea >> nth=0', 'https://logseq.com/')
+  await page.press('textarea >> nth=0', selectAll)
+  await page.press('textarea >> nth=0', hotKey)
+  expect(await page.inputValue('textarea >> nth=0')).toBe('[](https://logseq.com/)')
+  await page.type('textarea >> nth=0', 'Logseq')
+  expect(await page.inputValue('textarea >> nth=0')).toBe('[Logseq](https://logseq.com/)')
 })

--- a/e2e-tests/page-rename.spec.ts
+++ b/e2e-tests/page-rename.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 import { test } from './fixtures'
-import { IsMac, createPage, newBlock, newInnerBlock, randomString, lastInnerBlock } from './utils'
+import { IsMac, createPage, newBlock, newInnerBlock, randomString, lastBlock } from './utils'
 
 /***
  * Test rename feature
@@ -18,7 +18,9 @@ async function page_rename_test(page, original_page_name: string, new_page_name:
 
   await createPage(page, original_name)
   await page.click('.page-title .title')
+  await page.waitForSelector('input[type="text"]')
   await page.keyboard.press(selectAll)
+  await page.keyboard.press('Backspace')
   await page.type('.title input', new_name)
   await page.keyboard.press('Enter')
   await page.click('.ui__confirm-modal button')
@@ -26,7 +28,7 @@ async function page_rename_test(page, original_page_name: string, new_page_name:
   expect(await page.innerText('.page-title .title')).toBe(new_name)
 
   // TODO: Test if page is renamed in re-entrance
-  
+
   // TODO: Test if page is hierarchy
 }
 

--- a/e2e-tests/page-search.spec.ts
+++ b/e2e-tests/page-search.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 import { test } from './fixtures'
-import { IsMac, createRandomPage, newBlock, newInnerBlock, randomString, lastInnerBlock, activateNewPage } from './utils'
+import { IsMac, createRandomPage, newBlock, newInnerBlock, randomString, lastBlock, activateNewPage, enterNextBlock } from './utils'
 
 /***
  * Test alias features
@@ -21,15 +21,15 @@ import { IsMac, createRandomPage, newBlock, newInnerBlock, randomString, lastInn
   // diacritic opening test
   await createRandomPage(page)
 
-  await page.fill(':nth-match(textarea, 1)', '[[Einführung in die Allgemeine Sprachwissenschaft' + rand + ']] diacritic-block-1')
+  await page.fill('textarea >> nth=0', '[[Einführung in die Allgemeine Sprachwissenschaft' + rand + ']] diacritic-block-1')
   await page.keyboard.press(hotkeyOpenLink)
 
   // build target Page with diacritics
   await activateNewPage(page)
-  await page.type(':nth-match(textarea, 1)', 'Diacritic title test content')
+  await page.type('textarea >> nth=0', 'Diacritic title test content')
 
   await page.keyboard.press('Enter')
-  await page.fill(':nth-match(textarea, 1)', '[[Einführung in die Allgemeine Sprachwissenschaft' + rand + ']] diacritic-block-2')
+  await page.fill('textarea >> nth=0', '[[Einführung in die Allgemeine Sprachwissenschaft' + rand + ']] diacritic-block-2')
   await page.keyboard.press(hotkeyBack)
 
   // check if diacritics are indexed
@@ -61,45 +61,46 @@ async function alias_test(page, page_name: string, search_kws: string[]) {
   // shortcut opening test
   let parent_title = await createRandomPage(page)
 
-  await page.fill(':nth-match(textarea, 1)', '[[' + target_name + ']]')
+  await page.fill('textarea >> nth=0', '[[' + target_name + ']]')
   await page.keyboard.press(hotkeyOpenLink)
 
+  await lastBlock(page)
   // build target Page with alias
-  await page.type(':nth-match(textarea, 1)', 'alias:: [[' + alias_name + ']]')
-  await page.press(':nth-match(textarea, 1)', 'Enter') // double Enter for exit property editing
-  await page.press(':nth-match(textarea, 1)', 'Enter')
-  await page.type(':nth-match(textarea, 1)', alias_test_content_1)
+  await page.fill('textarea >> nth=0', 'alias:: [[' + alias_name + ']]')
+  await page.press('textarea >> nth=0', 'Enter') // double Enter for exit property editing
+  await enterNextBlock(page)
+  await page.type('textarea >> nth=0', alias_test_content_1)
   await page.keyboard.press(hotkeyBack)
 
   // create alias ref in origin Page
   await newBlock(page)
-  await page.type(':nth-match(textarea, 1)', '[[' + alias_name + ']]')
+  await page.fill('textarea >> nth=0', '[[' + alias_name + ']]')
   await page.keyboard.press(hotkeyOpenLink)
 
   // shortcut opening test
-  await lastInnerBlock(page)
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe(alias_test_content_1)
+  await lastBlock(page)
+  expect(await page.inputValue('textarea >> nth=0')).toBe(alias_test_content_1)
   await newInnerBlock(page)
-  await page.type(':nth-match(textarea, 1)', alias_test_content_2)
+  await page.type('textarea >> nth=0', alias_test_content_2)
   await page.keyboard.press(hotkeyBack)
 
   // pressing enter opening test
-  await lastInnerBlock(page)
-  await page.press(':nth-match(textarea, 1)', 'ArrowLeft')
-  await page.press(':nth-match(textarea, 1)', 'ArrowLeft')
-  await page.press(':nth-match(textarea, 1)', 'ArrowLeft')
-  await page.press(':nth-match(textarea, 1)', 'Enter')
-  await lastInnerBlock(page)
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe(alias_test_content_2)
+  await lastBlock(page)
+  await page.press('textarea >> nth=0', 'ArrowLeft')
+  await page.press('textarea >> nth=0', 'ArrowLeft')
+  await page.press('textarea >> nth=0', 'ArrowLeft')
+  await page.press('textarea >> nth=0', 'Enter')
+  await lastBlock(page)
+  expect(await page.inputValue('textarea >> nth=0')).toBe(alias_test_content_2)
   await newInnerBlock(page)
-  await page.type(':nth-match(textarea, 1)', alias_test_content_3)
+  await page.type('textarea >> nth=0', alias_test_content_3)
   await page.keyboard.press(hotkeyBack)
 
   // clicking opening test
   await page.waitForSelector('.page-blocks-inner .ls-block .page-ref >> nth=-1')
   await page.click('.page-blocks-inner .ls-block .page-ref >> nth=-1')
-  await lastInnerBlock(page)
-  expect(await page.inputValue(':nth-match(textarea, 1)')).toBe(alias_test_content_3)
+  await lastBlock(page)
+  expect(await page.inputValue('textarea >> nth=0')).toBe(alias_test_content_3)
 
   // TODO: test alias from graph clicking
 
@@ -127,8 +128,8 @@ async function alias_test(page, page_name: string, search_kws: string[]) {
     page.keyboard.press("Enter")
     await page.waitForNavigation()
     await page.waitForTimeout(100)
-    await lastInnerBlock(page)
-    expect(await page.inputValue(':nth-match(textarea, 1)')).toBe(alias_test_content_3)
+    await lastBlock(page)
+    expect(await page.inputValue('textarea >> nth=0')).toBe(alias_test_content_3)
 
     // test search clicking (block)
     await page.click('#search-button')
@@ -138,8 +139,8 @@ async function alias_test(page, page_name: string, search_kws: string[]) {
     page.click(":nth-match(.menu-link, 2)")
     await page.waitForNavigation()
     await page.waitForTimeout(500)
-    await lastInnerBlock(page)
-    expect(await page.inputValue(':nth-match(textarea, 1)')).toBe("[[" + alias_name + "]]")
+    await lastBlock(page)
+    expect(await page.inputValue('textarea >> nth=0')).toBe("[[" + alias_name + "]]")
     await page.keyboard.press(hotkeyBack)
   }
 

--- a/e2e-tests/page-search.spec.ts
+++ b/e2e-tests/page-search.spec.ts
@@ -1,6 +1,6 @@
-import { expect } from '@playwright/test'
+import { expect, Page } from '@playwright/test'
 import { test } from './fixtures'
-import { IsMac, createRandomPage, newBlock, newInnerBlock, randomString, lastBlock, activateNewPage, enterNextBlock } from './utils'
+import { IsMac, createRandomPage, newBlock, newInnerBlock, randomString, lastBlock, enterNextBlock } from './utils'
 
 /***
  * Test alias features
@@ -25,7 +25,7 @@ import { IsMac, createRandomPage, newBlock, newInnerBlock, randomString, lastBlo
   await page.keyboard.press(hotkeyOpenLink)
 
   // build target Page with diacritics
-  await activateNewPage(page)
+  await lastBlock(page)
   await page.type('textarea >> nth=0', 'Diacritic title test content')
 
   await page.keyboard.press('Enter')
@@ -43,7 +43,7 @@ import { IsMac, createRandomPage, newBlock, newInnerBlock, randomString, lastBlo
   await page.keyboard.press("Escape")
 })
 
-async function alias_test(page, page_name: string, search_kws: string[]) {
+async function alias_test(page: Page, page_name: string, search_kws: string[]) {
   let hotkeyOpenLink = 'Control+o'
   let hotkeyBack = 'Control+['
   if (IsMac) {
@@ -65,22 +65,32 @@ async function alias_test(page, page_name: string, search_kws: string[]) {
   await page.keyboard.press(hotkeyOpenLink)
 
   await lastBlock(page)
+  await page.waitForTimeout(500)
+
   // build target Page with alias
-  await page.fill('textarea >> nth=0', 'alias:: [[' + alias_name + ']]')
+  await page.type('textarea >> nth=0', 'alias:: [[' + alias_name)
+  await page.press('textarea >> nth=0', 'ArrowRight')
+  await page.press('textarea >> nth=0', 'ArrowRight')
   await page.press('textarea >> nth=0', 'Enter') // double Enter for exit property editing
-  await enterNextBlock(page)
+  await page.press('textarea >> nth=0', 'Enter') // double Enter for exit property editing
+  await page.waitForTimeout(500)
   await page.type('textarea >> nth=0', alias_test_content_1)
   await page.keyboard.press(hotkeyBack)
 
+  await page.waitForTimeout(100) // await navigation
   // create alias ref in origin Page
   await newBlock(page)
-  await page.fill('textarea >> nth=0', '[[' + alias_name + ']]')
+  await page.type('textarea >> nth=0', '[[' + alias_name)
+  await page.waitForTimeout(100)
+
   await page.keyboard.press(hotkeyOpenLink)
+  await page.waitForTimeout(100) // await navigation
 
   // shortcut opening test
   await lastBlock(page)
   expect(await page.inputValue('textarea >> nth=0')).toBe(alias_test_content_1)
-  await newInnerBlock(page)
+
+  await enterNextBlock(page)
   await page.type('textarea >> nth=0', alias_test_content_2)
   await page.keyboard.press(hotkeyBack)
 

--- a/e2e-tests/sidebar.spec.ts
+++ b/e2e-tests/sidebar.spec.ts
@@ -1,12 +1,13 @@
 import { expect } from '@playwright/test'
 import { test } from './fixtures'
-import { createRandomPage, searchAndJumpToPage } from './utils'
+import { createRandomPage, openLeftSidebar, searchAndJumpToPage } from './utils'
 
 /***
  * Test side bar features
  ***/
 
 test('favorite item and recent item test', async ({ page }) => {
+  await openLeftSidebar(page)
   // add page to fav
   const fav_page_name = await createRandomPage(page)
   let favs = await page.$$('.favorite-item a')
@@ -37,10 +38,10 @@ test('favorite item and recent item test', async ({ page }) => {
 
 test('recent is updated #4320', async ({ page }) => {
   const page1 = await createRandomPage(page)
-  await page.fill(':nth-match(textarea, 1)', 'Random Thought')
+  await page.fill('textarea >> nth=0', 'Random Thought')
 
   const page2 = await createRandomPage(page)
-  await page.fill(':nth-match(textarea, 1)', 'Another Random Thought')
+  await page.fill('textarea >> nth=0', 'Another Random Thought')
 
   const firstRecent = page.locator('.nav-content-item.recent li >> nth=0')
   expect(await firstRecent.textContent()).toContain(page2)

--- a/e2e-tests/utils.ts
+++ b/e2e-tests/utils.ts
@@ -63,9 +63,14 @@ export async function lastBlock(page: Page): Promise<Locator> {
   // discard any popups
   await page.keyboard.press('Escape')
   // click last block
-  await page.click('.page-blocks-inner .ls-block >> nth=-1')
+  if (await page.locator('text="Click here to edit..."').isVisible()) {
+    await page.click('text="Click here to edit..."')
+  } else {
+    await page.click('.page-blocks-inner .ls-block >> nth=-1')
+  }
   // wait for textarea
   await page.waitForSelector('textarea >> nth=0', { state: 'visible' })
+  await page.waitForTimeout(100)
   return page.locator('textarea >> nth=0')
 }
 
@@ -93,10 +98,10 @@ export async function newInnerBlock(page: Page): Promise<Locator> {
 }
 
 export async function newBlock(page: Page): Promise<Locator> {
-  let blockNumber = await page.locator('.ls-block').count()
+  let blockNumber = await page.locator('.page-blocks-inner .ls-block').count()
   const prev = await lastBlock(page)
   await page.press('textarea >> nth=0', 'Enter')
-  await page.waitForSelector(`.ls-block >> nth=${blockNumber} >> textarea`, { state: 'visible' })
+  await page.waitForSelector(`.page-blocks-inner .ls-block >> nth=${blockNumber} >> textarea`, { state: 'visible' })
   return page.locator('textarea >> nth=0')
 }
 

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
         "react-textarea-autosize": "8.3.3",
         "react-tippy": "1.4.0",
         "react-transition-group": "4.3.0",
+        "react-virtuoso": "^2.8.5",
         "reakit": "0.11.1",
         "remove-accents": "0.4.2",
         "send-intent": "3.0.11",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
         "react-textarea-autosize": "8.3.3",
         "react-tippy": "1.4.0",
         "react-transition-group": "4.3.0",
-        "react-virtuoso": "^2.8.5",
         "reakit": "0.11.1",
         "remove-accents": "0.4.2",
         "send-intent": "3.0.11",

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -496,7 +496,7 @@
 (defmethod handle-step :editor/restore-saved-cursor [[_]]
   (when-let [input-id (state/get-edit-input-id)]
     (when-let [current-input (gdom/getElement input-id)]
-      (cursor/move-cursor-to current-input (:editor/last-saved-cursor @state/state)))))
+      (cursor/move-cursor-to current-input (state/get-editor-last-pos)))))
 
 (defmethod handle-step :editor/clear-current-slash [[_ space?]]
   (when-let [input-id (state/get-edit-input-id)]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -576,7 +576,7 @@
 
 (rum/defc block-embed < rum/reactive db-mixins/query
   [config id]
-  (let [blocks (db/sub-block-and-children (state/get-current-repo) id)]
+  (let [blocks (db/get-paginated-blocks (state/get-current-repo) id)]
     [:div.color-level.embed-block.bg-base-2
      {:style {:z-index 2}
       :on-double-click #(edit-parent-block % config)
@@ -605,7 +605,8 @@
                   page-name)
             (not= (util/page-name-sanity-lc (get config :id ""))
                   page-name))
-       (let [blocks (db/get-page-blocks (state/get-current-repo) page-name)]
+       (let [page (model/get-page page-name)
+             blocks (db/get-paginated-blocks (state/get-current-repo) (:db/id page))]
          (blocks-container blocks (assoc config
                                          :id page-name
                                          :embed? true

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -611,6 +611,7 @@
        (let [page (model/get-page page-name)
              blocks (db/get-paginated-blocks (state/get-current-repo) (:db/id page))]
          (blocks-container blocks (assoc config
+                                         :db/id (:db/id page)
                                          :id page-name
                                          :embed? true
                                          :page-embed? true

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2887,7 +2887,7 @@
                                (load-more-blocks! config flat-blocks)))
             has-more? (and
                        (> (count flat-blocks) model/initial-blocks-length)
-                       (some? (model/get-next-open-block (last flat-blocks) db-id)))
+                       (some? (model/get-next-open-block (db/get-conn) (last flat-blocks) db-id)))
             dom-id (str "lazy-blocks-" (::id state))]
         [:div {:id dom-id}
          (ui/infinite-list

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1950,8 +1950,9 @@
                      :block-parent-id block-id
                      :format format
                      :heading-level heading-level
-                     :on-hide (fn [_value event]
+                     :on-hide (fn [value event]
                                 (when (= event :esc)
+                                  (editor-handler/save-block! (editor-handler/get-state) value)
                                   (editor-handler/escape-editing)))}
                     edit-input-id
                     config))]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2881,7 +2881,9 @@
       (block-list config blocks)
       (let [last-block-id (:db/id (last flat-blocks))
             bottom-reached (fn []
-                             (when db-id
+                             (when (and db-id
+                                        ;; To prevent scrolling after inserting new blocks
+                                        (> (- (util/time-ms) (:start-time config)) 200))
                                (load-more-blocks! config flat-blocks)))
             has-more? (when db-id
                         (and (not= last-block-id (model/get-block-last-child db-id))
@@ -2914,7 +2916,8 @@
         doc-mode? (:document/mode? config)]
     (when (seq blocks)
       (let [blocks->vec-tree #(if (custom-query-or-ref? config) % (tree/blocks->vec-tree % (:id config)))
-            flat-blocks (vec blocks)]
+            flat-blocks (vec blocks)
+            config (assoc config :start-time (util/time-ms))]
         [:div.blocks-container.flex-1
          {:class (when doc-mode? "document-mode")}
          (lazy-blocks config flat-blocks blocks->vec-tree)]))))

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2178,7 +2178,7 @@
                nil)
              (assoc state ::control-show? (atom false))))
    :should-update (fn [old-state new-state]
-                    (let [compare-keys [:block/uuid :block/content :block/parent :block/collapsed? :block/children
+                    (let [compare-keys [:block/uuid :block/content :block/parent :block/collapsed?
                                         :block/properties :block/left :block/children :block/_refs]
                           config-compare-keys [:show-cloze?]
                           b1 (second (:rum/args old-state))
@@ -2230,16 +2230,16 @@
         review-cards? (:review-cards? config)]
     [:div.ls-block
      (cond->
-      {:id block-id
-       :data-refs data-refs
-       :data-refs-self data-refs-self
-       :data-collapsed (and collapsed? has-child?)
-       :class (str uuid
-                   (when pre-block? " pre-block")
-                   (when (and card? (not review-cards?)) " shadow-xl"))
-       :blockid (str uuid)
-       :haschild (str has-child?)
-       :style {:padding-left (* (- level 1) 24)}}
+       {:id block-id
+        :data-refs data-refs
+        :data-refs-self data-refs-self
+        :data-collapsed (and collapsed? has-child?)
+        :class (str uuid
+                    (when pre-block? " pre-block")
+                    (when (and card? (not review-cards?)) " shadow-xl"))
+        :blockid (str uuid)
+        :haschild (str has-child?)
+        :style {:padding-left (* (- level 1) 24)}}
 
        level
        (assoc :level level)

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -153,10 +153,13 @@
 
     (rum/use-effect!
      (fn []
-       (let [^js el (rum/deref *el-ref)
-             {:keys [x y]} (util/calc-delta-rect-offset el js/document.documentElement)]
-         (set! (.. el -style -transform)
-               (str "translate3d(" (if (neg? x) x 0) "px," (if (neg? y) (- y 10) 0) "px" ",0)")))
+       (js/setTimeout
+        (fn []
+          (let [^js el (rum/deref *el-ref)
+               {:keys [x y]} (util/calc-delta-rect-offset el js/document.documentElement)]
+           (set! (.. el -style -transform)
+                 (str "translate3d(" (if (neg? x) x 0) "px," (if (neg? y) (- y 10) 0) "px" ",0)"))))
+        10)
        #())
      [])
 

--- a/src/main/frontend/components/content.css
+++ b/src/main/frontend/components/content.css
@@ -13,7 +13,9 @@
 
 #custom-context-menu {
   @apply rounded-md shadow-lg transition ease-out duration-100 transform
-  opacity-100 scale-100 absolute;
+  opacity-100 scale-100 absolute overflow-y-auto;
 
+  max-height: calc(100vh - 100px) !important;;
+  overflow-y: scroll;
   z-index: calc(var(--ls-z-index-level-1) + 1);
 }

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -101,7 +101,7 @@
   "Embedded page searching popup"
   [id format]
   (when (state/sub :editor/show-page-search?)
-    (let [pos (:editor/last-saved-cursor @state/state)
+    (let [pos (state/get-editor-last-pos)
           input (gdom/getElement id)]
       (when input
         (let [current-pos (cursor/pos input)
@@ -191,7 +191,7 @@
                    state)}
   [state id _format]
   (when (state/sub :editor/show-block-search?)
-    (let [pos (:editor/last-saved-cursor @state/state)
+    (let [pos (state/get-editor-last-pos)
           input (gdom/getElement id)
           [id format] (:rum/args state)
           current-pos (cursor/pos input)
@@ -208,7 +208,7 @@
   {:will-unmount (fn [state] (reset! editor-handler/*selected-text nil) state)}
   [id _format]
   (when (state/sub :editor/show-template-search?)
-    (let [pos (:editor/last-saved-cursor @state/state)
+    (let [pos (state/get-editor-last-pos)
           input (gdom/getElement id)]
       (when input
         (let [current-pos (cursor/pos input)
@@ -234,7 +234,6 @@
    [:button.bottom-action
     {:on-mouse-down (fn [e]
                       (util/stop e)
-                      (state/set-state! :editor/pos (cursor/pos (state/get-input)))
                       (editor-handler/indent-outdent indent?))}
     (ui/icon icon {:style {:fontSize ui/icon-size}})]])
 
@@ -573,7 +572,8 @@
 
 (rum/defcs box < rum/reactive
   {:init (fn [state]
-           (assoc state ::heading-level (:heading-level (first (:rum/args state)))))
+           (assoc state ::heading-level (:heading-level (first (:rum/args state)))
+                  ::id (str (random-uuid))))
    :did-mount (fn [state]
                 (state/set-editor-args! (:rum/args state))
                 state)}

--- a/src/main/frontend/components/journal.cljs
+++ b/src/main/frontend/components/journal.cljs
@@ -68,15 +68,16 @@
 (rum/defc journals < rum/reactive
   [latest-journals]
   [:div#journals
-   (ui/infinite-list "main-content-container"
-                     (for [{:block/keys [name format]} latest-journals]
-                       [:div.journal-item.content {:key name}
-                        (journal-cp [name format])])
-                     {:has-more (page-handler/has-more-journals?)
-                      :more-class "text-4xl"
-                      :on-top-reached page-handler/create-today-journal!
-                      :on-load (fn []
-                                 (page-handler/load-more-journals!))})])
+   (ui/infinite-list
+    "main-content-container"
+    (for [{:block/keys [name format]} latest-journals]
+      [:div.journal-item.content {:key name}
+       (journal-cp [name format])])
+    {:has-more (page-handler/has-more-journals?)
+     :more-class "text-4xl"
+     :on-top-reached page-handler/create-today-journal!
+     :on-load (fn []
+                (page-handler/load-more-journals!))})])
 
 (rum/defc all-journals < rum/reactive db-mixins/query
   []

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -125,7 +125,6 @@
                               :db/id (:db/id block-entity)
                               :block? block?
                               :editor-box editor/box
-                              :page page
                               :document/mode? document-mode?}
                              config)
               hiccup-config (common-handler/config-with-document-mode hiccup-config)

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -47,10 +47,10 @@
     (let [root (if block-id
                  (db/pull [:block/uuid block-id])
                  (model/get-page page-name))
-          blocks (db/get-paginated-blocks repo (:db/id root))]
-      (if block-id
-        (cons root blocks)
-        blocks))))
+          opts (if block-id
+                 {:scoped-block-id (:db/id root)}
+                 {})]
+      (db/get-paginated-blocks repo (:db/id root) opts))))
 
 (defn- open-first-block!
   [state]

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -44,13 +44,13 @@
 (defn- get-blocks
   [repo page-name block-id]
   (when page-name
-    (if block-id
-      (when-let [root-block (db/pull [:block/uuid block-id])]
-        (let [blocks (-> (db/sub-block-and-children repo block-id)
-                         (model/sort-blocks root-block {}))]
-          (cons root-block blocks)))
-      (when-let [page (db/pull [:block/name (util/safe-page-name-sanity-lc page-name)])]
-        (db/get-page-blocks repo page-name)))))
+    (let [root (if block-id
+                 (db/pull [:block/uuid block-id])
+                 (model/get-page page-name))
+          blocks (db/get-paginated-blocks repo (:db/id root))]
+      (if block-id
+        (cons root blocks)
+        blocks))))
 
 (defn- open-first-block!
   [state]

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -117,8 +117,12 @@
       (if (empty? page-blocks)
         (dummy-block page-name)
         (let [document-mode? (state/sub :document/mode?)
+              block-entity (db/entity (if block-id
+                                       [:block/uuid block-id]
+                                       [:block/name page-name]))
               hiccup-config (merge
                              {:id (if block? (str block-id) page-name)
+                              :db/id (:db/id block-entity)
                               :block? block?
                               :editor-box editor/box
                               :page page

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -50,8 +50,7 @@
                          (model/sort-blocks root-block {}))]
           (cons root-block blocks)))
       (when-let [page (db/pull [:block/name (util/safe-page-name-sanity-lc page-name)])]
-        (-> (db/get-page-blocks repo page-name)
-            (model/sort-blocks page {}))))))
+        (db/get-page-blocks repo page-name)))))
 
 (defn- open-first-block!
   [state]

--- a/src/main/frontend/db.cljs
+++ b/src/main/frontend/db.cljs
@@ -39,14 +39,14 @@
   blocks-count blocks-count-cache clean-export!  cloned? delete-blocks get-pre-block
   delete-file! delete-file-blocks! delete-page-blocks delete-file-pages! delete-file-tx delete-files delete-pages-by-files
   filter-only-public-pages-and-blocks get-all-block-contents get-all-tagged-pages
-  get-all-templates get-block-and-children sub-block-and-children get-block-by-uuid get-block-children sort-by-left
+  get-all-templates get-block-and-children get-block-by-uuid get-block-children sort-by-left
   get-block-parent get-block-parents parents-collapsed? get-block-referenced-blocks
   get-block-children-ids get-block-immediate-children get-block-page
   get-blocks-contents get-custom-css
   get-date-scheduled-or-deadlines get-db-type
   get-file-blocks get-file-contents get-file-last-modified-at get-file get-file-page get-file-page-id file-exists?
   get-file-pages get-files get-files-blocks get-files-full get-journals-length
-  get-latest-journals get-matched-blocks get-page get-page-alias get-page-alias-names get-page-blocks get-page-linked-refs-refed-pages
+  get-latest-journals get-matched-blocks get-page get-page-alias get-page-alias-names get-paginated-blocks get-page-linked-refs-refed-pages
   get-page-blocks-count get-page-blocks-no-cache get-page-file get-page-format get-page-properties
   get-page-referenced-blocks get-page-referenced-pages get-page-unlinked-references get-page-referenced-blocks-no-cache
   get-all-pages get-pages get-pages-relation get-pages-that-mentioned-page get-public-pages get-tag-pages

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -569,7 +569,7 @@
                                                                                             :scoped-block-id scoped-block-id})]
                                           (concat previous-blocks more))))
 
-                                    ;; TODO: drag && drop, move blocks up/down
+                                    ;; TODO: expand | collapse, drag && drop, move blocks up/down
 
                                     :else
                                     nil)

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -579,10 +579,16 @@
         cached-ids-set (set (conj cached-ids page-id))
         first-changed-id (if (= outliner-op :move-subtree)
                            (let [{:keys [move-blocks target from-page to-page]} tx-meta]
-                             (if (not= from-page to-page)
+                             (cond
+                               (= page-id target) ; move to the first block
+                               nil
+
+                               (and from-page to-page (not= from-page to-page))
                                (if (= page-id from-page)
                                  (first move-blocks)
                                  target)
+
+                               :else
                                ;; same page, get the most top block before dragging
                                (let [match-ids (set (conj move-blocks target))]
                                  (loop [[id & others] cached-ids]

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -642,7 +642,8 @@
                             limit initial-blocks-length
                             use-cache? true
                             scoped-block-id nil}}]
-   (assert (integer? block-id))
+   (when block-id
+     (assert (integer? block-id) (str "wrong block-id: " block-id))
    (let [entity (db-utils/entity repo-url block-id)
          page? (some? (:block/name entity))
          page-entity (if page? entity (:block/page entity))
@@ -686,7 +687,7 @@
                            blocks (remove (fn [b] (nil? (:block/content b))) blocks)]
                        (map (fn [b] (assoc b :block/page bare-page-map)) blocks)))}
         nil)
-      react))))
+      react)))))
 
 (defn get-page-blocks-no-cache
   ([page]

--- a/src/main/frontend/db/outliner.cljs
+++ b/src/main/frontend/db/outliner.cljs
@@ -8,14 +8,7 @@
     (d/pull @conn '[*] id)
     (catch js/Error _e nil)))
 
-(defn get-by-parent-&-left
-  [conn parent-id left-id]
-  (when (and parent-id left-id)
-    (let [lefts (:block/_left (d/entity @conn left-id))
-          children (:block/_parent (d/entity @conn parent-id))
-          ids (set/intersection lefts children)
-          id (:db/id (first ids))]
-      (when id (d/pull @conn '[*] id)))))
+
 
 ;; key [:block/children parent-id]
 
@@ -34,11 +27,3 @@
   (mapv (fn [id-or-look-ref]
          [:db.fn/retractEntity id-or-look-ref])
     ids-or-look-refs))
-
-(defn get-journals
-  [conn]
-  (let [r (d/q '[:find (pull ?a [*])
-                 :where
-                 [?a :block/journal? true]]
-               @conn)]
-    (flatten r)))

--- a/src/main/frontend/db/outliner.cljs
+++ b/src/main/frontend/db/outliner.cljs
@@ -1,14 +1,11 @@
 (ns frontend.db.outliner
-  (:require [datascript.core :as d]
-            [clojure.set :as set]))
+  (:require [datascript.core :as d]))
 
 (defn get-by-id
   [conn id]
   (try
     (d/pull @conn '[*] id)
     (catch js/Error _e nil)))
-
-
 
 ;; key [:block/children parent-id]
 

--- a/src/main/frontend/db/react.cljs
+++ b/src/main/frontend/db/react.cljs
@@ -310,9 +310,12 @@
               (when (or query query-fn)
                 (try
                   (let [f #(execute-query! repo-url db k tx cache)]
+                    (f)
+                    ;; Detects whether user is editing in a custom query, if so, execute the query immediately
                     (if (and custom?
                              ;; modifying during cards review need to be executed immediately
-                             (not (:cards-query? (meta query))))
+                             (not (:cards-query? (meta query)))
+                             (not (state/edit-in-query-component)))
                       (async/put! (state/get-reactive-custom-queries-chan) [f query])
                       (f)))
                   (catch js/Error e

--- a/src/main/frontend/db/react.cljs
+++ b/src/main/frontend/db/react.cljs
@@ -310,7 +310,6 @@
               (when (or query query-fn)
                 (try
                   (let [f #(execute-query! repo-url db k tx cache)]
-                    (f)
                     ;; Detects whether user is editing in a custom query, if so, execute the query immediately
                     (if (and custom?
                              ;; modifying during cards review need to be executed immediately

--- a/src/main/frontend/db/react.cljs
+++ b/src/main/frontend/db/react.cljs
@@ -77,6 +77,11 @@
   (when-let [result-atom (get-in @query-state [k :result])]
     (reset! result-atom new-result)))
 
+(defn swap-new-result!
+  [k f]
+  (when-let [result-atom (get-in @query-state [k :result])]
+    (swap! result-atom f)))
+
 (defn kv
   [key value]
   {:db/id -1

--- a/src/main/frontend/db/react.cljs
+++ b/src/main/frontend/db/react.cljs
@@ -10,7 +10,6 @@
             [frontend.db.utils :as db-utils]
             [frontend.state :as state]
             [frontend.util :as util :refer [react]]
-            [frontend.db-schema :as db-schema]
             [cljs.spec.alpha :as s]
             [clojure.core.async :as async]))
 
@@ -18,9 +17,6 @@
 ;; ::block
 ;; pull-block react-query
 (s/def ::block (s/tuple #(= ::block %) uuid?))
-;; ::block-refs-count
-;; (count (:block/refs block)) react-query
-(s/def ::block-refs-count (s/tuple #(= ::block-refs-count %) int?))
 ;; ::page-blocks
 ;; get page-blocks react-query
 (s/def ::page-blocks (s/tuple #(= ::page-blocks %) int?))
@@ -49,7 +45,6 @@
 (s/def ::custom any?)
 
 (s/def ::react-query-keys (s/or :block ::block
-                                :block-refs-count ::block-refs-count
                                 :page-blocks ::page-blocks
                                 :block-and-children ::block-and-children
                                 :journals ::journals
@@ -254,7 +249,7 @@
                               (let [entity (db-utils/entity ref)]
                                 (if (:block/name entity) ; page
                                   [::page-blocks ref]
-                                  [::block-refs-count ref])))
+                                  [::page-blocks (:db/id (:block/page entity))])))
                             refs))
         others (->>
                 (keys @query-state)
@@ -311,7 +306,7 @@
                  (or (get affected-keys (vec (rest k)))
                      custom?
                      kv?))
-            (let [{:keys [query query-fn result]} cache]
+            (let [{:keys [query query-fn]} cache]
               (when (or query query-fn)
                 (try
                   (let [f #(execute-query! repo-url db k tx cache)]

--- a/src/main/frontend/db_schema.cljs
+++ b/src/main/frontend/db_schema.cljs
@@ -26,7 +26,8 @@
    :block/uuid {:db/unique :db.unique/identity}
    :block/parent {:db/valueType :db.type/ref
                   :db/index true}
-   :block/left {:db/valueType :db.type/ref}
+   :block/left   {:db/valueType :db.type/ref
+                  :db/index true}
    :block/collapsed? {:db/index true}
 
    ;; :markdown, :org

--- a/src/main/frontend/debug.cljs
+++ b/src/main/frontend/debug.cljs
@@ -1,58 +1,9 @@
 (ns frontend.debug
-  (:require-macros [frontend.debug])
-  (:refer-clojure :exclude [print])
   (:require [cljs.pprint :as pprint]
-            [frontend.state :as state]
-            [frontend.util :as util]))
+            [frontend.state :as state]))
 
 (defn pprint
   [& xs]
   (when (state/developer-mode?)
     (doseq [x xs]
       (pprint/pprint x))))
-
-(defn print
-  [& xs]
-  (println "Time: " (str (js/Date.)))
-  (apply println xs))
-
-(defonce ack-wait-timeouts (atom {}))
-
-(defonce default-write-ack-timeout 10000)
-
-;; For debugging file changes are not saved on disk.
-(defn wait-for-write-ack!
-  [_page-title file-path]
-  (when file-path
-    (let [requested-at (util/time-ms)]
-      (state/set-state! [:debug/write-acks file-path :last-requested-at] requested-at)
-      (when-let [timeout (get @ack-wait-timeouts file-path)]
-        (js/clearTimeout timeout))
-      (let [timeout (js/setTimeout (fn []
-                                     (let [last-ack-at (get-in @state/state [:debug/write-acks file-path :last-ack-at])]
-                                       (when-not (and last-ack-at
-                                                      (< requested-at last-ack-at (+ requested-at default-write-ack-timeout)))
-                                         (let [step (get-in @state/state [:debug/write-acks file-path :step])]
-                                           (state/pub-event! [:instrument {:type :debug/write-failed
-                                                                           :payload {:step step}}])
-                                           ;; (notification/show!
-                                           ;;  (str "Logseq failed to save the page "
-                                           ;;       page-title
-                                           ;;       " to the file: "
-                                           ;;       file-path
-                                           ;;       ". Stop editing this page anymore, and copy all the blocks of this page to another editor to avoid any data-loss.\n"
-                                           ;;       "Last step: "
-                                           ;;       step)
-                                           ;;  :error)
-                                           ))))
-                                   default-write-ack-timeout)]
-        (swap! ack-wait-timeouts assoc file-path timeout)))))
-
-(defn ack-file-write!
-  [file-path]
-  (let [ack-at (util/time-ms)]
-    (state/set-state! [:debug/write-acks file-path :last-ack-at] ack-at)))
-
-(defn set-ack-step!
-  [file-path step]
-  (state/set-state! [:debug/write-acks file-path :step] step))

--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -286,11 +286,7 @@
                       (when-let [textarea (rum/ref-node state textarea-ref-name)]
                         (gobj/set textarea "defaultValue" code)
                         (gobj/set textarea "value" code))))
-                  state)
-
-   :did-update (fn [state]
-                 (load-and-render! state)
-                 state)}
+                  state)}
   [state _config id attr code _theme _options]
   [:div.extensions__code
    (when-let [mode (:data-lang attr)]

--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -188,14 +188,10 @@
         :else
         nil))))
 
-;; Avoid reentrancy
-(def *code-saving (atom false))
-(defn save-file-or-block-when-blur-or-esc!
+(defn- save-file-or-block-when-blur-or-esc!
   [editor textarea config state]
-  (when-not @*code-saving
-    (reset! *code-saving true)
-    (save-file-or-block! editor textarea config state)
-    (reset! *code-saving false)))
+  (state/set-block-component-editing-mode! false)
+  (save-file-or-block! editor textarea config state))
 
 (defn- text->cm-mode
   ([text]
@@ -237,6 +233,8 @@
                           {:mode mode
                            :readOnly (if ui-config/publishing? "nocursor" false)
                            :extraKeys #js {"Esc" (fn [cm]
+                                                   ;; Avoid reentrancy
+                                                   (gobj/set cm "escPressed" true)
                                                    (save-file-or-block-when-blur-or-esc! cm textarea config state)
                                                    (when-let [block-id (:block/uuid config)]
                                                      (let [block (db/pull [:block/uuid block-id])]
@@ -251,10 +249,10 @@
           (.on editor "change" (fn [_cm _e]
                                  (let [new-code (.getValue editor)]
                                    (reset! (:calc-atom state) (calc/eval-lines new-code))))))
-        (.on editor "blur" (fn [_cm e]
+        (.on editor "blur" (fn [cm e]
                              (when e (util/stop e))
-                             (state/set-block-component-editing-mode! false)
-                             (save-file-or-block-when-blur-or-esc! editor textarea config state)))
+                             (when-not (gobj/get cm "escPressed")
+                               (save-file-or-block-when-blur-or-esc! editor textarea config state))))
         (.addEventListener element "mousedown"
                            (fn [e]
                              (state/clear-selection!)

--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -286,7 +286,11 @@
                       (when-let [textarea (rum/ref-node state textarea-ref-name)]
                         (gobj/set textarea "defaultValue" code)
                         (gobj/set textarea "value" code))))
-                  state)}
+                  state)
+   ;; codemirror need to be re-rendered to get the new pos_meta
+   :did-update (fn [state]
+                 (load-and-render! state)
+                 state)}
   [state _config id attr code _theme _options]
   [:div.extensions__code
    (when-let [mode (:data-lang attr)]

--- a/src/main/frontend/extensions/slide.cljs
+++ b/src/main/frontend/extensions/slide.cljs
@@ -94,7 +94,7 @@
         page (db/entity [:block/name page-name])
         journal? (:journal? page)
         repo (state/get-current-repo)
-        blocks (-> (db/get-page-blocks repo page-name)
+        blocks (-> (db/get-paginated-blocks repo (:db/id page))
                    (outliner-tree/blocks->vec-tree page-name))
         blocks (if journal?
                  (rest blocks)

--- a/src/main/frontend/extensions/srs.cljs
+++ b/src/main/frontend/extensions/srs.cljs
@@ -509,7 +509,8 @@
 
 (rum/defc preview-cp
   [block-id]
-  (let [blocks-f (fn [] (db/get-paginated-blocks (state/get-current-repo) block-id))]
+  (let [blocks-f (fn [] (db/get-paginated-blocks (state/get-current-repo) block-id
+                                                 {:scoped-block-id block-id}))]
     (view-modal blocks-f {:preview? true} (atom 0))))
 
 (defn preview

--- a/src/main/frontend/extensions/srs.cljs
+++ b/src/main/frontend/extensions/srs.cljs
@@ -509,7 +509,7 @@
 
 (rum/defc preview-cp
   [block-id]
-  (let [blocks-f (fn [] (db/sub-block-and-children (state/get-current-repo) block-id))]
+  (let [blocks-f (fn [] (db/get-paginated-blocks (state/get-current-repo) block-id))]
     (view-modal blocks-f {:preview? true} (atom 0))))
 
 (defn preview

--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -496,10 +496,9 @@
                   blocks)
                  blocks)
         blocks (map (fn [block]
-                      (let [delete-keys (if with-body?
-                                          [:block/anchor]
-                                          [:block/anchor :block/body])]
-                        (apply dissoc block delete-keys))) blocks)]
+                      (if with-body?
+                        block
+                        (dissoc block :block/body))) blocks)]
     (with-path-refs blocks)))
 
 (defn ^:large-vars/cleanup-todo extract-blocks

--- a/src/main/frontend/fs/node.cljs
+++ b/src/main/frontend/fs/node.cljs
@@ -9,8 +9,7 @@
             [frontend.util :as util]
             [goog.object :as gobj]
             [lambdaisland.glogi :as log]
-            [promesa.core :as p]
-            [frontend.debug :as debug]))
+            [promesa.core :as p]))
 
 (defn concat-path
   [dir path]

--- a/src/main/frontend/fs/node.cljs
+++ b/src/main/frontend/fs/node.cljs
@@ -63,20 +63,13 @@
          (not (contains? #{"excalidraw" "edn" "css"} ext))
          (not (string/includes? path "/.recycle/"))
          (zero? pending-writes))
-        (do
-          (when (util/electron?)
-            (debug/set-ack-step! path :saved-successfully)
-            (debug/ack-file-write! path))
-          (p/let [disk-content (encrypt/decrypt disk-content)]
-            (state/pub-event! [:file/not-matched-from-disk path disk-content content])))
+        (p/let [disk-content (encrypt/decrypt disk-content)]
+          (state/pub-event! [:file/not-matched-from-disk path disk-content content]))
 
         :else
         (->
          (p/let [result (ipc/ipc "writeFile" repo path content)
                  mtime (gobj/get result "mtime")]
-           (when (util/electron?)
-             (debug/set-ack-step! path :saved-successfully)
-             (debug/ack-file-write! path))
            (db/set-file-last-modified-at! repo path mtime)
            (p/let [content (if (encrypt/encrypted-db? (state/get-current-repo))
                              (encrypt/decrypt content)

--- a/src/main/frontend/handler.cljs
+++ b/src/main/frontend/handler.cljs
@@ -90,12 +90,11 @@
                    (when (and @interval js/window.pfs)
                      (js/clearInterval @interval)
                      (reset! interval nil)
-                     ;; `(state/set-db-restoring! true)` already executed before restoring
-                     (-> (p/all (db/restore!
-                                 (assoc me :repos repos)
-                                 old-db-schema
-                                 (fn [repo]
-                                   (file-handler/restore-config! repo false))))
+                     (-> (db/restore!
+                          (assoc me :repos repos)
+                          old-db-schema
+                          (fn [repo]
+                            (file-handler/restore-config! repo false)))
                          (p/then
                           (fn []
                             ;; try to load custom css only for current repo

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -112,7 +112,8 @@
         option (cond-> {:limit step-loading-blocks}
                  block?
                  (assoc :scoped-block-id db-id))
-        more-data (db-model/get-paginated-blocks-no-cache start-id option)]
+        more-data (->> (db-model/get-paginated-blocks-no-cache start-id option)
+                       (map #(db/pull (:db/id %))))]
     (react/swap-new-result! query-k
                             (fn [result]
                               (->> (concat result more-data)

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -101,8 +101,10 @@
   (get-timestamp block "Deadline"))
 
 (defn load-more!
-  [block? db-id start-id]
+  [db-id start-id]
   (let [repo (state/get-current-repo)
+        block (db/entity repo db-id)
+        block? (not (:block/name block))
         k (if block?
             :frontend.db.react/block-and-children
             :frontend.db.react/page-blocks)

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -5,7 +5,8 @@
             [frontend.db.model :as db-model]
             [frontend.db.react :as db-react]
             [frontend.state :as state]
-            [frontend.format.block :as block]))
+            [frontend.format.block :as block]
+            [frontend.util :as util]))
 
 ;; lazy loading
 
@@ -105,7 +106,8 @@
         query-k (if block?
                   [repo :frontend.db.react/block-and-children (:block/uuid (db/pull db-id))]
                   [repo :frontend.db.react/page-blocks db-id])
-        more-data (db-model/get-paginated-blocks start-id {:limit step-loading-blocks})]
+        more-data (db-model/get-paginated-blocks-no-cache start-id {:limit step-loading-blocks})]
     (db-react/swap-new-result! query-k
                                (fn [result]
-                                 (concat result more-data)))))
+                                 (->> (concat result more-data)
+                                      (util/distinct-by :db/id))))))

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -3,7 +3,7 @@
             [clojure.walk :as walk]
             [frontend.db :as db]
             [frontend.db.model :as db-model]
-            [frontend.db.react :as db-react]
+            [frontend.db.react :as react]
             [frontend.state :as state]
             [frontend.format.block :as block]
             [frontend.util :as util]))
@@ -113,7 +113,7 @@
                  block?
                  (assoc :scoped-block-id db-id))
         more-data (db-model/get-paginated-blocks-no-cache start-id option)]
-    (db-react/swap-new-result! query-k
-                               (fn [result]
-                                 (->> (concat result more-data)
-                                      (util/distinct-by :db/id))))))
+    (react/swap-new-result! query-k
+                            (fn [result]
+                              (->> (concat result more-data)
+                                   (util/distinct-by :db/id))))))

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -98,6 +98,7 @@
 (defn load-more!
   [db-id start-id]
   (let [repo (state/get-current-repo)
+        db (db/get-conn repo)
         block (db/entity repo db-id)
         block? (not (:block/name block))
         k (if block?
@@ -107,7 +108,7 @@
         option (cond-> {:limit db-model/step-loading-blocks}
                  block?
                  (assoc :scoped-block-id db-id))
-        more-data (->> (db-model/get-paginated-blocks-no-cache start-id option)
+        more-data (->> (db-model/get-paginated-blocks-no-cache db start-id option)
                        (map #(db/pull (:db/id %))))]
     (react/swap-new-result! query-k
                             (fn [result]

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -8,17 +8,12 @@
             [frontend.format.block :as block]
             [frontend.util :as util]))
 
-;; lazy loading
-
-(def initial-blocks-length 50)
-
-(def step-loading-blocks 50)
 
 ;;  Fns
 
 (defn long-page?
   [repo page-id]
-  (>= (db/get-page-blocks-count repo page-id) initial-blocks-length))
+  (>= (db/get-page-blocks-count repo page-id) db-model/initial-blocks-length))
 
 (defn get-block-refs-with-children
   [block]
@@ -109,7 +104,7 @@
             :frontend.db.react/block-and-children
             :frontend.db.react/page-blocks)
         query-k [repo k db-id]
-        option (cond-> {:limit step-loading-blocks}
+        option (cond-> {:limit db-model/step-loading-blocks}
                  block?
                  (assoc :scoped-block-id db-id))
         more-data (->> (db-model/get-paginated-blocks-no-cache start-id option)

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -12,7 +12,7 @@
 
 (def initial-blocks-length 50)
 
-(def step-loading-blocks 25)
+(def step-loading-blocks 50)
 
 ;;  Fns
 
@@ -103,10 +103,14 @@
 (defn load-more!
   [block? db-id start-id]
   (let [repo (state/get-current-repo)
-        query-k (if block?
-                  [repo :frontend.db.react/block-and-children (:block/uuid (db/pull db-id))]
-                  [repo :frontend.db.react/page-blocks db-id])
-        more-data (db-model/get-paginated-blocks-no-cache start-id {:limit step-loading-blocks})]
+        k (if block?
+            :frontend.db.react/block-and-children
+            :frontend.db.react/page-blocks)
+        query-k [repo k db-id]
+        option (cond-> {:limit step-loading-blocks}
+                 block?
+                 (assoc :scoped-block-id db-id))
+        more-data (db-model/get-paginated-blocks-no-cache start-id option)]
     (db-react/swap-new-result! query-k
                                (fn [result]
                                  (->> (concat result more-data)

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -10,9 +10,9 @@
 
 ;; lazy loading
 
-(def initial-blocks-length 100)
+(def initial-blocks-length 50)
 
-(def step-loading-blocks 30)
+(def step-loading-blocks 25)
 
 ;;  Fns
 

--- a/src/main/frontend/handler/common.cljs
+++ b/src/main/frontend/handler/common.cljs
@@ -228,10 +228,15 @@
         client-y (gobj/get e "clientY")
         scroll-y (util/cur-doc-top)]
     (state/show-custom-context-menu! context-menu-content)
-    (when-let [context-menu (d/by-id "custom-context-menu")]
-      (d/set-style! context-menu
-                    :left (str client-x "px")
-                    :top (str (+ scroll-y client-y) "px")))))
+
+    ;; FIXME: use setTimeout here because rum renders lazily.
+    (js/setTimeout
+     (fn []
+       (when-let [context-menu (d/by-id "custom-context-menu")]
+        (d/set-style! context-menu
+                      :left (str client-x "px")
+                      :top (str (+ scroll-y client-y) "px"))))
+     10)))
 
 (defn parse-config
   "Parse configuration from file `content` such as from config.edn."

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -544,9 +544,7 @@
                        (wrap-parse-block))
         sibling? (when block-self? false)]
     (outliner-insert-block! config current-block next-block {:sibling? sibling?})
-    ;; WORKAROUND: The block won't refresh itself even if the content is empty.
-    (when block-self?
-      (gobj/set input "value" ""))
+    (util/set-change-value input fst-block-text)
     (ok-handler next-block)))
 
 (defn clear-when-saved!

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -544,22 +544,15 @@
                                                   :block/page :block/journal?]) new-m)
                        (wrap-parse-block))
         sibling? (when block-self? false)]
-    (profile
-     "outliner insert block"
-     (outliner-insert-block! config current-block next-block {:sibling? sibling?}))
+    (outliner-insert-block! config current-block next-block {:sibling? sibling?})
     ;; WORKAROUND: The block won't refresh itself even if the content is empty.
     (when block-self?
       (gobj/set input "value" ""))
-    (profile "ok handler" (ok-handler next-block))))
+    (ok-handler next-block)))
 
 (defn clear-when-saved!
   []
-  (state/set-editor-show-input! nil)
-  (state/set-editor-show-zotero! false)
-  (state/set-editor-show-date-picker! false)
-  (state/set-editor-show-page-search! false)
-  (state/set-editor-show-block-search! false)
-  (state/set-editor-show-template-search! false)
+  (state/clear-editor-show-state!)
   (commands/restore-state true))
 
 (defn get-state
@@ -1836,7 +1829,7 @@
                        (let [nodes (mapv outliner-core/block blocks)]
                          (outliner-core/move-nodes nodes up?)
                          (rehighlight-selected-nodes)
-                         (let [block-node (util/get-first-block-by-id (:block/uuid (first blocks)))]
+                         (when-let [block-node (util/get-first-block-by-id (:block/uuid (first blocks)))]
                            (.scrollIntoView block-node #js {:behavior "smooth" :block "nearest"}))))]
       (if edit-block-id
         (when-let [block (db/pull [:block/uuid edit-block-id])]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2662,7 +2662,6 @@
         ^js input (state/get-input)
         current-pos (cursor/pos input)
         value (gobj/get input "value")
-        repo (state/get-current-repo)
         right (outliner-core/get-right-node (outliner-core/block current-block))
         current-block-has-children? (db/has-children? (:block/uuid current-block))
         collapsed? (util/collapsed? current-block)

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2044,7 +2044,7 @@
           parent-block (db/pull parent)
           left (:db/id (:block/left editing-block))
           left-block (db/pull left)
-          [_ _ config] (state/get-editor-args)
+          config (last (state/get-editor-args))
           block-id (:block/uuid editing-block)
           block-self? (block-self-alone-when-insert? config block-id)
           has-children? (db/has-children? (state/get-current-repo)
@@ -3441,7 +3441,7 @@
 
 (defn- skip-collapsing-in-db?
   []
-  (let [config (:config (state/get-editor-args))]
+  (let [config (last (state/get-editor-args))]
     (:ref? config)))
 
 (defn- set-blocks-collapsed!

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -460,8 +460,7 @@
         skip-save-current-block? (:skip-save-current-block? config)
         [current-node new-node]
         (mapv outliner-core/block [current-block new-block])
-        has-children? (db/has-children? (state/get-current-repo)
-                                        (tree/-get-id current-node))
+        has-children? (db/has-children? (tree/-get-id current-node))
         sibling? (cond
                    ref-top-block?
                    false
@@ -2047,8 +2046,7 @@
           config (last (state/get-editor-args))
           block-id (:block/uuid editing-block)
           block-self? (block-self-alone-when-insert? config block-id)
-          has-children? (db/has-children? (state/get-current-repo)
-                                          (:block/uuid editing-block))
+          has-children? (db/has-children? (:block/uuid editing-block))
           collapsed? (util/collapsed? editing-block)]
       (conj (match (mapv boolean [(seq fst-block-text) (seq snd-block-text)
                                   block-self? has-children? (= parent left) collapsed?])
@@ -2668,17 +2666,17 @@
         value (gobj/get input "value")
         repo (state/get-current-repo)
         right (outliner-core/get-right-node (outliner-core/block current-block))
-        current-block-has-children? (db/has-children? repo (:block/uuid current-block))
+        current-block-has-children? (db/has-children? (:block/uuid current-block))
         collapsed? (util/collapsed? current-block)
         first-child (:data (tree/-get-down (outliner-core/block current-block)))
         next-block (if (or collapsed? (not current-block-has-children?))
                      (:data right)
                      first-child)]
     (cond
-      (and collapsed? right (db/has-children? repo (tree/-get-id right)))
+      (and collapsed? right (db/has-children? (tree/-get-id right)))
       nil
 
-      (and (not collapsed?) first-child (db/has-children? repo (:block/uuid first-child)))
+      (and (not collapsed?) first-child (db/has-children? (:block/uuid first-child)))
       nil
 
       :else

--- a/src/main/frontend/handler/extract.cljs
+++ b/src/main/frontend/handler/extract.cljs
@@ -130,7 +130,7 @@
           pages (remove nil? pages)
           pages (map (fn [page] (assoc page :block/uuid (db/new-block-id))) pages)
           blocks (->> (remove nil? blocks)
-                      (map (fn [b] (dissoc b :block/title :block/body))))]
+                      (map (fn [b] (dissoc b :block/title :block/body :block/level :block/children :block/meta))))]
       [pages blocks])
     (catch js/Error e
       (log/error :exception e))))

--- a/src/main/frontend/handler/extract.cljs
+++ b/src/main/frontend/handler/extract.cljs
@@ -130,7 +130,7 @@
           pages (remove nil? pages)
           pages (map (fn [page] (assoc page :block/uuid (db/new-block-id))) pages)
           blocks (->> (remove nil? blocks)
-                      (map (fn [b] (dissoc b :block/title :block/body :block/level :block/children :block/meta))))]
+                      (map (fn [b] (dissoc b :block/title :block/body :block/level :block/children :block/meta :block/anchor))))]
       [pages blocks])
     (catch js/Error e
       (log/error :exception e))))

--- a/src/main/frontend/handler/file.cljs
+++ b/src/main/frontend/handler/file.cljs
@@ -21,7 +21,6 @@
             [frontend.util :as util]
             [lambdaisland.glogi :as log]
             [promesa.core :as p]
-            [frontend.debug :as debug]
             [frontend.mobile.util :as mobile]
             [clojure.set :as set]))
 
@@ -297,9 +296,7 @@
   []
   (let [chan (state/get-file-write-chan)]
     (async/go-loop []
-      (let [args (async/<! chan)
-            files (second args)]
-
+      (let [args (async/<! chan)]
         ;; return a channel
         (try
           (<p! (apply alter-files-handler! args))

--- a/src/main/frontend/handler/file.cljs
+++ b/src/main/frontend/handler/file.cljs
@@ -131,7 +131,7 @@
 
                 (and (mobile/native-android?) (not= "/" (first file)))
                 file
-                
+
                 (and (mobile/native-ios?) (not= "/" (first file)))
                 file
 
@@ -244,7 +244,6 @@
                           (-> (p/let [_ (or
                                          (util/electron?)
                                          (nfs/check-directory-permission! repo))]
-                                (debug/set-ack-step! path :write-file)
                                 (fs/write-file! repo (config/get-repo-dir repo) path content
                                                 {:old-content original-content}))
                               (p/catch (fn [error]
@@ -300,9 +299,6 @@
     (async/go-loop []
       (let [args (async/<! chan)
             files (second args)]
-
-        (doseq [path (map first files)]
-          (debug/set-ack-step! path :start-write-file))
 
         ;; return a channel
         (try

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -471,7 +471,7 @@
                                     (outliner-core/block)
                                     (outliner-tree/-get-down)
                                     (outliner-core/get-data))
-          to-last-direct-child-id (model/get-block-last-direct-child to-id)
+          to-last-direct-child-id (model/get-block-last-direct-child (db/get-conn) to-id)
           repo (state/get-current-repo)
           conn (conn/get-conn repo false)
           datoms (d/datoms @conn :avet :block/page from-id)

--- a/src/main/frontend/handler/ui.cljs
+++ b/src/main/frontend/handler/ui.cljs
@@ -232,9 +232,11 @@
   (let [[matched {:keys [on-chosen-open-link]}] (:rum/args state)
         current-idx (get state :frontend.ui/current-idx)]
     (util/stop e)
-    (when (and (seq matched)
-             (> (count matched)
-                @current-idx))
+    ;; FIXME: on-chosen-open-link might be nil
+    (when (and on-chosen-open-link
+               (seq matched)
+               (> (count matched)
+                  @current-idx))
       (on-chosen-open-link (nth matched @current-idx) false))))
 
 ;; date-picker

--- a/src/main/frontend/handler/ui.cljs
+++ b/src/main/frontend/handler/ui.cljs
@@ -229,15 +229,14 @@
 
 (defn auto-complete-open-link
   [state e]
-  (let [[matched {:keys [on-chosen-open-link]}] (:rum/args state)
-        current-idx (get state :frontend.ui/current-idx)]
-    (util/stop e)
-    ;; FIXME: on-chosen-open-link might be nil
-    (when (and on-chosen-open-link
-               (seq matched)
-               (> (count matched)
-                  @current-idx))
-      (on-chosen-open-link (nth matched @current-idx) false))))
+  (let [[matched {:keys [on-chosen-open-link]}] (:rum/args state)]
+    (when (and on-chosen-open-link (not (state/editing?)))
+      (let [current-idx (get state :frontend.ui/current-idx)]
+        (util/stop e)
+        (when (and (seq matched)
+                   (> (count matched)
+                      @current-idx))
+          (on-chosen-open-link (nth matched @current-idx) false))))))
 
 ;; date-picker
 ;; TODO: find a better way

--- a/src/main/frontend/modules/file/core.cljs
+++ b/src/main/frontend/modules/file/core.cljs
@@ -7,7 +7,6 @@
             [frontend.db.utils :as db-utils]
             [frontend.state :as state]
             [frontend.util :as util]
-            [frontend.debug :as debug]
             [frontend.util.property :as property]))
 
 (defn- indented-block-content

--- a/src/main/frontend/modules/file/core.cljs
+++ b/src/main/frontend/modules/file/core.cljs
@@ -107,8 +107,6 @@
     (assert (some? chan) "File write chan shouldn't be nil")
     (let [chan-callback (:chan-callback opts)]
       (async/put! chan [repo files opts])
-      (doseq [file (map first files)]
-        (debug/set-ack-step! file :pushed-to-channel))
       (when chan-callback
         (chan-callback)))))
 

--- a/src/main/frontend/modules/outliner/core.cljs
+++ b/src/main/frontend/modules/outliner/core.cljs
@@ -601,7 +601,9 @@
       (let [root-page (:db/id (:block/page (:data root)))
             target-page (:db/id (:block/page (:data target-node)))
             not-same-page? (not= root-page target-page)
-            opts (cond-> {:outliner-op :move-subtree}
+            opts (cond-> {:outliner-op :move-subtree
+                          :move-blocks [(:db/id (get-data root))]
+                          :target (:db/id (get-data target-node))}
                    not-same-page?
                    (assoc :from-page root-page
                           :target-page target-page))]

--- a/src/main/frontend/modules/outliner/core.cljs
+++ b/src/main/frontend/modules/outliner/core.cljs
@@ -30,13 +30,14 @@
     (when r (->Block r))))
 
 (defn- get-by-parent-&-left
-  [parent-id left-id]
-  (some->
-   (db-model/get-by-parent-&-left
-    (conn/get-conn false)
-    [:block/uuid parent-id]
-    [:block/uuid left-id])
-   (block)))
+  [parent-uuid left-uuid]
+  (let [parent-id (:db/id (db/entity [:block/uuid parent-uuid]))
+        left-id (:db/id (db/entity [:block/uuid left-uuid]))]
+    (some->
+     (db-model/get-by-parent-&-left (conn/get-conn false) parent-id left-id)
+     :db/id
+     db/pull
+     block)))
 
 (defn- block-with-timestamps
   [block]

--- a/src/main/frontend/modules/outliner/core.cljs
+++ b/src/main/frontend/modules/outliner/core.cljs
@@ -125,7 +125,7 @@
             "db should be satisfied outliner-tx-state?")
     (let [m (-> (:data this)
                 (dissoc :block/children :block/meta :block/top? :block/bottom?
-                        :block/title :block/body)
+                        :block/title :block/body :block/level)
                 (util/remove-nils))
           m (if (state/enable-block-timestamps?) (block-with-timestamps m) m)
           other-tx (:db/other-tx m)

--- a/src/main/frontend/modules/outliner/core.cljs
+++ b/src/main/frontend/modules/outliner/core.cljs
@@ -34,7 +34,7 @@
   (let [parent-id (:db/id (db/entity [:block/uuid parent-uuid]))
         left-id (:db/id (db/entity [:block/uuid left-uuid]))]
     (some->
-     (db-model/get-by-parent-&-left (conn/get-conn false) parent-id left-id)
+     (db-model/get-by-parent-&-left (conn/get-conn) parent-id left-id)
      :db/id
      db/pull
      block)))

--- a/src/main/frontend/modules/outliner/core.cljs
+++ b/src/main/frontend/modules/outliner/core.cljs
@@ -32,11 +32,11 @@
 (defn- get-by-parent-&-left
   [parent-id left-id]
   (some->
-    (db-outliner/get-by-parent-&-left
-      (conn/get-conn false)
-      [:block/uuid parent-id]
-      [:block/uuid left-id])
-    (block)))
+   (db-model/get-by-parent-&-left
+    (conn/get-conn false)
+    [:block/uuid parent-id]
+    [:block/uuid left-id])
+   (block)))
 
 (defn- block-with-timestamps
   [block]

--- a/src/main/frontend/modules/outliner/datascript.cljc
+++ b/src/main/frontend/modules/outliner/datascript.cljc
@@ -48,7 +48,12 @@
 #?(:cljs
    (defn transact!
      [txs opts]
-     (let [txs (remove-nil-from-transaction txs)]
+     (let [txs (remove-nil-from-transaction txs)
+           txs (map (fn [m] (if (map? m)
+                              (dissoc m
+                                      :block/children :block/meta :block/top? :block/bottom?
+                                      :block/title :block/body :block/level)
+                              m)) txs)]
        ;; (util/pprint txs)
        (when (and (seq txs)
                  (not (:skip-transact? opts)))

--- a/src/main/frontend/modules/outliner/file.cljs
+++ b/src/main/frontend/modules/outliner/file.cljs
@@ -53,13 +53,12 @@
 
 (defn sync-to-file
   [{page-db-id :db/id}]
-  ;; (if (nil? page-db-id)
-  ;;   (notification/show!
-  ;;    "Write file failed, can't find the current page!"
-  ;;    :error)
-  ;;   (when-let [repo (state/get-current-repo)]
-  ;;     (async/put! write-chan [repo page-db-id])))
-  )
+  (if (nil? page-db-id)
+    (notification/show!
+     "Write file failed, can't find the current page!"
+     :error)
+    (when-let [repo (state/get-current-repo)]
+      (async/put! write-chan [repo page-db-id]))))
 
 (util/batch write-chan
             batch-write-interval

--- a/src/main/frontend/modules/outliner/file.cljs
+++ b/src/main/frontend/modules/outliner/file.cljs
@@ -53,12 +53,13 @@
 
 (defn sync-to-file
   [{page-db-id :db/id}]
-  (if (nil? page-db-id)
-    (notification/show!
-     "Write file failed, can't find the current page!"
-     :error)
-    (when-let [repo (state/get-current-repo)]
-      (async/put! write-chan [repo page-db-id]))))
+  ;; (if (nil? page-db-id)
+  ;;   (notification/show!
+  ;;    "Write file failed, can't find the current page!"
+  ;;    :error)
+  ;;   (when-let [repo (state/get-current-repo)]
+  ;;     (async/put! write-chan [repo page-db-id])))
+  )
 
 (util/batch write-chan
             batch-write-interval

--- a/src/main/frontend/modules/outliner/pipeline.cljs
+++ b/src/main/frontend/modules/outliner/pipeline.cljs
@@ -1,9 +1,6 @@
 (ns frontend.modules.outliner.pipeline
   (:require [frontend.modules.datascript-report.core :as ds-report]
-            [frontend.modules.outliner.file :as file]
-            [frontend.db :as db]
-            [frontend.util :as util]
-            [frontend.debug :as debug]))
+            [frontend.modules.outliner.file :as file]))
 
 (defn updated-page-hook
   [page]

--- a/src/main/frontend/modules/outliner/pipeline.cljs
+++ b/src/main/frontend/modules/outliner/pipeline.cljs
@@ -7,13 +7,6 @@
 
 (defn updated-page-hook
   [page]
-  (let [page (db/entity (:db/id page))
-        path (:file/path (:block/file page))
-        page-title (or (:block/original-name page)
-                       (:block/name page))]
-    (when (util/electron?)
-      (debug/set-ack-step! path :start-writing)
-      (debug/wait-for-write-ack! page-title path)))
   (file/sync-to-file page))
 
 (defn invoke-hooks

--- a/src/main/frontend/modules/outliner/tree.cljs
+++ b/src/main/frontend/modules/outliner/tree.cljs
@@ -80,3 +80,20 @@
   [blocks-exclude-root root]
   (let [parent-groups (atom (group-by :block/parent blocks-exclude-root))]
     (flatten (concat (sort-blocks-aux [root] parent-groups) (vals @parent-groups)))))
+
+(defn blocks-with-level
+  "`blocks` should be sorted already."
+  [blocks]
+  (let [level->block (atom {})]
+    (loop [blocks blocks
+           result []]
+      (if-let [block (first blocks)]
+        (let [parent-id (:db/id (:block/parent block))
+              parent-level (get @level->block parent-id)
+              level' (inc (or parent-level 0))
+              block (assoc block :block/level level')]
+          (when-not parent-level
+            (swap! level->block assoc parent-id parent-level))
+          (swap! level->block assoc (:db/id block) level')
+          (recur (rest blocks) (conj result block)))
+        result))))

--- a/src/main/frontend/modules/outliner/tree.cljs
+++ b/src/main/frontend/modules/outliner/tree.cljs
@@ -80,20 +80,3 @@
   [blocks-exclude-root root]
   (let [parent-groups (atom (group-by :block/parent blocks-exclude-root))]
     (flatten (concat (sort-blocks-aux [root] parent-groups) (vals @parent-groups)))))
-
-(defn blocks-with-level
-  "`blocks` should be sorted already."
-  [blocks]
-  (let [level->block (atom {})]
-    (loop [blocks blocks
-           result []]
-      (if-let [block (first blocks)]
-        (let [parent-id (:db/id (:block/parent block))
-              parent-level (get @level->block parent-id)
-              level' (inc (or parent-level 0))
-              block (assoc block :block/level level')]
-          (when-not parent-level
-            (swap! level->block assoc parent-id parent-level))
-          (swap! level->block assoc (:db/id block) level')
-          (recur (rest blocks) (conj result block)))
-        result))))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -111,7 +111,6 @@
      :editor/show-zotero                    false
      :editor/last-saved-cursor              nil
      :editor/editing?                       nil
-     ;; This key is not currently used but may be useful later?
      :editor/in-composition?                false
      :editor/content                        {}
      :editor/block                          nil

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -207,8 +207,7 @@
      :srs/mode?                             false
 
      :srs/cards-due-count                   nil
-
-     :reactive/query-dbs                    {}})))
+     })))
 
 ;; block uuid -> {content(String) -> ast}
 (def blocks-ast-cache (atom {}))
@@ -1627,20 +1626,6 @@
 (defn sub-collapsed
   [block-id]
   (sub [:ui/collapsed-blocks (get-current-repo) block-id]))
-
-(defn get-reactive-query-db
-  [ks]
-  (get-in @state [:reactive/query-dbs ks]))
-
-(defn delete-reactive-query-db!
-  [ks]
-  (update-state! :reactive/query-dbs (fn [dbs] (dissoc dbs ks))))
-
-(defn set-reactive-query-db!
-  [ks db-value]
-  (if db-value
-    (set-state! [:reactive/query-dbs ks] db-value)
-    (delete-reactive-query-db! ks)))
 
 (defn get-modal-id
   []

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -873,7 +873,8 @@
   []
   (swap! state merge {:editor/editing? nil
                       :editor/block    nil
-                      :cursor-range    nil}))
+                      :cursor-range    nil
+                      :editor/last-saved-cursor nil}))
 
 (defn into-code-editor-mode!
   []

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -112,7 +112,6 @@
      :editor/last-saved-cursor              nil
      :editor/editing?                       nil
      ;; This key is not currently used but may be useful later?
-     :editor/last-edit-block-input-id       nil
      :editor/in-composition?                false
      :editor/content                        {}
      :editor/block                          nil
@@ -851,22 +850,16 @@
                 (-> state
                     (assoc-in [:editor/content edit-input-id] content)
                     (assoc
-                      :editor/block block
-                      :editor/editing? {edit-input-id true}
-                      :editor/last-edit-block-input-id edit-input-id
-                      :editor/last-edit-block block
-                      :editor/last-key-code nil
-                      :cursor-range cursor-range))))
-
+                     :editor/block block
+                     :editor/editing? {edit-input-id true}
+                     :editor/last-edit-block block
+                     :editor/last-key-code nil
+                     :cursor-range cursor-range))))
        (when-let [input (gdom/getElement edit-input-id)]
          (let [pos (count cursor-range)]
            (when content
-             (util/set-change-value input content)
-             ;; FIXME
-             ;; use set-change-value for now
-             ;; until somebody can figure out why set! value doesn't work here
-             ;; it seems to me textarea autoresize is completely broken
-             #_(set! (.-value input) (string/trim content)))
+             (util/set-change-value input content))
+
            (when move-cursor?
              (cursor/move-cursor-to input pos))
 

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -118,7 +118,6 @@
      :editor/block-dom-id                   nil
      :editor/set-timestamp-block            nil
      :editor/last-input-time                nil
-     :editor/pos                            nil
      :editor/document-mode?                 document-mode?
      :editor/args                           nil
      :editor/on-paste?                      false
@@ -524,16 +523,7 @@
        (when-let [input (gdom/getElement input-id)]
          (util/set-change-value input value)))
      (update-state! :editor/content (fn [m]
-                                      (assoc m input-id value)))
-     ;; followers
-     ;; (when-let [s (util/extract-uuid input-id)]
-     ;;   (let [input (gdom/getElement input-id)
-     ;;         leader-parent (util/rec-get-block-node input)
-     ;;         followers (->> (array-seq (js/document.getElementsByClassName s))
-     ;;                        (remove #(= leader-parent %)))]
-     ;;     (prn "followers: " (count followers))
-     ;;     ))
-     )))
+                                      (assoc m input-id value))))))
 
 (defn get-edit-input-id
   []
@@ -891,9 +881,17 @@
                       :cursor-range      nil
                       :editor/code-mode? true}))
 
-(defn set-last-pos!
+(defn set-editor-last-pos!
   [new-pos]
   (set-state! :editor/last-saved-cursor new-pos))
+
+(defn clear-editor-last-pos!
+  []
+  (set-state! :editor/last-saved-cursor nil))
+
+(defn get-editor-last-pos
+  []
+  (:editor/last-saved-cursor @state))
 
 (defn set-block-content-and-last-pos!
   [edit-input-id content new-pos]

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1636,3 +1636,9 @@
 (defn get-modal-id
   []
   (:modal/id @state))
+
+(defn edit-in-query-component
+  []
+  (and (editing?)
+       ;; config
+       (:custom-query? (last (get-editor-args)))))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -637,6 +637,19 @@
   [value]
   (set-state! :editor/show-zotero value))
 
+;; TODO: refactor, use one state
+(defn clear-editor-show-state!
+  []
+  (swap! state (fn [state]
+                 (assoc state
+                        :editor/show-input nil
+                        :editor/show-zotero false
+                        :editor/show-date-picker? false
+                        :editor/show-block-search? false
+                        :editor/show-template-search? false
+                        :editor/show-page-search? false
+                        :editor/show-page-search-hashtag? false))))
+
 (defn set-edit-input-id!
   [input-id]
   (swap! state update :editor/editing?

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -24,7 +24,6 @@
             ["react-textarea-autosize" :as TextareaAutosize]
             ["react-tippy" :as react-tippy]
             ["react-transition-group" :refer [CSSTransition TransitionGroup]]
-            ["react-virtuoso" :refer [Virtuoso]]
             ["@logseq/react-tweet-embed" :as react-tweet-embed]
             [rum.core :as rum]
             [frontend.db-mixins :as db-mixins]
@@ -34,7 +33,6 @@
 (defonce transition-group (r/adapt-class TransitionGroup))
 (defonce css-transition (r/adapt-class CSSTransition))
 (defonce textarea (r/adapt-class (gobj/get TextareaAutosize "default")))
-(defonce virtual-list (r/adapt-class Virtuoso))
 (def resize-provider (r/adapt-class (gobj/get Resize "ResizeProvider")))
 (def resize-consumer (r/adapt-class (gobj/get Resize "ResizeConsumer")))
 (def Tippy (r/adapt-class (gobj/get react-tippy "Tooltip")))

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -391,7 +391,7 @@
   (let [list-element-id (first (:rum/args state))
         opts (-> state :rum/args (nth 2))
         node (js/document.getElementById list-element-id)
-        debounced-on-scroll (debounce #(on-scroll node opts) 500)]
+        debounced-on-scroll (debounce #(on-scroll node opts) 100)]
     (mixins/listen state node :scroll debounced-on-scroll)))
 
 (rum/defcs infinite-list <

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -24,6 +24,7 @@
             ["react-textarea-autosize" :as TextareaAutosize]
             ["react-tippy" :as react-tippy]
             ["react-transition-group" :refer [CSSTransition TransitionGroup]]
+            ["react-virtuoso" :refer [Virtuoso]]
             ["@logseq/react-tweet-embed" :as react-tweet-embed]
             [rum.core :as rum]
             [frontend.db-mixins :as db-mixins]
@@ -33,6 +34,7 @@
 (defonce transition-group (r/adapt-class TransitionGroup))
 (defonce css-transition (r/adapt-class CSSTransition))
 (defonce textarea (r/adapt-class (gobj/get TextareaAutosize "default")))
+(defonce virtual-list (r/adapt-class Virtuoso))
 (def resize-provider (r/adapt-class (gobj/get Resize "ResizeProvider")))
 (def resize-consumer (r/adapt-class (gobj/get Resize "ResizeConsumer")))
 (def Tippy (r/adapt-class (gobj/get react-tippy "Tooltip")))

--- a/src/test/frontend/db/outliner_test.cljs
+++ b/src/test/frontend/db/outliner_test.cljs
@@ -15,19 +15,19 @@
         result (outliner/get-by-id conn [:block/uuid block-id])]
     (is (= block-id (:block/uuid result)))))
 
-(deftest test-get-by-parent-&-left
-  (let [conn (core-test/get-current-conn)
-        data [{:block/uuid "1"}
-              {:block/uuid "2"
-               :block/parent [:block/uuid "1"]
-               :block/left [:block/uuid "1"]}
-              {:block/uuid "3"
-               :block/parent [:block/uuid "1"]
-               :block/left [:block/uuid "2"]}]
-        _ (d/transact! conn data)
-        result (outliner/get-by-parent-&-left
-                 conn [:block/uuid "1"] [:block/uuid "2"])]
-    (is (= "3" (:block/uuid result)))))
+;; (deftest test-get-by-parent-&-left
+;;   (let [conn (core-test/get-current-conn)
+;;         data [{:block/uuid "1"}
+;;               {:block/uuid "2"
+;;                :block/parent [:block/uuid "1"]
+;;                :block/left [:block/uuid "1"]}
+;;               {:block/uuid "3"
+;;                :block/parent [:block/uuid "1"]
+;;                :block/left [:block/uuid "2"]}]
+;;         _ (d/transact! conn data)
+;;         result (outliner/get-by-parent-&-left
+;;                  conn [:block/uuid "1"] [:block/uuid "2"])]
+;;     (is (= "3" (:block/uuid result)))))
 
 (deftest test-get-by-parent-id
   (let [conn (core-test/get-current-conn)
@@ -53,18 +53,3 @@
         _ (outliner/del-block conn [:block/uuid "2"])
         result (d/entity @conn [:block/uuid "2"])]
     (is (nil? result))))
-
-(deftest test-get-journals
-  (let [conn (core-test/get-current-conn)
-        data [{:block/uuid "1"}
-              {:block/uuid "2"
-               :block/parent [:block/uuid "1"]
-               :block/left [:block/uuid "1"]
-               :block/journal? true}
-              {:block/uuid "3"
-               :block/parent [:block/uuid "1"]
-               :block/left [:block/uuid "2"]
-               :block/journal? true}]
-        _ (d/transact! conn data)
-        result (outliner/get-journals conn)]
-    (is (= ["2" "3"] (mapv :block/uuid result)))))

--- a/src/test/frontend/db/outliner_test.cljs
+++ b/src/test/frontend/db/outliner_test.cljs
@@ -26,7 +26,7 @@
 ;;                :block/left [:block/uuid "2"]}]
 ;;         _ (d/transact! conn data)
 ;;         result (outliner/get-by-parent-&-left
-;;                  conn [:block/uuid "1"] [:block/uuid "2"])]
+;;                  @conn [:block/uuid "1"] [:block/uuid "2"])]
 ;;     (is (= "3" (:block/uuid result)))))
 
 (deftest test-get-by-parent-id

--- a/src/test/frontend/handler/extract_test.cljs
+++ b/src/test/frontend/handler/extract_test.cljs
@@ -13,7 +13,7 @@
       (do
         (util/pprint (map (fn [x] (select-keys x [:block/uuid :block/level :block/content :block/left])) result))
         (throw (js/Error. ":block/parent && :block/left conflicts")))
-      (mapv (juxt :block/level :block/content) result))))
+      (mapv :block/content result))))
 
 (defn- async-test
   [x y]
@@ -30,7 +30,7 @@
    "- a
   - b
     - c"
-   [[1 "a"] [2 "b"] [3 "c"]])
+   ["a" "b" "c"])
 
   (async-test
    "## hello
@@ -39,7 +39,7 @@
         - nice
       - bingo
       - world"
-   [[1 "## hello"] [2 "world"] [3 "nice"] [4 "nice"] [3 "bingo"] [3 "world"]])
+   ["## hello" "world" "nice" "nice" "bingo" "world"])
 
   (async-test
    "# a
@@ -53,16 +53,7 @@
   - i
 - j"
 
-   [[1 "# a"]
-    [1 "## b"]
-    [1 "### c"]
-    [1 "#### d"]
-    [1 "### e"]
-    [1 "f"]
-    [2 "g"]
-    [3 "h"]
-    [2 "i"]
-    [1 "j"]]))
+   ["# a" "## b" "### c" "#### d" "### e" "f" "g" "h" "i" "j"]))
 
 (deftest test-regression-1902
   []
@@ -71,6 +62,6 @@
     - line2
       - line3
      - line4"
-   [[1 "line1"] [2 "line2"] [3 "line3"] [3 "line4"]]))
+   ["line1" "line2" "line3" "line4"]))
 
 #_(cljs.test/run-tests)

--- a/src/test/frontend/modules/outliner/ds_test.cljs
+++ b/src/test/frontend/modules/outliner/ds_test.cljs
@@ -12,7 +12,6 @@
                     nil
                     (let [datom [{:block/uuid #uuid"606c1962-ad7f-424e-b120-0dc7fcb25415",
                                   :block/refs (),
-                                  :block/anchor "level_2123123",
                                   :block/repo "logseq_local_test_navtive_fs",
                                   :block/meta {:timestamps [], :properties [], :start-pos 0, :end-pos 15},
                                   :block/format :markdown,
@@ -24,14 +23,11 @@
                                   :block/path-refs (),}]]
                       (ds/add-txs txs-state datom)))
         rt [[72 :block/uuid #uuid "606c1962-ad7f-424e-b120-0dc7fcb25415" 536870913 true]
-            [72 :block/anchor "level_2123123" 536870913 true]
             [72 :block/repo "logseq_local_test_navtive_fs" 536870913 true]
-            [72 :block/meta {:timestamps [], :properties [], :start-pos 0, :end-pos 15} 536870913 true]
             [72 :block/format :markdown 536870913 true]
-            [72 :block/level 1 536870913 true]
             [72 :block/refs-with-children () 536870913 true]
             [72 :block/content "level test" 536870913 true]]]
     (is (= rt (mapv vec (:tx-data db-report))))))
 
 (comment
-  (run-test test-with-db-macro))
+  (test/run-tests))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,18 +1271,6 @@
   dependencies:
     "@types/node" "*"
 
-"@virtuoso.dev/react-urx@^0.2.12":
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/@virtuoso.dev/react-urx/-/react-urx-0.2.13.tgz#e2cfc42d259d2a002695e7517d34cb97b64ee9c4"
-  integrity sha512-MY0ugBDjFb5Xt8v2HY7MKcRGqw/3gTpMlLXId2EwQvYJoC8sP7nnXjAxcBtTB50KTZhO0SbzsFimaZ7pSdApwA==
-  dependencies:
-    "@virtuoso.dev/urx" "^0.2.13"
-
-"@virtuoso.dev/urx@^0.2.12", "@virtuoso.dev/urx@^0.2.13":
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/@virtuoso.dev/urx/-/urx-0.2.13.tgz#a65e7e8d923cb03397ac876bfdd45c7f71c8edf1"
-  integrity sha512-iirJNv92A1ZWxoOHHDYW/1KPoi83939o83iUBQHIim0i3tMeSKEh+bxhJdTHQ86Mr4uXx9xGUTq69cp52ZP8Xw==
-
 acorn-node@^1.6.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/acorn-node/-/acorn-node-1.8.2.tgz#114c95d64539e53dede23de8b9d96df7c7ae2af8"
@@ -6837,14 +6825,6 @@ react-transition-group@4.3.0:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
-
-react-virtuoso@^2.8.5:
-  version "2.8.5"
-  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-2.8.5.tgz#92f22d22255b444380dd0a29004d9bf678df834a"
-  integrity sha512-ayFESqgt++or9NLZ5XZR9Pta5W9jiT9pf9cYa/FYX5BoDuWMFYhou7xCal624JY6CzOOnwUlCGck95dtxsVDiA==
-  dependencies:
-    "@virtuoso.dev/react-urx" "^0.2.12"
-    "@virtuoso.dev/urx" "^0.2.12"
 
 react@17.0.2:
   version "17.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,6 +1271,18 @@
   dependencies:
     "@types/node" "*"
 
+"@virtuoso.dev/react-urx@^0.2.12":
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/@virtuoso.dev/react-urx/-/react-urx-0.2.13.tgz#e2cfc42d259d2a002695e7517d34cb97b64ee9c4"
+  integrity sha512-MY0ugBDjFb5Xt8v2HY7MKcRGqw/3gTpMlLXId2EwQvYJoC8sP7nnXjAxcBtTB50KTZhO0SbzsFimaZ7pSdApwA==
+  dependencies:
+    "@virtuoso.dev/urx" "^0.2.13"
+
+"@virtuoso.dev/urx@^0.2.12", "@virtuoso.dev/urx@^0.2.13":
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/@virtuoso.dev/urx/-/urx-0.2.13.tgz#a65e7e8d923cb03397ac876bfdd45c7f71c8edf1"
+  integrity sha512-iirJNv92A1ZWxoOHHDYW/1KPoi83939o83iUBQHIim0i3tMeSKEh+bxhJdTHQ86Mr4uXx9xGUTq69cp52ZP8Xw==
+
 acorn-node@^1.6.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/acorn-node/-/acorn-node-1.8.2.tgz#114c95d64539e53dede23de8b9d96df7c7ae2af8"
@@ -6825,6 +6837,14 @@ react-transition-group@4.3.0:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
+
+react-virtuoso@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-2.8.5.tgz#92f22d22255b444380dd0a29004d9bf678df834a"
+  integrity sha512-ayFESqgt++or9NLZ5XZR9Pta5W9jiT9pf9cYa/FYX5BoDuWMFYhou7xCal624JY6CzOOnwUlCGck95dtxsVDiA==
+  dependencies:
+    "@virtuoso.dev/react-urx" "^0.2.12"
+    "@virtuoso.dev/urx" "^0.2.12"
 
 react@17.0.2:
   version "17.0.2"


### PR DESCRIPTION
This PR uses both `:block/parent` and `:block/left` to load blocks lazily instead of querying the whole list as previously. The result is that it's fast to open a page no matter how many blocks it has.

Other enhancements:
1. `get-page-blocks` and `sub-block-and-children` are replaced with `get-paginated-blocks`.
2. Queries' db cache and `frontend.db.react/new-db` are removed to avoid unneeded complexity.
3. `:frontend.db.react/block-refs-count` is removed too
4. Bumped rum to latest version which brings back the old batch updates optimization, which means several set-state! calls will be batched together to trigger re-render once, but it makes e2e tests failed, thanks to @andelf for the quick fix!
5. Only restore the last graph instead of all of them.

There's a try to use https://github.com/petyosi/react-virtuoso(virtual list) to reduce blocks rendering. The performance improvement is amazing, and it's always fast for 5k+ blocks. The problem is that the flatten dom list is incompatible with some custom themes and plugins because we're rendering blocks tree now. We need to do more research on virtual trees.

Demos:
1. Current version:
   https://www.loom.com/share/38aa2e395bd341c683bf4ad8267e7736
6. Virtual list implementation:
   https://www.loom.com/share/203153b25e6e4ea2a81a16e781d7326a
