### PR TITLE
fix: notify graph dir is gone when starting or running the apps

### DIFF
--- a/src/electron/electron/fs_watcher.cljs
+++ b/src/electron/electron/fs_watcher.cljs
@@ -44,51 +44,54 @@
 
 (defn watch-dir!
   "Watch a directory if no such file watcher exists"
-  [_win dir]
-  (when (and (fs/existsSync dir)
-             (not (get @*file-watcher dir)))
-    (let [watcher-opts (clj->js
-                        {:ignored (fn [path]
-                                    (utils/ignored-path? dir path))
-                         :ignoreInitial false
-                         :ignorePermissionErrors true
-                         :interval polling-interval
-                         :binaryInterval polling-interval
-                         :persistent true
-                         :disableGlobbing true
-                         :usePolling false
-                         :awaitWriteFinish true})
-          dir-watcher (.watch watcher dir watcher-opts)
-          watcher-del-f #(.close dir-watcher)]
-      (swap! *file-watcher assoc dir [dir-watcher watcher-del-f])
-      ;; TODO: batch sender
-      (.on dir-watcher "unlinkDir"
-           (fn [path]
-             (when (= dir path)
-               (publish-file-event! dir dir "unlinkDir"))))
-      (.on dir-watcher "addDir"
-           (fn [path]
-             (when (= dir path)
-               (publish-file-event! dir dir "addDir"))))
-      (.on dir-watcher "add"
-           (fn [path]
-             (publish-file-event! dir path "add")))
-      (.on dir-watcher "change"
-           (fn [path]
-             (publish-file-event! dir path "change")))
-      (.on dir-watcher "unlink"
-           (fn [path]
-             (publish-file-event! dir path "unlink")))
-      (.on dir-watcher "error"
-           (fn [path]
-             (println "Watch error happened: "
-                      {:path path})))
+  [dir]
+  (when-not (get @*file-watcher dir)
+    (if (fs/existsSync dir)
+      (let [watcher-opts (clj->js
+                          {:ignored (fn [path]
+                                      (utils/ignored-path? dir path))
+                           :ignoreInitial false
+                           :ignorePermissionErrors true
+                           :interval polling-interval
+                           :binaryInterval polling-interval
+                           :persistent true
+                           :disableGlobbing true
+                           :usePolling false
+                           :awaitWriteFinish true})
+            dir-watcher (.watch watcher dir watcher-opts)
+            watcher-del-f #(.close dir-watcher)]
+        (swap! *file-watcher assoc dir [dir-watcher watcher-del-f])
+        ;; TODO: batch sender
+        (.on dir-watcher "unlinkDir"
+             (fn [path]
+               (when (= dir path)
+                 (publish-file-event! dir dir "unlinkDir"))))
+        (.on dir-watcher "addDir"
+             (fn [path]
+               (when (= dir path)
+                 (publish-file-event! dir dir "addDir"))))
+        (.on dir-watcher "add"
+             (fn [path]
+               (publish-file-event! dir path "add")))
+        (.on dir-watcher "change"
+             (fn [path]
+               (publish-file-event! dir path "change")))
+        (.on dir-watcher "unlink"
+             (fn [path]
+               (publish-file-event! dir path "unlink")))
+        (.on dir-watcher "error"
+             (fn [path]
+               (println "Watch error happened: "
+                        {:path path})))
 
-      ;; electron app extends `EventEmitter`
-      ;; TODO check: duplicated with the logic in "window-all-closed" ?
-      (.on app "quit" watcher-del-f)
+        ;; electron app extends `EventEmitter`
+        ;; TODO check: duplicated with the logic in "window-all-closed" ?
+        (.on app "quit" watcher-del-f)
 
-      true)))
+        true)
+      ;; retry if the `dir` not exists, which is useful when a graph's folder is
+      ;; back after refreshing the window
+      (js/setTimeout #(watch-dir! dir) 5000))))
 
 (defn close-watcher!
   "If no `dir` provided, close all watchers;

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -395,6 +395,10 @@
   (when dir
     (watcher/watch-dir! dir)))
 
+(defmethod handle :unwatchDir [^js _window [_ dir]]
+  (when dir
+    (watcher/close-watcher! dir)))
+
 (defn open-new-window!
   "Persist db first before calling! Or may break db persistency"
   []

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -386,7 +386,7 @@
         windows (win/get-graph-all-windows dir)]
     (> (count windows) 1)))
 
-(defmethod handle :addDirWatcher [^js window [_ dir]]
+(defmethod handle :addDirWatcher [^js _window [_ dir]]
   ;; receive dir path (not repo / graph) from frontend
   ;; Windows on same dir share the same watcher
   ;; Only close file watcher when:

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -332,7 +332,8 @@
 (defn set-current-graph!
   [window graph-path]
   (let [old-path (state/get-window-graph-path window)]
-    (when old-path (close-watcher-when-orphaned! window old-path))
+    (when (and old-path graph-path (not= old-path graph-path))
+      (close-watcher-when-orphaned! window old-path))
     (swap! state/state assoc :graph/current graph-path)
     (swap! state/state assoc-in [:window/graph window] graph-path)
     nil))
@@ -392,10 +393,7 @@
   ;;    1. there is no one window on the same dir
   ;;    2. reset file watcher to resend `add` event on window refreshing
   (when dir
-    ;; adding dir watcher when the window has watcher already - must be cmd + r refreshing
-    ;; maintain only one file watcher when multiple windows on the same dir
-    (close-watcher-when-orphaned! window dir)
-    (watcher/watch-dir! window dir)))
+    (watcher/watch-dir! dir)))
 
 (defn open-new-window!
   "Persist db first before calling! Or may break db persistency"

--- a/src/electron/electron/state.cljs
+++ b/src/electron/electron/state.cljs
@@ -15,10 +15,10 @@
 
          ;; window -> current graph
          :window/graph {}
-         
+
          ;; job to do when persistGraph is done on renderer
          :window/once-persist-done nil
-         
+
          ;; job to do when graph is loaded on renderer
          :window/once-graph-ready nil}))
 

