### PR TITLE
feat: add macro `video` to embed various video URLs

### DIFF
--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -281,19 +281,13 @@
                  (p/let [_ (draw/create-draw-with-default-content path)]
                    (println "draw file created, " path))
                  text)) "Draw a graph with Excalidraw"]
-
-     (when (util/zh-CN-supported?)
-       ["Embed Bilibili video" [[:editor/input "{{bilibili }}" {:last-pattern (state/get-editor-command-trigger)
-                                                                :backward-pos 2}]]])
+     
      ["Embed HTML " (->inline "html")]
 
-     ["Embed Youtube video" [[:editor/input "{{youtube }}" {:last-pattern (state/get-editor-command-trigger)
-                                                            :backward-pos 2}]]]
+     ["Embed Video URL" [[:editor/input "{{video }}" {:last-pattern (state/get-editor-command-trigger)
+                                                    :backward-pos 2}]]]
 
      ["Embed Youtube timestamp" [[:youtube/insert-timestamp]]]
-
-     ["Embed Vimeo video" [[:editor/input "{{vimeo }}" {:last-pattern (state/get-editor-command-trigger)
-                                                        :backward-pos 2}]]]
 
      ["Embed Twitter tweet" [[:editor/input "{{tweet }}" {:last-pattern (state/get-editor-command-trigger)
                                                           :backward-pos 2}]]]]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2907,11 +2907,9 @@
       (html-link-format! text)
 
       (and (gp-util/url? text)
-           (or (string/includes? text "youtube.com")
-               (string/includes? text "youtu.be"))
-           (mobile-util/is-native-platform?))
-      (commands/simple-insert! (state/get-edit-input-id) (util/format "{{youtube %s}}" text) nil)
-
+           (boolean (text/get-matched-video text)))
+      (commands/simple-insert! (state/get-edit-input-id) (util/format "{{video %s}}" text) nil)
+      
       (and (gp-util/url? text)
            (string/includes? text "twitter.com")
            (mobile-util/is-native-platform?))

