### PR TITLE
Feat: open action for logseq protocol 

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -20,6 +20,7 @@
             [electron.exceptions :as exceptions]
             ["/electron/utils" :as utils]))
 
+;; Keep same as main/frontend.util.url
 (defonce LSP_SCHEME "logseq")
 (defonce FILE_LSP_SCHEME "lsp")
 (defonce LSP_PROTOCOL (str FILE_LSP_SCHEME "://"))

--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -2,7 +2,7 @@
   (:require [electron.handler :as handler]
             [electron.search :as search]
             [electron.updater :refer [init-updater]]
-            [electron.utils :refer [*win mac? linux? dev? logger get-win-from-sender restore-user-fetch-agent send-to-renderer]]
+            [electron.utils :refer [*win mac? linux? dev? logger get-win-from-sender restore-user-fetch-agent send-to-renderer get-URL-decoded-params]]
             [clojure.string :as string]
             [promesa.core :as p]
             [cljs-bean.core :as bean]
@@ -40,26 +40,45 @@
                    :logger logger
                    :win    win})))
 
+(defn local-url-handler
+  [^js win parsed-url url-path]
+  (cond
+    (= "open" url-path)
+    (let [[graph page block-id] (get-URL-decoded-params parsed-url ["graph" "page" "block-id"])
+          graph-name (handler/get-graph-name graph)]
+      (if graph-name
+        (send-to-renderer win "openNewWindowOfGraph" graph-name)
+        (if graph
+          (send-to-renderer "notification" {:type "error"
+                                          :payload (str "Open link failed. Cannot match graph name `" graph
+                                                        "` to any linked graph for action `open`.")})
+          (send-to-renderer "notification" {:type "error"
+                                            :payload (str "Open link failed. Missing required parameter `graph=<graph name>` for action `open`. Typo?")}))))
+    :else
+    (send-to-renderer "notification" {:type "error"
+                                      :payload (str "Open link failed. Cannot match `" url-path
+                                                    "` to any action.")})))
+
 (defn open-url-handler
   [win url]
   (.info logger "open-url" (str {:url url}))
 
   (let [parsed-url (js/URL. url)
         url-protocol (.-protocol parsed-url)
-        url-host (.-host parsed-url)]
+        url-host (.-host parsed-url)
+        url-path (string/replace (.-pathname parsed-url) "/" "")]
     (when (= (str LSP_SCHEME ":") url-protocol)
       (cond
         (= "auth-callback" url-host)
         (send-to-renderer win "loginCallback" (.get (.-searchParams parsed-url) "code"))
 
         (= "local" url-host)
-        (let [[graph page block-id] (utils/get-URL-decoded-params parsed-url ["graph" "page" "block-id"])
-              graph-name (handler/get-graph-name graph)]
-          (if graph-name
-            (utils/send-to-renderer win "openNewWindowOfGraph" graph-name)
-            (utils/send-to-renderer "notification" {:type "error"
-                                                    :payload (str "Cannot match graph name " graph
-                                                                  " to any linked graph.")})))))))
+        (local-url-handler win parsed-url url-path)
+
+        :else
+        (send-to-renderer "notification" {:type "error"
+                                          :payload (str "Open link failed. Cannot match `" url-host
+                                                        "` to any target.")})))))
 
 (defn setup-interceptor! [^js app]
   (.setAsDefaultProtocolClient app LSP_SCHEME)
@@ -226,10 +245,10 @@
                (.. logger (info (str "Logseq App(" (.getVersion app) ") Starting... ")))
 
                (Deeplink. #js
-                          {:app app
-                           :mainWindow win
-                           :protocol LSP_SCHEME
-                           :isDev dev?})
+                           {:app app
+                            :mainWindow win
+                            :protocol LSP_SCHEME
+                            :isDev dev?})
 
                (restore-user-fetch-agent)
 

--- a/src/electron/electron/fs_watcher.cljs
+++ b/src/electron/electron/fs_watcher.cljs
@@ -36,6 +36,7 @@
                                  :stat (fs/statSync path)}))
 
 (defn watch-dir!
+  "Watch a directory if no such file watcher exists"
   [_win dir]
   (when (and (fs/existsSync dir)
              (not (get @*file-watcher dir)))

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -218,7 +218,7 @@
          (map graph-name->path))))
 
 (defn get-graph-name
-  "Given a graph's name, returns the graph's fullname.
+  "Given a graph's name of string, returns the graph's fullname.
    E.g., given `cat`, returns `logseq_local_<path_to_directory>/cat`
    Returns `nil` if no such graph exists."
   [graph]

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -217,14 +217,15 @@
          (map #(path/basename % ".transit"))
          (map graph-name->path))))
 
+;; TODO support alias mechanism
 (defn get-graph-name
   "Given a graph's name of string, returns the graph's fullname.
    E.g., given `cat`, returns `logseq_local_<path_to_directory>/cat`
    Returns `nil` if no such graph exists."
-  [graph]
+  [graph-identifier]
   (->> (get-graphs)
        (some #(when (string/ends-with? (utils/normalize-lc %)
-                                       (str "/" (utils/normalize-lc graph)))
+                                       (str "/" (utils/normalize-lc graph-identifier)))
                 %))))
 
 (defmethod handle :getGraphs [_window [_]]

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -222,9 +222,10 @@
    E.g., given `cat`, returns `logseq_local_<path_to_directory>/cat`
    Returns `nil` if no such graph exists."
   [graph]
-  ;; FIXME: path-normalize for electron?
   (->> (get-graphs)
-       (some #(when (string/ends-with? % (str "/" graph)) %))))
+       (some #(when (string/ends-with? (utils/normalize-lc %)
+                                       (str "/" (utils/normalize-lc graph)))
+                %))))
 
 (defmethod handle :getGraphs [_window [_]]
   (get-graphs))
@@ -413,6 +414,11 @@
 (defmethod handle :openNewWindow [_window [_]]
   (open-new-window!)
   nil)
