### PR TITLE
fix: increase `td` width to prevent content overflow

### DIFF
--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -700,7 +700,7 @@
       [:tbody
        (for [[n {:block/keys [name created-at updated-at backlinks] :as page}] (medley/indexed pages)]
          [:tr {:key name}
-          [:td.n.w-10 [:span.opacity-70 (str (inc n) ". ")]]
+          [:td.n.w-12 [:span.opacity-70 (str (inc n) ".")]]
           [:td.name [:a {:href     (rfe/href :page {:name (:block/name page)})}
                      (block/page-cp {} page)]]
           [:td.backlinks [:span (or backlinks "0")]]


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

As shown in the following screenshot:

<img width="734" alt="image" src="https://user-images.githubusercontent.com/15034155/163134437-59fd9446-4008-42ee-b007-461c185a3621.png">
