### PR TITLE
fix(dev): missing today queries key

### DIFF
--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -147,15 +147,13 @@
       (when (seq queries)
         [:div#today-queries.mt-10
          (for [query queries]
-           (ui/catch-error
-            (rum/with-key
+           (rum/with-key
+             (ui/catch-error
               (ui/component-error "Failed default query:" {:content (pr-str query)})
-              (str repo "-custom-query-" (:query query)))
-            (rum/with-key
               (block/custom-query {:attr {:class "mt-10"}
                                    :editor-box editor/box
-                                   :page page} query)
-              (str repo "-custom-query-" (:query query)))))]))))
+                                   :page page} query))
+             (str repo "-custom-query-" (:query query))))]))))
 
 (defn tagged-pages
   [repo tag]


### PR DESCRIPTION
Reorder `ui/catch-error` and `rum/with-key` 
To fix the following:
<img width="754" alt="image" src="https://user-images.githubusercontent.com/72891/160548467-8d0cfc74-b671-469a-a2e7-b5e194d11ac7.png">

Never mind, this is a dev-only warning. 