### PR TITLE
(chore): Update getAllPages typescript

### DIFF
--- a/libs/src/LSPlugin.ts
+++ b/libs/src/LSPlugin.ts
@@ -196,6 +196,7 @@ export interface PageEntity {
   children?: Array<PageEntity>
   format?: 'markdown' | 'org'
   journalDay?: number
+  updatedAt?: number
 }
 
 export type BlockIdentity = BlockUUID | Pick<BlockEntity, 'uuid'>

--- a/libs/src/LSPlugin.ts
+++ b/libs/src/LSPlugin.ts
@@ -622,7 +622,7 @@ export interface IEditorProxy extends Record<string, any> {
 
   renamePage: (oldName: string, newName: string) => Promise<void>
 
-  getAllPages: (repo?: string) => Promise<any>
+  getAllPages: (repo?: string) => Promise<PageEntity[] | null>
 
   prependBlockInPage: (
     page: PageIdentity,


### PR DESCRIPTION
I noticed this response was `any`, when it could be a more specific array of `PageEntity`'s. I added `| null` since some other types have that, and figured its safe to assume that's what logseq returns if it can't get the pages for whatever reason.

This is my first logseq PR so let me know if I need to add anything