### PR TITLE
style: optimize block alignment

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1618,8 +1618,6 @@
                            [(str class " checked") true])]
     (when class
       (ui/checkbox {:class class
-                    :style {:margin-top -2
-                            :margin-right 5}
                     :checked checked?
                     :on-mouse-down (fn [e]
                                      (util/stop-propagation e))
@@ -1720,7 +1718,7 @@
         html-export? (:html-export? config)
         checkbox (when (and (not pre-block?)
                             (not html-export?))
-                   (block-checkbox t (str "mr-1 cursor")))
+                   (block-checkbox t "mr-1 cursor"))
         marker-switch (when (and (not pre-block?)
                                  (not html-export?))
                         (marker-switch t))
@@ -1737,7 +1735,7 @@
         elem (if heading-level
                (keyword (str "h" heading-level
                              (when block-ref? ".inline")))
-               :span.inline)]
+               :span.inline-flex.items-center)]
     (->elem
      elem
      (merge

--- a/src/main/frontend/components/theme.css
+++ b/src/main/frontend/components/theme.css
@@ -48,7 +48,6 @@ html {
   border-color: var(--ls-page-checkbox-border-color, #6093a0);
   border: none;
   position: relative;
-  top: -1px;
 }
 
 .form-checkbox:hover {


### PR DESCRIPTION
As the title.

Use `inline-flex.items-center` to prevent the hard code styles.