### PR TITLE
enhance(editor): allow global git cmd shortcut

### DIFF
--- a/src/main/frontend/components/shell.cljs
+++ b/src/main/frontend/components/shell.cljs
@@ -33,7 +33,7 @@
         [:h1.title
          "Input command"]
         [:div.mt-4.mb-4.relative.rounded-md.shadow-sm.max-w-xs
-         [:input#run-command.form-input.block.w-full.sm:text-sm.sm:leading-5
+         [:input#run-command.form-input.font-mono.block.w-full.sm:text-sm.sm:leading-5
           {:autoFocus true
            :on-key-down util/stop-propagation
            :placeholder "git commit -m ..."

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -278,7 +278,9 @@
 
    :command/run                    {:binding "mod+shift+1"
                                     :inactive (not (util/electron?))
-                                    :fn      #(state/pub-event! [:command/run])}
+                                    :fn      #(do
+                                                (editor-handler/escape-editing)
+                                                (state/pub-event! [:command/run]))}
 
    :go/home                        {:binding "g h"
                                     :fn      route-handler/redirect-to-home!}
@@ -438,7 +440,8 @@
 
     :shortcut.handler/editor-global
     (->
-     (build-category-map [:command-palette/toggle
+     (build-category-map [:command/run
+                          :command-palette/toggle
                           :graph/open
                           :graph/remove
                           :graph/add
@@ -487,8 +490,7 @@
 
     :shortcut.handler/global-non-editing-only
     (->
-     (build-category-map [:command/run
-                          :go/home
+     (build-category-map [:go/home
                           :go/journals
                           :go/all-pages
                           :go/flashcards


### PR DESCRIPTION
- git command should be available globally
- use mono-font