### PR TITLE
fix(publishing): add missing katex.min.js

### DIFF
--- a/src/main/frontend/publishing/html.cljs
+++ b/src/main/frontend/publishing/html.cljs
@@ -87,4 +87,5 @@
            [:script {:src "static/js/main.js"}]
            [:script {:src "static/js/highlight.min.js"}]
            [:script {:src "static/js/interact.min.js"}]
+           [:script {:src "static/js/katex.min.js"}]
            [:script {:src "static/js/code-editor.js"}]]))))


### PR DESCRIPTION
Adding `<script src="static/js/katex.min.js"></script>` into the exported HTML.
Fix #4110 #4312 