--- a/src/main/frontend/fs.cljs
+++ b/src/main/frontend/fs.cljs
@@ -167,6 +167,10 @@
   [dir]
   (protocol/watch-dir! (get-record) dir))
 
+(defn unwatch-dir!
+  [dir]
+  (protocol/unwatch-dir! (get-record) dir))
+
 (defn mkdir-if-not-exists
   [dir]
   (->

--- a/src/main/frontend/fs.cljs
+++ b/src/main/frontend/fs.cljs
@@ -200,3 +200,7 @@
    (stat dir path)
    (fn [_stat] true)
    (fn [_e] false)))
+
+(defn dir-exists?
+  [dir]
+  (file-exists? dir ""))

--- a/src/main/frontend/fs/bfs.cljs
+++ b/src/main/frontend/fs/bfs.cljs
@@ -35,4 +35,6 @@
   (get-files [_this _path-or-handle _ok-handler]
     nil)
   (watch-dir! [_this _dir]
+    nil)
+  (unwatch-dir! [_this _dir]
     nil))

--- a/src/main/frontend/fs/capacitor_fs.cljs
+++ b/src/main/frontend/fs/capacitor_fs.cljs
@@ -298,4 +298,6 @@
   (watch-dir! [_this dir]
     (p/do!
      (.unwatch mobile-util/fs-watcher)
-     (.watch mobile-util/fs-watcher #js {:path dir}))))
+     (.watch mobile-util/fs-watcher #js {:path dir})))
+  (unwatch-dir! [_this _dir]
+    (.unwatch mobile-util/fs-watcher)))

--- a/src/main/frontend/fs/node.cljs
+++ b/src/main/frontend/fs/node.cljs
@@ -127,4 +127,6 @@
   (get-files [_this path-or-handle _ok-handler]
     (ipc/ipc "getFiles" path-or-handle))
   (watch-dir! [_this dir]
-    (ipc/ipc "addDirWatcher" dir)))
+    (ipc/ipc "addDirWatcher" dir))
+  (unwatch-dir! [_this dir]
+    (ipc/ipc "unwatchDir" dir)))

--- a/src/main/frontend/fs/protocol.cljs
+++ b/src/main/frontend/fs/protocol.cljs
@@ -15,7 +15,8 @@
   (stat [this dir path])
   (open-dir [this ok-handler])
   (get-files [this path-or-handle ok-handler])
