### PR TITLE
fix(blocks): scrollbar appearing with code block and some latex 

### DIFF
--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -4,7 +4,7 @@
 
   @screen sm {
     width: calc(100% - 33px);
-    overflow-x: auto;
+    overflow-x: visible;
   }
 }
 


### PR DESCRIPTION
closes #5273 
closes #5198 

Before: 
<img width="865" alt="Screen Shot 2022-05-14 at 12 51 44 PM" src="https://user-images.githubusercontent.com/80150109/168418595-7a896b7d-670d-4918-a37a-7bf8059c913f.png">

After
<img width="862" alt="Screen Shot 2022-05-14 at 12 52 17 PM" src="https://user-images.githubusercontent.com/80150109/168418621-34267357-a4d6-4aa2-a089-75484c654da9.png">


Also prevents minor clipping of code block background in some cases