### PR TITLE
Feature: sort the flashcard by the ':card-next-schedule' property

### DIFF
--- a/src/main/frontend/extensions/srs.cljs
+++ b/src/main/frontend/extensions/srs.cljs
@@ -285,9 +285,11 @@
                                          (nil? next-sched)
                                          (nil? next-sched*)
                                          (t/before? next-sched* time))))
-                                 blocks)]
+                                 blocks),
+        sort-by-next-shedule   (sort-by (fn [b]
+                                (get (get b :block/properties) card-next-schedule-property)) filtered-result)]
     {:total (count blocks)
-     :result filtered-result}))
+     :result sort-by-next-shedule}))
 
 
 ;;; ================================================================


### PR DESCRIPTION




Hi, I find a problem with the flashcard feature. I have used flashcards for a while. When I have 500+ cards, I cannot review all the cards one day, so I have to review part of it. The problem is that the cards at the bottom of the review card set which I left for tomorrow, still seem to be at the bottom of the card set tomorrow. If I cannot review all the cards once, it seems that the bottom part of the card will never be reviewed.
So I check the source code and find that I can easily solve this problem by modifying the 'query-scheduled' function in the 'src/main/frontend/extensions/srs.cljs' path.
I have tested it. It seems to be OK. So I post this PR.
I also posted a discussion in the forum, please check https://discuss.logseq.com/t/sort-the-flashcards/6540







Signed-off-by: FelixGibson <jjtom5f@gmail.com>