### PR TITLE
fix: disable some functions for published graph

### DIFF
--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -72,7 +72,7 @@
         {:on-click toggle-fn}
         (ui/icon "dots" {:style {:fontSize ui/icon-size}})])
      (->>
-      [(when-not (state/publishing-enable-editing?)
+      [(when (state/enable-editing?)
          {:title (t :settings)
           :options {:on-click state/open-settings!}
           :icon (ui/icon "settings")})
@@ -92,7 +92,7 @@
           :options {:on-click #(state/set-modal! export/export)}
           :icon (ui/icon "database-export")})
 
-       (when current-repo
+       (when (and current-repo (state/enable-editing?))
          {:title (t :import)
           :options {:href (rfe/href :import)}
           :icon (ui/icon "file-upload")})

--- a/src/main/frontend/components/sidebar.cljs
+++ b/src/main/frontend/components/sidebar.cljs
@@ -244,7 +244,7 @@
 
       (favorites t)
 
-      (when left-sidebar-open? (recent-pages t))
+      (when (and left-sidebar-open? (not config/publishing?)) (recent-pages t))
 
       [:nav.px-2 {:aria-label "Sidebar"
                   :class      "new-page"}

--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -135,6 +135,7 @@
             [frontend.state :as state]
             [frontend.utf8 :as utf8]
             [frontend.util :as util]
+            [frontend.config :as ui-config]
             [goog.dom :as gdom]
             [goog.object :as gobj]
             [rum.core :as rum]))
@@ -234,6 +235,7 @@
         cm-options (merge default-cm-options
                           (extra-codemirror-options)
                           {:mode mode
+                           :readOnly (if ui-config/publishing? "nocursor" false)
                            :extraKeys #js {"Esc" (fn [cm]
                                                    (save-file-or-block-when-blur-or-esc! cm textarea config state)
                                                    (when-let [block-id (:block/uuid config)]

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -824,6 +824,10 @@
   []
   (and @publishing? (:publishing/enable-editing? (get-config))))
 
+(defn enable-editing?
+  []
+  (or (not @publishing?) (:publishing/enable-editing? (get-config))))
+
 (defn set-editing!
   ([edit-input-id content block cursor-range]
    (set-editing! edit-input-id content block cursor-range true))


### PR DESCRIPTION
Disable the following functionalities for the published graph
- settings
- import
- recent
- code editor will be read only