### PR TITLE
Reduce flicker when moving between blocks with keyboard

### DIFF
--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -878,7 +878,7 @@ h1.title {
 
 .block-highlight,
 .content .selected {
-  transition: background-color 0.15s;
+  transition: background-color 0.2s cubic-bezier(0, 1, 0, 1);
   background-color: var(--ls-block-highlight-color);
   padding: -1px;
 }

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -335,6 +335,7 @@
   min-height: 24px;
   padding: 2px 0;
   border-bottom: 1px solid transparent;
+  transition: background-color 0.3s cubic-bezier(0.16, 1, 0.3, 1);
 
   &.selected {
     border-bottom-color: var(--ls-primary-background-color);


### PR DESCRIPTION
This reduces a flickery appearance I was noticing when moving between blocks with the up/down arrow keys, by changing the ease function to be a fast ease-out bezier (specifically, easeOutQart from here: https://easings.net/ for easing the color out, and the stiffer https://cubic-bezier.com/?#0,1,0,1 for easing the new color in, so that the new color is transitioned in before the old one is coming out)

It's most pronounced when navigating nested blocks.

I'm not sure why matching eases don't result in the backgrounds adding up to 100% when a child is easing out and a parent is easing in or vice-versa, but I found these curves have the best result from testing. Maybe the removing of one class and adding of the other class happen asynchronously / not in the same JS frame? Or backgrounds don't add up the way I thought they did.

Before:
<video src="https://user-images.githubusercontent.com/491376/175873656-948641ce-4d6f-45b1-af96-68520234a5a9.mp4"/>

After:
<video src="https://user-images.githubusercontent.com/491376/175875109-c60ac591-0f78-4acd-ba75-58800c062c09.mp4"/>
