### PR TITLE
fix(electron): check destroyed window before access property

### DIFF
--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -103,7 +103,9 @@
 (defn graph-has-other-windows? [win dir]
   (let [windows (get-graph-all-windows dir)]
         ;; windows (filter #(.isVisible %) windows) ;; for mac .hide windows. such windows should also included
-    (boolean (some (fn [^js window] (not= (.-id win) (.-id window))) windows))))
+    (boolean (some (fn [^js window] (and (not (.isDestroyed window))
+                                         (not= (.-id win) (.-id window))))
+                   windows))))
 
 (defn- open-default-app!
   [url default-open]


### PR DESCRIPTION
Fix #5771

When a window is destroyed, any property access will fail.