### PR TITLE
feat: resolve datascript query inputs with Logseq DSL for plugins

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2559,11 +2559,12 @@
        (when-not (and built-in? (empty? result))
          (ui/foldable
           [:div.custom-query-title
-           [:span.title-text (if (vector? title)
-                               title
-                               (inline-text config
-                                            (get-in config [:block :block/format] :markdown)
-                                            (str title)))]
+           [:span.title-text (cond
+                               (vector? title) title
+                               (string? title) (inline-text config
+                                                            (get-in config [:block :block/format] :markdown)
+                                                            title)
+                               :else title)]
            [:span.opacity-60.text-sm.ml-2.results-count
             (str (count transformed-query-result) " results")]]
           (fn []

--- a/src/main/frontend/db/query_react.cljs
+++ b/src/main/frontend/db/query_react.cljs
@@ -14,7 +14,7 @@
             [frontend.util :as util]
             [lambdaisland.glogi :as log]))
 
-(defn- resolve-input
+(defn resolve-input
   [input]
   (cond
     (= :right-now-ms input) (util/time-ms)

--- a/src/main/logseq/api.cljs
+++ b/src/main/logseq/api.cljs
@@ -13,6 +13,7 @@
             [frontend.db.model :as db-model]
             [frontend.db.query-dsl :as query-dsl]
             [frontend.db.utils :as db-utils]
+            [frontend.db.query-react :as query-react]
             [frontend.fs :as fs]
             [frontend.handler.dnd :as editor-dnd-handler]
             [frontend.handler.editor :as editor-handler]
@@ -676,7 +677,8 @@
   (when-let [repo (state/get-current-repo)]
     (when-let [db (db/get-db repo)]
       (let [query (cljs.reader/read-string query)
-            result (apply d/q query db inputs)]
+            resolved-inputs (map (comp query-react/resolve-input cljs.reader/read-string) inputs)
+            result (apply d/q query db resolved-inputs)]
         (clj->js result)))))
 
 (def ^:export custom_query db/custom-query)


### PR DESCRIPTION
1. allow plugins to pass in `:today` etc in `logseq.DB.datascriptQuery`

```js

logseq.DB.datascriptQuery(
  `[:find (pull ?h [*])
            :in $ ?start ?next
            :where
            [?h :block/marker ?marker]
            [?h :block/refs ?p]
            [?p :block/journal? true]
            [?p :block/journal-day ?d]
            [(> ?d ?start)]
            [(< ?d ?next)]]`,
  ":today",
  ":7d-after"
);

```

2. fix a display issue of query DSLs
<img width="285" alt="截屏2022-04-23 19 52 06" src="https://user-images.githubusercontent.com/584378/164893370-77fb83b5-deb2-452d-841c-b176f56d0b72.png">

