### PR TITLE
Enhance: Add error screen for root component

### DIFF
--- a/src/main/frontend/page.cljs
+++ b/src/main/frontend/page.cljs
@@ -34,40 +34,45 @@
       [:div#main-content-container.scrollbar-spacing.w-full.flex.justify-center
        [:div.cp__sidebar-main-content
         [:div.ls-center
-         [:div.text-center (ui/icon "bug" {:style {:font-size ui/icon-size}})]
-         [:div.font-bold.text-center
+         [:div (ui/icon "bug" {:style {:font-size ui/icon-size}})]
+         [:div.font-bold
           "Sorry. Something went wrong!"]
          [:div.mt-2.mb-2 "Logseq is having a problem. To try to get it back to a
          working state, please try the following safe steps in order:"]
          [:div
+          ;; TODO: Enable once multi-window case doesn't result in possible data loss
+          #_[:div.flex.flex-row.justify-between.align-items.mb-2
+             [:div.flex.flex-col.items-start
+              [:div.text-xs "STEP 1"]
+              [:div [:span.font-bold "Reload"] " the app"]]
+             [:div (ui/icon "command") (ui/icon "letter-r")]]
           [:div.flex.flex-row.justify-between.align-items.mb-2
            [:div.flex.flex-col.items-start
             [:div.text-xs "STEP 1"]
-            [:div [:span.font-bold "Reload"] " the app"]]
-           [:div (ui/icon "command") (ui/icon "letter-r")]]
+            [:div [:span.font-bold "Rebuild"] " search index"]]
+           [:div
+            (ui/button "Try"
+                           :small? true
+                           :on-click (fn []
+                                       (search-handler/rebuild-indices! true)))]]
           [:div.flex.flex-row.justify-between.align-items.mb-2
            [:div.flex.flex-col.items-start
             [:div.text-xs "STEP 2"]
             [:div [:span.font-bold "Relaunch"] " the app"]
             [:div.text-xs "Quit the app and then reopen it."]]
-           [:div (ui/icon "command") (ui/icon "letter-q")]]
-          [:div.flex.flex-row.justify-between.align-items.mb-2
+           [:div (ui/icon "command" {:class "rounded-md p-1 mr-2 bg-quaternary"})
+            (ui/icon "letter-q" {:class "rounded-md p-1 bg-quaternary"})]]
+          [:div.flex.flex-row.justify-between.align-items.mb-4
            [:div.flex.flex-col.items-start
             [:div.text-xs "STEP 3"]
-            [:div [:span.font-bold "Clear"] " local storage"]]
-           (ui/button "Try"
-                      :small? true
-                      :on-click (fn []
-                                  (.clear js/localStorage)
-                                  (notification/show! "Cleared!" :success)))]
-          [:div.flex.flex-row.justify-between.align-items.mb-2
-           [:div.flex.flex-col.items-start
-            [:div.text-xs "STEP 4"]
-            [:div [:span.font-bold "Rebuild"] " search index"]]
-           (ui/button "Try"
-                      :small? true
-                      :on-click (fn []
-                                  (search-handler/rebuild-indices! true)))]]
+            [:div [:span.font-bold "Clear"] " local storage"]
+            [:div.text-xs "This does delete minor preferences like dark/light theme preference."]]
+           [:div
+            (ui/button "Try"
+                       :small? true
+                       :on-click (fn []
+                                   (.clear js/localStorage)
+                                   (notification/show! "Cleared!" :success)))]]]
          [:div
           [:p "If you think you have experienced data loss, check for backup files under
           the folder logseq/bak/."]

--- a/src/main/frontend/page.cljs
+++ b/src/main/frontend/page.cljs
@@ -3,6 +3,8 @@
             [frontend.state :as state]
             [frontend.ui :as ui]
             [frontend.components.sidebar :as sidebar]
+            [frontend.handler.search :as search-handler]
+            [frontend.handler.notification :as notification]
             [frontend.handler.plugin :as plugin-handler]))
 
 (rum/defc route-view
@@ -17,6 +19,63 @@
       (ui/setup-patch-ios-visual-viewport-state!))
     (catch js/Error _e
       nil)))
