### PR TITLE
Performance improvements for pages with many linked references

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "main": "static/electron.js",
     "devDependencies": {
         "@capacitor/cli": "3.2.2",
+        "@logseq/nbb-logseq": "^0.3.10",
         "@playwright/test": "^1.19.2",
         "@tailwindcss/ui": "0.7.2",
         "@types/gulp": "^4.0.7",
@@ -13,7 +14,6 @@
         "del": "^6.0.0",
         "gulp": "^4.0.2",
         "gulp-clean-css": "^4.3.0",
-        "@logseq/nbb-logseq": "^0.3.10",
         "npm-run-all": "^4.1.5",
         "playwright": "^1.19.2",
         "postcss": "8.2.13",
@@ -113,6 +113,7 @@
         "react-textarea-autosize": "8.3.3",
         "react-tippy": "1.4.0",
         "react-transition-group": "4.3.0",
+        "react-visibility-sensor": "^5.1.1",
         "reakit": "0.11.1",
         "remove-accents": "0.4.2",
         "send-intent": "3.0.11",

--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -1169,3 +1169,8 @@ html[data-theme='dark'] .keyboard-shortcut > code {
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+.lazy-visibility {
+    min-width: 1px;
+    min-height: 1px;
+}

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2271,11 +2271,7 @@
         embed? (:embed? config)
         reference? (:reference? config)
         block-id (str "ls-block-" blocks-container-id "-" uuid)
-        has-child? (boolean
-                    (and
-                     (not pre-block?)
-                     (coll? children)
-                     (seq children)))
+        has-child? (first (:block/_parent (db/entity (:db/id block))))
         attrs (on-drag-and-mouse-attrs block uuid top? block-id *move-to)
         children-refs (get-children-refs children)
         data-refs (build-refs-data-value children-refs)
@@ -2371,7 +2367,7 @@
         ref? (:ref? config)
         custom-query? (boolean (:custom-query? config))
         ref-or-custom-query? (or ref? custom-query?)]
-    (if ref-or-custom-query?
+    (if (and ref-or-custom-query? (not (:ref-child? config)))
       (let [*visible? (::visible? state)]
         (ui/lazy-visible
          *visible?

--- a/src/main/frontend/components/journal.cljs
+++ b/src/main/frontend/components/journal.cljs
@@ -21,7 +21,7 @@
   (when-let [page-e (db/pull [:block/name (util/page-name-sanity-lc page)])]
     (page/page-blocks-cp repo page-e {})))
 
-(rum/defc journal-cp < rum/reactive
+(rum/defc journal-cp-inner < rum/reactive
   [[title format]]
   (let [;; Don't edit the journal title
         page (string/lower-case title)
@@ -62,6 +62,10 @@
      (rum/with-key
        (reference/references title false)
        (str title "-refs"))]))
+
+(rum/defc journal-cp
+  [journal]
+  (ui/lazy-visible nil (fn [] (journal-cp-inner journal)) nil))
 
 (rum/defc journals < rum/reactive
   [latest-journals]

--- a/src/main/frontend/components/journal.cljs
+++ b/src/main/frontend/components/journal.cljs
@@ -60,7 +60,7 @@
      (page/today-queries repo today? false)
 
      (rum/with-key
-       (reference/references title)
+       (reference/references title false)
        (str title "-refs"))]))
 
 (rum/defc journals < rum/reactive

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -387,7 +387,7 @@
        ;; referenced blocks
        [:div {:key "page-references"}
         (rum/with-key
-          (reference/references route-page-name)
+          (reference/references route-page-name sidebar?)
           (str route-page-name "-refs"))]
 
        (when-not block?

--- a/src/main/frontend/components/reference.cljs
+++ b/src/main/frontend/components/reference.cljs
@@ -165,14 +165,14 @@
              {:default-collapsed? default-collapsed?
               :title-trigger? true}))]]))))
 
-(rum/defcs references <
-  (rum/local false ::visible?)
-  [state page-name sidebar?]
+(rum/defc references
+  [page-name sidebar?]
   (ui/catch-error
    (ui/component-error "Linked References: Unexpected error")
    (ui/lazy-visible
-    (::visible? state)
-    (if sidebar? nil "loading references...")
+    (if (or sidebar? (gp-util/uuid-string? page-name))
+      nil
+      "loading references...")
     (fn []
       (references* page-name))
     nil)))

--- a/src/main/frontend/components/reference.cljs
+++ b/src/main/frontend/components/reference.cljs
@@ -49,24 +49,6 @@
   (fn [close-fn]
     (filter-dialog-inner filters-atom close-fn references page-name)))
 
