### PR TITLE
feat: setting to allow to collapse all linked refs by default

### DIFF
--- a/src/main/frontend/components/reference.cljs
+++ b/src/main/frontend/components/reference.cljs
@@ -79,7 +79,7 @@
           refed-blocks-ids (model-db/get-referenced-blocks-ids page-name)
           *n-ref (::n-ref state)
           n-ref (or (rum/react *n-ref) (count refed-blocks-ids))
-          default-collapsed? (>= (count refed-blocks-ids) threshold)
+          default-collapsed? (or (state/enable-collapse-references?)(>= (count refed-blocks-ids) threshold))
           filters-atom (get state ::filters)
           filter-state (rum/react filters-atom)
           block? (util/uuid-string? page-name)

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -340,6 +340,13 @@
           (fn []
             (state/toggle-shortcut-tooltip!))))
 
+(defn show-collapse-references-row [t enable-collapse-references?]
+  (toggle "collapse_references"
+          (t :settings-page/enable-collapse-references)
+          enable-collapse-references?
+          (fn []
+            (config-handler/toggle-collapse-references!))))
+
 (defn timetracking-row [t enable-timetracking?]
   (toggle "enable_timetracking"
           (t :settings-page/enable-timetracking)
@@ -532,6 +539,7 @@
         logical-outdenting? (state/logical-outdenting?)
         enable-tooltip? (state/enable-tooltip?)
         enable-shortcut-tooltip? (state/sub :ui/shortcut-tooltip?)
+        enable-collapse-references? (state/enable-collapse-references?)
         show-brackets? (state/show-brackets?)
         enable-git-auto-push? (state/enable-git-auto-push? current-repo)]
 
@@ -547,6 +555,7 @@
        (shortcut-tooltip-row t enable-shortcut-tooltip?))
      (when-not (or (util/mobile?) (mobile-util/is-native-platform?))
        (tooltip-row t enable-tooltip?))
+     (show-collapse-references-row t enable-collapse-references?)
      (timetracking-row t enable-timetracking?)
      (journal-row t enable-journals?)
      (when (not enable-journals?)

--- a/src/main/frontend/dicts.cljc
+++ b/src/main/frontend/dicts.cljc
@@ -158,6 +158,7 @@
         :settings-page/preferred-file-format "Preferred file format"
         :settings-page/preferred-workflow "Preferred workflow"
         :settings-page/enable-shortcut-tooltip "Enable shortcut tooltip"
+        :settings-page/enable-collapse-references "Collapse references"
         :settings-page/enable-timetracking "Timetracking"
         :settings-page/enable-tooltip "Tooltips"
         :settings-page/enable-journals "Journals"

--- a/src/main/frontend/handler/config.cljs
+++ b/src/main/frontend/handler/config.cljs
@@ -19,3 +19,7 @@
 (defn toggle-ui-enable-tooltip! []
   (let [enable-tooltip? (state/enable-tooltip?)]
     (set-config! :ui/enable-tooltip? (not enable-tooltip?))))
+
+(defn toggle-collapse-references! []
+  (let [enable-collapse-references? (state/enable-collapse-references?)]
+    (set-config! :ui/enable-collapse-references? (not enable-collapse-references?))))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1177,6 +1177,12 @@
     (set-state! :ui/shortcut-tooltip? (not mode))
     (storage/set :ui/shortcut-tooltip? (not mode))))
 
+(defn enable-collapse-references?
+  []
+  (get (get (sub-config) (get-current-repo))
+       :ui/enable-collapse-references?
+       false))
+
 (defn enable-tooltip?
   []
   (if (or (util/mobile?) (mobile-util/is-native-platform?))

--- a/templates/config.edn
+++ b/templates/config.edn
@@ -24,6 +24,10 @@
  ;; Default is true, you can also toggle this via setting page
  :ui/enable-tooltip? true
 
+ ;; Wheter to enable references to show collapsed
+ ;; Default is false, you can also toggle this via settings page
+ :ui/enable-collapse-references? false
+
  :feature/enable-block-timestamps? false
 
  ;; Specify the date on which the week starts.


### PR DESCRIPTION
## What does it do? 

I'm proposing this feature to solve the bug reported on #5327.

The user complains that the state of the foldable linked references is not preserved, and because she/he has long lists of linked references, it becomes a bit cumbersome to have them expanded/toggled by default.

I thought it would be too much to save the state of each linked ref's foldable block (though it could be a good idea to implement in the future 🤔 ).

I've also understood, after deep-diving into the codebase, that we actually collapse foldable components when foldable children (items) are greater than a threshold of 50.

I thought 50 is reasonable, but for some people, it can be too much, so it could be cool to allow a specific behavior as a setting on Settings > Editor.

And so I did it, the "Collapse references" will be false, by default, so that the first-time users have the privilege to see them unfolded, but if the user wants they can be collapsed by default.

So, the default behavior will be that Linked references foldable are not collapsed by default. But they collapse if the number of items in the Linked references is greater than 50 (as it would before).

In case the user activates the Settings > Editor > Collapse references, they'll always show up collapsed.

## Concerns?

This feature was not requested/discussed with the core team, so feel free to ignore it if you, everyone, don't think this is an improvement, or if it's simply not the right improvement.

I basically did it to learn and understand the codebase.
I'm a first-time contributor (actually this is my second contribution 🥳 ), so please check it carefully 🙏🏻 

## Preview

![CleanShot 2022-05-16 at 23 18 36](https://user-images.githubusercontent.com/956832/168691582-b9ab3ab8-bf50-4b62-9440-9896218a1a13.gif)
 