### PR TITLE
fix(ui): wrong position of page preview tip

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -462,7 +462,7 @@
         redirect-page-name (or (model/get-redirect-page-name page-name (:block/alias? config))
                                page-name)
         page-original-name (model/get-page-original-name redirect-page-name)
-        html-template (rum/defc _ []
+        html-template #_:clj-kondo/ignore (rum/defc _ []
                         (let [*el-popup (rum/use-ref nil)]
 
                           (rum/use-effect!

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -462,7 +462,7 @@
         redirect-page-name (or (model/get-redirect-page-name page-name (:block/alias? config))
                                page-name)
         page-original-name (model/get-page-original-name redirect-page-name)
-        html-template #_:clj-kondo/ignore (rum/defc _ []
+        _  #_:clj-kondo/ignore (rum/defc html-template []
                         (let [*el-popup (rum/use-ref nil)]
 
                           (rum/use-effect!


### PR DESCRIPTION
### Refs:
- [x] support `ESC` to close preview tip #5306
- [x] fix #5268  

![CleanShot 2022-05-14 at 16 20 16](https://user-images.githubusercontent.com/1779837/168417624-cf841d25-7e83-4a7e-bba9-b87eabb87c99.gif)

