### PR TITLE
feat: open plaintext assets in logseq

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/config.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/config.cljs
@@ -31,7 +31,7 @@
 (defn text-formats
   []
   #{:json :org :md :yml :dat :asciidoc :rst :txt :markdown :adoc :html :js :ts :edn :clj :ml :rb :ex :erl :java :php :c :css
-    :excalidraw})
+    :excalidraw :sh})
 
 (defn img-formats
   []

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -273,8 +273,8 @@
     (when @src
       (let [ext (keyword (util/get-file-ext @src))
             repo (state/get-current-repo)
-            repo-dir (config/get-repo-dir (state/get-current-repo))
-            path (str (config/get-repo-dir repo) href)
+            repo-dir (config/get-repo-dir repo)
+            path (str repo-dir href)
             share-fn (fn [event]
                        (util/stop event)
                        (when (mobile-util/native-platform?)


### PR DESCRIPTION
On mobile, it's hard to open plaintext assets by external viewers, since not all users have those viewers installed. 
This PR made Logseq open those asset links internally by CodeMirror, which makes external viewers no needed anymore. 