+
+(defmethod handle :graphReady [window [_ graph-name]]
+  (when-let [f (:window/once-graph-ready @state/state)]
+    (f window graph-name)
+    (state/set-state! :window/once-graph-ready nil)))
 
 (defmethod handle :searchVersionChanged?
   [^js _win [_ graph]]

--- a/src/electron/electron/state.cljs
+++ b/src/electron/electron/state.cljs
@@ -17,7 +17,10 @@
          :window/graph {}
          
          ;; job to do when persistGraph is done on renderer
-         :window/once-persist-done nil}))
+         :window/once-persist-done nil
+         
+         ;; job to do when graph is loaded on renderer
+         :window/once-graph-ready nil}))
 
 (defn set-state!
   [path value]

--- a/src/electron/electron/state.cljs
+++ b/src/electron/electron/state.cljs
@@ -14,7 +14,10 @@
          :graph/current nil
 
          ;; window -> current graph
-         :window/graph {}}))
+         :window/graph {}
+         
+         ;; job to do when persistGraph is done on renderer
+         :window/once-persist-done nil}))
 
 (defn set-state!
   [path value]

--- a/src/electron/electron/url.cljs
+++ b/src/electron/electron/url.cljs
@@ -1,0 +1,41 @@
+(ns electron.url
+  (:require [electron.handler :as handler]
+            [electron.utils :refer [send-to-renderer get-URL-decoded-params]]
+            [clojure.string :as string]
+            [promesa.core :as p]))
+
+(defn local-url-handler
+  [^js win parsed-url url-path]
+  (cond
+    (= "open" url-path)
+    (let [[graph _page _block-id] (get-URL-decoded-params parsed-url ["graph" "page" "block-id"])
+          graph-name (handler/get-graph-name graph)]
+      (if graph-name
+        (p/let [_ (handler/broadcast-persist-graph! graph-name)]
+          (send-to-renderer win "openNewWindowOfGraph" graph-name))
+        (if graph
+          (send-to-renderer "notification" {:type "error"
+                                            :payload (str "Open link failed. Cannot match graph name `" graph
+                                                          "` to any linked graph for action `open`.")})
+          (send-to-renderer "notification" {:type "error"
+                                            :payload (str "Open link failed. Missing required parameter `graph=<graph name>` for action `open`. Typo?")}))))
+    :else
+    (send-to-renderer "notification" {:type "error"
+                                      :payload (str "Open link failed. Cannot match `" url-path
+                                                    "` to any action.")})))
+
+(defn logseq-url-handler
+  [^js win parsed-url]
+  (let [url-host (.-host parsed-url)
+        url-path (string/replace (.-pathname parsed-url) "/" "")]
+    (cond
+      (= "auth-callback" url-host)
+      (send-to-renderer win "loginCallback" (.get (.-searchParams parsed-url) "code"))
+
+      (= "local" url-host)
+      (local-url-handler win parsed-url url-path)
+
+      :else
+      (send-to-renderer "notification" {:type "error"
+                                        :payload (str "Open link failed. Cannot match `" url-host
+                                                      "` to any target.")}))))

--- a/src/electron/electron/url.cljs
+++ b/src/electron/electron/url.cljs
@@ -1,24 +1,39 @@
 (ns electron.url
   (:require [electron.handler :as handler]
+            [electron.state :as state]
             [electron.utils :refer [send-to-renderer get-URL-decoded-params]]
             [clojure.string :as string]
             [promesa.core :as p]))
 
+(defn graph-name-error-handler
+  [graph]
+  (if graph
+    (send-to-renderer "notification" {:type "error"
+                                      :payload (str "Open link failed. Cannot match graph name `" graph "` to any linked graph for action `open`.")})
+    (send-to-renderer "notification" {:type "error"
+                                      :payload (str "Open link failed. Missing required parameter `graph=<graph name>` for action `open`.")})))
+
 (defn local-url-handler
+  "Given a URL with `open` as path, and `graph` (required), `page` (optional) and `block-id` (optional) as parameters,
+   open the local graphs accordingly.
+   `graph` is the name of the graph to open, e.g. `lambda`"
   [^js win parsed-url url-path]
   (cond
     (= "open" url-path)
-    (let [[graph _page _block-id] (get-URL-decoded-params parsed-url ["graph" "page" "block-id"])
+    (let [[graph page-name block-id] (get-URL-decoded-params parsed-url ["graph" "page" "block-id"])
           graph-name (handler/get-graph-name graph)]
       (if graph-name
         (p/let [_ (handler/broadcast-persist-graph! graph-name)]
+          ;; TODO: call open new window on new graph without renderer (remove the reliance on local storage)
+          ;; TODO: allow open new window on specific page, without waiting for `graph ready` ipc then redirect to that page
+          (when (or page-name block-id)
+            (let [then-f (fn [win' graph-name']
+                           (when (= graph-name graph-name')
+                             (send-to-renderer win' "redirectWhenExists" {:page-name page-name
+                                                                         :block-id block-id})))]
+              (state/set-state! :window/once-graph-ready then-f)))
           (send-to-renderer win "openNewWindowOfGraph" graph-name))
-        (if graph
-          (send-to-renderer "notification" {:type "error"
-                                            :payload (str "Open link failed. Cannot match graph name `" graph
-                                                          "` to any linked graph for action `open`.")})
-          (send-to-renderer "notification" {:type "error"
-                                            :payload (str "Open link failed. Missing required parameter `graph=<graph name>` for action `open`. Typo?")}))))
+        (graph-name-error-handler graph)))
     :else
     (send-to-renderer "notification" {:type "error"
                                       :payload (str "Open link failed. Cannot match `" url-path

--- a/src/electron/electron/url.cljs
+++ b/src/electron/electron/url.cljs
@@ -23,14 +23,14 @@
   [graph-identifier]
   (if graph-identifier
     (send-to-renderer "notification" {:type "error"
-                                      :payload (str "Open link failed. Cannot match graph identifier `" graph-identifier "` to any linked graph.")})
+                                      :payload (str "Failed to open link. Cannot match graph identifier `" graph-identifier "` to any linked graph.")})
     (send-to-renderer "notification" {:type "error"
-                                      :payload (str "Open link failed. Missing graph identifier after `logseq://graph/`.")})))
+                                      :payload (str "Failed to open link. Missing graph identifier after `logseq://graph/`.")})))
 
 (defn local-url-handler
-  "Given a URL with `graph` as path, and `graph identifier` as path, `page` (optional) and `block-id` (optional) as parameters,
-   open the local graphs accordingly.
-   `graph` is the name of the graph to open, e.g. `lambda`"
+  "Given a URL with `graph identifier` as path, `page` (optional) and `block-id` 
+   (optional) as parameters, open the local graphs accordingly.
+   `graph identifier` is the name of the graph to open, e.g. `lambda`"
   [^js win parsed-url]
   (let [graph-identifier (decode (string/replace (.-pathname parsed-url) "/" ""))
         [page-name block-id] (get-URL-decoded-params parsed-url ["page" "block-id"])
@@ -61,5 +61,5 @@
 
       :else
       (send-to-renderer "notification" {:type "error"
-                                        :payload (str "Open link failed. Cannot match `" url-host
+                                        :payload (str "Failed to open link. Cannot match `" url-host
                                                       "` to any target.")}))))

--- a/src/electron/electron/url.cljs
+++ b/src/electron/electron/url.cljs
@@ -1,54 +1,63 @@
 (ns electron.url
   (:require [electron.handler :as handler]
             [electron.state :as state]
-            [electron.utils :refer [send-to-renderer get-URL-decoded-params]]
+            [electron.utils :refer [send-to-renderer]]
             [clojure.string :as string]
             [promesa.core :as p]))
 
-(defn graph-name-error-handler
-  [graph]
-  (if graph
+;; Keep same as main/frontend.util.url
+(def decode js/decodeURI)
+(def decode-param js/decodeURIComponent)
+
+(defn get-URL-decoded-params
+  "Get decoded URL parameters from parsed js/URL.
+   `nil` for non-existing keys."
+  [^js parsed-url keys]
+  (let [params (.-searchParams parsed-url)]
+    (map (fn [key]
+           (when-let [value (.get params key)]
+             (decode-param value)))
+         keys)))
+
+(defn graph-identifier-error-handler
+  [graph-identifier]
+  (if graph-identifier
     (send-to-renderer "notification" {:type "error"
-                                      :payload (str "Open link failed. Cannot match graph name `" graph "` to any linked graph for action `open`.")})
+                                      :payload (str "Open link failed. Cannot match graph identifier `" graph-identifier "` to any linked graph.")})
     (send-to-renderer "notification" {:type "error"
-                                      :payload (str "Open link failed. Missing required parameter `graph=<graph name>` for action `open`.")})))
+                                      :payload (str "Open link failed. Missing graph identifier after `logseq://graph/`.")})))
 
 (defn local-url-handler
-  "Given a URL with `open` as path, and `graph` (required), `page` (optional) and `block-id` (optional) as parameters,
+  "Given a URL with `graph` as path, and `graph identifier` as path, `page` (optional) and `block-id` (optional) as parameters,
    open the local graphs accordingly.
    `graph` is the name of the graph to open, e.g. `lambda`"
-  [^js win parsed-url url-path]
-  (cond
-    (= "open" url-path)
-    (let [[graph page-name block-id] (get-URL-decoded-params parsed-url ["graph" "page" "block-id"])
-          graph-name (when graph (handler/get-graph-name graph))]
-      (if graph-name
-        (p/let [_ (handler/broadcast-persist-graph! graph-name)]
+  [^js win parsed-url]
+  (let [graph-identifier (decode (string/replace (.-pathname parsed-url) "/" ""))
+        [page-name block-id] (get-URL-decoded-params parsed-url ["page" "block-id"])
+        graph-name (when graph-identifier (handler/get-graph-name graph-identifier))]
+    (if graph-name
+      (p/let [_ (handler/broadcast-persist-graph! graph-name)]
           ;; TODO: call open new window on new graph without renderer (remove the reliance on local storage)
           ;; TODO: allow open new window on specific page, without waiting for `graph ready` ipc then redirect to that page
-          (when (or page-name block-id)
-            (let [then-f (fn [win' graph-name']
-                           (when (= graph-name graph-name')
-                             (send-to-renderer win' "redirectWhenExists" {:page-name page-name
-                                                                         :block-id block-id})))]
-              (state/set-state! :window/once-graph-ready then-f)))
-          (send-to-renderer win "openNewWindowOfGraph" graph-name))
-        (graph-name-error-handler graph)))
-    :else
-    (send-to-renderer "notification" {:type "error"
-                                      :payload (str "Open link failed. Cannot match `" url-path
-                                                    "` to any action.")})))
+        (when (or page-name block-id)
+          (let [then-f (fn [win' graph-name']
+                         (when (= graph-name graph-name')
+                           (send-to-renderer win' "redirectWhenExists" {:page-name page-name
+                                                                        :block-id block-id})))]
+            (state/set-state! :window/once-graph-ready then-f)))
+        (send-to-renderer win "openNewWindowOfGraph" graph-name))
+      (graph-identifier-error-handler graph-identifier))))
 
 (defn logseq-url-handler
   [^js win parsed-url]
-  (let [url-host (.-host parsed-url)
-        url-path (string/replace (.-pathname parsed-url) "/" "")]
+  (let [url-host (.-host parsed-url)] ;; return "" when no pathname provided
     (cond
       (= "auth-callback" url-host)
       (send-to-renderer win "loginCallback" (.get (.-searchParams parsed-url) "code"))
 
-      (= "local" url-host)
-      (local-url-handler win parsed-url url-path)
+      ;; identifier of graph in local
+      (= "graph" url-host)
+      (local-url-handler win parsed-url)
 
       :else
       (send-to-renderer "notification" {:type "error"

--- a/src/electron/electron/url.cljs
+++ b/src/electron/electron/url.cljs
@@ -21,7 +21,7 @@
   (cond
     (= "open" url-path)
     (let [[graph page-name block-id] (get-URL-decoded-params parsed-url ["graph" "page" "block-id"])
-          graph-name (handler/get-graph-name graph)]
+          graph-name (when graph (handler/get-graph-name graph))]
       (if graph-name
         (p/let [_ (handler/broadcast-persist-graph! graph-name)]
           ;; TODO: call open new window on new graph without renderer (remove the reliance on local storage)

--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -133,3 +133,12 @@
            (when-let [value (.get params key)]
              (js/decodeURI value)))
          keys)))
+
+;; Keep update with the normalization in main
+(defn normalize
+  [s]
+  (.normalize s "NFC"))
+
+(defn normalize-lc
+  [s]
+  (normalize (string/lower-case s)))

--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -123,3 +123,13 @@
 (defn get-graph-dir
   [graph-name]
   (string/replace graph-name "logseq_local_" ""))
+
+(defn get-URL-decoded-params
+  "Get decoded URL parameters from parsed js/URL.
+   `nil` for non-existing keys."
+  [^js parsed-url keys]
+  (let [params (.-searchParams parsed-url)]
+    (map (fn [key]
+           (when-let [value (.get params key)]
+             (js/decodeURI value)))
+         keys)))

--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -131,7 +131,7 @@
   (let [params (.-searchParams parsed-url)]
     (map (fn [key]
            (when-let [value (.get params key)]
-             (js/decodeURI value)))
+             (js/decodeURIComponent value)))
          keys)))
 
 ;; Keep update with the normalization in main

--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -124,16 +124,6 @@
   [graph-name]
   (string/replace graph-name "logseq_local_" ""))
 
-(defn get-URL-decoded-params
-  "Get decoded URL parameters from parsed js/URL.
-   `nil` for non-existing keys."
-  [^js parsed-url keys]
-  (let [params (.-searchParams parsed-url)]
-    (map (fn [key]
-           (when-let [value (.get params key)]
-             (js/decodeURIComponent value)))
-         keys)))
-
 ;; Keep update with the normalization in main
 (defn normalize
   [s]

--- a/src/main/electron/listener.cljs
+++ b/src/main/electron/listener.cljs
@@ -101,6 +101,7 @@
   
   (js/window.apis.on "openNewWindowOfGraph"
                      ;; Handle open new window in renderer, until the destination graph doesn't rely on setting local storage
+                     ;; No db cache persisting ensured. Should be handled by the caller
                      (fn [repo]
                        (ui-handler/open-new-window! nil repo))))
 

--- a/src/main/electron/listener.cljs
+++ b/src/main/electron/listener.cljs
@@ -78,12 +78,13 @@
 
   (js/window.apis.on "persistGraph"
                      ;; electron is requesting window for persisting a graph in it's db
+                     ;; fire back "broadcastPersistGraphDone" on done
                      (fn [data]
                        (let [repo (bean/->clj data)
                              before-f #(notification/show!
                                         (ui/loading (t :graph/persist))
                                         :warning)
-                             after-f #(ipc/ipc "persistGraphDone" repo)
+                             after-f #(ipc/ipc "broadcastPersistGraphDone")
                              error-f (fn []
                                        (after-f)
                                        (notification/show!
@@ -96,7 +97,12 @@
 
   (js/window.apis.on "loginCallback"
                      (fn [code]
-                       (user/login-callback code))))
+                       (user/login-callback code)))
+  
+  (js/window.apis.on "openNewWindowOfGraph"
+                     ;; Handle open new window in renderer, until the destination graph doesn't rely on setting local storage
+                     (fn [repo]
+                       (ui-handler/open-new-window! nil repo))))
 
 (defn listen!
   []

--- a/src/main/electron/listener.cljs
+++ b/src/main/electron/listener.cljs
@@ -71,15 +71,19 @@
                          (route-handler/redirect! payload))))
 
   (js/window.apis.on "redirectWhenExists"
-                     ;; either page-name or block-id is required
+                     ;;  Redirect to the given page or block when the provided page or block exists.
+                     ;;  Either :page-name or :block-id is required.
+                     ;;  :page-name : the original-name of the page.
+                     ;;  :block-id : uuid.
                      (fn [data]
                        (let [{:keys [page-name block-id]} (bean/->clj data)]
-                         ;; TODO Junyi
                          (cond
                            page-name
-                           (let [page-name (db-model/get-redirect-page-name page-name)]
-                             (editor-handler/insert-first-page-block-if-not-exists! page-name)
-                             (route-handler/redirect-to-page! page-name))
+                           (let [db-page-name (db-model/get-redirect-page-name page-name)]
+                             ;; No error handling required, as a page name is always valid
+                             ;; Open new page if the page does not exist
+                             (editor-handler/insert-first-page-block-if-not-exists! db-page-name)
+                             (route-handler/redirect-to-page! db-page-name))
 
                            block-id
                            (if (db-model/get-block-by-uuid block-id)

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -6,7 +6,6 @@
             [frontend.components.editor :as editor]
             [frontend.components.page-menu :as page-menu]
             [frontend.components.export :as export]
-            [frontend.components.repo :as repo]
             [frontend.config :as config]
             [frontend.context.i18n :refer [t]]
             [frontend.db :as db]
@@ -220,10 +219,8 @@
              {:key      "Copy block URL"
               :on-click (fn [_e]
                           (let [current-repo (state/get-current-repo)
-                                repo-path (repo/get-repo-name current-repo)
-                                short-repo-name (repo/get-short-repo-name repo-path)
                                 tap-f (fn [block-id]
-                                        (url-util/get-local-logseq-url-by-uuid short-repo-name block-id))]
+                                        (url-util/get-local-logseq-entity-url-by-uuid current-repo block-id))]
                             (editor-handler/copy-block-ref! block-id tap-f)))}
              "Copy block URL"))
 

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -26,6 +26,8 @@
             [goog.object :as gobj]
             [rum.core :as rum]))
 
