### PR TITLE
Disable gesture on query table and logbook

### DIFF
--- a/ios/App/App/capacitor.config.json
+++ b/ios/App/App/capacitor.config.json
@@ -17,9 +17,5 @@
 	},
 	"ios": {
 		"scheme": "Logseq"
-	},
-	"server": {
-		"url": "http://192.168.1.59:3001",
-		"cleartext": true
 	}
 }

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -156,6 +156,7 @@
                                   [:mobile :gestures/disabled-in-block-with-tags])]
     (or (.closest target ".dsl-query")
         (.closest target ".drawer")
+        (.closest target ".draw-wrap")
         (some #(.closest target (util/format "[data-refs-self*=%s]" %))
               user-defined-tags))))
 

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -150,22 +150,29 @@
 (def *swipe (atom nil))
 (def *touch-start (atom nil))
 
+(defn- target-disable-swipe?
+  [target]
+  (or (.closest target ".dsl-query")
+      (.closest target ".drawer")))
+
 (defn on-touch-start
   [event uuid]
-  (let [input (state/get-input)
+  (let [target (.-target event)
+        input (state/get-input)
         input-id (state/get-edit-input-id)
         selection-type (.-type (.getSelection js/document))]
     (reset! *touch-start (js/Date.now))
     (when-not (and input
                    (string/ends-with? input-id (str uuid)))
       (state/clear-edit!))
-    (when (not= selection-type "Range")
-      (when-let [touches (.-targetTouches event)]
-        (when (= (.-length touches) 1)
-          (let [touch (aget touches 0)
-                x (.-clientX touch)
-                y (.-clientY touch)]
-            (reset! *swipe {:x0 x :y0 y :xi x :yi y :tx x :ty y :direction nil})))))))
+    (when-not (target-disable-swipe? target)
+      (when (not= selection-type "Range")
+        (when-let [touches (.-targetTouches event)]
+          (when (= (.-length touches) 1)
+            (let [touch (aget touches 0)
+                  x (.-clientX touch)
+                  y (.-clientY touch)]
+              (reset! *swipe {:x0 x :y0 y :xi x :yi y :tx x :ty y :direction nil}))))))))
 
 (defn on-touch-move
   [event block uuid edit? *show-left-menu? *show-right-menu?]

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -152,8 +152,14 @@
 
 (defn- target-disable-swipe?
   [target]
-  (or (.closest target ".dsl-query")
-      (.closest target ".drawer")))
+  (let [user-defined-tags (get-in (state/get-config)
+                                  [:mobile :gestures/disabled-in-block-with-tags])]
+    (prn (some #(.closest target (util/format "[data-refs-self*=%s]" %))
+           user-defined-tags))
+    (or (.closest target ".dsl-query")
+        (.closest target ".drawer")
+        (some #(.closest target (util/format "[data-refs-self*=%s]" %))
+              user-defined-tags))))
 
 (defn on-touch-start
   [event uuid]

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -204,8 +204,8 @@
               (let [{:keys [x0 y0]} @*swipe
                     dx (- tx x0)
                     dy (- ty y0)]
-                (when (and (< (. js/Math abs dy) 20)
-                           (> (. js/Math abs dx) 10))
+                (when (and (< (. js/Math abs dy) 30)
+                           (> (. js/Math abs dx) 30))
                   (let [left (gdom/getElement (str "block-left-menu-" uuid))
                         right (gdom/getElement (str "block-right-menu-" uuid))]
 

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -154,8 +154,6 @@
   [target]
   (let [user-defined-tags (get-in (state/get-config)
                                   [:mobile :gestures/disabled-in-block-with-tags])]
-    (prn (some #(.closest target (util/format "[data-refs-self*=%s]" %))
-           user-defined-tags))
     (or (.closest target ".dsl-query")
         (.closest target ".drawer")
         (some #(.closest target (util/format "[data-refs-self*=%s]" %))

--- a/templates/config.edn
+++ b/templates/config.edn
@@ -223,6 +223,11 @@
  ;; :mobile/photo
  ;; {:allow-editing? true}
 
+ ;; Mobile features options
+ ;; Gestures
+ ;; :mobile
+ ;; {:gestures/disabled-in-block-with-tags ["kanban"]}
+
  ;; Extra CodeMirror options
  ;; :editor/extra-codemirror-options {:keyMap "emacs" :lineWrapping true}
 


### PR DESCRIPTION
1. Disabled gestures on query table, logbook, excalidraw . fix #5783, #5837
2. Disable gestures on blocks with customized tags in `config.edn` 
    ```
   :mobile
   {:gestures/disabled-in-block-with-tags ["kanban"]}
   ```
3. Increase the threshold to activate gestures to avoid conflicts with scroll.