### PR TITLE
fix error in mailto Link

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1286,7 +1286,7 @@
          ["Email" address]
          (let [{:keys [local_part domain]} address
                address (str local_part "@" domain)]
-           [:a {:href (str "mainto:" address)} address])
+           [:a {:href (str "mailto:" address)} address])
 
          ["Nested_link" link]
          (nested-link config html-export? link)


### PR DESCRIPTION
Update block.cljs. Fix mailto link wrong.
See [Issue 5080](https://github.com/logseq/logseq/issues/5080)