+;; TODO i18n support
+
 (defn- set-format-js-loading!
   [format value]
   (when format
@@ -220,7 +222,7 @@
               :on-click (fn [_e]
                           (let [current-repo (state/get-current-repo)
                                 tap-f (fn [block-id]
-                                        (url-util/get-local-logseq-entity-url-by-uuid current-repo block-id))]
+                                        (url-util/get-logseq-graph-uuid-url nil current-repo block-id))]
                             (editor-handler/copy-block-ref! block-id tap-f)))}
              "Copy block URL"))
 

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -6,6 +6,7 @@
             [frontend.components.editor :as editor]
             [frontend.components.page-menu :as page-menu]
             [frontend.components.export :as export]
+            [frontend.components.repo :as repo]
             [frontend.config :as config]
             [frontend.context.i18n :refer [t]]
             [frontend.db :as db]
@@ -21,6 +22,7 @@
             [frontend.state :as state]
             [frontend.ui :as ui]
             [frontend.util :as util]
+            [frontend.util.url :as url-util]
             [goog.dom :as gdom]
             [goog.object :as gobj]
             [rum.core :as rum]))
@@ -211,6 +213,19 @@
             :on-click (fn [_e]
                         (editor-handler/copy-block-ref! block-id #(util/format "{{embed ((%s))}}" %)))}
            "Copy block embed")
+          
+          ;; TODO Logseq protocol mobile support
+          (when (util/electron?)
+            (ui/menu-link
+             {:key      "Copy block URL"
+              :on-click (fn [_e]
+                          (let [current-repo (state/get-current-repo)
+                                repo-path (repo/get-repo-name current-repo)
+                                short-repo-name (repo/get-short-repo-name repo-path)
+                                tap-f (fn [block-id]
+                                        (url-util/get-local-logseq-url-by-uuid short-repo-name block-id))]
+                            (editor-handler/copy-block-ref! block-id tap-f)))}
+             "Copy block URL"))
 
           (block-template block-id)
 

--- a/src/main/frontend/components/page_menu.cljs
+++ b/src/main/frontend/components/page_menu.cljs
@@ -10,6 +10,7 @@
             [frontend.state :as state]
             [frontend.ui :as ui]
             [frontend.util :as util]
+            [frontend.util.url :as url-util]
             [frontend.handler.shell :as shell]
             [frontend.handler.plugin :as plugin-handler]
             [frontend.mobile.util :as mobile-util]
@@ -101,6 +102,11 @@
               :options {:on-click #(js/window.apis.showItemInFolder file-path)}}
              {:title   (t :page/open-with-default-app)
               :options {:on-click #(js/window.apis.openPath file-path)}}])
+          
+          (when (util/electron?)
+            {:title   (t :page/copy-page-url)
+              :options {:on-click #(util/copy-to-clipboard!
+                                    (url-util/get-logseq-graph-page-url nil repo page-original-name))}})
 
           (when-not contents?
             {:title   (t :page/delete)

--- a/src/main/frontend/components/repo.cljs
+++ b/src/main/frontend/components/repo.cljs
@@ -183,32 +183,11 @@
     (p/let [multiple-windows? (ipc/ipc "graphHasMultipleWindows" (state/get-current-repo))]
       (reset! (::electron-multiple-windows? state) multiple-windows?))))
 
-;; TODO move to else where?
-(defn get-repo-name [repo]
-  (cond
-    (mobile-util/is-native-platform?)
-    (text/get-graph-name-from-path repo)
-
-    (config/local-db? repo)
-    (config/get-local-dir repo)
-
-    :else
-    (db/get-repo-path repo)))
-
-;; TODO move to else where?
-(defn get-short-repo-name
-  "repo-path: output of `get-repo-name`"
-  [repo-path]
-  (if (or (util/electron?)
-          (mobile-util/is-native-platform?))
-    (text/get-file-basename repo-path)
-    repo-path))
-
 (defn- repos-dropdown-links [repos current-repo *multiple-windows?]
   (let [switch-repos (remove (fn [repo] (= current-repo (:url repo))) repos) ; exclude current repo
         repo-links (mapv
                     (fn [{:keys [url]}]
-                      (let [repo-path (get-repo-name url)
+                      (let [repo-path (db/get-repo-name url)
                             short-repo-name (text/get-graph-name-from-path repo-path)]
                         {:title short-repo-name
                          :hover-detail repo-path ;; show full path on hover
@@ -283,8 +262,8 @@
             repos (remove (fn [r] (= config/local-repo (:url r))) repos)
             links (repos-dropdown-links repos current-repo multiple-windows?)
             render-content (fn [{:keys [toggle-fn]}]
-                             (let [repo-path (get-repo-name current-repo)
-                                   short-repo-name (get-short-repo-name repo-path)]
+                             (let [repo-path (db/get-repo-name current-repo)
+                                   short-repo-name (db/get-short-repo-name repo-path)]
                                [:a.item.group.flex.items-center.px-2.py-2.text-sm.font-medium.rounded-md
                                 {:on-click (fn []
                                              (check-multiple-windows? state)

--- a/src/main/frontend/components/repo.cljs
+++ b/src/main/frontend/components/repo.cljs
@@ -183,7 +183,8 @@
     (p/let [multiple-windows? (ipc/ipc "graphHasMultipleWindows" (state/get-current-repo))]
       (reset! (::electron-multiple-windows? state) multiple-windows?))))
 
-(defn- get-repo-name [repo]
+;; TODO move to else where?
+(defn get-repo-name [repo]
   (cond
     (mobile-util/is-native-platform?)
     (text/get-graph-name-from-path repo)
@@ -193,6 +194,15 @@
 
     :else
     (db/get-repo-path repo)))
+
+;; TODO move to else where?
+(defn get-short-repo-name
+  "repo-path: output of `get-repo-name`"
+  [repo-path]
+  (if (or (util/electron?)
+          (mobile-util/is-native-platform?))
+    (text/get-file-basename repo-path)
+    repo-path))
 
 (defn- repos-dropdown-links [repos current-repo *multiple-windows?]
   (let [switch-repos (remove (fn [repo] (= current-repo (:url repo))) repos) ; exclude current repo
@@ -274,10 +284,7 @@
             links (repos-dropdown-links repos current-repo multiple-windows?)
             render-content (fn [{:keys [toggle-fn]}]
                              (let [repo-path (get-repo-name current-repo)
-                                   short-repo-name (if (or (util/electron?)
-                                                           (mobile-util/is-native-platform?))
-                                                     (text/get-file-basename repo-path)
-                                                     repo-path)]
+                                   short-repo-name (get-short-repo-name repo-path)]
                                [:a.item.group.flex.items-center.px-2.py-2.text-sm.font-medium.rounded-md
                                 {:on-click (fn []
                                              (check-multiple-windows? state)

--- a/src/main/frontend/db.cljs
+++ b/src/main/frontend/db.cljs
@@ -183,7 +183,6 @@
                 (d/transact! db-conn [(me-tx (d/db db-conn) me)])))]
     (d/transact! db-conn [{:schema/version db-schema/version}])))
 
-;; reduce memory usage. pub event :graph/ready when a graph is restored, and finish the TODOs in :graph/ready
 (defn restore!
   [{:keys [repos] :as me} _old-db-schema restore-config-handler]
   (let [repo (or (state/get-current-repo) (:url (first repos)))]

--- a/src/main/frontend/db.cljs
+++ b/src/main/frontend/db.cljs
@@ -23,6 +23,8 @@
   ;; TODO: remove later
   conns
   get-repo-path
+  get-repo-name
+  get-short-repo-name
   datascript-db
   get-conn
   me-tx

--- a/src/main/frontend/db/conn.cljs
+++ b/src/main/frontend/db/conn.cljs
@@ -4,8 +4,10 @@
             [frontend.db-schema :as db-schema]
             [frontend.db.default :as default-db]
             [frontend.util :as util]
+            [frontend.mobile.util :as mobile-util]
             [frontend.state :as state]
             [frontend.config :as config]
+            [frontend.text :as text]
             [datascript.core :as d]))
 
 (defonce conns (atom {}))
@@ -16,6 +18,26 @@
     (->> (take-last 2 (string/split url #"/"))
          (string/join "/"))
     url))
+
+(defn get-repo-name
+  [repo]
+  (cond
+    (mobile-util/is-native-platform?)
+    (text/get-graph-name-from-path repo)
+
+    (config/local-db? repo)
+    (config/get-local-dir repo)
+
+    :else
+    (get-repo-path repo)))
+
+(defn get-short-repo-name
+  "repo-path: output of `get-repo-name`"
+  [repo-path]
+  (if (or (util/electron?)
+          (mobile-util/is-native-platform?))
+    (text/get-file-basename repo-path)
+    repo-path))
 
 (defn datascript-db
   [repo]

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -888,7 +888,8 @@
     (db-utils/entity [:block/name (util/page-name-sanity-lc page-name)])))
 
 (defn get-redirect-page-name
-  "Accepts both sanitized or unsanitized
+  "Given any readable page-name, return the exact page-name in db. Accepts both 
+   sanitized or unsanitized names.
    alias?: if true, alias is allowed to be returned; otherwise, it would be deref."
   ([page-name] (get-redirect-page-name page-name false))
   ([page-name alias?]

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -888,7 +888,8 @@
     (db-utils/entity [:block/name (util/page-name-sanity-lc page-name)])))
 
 (defn get-redirect-page-name
-  "Accepts both sanitized or unsanitized"
+  "Accepts both sanitized or unsanitized
+   alias?: if true, alias is allowed to be returned; otherwise, it would be deref."
   ([page-name] (get-redirect-page-name page-name false))
   ([page-name alias?]
    (when page-name

--- a/src/main/frontend/dicts.cljc
+++ b/src/main/frontend/dicts.cljc
@@ -186,6 +186,7 @@
         :page/new-title "What's your new page title?"
         :page/earlier "Earlier"
         :page/no-more-journals "No more journals"
+        :page/copy-page-url "Copy page URL"
         :publishing/pages "Pages"
         :publishing/page-name "Page name"
         :publishing/current-project "Current project"

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -126,7 +126,7 @@
      (when (util/electron?)
        (p/do!
         (repo-handler/persist-db! current-repo persist-db-noti-m)
-        (repo-handler/persist-otherwindow-db! graph)))
+        (repo-handler/broadcast-persist-db! graph)))
      (repo-handler/restore-and-setup-repo! graph)
      (graph-switch graph))))
 
@@ -138,13 +138,13 @@
      "Please wait seconds until all changes are saved for the current graph."
      :warning)))
 
-(defmethod handle :graph/open-new-window [[_ repo]]
+(defmethod handle :graph/open-new-window [[ev repo]]
   (p/let [current-repo (state/get-current-repo)
           target-repo (or repo current-repo)
-          _ (repo-handler/persist-db! current-repo persist-db-noti-m)
+          _ (repo-handler/persist-db! current-repo persist-db-noti-m) ;; FIXME: redundant when opening non-current-graph window
           _ (when-not (= current-repo target-repo)
-              (repo-handler/persist-otherwindow-db! repo))]
-    (ui-handler/open-new-window! _ repo)))
+              (repo-handler/broadcast-persist-db! repo))]
+    (ui-handler/open-new-window! ev repo)))
 
 (defmethod handle :graph/migrated [[_ _repo]]
   (js/alert "Graph migrated."))

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -265,10 +265,9 @@
   (p/let [content (when content (encrypt/decrypt content))]
     (state/set-modal! #(git-component/file-specific-version path hash content))))
 
-;; TODO: when "only restore the current graph instead of all the graphs" is done,
-;; remove invoke of :graph/ready in graph/switch and restore-and-setup!
 (defmethod handle :graph/ready [[_ repo]]
-  (search-handler/rebuild-indices-when-stale! repo))
+  (search-handler/rebuild-indices-when-stale! repo)
+  (repo-handler/graph-ready! repo))
 
 (defmethod handle :notification/show [[_ {:keys [content status clear?]}]]
   (notification/show! content status clear?))

--- a/src/main/frontend/handler/repo.cljs
+++ b/src/main/frontend/handler/repo.cljs
@@ -666,7 +666,7 @@
                (when on-error
                  (on-error)))))))
 
-(defn persist-otherwindow-db!
+(defn broadcast-persist-db!
   "Only works for electron
    Call backend to handle persisting a specific db on other window
    Skip persisting if no other windows is open (controlled by electron)

--- a/src/main/frontend/handler/repo.cljs
+++ b/src/main/frontend/handler/repo.cljs
@@ -677,3 +677,8 @@
   [graph]
   (p/let [_ (ipc/ipc "broadcastPersistGraph" graph)] ;; invoke for chaining promise
     nil))
+
+(defn graph-ready!
+  "Call electron that the graph is loaded."
+  [graph]
+  (ipc/ipc "graphReady" graph))

--- a/src/main/frontend/handler/repo.cljs
+++ b/src/main/frontend/handler/repo.cljs
@@ -670,17 +670,10 @@
   "Only works for electron
    Call backend to handle persisting a specific db on other window
    Skip persisting if no other windows is open (controlled by electron)
-     step 1. [In HERE]  a window         --persistGraph----->   electron
-     step 2.            electron         --persistGraph----->   window holds the graph
-     step 3.            window w/ graph  --persistGraphDone->   electron
-     step 4. [In HERE]  electron         --persistGraphDone->   all windows"
+     step 1. [In HERE]  a window         ---broadcastPersistGraph---->   electron
+     step 2.            electron         ---------persistGraph------->   window holds the graph
+     step 3.            window w/ graph  --broadcastPersistGraphDone->   electron
+     step 4. [In HERE]  a window         <---broadcastPersistGraph----   electron"
   [graph]
-  (p/create (fn [resolve _]
-              (js/window.apis.on "persistGraphDone"
-                                 #(let [repo (bean/->clj %)]
-                                    (prn "received persistGraphDone" repo)
-                                    (when (= graph repo)
-                                       ;; js/window.apis.once doesn't work
-                                      (js/window.apis.removeAllListeners "persistGraphDone")
-                                      (resolve repo))))
-              (ipc/ipc "persistGraph" graph))))
+  (p/let [_ (ipc/ipc "broadcastPersistGraph" graph)] ;; invoke for chaining promise
+    nil))

--- a/src/main/frontend/handler/ui.cljs
+++ b/src/main/frontend/handler/ui.cljs
@@ -305,5 +305,6 @@
   ([_e repo]
    ;; TODO: find out a better way to open a new window with a different repo path. Using local storage for now
    ;; TODO: also write local storage with the current repo state, to make behavior consistent
+   ;; then we can remove the `openNewWindowOfGraph` ipcMain call
    (when (string? repo) (storage/set :git/current-repo repo))
    (ipc/ipc "openNewWindow")))

--- a/src/main/frontend/handler/ui.cljs
+++ b/src/main/frontend/handler/ui.cljs
@@ -298,9 +298,12 @@
     (state/pub-event! [:modal/show-cards])))
 
 (defn open-new-window!
+  "Open a new Electron window.
+   No db cache persisting ensured. Should be handled by the caller."
   ([_e]
    (open-new-window! _e nil))
   ([_e repo]
-   ; TODO: find out a better way to open a new window with a different repo path
+   ;; TODO: find out a better way to open a new window with a different repo path. Using local storage for now
+   ;; TODO: also write local storage with the current repo state, to make behavior consistent
    (when (string? repo) (storage/set :git/current-repo repo))
    (ipc/ipc "openNewWindow")))

--- a/src/main/frontend/util/url.cljs
+++ b/src/main/frontend/util/url.cljs
@@ -1,16 +1,35 @@
-(ns frontend.util.url)
+(ns frontend.util.url
+  (:require [frontend.db.conn :as db-conn]))
 
-;; Keep same as electron/core.cljs
+;; Keep same as electron/electron.core
 (def LSP_SCHEME "logseq")
-(def encoder js/encodeURIComponent)
 
-(defn get-logseq-url-by-uuid
-  "Only the name of repo is required (not full path)"
-  [host repo-name uuid]
-  (str LSP_SCHEME "://" host "/open?graph=" (encoder repo-name) "&block-id=" uuid))
+;; Keep same as electron/electron.url
+(def encode js/encodeURI)
+(def encode-param js/encodeURIComponent)
 
-(defn get-local-logseq-url-by-uuid
-  "Ensure repo-name and uuid are valid string before hand.
+(defn get-repo-identifier
+  "repo-path: output of `get-repo-name`"
+  [repo]
+  (let [repo-path (db-conn/get-repo-name repo)]
+    (db-conn/get-short-repo-name repo-path)))
+
+(defn get-logseq-repo-url
+  "Get Logseq protocol URL, w/o param (v0.1).
+   host: set to `nil` for local graph
+   protocol?: if true, returns with protocol prefix"
+  ([host action repo-identifier]
+   (get-logseq-repo-url host action repo-identifier true))
+  ([host action repo-identifier protocol?]
+   (str (when protocol? (str LSP_SCHEME "://")) 
+        (when host (str host "/")) 
+        action "/" 
+        (encode repo-identifier)))
+)
+
+(defn get-local-logseq-entity-url-by-uuid
+  "The URL represents an entity in graph.
+   Ensure repo-identifier and uuid are valid string before hand.
    Only the name of repo is required (not full path)"
-  [repo-name uuid]
-  (get-logseq-url-by-uuid "local" repo-name uuid))
+  [repo uuid]
+  (str (get-logseq-repo-url nil "graph" (get-repo-identifier repo)) "?block-id=" uuid))

--- a/src/main/frontend/util/url.cljs
+++ b/src/main/frontend/util/url.cljs
@@ -1,0 +1,16 @@
+(ns frontend.util.url)
+
+;; Keep same as electron/core.cljs
+(def LSP_SCHEME "logseq")
+(def encoder js/encodeURIComponent)
+
+(defn get-logseq-url-by-uuid
+  "Only the name of repo is required (not full path)"
+  [host repo-name uuid]
+  (str LSP_SCHEME "://" host "/open?graph=" (encoder repo-name) "&block-id=" uuid))
+
+(defn get-local-logseq-url-by-uuid
+  "Ensure repo-name and uuid are valid string before hand.
+   Only the name of repo is required (not full path)"
+  [repo-name uuid]
+  (get-logseq-url-by-uuid "local" repo-name uuid))

--- a/src/main/frontend/util/url.cljs
+++ b/src/main/frontend/util/url.cljs
@@ -8,28 +8,57 @@
 (def encode js/encodeURI)
 (def encode-param js/encodeURIComponent)
 
-(defn get-repo-identifier
-  "repo-path: output of `get-repo-name`"
+(defn get-local-repo-identifier
   [repo]
   (let [repo-path (db-conn/get-repo-name repo)]
     (db-conn/get-short-repo-name repo-path)))
 
-(defn get-logseq-repo-url
+(defn get-repoid-url
   "Get Logseq protocol URL, w/o param (v0.1).
    host: set to `nil` for local graph
-   protocol?: if true, returns with protocol prefix"
+   protocol?: if true, returns URL with protocol prefix"
   ([host action repo-identifier]
-   (get-logseq-repo-url host action repo-identifier true))
+   (get-repoid-url host action repo-identifier true))
   ([host action repo-identifier protocol?]
    (str (when protocol? (str LSP_SCHEME "://")) 
         (when host (str host "/")) 
         action "/" 
-        (encode repo-identifier)))
-)
+        (encode repo-identifier))))
 
