### PR TITLE
ui: capture invalid pdf error

### DIFF
--- a/src/main/frontend/extensions/pdf/highlights.cljs
+++ b/src/main/frontend/extensions/pdf/highlights.cljs
@@ -1078,9 +1078,19 @@
             "MissingPDFException"
             (do
               (notification/show!
-                (str (.-message error) " Is this the correct path?")
-                :error
-                false)
+               (str (.-message error) " Is this the correct path?")
+               :error
+               false)
+              (state/set-state! :pdf/current nil))
+
+            "InvalidPDFException"
+            (do
+              (notification/show!
+               (str (.-message error) "\n"
+                    "Is this .pdf file corrupted?\n"
+                    "Please confirm with external pdf viewer.")
+               :error
+               false)
               (state/set-state! :pdf/current nil)))))
       [(:error state)])
 

--- a/src/main/frontend/page.cljs
+++ b/src/main/frontend/page.cljs
@@ -97,7 +97,7 @@
   (when-let [route-match (state/sub :route-match)]
     (let [route-name (get-in route-match [:data :name])]
       (when-let [view (:view (:data route-match))]
-        (ui/catch-error
+        (ui/catch-error-and-notify
          (helpful-default-error-screen)
          (if (= :draw route-name)
            (view route-match)

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -715,6 +715,9 @@
   < {:did-catch
      (fn [state error _info]
        (log/error :exception error)
+       (notification-handler/show!
+        (str "Error caught by UI!\n " error)
+        :error)
        (assoc state ::error error))}
   [{error ::error, c :rum/react-component} error-view view]
   (if (some? error)

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -715,6 +715,16 @@
   < {:did-catch
      (fn [state error _info]
        (log/error :exception error)
+       (assoc state ::error error))}
+  [{error ::error, c :rum/react-component} error-view view]
+  (if (some? error)
+    error-view
+    view))
+
+(rum/defcs catch-error-and-notify
+  < {:did-catch
+     (fn [state error _info]
+       (log/error :exception error)
        (notification-handler/show!
         (str "Error caught by UI!\n " error)
         :error)


### PR DESCRIPTION
* To help users to locate errors, prompt up error notification when error caught by `helpful-default-error-screen`, instead of printing to console only.
* Add error notification for `InvalidPDFException`
Close #4986

* The CI looks broken. Fixed it by switching the jdk distribution