### PR TITLE
Icon alignment + various little UI changes

### DIFF
--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -808,6 +808,14 @@ li p:last-child,
   border-right-color: var(--ls-border-color, #ccc);
 }
 
+i.ti {
+  /*
+  compensates the wrong top spacing in the iconfont.
+  See https://github.com/tabler/tabler-icons/issues/118/
+  */
+  transform: translateY(-1px);
+}
+
 .dnd-separator {
   border-bottom: 3px solid #ccc;
 }

--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -25,7 +25,7 @@
 
 (rum/defc home-button []
   (ui/with-shortcut :go/home "left"
-    [:a.button
+    [:button.button.icon.inline
      {:href     (rfe/href :home)
       :on-click #(do
                    (when (mobile-util/native-iphone?)
@@ -40,13 +40,13 @@
       (if (user-handler/logged-in?)
         (ui/dropdown-with-links
          (fn [{:keys [toggle-fn]}]
-           [:a.button
+           [:button.button
             {:on-click toggle-fn}
             [:span.text-sm.font-medium (user-handler/email)]])
          [{:title (t :logout)
            :options {:on-click user-handler/logout}}]
          {})
-        [:a.button.text-sm.font-medium.block {:on-click #(js/window.open config/LOGIN-URL)}
+        [:button.button.text-sm.font-medium.block {:on-click #(js/window.open config/LOGIN-URL)}
          [:span (t :login)]]))))
 
 (rum/defcs file-sync-remote-graphs <
@@ -90,10 +90,10 @@
         (ui/dropdown-with-links
          (fn [{:keys [toggle-fn]}]
            (if not-syncing?
-             [:a.button
+             [:button.button.icon.inline
               {:on-click toggle-fn}
               (ui/icon "cloud-off" {:style {:fontSize ui/icon-size}})]
-             [:a.button
+             [:button.button.icon.inline
               {:on-click toggle-fn}
               (ui/icon "cloud" {:style {:fontSize ui/icon-size}})]))
          (cond-> []
@@ -131,11 +131,9 @@
 (rum/defc left-menu-button < rum/reactive
   [{:keys [on-click]}]
   (ui/with-shortcut :ui/toggle-left-sidebar "bottom"
-    [:a#left-menu.cp__header-left-menu.button
-     {:on-click on-click
-      :style    {:margin-left 12}}
-     [:span.inner
-      (ui/icon "menu-2" {:style {:fontSize ui/icon-size}})]]))
+    [:button.#left-menu.cp__header-left-menu.button.icon
+     {:on-click on-click}
+      (ui/icon "menu-2" {:style {:fontSize ui/icon-size}})]))
 
 (rum/defc dropdown-menu < rum/reactive
   [{:keys [current-repo t]}]
@@ -144,7 +142,7 @@
                            (concat page-menu [{:hr true}]))]
     (ui/dropdown-with-links
      (fn [{:keys [toggle-fn]}]
-       [:a.button
+       [:button.button.icon
         {:on-click toggle-fn}
         (ui/icon "dots" {:style {:fontSize ui/icon-size}})])
      (->>
@@ -188,12 +186,12 @@
   [:div.flex.flex-row
 
    (ui/with-shortcut :go/backward "bottom"
-     [:a.it.navigation.nav-left.button
+     [:button.it.navigation.nav-left.button.icon
       {:title "Go back" :on-click #(js/window.history.back)}
       (ui/icon "arrow-left" {:style {:fontSize ui/icon-size}})])
 
    (ui/with-shortcut :go/forward "bottom"
-     [:a.it.navigation.nav-right.button
+     [:button.it.navigation.nav-right.button.icon
       {:title "Go forward" :on-click #(js/window.history.forward)}
       (ui/icon "arrow-right" {:style {:fontSize ui/icon-size}})])])
 
@@ -244,12 +242,12 @@
                                       (.. target -classList (contains "cp__header")))
                              (js/window.apis.toggleMaxOrMinActiveWindow))))
       :style           {:fontSize  50}}
-     [:div.l.flex
+     [:div.l.flex.gap-1
       (when-not (mobile-util/native-platform?)
         [left-menu
          (when current-repo ;; this is for the Search button
            (ui/with-shortcut :go/search "right"
-             [:a.button#search-button
+             [:button.button.icon#search-button
               {:on-click #(do (when (or (mobile-util/native-android?)
                                         (mobile-util/native-iphone?))
                                 (state/set-left-sidebar-open! false))
@@ -259,11 +257,11 @@
         (if (state/home?)
           left-menu
           (ui/with-shortcut :go/backward "bottom"
-            [:a.it.navigation.nav-left.button
+            [:button.it.navigation.nav-left.button.icon
              {:title "Go back" :on-click #(js/window.history.back)}
              (ui/icon "chevron-left" {:style {:fontSize 25}})])))]
 
-     [:div.r.flex
+     [:div.r.flex.gap-1
       (when-not file-sync-handler/hiding-login&file-sync
         (file-sync))
       (when-not file-sync-handler/hiding-login&file-sync
@@ -281,7 +279,7 @@
         (new-block-mode))
 
       (when show-open-folder?
-        [:a.text-sm.font-medium.button.add-graph-btn.flex.items-center
+        [:a.text-sm.font-medium.button.icon.add-graph-btn.flex.items-center
          {:on-click #(route-handler/redirect! {:to :repo-add})}
          (ui/icon "folder-plus")
          (when-not config/mobile?
@@ -289,7 +287,7 @@
             (t :on-boarding/add-graph)])])
 
       (when config/publishing?
-        [:a.text-sm.font-medium.button {:href (rfe/href :graph)}
+        [:button.text-sm.font-medium.button {:href (rfe/href :graph)}
          (t :graph)])
 
       (dropdown-menu {:t            t

--- a/src/main/frontend/components/header.css
+++ b/src/main/frontend/components/header.css
@@ -17,6 +17,7 @@
   white-space: nowrap;
 
   > .l {
+    @apply pl-4;
     width: var(--ls-left-sidebar-width);
     height: 100%;
     align-items: center;
@@ -24,8 +25,8 @@
   }
 
   > .r {
+    @apply pr-4;
     align-items: center;
-    padding-right: 0.5rem;
     flex: 1;
     justify-content: flex-end;
   }
@@ -41,10 +42,7 @@
     transform: scale(0.8);
   }
 
-  a.button {
-    margin: 0 4px;
-    height: 30px;
-    min-width: 30px;
+  .button {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -119,18 +117,6 @@
       top: 1px;
     }
   }
-
-  &-left-menu {
-    &.button {
-      margin: 0;
-      padding: 0;
-    }
-
-    > .inner {
-      line-height: 0;
-      padding: 3px;
-    }
-  }
 }
 
 .is-electron.is-mac .cp__header {
@@ -191,11 +177,9 @@
   height: 14px;
 }
 
-a.button {
-  padding: 0.25rem;
-  opacity: 0.6;
+.button {
+  @apply h-8 px-2.5 py-1 rounded-md opacity-60;
   display: block;
-  border-radius: 4px;
   user-select: none;
 
   &:hover, &.active {
@@ -210,6 +194,10 @@ a.button {
   &:active {
     opacity: .7;
   }
+}
+
+.button.icon {
+  @apply w-8 h-8 text-lg p-1;
 }
 
 .is-mac.is-electron :is(.cp__header, .cp__right-sidebar-topbar) :is(button, .button, a) {
@@ -257,7 +245,7 @@ html.is-native-ipad {
       display: flex;
     }
 
-    a.button {
+    .button {
       opacity: 1;
     }
   }

--- a/src/main/frontend/components/onboarding/index.css
+++ b/src/main/frontend/components/onboarding/index.css
@@ -487,7 +487,7 @@ body[data-page=import] {
 
     .bd {
       ul a {
-        padding: 2px 4px !important;
+        padding: 2px 8px !important;
       }
     }
   }

--- a/src/main/frontend/components/right_sidebar.cljs
+++ b/src/main/frontend/components/right_sidebar.cljs
@@ -221,7 +221,7 @@
        [:div
         (toggle)]]
 
-      [:.sidebar-item-list.flex-1.scrollbar-spacing
+      [:.sidebar-item-list.flex-1.scrollbar-spacing.flex.flex-col.gap-2
        (if @*anim-finished?
          (for [[idx [repo db-id block-type]] (medley/indexed blocks)]
            (rum/with-key

--- a/src/main/frontend/components/right_sidebar.cljs
+++ b/src/main/frontend/components/right_sidebar.cljs
@@ -24,7 +24,7 @@
   []
   (when-not (util/mobile?)
     (ui/with-shortcut :ui/toggle-right-sidebar "left"
-      [:a.button.fade-link.toggle-right-sidebar
+      [:button.button.icon.fade-link.toggle-right-sidebar
        {:on-click ui-handler/toggle-right-sidebar!}
        (ui/icon "layout-sidebar-right" {:style {:fontSize "20px"}})])))
 
@@ -197,15 +197,15 @@
 
      (sidebar-resizer)
      [:div.cp__right-sidebar-scrollable
-      [:div.cp__right-sidebar-topbar.flex.flex-row.justify-between.items-center.pl-4.pr-2.h-12
-       [:div.cp__right-sidebar-settings.hide-scrollbar {:key "right-sidebar-settings"}
-        [:div.ml-4.text-sm
-         [:a.cp__right-sidebar-settings-btn {:on-click (fn [_e]
+      [:div.cp__right-sidebar-topbar.flex.flex-row.justify-between.items-center.pl-4.pr-4.h-12
+       [:div.cp__right-sidebar-settings.hide-scrollbar.gap-1 {:key "right-sidebar-settings"}
+        [:div.text-sm
+         [:button.button.cp__right-sidebar-settings-btn {:on-click (fn [_e]
                                                          (state/sidebar-add-block! repo "contents" :contents))}
           (t :right-side-bar/contents)]]
 
-        [:div.ml-4.text-sm
-         [:a.cp__right-sidebar-settings-btn {:on-click (fn []
+        [:div.text-sm
+         [:button.button.cp__right-sidebar-settings-btn {:on-click (fn []
                                                          (when-let [page (get-current-page)]
                                                            (state/sidebar-add-block!
                                                             repo
@@ -213,13 +213,12 @@
                                                             :page-graph)))}
           (t :right-side-bar/page)]]
 
-        [:div.ml-4.text-sm
-         [:a.cp__right-sidebar-settings-btn {:on-click (fn [_e]
+        [:div.text-sm
+         [:button.button.cp__right-sidebar-settings-btn {:on-click (fn [_e]
                                                          (state/sidebar-add-block! repo "help" :help))}
           (t :right-side-bar/help)]]]
 
-       [:div.flex.align-items {:style {:z-index 999
-                                       :margin-right 2}}
+       [:div
         (toggle)]]
 
       [:.sidebar-item-list.flex-1.scrollbar-spacing

--- a/src/main/frontend/components/sidebar.cljs
+++ b/src/main/frontend/components/sidebar.cljs
@@ -47,7 +47,7 @@
   [:div.nav-content-item.is-expand
    {:class class}
    [:div.nav-content-item-inner
-    [:div.header.items-center
+    [:div.header.items-center.mb-1
      {:on-click (fn [^js/MouseEvent e]
                   (let [^js target (.-target e)
                         ^js parent (.closest target ".nav-content-item")]

--- a/src/main/frontend/components/sidebar.cljs
+++ b/src/main/frontend/components/sidebar.cljs
@@ -47,7 +47,7 @@
   [:div.nav-content-item.is-expand
    {:class class}
    [:div.nav-content-item-inner
-    [:div.header.items-center.mb-1
+    [:div.header.items-center
      {:on-click (fn [^js/MouseEvent e]
                   (let [^js target (.-target e)
                         ^js parent (.closest target ".nav-content-item")]
@@ -223,11 +223,11 @@
                    (when (some (fn [sel] (boolean (.closest target sel)))
                                [".favorites .bd" ".recent .bd" ".dropdown-wrapper" ".nav-header"])
                      (close-modal-fn)))}
-     [:div.flex.flex-col.pb-4.wrap
-      [:nav.px-4.pt-1.space-y-1 {:aria-label "Sidebar"}
+     [:div.flex.flex-col.pb-4.wrap.gap-4
+      [:nav.px-4.flex.flex-col.gap-1 {:aria-label "Sidebar"}
        (repo/repos-dropdown)
 
-       [:div.nav-header
+       [:div.nav-header.flex.gap-1.flex-col
         (if-let [page (:page default-home)]
           (sidebar-item
             {:class            "home-nav"

--- a/src/main/frontend/components/sidebar.css
+++ b/src/main/frontend/components/sidebar.css
@@ -82,11 +82,13 @@
   }
 
   .page-icon {
+    @apply mr-1 align-baseline;
+    width: 16px;
+    height: 16px;
     text-align: center;
     display: inline-block;
     line-height: 1em;
-    color: #aaa;
-    padding: 0 4px 0 8px;
+    color: var(--ls-icon-color);
   }
 
   a.item {
@@ -120,12 +122,12 @@
     }
 
     .header {
+      @apply px-6 py-1;
       display: flex;
       justify-content: space-between;
       align-items: center;
       user-select: none;
       cursor: pointer;
-      padding: 4px 25px;
 
       > span {
         > a {
@@ -173,7 +175,6 @@
         > span {
           font-size: 11px;
           font-weight: 600;
-          padding-top: 2px;
         }
       }
     }
@@ -188,7 +189,7 @@
 
         a {
           width: 100%;
-          padding: 2px 18px;
+          padding: 2px 24px;
           display: block;
           text-overflow: ellipsis;
           overflow: hidden;

--- a/src/main/frontend/components/sidebar.css
+++ b/src/main/frontend/components/sidebar.css
@@ -92,7 +92,6 @@
   a.item {
     user-select: none;
     transition: background-color .3s;
-    margin-bottom: 2px;
 
     > .ti {
       font-size: 16px;
@@ -116,8 +115,6 @@
   }
 
   .nav-content-item {
-    margin-top: 14px;
-
     &-inner {
       border-radius: 8px;
     }
@@ -242,7 +239,7 @@
     background-color: var(--ls-secondary-background-color);
 
     > .wrap {
-      margin-top: 50px;
+      margin-top: 52px;
     }
 
     .new-page {
@@ -472,9 +469,7 @@ html[data-theme='dark'] {
   }
 
   .sidebar-item {
-    padding-top: 24px;
-    padding-bottom: 24px;
-    margin-bottom: 8px;
+    @apply p-4;
 
     .close {
       transform: scale(0.8);

--- a/src/main/frontend/components/sidebar.css
+++ b/src/main/frontend/components/sidebar.css
@@ -428,7 +428,6 @@ html[data-theme='dark'] {
 
   &-settings {
     @apply flex flex-row;
-    margin: -15px;
     margin-bottom: 0;
     margin-top: 0;
     overflow: auto;


### PR DESCRIPTION
Fixes #5652 and #5646.

- Header buttons now all have the same height (yes, some had a different height)  
- On the right sidebar, the clickable labels at the top ("Content", "Page graph", "Help") are now buttons with consistent styling (before, they weren't even links)  
- Header button, which were `a` tags, are now `button` tags (it's semantically more correct)  
- Buttons style now use more tailwindcss classes and less custom css, to improve consistency  
- I've replaced many margins and paddings with flex gaps, and I've reused the same gap size where possible, to make things consistent

I haven't been able to test the interface with some header buttons (the ones for previous and next page and some other ones...) because I don't exactly know how to show them. Please have a look at the UI yourself to check if everything is ok.

Before:

https://user-images.githubusercontent.com/23294184/173190893-bf41061d-3a66-46d7-bc5a-0e8405487a77.mp4

After:

https://user-images.githubusercontent.com/23294184/173190981-82f2f614-4619-4996-8ca0-ae92d283d141.mp4







