### PR TITLE
enhance(edit): add smooth-select action

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1260,22 +1260,22 @@
   (cond
       ;; when editing, quit editing and select current block
     (state/editing?)
-(state/exit-editing-and-set-selected-blocks! [(gdom/getElement (state/get-editing-block-dom-id))])
+    (state/exit-editing-and-set-selected-blocks! [(gdom/getElement (state/get-editing-block-dom-id))])
 
       ;; when selection and one block selected, select next block
     (and (state/selection?) (== 1 (count (state/get-selection-blocks))))
-(let [f (if (= :up direction) util/get-prev-block-non-collapsed util/get-next-block-non-collapsed-skip)
-      element (f (first (state/get-selection-blocks)))]
-  (when element
-    (state/conj-selection-block! element direction)))
+    (let [f (if (= :up direction) util/get-prev-block-non-collapsed util/get-next-block-non-collapsed-skip)
+          element (f (first (state/get-selection-blocks)))]
+      (when element
+        (state/conj-selection-block! element direction)))
 
       ;; if same direction, keep conj on same direction
     (and (state/selection?) (= direction (state/get-selection-direction)))
-(let [f (if (= :up direction) util/get-prev-block-non-collapsed util/get-next-block-non-collapsed-skip)
-      first-last (if (= :up direction) first last)
-      element (f (first-last (state/get-selection-blocks)))]
-  (when element
-    (state/conj-selection-block! element direction)))
+    (let [f (if (= :up direction) util/get-prev-block-non-collapsed util/get-next-block-non-collapsed-skip)
+          first-last (if (= :up direction) first last)
+          element (f (first-last (state/get-selection-blocks)))]
+      (when element
+        (state/conj-selection-block! element direction)))
 
       ;; if different direction, keep clear until one left
     (state/selection?)

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -180,6 +180,12 @@
    :editor/select-block-down       {:binding "shift+down"
                                     :fn      (editor-handler/on-select-block :down)}
 
+   :editor/select-up               {:binding false
+                                    :fn      (editor-handler/shortcut-select-up-down :up)}
+
+   :editor/select-down             {:binding false
+                                    :fn      (editor-handler/shortcut-select-up-down :down)}
+
    :editor/delete-selection        {:binding ["backspace" "delete"]
                                     :fn      editor-handler/delete-selection}
 
@@ -451,6 +457,8 @@
                           :editor/down
                           :editor/left
                           :editor/right
+                          :editor/select-up
+                          :editor/select-down
                           :editor/move-block-up
                           :editor/move-block-down
                           :editor/open-edit
@@ -592,7 +600,9 @@
     :editor/forward-kill-word
     :editor/backward-kill-word
     :editor/replace-block-reference-at-point
-    :editor/paste-text-in-one-block-at-point]
+    :editor/paste-text-in-one-block-at-point
+    :editor/select-up
+    :editor/select-down]
 
    :shortcut.category/block-selection
    [:editor/open-edit

--- a/src/main/frontend/modules/shortcut/dicts.cljc
+++ b/src/main/frontend/modules/shortcut/dicts.cljc
@@ -53,6 +53,8 @@
    :editor/down                    "Move cursor down / Select down"
    :editor/left                    "Move cursor left / Open selected block at beginning"
    :editor/right                   "Move cursor right / Open selected block at end"
+   :editor/select-up               "Select content above"
+   :editor/select-down             "Select content below"
    :editor/move-block-up           "Move block up"
    :editor/move-block-down         "Move block down"
    :editor/open-edit               "Edit selected block"

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -368,6 +368,11 @@
   (when input
     (.-selectionEnd input)))
 
+(defn get-selection-direction
+  [input]
+  (when input
+    (.-selectionDirection input)))
+
 (defn get-first-or-last-line-pos
   [input]
   (let [pos (get-selection-start input)


### PR DESCRIPTION
Relate to #4346.

The new smooth-select action will select lines until you hit the top/bottom of the block, and then it starts selecting whole blocks.

I feel that it is risky to change the default keymap, so I just leave these new actions **unbound**.