### PR TITLE
feat: custom query title may also render rich texts

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2566,7 +2566,9 @@
        (when-not (and built-in? (empty? result))
          (ui/foldable
           [:div.custom-query-title
-           [:span.title-text title]
+           [:span.title-text (inline-text config
+                                          (or (:block/format config) :markdown)
+                                          title)]
            [:span.opacity-60.text-sm.ml-2.results-count
             (str (count transformed-query-result) " results")]]
           (fn []

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2566,9 +2566,11 @@
        (when-not (and built-in? (empty? result))
          (ui/foldable
           [:div.custom-query-title
-           [:span.title-text (inline-text config
-                                          (or (:block/format config) :markdown)
-                                          title)]
+           [:span.title-text (if (vector? title)
+                               title
+                               (inline-text config
+                                            (get-in config [:block :block/format] :markdown)
+                                            (str title)))]
            [:span.opacity-60.text-sm.ml-2.results-count
             (str (count transformed-query-result) " results")]]
           (fn []


### PR DESCRIPTION
This will allow users to put custom macros etc into the title. e.g.,

```
#+BEGIN_QUERY
{:title "{{poem 123}}"
    :query ...}
#+END_QUERY
```

will render as 
<img width="514" alt="image" src="https://user-images.githubusercontent.com/584378/164214515-967db69a-d63b-49b8-bc6d-64ae2f8aef95.png">