--- a/src/main/frontend/mobile/intent.cljs
+++ b/src/main/frontend/mobile/intent.cljs
@@ -1,22 +1,23 @@
 (ns frontend.mobile.intent
   (:require ["@capacitor/filesystem" :refer [Filesystem]]
+            ["path" :as path]
             ["send-intent" :refer [^js SendIntent]]
-            [lambdaisland.glogi :as log]
-            [promesa.core :as p]
+            [clojure.pprint :as pprint]
+            [clojure.set :as set]
             [clojure.string :as string]
+            [frontend.config :as config]
+            [frontend.date :as date]
             [frontend.db :as db]
             [frontend.handler.editor :as editor-handler]
-            [frontend.state :as state]
-            [frontend.date :as date]
-            [frontend.util :as util]
-            [frontend.config :as config]
-            [logseq.graph-parser.mldoc :as gp-mldoc]
-            [logseq.graph-parser.config :as gp-config]
-            ["path" :as path]
-            [frontend.mobile.util :as mobile-util]
             [frontend.handler.notification :as notification]
-            [clojure.pprint :as pprint]
-            [clojure.set :as set]))
+            [frontend.mobile.util :as mobile-util]
+            [frontend.state :as state]
+            [frontend.util :as util]
+            [lambdaisland.glogi :as log]
+            [logseq.graph-parser.config :as gp-config]
+            [logseq.graph-parser.mldoc :as gp-mldoc]
+            [logseq.graph-parser.text :as text]
+            [promesa.core :as p]))
 
 (defn- handle-received-text [result]
   (let [{:keys [title url]} result
@@ -33,9 +34,8 @@
                      (string/split url "\"\n"))
         text (some-> text (string/replace #"^\"" ""))
         url (and url
-                 (cond (or (string/includes? url "youtube.com")
-                           (string/includes? url "youtu.be"))
-                       (util/format "{{youtube %s}}" url)
+                 (cond (boolean (text/get-matched-video url))
+                       (util/format "{{video %s}}" url)
 
                        (and (string/includes? url "twitter.com")
                             (string/includes? url "status"))

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1040,29 +1040,6 @@
       (string/replace "&quot;" "\"")
       (string/replace "&apos;" "'")))
 
-#?(:cljs
-   (defn system-locales
-     []
-     (when-not node-test?
-       (when-let [navigator (and js/window (.-navigator js/window))]
-         ;; https://zzz.buzz/2016/01/13/detect-browser-language-in-javascript/
-         (when navigator
-           (let [v (js->clj
-                    (or
-                     (.-languages navigator)
-                     (.-language navigator)
-                     (.-userLanguage navigator)
-                     (.-browserLanguage navigator)
-                     (.-systemLanguage navigator)))]
-             (if (string? v) [v] v)))))))
-
-#?(:cljs
-   (defn zh-CN-supported?
-     []
-     (let [system-locales (set (system-locales))]
-       (or (contains? system-locales "zh-CN")
-           (contains? system-locales "zh-Hans-CN")))))
-
 (comment
   (= (get-relative-path "journals/2020_11_18.org" "pages/grant_ideas.org")
      "../pages/grant_ideas.org")

--- a/src/main/logseq/graph_parser/text.cljs
+++ b/src/main/logseq/graph_parser/text.cljs
@@ -122,6 +122,18 @@
   [s]
   (string/split s #"(\"[^\"]*\")"))
 
+(def bilibili-regex #"^((?:https?:)?//)?((?:www).)?((?:bilibili.com|b23.tv))(/(?:video/)?)([\w-]+)(\S+)?$")
+(def loom-regex #"^((?:https?:)?//)?((?:www).)?((?:loom.com))(/(?:share/|embed/))([\w-]+)(\S+)?$")
+(def vimeo-regex #"^((?:https?:)?//)?((?:www).)?((?:player.vimeo.com|vimeo.com))(/(?:video/)?)([\w-]+)(\S+)?$")
+(def youtube-regex #"^((?:https?:)?//)?((?:www|m).)?((?:youtube.com|youtu.be|y2u.be|youtube-nocookie.com))(/(?:[\w-]+\?v=|embed/|v/)?)([\w-]+)([\S^\?]+)?$")
+
+(defn get-matched-video
+  [url]
+  (or (re-find youtube-regex url)
+      (re-find loom-regex url)
+      (re-find vimeo-regex url)
+      (re-find bilibili-regex url)))
+
 (def markdown-link #"\[([^\[]+)\](\(.*\))")
 
 (defn split-page-refs-without-brackets

--- a/src/main/logseq/graph_parser/text.cljs
+++ b/src/main/logseq/graph_parser/text.cljs
@@ -122,7 +122,7 @@
   [s]
   (string/split s #"(\"[^\"]*\")"))
 
-(def bilibili-regex #"^((?:https?:)?//)?((?:www).)?((?:bilibili.com|b23.tv))(/(?:video/)?)([\w-]+)(\S+)?$")
+(def bilibili-regex #"^((?:https?:)?//)?((?:www).)?((?:bilibili.com))(/(?:video/)?)([\w-]+)(\S+)?$")
 (def loom-regex #"^((?:https?:)?//)?((?:www).)?((?:loom.com))(/(?:share/|embed/))([\w-]+)(\S+)?$")
 (def vimeo-regex #"^((?:https?:)?//)?((?:www).)?((?:player.vimeo.com|vimeo.com))(/(?:video/)?)([\w-]+)(\S+)?$")
 (def youtube-regex #"^((?:https?:)?//)?((?:www|m).)?((?:youtube.com|youtu.be|y2u.be|youtube-nocookie.com))(/(?:[\w-]+\?v=|embed/|v/)?)([\w-]+)([\S^\?]+)?$")


### PR DESCRIPTION
This PR adds a `{{video url}}` macro to allow Logseq to embed more video URLs.
Use `Mod+Shift+V` to wrap clipboard URL as `{{video url}}`.

# BREAKING CHANGE
This macro replaces `youtube`, `vimeo` and `bilibili` macros.
Users can still use above macros in logseq for backward compatibility, 
but they can't access those commands from the commands menu anymore.
