### PR TITLE
Enhance: Adds emacs keybindings to other up/down movements

### DIFF
--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -37,10 +37,10 @@
    :date-picker/next-day         {:binding "right"
                                   :fn      ui-handler/shortcut-next-day}
 
-   :date-picker/prev-week        {:binding "up"
+   :date-picker/prev-week        {:binding ["up" "ctrl+p"]
                                   :fn      ui-handler/shortcut-prev-week}
 
-   :date-picker/next-week        {:binding "down"
+   :date-picker/next-week        {:binding ["down" "ctrl+n"]
                                   :fn      ui-handler/shortcut-next-week}
 
    :pdf/previous-page            {:binding "alt+p"
@@ -152,10 +152,10 @@
    :editor/cycle-todo              {:binding "mod+enter"
                                     :fn      editor-handler/cycle-todo!}
 
-   :editor/up                      {:binding "up"
+   :editor/up                      {:binding ["up" "ctrl+p"]
                                     :fn      (editor-handler/shortcut-up-down :up)}
 
-   :editor/down                    {:binding "down"
+   :editor/down                    {:binding ["down" "ctrl+n"]
                                     :fn      (editor-handler/shortcut-up-down :down)}
 
    :editor/left                    {:binding "left"


### PR DESCRIPTION
Follow up to #5202 which adds the same keybindings to datepicker and editor so that logseq consistently provides emacs keybindings