### PR TITLE
add shortcuts for opening file in default app and directory

### DIFF
--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -344,11 +344,11 @@
    :command/toggle-favorite         {:binding "mod+shift+f"
                                      :fn      page-handler/toggle-favorite!}
 
-   :editor/open-file-in-default-app {:binding "mod+d"
+   :editor/open-file-in-default-app {:binding "mod+d mod+a"
                                      :inactive (not (util/electron?))
                                      :fn      page-handler/open-file-in-default-app}
 
-   :editor/open-file-in-directory   {:binding "mod+shift+d"
+   :editor/open-file-in-directory   {:binding "mod+d"
                                      :inactive (not (util/electron?))
                                      :fn      page-handler/open-file-in-directory}
 

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -348,7 +348,7 @@
                                      :inactive (not (util/electron?))
                                      :fn      page-handler/open-file-in-default-app}
 
-   :editor/open-file-in-directory   {:binding "mod+d"
+   :editor/open-file-in-directory   {:binding "mod+d mod+i"
                                      :inactive (not (util/electron?))
                                      :fn      page-handler/open-file-in-directory}
 

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -344,11 +344,11 @@
    :command/toggle-favorite         {:binding "mod+shift+f"
                                      :fn      page-handler/toggle-favorite!}
 
-   :editor/open-file-in-default-app {:binding false
+   :editor/open-file-in-default-app {:binding "mod+d"
                                      :inactive (not (util/electron?))
                                      :fn      page-handler/open-file-in-default-app}
 
-   :editor/open-file-in-directory   {:binding false
+   :editor/open-file-in-directory   {:binding "mod+shift+d"
                                      :inactive (not (util/electron?))
                                      :fn      page-handler/open-file-in-directory}
 
@@ -638,6 +638,8 @@
     :sidebar/open-today-page
     :search/re-index
     :editor/insert-youtube-timestamp
+    :editor/open-file-in-default-app
+    :editor/open-file-in-directory
     :auto-complete/prev
     :auto-complete/next
     :auto-complete/complete


### PR DESCRIPTION
This PR makes it possible to add shortcuts to open current file in directory or to open file in default app. 

The shortcuts used are

`mod+d` open file in default app
`mod+shift+d` open file in directory

It appears as if this functionality used to be there but was removed. 

The shortcuts were previously: 

`o d` open file in default app
`o f` open file in directory

This is another option. Curious as to the reasoning for removal of tihs shortcut. Was there a bug that necessitated the removal?