### PR TITLE
fix(editor): copy with both plain and rich text

### DIFF
--- a/src/main/frontend/components/export.cljs
+++ b/src/main/frontend/components/export.cljs
@@ -126,5 +126,6 @@
      [:div.mt-4
       (ui/button (if @copied? "Copied to clipboard!" "Copy to clipboard")
         :on-click (fn []
-                    (util/copy-to-clipboard! content (= type :html))
+                    (util/copy-to-clipboard! content (when (= type :html)
+                                                       content))
                     (reset! copied? true)))]]))

--- a/src/main/frontend/handler/common.cljs
+++ b/src/main/frontend/handler/common.cljs
@@ -16,9 +16,7 @@
 
 (defn copy-to-clipboard-without-id-property!
   [format raw-text html]
-  (util/copy-to-clipboard! (property/remove-id-property format raw-text))
-  (when html
-    (util/copy-to-clipboard! html true)))
+  (util/copy-to-clipboard! (property/remove-id-property format raw-text) html))
 
 (defn config-with-document-mode
   [config]

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -713,9 +713,9 @@
 #?(:cljs
    (defn copy-to-clipboard!
      ([s]
-      (utils/writeClipboard s false))
-     ([s html?]
-      (utils/writeClipboard s html?))))
+      (utils/writeClipboard (clj->js {:text s})))
+     ([s html]
+      (utils/writeClipboard (clj->js {:text s :html html})))))
 
 (defn drop-nth [n coll]
   (keep-indexed #(when (not= %1 n) %2) coll))

--- a/src/main/frontend/utils.js
+++ b/src/main/frontend/utils.js
@@ -245,7 +245,7 @@ export const getClipText = (cb, errorHandler) => {
 }
 
 // TODO split the capacitor clipboard to a separate file for capacitor APIs
-export const writeClipboard = (text, isHtml) => {
+export const writeClipboard = ({text, html}) => {
     if (typeof navigator.permissions == "undefined") {
         CapacitorClipboard.write({ string: text });
         return
@@ -260,18 +260,18 @@ export const writeClipboard = (text, isHtml) => {
         let promise_written = null
         if (typeof ClipboardItem !== 'undefined') {
             let blob = new Blob([text], {
-            type: ["text/plain"]
+              type: ["text/plain"]
             });
             let data = [new ClipboardItem({
                 ["text/plain"]: blob
             })];
-            if (isHtml) {
-                blob = new Blob([text], {
-                    type: ["text/plain", "text/html"]
+            if (html) {
+                let richBlob = new Blob([html], {
+                    type: ["text/html"]
                 })
                 data = [new ClipboardItem({
                     ["text/plain"]: blob,
-                    ["text/html"]: blob
+                    ["text/html"]: richBlob
                 })];
             }
             promise_written = navigator.clipboard.write(data)


### PR DESCRIPTION
Allow using "Paste and match style" outside Logseq App.
Avoid setting HTML as plain text, which will be recognized wrongly by an external editor.