### PR TITLE
Fix: auto expand for linked references

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3493,7 +3493,8 @@
   1. References.
   2. Custom queries."
   [block config]
-  (or
+  (if (or (:ref? config)
+          (:custom-query? config))
    (and
     (or (:ref? config) (:custom-query? config))
     (>= (inc (:block/level block))


### PR DESCRIPTION
Close https://github.com/logseq/logseq/issues/5431