### PR TITLE
fix(ui): wrong condition for rendering heading

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2200,7 +2200,7 @@
         config (if (nil? (:query-result config))
                  (assoc config :query-result (atom nil))
                  config)
-        heading? (and (= type :heading) heading-level (<= heading-level 6))
+        heading? (or (= type :heading) (and heading-level (<= heading-level 6)))
         *control-show? (get state ::control-show?)
         ref? (:ref? config)
         db-collapsed? (util/collapsed? block)


### PR DESCRIPTION
Fix #4843

The original bug affects Level 1 and Level 2 headings.

This is a temporary fix. The root cause is 
When expanding from a template, `:block/type` property is missing.

Logseq allows a text block to become a heading, so the condition should use `or`.
