### PR TITLE
fix(deps): link static vcruntime under windows

### DIFF
--- a/resources/package.json
+++ b/resources/package.json
@@ -36,7 +36,7 @@
     "https-proxy-agent": "5.0.0",
     "@sentry/electron": "2.5.1",
     "posthog-js": "1.10.2",
-    "@logseq/rsapi": "0.0.16",
+    "@logseq/rsapi": "0.0.20",
     "electron-deeplink": "1.0.10"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes startup runtime errors under specific Windows platforms (lacking VC++ 2015 runtime, ARM Windows machines)

Fix #5467
Fix #5167 

static link to vcruntime, remove `vcruntime140.dll` dependency:

```console
> rabin2 -l rsapi.win32-x64-msvc.node
[Linked libraries]
advapi32.dll
bcrypt.dll
ntdll.dll
kernel32.dll
ws2_32.dll
shell32.dll
ole32.dll
api-ms-win-crt-runtime-l1-1-0.dll
api-ms-win-crt-string-l1-1-0.dll
api-ms-win-crt-stdio-l1-1-0.dll
api-ms-win-crt-convert-l1-1-0.dll
api-ms-win-crt-heap-l1-1-0.dll
```