### PR TITLE
fix: preview image file with capitalized extension

### DIFF
--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -177,7 +177,8 @@
   (into {} (remove (comp nil? second)) nm))
 
 (defn ext-of-image? [s]
-  (some #(string/ends-with? s %)
+  (some #(-> (string/lower-case s)
+             (string/ends-with? %))
         [".png" ".jpg" ".jpeg" ".bmp" ".gif" ".webp" ".svg"]))
 
 ;; ".lg:absolute.lg:inset-y-0.lg:right-0.lg:w-1/2"


### PR DESCRIPTION
fix https://github.com/logseq/logseq/issues/4685