+
+(rum/defc helpful-default-error-screen
+  "This screen is displayed when the UI has crashed hard. It provides the user
+  with basic troubleshooting steps to get them back to a working state. This
+  component is purposefully stupid simple as it needs to render under any number
+  of broken conditions"
+  []
+  ;; This layout emulates most of sidebar/sidebar
+  [:div#main-container.cp__sidebar-main-layout.flex-1.flex
+   [:div.#app-container
+    [:div#left-container
+     [:div#main-container.cp__sidebar-main-layout.flex-1.flex
+      [:div#main-content-container.scrollbar-spacing.w-full.flex.justify-center
+       [:div.cp__sidebar-main-content
+        [:div.ls-center
+         [:div.text-center (ui/icon "bug" {:style {:font-size ui/icon-size}})]
+         [:div.font-bold.text-center
+          "Sorry. Something went wrong!"]
+         [:div.mt-2.mb-2 "Logseq is having a problem. To try to get it back to a
+         working state, please try the following safe steps in order:"]
+         [:div
+          [:div.flex.flex-row.justify-between.align-items.mb-2
+           [:div.flex.flex-col.items-start
+            [:div.text-xs "STEP 1"]
+            [:div [:span.font-bold "Reload"] " the app"]]
+           [:div (ui/icon "command") (ui/icon "letter-r")]]
+          [:div.flex.flex-row.justify-between.align-items.mb-2
+           [:div.flex.flex-col.items-start
+            [:div.text-xs "STEP 2"]
+            [:div [:span.font-bold "Relaunch"] " the app"]
+            [:div.text-xs "Quit the app and then reopen it."]]
+           [:div (ui/icon "command") (ui/icon "letter-q")]]
+          [:div.flex.flex-row.justify-between.align-items.mb-2
+           [:div.flex.flex-col.items-start
+            [:div.text-xs "STEP 3"]
+            [:div [:span.font-bold "Clear"] " local storage"]]
+           (ui/button "Try"
+                      :small? true
+                      :on-click (fn []
+                                  (.clear js/localStorage)
+                                  (notification/show! "Cleared!" :success)))]
+          [:div.flex.flex-row.justify-between.align-items.mb-2
+           [:div.flex.flex-col.items-start
+            [:div.text-xs "STEP 4"]
+            [:div [:span.font-bold "Rebuild"] " search index"]]
+           (ui/button "Try"
+                      :small? true
+                      :on-click (fn []
+                                  (search-handler/rebuild-indices! true)))]]
+         [:div
+          [:p "If you think you have experienced data loss, check for backup files under
+          the folder logseq/bak/."]
+          [:p "If these troubleshooting steps have not solved your problem, please "
+           [:a.underline
+            {:href "https://github.com/logseq/logseq/issues"}
+            "open an issue."]]]]]]]]]
+   (ui/notification)])
 
 (rum/defc current-page < rum/reactive
   {:did-mount    (fn [state]
@@ -33,11 +92,13 @@
   (when-let [route-match (state/sub :route-match)]
     (let [route-name (get-in route-match [:data :name])]
       (when-let [view (:view (:data route-match))]
-        (if (= :draw route-name)
-          (view route-match)
-          (sidebar/sidebar
-           route-match
-           (view route-match)))))))
+        (ui/catch-error
+         (helpful-default-error-screen)
+         (if (= :draw route-name)
+           (view route-match)
+           (sidebar/sidebar
+            route-match
+            (view route-match))))))))
 
         ;; FIXME: disable for now
         ;; (let [route-name (get-in route-match [:data :name])

--- a/src/main/frontend/ui.css
+++ b/src/main/frontend/ui.css
@@ -285,3 +285,6 @@ html.is-mobile {
   transition: all 100ms ease-in 0ms;
 }
 
+.bg-quaternary {
+  background-color: var(--ls-quaternary-background-color);
+}


### PR DESCRIPTION
This PR adds a root error screen for when the app fails unexpectedly, as described and mocked up in https://quire.io/w/Logseq-_team_dedicated_to_sport_of_knowledge/614/UI_Error_Screen?sublist=Cycle2&view=board . Instead of a blank screen when our app fails, we now see this:
<img width="869" alt="Screen Shot 2022-03-30 at 1 19 50 PM" src="https://user-images.githubusercontent.com/97210743/160894493-23467ca4-8158-4829-9b6d-d917a86f1855.png">

