### PR TITLE
display version info on mobile

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -509,12 +509,12 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = App/AppDebug.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = K378MFWK59;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 0.0.7;
+				MARKETING_VERSION = 0.6.6;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.logseq.logseq;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -535,12 +535,12 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = K378MFWK59;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 0.0.7;
+				MARKETING_VERSION = 0.6.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.logseq.logseq;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
@@ -557,7 +557,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = ShareViewController/ShareViewController.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = K378MFWK59;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ShareViewController/Info.plist;
@@ -565,7 +565,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 0.0.7;
+				MARKETING_VERSION = 0.6.6;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.logseq.logseq.ShareViewController;
@@ -584,7 +584,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = ShareViewController/ShareViewController.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = K378MFWK59;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ShareViewController/Info.plist;
@@ -592,7 +592,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 0.0.7;
+				MARKETING_VERSION = 0.6.6;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.logseq.logseq.ShareViewController;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -48,11 +48,28 @@
 
       [:div.mt-1.sm:mt-0.sm:col-span-2
        {:style {:display "flex" :gap "0.5rem" :align-items "center"}}
-       [:div (ui/button
-               (if update-pending? "Checking ..." "Check for updates")
-               :class "text-sm p-1 mr-1"
-               :disabled update-pending?
-               :on-click #(js/window.apis.checkForUpdates false))]
+       [:div (cond
+               (mobile-util/native-android?)
+               (ui/button
+                "Check for updates"
+                :class "text-sm p-1 mr-1"
+                :href "https://github.com/logseq/logseq/releases" )
+
+               (mobile-util/native-ios?)
+               (ui/button
+                "Check for updates"
+                :class "text-sm p-1 mr-1"
+                :href "https://apps.apple.com/app/logseq/id1601013908" )
+
+               (util/electron?)
+               (ui/button
+                (if update-pending? "Checking ..." "Check for updates")
+                :class "text-sm p-1 mr-1"
+                :disabled update-pending?
+                :on-click #(js/window.apis.checkForUpdates false))
+
+               :else
+               nil)]
 
        [:div.text-sm.opacity-50 (str "Version " version)]]]
 
@@ -521,8 +538,7 @@
         system-theme? (state/sub :ui/system-theme?)
         switch-theme (if dark? "light" "dark")]
     [:div.panel-wrap.is-general
-     (when-not (mobile-util/is-native-platform?)
-       (version-row t version))
+     (version-row t version)
      (language-row t preferred-language)
      (theme-modes-row t switch-theme system-theme? dark?)
      (when current-repo (edit-config-edn))


### PR DESCRIPTION
Since iOS app is already on AppStore now, better to add version info back in the settings panel. 
![image](https://user-images.githubusercontent.com/3996879/164147415-d92a07d4-bf0e-4a0a-82f3-cbf7fa094abc.png)

BTW, iOS version will follow the desktop's from now on.