### PR TITLE
Ask bug reporters to use English

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report a bug encountered while using Logseq
+description: [PLEASE USE ENGLISH] Report a bug encountered while using Logseq.
 body:
   - type: textarea
     id: problem


### PR DESCRIPTION
The language of the Logseq repo is obviously English. Given that a [surprising](https://github.com/logseq/logseq/issues/5680) [number](https://github.com/logseq/logseq/issues/5653) of [bug](https://github.com/logseq/logseq/issues/5568) [reports](https://github.com/logseq/logseq/issues/5539) are [written](https://github.com/logseq/logseq/issues/5574) in [Chinese](https://github.com/logseq/logseq/issues/5687), it makes sense to ask bug reporters to please use English.

It would help if GitHub had an automatic translation feature (like Facebook group chat comments, for example), but that isn't the case yet).

Either party (bug reporters or bug readers / devs) can use an external translation tool, but the bug reporter only needs to do so once, while if they go ahead a report the bug in a non-English language, then every reader or dev would have to translate. In many cases this won't happen, which deprives the bug submitter of help they would otherwise get, if they posted in English.

Plus, if a bug submitter is asking devs to spend time examining their bug report, it seems polite to make it as easy as possible for the devs to do so, e.g. by removing the language barrier.