-  (watch-dir! [this dir]) 
+  (watch-dir! [this dir])
+  (unwatch-dir! [this dir])
   ;; Ensure the dir is watched, window agnostic.
   ;; Implementation should handle the actual watcher's construction / destruction.
   ;; So shouldn't consider `unwatch-dir!`.

--- a/src/main/frontend/fs/watcher_handler.cljs
+++ b/src/main/frontend/fs/watcher_handler.cljs
@@ -8,7 +8,6 @@
             [frontend.handler.page :as page-handler]
             [frontend.handler.repo :as repo-handler]
             [frontend.handler.ui :as ui-handler]
-            [frontend.handler.notification :as notification]
             [logseq.graph-parser.util :as gp-util]
             [frontend.util.text :as text-util]
             [lambdaisland.glogi :as log]

--- a/src/main/frontend/fs/watcher_handler.cljs
+++ b/src/main/frontend/fs/watcher_handler.cljs
@@ -55,22 +55,10 @@
                  (not (:encryption/graph-parsing? @state/state)))
         (cond
           (and (= "unlinkDir" type) dir)
-          (do
-            (state/pub-event! [:notification/show
-                               {:content (str "The directory " dir " has been renamed or deleted, the editor will be disabled for this graph, you can unlink the graph.")
-                                :status :error
-                                :clear? false}])
-            (state/update-state! :file/unlinked-dirs (fn [dirs] (conj dirs dir))))
+          (state/pub-event! [:graph/dir-gone dir])
 
-          (= "addDir" type)
-          (when (contains? (:file/unlinked-dirs @state/state) dir)
-            (notification/clear-all!)
-            (state/pub-event! [:notification/show
-                               {:content (str "The directory " dir " has been back, you can edit your graph now.")
-                                :status :success
-                                :clear? true}])
-            (fs/watch-dir! dir)
-            (state/update-state! :file/unlinked-dirs (fn [dirs] (disj dirs dir))))
+          (and (= "addDir" type) dir)
+          (state/pub-event! [:graph/dir-back repo dir])
 
           (contains? (:file/unlinked-dirs @state/state) dir)
           nil

--- a/src/main/frontend/handler/file.cljs
+++ b/src/main/frontend/handler/file.cljs
@@ -258,6 +258,7 @@
   []
   (when-let [repo (state/get-current-repo)]
     (when-let [dir (config/get-repo-dir repo)]
+      (fs/unwatch-dir! dir)
       (fs/watch-dir! dir))))
 
 (defn create-metadata-file

--- a/src/main/frontend/handler/metadata.cljs
+++ b/src/main/frontend/handler/metadata.cljs
@@ -41,20 +41,21 @@
 
 (defn set-pages-metadata!
   [repo]
-  (let [path (config/get-pages-metadata-path repo)
-        all-pages (->> (db/get-all-pages repo)
-                       (common-handler/fix-pages-timestamps)
-                       (map #(select-keys % [:block/name :block/created-at :block/updated-at]))
-                       (sort-by :block/name)
-                       (vec))]
-    (p/let [_ (-> (file-handler/create-pages-metadata-file repo)
-                  (p/catch (fn [] nil)))]
-      (let [new-content (with-out-str (cljs.pprint/pprint all-pages))]
-        (fs/write-file! repo
-                        (config/get-repo-dir repo)
-                        path
-                        new-content
-                        {})))))
+  (when-not (state/unlinked-dir? (config/get-repo-dir repo))
+    (let [path (config/get-pages-metadata-path repo)
+          all-pages (->> (db/get-all-pages repo)
+                         (common-handler/fix-pages-timestamps)
+                         (map #(select-keys % [:block/name :block/created-at :block/updated-at]))
+                         (sort-by :block/name)
+                         (vec))]
+      (p/let [_ (-> (file-handler/create-pages-metadata-file repo)
+                    (p/catch (fn [] nil)))]
+        (let [new-content (with-out-str (cljs.pprint/pprint all-pages))]
+          (fs/write-file! repo
+                          (config/get-repo-dir repo)
+                          path
+                          new-content
+                          {}))))))
 
 (defn set-db-encrypted-secret!
   [encrypted-secret]

--- a/src/main/frontend/handler/repo.cljs
+++ b/src/main/frontend/handler/repo.cljs
@@ -381,26 +381,29 @@
 
 (defn rebuild-index!
   [url]
-  (when url
-    (search/reset-indice! url)
-    (db/remove-conn! url)
-    (db/clear-query-state!)
-    (-> (p/do! (db-persist/delete-graph! url))
-        (p/catch (fn [error]
-                   (prn "Delete repo failed, error: " error))))))
+  (when-not (state/unlinked-dir? (config/get-repo-dir url))
+    (when url
+      (search/reset-indice! url)
+      (db/remove-conn! url)
+      (db/clear-query-state!)
+      (-> (p/do! (db-persist/delete-graph! url))
+          (p/catch (fn [error]
+                     (prn "Delete repo failed, error: " error)))))))
 
 (defn re-index!
   [nfs-rebuild-index! ok-handler]
-  (route-handler/redirect-to-home!)
   (when-let [repo (state/get-current-repo)]
-    (let [local? (config/local-db? repo)]
-      (if local?
-        (p/let [_ (metadata-handler/set-pages-metadata! repo)]
-          (nfs-rebuild-index! repo ok-handler))
-        (rebuild-index! repo))
-      (js/setTimeout
+    (let [dir (config/get-repo-dir repo)]
+      (when-not (state/unlinked-dir? dir)
        (route-handler/redirect-to-home!)
-       500))))
+       (let [local? (config/local-db? repo)]
+         (if local?
+           (p/let [_ (metadata-handler/set-pages-metadata! repo)]
+             (nfs-rebuild-index! repo ok-handler))
+           (rebuild-index! repo))
+         (js/setTimeout
+          (route-handler/redirect-to-home!)
+          500))))))
 
 (defn persist-db!
   ([]

--- a/src/main/frontend/handler/web/nfs.cljs
+++ b/src/main/frontend/handler/web/nfs.cljs
@@ -326,9 +326,11 @@
             _ (ok-handler)]
       (state/set-nfs-refreshing! false))))
 
