### PR TITLE
feat: show arrow when collapsed

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1439,7 +1439,7 @@
                      (if collapsed?
                        (editor-handler/expand-block! uuid)
                        (editor-handler/collapse-block! uuid))))}
-      [:span {:class (if control-show? "control-show cursor-pointer" "control-hide")}
+      [:span {:class (if (or control-show? collapsed?) "control-show cursor-pointer" "control-hide")}
        (ui/rotating-arrow collapsed?)]]
      (let [bullet [:a {:on-click (fn [event]
                                    (bullet-on-click event block uuid))}

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -683,7 +683,7 @@
                         :margin-left -30}}
              (not title-trigger?)
              (assoc :on-mouse-down on-mouse-down))
-           [:span {:class (if @control? "control-show cursor-pointer" "control-hide")}
+           [:span {:class (if (or @control? @collapsed?) "control-show cursor-pointer" "control-hide")}
             (rotating-arrow @collapsed?)]])
         (if (fn? header)
           (header @collapsed?)


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

Proposal: https://discuss.logseq.com/t/always-show-the-arrow-when-a-block-collapsed/6387.

Perhaps there could be a better solution to this problem. I just made changes based on the existence. ✌🏽