### PR TITLE
fix(utils): classname utils for string input

### DIFF
--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1277,7 +1277,7 @@
              #(if (map? %)
                 (for [[k v] %]
                   (when v (name k)))
-                (name %))
+                [(name %)])
              args)))
 
 #?(:cljs


### PR DESCRIPTION
try to resolved https://github.com/logseq/logseq/issues/4967