### PR TITLE
fix(editor): handle windows crlf in clipboard

### DIFF
--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -63,8 +63,8 @@
   [text e html]
   (util/stop e)
   (let [copied-blocks (state/get-copied-blocks)
-        copied-graph (:copy/graph copied-blocks)
         input (state/get-input)
+        text (string/replace text "\r\n" "\n") ;; Fix for Windows platform
         internal-paste? (and
                          (seq (:copy/blocks copied-blocks))
                          ;; not copied from the external clipboard


### PR DESCRIPTION
See-also #5723 

On Windows, \r\n is used when copying & cutting.

Known Issue: Close Logseq App then Re-open, this method fails.