### PR TITLE
fix: command palette is no long working

### DIFF
--- a/src/main/frontend/handler/command_palette.cljs
+++ b/src/main/frontend/handler/command_palette.cljs
@@ -49,6 +49,7 @@
 
 (defn invoke-command [{:keys [action] :as cmd}]
   (add-history cmd)
+  (state/set-state! :ui/command-palette-open? false)
   (state/close-modal!)
   (action))
 

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -571,8 +571,7 @@
 
     :shortcut.handler/misc
     ;; always overrides the copy due to "mod+c mod+s"
-    {:misc/copy              (:misc/copy              all-default-keyboard-shortcuts)
-     :command-palette/toggle (:command-palette/toggle all-default-keyboard-shortcuts)}
+    {:misc/copy              (:misc/copy              all-default-keyboard-shortcuts)}
 
     :shortcut.handler/global-non-editing-only
     (->


### PR DESCRIPTION
I created a card https://github.com/logseq/logseq/compare/fix/command-palette?expand=1 to add e2e tests for the command palette. Our next cycle will be mostly adding tests and code refactoring.