+;; TODO: move to frontend.handler.repo
 (defn refresh!
   [repo ok-handler]
-  (when repo
+  (when (and repo
+             (not (state/unlinked-dir? (config/get-repo-dir repo))))
     (state/set-nfs-refreshing! true)
     (p/let [_ (reload-dir! repo)
             _ (ok-handler)]

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1699,3 +1699,7 @@
   [repo]
   (:feature/enable-encryption?
    (get (sub-config) repo)))
+
+(defn unlinked-dir?
+  [dir]
+  (contains? (:file/unlinked-dirs @state) dir))

--- a/yarn.lock
+++ b/yarn.lock
@@ -6806,6 +6806,11 @@ react-grid-layout@0.16.6:
     react-draggable "3.x"
     react-resizable "1.x"
 
+react-icon-base@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-icon-base/-/react-icon-base-2.1.0.tgz#a196e33fdf1e7aaa1fda3aefbb68bdad9e82a79d"
+  integrity sha512-9wwKJa2LB8ujtJB5MAXYYEM7JfYThZTj0YnfGxzLLWkifaLIGc7iTde2EpJ7ka5MjneRHnlxbIn5VV9k2WjUVA==
+
 react-icon-base@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/react-icon-base/-/react-icon-base-2.1.2.tgz#a17101dad9c1192652356096860a9ab43a0766c7"
@@ -6815,8 +6820,6 @@ react-icons@2.2.7:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-2.2.7.tgz#d7860826b258557510dac10680abea5ca23cf650"
   integrity sha512-0n4lcGqzJFcIQLoQytLdJCE0DKSA9dkwEZRYoGrIDJZFvIT6Hbajx5mv9geqhqFiNjUgtxg8kPyDfjlhymbGFg==
-  dependencies:
-    react-icon-base "2.1.0"
 
 react-is@^16.13.1, react-is@^16.3.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
Also, disabled both re-index and refresh when logseq detects that a graph's dir doesn't exist anymore.

Related to https://github.com/logseq/logseq/issues/5549#issuecomment-1151000104

Demo:
https://www.loom.com/share/03a0ee11328d4d7c99966a6c1d8ec449