### PR TITLE
fix(fs-watcher): notify all graph files, skip reading non-text

### DIFF
--- a/ios/App/App/FileSync/Extensions.swift
+++ b/ios/App/App/FileSync/Extensions.swift
@@ -8,11 +8,6 @@
 import Foundation
 import CryptoKit
 
-
-import var CommonCrypto.CC_MD5_DIGEST_LENGTH
-import func CommonCrypto.CC_MD5
-import typealias CommonCrypto.CC_LONG
-
 // via https://github.com/krzyzanowskim/CryptoSwift
 extension Array where Element == UInt8 {
   public init(hex: String) {
@@ -120,27 +115,8 @@ extension Data {
 
 extension String {
     var MD5: String {
-        // TODO: incremental hash
-        if #available(iOS 13.0, *) {
-            let computed = Insecure.MD5.hash(data: self.data(using: .utf8)!)
-            return computed.map { String(format: "%02hhx", $0) }.joined()
-        } else {
-            // Fallback on earlier versions, no CryptoKit
-            let length = Int(CC_MD5_DIGEST_LENGTH)
-            let messageData = self.data(using:.utf8)!
-            var digestData = Data(count: length)
-            
-            _ = digestData.withUnsafeMutableBytes { digestBytes -> UInt8 in
-                messageData.withUnsafeBytes { messageBytes -> UInt8 in
-                    if let messageBytesBaseAddress = messageBytes.baseAddress, let digestBytesBlindMemory = digestBytes.bindMemory(to: UInt8.self).baseAddress {
-                        let messageLength = CC_LONG(messageData.count)
-                        CC_MD5(messageBytesBaseAddress, messageLength, digestBytesBlindMemory)
-                    }
-                    return 0
-                }
-            }
-            return digestData.map { String(format: "%02hhx", $0) }.joined()
-        }
+        let computed = Insecure.MD5.hash(data: self.data(using: .utf8)!)
+        return computed.map { String(format: "%02hhx", $0) }.joined()
     }
     
     func encodeAsFname() -> String {

--- a/src/main/frontend/handler/web/nfs.cljs
+++ b/src/main/frontend/handler/web/nfs.cljs
@@ -26,12 +26,12 @@
             [frontend.encrypt :as encrypt]))
 
 (defn remove-ignore-files
-  [files]
+  [files dir-name nfs?]
   (let [files (remove (fn [f]
                         (let [path (:file/path f)]
                           (or (string/starts-with? path ".git/")
                               (string/includes? path ".git/")
-                              (and (util-fs/ignored-path? "" path)
+                              (and (util-fs/ignored-path? (if nfs? "" dir-name) path)
                                    (not= (:file/name f) ".gitignore")))))
                       files)]
     (if-let [ignore-file (some #(when (= (:file/name %) ".gitignore")
@@ -55,7 +55,7 @@
              :file/last-modified-at mtime
              :file/size             size
              :file/content content})
-       result)
+          result)
 
      electron?
      (map (fn [{:keys [path stat content]}]
@@ -64,7 +64,7 @@
                :file/last-modified-at mtime
                :file/size             size
                :file/content content}))
-       result)
+          result)
 
      :else
      (let [result (flatten (bean/->clj result))]
@@ -147,7 +147,7 @@
                      (nfs/add-nfs-file-handle! root-handle-path root-handle))
                  result (nth result 1)
                  files (-> (->db-files mobile-native? electron? dir-name result)
-                           remove-ignore-files)
+                           (remove-ignore-files dir-name nfs?))
                  _ (when nfs?
                      (let [file-paths (set (map :file/path files))]
                        (swap! path-handles (fn [handles]
@@ -297,7 +297,7 @@
                                                  (when nfs?
                                                    (swap! path-handles assoc path handle))))
                     new-files (-> (->db-files mobile-native? electron? dir-name files-result)
-                                  remove-ignore-files)
+                                  (remove-ignore-files dir-name nfs?))
                     _ (when nfs?
                         (let [file-paths (set (map :file/path new-files))]
                           (swap! path-handles (fn [handles]

--- a/src/main/frontend/util/fs.cljs
+++ b/src/main/frontend/util/fs.cljs
@@ -4,17 +4,22 @@
 
 ;; TODO: move all file path related util functions to here
 
-;; keep same as ignored-path? in src/electron/electron/utils.cljs
-;; TODO: merge them
+;; NOTE: This is not the same ignored-path? as src/electron/electron/utils.cljs.
+;;       The assets directory is ignored.
+;;
+;; When in nfs-mode, dir is "", path is relative path to graph dir.
+;; When in native-mode, dir and path are absolute paths.
 (defn ignored-path?
+  "Ignore path for ls-dir-files-with-handler! and reload-dir!"
   [dir path]
   (when (string? path)
     (or
      (some #(string/starts-with? path (str dir "/" %))
-           ["." ".recycle" "assets" "node_modules" "logseq/bak"])
+           ["." ".recycle" "assets" "node_modules" "logseq/bak" "version-files"])
      (some #(string/includes? path (str "/" % "/"))
-           ["." ".recycle" "assets" "node_modules" "logseq/bak"])
-     (string/ends-with? path ".DS_Store")
+           ["." ".recycle" "assets" "node_modules" "logseq/bak" "version-files"])
+     (some #(string/ends-with? path %)
+           [".DS_Store" "logseq/graphs-txid.edn" "logseq/broken-config.edn"])
      ;; hidden directory or file
      (let [relpath (path/relative dir path)]
        (or (re-find #"/\.[^.]+" relpath)


### PR DESCRIPTION
This PR is to fix the following:

- changes in assets directory are not notified
  - [x] electron
  - [x] iOS
  - [x] Android
- [x] metadata of binary files is nil on iOS
- [x] Fix Android <= 9 broken