### PR TITLE
fix(help): fix broken links and reorganize help menu

### DIFF
--- a/src/main/frontend/components/onboarding.cljs
+++ b/src/main/frontend/components/onboarding.cljs
@@ -23,7 +23,7 @@
                          [:span.mr-1 (t :help/shortcuts)]
                          (ui/icon "command" {:style {:font-size 20}})]]]
                       [(t :help/docs) "https://docs.logseq.com/"]
-                      [(t :help/start) "https://docs.logseq.com/#/page/tutorial?anchor=ls-block-62b17063-135d-4176-b755-fb5841556044"]
+                      [(t :help/start) "https://docs.logseq.com/#/page/tutorial"]
                       ["FAQ" "https://docs.logseq.com/#/page/faq"]]}
           
           {:title "Community"


### PR DESCRIPTION
This PR rearranges the items in the help menu on the right sidebar, adds the Logseq blog and fixes some broken links as reported on discord. 
@logseqramses 

Before: 
<img width="305" alt="Screenshot 2022-06-21 at 9 51 51 PM" src="https://user-images.githubusercontent.com/80150109/174866096-66635e58-e6bd-476e-b75b-636abc291701.png">


After:
<img width="577" alt="Screenshot 2022-06-21 at 9 51 12 PM" src="https://user-images.githubusercontent.com/80150109/174866058-12384da7-8da7-4c4e-a5e9-b13c41bea6dc.png">


