### PR TITLE
fix: the popup position is sometimes wrong

### DIFF
--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -408,7 +408,7 @@
               (when set-default-width?
                 {:width max-width})
               (let [^js/HTMLElement textarea
-                    (js/document.querySelector "textarea")]
+                    (js/document.querySelector "textarea.ls-textarea")]
                 (if (<= (.-clientWidth textarea) (+ left (if set-default-width? max-width 500)))
                   {:right 0}
                   {:left (if (and y-diff (= y-diff 0)) left 0)})))}
@@ -476,6 +476,7 @@
   (let [content (if content (str content) "")]
     ;; as the function is binding to the editor content, optimization is welcome
     (str
+     "ls-textarea "
      (if (or (> (.-length content) 1000)
              (string/includes? content "\n"))
        "multiline-block"


### PR DESCRIPTION
The issue is that codemirror also has a `textarea` in the DOM, which causes the positioning of popover is incorrect.
I added a `ls-textarea` class name to the logseq editor/textarea to distinguish the editor identity with the codemirror.

Bug screenshot:
<img width="850" alt="Screen Shot 2022-05-03 at 00 50 19" src="https://user-images.githubusercontent.com/584378/166290350-00cafbfc-b94d-47b1-9a41-f178dd4e62a6.png">
