### PR TITLE
enhance(ui/auto-complete): split hover and focus status

### DIFF
--- a/src/main/frontend/components/command_palette.css
+++ b/src/main/frontend/components/command_palette.css
@@ -16,7 +16,6 @@
     }
 
     .menu-link {
-      background-color: transparent;
       transition: none;
       border: none;
       border-radius: unset !important;

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -432,7 +432,6 @@
                     (menu-link
                      {:id            (str "ac-" idx)
                       :class         (when chosen? "chosen")
-                      :on-mouse-enter #(reset! current-idx idx)
                       :on-mouse-down (fn [e]
                                        (util/stop e)
                                        (if (and (gobj/get e "shiftKey") on-shift-chosen)


### PR DESCRIPTION
Close #3773.
This is a bare fix because 
- The style changed in a minimal modified-code way instead of proper CSS adjustment.
- The original need was to fix the command-palette instead of all `auto-complete`.

The idea here is to **split** *hover* and *focus* status handling. After some searches, I figured out that changing the focus item via mouse needs some ugly [workarounds](https://stackoverflow.com/questions/16529807/mousemove-event-is-triggered-onscroll-even-when-mouse-was-not-moved-on-chrome?rq=1), and the behavior may not be a common need. We could just style the hovered item and leave the active item unchanged, e.g. [vuetify](https://vuetifyjs.com/en/components/autocompletes/).

Feel free to modify/reject it. 