-(defn get-local-logseq-entity-url-by-uuid
-  "The URL represents an entity in graph.
-   Ensure repo-identifier and uuid are valid string before hand.
-   Only the name of repo is required (not full path)"
-  [repo uuid]
-  (str (get-logseq-repo-url nil "graph" (get-repo-identifier repo)) "?block-id=" uuid))
+(defn get-logseq-graph-url
+  "The URL represents an graph, for example:
+   logseq://graph/abc
+   Ensure repo is valid before hand.
+   host: set to `nil` for local graph
+   protocol?: if true, returns URL with protocol prefix"
+  ([host repo]
+   (get-logseq-graph-url host repo true))
+  ([host repo protocol?]
+   (let [repo-identifier (if host
+                           repo ;; resolve remote repo identifier here
+                           (get-local-repo-identifier repo))]
+     (get-repoid-url host "graph" repo-identifier protocol?))))
+
+(defn get-logseq-graph-uuid-url
+  "The URL represents an entity in graph with uuid, for example:
+   logseq://graph/abc?block-id=<uuid>
+   Ensure repo and uuid are valid before hand.
+   host: set to `nil` for local graph
+   protocol?: if true, returns URL with protocol prefix"
+  ([host repo uuid]
+   (get-logseq-graph-uuid-url host repo uuid true))
+  ([host repo uuid protocol?]
+   (str (get-logseq-graph-url host repo protocol?)
+        "?block-id=" uuid)))
+
+(defn get-logseq-graph-page-url
+  "The URL represents an page in graph with pagename, for example:
+   logseq://graph/abc?page=<page-name>
+   Ensure repo and page-name are valid before hand.
+   host: set to `nil` for local graph
+   protocol?: if true, returns URL with protocol prefix"
+  ([host repo page-name]
+   (get-logseq-graph-page-url host repo page-name true))
+  ([host repo page-name protocol?]
+   (str (get-logseq-graph-url host repo protocol?)
+        "?page=" (encode-param page-name))))

