### PR TITLE
fix(build): update rsapi to resolve windows crash

### DIFF
--- a/resources/package.json
+++ b/resources/package.json
@@ -36,7 +36,7 @@
     "https-proxy-agent": "5.0.0",
     "@sentry/electron": "2.5.1",
     "posthog-js": "1.10.2",
-    "@logseq/rsapi": "0.0.9",
+    "@logseq/rsapi": "0.0.11",
     "electron-deeplink": "1.0.9"
   },
   "devDependencies": {


### PR DESCRIPTION
Fix Windows crash.
Fix Linux crash warning on libssl missing.

- revert to old napi-rs
- rm native-tls

See-also: https://github.com/napi-rs/napi-rs/issues/1175

Fix #5263
Close #5154
Close #4956
