### PR TITLE
enhance(ux): support idiomatic shortcut `ctrl+n` for auto-complete navigation

### DIFF
--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -58,6 +58,12 @@
    :auto-complete/next           {:binding "down"
                                   :fn      ui-handler/auto-complete-next}
 
+   :auto-complete/ctrl-prev      {:binding "ctrl+p"
+                                  :fn      ui-handler/auto-complete-prev}
+
+   :auto-complete/ctrl-next      {:binding "ctrl+n"
+                                  :fn      ui-handler/auto-complete-next}
+
    :auto-complete/shift-complete {:binding "shift+enter"
                                   :fn      ui-handler/auto-complete-shift-complete}
 
@@ -406,6 +412,8 @@
     (build-category-map [:auto-complete/complete
                          :auto-complete/prev
                          :auto-complete/next
+                         :auto-complete/ctrl-prev
+                         :auto-complete/ctrl-next
                          :auto-complete/shift-complete
                          :auto-complete/open-link])
 
@@ -642,6 +650,8 @@
     :editor/open-file-in-directory
     :auto-complete/prev
     :auto-complete/next
+    :auto-complete/ctrl-prev
+    :auto-complete/ctrl-next
     :auto-complete/complete
     :auto-complete/shift-complete
     :auto-complete/open-link

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -52,16 +52,10 @@
    :auto-complete/complete       {:binding "enter"
                                   :fn      ui-handler/auto-complete-complete}
 
-   :auto-complete/prev           {:binding "up"
+   :auto-complete/prev           {:binding ["up" "ctrl+p"]
                                   :fn      ui-handler/auto-complete-prev}
 
-   :auto-complete/next           {:binding "down"
-                                  :fn      ui-handler/auto-complete-next}
-
-   :auto-complete/ctrl-prev      {:binding "ctrl+p"
-                                  :fn      ui-handler/auto-complete-prev}
-
-   :auto-complete/ctrl-next      {:binding "ctrl+n"
+   :auto-complete/next           {:binding ["down" "ctrl+n"]
                                   :fn      ui-handler/auto-complete-next}
 
    :auto-complete/shift-complete {:binding "shift+enter"
@@ -412,8 +406,6 @@
     (build-category-map [:auto-complete/complete
                          :auto-complete/prev
                          :auto-complete/next
-                         :auto-complete/ctrl-prev
-                         :auto-complete/ctrl-next
                          :auto-complete/shift-complete
                          :auto-complete/open-link])
 
@@ -650,8 +642,6 @@
     :editor/open-file-in-directory
     :auto-complete/prev
     :auto-complete/next
-    :auto-complete/ctrl-prev
-    :auto-complete/ctrl-next
     :auto-complete/complete
     :auto-complete/shift-complete
     :auto-complete/open-link

--- a/src/main/frontend/modules/shortcut/dicts.cljc
+++ b/src/main/frontend/modules/shortcut/dicts.cljc
@@ -18,6 +18,8 @@
    :auto-complete/complete       "Auto-complete: Choose selected item"
    :auto-complete/prev           "Auto-complete: Select previous item"
    :auto-complete/next           "Auto-complete: Select next item"
+   :auto-complete/ctrl-prev      "Auto-complete: Select previous item"
+   :auto-complete/ctrl-next      "Auto-complete: Select next item"
    :auto-complete/shift-complete "Auto-complete: Open selected item in sidebar"
    :auto-complete/open-link      "Auto-complete: Open selected item in browser"
    :cards/toggle-answers         "Cards: show/hide answers/clozes"

--- a/src/main/frontend/modules/shortcut/dicts.cljc
+++ b/src/main/frontend/modules/shortcut/dicts.cljc
@@ -18,8 +18,6 @@
    :auto-complete/complete       "Auto-complete: Choose selected item"
    :auto-complete/prev           "Auto-complete: Select previous item"
    :auto-complete/next           "Auto-complete: Select next item"
-   :auto-complete/ctrl-prev      "Auto-complete: Select previous item"
-   :auto-complete/ctrl-next      "Auto-complete: Select next item"
    :auto-complete/shift-complete "Auto-complete: Open selected item in sidebar"
    :auto-complete/open-link      "Auto-complete: Open selected item in browser"
    :cards/toggle-answers         "Cards: show/hide answers/clozes"


### PR DESCRIPTION
![2022-05-03 16 43 00](https://user-images.githubusercontent.com/1779837/166426381-8bbaeebb-e723-430a-a936-a20a809c37eb.gif)
