### PR TITLE
fix key duplicates caused by key case when insert page property

### DIFF
--- a/src/main/frontend/util/page_property.cljs
+++ b/src/main/frontend/util/page_property.cljs
@@ -13,15 +13,15 @@
     (let [key (if (string? key) (keyword key) key)
           key-part (util/format (case format
                                   :org "#+%s: "
-                                  "%s:: ") (string/upper-case (name key)))
+                                  "%s:: ") (string/lower-case (name key)))
           new-property-line (str key-part value)
           lines (string/split-lines content)
           key-exists? (atom false)
           lines (doall
                  (map (fn [line]
                         (if (and (string/starts-with?
-                                  (string/upper-case line)
-                                  (string/upper-case key-part))
+                                  (string/lower-case line)
+                                  (string/lower-case key-part))
                                  (not @key-exists?)) ; only replace the first match
                           (do
                             (reset! key-exists? true)

--- a/src/main/frontend/util/page_property.cljs
+++ b/src/main/frontend/util/page_property.cljs
@@ -13,13 +13,16 @@
     (let [key (if (string? key) (keyword key) key)
           key-part (util/format (case format
                                   :org "#+%s: "
-                                  "%s:: ") (name key))
+                                  "%s:: ") (string/upper-case (name key)))
           new-property-line (str key-part value)
           lines (string/split-lines content)
           key-exists? (atom false)
           lines (doall
                  (map (fn [line]
-                        (if (and (string/starts-with? line key-part) (not @key-exists?)) ; only replace the first match
+                        (if (and (string/starts-with?
+                                  (string/upper-case line)
+                                  (string/upper-case key-part))
+                                 (not @key-exists?)) ; only replace the first match
                           (do
                             (reset! key-exists? true)
                             new-property-line)

--- a/src/test/frontend/util/page_property_test.cljs
+++ b/src/test/frontend/util/page_property_test.cljs
@@ -6,99 +6,99 @@
   (testing "add org page property"
     (are [x y] (= x y)
       (property/insert-property :org "" :title "title")
-      "#+title: title"
+      "#+TITLE: title"
 
       (property/insert-property :org "hello" :title "title")
-      "#+title: title\nhello"
+      "#+TITLE: title\nhello"
 
-      (property/insert-property :org "#+title: title\nhello" :title "new title")
-      "#+title: new title\nhello"
+      (property/insert-property :org "#+TITLE: title\nhello" :title "new title")
+      "#+TITLE: new title\nhello"
 
-      (property/insert-property :org "#+title: title\nhello" :alias "alias1")
-      "#+alias: alias1\n#+title: title\nhello"
+      (property/insert-property :org "#+TITLE: title\nhello" :alias "alias1")
+      "#+ALIAS: alias1\n#+TITLE: title\nhello"
 
-      (property/insert-property :org "#+title: title\n#+alias: alias1\nhello" :alias "alias2")
-      "#+title: title\n#+alias: alias2\nhello"
+      (property/insert-property :org "#+TITLE: title\n#+ALIAS: alias1\nhello" :alias "alias2")
+      "#+TITLE: title\n#+ALIAS: alias2\nhello"
 
-      (property/insert-property :org "#+title: title\n#+alias: alias1, alias2\nhello" :alias "alias3")
-      "#+title: title\n#+alias: alias3\nhello"))
+      (property/insert-property :org "#+TITLE: title\n#+ALIAS: alias1, alias2\nhello" :alias "alias3")
+      "#+TITLE: title\n#+ALIAS: alias3\nhello"))
 
   (testing "add markdown page property"
     (are [x y] (= x y)
       (property/insert-property :markdown "" :title "title")
-      "title:: title"
+      "TITLE:: title"
 
       (property/insert-property :markdown "hello" :title "title")
-      "title:: title\nhello"
+      "TITLE:: title\nhello"
 
-      (property/insert-property :markdown "title:: title\nhello" :title "new title")
-      "title:: new title\nhello"
+      (property/insert-property :markdown "TITLE:: title\nhello" :title "new title")
+      "TITLE:: new title\nhello"
 
-      (property/insert-property :markdown "title:: title\nhello" :alias "alias1")
-      "alias:: alias1\ntitle:: title\nhello"
+      (property/insert-property :markdown "TITLE:: title\nhello" :alias "alias1")
+      "ALIAS:: alias1\nTITLE:: title\nhello"
 
-      (property/insert-property :markdown "title:: title\nalias:: alias1\nhello" :alias "alias2")
-      "title:: title\nalias:: alias2\nhello"
+      (property/insert-property :markdown "TITLE:: title\nALIAS:: alias1\nhello" :alias "alias2")
+      "TITLE:: title\nALIAS:: alias2\nhello"
 
-      (property/insert-property :markdown "title:: title\nalias:: alias1, alias2\nhello" :alias "alias3")
-      "title:: title\nalias:: alias3\nhello"
+      (property/insert-property :markdown "TITLE:: title\nALIAS:: alias1, alias2\nhello" :alias "alias3")
+      "TITLE:: title\nALIAS:: alias3\nhello"
 
-      (property/insert-property :markdown "title:: title\nalias:: alias1, alias2\nhello" :aliases "aliases1")
-      "aliases:: aliases1\ntitle:: title\nalias:: alias1, alias2\nhello"
+      (property/insert-property :markdown "TITLE:: title\nALIAS:: alias1, alias2\nhello" :aliases "aliases1")
+      "ALIASES:: aliases1\nTITLE:: title\nALIAS:: alias1, alias2\nhello"
 
-      (property/insert-property :markdown "title:: title\nalias:: alias1, alias2\naliases:: aliases1\nhello" :aliases "aliases2")
-      "title:: title\nalias:: alias1, alias2\naliases:: aliases2\nhello")))
+      (property/insert-property :markdown "TITLE:: title\nALIAS:: alias1, alias2\nALIASES:: aliases1\nhello" :aliases "aliases2")
+      "TITLE:: title\nALIAS:: alias1, alias2\nALIASES:: aliases2\nhello")))
 
 (deftest test-insert-properties
   (testing "add org page properties"
     (are [x y] (= x y)
 
       (property/insert-properties :org "" {:title "title"})
-      "#+title: title"
+      "#+TITLE: title"
 
       (property/insert-properties :org "hello" {:title "title"})
-      "#+title: title\nhello"
+      "#+TITLE: title\nhello"
 
-      (property/insert-properties :org "#+title: title\nhello"
+      (property/insert-properties :org "#+TITLE: title\nhello"
                                   {:title "new title"
                                    :alias "alias1"})
-      "#+alias: alias1\n#+title: new title\nhello"
+      "#+ALIAS: alias1\n#+TITLE: new title\nhello"
 
-      (property/insert-properties :org "#+title: title\n#+alias: alias1\nhello"
+      (property/insert-properties :org "#+TITLE: title\n#+ALIAS: alias1\nhello"
                                   {:title "new title"
                                    :alias "alias2"
                                    :aliases "aliases1"})
-      "#+aliases: aliases1\n#+title: new title\n#+alias: alias2\nhello"
+      "#+ALIASES: aliases1\n#+TITLE: new title\n#+ALIAS: alias2\nhello"
 
-      (property/insert-properties :org "#+title: title\n#+alias: alias1, alias2\n#+aliases: aliases1\nhello"
+      (property/insert-properties :org "#+TITLE: title\n#+ALIAS: alias1, alias2\n#+ALIASES: aliases1\nhello"
                                   {:title "new title"
                                    :alias "alias2"
                                    :aliases "aliases1"})
-      "#+title: new title\n#+alias: alias2\n#+aliases: aliases1\nhello"))
+      "#+TITLE: new title\n#+ALIAS: alias2\n#+ALIASES: aliases1\nhello"))
 
   (testing "add markdown page properties"
     (are [x y] (= x y)
       (property/insert-properties :markdown "" {:title "title"})
-      "title:: title"
+      "TITLE:: title"
 
       (property/insert-properties :markdown "hello" {:title "title"})
-      "title:: title\nhello"
+      "TITLE:: title\nhello"
 
-      (property/insert-properties :markdown "title:: title\nhello"
+      (property/insert-properties :markdown "TITLE:: title\nhello"
                                   {:title "new title"
                                    :alias "alias1"})
-      "alias:: alias1\ntitle:: new title\nhello"
+      "ALIAS:: alias1\nTITLE:: new title\nhello"
 
-      (property/insert-properties :markdown "title:: title\nalias:: alias1\nhello"
+      (property/insert-properties :markdown "TITLE:: title\nalias:: alias1\nhello"
                                   {:title "new title"
                                    :alias "alias2"
                                    :aliases "aliases1"})
-      "aliases:: aliases1\ntitle:: new title\nalias:: alias2\nhello"
+      "ALIASES:: aliases1\nTITLE:: new title\nALIAS:: alias2\nhello"
 
-      (property/insert-properties :markdown "title:: title\nalias:: alias1, alias2\naliases:: aliases1\nhello"
+      (property/insert-properties :markdown "TITLE:: title\nALIAS:: alias1, alias2\nALIASES:: aliases1\nhello"
                                   {:title "new title"
                                    :alias "alias2"
                                    :aliases "aliases1"})
-      "title:: new title\nalias:: alias2\naliases:: aliases1\nhello")))
+      "TITLE:: new title\nALIAS:: alias2\nALIASES:: aliases1\nhello")))
 
 #_(cljs.test/run-tests)

--- a/src/test/frontend/util/page_property_test.cljs
+++ b/src/test/frontend/util/page_property_test.cljs
@@ -6,99 +6,99 @@
   (testing "add org page property"
     (are [x y] (= x y)
       (property/insert-property :org "" :title "title")
-      "#+TITLE: title"
+      "#+title: title"
 
       (property/insert-property :org "hello" :title "title")
-      "#+TITLE: title\nhello"
+      "#+title: title\nhello"
 
-      (property/insert-property :org "#+TITLE: title\nhello" :title "new title")
-      "#+TITLE: new title\nhello"
+      (property/insert-property :org "#+title: title\nhello" :title "new title")
+      "#+title: new title\nhello"
 
-      (property/insert-property :org "#+TITLE: title\nhello" :alias "alias1")
-      "#+ALIAS: alias1\n#+TITLE: title\nhello"
+      (property/insert-property :org "#+title: title\nhello" :alias "alias1")
+      "#+alias: alias1\n#+title: title\nhello"
 
-      (property/insert-property :org "#+TITLE: title\n#+ALIAS: alias1\nhello" :alias "alias2")
-      "#+TITLE: title\n#+ALIAS: alias2\nhello"
+      (property/insert-property :org "#+title: title\n#+alias: alias1\nhello" :alias "alias2")
+      "#+title: title\n#+alias: alias2\nhello"
 
-      (property/insert-property :org "#+TITLE: title\n#+ALIAS: alias1, alias2\nhello" :alias "alias3")
-      "#+TITLE: title\n#+ALIAS: alias3\nhello"))
+      (property/insert-property :org "#+title: title\n#+alias: alias1, alias2\nhello" :alias "alias3")
+      "#+title: title\n#+alias: alias3\nhello"))
 
   (testing "add markdown page property"
     (are [x y] (= x y)
       (property/insert-property :markdown "" :title "title")
-      "TITLE:: title"
+      "title:: title"
 
       (property/insert-property :markdown "hello" :title "title")
-      "TITLE:: title\nhello"
+      "title:: title\nhello"
 
-      (property/insert-property :markdown "TITLE:: title\nhello" :title "new title")
-      "TITLE:: new title\nhello"
+      (property/insert-property :markdown "title:: title\nhello" :title "new title")
+      "title:: new title\nhello"
 
-      (property/insert-property :markdown "TITLE:: title\nhello" :alias "alias1")
-      "ALIAS:: alias1\nTITLE:: title\nhello"
+      (property/insert-property :markdown "title:: title\nhello" :alias "alias1")
+      "alias:: alias1\ntitle:: title\nhello"
 
-      (property/insert-property :markdown "TITLE:: title\nALIAS:: alias1\nhello" :alias "alias2")
-      "TITLE:: title\nALIAS:: alias2\nhello"
+      (property/insert-property :markdown "title:: title\nalias:: alias1\nhello" :alias "alias2")
+      "title:: title\nalias:: alias2\nhello"
 
-      (property/insert-property :markdown "TITLE:: title\nALIAS:: alias1, alias2\nhello" :alias "alias3")
-      "TITLE:: title\nALIAS:: alias3\nhello"
+      (property/insert-property :markdown "title:: title\nalias:: alias1, alias2\nhello" :alias "alias3")
+      "title:: title\nalias:: alias3\nhello"
 
-      (property/insert-property :markdown "TITLE:: title\nALIAS:: alias1, alias2\nhello" :aliases "aliases1")
-      "ALIASES:: aliases1\nTITLE:: title\nALIAS:: alias1, alias2\nhello"
+      (property/insert-property :markdown "title:: title\nalias:: alias1, alias2\nhello" :aliases "aliases1")
+      "aliases:: aliases1\ntitle:: title\nalias:: alias1, alias2\nhello"
 
-      (property/insert-property :markdown "TITLE:: title\nALIAS:: alias1, alias2\nALIASES:: aliases1\nhello" :aliases "aliases2")
-      "TITLE:: title\nALIAS:: alias1, alias2\nALIASES:: aliases2\nhello")))
+      (property/insert-property :markdown "title:: title\nalias:: alias1, alias2\naliases:: aliases1\nhello" :aliases "aliases2")
+      "title:: title\nalias:: alias1, alias2\naliases:: aliases2\nhello")))
 
 (deftest test-insert-properties
   (testing "add org page properties"
     (are [x y] (= x y)
 
       (property/insert-properties :org "" {:title "title"})
-      "#+TITLE: title"
+      "#+title: title"
 
       (property/insert-properties :org "hello" {:title "title"})
-      "#+TITLE: title\nhello"
+      "#+title: title\nhello"
 
-      (property/insert-properties :org "#+TITLE: title\nhello"
+      (property/insert-properties :org "#+title: title\nhello"
                                   {:title "new title"
                                    :alias "alias1"})
-      "#+ALIAS: alias1\n#+TITLE: new title\nhello"
+      "#+alias: alias1\n#+title: new title\nhello"
 
-      (property/insert-properties :org "#+TITLE: title\n#+ALIAS: alias1\nhello"
+      (property/insert-properties :org "#+title: title\n#+alias: alias1\nhello"
                                   {:title "new title"
                                    :alias "alias2"
                                    :aliases "aliases1"})
-      "#+ALIASES: aliases1\n#+TITLE: new title\n#+ALIAS: alias2\nhello"
+      "#+aliases: aliases1\n#+title: new title\n#+alias: alias2\nhello"
 
-      (property/insert-properties :org "#+TITLE: title\n#+ALIAS: alias1, alias2\n#+ALIASES: aliases1\nhello"
+      (property/insert-properties :org "#+title: title\n#+alias: alias1, alias2\n#+aliases: aliases1\nhello"
                                   {:title "new title"
                                    :alias "alias2"
                                    :aliases "aliases1"})
-      "#+TITLE: new title\n#+ALIAS: alias2\n#+ALIASES: aliases1\nhello"))
+      "#+title: new title\n#+alias: alias2\n#+aliases: aliases1\nhello"))
 
   (testing "add markdown page properties"
     (are [x y] (= x y)
       (property/insert-properties :markdown "" {:title "title"})
-      "TITLE:: title"
+      "title:: title"
 
       (property/insert-properties :markdown "hello" {:title "title"})
-      "TITLE:: title\nhello"
+      "title:: title\nhello"
 
-      (property/insert-properties :markdown "TITLE:: title\nhello"
+      (property/insert-properties :markdown "title:: title\nhello"
                                   {:title "new title"
                                    :alias "alias1"})
-      "ALIAS:: alias1\nTITLE:: new title\nhello"
+      "alias:: alias1\ntitle:: new title\nhello"
 
-      (property/insert-properties :markdown "TITLE:: title\nalias:: alias1\nhello"
+      (property/insert-properties :markdown "title:: title\nalias:: alias1\nhello"
                                   {:title "new title"
                                    :alias "alias2"
                                    :aliases "aliases1"})
-      "ALIASES:: aliases1\nTITLE:: new title\nALIAS:: alias2\nhello"
+      "aliases:: aliases1\ntitle:: new title\nalias:: alias2\nhello"
 
-      (property/insert-properties :markdown "TITLE:: title\nALIAS:: alias1, alias2\nALIASES:: aliases1\nhello"
+      (property/insert-properties :markdown "title:: title\nalias:: alias1, alias2\naliases:: aliases1\nhello"
                                   {:title "new title"
                                    :alias "alias2"
                                    :aliases "aliases1"})
-      "TITLE:: new title\nALIAS:: alias2\nALIASES:: aliases1\nhello")))
+      "title:: new title\nalias:: alias2\naliases:: aliases1\nhello")))
 
 #_(cljs.test/run-tests)


### PR DESCRIPTION
Always insert a lower-cased key, and replace the uppercased key with a lower-cased one.
fix #5826