-(defn- block-with-ref-level
-  [block level]
-  (if (:block/children block)
-    (-> (update block :block/children
-                (fn [blocks]
-                  (map (fn [block]
-                         (let [level (inc level)
-                               block (assoc block :ref/level level)]
-                           (block-with-ref-level block level))) blocks)))
-        (assoc :ref/level level))
-    (assoc block :ref/level level)))
-
-(defn- blocks-with-ref-level
-  [page-blocks]
-  (map (fn [[page blocks]]
-         [page (map #(block-with-ref-level % 1) blocks)])
-    page-blocks))
-
 (rum/defc block-linked-references < rum/reactive db-mixins/query
   [block-id]
   (let [refed-blocks-ids (model-db/get-referenced-blocks-ids (str block-id))]
@@ -163,8 +145,7 @@
                      filters (when (seq filter-state)
                                (->> (group-by second filter-state)
                                     (medley/map-vals #(map first %))))
-                     filtered-ref-blocks (->> (block-handler/filter-blocks repo ref-blocks filters true)
-                                              blocks-with-ref-level)
+                     filtered-ref-blocks (block-handler/filter-blocks repo ref-blocks filters true)
                      n-ref (apply +
                              (for [[_ rfs] filtered-ref-blocks]
                                (count rfs)))]
@@ -186,14 +167,15 @@
 
 (rum/defcs references <
   (rum/local false ::visible?)
-  [state page-name]
+  [state page-name sidebar?]
   (ui/catch-error
    (ui/component-error "Linked References: Unexpected error")
    (ui/lazy-visible
     (::visible? state)
-    "loading references..."
+    (if sidebar? nil "loading references...")
     (fn []
-      (references* page-name)))))
+      (references* page-name))
+    nil)))
 
 (rum/defcs unlinked-references-aux
   < rum/reactive db-mixins/query

--- a/src/main/frontend/components/reference.cljs
+++ b/src/main/frontend/components/reference.cljs
@@ -184,11 +184,16 @@
              {:default-collapsed? default-collapsed?
               :title-trigger? true}))]]))))
 
-(rum/defc references
-  [page-name]
+(rum/defcs references <
+  (rum/local false ::visible?)
+  [state page-name]
   (ui/catch-error
    (ui/component-error "Linked References: Unexpected error")
-   (references* page-name)))
+   (ui/lazy-visible
+    (::visible? state)
+    "loading references..."
+    (fn []
+      (references* page-name)))))
 
 (rum/defcs unlinked-references-aux
   < rum/reactive db-mixins/query

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -815,6 +815,20 @@
           block-uuid)
         (sort-by-left (db-utils/entity [:block/uuid block-uuid])))))
 
+(defn sub-block-direct-children
+  "Doesn't include nested children."
+  [repo block-uuid]
+  (when-let [db (conn/get-db repo)]
+    (-> (react/q repo [:frontend.db.react/block-direct-children block-uuid] {}
+          '[:find [(pull ?b [*]) ...]
+            :in $ ?parent-id
+            :where
+            [?parent :block/uuid ?parent-id]
+            [?b :block/parent ?parent]]
+          block-uuid)
+        react
+        (sort-by-left (db-utils/entity [:block/uuid block-uuid])))))
+
 (defn get-block-children
   "Including nested children."
   [repo block-uuid]
@@ -1090,10 +1104,7 @@
                               :where
                               [?block :block/refs ?ref-page]]
                             pages
