### PR TITLE
fix: editing empty last block if `:replace-empty-target?` non-nils

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -650,7 +650,10 @@
                                                           :keep-uuid? true
                                                           :replace-empty-target? replace-empty-target?})
             (when edit-block?
-              (js/setTimeout #(edit-block! new-block :max (:block/uuid new-block)) 10))
+              (if (and replace-empty-target?
+                       (string/blank? (:block/content last-block)))
+                (js/setTimeout #(edit-block! last-block :max (:block/uuid last-block)) 10)
+                (js/setTimeout #(edit-block! new-block :max (:block/uuid new-block)) 10)))
             new-block))))))
 
 (defn insert-first-page-block-if-not-exists!

--- a/src/main/frontend/mobile/footer.cljs
+++ b/src/main/frontend/mobile/footer.cljs
@@ -54,14 +54,10 @@
      (mobile-bar-command #(state/toggle-document-mode!) "notes")
      (mobile-bar-command
       #(let [page (or (state/get-current-page)
-                      (string/lower-case (date/journal-name)))
-             block (editor-handler/api-insert-new-block!
+                      (string/lower-case (date/journal-name)))]
+         (editor-handler/api-insert-new-block!
                     ""
                     {:page page
-                     :replace-empty-target? true})]
-         (js/setTimeout
-          (fn [] (editor-handler/edit-block!
-                  block
-                  :max
-                  (:block/uuid block))) 100))
+                     :edit-block? true
+                     :replace-empty-target? true}))
       "edit")]))

--- a/src/main/frontend/mobile/intent.cljs
+++ b/src/main/frontend/mobile/intent.cljs
@@ -53,6 +53,7 @@
     (if (state/get-edit-block)
       (state/append-current-edit-content! values)
       (editor-handler/api-insert-new-block! values {:page page
+                                                    :edit-block? false
                                                     :replace-empty-target? true}))))
 
 (defn- embed-asset-file [url format]
@@ -99,6 +100,7 @@
     (if (state/get-edit-block)
       (state/append-current-edit-content! content)
       (editor-handler/api-insert-new-block! content {:page page
+                                                     :edit-block? false
                                                      :replace-empty-target? true}))))
 
 (defn- handle-received-application [result]
@@ -124,6 +126,7 @@
     (if (state/get-edit-block)
       (state/append-current-edit-content! content)
       (editor-handler/api-insert-new-block! content {:page page
+                                                     :edit-block? false
                                                      :replace-empty-target? true}))))
 
 (defn decode-received-result [m]

--- a/src/main/frontend/mobile/record.cljs
+++ b/src/main/frontend/mobile/record.cljs
@@ -60,6 +60,7 @@
     (if edit-block
       (state/append-current-edit-content! file-link)
       (editor-handler/api-insert-new-block! file-link {:page page
+                                                       :edit-block? false
                                                        :replace-empty-target? true}))))
 
 (defn stop-recording []


### PR DESCRIPTION
Also, set `edit-block?` to false for some functions.