### PR TITLE
Feat: copy && paste with rich-text formats

### DIFF
--- a/src/main/frontend/extensions/html_parser.cljs
+++ b/src/main/frontend/extensions/html_parser.cljs
@@ -75,6 +75,9 @@
                                     (if (string? pattern) pattern (apply str (reverse pattern))))))
         wrapper (fn [tag content]
                   (cond
+                    (= tag :comment)
+                    nil
+
                     (and (= tag :p) (:in-table? opts))
                     content
 

--- a/src/main/frontend/extensions/html_parser.cljs
+++ b/src/main/frontend/extensions/html_parser.cljs
@@ -99,7 +99,7 @@
                            :h5 (block-transform 5 children)
                            :h6 (block-transform 6 children)
                            :a (let [href (:href attrs)
-                                    label (map-join children)
+                                    label (or (map-join children) "")
                                     has-img-tag? (util/safe-re-find #"\[:img" (str x))]
                                 (if has-img-tag?
                                   (export-hiccup x)
@@ -108,7 +108,7 @@
                                     :org (util/format "[[%s][%s]]" href label)
                                     nil)))
                            :img (let [src (:src attrs)
-                                      alt (:alt attrs)]
+                                      alt (or (:alt attrs) "")]
                                   (case format
                                     :markdown (util/format "![%s](%s)" alt src)
                                     :org (util/format "[[%s][%s]]" src alt)

--- a/src/main/frontend/extensions/html_parser.cljs
+++ b/src/main/frontend/extensions/html_parser.cljs
@@ -24,7 +24,9 @@
   [format hiccup]
   (let [transform-fn (fn [hiccup]
                        (hiccup->doc-inner format hiccup))
-        block-pattern (config/get-block-pattern format)
+        block-pattern (if (= format :markdown)
+                        "#"
+                        (config/get-block-pattern format))
         map-join (fn [children] (apply str (map transform-fn children)))
         block-transform (fn [level children]
                           (str (apply str (repeat level block-pattern))

--- a/src/main/frontend/extensions/html_parser.cljs
+++ b/src/main/frontend/extensions/html_parser.cljs
@@ -20,6 +20,20 @@
 
                (str (hiccup-without-style hiccup))))
 
+(def allowed-tags
+  #{:address, :article, :aside, :footer, :header,
+    :h1, :h2, :h3, :h4, :h5, :h6, :hgroup,
+    :main, :nav, :section,
+    :blockquote, :dd, :div, :dl, :dt, :figcaption, :figure,
+    :hr, :li, :ol, :p, :pre, :ul,
+    :a, :abbr, :b, :bdi, :bdo, :br, :cite, :code, :data, :dfn,
+    :em, :i, :kbd, :mark, :q,
+    :rb, :rp, :rt, :rtc, :ruby,
+    :s, :samp, :small, :span, :strong, :sub, :sup, :time, :u, :var, :wbr,
+    :caption, :col, :colgroup, :table, :tbody, :td, :tfoot, :th,
+    :thead, :tr
+    :body :html})
+
 (defn ^:large-vars/cleanup-todo hiccup->doc-inner
   [format hiccup opts]
   (let [transform-fn (fn [hiccup opts]
@@ -77,7 +91,10 @@
                                       (if (string? pattern) pattern (apply str (reverse pattern)))))))
         wrapper (fn [tag content]
                   (let [content (cond
-                                  (contains? #{:comment :head :w :style :xml :o:p} tag)
+                                  (not (contains? allowed-tags tag))
+                                  nil
+
+                                  (contains? #{:comment :head :style :xml} tag)
                                   nil
 
                                   (and (= tag :p) (:in-table? opts))
@@ -239,7 +256,6 @@
   (when-not (string/blank? html)
     (let [hiccup (hickory/as-hiccup (hickory/parse html))
           decoded-hiccup (html-decode-hiccup hiccup)]
-      (def hiccup hiccup)
       (hiccup->doc format decoded-hiccup))))
 
 (comment

--- a/src/main/frontend/extensions/zotero/extractor.cljs
+++ b/src/main/frontend/extensions/zotero/extractor.cljs
@@ -140,7 +140,7 @@
 (defmethod extract "note"
   [item]
   (let [note-html (-> item :data :note)]
-    (html-parser/parse :markdown note-html)))
+    (html-parser/convert :markdown note-html)))
 
 (defn zotero-imported-file-macro [item-key filename]
   (util/format "{{zotero-imported-file %s, %s}}" item-key (pr-str filename)))

--- a/src/main/frontend/handler/common.cljs
+++ b/src/main/frontend/handler/common.cljs
@@ -15,8 +15,9 @@
             [borkdude.rewrite-edn :as rewrite]))
 
 (defn copy-to-clipboard-without-id-property!
-  [format content]
-  (util/copy-to-clipboard! (property/remove-id-property format content)))
+  [format raw-text html]
+  (util/copy-to-clipboard! (property/remove-id-property format raw-text))
+  (util/copy-to-clipboard! html true))
 
 (defn config-with-document-mode
   [config]

--- a/src/main/frontend/handler/common.cljs
+++ b/src/main/frontend/handler/common.cljs
@@ -17,7 +17,8 @@
 (defn copy-to-clipboard-without-id-property!
   [format raw-text html]
   (util/copy-to-clipboard! (property/remove-id-property format raw-text))
-  (util/copy-to-clipboard! html true))
+  (when html
+    (util/copy-to-clipboard! html true)))
 
 (defn config-with-document-mode
   [config]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -978,7 +978,7 @@
      (into [] (state/get-export-block-text-remove-options)))))
 
 (defn copy-selection-blocks
-  []
+  [html?]
   (when-let [blocks (seq (state/get-selection-blocks))]
     (let [repo (state/get-current-repo)
           ids (distinct (keep #(when-let [id (dom/attr % "blockid")]
@@ -987,7 +987,7 @@
           block (db/entity [:block/uuid (first ids)])]
       (when block
         (let [html (export/export-blocks-as-html repo ids)]
-          (common-handler/copy-to-clipboard-without-id-property! (:block/format block) content html))
+          (common-handler/copy-to-clipboard-without-id-property! (:block/format block) content (when html? html)))
         (state/set-copied-blocks content ids)
         (notification/show! "Copied!" :success)))))
 
@@ -1056,7 +1056,7 @@
 
 (defn cut-selection-blocks
   [copy?]
-  (when copy? (copy-selection-blocks))
+  (when copy? (copy-selection-blocks true))
   (when-let [blocks (seq (get-selected-blocks))]
     ;; remove embeds, references and queries
     (let [dom-blocks (remove (fn [block]
@@ -2990,7 +2990,7 @@
 
 (defn shortcut-copy-selection
   [_e]
-  (copy-selection-blocks))
+  (copy-selection-blocks true))
 
 (defn shortcut-cut-selection
   [e]
@@ -3034,6 +3034,19 @@
         (if (= selected-start selected-end)
           (copy-current-block-ref)
           (js/document.execCommand "copy")))
+
+      :else
+      (js/document.execCommand "copy"))))
+
+(defn shortcut-copy-text
+  "shortcut copy action:
+  * when in selection mode, copy selected blocks
+  * when in edit mode with text selected, copy selected text as normal"
+  [_e]
+  (when-not (auto-complete?)
+    (cond
+      (state/selection?)
+      (copy-selection-blocks false)
 
       :else
       (js/document.execCommand "copy"))))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2966,6 +2966,7 @@
                  (html-parser/convert format html)
                  initial-text)
           input (state/get-input)]
+      ;; (def html html)
       (if-not (string/blank? text)
         (if (or (thingatpt/markdown-src-at-point input)
                 (thingatpt/org-admonition&src-at-point input))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -986,7 +986,8 @@
           content (compose-copied-blocks-contents repo ids)
           block (db/entity [:block/uuid (first ids)])]
       (when block
-        (common-handler/copy-to-clipboard-without-id-property! (:block/format block) content)
+        (let [html (export/export-blocks-as-html repo ids)]
+          (common-handler/copy-to-clipboard-without-id-property! (:block/format block) content html))
         (state/set-copied-blocks content ids)
         (notification/show! "Copied!" :success)))))
 
@@ -1194,9 +1195,10 @@
   (when-let [block (db/pull [:block/uuid block-id])]
     (let [repo (state/get-current-repo)
           ;; TODO: support org mode
-          md-content (compose-copied-blocks-contents repo [block-id])]
+          md-content (compose-copied-blocks-contents repo [block-id])
+          html (export/export-blocks-as-html repo [block-id])]
       (state/set-copied-full-blocks md-content [block])
-      (common-handler/copy-to-clipboard-without-id-property! (:block/format block) md-content)
+      (common-handler/copy-to-clipboard-without-id-property! (:block/format block) md-content html)
       (delete-block-aux! block true))))
 
 (defn clear-last-selected-block!
@@ -2966,7 +2968,6 @@
                  (html-parser/convert format html)
                  initial-text)
           input (state/get-input)]
