### PR TITLE
Docker: Add support for arm64 image & autobuild

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -3,6 +3,8 @@ name: Build-Docker
 on:
   workflow_dispatch:
   workflow_call:
+  release:
+    types: [published]
 
 env:
   CLOJURE_VERSION: '1.10.1.727'
@@ -19,16 +21,24 @@ jobs:
           fetch-depth: 1
           submodules: 'true'
 
-      - name: Build Docker
-        run: |
-          docker build -t ghcr.io/logseq/logseq-webapp:latest .
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
 
       - name: Docker Login
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish Docker Image
-        run: docker push ghcr.io/logseq/logseq-webapp:latest
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/${{ github.repository_owner }}/logseq-webapp:latest


### PR DESCRIPTION
Leveraging Docker buildx allows building for multiple architectures, in this case amd64 and arm64. (armv7 and lower do not appear to be supported by clojure). **Note**: *Build time is significantly increased by this ~50m, but the result is as intended.*
Additionally, the workflow can be triggered when a new release is published.
