### PR TITLE
dev: add bb lint cmd

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -24,6 +24,9 @@
   dev:validate-local-storage
   logseq.tasks.spec/validate-local-storage
 
+  dev:lint
+  logseq.tasks.dev/lint
+
   test:load-nbb-compatible-namespaces
   logseq.tasks.nbb/load-compatible-namespaces
 

--- a/scripts/src/logseq/tasks/dev.clj
+++ b/scripts/src/logseq/tasks/dev.clj
@@ -24,3 +24,20 @@
                (shell "yarn dev-electron-app")
                (println "Waiting for app to build..."))
              (Thread/sleep 1000))))
+
+
+(defn lint
+  "Run
+  - clj-kondo lint
+  - carve lint for unused vars
+  - lint for vars that are too large
+  - lint invalid translation entries
+  - Lint datalog rules"
+  []
+  (doseq [cmd ["clojure -M:clj-kondo --parallel --lint src"
+               "scripts/carve.clj"
+               "scripts/large_vars.clj"
+               "bb lang:invalid-translations"
+               "scripts/lint_rules.clj"]]
+    (println cmd)
+    (shell cmd)))


### PR DESCRIPTION
add a bb cmd(`bb dev:lint`) to avoid type commands to run lints at local env