### PR TITLE
fix: missing title properties when page name contains `/` or reserved chars

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -398,7 +398,7 @@
              (:db/id page-entity)
              :page
              {:page page-entity}))
-          (state/pub-event! [:page/create redirect-page-name]))
+          (state/pub-event! [:page/create page-name-in-block]))
         (when (and contents-page?
                    (util/mobile?)
                    (state/get-left-sidebar-open?))

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -391,12 +391,18 @@
       :on-mouse-down
       (fn [e]
         (util/stop e)
-        (if (gobj/get e "shiftKey")
+        (cond
+          (gobj/get e "shiftKey")
           (when-let [page-entity (db/entity [:block/name redirect-page-name])]
             (state/sidebar-add-block!
              (state/get-current-repo)
              (:db/id page-entity)
              :page))
+
+          (not= redirect-page-name page-name)
+          (route-handler/redirect-to-page! redirect-page-name)
+
+          :else
           (state/pub-event! [:page/create page-name-in-block]))
         (when (and contents-page?
                    (util/mobile?)

--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -264,7 +264,7 @@
          :block/original-name original-page-name}
         (when with-id?
           (if page-entity
-            {}
+            {:block/uuid (:block/uuid page-entity)}
             {:block/uuid (db/new-block-id)}))
         (when namespace?
           (let [namespace (first (gp-util/split-last "/" original-page-name))]

--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -258,7 +258,8 @@
            [original-page-name page-name journal-day] (convert-page-if-journal original-page-name)
            namespace? (and (not (boolean (text/get-nested-page-name original-page-name)))
                            (text/namespace-page? original-page-name))
-           page-entity (db/entity [:block/name page-name])]
+           page-entity (db/entity [:block/name page-name])
+           original-page-name (or (:block/original-name page-entity) original-page-name)]
        (merge
         {:block/name page-name
          :block/original-name original-page-name}

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -658,12 +658,12 @@
             new-block))))))
 
 (defn insert-first-page-block-if-not-exists!
-  ([page-name]
-   (insert-first-page-block-if-not-exists! page-name {}))
-  ([page-name opts]
-   (when (and (string? page-name)
-              (not (string/blank? page-name)))
-     (state/pub-event! [:page/create page-name opts]))))
+  ([page-title]
+   (insert-first-page-block-if-not-exists! page-title {}))
+  ([page-title opts]
+   (when (and (string? page-title)
+              (not (string/blank? page-title)))
+     (state/pub-event! [:page/create page-title opts]))))
 
 (defn properties-block
   [properties format page]

--- a/src/main/frontend/handler/extract.cljs
+++ b/src/main/frontend/handler/extract.cljs
@@ -32,7 +32,7 @@
             file-name (when-let [file-name (last (string/split file #"/"))]
                         (let [result (first (gp-util/split-last "." file-name))]
                           (if (config/mldoc-support? (string/lower-case (util/get-file-ext file)))
-                            (string/replace result "." "/")
+                            (util/url-decode (string/replace result "." "/"))
                             result)))]
         (or property-name
             (if (= (state/page-name-order) "heading")

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -366,7 +366,7 @@
   "Only accepts unsanitized page names"
   [old-name new-name redirect?]
   (let [old-page-name       (util/page-name-sanity-lc old-name)
-        new-file-name       (util/page-name-sanity new-name true)
+        new-file-name       (util/file-name-sanity new-name)
         new-page-name       (util/page-name-sanity-lc new-name)
         repo                (state/get-current-repo)
         page                (db/pull [:block/name old-page-name])]

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -134,7 +134,9 @@
                            ;; for namespace pages, only last page need properties
                            drop-last
                            (mapcat #(build-page-tx format nil % journal?))
-                           (remove nil?))
+                           (remove nil?)
+                           (remove (fn [m]
+                                     (some? (db/entity [:block/name (:block/name m)])))))
              last-txs (build-page-tx format properties (last pages) journal?)
              txs      (concat txs last-txs)]
          (when (seq txs)

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -91,12 +91,16 @@
 (defn- build-page-tx [format properties page journal?]
   (when (:block/uuid page)
     (let [page-entity [:block/uuid (:block/uuid page)]
-          create-title? (create-title-property? journal? (:block/name page))
+          create-title? (create-title-property? journal?
+                                                (or
+                                                 (:block/original-name page)
+                                                 (:block/name page)))
           page (if (seq properties) (assoc page :block/properties properties) page)]
       (cond
         create-title?
-        [page
-         (default-properties-block (build-title page) format page-entity properties)]
+        (let [properties-block (default-properties-block (build-title page) format page-entity properties)]
+          [page
+           properties-block])
 
         (seq properties)
         [page (editor-handler/properties-block properties format page-entity)]
@@ -117,7 +121,7 @@
          title (util/remove-boundary-slashes title)
          page-name (util/page-name-sanity-lc title)
          repo (state/get-current-repo)]
-     (when-not (db/page-exists? page-name)
+     (when (db/page-empty? repo page-name)
        (let [pages    (if split-namespace?
                         (util/split-namespace-pages title)
                         [title])
@@ -133,13 +137,14 @@
                            (remove nil?))
              last-txs (build-page-tx format properties (last pages) journal?)
              txs      (concat txs last-txs)]
-         (db/transact! txs)))
+         (when (seq txs)
+           (db/transact! txs)))
 
-     (when create-first-block?
-       (when (or
-              (db/page-empty? repo (:db/id (db/entity [:block/name page-name])))
-              (create-title-property? journal? page-name))
-         (editor-handler/api-insert-new-block! "" {:page page-name})))
+       (when create-first-block?
+         (when (or
+                (db/page-empty? repo (:db/id (db/entity [:block/name page-name])))
+                (create-title-property? journal? page-name))
+           (editor-handler/api-insert-new-block! "" {:page page-name}))))
 
      (when redirect?
        (route-handler/redirect-to-page! page-name))

--- a/src/main/frontend/modules/file/core.cljs
+++ b/src/main/frontend/modules/file/core.cljs
@@ -31,7 +31,10 @@
   [{:block/keys [collapsed? format pre-block? unordered content heading-level left page parent properties]} level {:keys [heading-to-list?]}]
   (let [content (or content "")
         first-block? (= left page)
-        pre-block? (and first-block? pre-block?)
+        pre-block? (or pre-block?
+                       (and (= page parent left) ; first block
+                            (= :markdown format)
+                            (string/includes? (first (string/split-lines content)) ":: ")))
         markdown? (= format :markdown)
         content (cond
                   pre-block?

--- a/src/main/frontend/modules/file/core.cljs
+++ b/src/main/frontend/modules/file/core.cljs
@@ -125,7 +125,7 @@
                   (if journal-page?
                     (date/journal-title->default title)
                     (-> (or (:block/original-name page) (:block/name page))
-                        (util/page-name-sanity true))) "."
+                        (util/file-name-sanity))) "."
                   (if (= format "markdown") "md" format))
             file-path (config/get-file-path repo path)
             file {:file/path file-path}

--- a/src/main/frontend/modules/file/core.cljs
+++ b/src/main/frontend/modules/file/core.cljs
@@ -30,7 +30,6 @@
 (defn transform-content
   [{:block/keys [collapsed? format pre-block? unordered content heading-level left page parent properties]} level {:keys [heading-to-list?]}]
   (let [content (or content "")
-        first-block? (= left page)
         pre-block? (or pre-block?
                        (and (= page parent left) ; first block
                             (= :markdown format)

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -936,7 +936,7 @@
                       (remove-boundary-slashes)
                       (normalize))]
      (if replace-slash?
-       (string/replace page #"/" ".")
+       (string/replace page #"/" "%2A")
        page))))
 
 (defn file-name-sanity
@@ -944,11 +944,12 @@
   [page-name]
   (some-> page-name
           page-name-sanity
-          ;; Windows reserved path characters
-          (string/replace windows-reserved-chars "_")
           ;; for android filesystem compatiblity
-          (string/replace #"[\\#|%]+" "_")
-          (string/replace #"/" ".")))
+          (string/replace #"[\\#|%]+" url-encode)
+          ;; Windows reserved path characters
+          (string/replace windows-reserved-chars url-encode)
+          (string/replace #"/" url-encode)
+          (string/replace "*" "%2A")))
 
 (defn page-name-sanity-lc
   "Sanitize the query string for a page name (mandate for :block/name)"

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -388,16 +388,6 @@
       (scroll-to (app-scroll-container-node) 0 animate?))))
 
 #?(:cljs
-   (defn url-encode
-     [string]
-     (some-> string str (js/encodeURIComponent) (.replace "+" "%20"))))
-
-#?(:cljs
-   (defn url-decode
-     [string]
-     (some-> string str (js/decodeURIComponent))))
-
-#?(:cljs
    (defn link?
      [node]
      (contains?
@@ -889,6 +879,16 @@
          (when (gp-util/uuid-string? block-id)
            (first (array-seq (js/document.getElementsByClassName block-id))))))))
 
+#?(:cljs
+   (defn url-encode
+     [string]
+     (some-> string str (js/encodeURIComponent) (.replace "+" "%20"))))
+
+#?(:cljs
+   (defn url-decode
+     [string]
+     (some-> string str (js/decodeURIComponent))))
+
 (def windows-reserved-chars #"[:\\*\\?\"<>|]+")
 
 #?(:cljs
@@ -939,17 +939,18 @@
        (string/replace page #"/" "%2A")
        page))))
 
-(defn file-name-sanity
-  "Sanitize page-name for file name (strict), for file writing."
-  [page-name]
-  (some-> page-name
-          page-name-sanity
-          ;; for android filesystem compatiblity
-          (string/replace #"[\\#|%]+" url-encode)
-          ;; Windows reserved path characters
-          (string/replace windows-reserved-chars url-encode)
-          (string/replace #"/" url-encode)
-          (string/replace "*" "%2A")))
+#?(:cljs
+   (defn file-name-sanity
+     "Sanitize page-name for file name (strict), for file writing."
+     [page-name]
+     (some-> page-name
+             page-name-sanity
+             ;; for android filesystem compatiblity
+             (string/replace #"[\\#|%]+" url-encode)
+             ;; Windows reserved path characters
+             (string/replace windows-reserved-chars url-encode)
+             (string/replace #"/" url-encode)
+             (string/replace "*" "%2A"))))
 
 (defn page-name-sanity-lc
   "Sanitize the query string for a page name (mandate for :block/name)"

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -928,20 +928,27 @@
      (removeAccents (.normalize (string/lower-case s) "NFKC"))))
 
 (defn page-name-sanity
-  "Sanitize the page-name for file name (strict), for file writting"
+  "Sanitize the page-name."
   ([page-name]
    (page-name-sanity page-name false))
   ([page-name replace-slash?]
    (let [page (some-> page-name
                       (remove-boundary-slashes)
-                      ;; Windows reserved path characters
-                      (string/replace windows-reserved-chars "_")
-                      ;; for android filesystem compatiblity
-                      (string/replace #"[\\#|%]+" "_")
                       (normalize))]
      (if replace-slash?
        (string/replace page #"/" ".")
        page))))
+
+(defn file-name-sanity
+  "Sanitize page-name for file name (strict), for file writing."
+  [page-name]
+  (some-> page-name
+          page-name-sanity
+          ;; Windows reserved path characters
+          (string/replace windows-reserved-chars "_")
+          ;; for android filesystem compatiblity
+          (string/replace #"[\\#|%]+" "_")
+          (string/replace #"/" ".")))
 
 (defn page-name-sanity-lc
   "Sanitize the query string for a page name (mandate for :block/name)"

--- a/src/test/frontend/handler/repo_test.cljs
+++ b/src/test/frontend/handler/repo_test.cljs
@@ -159,7 +159,7 @@
                   (into {})))
           "Counts for blocks with common block attributes")
 
-      (is (= #{"term" "setting" "book" "templates" "Query" "Query/table" "page"}
+      (is (= #{"term" "setting" "book" "Templates" "Query" "Query/table" "page"}
              (->> (d/q '[:find (pull ?n [*]) :where [?b :block/namespace ?n]] db)
                   (map (comp :block/original-name first))
                   set))


### PR DESCRIPTION
We shouldn't convert reserved chars for page names, those rules are only limited to file paths.

Now page names will be url-encoded when creating a new file, which means in theory we don't need to save a namespace page `a/b` as an `a.b.md` file. But removing the `.` hack now could result in namespace pages not being recognized if there's no title property in the markdown/org file. In the future, we might need to provide a way to allow users to convert those `.` files to the `url-encoded` version.

Fix #5171