### PR TITLE
fix: load legacy theme

### DIFF
--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -326,9 +326,10 @@
 
 (defn apply-custom-theme-effect! [theme]
   (when-let [custom-theme (state/sub [:ui/custom-theme (keyword theme)])]
-    (js/LSPluginCore.selectTheme (bean/->js custom-theme)
-                                 (bean/->js {:effect false :emit false}))
-    (state/set-state! :plugin/selected-theme (:url custom-theme))))
+    (when-let [url (:url custom-theme)]
+      (js/LSPluginCore.selectTheme (bean/->js custom-theme)
+                                   (bean/->js {:effect false :emit false}))
+      (state/set-state! :plugin/selected-theme (:url url)))))
 
 (defn setup-system-theme-effect!
   []


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

This PR fixes an error due to the introduction of #4741. After the fix, in the first rendering, the old theme that has been set will not be replaced by the new rendering mechanism.