### PR TITLE
perf: optimize the calculation of clock-summary

### DIFF
--- a/src/main/frontend/util/clock.cljs
+++ b/src/main/frontend/util/clock.cljs
@@ -91,7 +91,8 @@
               duration (t/period :hours hours
                                  :minutes minutes
                                  :seconds seconds)
-              zero-minutes? (zero? (+ (* hours 60) minutes (quot seconds 60)))]
+              duration-in-minutes (t/in-minutes duration)
+              zero-minutes? (zero? duration-in-minutes)]
           (if string?
             (if zero-minutes?
               (str seconds "s")
@@ -101,4 +102,4 @@
                   (string/replace #"\s+minutes?$" "m")))
             (if zero-minutes?
               seconds
-              (+ (* hours 60) minutes))))))))
+              duration-in-minutes)))))))


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

Ref: https://discuss.logseq.com/t/logbook-clock-can-be-measured-in-days-automatically/7021.

Now it looks like:

<img width="317" alt="image" src="https://user-images.githubusercontent.com/15034155/166089921-477fa075-6d46-4ffe-80ee-325061dc27a8.png">

In addition to rendering `days`. This PR also reduces the calculation and uses `seq` to fix the check if clock-lines is empty.