-                            block-attrs
-                            ;; TODO: :block/_parent slow recursive query
-                            ;; (butlast block-attrs)
-                            )
+                            (butlast block-attrs))
              result (->> query-result
                          react
                          (remove (fn [block]

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -1082,38 +1082,23 @@
        (let [page-id (:db/id (db-utils/entity [:block/name (util/safe-page-name-sanity-lc page)]))
              pages (page-alias-set repo page)
              aliases (set/difference pages #{page-id})
-             query-result (if (seq aliases)
-                            (let [rules '[[(find-blocks ?block ?ref-page ?pages ?alias ?aliases)
-                                           [?block :block/page ?alias]
-                                           [(contains? ?aliases ?alias)]]
-                                          [(find-blocks ?block ?ref-page ?pages ?alias ?aliases)
-                                           [?block :block/refs ?ref-page]
-                                           [(contains? ?pages ?ref-page)]]]]
-                              (react/q repo
-                                       [:frontend.db.react/page<-blocks-or-block<-blocks page-id]
-                                       {}
-                                       '[:find [(pull ?block ?block-attrs) ...]
-                                         :in $ % ?pages ?aliases ?block-attrs
-                                         :where
-                                         (find-blocks ?block ?ref-page ?pages ?alias ?aliases)]
-                                       rules
-                                       pages
-                                       aliases
-                                       block-attrs))
-                            (react/q repo
-                                     [:frontend.db.react/page<-blocks-or-block<-blocks page-id]
-                                     {:use-cache? false}
-                                     '[:find [(pull ?ref-block ?block-attrs) ...]
-                                       :in $ ?page ?block-attrs
-                                       :where
-                                       [?ref-block :block/refs ?page]]
-                                     page-id
-                                     block-attrs))
+             query-result (react/q repo
+                            [:frontend.db.react/page<-blocks-or-block<-blocks page-id]
+                            {}
+                            '[:find [(pull ?block ?block-attrs) ...]
+                              :in $ [?ref-page ...] ?block-attrs
+                              :where
+                              [?block :block/refs ?ref-page]]
+                            pages
+                            block-attrs
+                            ;; TODO: :block/_parent slow recursive query
+                            ;; (butlast block-attrs)
+                            )
              result (->> query-result
                          react
-                         (sort-by-left-recursive)
                          (remove (fn [block]
                                    (= page-id (:db/id (:block/page block)))))
+                         (sort-by-left-recursive)
                          db-utils/group-by-page
                          (map (fn [[k blocks]]
                                 (let [k (if (contains? aliases (:db/id k))
@@ -1129,35 +1114,14 @@
   ([repo page]
    (when repo
      (when-let [db (conn/get-db repo)]
-       (let [page-id (:db/id (db-utils/entity [:block/name (util/safe-page-name-sanity-lc page)]))
-             pages (page-alias-set repo page)
-             aliases (set/difference pages #{page-id})
-             query-result (if (seq aliases)
-                            (let [rules '[[(find-blocks ?block ?ref-page ?pages ?alias ?aliases)
-                                           [?block :block/page ?alias]
-                                           [(contains? ?aliases ?alias)]]
-                                          [(find-blocks ?block ?ref-page ?pages ?alias ?aliases)
-                                           [?block :block/refs ?ref-page]
-                                           [(contains? ?pages ?ref-page)]]]]
-                              (d/q
-                                '[:find ?block
-                                  :in $ % ?pages ?aliases ?block-attrs
-                                  :where
-                                  (find-blocks ?block ?ref-page ?pages ?alias ?aliases)]
-                                db
-                                rules
-                                pages
-                                aliases
-                                block-attrs))
-                            (d/q
-                              '[:find ?ref-block
-                                :in $ ?page ?block-attrs
-                                :where
-                                [?ref-block :block/refs ?page]]
-                              db
-                              page-id
-                              block-attrs))]
-         query-result)))))
+       (let [pages (page-alias-set repo page)]
+         (d/q
+           '[:find ?block
+             :in $ [?ref-page ...]
+             :where
+             [?block :block/refs ?ref-page]]
+           db
+           pages))))))
 
 (defn get-date-scheduled-or-deadlines
   [journal-title]

--- a/src/main/frontend/db/react.cljs
+++ b/src/main/frontend/db/react.cljs
@@ -316,20 +316,19 @@
                  (or (get affected-keys (vec (rest k)))
                      custom?
                      kv?))
