### PR TITLE
Fix: Add test for graph-parser bug and prevent future data deletion

### DIFF
--- a/deps/graph-parser/test/logseq/graph_parser/nbb_test_runner.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/nbb_test_runner.cljs
@@ -6,7 +6,8 @@
             [logseq.graph-parser.block-test]
             [logseq.graph-parser.property-test]
             [logseq.graph-parser.extract-test]
-            [logseq.graph-parser.cli-test]))
+            [logseq.graph-parser.cli-test]
+            [logseq.graph-parser-test]))
 
 (defmethod cljs.test/report [:cljs.test/default :end-run-tests] [m]
   (when-not (cljs.test/successful? m)
@@ -19,4 +20,5 @@
                'logseq.graph-parser.property-test
                'logseq.graph-parser.block-test
                'logseq.graph-parser.extract-test
-               'logseq.graph-parser.cli-test))
+               'logseq.graph-parser.cli-test
+               'logseq.graph-parser-test))

--- a/deps/graph-parser/test/logseq/graph_parser_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser_test.cljs
@@ -1,0 +1,29 @@
+(ns logseq.graph-parser-test
+  (:require [cljs.test :refer [deftest testing is]]
+            [logseq.graph-parser :as graph-parser]
+            [logseq.graph-parser.db :as gp-db]
+            [datascript.core :as d]))
+
+(deftest parse-file
+  (testing "id properties"
+    (let [conn (gp-db/start-conn)]
+      (graph-parser/parse-file conn "foo.md" "- id:: 628953c1-8d75-49fe-a648-f4c612109098" {})
+      (is (= [{:id "628953c1-8d75-49fe-a648-f4c612109098"}]
+             (->> (d/q '[:find (pull ?b [*])
+                         :in $
+                         :where [?b :block/content] [(missing? $ ?b :block/name)]]
+                       @conn)
+                  (map first)
+                  (map :block/properties)))
+          "id as text has correct :block/properties"))
+
+    (let [conn (gp-db/start-conn)]
+      (graph-parser/parse-file conn "foo.md" "- id:: [[628953c1-8d75-49fe-a648-f4c612109098]]" {})
+      (is (= [{:id #{"628953c1-8d75-49fe-a648-f4c612109098"}}]
+             (->> (d/q '[:find (pull ?b [*])
+                         :in $
+                         :where [?b :block/content] [(missing? $ ?b :block/name)]]
+                       @conn)
+                  (map first)
+                  (map :block/properties)))
+          "id as linked ref has correct :block/properties"))))

--- a/deps/graph-parser/test/logseq/graph_parser_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser_test.cljs
@@ -2,6 +2,7 @@
   (:require [cljs.test :refer [deftest testing is]]
             [logseq.graph-parser :as graph-parser]
             [logseq.graph-parser.db :as gp-db]
+            [logseq.graph-parser.block :as gp-block]
             [datascript.core :as d]))
 
 (deftest parse-file
@@ -26,4 +27,17 @@
                        @conn)
                   (map first)
                   (map :block/properties)))
-          "id as linked ref has correct :block/properties"))))
+          "id as linked ref has correct :block/properties")))
+
+  (testing "unexpected failure during block extraction"
+    (let [conn (gp-db/start-conn)
+          deleted-page (atom nil)]
+      (with-redefs [gp-block/with-pre-block-if-exists (fn stub-failure [& _args]
+                                              (throw (js/Error "Testing unexpected failure")))]
+        (try
+          (graph-parser/parse-file conn "foo.md" "- id:: 628953c1-8d75-49fe-a648-f4c612109098"
+                                  {:delete-blocks-fn (fn [page _file]
+                                                       (reset! deleted-page page))})
+          (catch :default _)))
+      (is (= nil @deleted-page)
+          "Page should not be deleted when there is unexpected failure"))))

--- a/src/main/frontend/modules/instrumentation/sentry.cljs
+++ b/src/main/frontend/modules/instrumentation/sentry.cljs
@@ -45,4 +45,4 @@
 (defn init []
   (when-not config/dev?
     (let [config (clj->js config)]
-     (Sentry/init config))))
+      (Sentry/init config))))


### PR DESCRIPTION
This PR adds tests for the bug I introduced that was fixed in #5553 (Thanks @andelf!). This PR prevents also future exceptions in `gp-block/extract-blocks` from deleting pages, as reported in #5548 . The cause of this behavior was the try catch in `gp-block/extract-blocks` which causes `:delete-blocks-fn` to receive a page that it deletes. This behavior can be confirmed with the last test in `graph-parser-test`. Note that removing this try/catch does effect paste and import fns by failing fast, which I think is a better user experience than pretending the action behaved correctly. If we need a try/catch for one of these user actions they should be moved up to the specific action that needs it. As a rule of thumb, I would encourage not having try/catch's far from where the user initiates an action as catch's allow buggy states to continue to propagate and cause secondary exceptions and more complex bugs. In this case, the error propagation lead to deleted user data