### PR TITLE
fix pasting in src block not working on iOS

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3177,8 +3177,9 @@
           input (state/get-input)]
       (if-not (string/blank? text)
         (if (thingatpt/org-admonition&src-at-point input)
-          (do (util/stop e)
-              (paste-text-in-one-block-at-point))
+          (when-not (mobile-util/native-ios?)
+            (util/stop e)
+            (paste-text-in-one-block-at-point))
           (paste-text text e))
         (let [_handled
               (let [clipboard-data (gobj/get e "clipboardData")


### PR DESCRIPTION
close https://github.com/logseq/logseq/issues/4914