### PR TITLE
Fix logbook clock-summary

### DIFF
--- a/src/main/frontend/util/clock.cljs
+++ b/src/main/frontend/util/clock.cljs
@@ -95,8 +95,7 @@
               seconds (mod reduced-seconds 60)
               minutes (mod (+ reduced-minutes (quot reduced-seconds 60)) 60)
               hours (+ reduced-hours
-                       (quot reduced-minutes 60)
-                       (quot (+ (mod reduced-minutes 60) reduced-seconds) 3600))]
+                       (quot (+ reduced-minutes (quot reduced-seconds 60)) 60))]
           (if string?
             (util/format "%s%s%s"
                          (if (>= hours 1)


### PR DESCRIPTION
Current implementation doesn't calculate hours correctly. E.g., for logbook records `0:30:30` and `0:29:30`, it would return `00:00:00`.