### PR TITLE
feat: Support for Page Level Templates

### DIFF
--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -414,6 +414,16 @@
            template
            {:target page}))))))
 
+(defmethod handle :page/insert-template [[_ page-name]]
+  (let [page-name (util/page-name-sanity-lc page-name)]
+    (when-let [page (db/pull [:block/name page-name])]
+      (when (db/page-empty? (state/get-current-repo) page-name)
+        (when-let [template (state/get-default-page-template)]
+          (editor-handler/insert-template!
+           nil
+           template
+           {:target page}))))))
+
 (defn run!
   []
   (let [chan (state/get-events-chan)]

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -153,7 +153,13 @@
          (when (or
                 (db/page-empty? repo (:db/id (db/entity [:block/name page-name])))
                 (create-title-property? journal? page-name))
-           (editor-handler/api-insert-new-block! "" {:page page-name}))))
+           (editor-handler/api-insert-new-block! "" {:page page-name})))
+           
+        (when-not journal (state/pub-event! [:journal/insert-template title])
+        
+        )
+           
+      )
 
      (when redirect?
        (route-handler/redirect-to-page! page-name))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -334,6 +334,12 @@
     (when-not (string/blank? template)
       (string/trim template))))
 
+(defn get-default-page-template
+  []
+  (when-let [template (get-in (get-config) [:default-templates :pages])]
+    (when-not (string/blank? template)
+      (string/trim template))))
+
 (defn all-pages-public?
   []
   (let [value (:publishing/all-pages-public? (get-config))

--- a/templates/config.edn
+++ b/templates/config.edn
@@ -18,7 +18,10 @@
  ;; When creating the new journal page, the app will use your template if there is one.
  ;; You only need to input your template name here.
  :default-templates
- {:journals ""}
+ {
+  :journals "",
+  :pages ""
+ }
 
  ;; Whether to enable hover on tooltip preview feature
  ;; Default is true, you can also toggle this via setting page


### PR DESCRIPTION
Looking to refactor the logic used by the journal templates in the config under `default-templates` to extend to pages.

A number of people are creating complex workflows or some "defaults" for their journals using the `default-templates` config item. However this was designed based on the code to be later extended to pages, cards and other places where you can load a template block into a page on creation, the same way a journal is created based on the template block if one is set in `default-templates`.

This feature will greatly contribute to the ability for people to create boilerplate templates that auto-apply on generation. As this feature is already in the code supporting journals but not other types of pages/content in Logseq.