### PR TITLE
feat(mobile): dynamically reorder toolbar commands by click counts

### DIFF
--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -26,7 +26,8 @@
             [goog.dom :as gdom]
             [promesa.core :as p]
             [rum.core :as rum]
-            [frontend.handler.history :as history]))
+            [frontend.handler.history :as history]
+            [frontend.handler.config :as config-handler]))
 
 (rum/defc commands < rum/reactive
   [id format]
@@ -239,18 +240,21 @@
     (ui/icon icon {:style {:fontSize ui/icon-size}})]])
 
 (def ^:private mobile-bar-icons-keywords
-  [:checkbox :brackets :parentheses :command :tag :a-b :list :microphone :camera
+  [:checkbox :brackets :parentheses :command :tag :a-b :list :camera
    :brand-youtube :link :rotate :rotate-clockwise :code :bold :italic :strikethrough :paint])
 
-(def ^:private mobile-bar-commands-state
-  (atom (into {} (mapv (fn [name] [name {:counts 0}])
-                       mobile-bar-icons-keywords))))
+(def ^:private mobile-bar-commands-stats
+  (atom (or (:mobile/toolbar-stats (state/get-config))
+            (into {} (mapv (fn [name] [name {:counts 0}])
+                           mobile-bar-icons-keywords)))))
 
-(defn set-command-state [icon]
+(defn set-command-stats [icon]
   (let [key (keyword icon)
-        counts (get-in @mobile-bar-commands-state [key :counts])]
-    (swap! mobile-bar-commands-state
-           assoc-in [key :counts] (inc counts))))
+        counts (get-in @mobile-bar-commands-stats [key :counts])]
+    (swap! mobile-bar-commands-stats
+           assoc-in [key :counts] (inc counts))
+    (config-handler/set-config!
+     :mobile/toolbar-stats @mobile-bar-commands-stats)))
 
 (rum/defc mobile-bar-command
   [command-handler icon & [count? event?]]
@@ -259,7 +263,7 @@
     {:on-mouse-down (fn [e]
                       (util/stop e)
                       (when count?
-                        (set-command-state icon))
+                        (set-command-stats icon))
                       (if event?
                         (command-handler e)
                         (command-handler)))}
