### PR TITLE
Reduce shadows on sidebar and inline cards

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2434,7 +2434,7 @@
         :data-collapsed (and collapsed? has-child?)
         :class (str uuid
                     (when pre-block? " pre-block")
-                    (when (and card? (not review-cards?)) " shadow-xl")
+                    (when (and card? (not review-cards?)) " shadow-md")
                     (when (:ui/selected? block) " selected noselect"))
         :blockid (str uuid)
         :haschild (str has-child?)}

--- a/src/main/frontend/components/right_sidebar.cljs
+++ b/src/main/frontend/components/right_sidebar.cljs
@@ -122,7 +122,7 @@
   (let [item (build-sidebar-item repo idx db-id block-type)]
     (when item
       (let [collapse? (state/sub [:ui/sidebar-collapsed-blocks db-id])]
-        [:div.sidebar-item.content.color-level.px-4.shadow-lg
+        [:div.sidebar-item.content.color-level.px-4.shadow-md
          (let [[title component] item]
            [:div.flex.flex-col
             [:div.flex.flex-row.justify-between


### PR DESCRIPTION
- Why are big shadows bad for cards? #card  
	- They take too much user attention. Cards don't need that much attention.  
	- Big shadow => floating thing. Cards shouldn't float over the page. They should *lie* on the page => only a slight shadow is needed 

Same reasoning applies to the right sidebar

Previous:
![Screenshot from 2022-06-05 21-53-14](https://user-images.githubusercontent.com/23294184/172068854-62406ade-d037-4c08-a00a-da3675e95cf5.png)
![Screenshot from 2022-06-05 21-56-20](https://user-images.githubusercontent.com/23294184/172068916-9f21c53f-34df-4510-8893-88483f8c71e8.png)



Next:
![Screenshot from 2022-06-05 21-53-06](https://user-images.githubusercontent.com/23294184/172068860-8e651831-48c9-43aa-9d6b-058d72199f6f.png)
![Screenshot from 2022-06-05 21-56-11](https://user-images.githubusercontent.com/23294184/172068919-f99b034d-d996-4d45-8443-76d00c844ad0.png)

