### PR TITLE
enhance gestures

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2094,12 +2094,14 @@
     [:div.indent (ui/icon "indent-increase" {:style {:fontSize 16}})]]])
 
 (rum/defc block-right-menu < rum/reactive
-  [_config {:block/keys [uuid] :as _block}]
+  [_config {:block/keys [uuid] :as _block} edit?]
   [:div.block-right-menu.flex.bg-base-2.rounded-md.ml-1
    [:div.commands-button.w-0.flex.flew-col.rounded-md
-    {:id (str "block-right-menu-" uuid)}
-    [:div.more (ui/icon "dots-circle-horizontal" {:style {:fontSize 16}})]
-    [:div.outdent (ui/icon "indent-decrease" {:style {:fontSize 16}})]]])
+    {:id (str "block-right-menu-" uuid)
+     :style {:max-width (if edit? 40 80)}}
+    [:div.outdent (ui/icon "indent-decrease" {:style {:fontSize 16}})]
+    (when-not edit?
+      [:div.more (ui/icon "dots-circle-horizontal" {:style {:fontSize 16}})])]])
 
 (rum/defcs block-content-or-editor < rum/reactive
   (rum/local true :hide-block-refs?)
@@ -2464,7 +2466,7 @@
       {:class (if (and heading? (seq (:block/title block))) "items-baseline" "")
        :on-touch-start block-handler/on-touch-start
        :on-touch-move (fn [event]
-                        (block-handler/on-touch-move event block uuid *show-left-menu? *show-right-menu?))
+                        (block-handler/on-touch-move event block uuid edit? *show-left-menu? *show-right-menu?))
        :on-touch-end (fn [event]
                        (block-handler/on-touch-end event block uuid *show-left-menu? *show-right-menu?))
        :on-touch-cancel block-handler/on-touch-cancel
@@ -2479,7 +2481,7 @@
         (block-left-menu config block))
       (block-content-or-editor config block edit-input-id block-id heading-level edit?)
       (when @*show-right-menu?
-        (block-right-menu config block))]
+        (block-right-menu config block edit?))]
 
      (block-children config children collapsed?)
 

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2464,7 +2464,7 @@
 
      [:div.flex.flex-row.pr-2
       {:class (if (and heading? (seq (:block/title block))) "items-baseline" "")
-       :on-touch-start block-handler/on-touch-start
+       :on-touch-start (fn [event uuid] (block-handler/on-touch-start event uuid))
        :on-touch-move (fn [event]
                         (block-handler/on-touch-move event block uuid edit? *show-left-menu? *show-right-menu?))
        :on-touch-end (fn [event]

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -191,7 +191,7 @@
     
     .commands-button {
         overflow: hidden;
-        max-width: 50px;
+        max-width: 40px;
         text-align: center;
         margin: auto 0;
 
@@ -207,7 +207,6 @@
 
     .commands-button {
         overflow: hidden;
-        max-width: 80px;
         text-align: center;
         margin: auto 0;
 

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -1,6 +1,7 @@
 (ns frontend.handler.block
   (:require
    [clojure.set :as set]
+   [clojure.string :as string]
    [clojure.walk :as walk]
    [frontend.db :as db]
    [frontend.db.model :as db-model]
@@ -149,8 +150,12 @@
 (def *swipe (atom nil))
 
 (defn on-touch-start
-  [event]
-  (let [input (state/get-input)]
+  [event uuid]
+  (let [input (state/get-input)
+        input-id (state/get-edit-input-id)]
+    (when-not (and input
+                   (string/ends-with? input-id (str uuid)))
+      (state/clear-edit!))
     (when (= (util/get-selection-start input)
              (util/get-selection-end input))
       (when-let [touches (.-targetTouches event)]

--- a/src/main/frontend/mobile/mobile_bar.cljs
+++ b/src/main/frontend/mobile/mobile_bar.cljs
@@ -44,14 +44,6 @@
                       (state/set-state! :mobile/toolbar-update-observer (rand-int 1000000)))}
     (ui/icon icon {:style {:fontSize ui/icon-size}})]])
 
-(rum/defc indent-outdent [indent? icon]
-  [:div
-   [:button.bottom-action
-    {:on-mouse-down (fn [e]
-                      (util/stop e)
-                      (editor-handler/indent-outdent indent?))}
-    (ui/icon icon {:style {:fontSize ui/icon-size}})]])
-
 (rum/defc timestamp-submenu
   [parent-id]
   (let [callback (fn [event]
@@ -127,8 +119,6 @@
                  (state/sub :editor/editing?))
         [:div#mobile-editor-toolbar.bg-base-2
          [:div.toolbar-commands
-          (indent-outdent false "indent-decrease")
-          (indent-outdent true "indent-increase")
           (command (editor-handler/move-up-down true) "arrow-bar-to-up")
           (command (editor-handler/move-up-down false) "arrow-bar-to-down")
           (command #(if (state/sub :document/mode?)


### PR DESCRIPTION
1. Switch outdent and more buttons to make swipe more natural.
2. disable the swipe action-bar when editing. Only allow indent/outdent when editing
3. resolve conflicts between selection and swipe when editing
4. Remove the indent/outdent button on the mobile toolbar