### PR TITLE
allow sharing office files into Logseq on mobile

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -265,9 +265,15 @@
         href (config/get-local-asset-absolute-path href)]
     (when (or granted? (util/electron?) (mobile-util/is-native-platform?))
       (p/then (editor-handler/make-asset-url href) #(reset! src %)))
-
+    
     (when @src
-      (let [ext (keyword (util/get-file-ext @src))]
+      (let [ext (keyword (util/get-file-ext @src))
+            share-fn (fn [event]
+                       (util/stop event)
+                       (when (mobile-util/is-native-platform?)
+                         (p/let [url (str (config/get-repo-dir (state/get-current-repo)) href)]
+                           (.share Share #js {:url url
+                                              :title "Open file with your favorite app"}))))]
         (cond
           (contains? config/audio-formats ext)
           (audio-cp @src)
@@ -276,19 +282,14 @@
           (resizable-image config title @src metadata full_text true)
 
           (= ext :pdf)
-          [:a.asset-ref.is-pdf
-           {:href @src
-            :on-click
-            (fn [event]
-              (util/stop event)
-              (when (mobile-util/is-native-platform?)
-                (p/let [url (str (config/get-repo-dir (state/get-current-repo)) href)]
-                  (.share Share #js {:url url
-                                     :title "Open PDF fils with your favorite app"}))))}
+          [:a.asset-ref.is-pdf {:href @src
+                                :on-click share-fn}
            title]
           
           :else
-          [:a.asset-ref {:ref @src} title])))))
+          [:a.asset-ref.is-doc {:ref @src
+                                :on-click share-fn}
+           title])))))
 
 (defn ar-url->http-url
   [href]
@@ -659,7 +660,7 @@
   (and (= 1 (count label))
        (let [label (first label)]
          (string? (last label))
-         (last label))))
+         (js/decodeURIComponent (last label)))))
 
 (defn- get-page
   [label]
@@ -841,28 +842,32 @@
 
 (defn- media-link
   [config url s label metadata full_text]
-  (let [ext (util/get-file-ext s)]
+  (let [ext (keyword (util/get-file-ext s))
+        label-text (get-label-text label)]
+    (js/alert ext)
     (cond
-      (contains? (set (map name config/audio-formats)) ext)
+      (contains? config/audio-formats ext)
       (audio-link config url s label metadata full_text)
 
-      (not (contains? #{"pdf" "mp4" "webm" "mov"} ext))
-      (image-link config url s label metadata full_text)
+      (contains? (config/doc-formats) ext)
+      (asset-link config label-text s metadata full_text)
 
       (= (util/get-file-ext s) "pdf")
-      (let [label-text (get-label-text label)]
-        (cond
-          (util/electron?)
-          [:a.asset-ref.is-pdf
-           {:href "javascript:void(0);"
-            :on-mouse-down (fn [_event]
-                             (when-let [current (pdf-assets/inflate-asset s)]
-                               (state/set-state! :pdf/current current)))}
-           label-text]
+      (cond
+        (util/electron?)
+        [:a.asset-ref.is-pdf
+         {:href "javascript:void(0);"
+          :on-mouse-down (fn [_event]
+                           (when-let [current (pdf-assets/inflate-asset s)]
+                             (state/set-state! :pdf/current current)))}
+         label-text]
 
-          (mobile-util/is-native-platform?)
-          (asset-link config label-text s metadata full_text)))
-      
+        (mobile-util/is-native-platform?)
+        (asset-link config label-text s metadata full_text))
+
+      (not (contains? #{"mp4" "webm" "mov"} ext))
+      (image-link config url s label metadata full_text)
+
       :else
       (asset-reference config label s))))
 

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -844,7 +844,6 @@
   [config url s label metadata full_text]
   (let [ext (keyword (util/get-file-ext s))
         label-text (get-label-text label)]
-    (js/alert ext)
     (cond
       (contains? config/audio-formats ext)
       (audio-link config url s label metadata full_text)
@@ -852,7 +851,7 @@
       (contains? (config/doc-formats) ext)
       (asset-link config label-text s metadata full_text)
 
-      (= (util/get-file-ext s) "pdf")
+      (= ext :pdf)
       (cond
         (util/electron?)
         [:a.asset-ref.is-pdf
@@ -865,7 +864,7 @@
         (mobile-util/is-native-platform?)
         (asset-link config label-text s metadata full_text))
 
-      (not (contains? #{"mp4" "webm" "mov"} ext))
+      (not (contains? #{:mp4 :webm :mov} ext))
       (image-link config url s label metadata full_text)
 
       :else

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -240,6 +240,19 @@ html.is-native-android {
       align-items: center;
     }
   }
+
+  &.is-doc {
+      &:before {
+          content: "[[📜";
+          opacity: .7;
+          margin-right: 4px;
+      }
+
+      &:after {
+          content: "]]";
+          opacity: .7;
+      }
+  }
 }
 
 .embed-page {

--- a/src/main/frontend/config.cljs
+++ b/src/main/frontend/config.cljs
@@ -85,6 +85,15 @@
      config-formats
      #{:gif :svg :jpeg :ico :png :jpg :bmp :webp})))
 
+(defn doc-formats
+  []
+  (let [config-formats (some->> (get-in @state/state [:config :document-formats])
+                                (map :keyword)
+                                (set))]
+    (set/union
+     config-formats
+     #{:doc :docx :xls :xlsx :ppt :pptx :one :epub})))
+
 (def audio-formats #{:mp3 :ogg :mpeg :wav :m4a :flac :wma :aac})
 
 (def media-formats (set/union (img-formats) audio-formats))

--- a/src/main/frontend/mobile/intent.cljs
+++ b/src/main/frontend/mobile/intent.cljs
@@ -112,7 +112,8 @@
                     (config/mldoc-support? application-type)
                     (embed-text-file url title)
 
-                    (contains? (set/union #{:pdf} config/media-formats) (keyword application-type))
+                    (contains? (set/union (config/doc-formats) config/media-formats)
+                               (keyword application-type))
                     (embed-asset-file url format)
 
                     :else

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -29,8 +29,7 @@
             [rum.core :as rum]
             [frontend.db-mixins :as db-mixins]
             [frontend.mobile.util :as mobile-util]
-            [goog.functions :refer [debounce]]
-            [frontend.mobile.util :refer [is-native-platform?]]))
+            [goog.functions :refer [debounce]]))
 
 (defonce transition-group (r/adapt-class TransitionGroup))
 (defonce css-transition (r/adapt-class CSSTransition))
@@ -947,7 +946,7 @@
 (rum/defcs lazy-visible <
   (rum/local false ::visible?)
   [state content-fn sensor-opts reset-height?]
-  (if (or (util/mobile?) (is-native-platform?))
+  (if (or (util/mobile?) (mobile-util/is-native-platform?))
     (content-fn)
     (let [*visible? (::visible? state)]
       (visibility-sensor


### PR DESCRIPTION
Following up to PR https://github.com/logseq/logseq/pull/5283, this PR allows users to share office files (word, excel, ppt, etc.) into Logseq assets directory on mobile. 

Also, users can open those file links by using their favorite external app. 