### PR TITLE
fix: file share issue if the filename contains special chars

### DIFF
--- a/src/main/frontend/mobile/intent.cljs
+++ b/src/main/frontend/mobile/intent.cljs
@@ -78,10 +78,12 @@
   (p/let [time (date/get-current-time)
           title (some-> (or title (path/basename url))
                         js/decodeURIComponent
-                        util/node-path.name)
+                        util/node-path.name
+                        util/file-name-sanity
+                        (string/replace "." ""))
           path (path/join (config/get-repo-dir (state/get-current-repo))
                           (config/get-pages-directory)
-                          (path/basename url))
+                          (str (js/encodeURI title) (path/extname url)))
           _ (p/catch
                 (.copy Filesystem (clj->js {:from url :to path}))
                 (fn [error]


### PR DESCRIPTION
If the shared filename contains special chars (e.g. `.`, `#`, etc), the page is inserted or not loaded correctly by Logseq, this PR fixes this issue.

Close https://github.com/logseq/logseq/issues/5351