### PR TITLE
fix: some unique "key" prop issues

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps
  {org.clojure/clojure                   {:mvn/version "1.10.0"}
   cheshire/cheshire                     {:mvn/version "5.10.0"}
-  rum/rum                               {:mvn/version "0.12.3"}
+  rum/rum                               {:mvn/version "0.12.8"}
   datascript/datascript                 {:mvn/version "1.3.8"}
   datascript-transit/datascript-transit {:mvn/version "0.3.0"}
   borkdude/rewrite-edn                  {:git/url "https://github.com/borkdude/rewrite-edn"

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps
  {org.clojure/clojure                   {:mvn/version "1.10.0"}
   cheshire/cheshire                     {:mvn/version "5.10.0"}
-  rum/rum                               {:mvn/version "0.12.8"}
+  rum/rum                               {:mvn/version "0.12.3"}
   datascript/datascript                 {:mvn/version "1.3.8"}
   datascript-transit/datascript-transit {:mvn/version "0.3.0"}
   borkdude/rewrite-edn                  {:git/url "https://github.com/borkdude/rewrite-edn"

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -198,7 +198,7 @@
                    (when @*resizing-image? (util/stop e)))}
         (and (:width metadata) (not (util/mobile?)))
         (assoc :style {:width (:width metadata)}))
-      [:div.asset-container
+      [:div.asset-container {:key "resize-asset-container"}
        [:img.rounded-sm.shadow-xl.relative
         (merge
          {:loading "lazy"

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -385,7 +385,7 @@
       (notification/show! (str "The page \"" value "\" doesn't exist yet. Please create that page first, and then try again.") :warning))))
 
 (defn journal-row [t enable-journals?]
-  [:<>
+  [:span
    (toggle "enable_journals"
            (t :settings-page/enable-journals)
            enable-journals?

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -385,7 +385,8 @@
       (notification/show! (str "The page \"" value "\" doesn't exist yet. Please create that page first, and then try again.") :warning))))
 
 (defn journal-row [t enable-journals?]
-  [(toggle "enable_journals"
+  [:<>
+   (toggle "enable_journals"
            (t :settings-page/enable-journals)
            enable-journals?
            (fn []

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -137,7 +137,7 @@
                        (when icon icon)
                        [:div {:style {:margin-right "8px"}} title]])]
           (if hr
-            [:hr.my-1]
+            [:hr.my-1 {:key "dropdown-hr"}]
             (rum/with-key
               (menu-link new-options child)
               title))))
@@ -834,7 +834,7 @@
                                (log/error :exception e)
                                [:div]))
                            [:div {:key "tippy"} ""])))
-           child)))
+           [:<> {:key "tippy-children"} child])))
 
 (defn slider
   [default-value {:keys [min max on-change]}]

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -834,7 +834,7 @@
                                (log/error :exception e)
                                [:div]))
                            [:div {:key "tippy"} ""])))
-           [:<> {:key "tippy-children"} child])))
+            (rum/fragment {:key "tippy-children"} child))))
 
 (defn slider
   [default-value {:keys [min max on-change]}]


### PR DESCRIPTION
During local development, there are some "Each child in a list should have a unique "key" prop." errors popping up in the console log.

It seems that the main issue is that the adapted components via `rum/adapt-class` will always treat the passed children as an element in an array. This is the reason why they are appended with the key prop for tippy/resize etc.

Also, upgrade Rum version to the latest to support React fragements.