### PR TITLE
revert `inline-flex`

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1735,7 +1735,7 @@
         elem (if heading-level
                (keyword (str "h" heading-level
                              (when block-ref? ".inline")))
-               :span.inline-flex.items-center)]
+               :span.inline.items-center)]
     (->elem
      elem
      (merge


### PR DESCRIPTION
solved block content display issue introduced in https://github.com/logseq/logseq/pull/5435#issuecomment-1139232465