-      ;; (def html html)
       (if-not (string/blank? text)
         (if (or (thingatpt/markdown-src-at-point input)
                 (thingatpt/org-admonition&src-at-point input))

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -204,6 +204,9 @@
    :editor/copy                    {:binding "mod+c"
                                     :fn      editor-handler/shortcut-copy}
 
+   :editor/copy-text               {:binding "mod+shift+c"
+                                    :fn      editor-handler/shortcut-copy-text}
+
    :editor/cut                     {:binding "mod+x"
                                     :fn      editor-handler/shortcut-cut}
 
@@ -334,7 +337,7 @@
    :ui/toggle-theme                 {:binding "t t"
                                      :fn      state/toggle-theme!}
 
-   :ui/toggle-contents              {:binding "mod+shift+c"
+   :ui/toggle-contents              {:binding "alt+shift+c"
                                      :fn      ui-handler/toggle-contents!}
 
    :ui/open-new-window              {:binding "mod+n"
@@ -470,6 +473,7 @@
                           :editor/indent
                           :editor/outdent
                           :editor/copy
+                          :editor/copy-text
                           :editor/cut
                           :editor/undo
                           :editor/redo
@@ -541,6 +545,7 @@
     :editor/undo
     :editor/redo
     :editor/copy
+    :editor/copy-text
     :editor/cut]
 
    :shortcut.category/formatting

--- a/src/main/frontend/modules/shortcut/dicts.cljc
+++ b/src/main/frontend/modules/shortcut/dicts.cljc
@@ -65,6 +65,7 @@
    :editor/indent                  "Indent block"
    :editor/outdent                 "Outdent block"
    :editor/copy                    "Copy (copies either selection, or block reference)"
+   :editor/copy-text               "Copy selections as text"
    :editor/cut                     "Cut"
    :editor/undo                    "Undo"
    :editor/redo                    "Redo"


### PR DESCRIPTION
This makes it easier to copy && paste content from Logseq and other tools like Google Docs.

Demo:
https://www.loom.com/share/22ea6a3c1d964b68b726da5f0ac3fcb8