### PR TITLE
Enhance: Better issue links

### DIFF
--- a/src/main/frontend/components/onboarding.cljs
+++ b/src/main/frontend/components/onboarding.cljs
@@ -31,7 +31,7 @@
 
           {:title "Development"
            :children [[(t :help/roadmap) "https://trello.com/b/8txSM12G/roadmap"]
-                      [(t :help/bug) "https://github.com/logseq/logseq/issues/new?assignees=&labels=&template=bug_report.md&title="]
+                      [(t :help/bug) "https://github.com/logseq/logseq/issues/new?labels=from:in-app&template=bug_report.yaml"]
                       [(t :help/feature) "https://github.com/logseq/logseq/issues/new?assignees=&labels=&template=feature_request.md&title="]
                       [(t :help/changelog) "https://docs.logseq.com/#/page/changelog"]]}
 

--- a/src/main/frontend/mobile/intent.cljs
+++ b/src/main/frontend/mobile/intent.cljs
@@ -148,7 +148,7 @@
             (notification/show!
              [:div
               "Parsing current shared content are not supported. Please report the following codes on "
-              [:a {:href "https://github.com/logseq/logseq/issues"
+              [:a {:href "https://github.com/logseq/logseq/issues/new?labels=from:in-app&template=bug_report.yaml"
                    :target "_blank"} "Github"]
               ". We will look into it soon."
               [:pre.code (with-out-str (pprint/pprint result))]] :warning false)))))))

--- a/src/main/frontend/page.cljs
+++ b/src/main/frontend/page.cljs
@@ -78,7 +78,7 @@
           the folder logseq/bak/."]
           [:p "If these troubleshooting steps have not solved your problem, please "
            [:a.underline
-            {:href "https://github.com/logseq/logseq/issues"}
+            {:href "https://github.com/logseq/logseq/issues/new?labels=from:in-app&template=bug_report.yaml"}
             "open an issue."]]]]]]]]]
    (ui/notification)])
 

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -729,7 +729,7 @@
    [:div.flex.justify-between.items-center.px-1
     [:h5.text-red-600.pb-1 title]
     [:a.text-xs.opacity-50.hover:opacity-80
-     {:href "https://github.com/logseq/logseq/issues"
+     {:href "https://github.com/logseq/logseq/issues/new?labels=from:in-app&template=bug_report.yaml"
       :target "_blank"} "report issue"]]
    (when content [:pre.m-0.text-sm content])])
 


### PR DESCRIPTION
I saw this change in our discord channels and think it'd be useful to have this in app as well. Currently users don't see any helpful template when reporting from the app