@@ -278,7 +282,6 @@
       (mobile-bar-command #(do (viewport-fn) (commands/simple-insert! parent-id "#" {})) "tag" true)
       (mobile-bar-command editor-handler/cycle-priority! "a-b" true)
       (mobile-bar-command editor-handler/toggle-list! "list" true)
-      (mobile-bar-command #(record/start-recording) "microphone" true)
       (mobile-bar-command #(mobile-camera/embed-photo parent-id) "camera" true)
       (mobile-bar-command commands/insert-youtube-timestamp "brand-youtube" true)
       (mobile-bar-command editor-handler/html-link-format! "link" true)
@@ -294,7 +297,8 @@
   [parent-state parent-id]
   (let [vw-state (state/sub :ui/visual-viewport-state)
         vw-pending? (state/sub :ui/visual-viewport-pending?)
-        commands (mobile-bar-commands parent-state parent-id)]
+        commands (mobile-bar-commands parent-state parent-id)
+        sorted-commands (sort-by (comp :counts second) > @mobile-bar-commands-stats)]
     [:div#mobile-editor-toolbar.bg-base-2
      {:style {:bottom (if vw-state
                         (- (.-clientHeight js/document.documentElement)
@@ -308,8 +312,8 @@
       (mobile-bar-command (editor-handler/move-up-down true) "arrow-bar-to-up")
       (mobile-bar-command (editor-handler/move-up-down false) "arrow-bar-to-down")
       (mobile-bar-command #(commands/simple-insert! parent-id "\n" {}) "arrow-back")
-      (for [command-key (sort-by val > @mobile-bar-commands-state)]
-        ((first command-key) commands))]
+      (for [command sorted-commands]
+        ((first command) commands))]
      [:div.toolbar-hide-keyboard
       (mobile-bar-command #(state/clear-edit!) "keyboard-show")]]))
 

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -238,24 +238,63 @@
                       (editor-handler/indent-outdent indent?))}
     (ui/icon icon {:style {:fontSize ui/icon-size}})]])
 
-(rum/defc mobile-bar-command [command-handler icon & [event?]]
+(def ^:private mobile-bar-icons-keywords
+  [:checkbox :brackets :parentheses :command :tag :a-b :list :microphone :camera
+   :brand-youtube :link :rotate :rotate-clockwise :code :bold :italic :strikethrough :paint])
+
+(def ^:private mobile-bar-commands-state
+  (atom (into {} (mapv (fn [name] [name {:counts 0}])
+                       mobile-bar-icons-keywords))))
+
+(defn set-command-state [icon]
+  (let [key (keyword icon)
+        counts (get-in @mobile-bar-commands-state [key :counts])]
+    (swap! mobile-bar-commands-state
+           assoc-in [key :counts] (inc counts))))
+
+(rum/defc mobile-bar-command
+  [command-handler icon & [count? event?]]
   [:div
    [:button.bottom-action
     {:on-mouse-down (fn [e]
                       (util/stop e)
+                      (when count?
+                        (set-command-state icon))
                       (if event?
                         (command-handler e)
                         (command-handler)))}
     (ui/icon icon {:style {:fontSize ui/icon-size}})]])
 
-(rum/defc mobile-bar < rum/reactive
+(defn mobile-bar-commands
   [_parent-state parent-id]
-  (let [vw-state (state/sub :ui/visual-viewport-state)
-        vw-pending? (state/sub :ui/visual-viewport-pending?)
-        ;; TODO: should we add this focus step to `simple-insert!`?
-        viewport-fn (fn [] (when-let [input (gdom/getElement parent-id)]
+  (let [viewport-fn (fn [] (when-let [input (gdom/getElement parent-id)]
                              (util/make-el-cursor-position-into-center-viewport input)
                              (.focus input)))]
+    (zipmap mobile-bar-icons-keywords
+     [(mobile-bar-command editor-handler/cycle-todo! "checkbox" true)
+      (mobile-bar-command #(editor-handler/toggle-page-reference-embed parent-id) "brackets" true)
+      (mobile-bar-command #(editor-handler/toggle-block-reference-embed parent-id) "parentheses" true)
+      (mobile-bar-command #(do (viewport-fn) (commands/simple-insert! parent-id "/" {})) "command" true)
+      (mobile-bar-command #(do (viewport-fn) (commands/simple-insert! parent-id "#" {})) "tag" true)
+      (mobile-bar-command editor-handler/cycle-priority! "a-b" true)
+      (mobile-bar-command editor-handler/toggle-list! "list" true)
+      (mobile-bar-command #(record/start-recording) "microphone" true)
+      (mobile-bar-command #(mobile-camera/embed-photo parent-id) "camera" true)
+      (mobile-bar-command commands/insert-youtube-timestamp "brand-youtube" true)
+      (mobile-bar-command editor-handler/html-link-format! "link" true)
+      (mobile-bar-command history/undo! "rotate" true true)
+      (mobile-bar-command history/redo! "rotate-clockwise" true true)
+      (mobile-bar-command #(do (viewport-fn) (commands/simple-insert! parent-id "<" {})) "code" true)
+      (mobile-bar-command editor-handler/bold-format! "bold" true)
+      (mobile-bar-command editor-handler/italics-format! "italic" true)
+      (mobile-bar-command editor-handler/strike-through-format! "strikethrough" true)
+      (mobile-bar-command editor-handler/highlight-format! "paint" true)])))
+
+(rum/defc mobile-bar < rum/reactive
+  [parent-state parent-id]
+  (let [vw-state (state/sub :ui/visual-viewport-state)
+        vw-pending? (state/sub :ui/visual-viewport-pending?)
+        commands (mobile-bar-commands parent-state parent-id)]
     [:div#mobile-editor-toolbar.bg-base-2
      {:style {:bottom (if vw-state
                         (- (.-clientHeight js/document.documentElement)
@@ -269,23 +308,8 @@
       (mobile-bar-command (editor-handler/move-up-down true) "arrow-bar-to-up")
       (mobile-bar-command (editor-handler/move-up-down false) "arrow-bar-to-down")
       (mobile-bar-command #(commands/simple-insert! parent-id "\n" {}) "arrow-back")
-      (mobile-bar-command editor-handler/cycle-todo! "checkbox")
-      (mobile-bar-command #(editor-handler/toggle-page-reference-embed parent-id) "brackets")
-      (mobile-bar-command #(editor-handler/toggle-block-reference-embed parent-id) "parentheses")
-      (mobile-bar-command #(do (viewport-fn) (commands/simple-insert! parent-id "/" {})) "command")
-      (mobile-bar-command #(do (viewport-fn) (commands/simple-insert! parent-id "#" {})) "tag")
-      (mobile-bar-command editor-handler/cycle-priority! "a-b")
-      (mobile-bar-command editor-handler/toggle-list! "list")
-      (mobile-bar-command #(mobile-camera/embed-photo parent-id) "camera")
-      (mobile-bar-command commands/insert-youtube-timestamp "brand-youtube")
-      (mobile-bar-command editor-handler/html-link-format! "link")
-      (mobile-bar-command history/undo! "rotate" true)
-      (mobile-bar-command history/redo! "rotate-clockwise" true)
-      (mobile-bar-command #(do (viewport-fn) (commands/simple-insert! parent-id "<" {})) "code")
-      (mobile-bar-command editor-handler/bold-format! "bold")
-      (mobile-bar-command editor-handler/italics-format! "italic")
-      (mobile-bar-command editor-handler/strike-through-format! "strikethrough")
-      (mobile-bar-command editor-handler/highlight-format! "paint")]
+      (for [command-key (sort-by val > @mobile-bar-commands-state)]
+        ((first command-key) commands))]
      [:div.toolbar-hide-keyboard
       (mobile-bar-command #(state/clear-edit!) "keyboard-show")]]))
 


### PR DESCRIPTION
This PR enables dynamically adjusting the commands icons of mobile toolbar. 
demo: https://www.loom.com/share/288b357f586c46cbba86e8c03a43f79c

The first five icons are fixed, while others are dynamically reordered based on the usage frequency. Also, the counts are saved in config file.

