### PR TITLE
feat: logseq protocol non-darwin OS support; open in running window if exist by default

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -213,10 +213,8 @@
 
       (.on app "second-instance"
            (fn [_event _commandLine _workingDirectory]
-             (when-let [win @*win]
-               (when (.isMinimized ^object win)
-                 (.restore win))
-               (.focus win))))
+             (when-let [window @*win]
+               (win/switch-to-window! window))))
 
       (.on app "window-all-closed" (fn []
                                      (try

--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -179,8 +179,22 @@
          (.removeHandler ipcMain call-app-channel)
          (.removeHandler ipcMain call-win-channel))))
 
-(defn main
-  []
+(defn- setup-deeplink! []
+  ;; Works for Deeplink v1.0.9
+  ;; :mainWindow is only used for handeling window restoring on second-instance,
+  ;; But we already handle window restoring without deeplink.
+  ;; https://github.com/glawson/electron-deeplink/blob/73d58edcde3d0e80b1819cd68a0c6e837a9c9258/src/index.ts#L150-L155
+  (-> (Deeplink. #js
+                  {:app app
+                   :mainWindow nil
+                   :protocol LSP_SCHEME
+                   :isDev dev?})
+      (.on "received"
+           (fn [url]
+             (when-let [win @*win]
+               (open-url-handler win url))))))
+
+(defn main []
   (if-not (.requestSingleInstanceLock app)
     (do
       (search/close!)
@@ -194,6 +208,9 @@
                               :privileges privileges}
                              {:scheme     FILE_LSP_SCHEME
                               :privileges privileges}]))
+      
+      (setup-deeplink!)
+
       (.on app "second-instance"
            (fn [_event _commandLine _workingDirectory]
              (when-let [win @*win]
@@ -214,12 +231,6 @@
                    ^js win (win/create-main-window)
                    _ (reset! *win win)]
                (.. logger (info (str "Logseq App(" (.getVersion app) ") Starting... ")))
-
-               (Deeplink. #js
-                           {:app app
-                            :mainWindow win
-                            :protocol LSP_SCHEME
-                            :isDev dev?})
 
                (restore-user-fetch-agent)
 
@@ -242,10 +253,6 @@
                                      #(doseq [f [t0 t1 t2 t3 tt]]
                                         (and f (f)))))))
 
-               (.on app "open-url"
-                    (fn [_event url]
-                      (open-url-handler win url)))
-
                ;; setup effects
                (@*setup-fn)
 