-            (util/profile (str "refresh! " (second k))
-             (let [{:keys [query query-fn]} cache]
-               (when (or query query-fn)
-                 (try
-                   (let [f #(execute-query! repo-url db k tx cache)]
-                     ;; Detects whether user is editing in a custom query, if so, execute the query immediately
-                     (if (and custom?
-                              ;; modifying during cards review need to be executed immediately
-                              (not (:cards-query? (meta query)))
-                              (not (state/edit-in-query-component)))
-                       (async/put! (state/get-reactive-custom-queries-chan) [f query])
-                       (f)))
-                   (catch js/Error e
-                     (js/console.error e))))))))))))
+            (let [{:keys [query query-fn]} cache]
+              (when (or query query-fn)
+                (try
+                  (let [f #(execute-query! repo-url db k tx cache)]
+                    ;; Detects whether user is editing in a custom query, if so, execute the query immediately
+                    (if (and custom?
+                             ;; modifying during cards review need to be executed immediately
+                             (not (:cards-query? (meta query)))
+                             (not (state/edit-in-query-component)))
+                      (async/put! (state/get-reactive-custom-queries-chan) [f query])
+                      (f)))
+                  (catch js/Error e
+                    (js/console.error e)))))))))))
 
 (defn set-key-value
   [repo-url key value]

--- a/src/main/frontend/db/react.cljs
+++ b/src/main/frontend/db/react.cljs
@@ -216,7 +216,7 @@
 
 (defn get-affected-queries-keys
   "Get affected queries through transaction datoms."
-  [{:keys [tx-data tx-meta db-before]}]
+  [{:keys [tx-data db-before]}]
   {:post [(s/valid? ::affected-keys %)]}
   (let [blocks (->> (filter (fn [datom] (contains? #{:block/left :block/parent :block/page} (:a datom))) tx-data)
                     (map :v)

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3473,12 +3473,11 @@
   1. References.
   2. Custom queries."
   [block config]
-  (if (or (:ref? config)
-          (:custom-query? config))
-    (and
-     (seq (:block/children block))
-     (or
-      (:custom-query? config)
-      (>= (:ref/level block)
-          (state/get-ref-open-blocks-level))))
-    (util/collapsed? block)))
+  (or
+   (and
+    (:ref? config)
+    (>= (inc (:block/level block))
+        (state/get-ref-open-blocks-level))
+    ;; has children
+    (first (:block/_parent (db/entity (:db/id block)))))
+   (util/collapsed? block)))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -453,9 +453,9 @@
 (declare save-current-block!)
 (defn outliner-insert-block!
   [config current-block new-block {:keys [sibling? keep-uuid? replace-empty-target?]}]
-  (let [ref-query-top-block? (and (:ref? config)
-                            (:custom-query? config)
-                            (not (:ref-or-query? config)))
+  (let [ref-query-top-block? (and (or (:ref? config)
+                                      (:custom-query? config))
+                                  (not (:ref-query-child? config)))
         has-children? (db/has-children? (:block/uuid current-block))
         sibling? (cond
                    ref-query-top-block?

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -453,11 +453,12 @@
 (declare save-current-block!)
 (defn outliner-insert-block!
   [config current-block new-block {:keys [sibling? keep-uuid? replace-empty-target?]}]
-  (let [ref-top-block? (and (:ref? config)
-                            (not (:ref-child? config)))
+  (let [ref-query-top-block? (and (:ref? config)
+                            (:custom-query? config)
+                            (not (:ref-or-query? config)))
         has-children? (db/has-children? (:block/uuid current-block))
         sibling? (cond
-                   ref-top-block?
+                   ref-query-top-block?
                    false
 
                    (boolean? sibling?)
@@ -3475,7 +3476,7 @@
   [block config]
   (or
    (and
-    (:ref? config)
+    (or (:ref? config) (:custom-query? config))
     (>= (inc (:block/level block))
         (state/get-ref-open-blocks-level))
     ;; has children

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -684,7 +684,7 @@
                         :margin-left -30}}
              (not title-trigger?)
              (assoc :on-mouse-down on-mouse-down))
-           [:span {:class (if @control? "control-show cursor-pointer" "control-hide")}
+           [:span {:class (if (or @control? @collapsed?) "control-show cursor-pointer" "control-hide")}
             (rotating-arrow @collapsed?)]])
         (if (fn? header)
           (header @collapsed?)
@@ -916,11 +916,13 @@
   [:div.lazy-visibility
    (if visible?
      (when (fn? content-fn) (content-fn))
-     (when loading-label (loading loading-label)))])
+     (when loading-label [:span.text-sm.font-medium
+                          loading-label]))])
 
-(rum/defc lazy-visible < rum/reactive
-  [*visible? loading-label content-fn sensor-opts]
-  (let [visible? (rum/react *visible?)]
+(rum/defcs lazy-visible <
+  (rum/local false ::visible?)
+  [state loading-label content-fn sensor-opts]
+  (let [*visible? (::visible? state)]
     (visibility-sensor
      (merge
       {:on-change #(reset! *visible? %)
@@ -928,4 +930,4 @@
        :offset {:top -300
                 :bottom -300}}
       sensor-opts)
-     (lazy-visible-inner visible? content-fn loading-label))))
+     (lazy-visible-inner @*visible? content-fn loading-label))))

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -25,6 +25,7 @@
             ["react-tippy" :as react-tippy]
             ["react-transition-group" :refer [CSSTransition TransitionGroup]]
             ["@logseq/react-tweet-embed" :as react-tweet-embed]
+            ["react-visibility-sensor" :as rvs]
             [rum.core :as rum]
             [frontend.db-mixins :as db-mixins]
             [frontend.mobile.util :as mobile-util]
@@ -37,6 +38,7 @@
 (def resize-consumer (r/adapt-class (gobj/get Resize "ResizeConsumer")))
 (def Tippy (r/adapt-class (gobj/get react-tippy "Tooltip")))
 (def ReactTweetEmbed (r/adapt-class react-tweet-embed))
+(def visibility-sensor (r/adapt-class (gobj/get rvs "default")))
 
 (defn reset-ios-whole-page-offset!
   []
@@ -908,3 +910,18 @@
     [:span.text-sm.font-medium
      label-right]]
    (progress-bar width)])
+
+(rum/defc lazy-visible-inner
+  [visible? content-fn loading-label]
+  [:div.lazy-visibility
+   (if visible?
+     (when (fn? content-fn) (content-fn))
+     (loading (or loading-label "loading...")))])
+
+(rum/defc lazy-visible < rum/reactive
+  [*visible? loading-label content-fn]
+  (let [visible? (rum/react *visible?)]
+    (visibility-sensor
+     {:on-change #(reset! *visible? %)
+      :partialVisibility true}
+     (lazy-visible-inner visible? content-fn loading-label))))

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -916,12 +916,16 @@
   [:div.lazy-visibility
    (if visible?
      (when (fn? content-fn) (content-fn))
-     (loading (or loading-label "loading...")))])
+     (when loading-label (loading loading-label)))])
 
 (rum/defc lazy-visible < rum/reactive
-  [*visible? loading-label content-fn]
+  [*visible? loading-label content-fn sensor-opts]
   (let [visible? (rum/react *visible?)]
     (visibility-sensor
-     {:on-change #(reset! *visible? %)
-      :partialVisibility true}
+     (merge
+      {:on-change #(reset! *visible? %)
+       :partialVisibility true
+       :offset {:top -300
+                :bottom -300}}
+      sensor-opts)
      (lazy-visible-inner visible? content-fn loading-label))))

--- a/yarn.lock
+++ b/yarn.lock
@@ -6624,7 +6624,7 @@ prompts@^2.3.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@15.x, prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.2:
+prop-types@15.x, prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -6812,11 +6812,6 @@ react-grid-layout@0.16.6:
     react-draggable "3.x"
     react-resizable "1.x"
 
-react-icon-base@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/react-icon-base/-/react-icon-base-2.1.0.tgz#a196e33fdf1e7aaa1fda3aefbb68bdad9e82a79d"
-  integrity sha1-oZbjP98eeqof2jrvu2i9rZ6Cp50=
-
 react-icon-base@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/react-icon-base/-/react-icon-base-2.1.2.tgz#a17101dad9c1192652356096860a9ab43a0766c7"
@@ -6885,6 +6880,13 @@ react-transition-group@4.3.0:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
+
+react-visibility-sensor@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/react-visibility-sensor/-/react-visibility-sensor-5.1.1.tgz#5238380960d3a0b2be0b7faddff38541e337f5a9"
+  integrity sha512-cTUHqIK+zDYpeK19rzW6zF9YfT4486TIgizZW53wEZ+/GPBbK7cNS0EHyJVyHYacwFEvvHLEKfgJndbemWhB/w==
+  dependencies:
+    prop-types "^15.7.2"
 
 react@17.0.2:
   version "17.0.2"


### PR DESCRIPTION
https://github.com/joshwnj/react-visibility-sensor is used to render components only when they go in the window viewport.
So we can use it to only render components (including both block list and even blocks themselves) if needed.
https://www.loom.com/share/38194babccc54430a138b37c9406e3f0