### PR TITLE
fix(ui) trailing space of search-auto-complete

### DIFF
--- a/src/main/frontend/components/search.cljs
+++ b/src/main/frontend/components/search.cljs
@@ -188,7 +188,7 @@
 
        :new-page
        [:div.text.font-bold (str (t :new-page) ": ")
-        [:span.ml-1 (str "\"" search-q "\"")]]
+        [:span.ml-1 (str "\"" (string/trim search-q) "\"")]]
 
        :page
        [:span {:data-page-ref data}


### PR DESCRIPTION
Before:
<img width="426" alt="image" src="https://user-images.githubusercontent.com/72891/177122206-f3703a51-3569-40ac-b0bb-ee12081f87c9.png">