@@ -260,7 +267,7 @@
                                     (async/go
                                       (let [_ (async/<! state/persistent-dbs-chan)]
                                         (if (or @win/*quitting? (not mac?))
-                                          ;; only cmd+q quitting will trigger actual closing on mac
+                                          ;; MacOS: only cmd+q quitting will trigger actual closing
                                           ;; otherwise, it's just hiding - don't do any actuall closing in that case
                                           ;; except saving transit
                                           (when-let [win @*win]
@@ -268,6 +275,7 @@
                                               (handler/close-watcher-when-orphaned! win dir))
                                             (state/close-window! win)
                                             (win/destroy-window! win)
+                                            ;; FIXME: what happens when closing main window on Windows?
                                             (reset! *win nil))
                                           ;; Just hiding - don't do any actuall closing operation
                                           (do (.preventDefault ^js/Event e)

--- a/src/electron/electron/url.cljs
+++ b/src/electron/electron/url.cljs
@@ -1,7 +1,8 @@
 (ns electron.url
   (:require [electron.handler :as handler]
             [electron.state :as state]
-            [electron.utils :refer [send-to-renderer]]
+            [electron.window :as win]
+            [electron.utils :refer [send-to-renderer] :as utils]
             [clojure.string :as string]
             [promesa.core :as p]))
 
@@ -31,21 +32,28 @@
   "Given a URL with `graph identifier` as path, `page` (optional) and `block-id` 
    (optional) as parameters, open the local graphs accordingly.
    `graph identifier` is the name of the graph to open, e.g. `lambda`"
-  [^js win parsed-url]
+  [^js win parsed-url force-new-window?]
   (let [graph-identifier (decode (string/replace (.-pathname parsed-url) "/" ""))
         [page-name block-id] (get-URL-decoded-params parsed-url ["page" "block-id"])
         graph-name (when graph-identifier (handler/get-graph-name graph-identifier))]
     (if graph-name
-      (p/let [_ (handler/broadcast-persist-graph! graph-name)]
+      (p/let [window-on-graph (first (win/get-graph-all-windows (utils/get-graph-dir graph-name)))
+              open-new-window? (or force-new-window? (not window-on-graph))
+              _ (when (and force-new-window? window-on-graph)
+                  (handler/broadcast-persist-graph! graph-name))]
           ;; TODO: call open new window on new graph without renderer (remove the reliance on local storage)
           ;; TODO: allow open new window on specific page, without waiting for `graph ready` ipc then redirect to that page
         (when (or page-name block-id)
-          (let [then-f (fn [win' graph-name']
+          (let [redirect-f (fn [win' graph-name']
                          (when (= graph-name graph-name')
                            (send-to-renderer win' "redirectWhenExists" {:page-name page-name
                                                                         :block-id block-id})))]
-            (state/set-state! :window/once-graph-ready then-f)))
-        (send-to-renderer win "openNewWindowOfGraph" graph-name))
+            (if open-new-window?
+              (state/set-state! :window/once-graph-ready redirect-f)
+              (do (win/switch-to-window! window-on-graph)
+                  (redirect-f window-on-graph graph-name)))))
+        (when open-new-window?
+          (send-to-renderer win "openNewWindowOfGraph" graph-name)))
       (graph-identifier-error-handler graph-identifier))))
 
 (defn logseq-url-handler
@@ -57,7 +65,10 @@
 
       ;; identifier of graph in local
       (= "graph" url-host)
-      (local-url-handler win parsed-url)
+      (local-url-handler win parsed-url false)
+
+      (= "new-window" url-host)
+      (local-url-handler win parsed-url true)
 
       :else
       (send-to-renderer "notification" {:type "error"

--- a/src/electron/electron/url.cljs
+++ b/src/electron/electron/url.cljs
@@ -34,7 +34,7 @@
    `graph identifier` is the name of the graph to open, e.g. `lambda`"
   [^js win parsed-url force-new-window?]
   (let [graph-identifier (decode (string/replace (.-pathname parsed-url) "/" ""))
-        [page-name block-id] (get-URL-decoded-params parsed-url ["page" "block-id"])
+        [page-name block-id file] (get-URL-decoded-params parsed-url ["page" "block-id" "file"])
         graph-name (when graph-identifier (handler/get-graph-name graph-identifier))]
     (if graph-name
       (p/let [window-on-graph (first (win/get-graph-all-windows (utils/get-graph-dir graph-name)))
@@ -43,11 +43,12 @@
                   (handler/broadcast-persist-graph! graph-name))]
           ;; TODO: call open new window on new graph without renderer (remove the reliance on local storage)
           ;; TODO: allow open new window on specific page, without waiting for `graph ready` ipc then redirect to that page
-        (when (or page-name block-id)
+        (when (or page-name block-id file)
           (let [redirect-f (fn [win' graph-name']
                          (when (= graph-name graph-name')
                            (send-to-renderer win' "redirectWhenExists" {:page-name page-name
-                                                                        :block-id block-id})))]
+                                                                        :block-id block-id
+                                                                        :file file})))]
             (if open-new-window?
               (state/set-state! :window/once-graph-ready redirect-f)
               (do (win/switch-to-window! window-on-graph)

--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -84,6 +84,12 @@
                          (when @*quitting?
                            (async/put! state/persistent-dbs-chan true)))))))
 
+(defn switch-to-window!
+  [^js win]
+  (when (.isMinimized ^object win)
+    (.restore win))
+  (.focus win))
+
 (defn get-all-windows
   []
   (.getAllWindows BrowserWindow))

--- a/src/main/electron/listener.cljs
+++ b/src/main/electron/listener.cljs
@@ -76,7 +76,7 @@
                      ;;  :page-name : the original-name of the page.
                      ;;  :block-id : uuid.
                      (fn [data]
-                       (let [{:keys [page-name block-id]} (bean/->clj data)]
+                       (let [{:keys [page-name block-id file]} (bean/->clj data)]
                          (cond
                            page-name
                            (let [db-page-name (db-model/get-redirect-page-name page-name)]
@@ -88,7 +88,12 @@
                            block-id
                            (if (db-model/get-block-by-uuid block-id)
                              (route-handler/redirect-to-page! block-id)
-                             (notification/show! (str "Open link failed. Block-id `" block-id "` doesn't exist in the graph.") :error false))))))
+                             (notification/show! (str "Open link failed. Block-id `" block-id "` doesn't exist in the graph.") :error false))
+
+                           file
+                           (if-let [db-page-name (db-model/get-file-page file false)]
+                             (route-handler/redirect-to-page! db-page-name)
+                             (notification/show! (str "Open link failed. File `" file "` doesn't exist in the graph.") :error false))))))
 
   (js/window.apis.on "dbsync"
                      (fn [data]


### PR DESCRIPTION
### Description
Now the `graph` action of Logseq protocol will try to open the target in a running window on that graph if exists;
The `new-window` action always open the target in a new window.

### Progress
- [x] logseq protocol non-darwin OS support
- [x] open in running window if exist by default for `graph` action
- [x] add `new-window` action, which always open in new window
- [x] `file` param for opening page given graph name and full path of file @sawhney17
- [ ] Investigate: close main window on Windows?