--- a/src/main/frontend/util/url.cljs
+++ b/src/main/frontend/util/url.cljs
@@ -13,12 +13,12 @@
   (let [repo-path (db-conn/get-repo-name repo)]
     (db-conn/get-short-repo-name repo-path)))
 
-(defn get-repoid-url
+(defn get-repo-id-url
   "Get Logseq protocol URL, w/o param (v0.1).
    host: set to `nil` for local graph
    protocol?: if true, returns URL with protocol prefix"
   ([host action repo-identifier]
-   (get-repoid-url host action repo-identifier true))
+   (get-repo-id-url host action repo-identifier true))
   ([host action repo-identifier protocol?]
    (str (when protocol? (str LSP_SCHEME "://")) 
         (when host (str host "/")) 
@@ -37,7 +37,7 @@
    (let [repo-identifier (if host
                            repo ;; resolve remote repo identifier here
                            (get-local-repo-identifier repo))]
-     (get-repoid-url host "graph" repo-identifier protocol?))))
+     (get-repo-id-url host "graph" repo-identifier protocol?))))
 
 (defn get-logseq-graph-uuid-url
   "The URL represents an entity in graph with uuid, for example:


### PR DESCRIPTION
### Feature:
The `open` action of logseq protocol would open the target in a new logseq window. For example:
logseq://local/open?graph=lambda will open graph `lambda`.
This PR only covers local graphs

### Use cases (v 0.1):
- Open block with uuid:
  - `logseq://graph/<graph name>?block-id=<block uuid>`
- Open graph:
  - `logseq://graph/<graph name>`
- Open page:
  - `logseq://graph/<graph name>?page=<page name>`

* Works on Desktop (Electron) only for now. Logseq should be OPEN, and the target graph should be LINKED before-hand.
* Parameter `graph` would match graph name from the existing graphs. Full graph path is not required.
* Parameter `page` receives page name. You may need to use [URL Encode](https://www.google.com/search?q=URL+encode) if your page name contains spaces or special characters.
* Parameter `block-id` receives uuid.

### UX
* Right click on block bullet, you may find the `copy block URL` button
* Open the page drop list, you may find the `copy page URL` button

### Progress:
- [x] graph (graph name) support
- [x] page (page name) support
- [x] block (uuid) support
- [x] copy block URL context menu UX
- [x] copy page URL context menu UX


Misc.:
- Deeplink is now usable
- ipc action `PersistGraph` now returns a promise

TODOs in future:
- Filename as param
- Remove the ipcMain call of `openNewWindowOfGraph`, provide redirecting options on opening window