### PR TITLE
fix bilibili video progress bar display

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1139,7 +1139,7 @@
       (when-not (string/blank? id)
         (let [width (min (- (util/get-width) 96)
                          560)
-              height (int (* width (/ 315 560)))]
+              height (int (* width (/ 360 560)))]
           [:iframe
            {:allowfullscreen true
             :framespacing "0"


### PR DESCRIPTION
close https://github.com/logseq/logseq/issues/5820
修改b站视频进度条显示问题