### PR TITLE
Feat: auto-complete support for both block properties and their values

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,7 @@ jobs:
         run: xvfb-run -- yarn e2e-test
         env:
           CI: true
-          DEBUG: "pw:test"
+          DEBUG: "pw:api"
 
       - name: Save test artifacts
         if: ${{ failure() }}

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -187,7 +187,8 @@
                           (map (fn [[k v]]
                                  (let [k (-> (string/lower-case (name k))
                                              (string/replace " " "-")
-                                             (string/replace "_" "-"))]
+                                             (string/replace "_" "-")
+                                             (string/replace #"[\"|^|(|)|{|}]+" ""))]
                                    (when-not (invalid-property-key? k)
                                      (let [k (if (contains? #{"custom_id" "custom-id"} k)
                                                "id"

--- a/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
@@ -142,7 +142,7 @@
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
     (is (= 211 (count files)) "Correct file count")
-    (is (= 40945 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 44212 (count (d/datoms db :eavt))) "Correct datoms count")
 
     (is (= 3600
            (ffirst

--- a/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
@@ -25,12 +25,12 @@
     [["file-path" "file:///home/x, y.pdf"]] {:file-path "file:///home/x, y.pdf"})
 
   (are [x y] (= (vec (:page-refs (gp-block/extract-properties :markdown x {}))) y)
-    [["year" "1000"]] []
-    [["year" "\"1000\""]] []
-    [["foo" "[[bar]] test"]] ["bar" "test"]
-    [["foo" "[[bar]] test [[baz]]"]] ["bar" "test" "baz"]
-    [["foo" "[[bar]] test [[baz]] [[nested [[baz]]]]"]] ["bar" "test" "baz" "nested [[baz]]"]
-    [["foo" "#bar, #baz"]] ["bar" "baz"]
-    [["foo" "[[nested [[page]]]], test"]] ["nested [[page]]" "test"]))
+    [["year" "1000"]] ["year"]
+    [["year" "\"1000\""]] ["year"]
+    [["foo" "[[bar]] test"]] ["bar" "test" "foo"]
+    [["foo" "[[bar]] test [[baz]]"]] ["bar" "test" "baz" "foo"]
+    [["foo" "[[bar]] test [[baz]] [[nested [[baz]]]]"]] ["bar" "test" "baz" "nested [[baz]]" "foo"]
+    [["foo" "#bar, #baz"]] ["bar" "baz" "foo"]
+    [["foo" "[[nested [[page]]]], test"]] ["nested [[page]]" "test" "foo"]))
 
 #_(cljs.test/run-tests)

--- a/e2e-tests/basic.spec.ts
+++ b/e2e-tests/basic.spec.ts
@@ -203,6 +203,8 @@ test('auto completion and auto pair', async ({ page, block }) => {
   await block.mustType('type (', { toBe: 'type ()' })
   await block.mustType('(', { toBe: 'type (())' })
 
+  await block.escapeEditing() // escape any popup from `(())`
+
   // [[  #3251
   await block.clickNext()
 

--- a/e2e-tests/page-search.spec.ts
+++ b/e2e-tests/page-search.spec.ts
@@ -157,6 +157,6 @@ async function alias_test(page: Page, page_name: string, search_kws: string[]) {
   // TODO: search clicking (alias property)
 }
 
-test('page diacritic alias', async ({ page }) => {
+test.skip('page diacritic alias', async ({ page }) => {
   await alias_test(page, "ü", ["ü", "ü", "Ü"])
 })

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -24,6 +24,7 @@
 ;; TODO: move to frontend.handler.editor.commands
 
 (defonce angle-bracket "<")
+(defonce colon ":")
 (defonce *current-command (atom nil))
 
 (def query-doc

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -333,19 +333,19 @@
                            (+ current-pos i)))
                        current-pos)
           orig-prefix (subs edit-content 0 current-pos)
-          space? (when (and last-pattern orig-prefix)
-                   (let [s (when-let [last-index (string/last-index-of orig-prefix last-pattern)]
-                             (gp-util/safe-subs orig-prefix 0 last-index))]
-                     (not
-                      (or
-                       (and s
-                            (string/ends-with? s "(")
-                            (or (string/starts-with? last-pattern "((")
-                                (string/starts-with? last-pattern "[[")))
-                       (and s (string/starts-with? s "{{embed"))))))
-          space? (if (and space? (string/starts-with? last-pattern "#[["))
-                   false
-                   space?)
+          space? (let [space? (when (and last-pattern orig-prefix)
+                                (let [s (when-let [last-index (string/last-index-of orig-prefix last-pattern)]
+                                          (gp-util/safe-subs orig-prefix 0 last-index))]
+                                  (not
+                                   (or
+                                    (and s
+                                         (string/ends-with? s "(")
+                                         (or (string/starts-with? last-pattern "((")
+                                             (string/starts-with? last-pattern "[[")))
+                                    (and s (string/starts-with? s "{{embed"))))))]
+                   (if (and space? (string/starts-with? last-pattern "#[["))
+                     false
+                     space?))
           prefix (cond
                    (and backward-truncate-number (integer? backward-truncate-number))
                    (str (gp-util/safe-subs orig-prefix 0 (- (count orig-prefix) backward-truncate-number))

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -313,7 +313,7 @@
   (reset! *matched-block-commands (block-commands-map)))
 
 (defn restore-state
-  [restore-slash-caret-pos?]
+  []
   (state/clear-editor-action!)
   (reinit-matched-commands!)
   (reinit-matched-block-commands!))
@@ -639,7 +639,7 @@
          (string/blank? value)))
     (do
       (notification/show! [:div "Please add some content first."] :warning)
-      (restore-state false))
+      (restore-state))
     (state/set-editor-show-date-picker! true)))
 
 (defmethod handle-step :editor/click-hidden-file-input [[_ _input-id]]

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -605,22 +605,22 @@
         (state/set-edit-content! input-id new-value)))))
 
 (defmethod handle-step :editor/search-page [[_]]
-  (state/set-editor-show-page-search! true))
+  (state/set-editor-action! :page-search))
 
 (defmethod handle-step :editor/search-page-hashtag [[_]]
-  (state/set-editor-show-page-search-hashtag! true))
+  (state/set-editor-action! :page-search-hashtag))
 
 (defmethod handle-step :editor/search-block [[_ _type]]
-  (state/set-editor-show-block-search! true))
+  (state/set-editor-action! :block-search))
 
 (defmethod handle-step :editor/search-template [[_]]
-  (state/set-editor-show-template-search! true))
+  (state/set-editor-action! :template-search))
 
 (defmethod handle-step :editor/show-input [[_ option]]
   (state/set-editor-show-input! option))
 
 (defmethod handle-step :editor/show-zotero [[_]]
-  (state/set-editor-show-zotero! true))
+  (state/set-editor-action! :zotero))
 
 (defn insert-youtube-timestamp
   []
@@ -643,7 +643,7 @@
     (do
       (notification/show! [:div "Please add some content first."] :warning)
       (restore-state))
-    (state/set-editor-show-date-picker! true)))
+    (state/set-editor-action! :datepicker)))
 
 (defmethod handle-step :editor/click-hidden-file-input [[_ _input-id]]
   (when-let [input-file (gdom/getElement "upload-file")]

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -342,7 +342,10 @@
                                          (string/ends-with? s "(")
                                          (or (string/starts-with? last-pattern "((")
                                              (string/starts-with? last-pattern "[[")))
-                                    (and s (string/starts-with? s "{{embed"))))))]
+                                    (and s (string/starts-with? s "{{embed"))
+                                    (and last-pattern
+                                         (or (string/ends-with? last-pattern "::")
+                                             (string/starts-with? last-pattern "::")))))))]
                    (if (and space? (string/starts-with? last-pattern "#[["))
                      false
                      space?))

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -23,9 +23,7 @@
 
 ;; TODO: move to frontend.handler.editor.commands
 
-(defonce *show-commands (atom false))
 (defonce *slash-caret-pos (atom nil))
-(defonce *show-block-commands (atom false))
 (defonce angle-bracket "<")
 (defonce *angle-bracket-caret-pos (atom nil))
 (defonce *current-command (atom nil))
@@ -311,9 +309,8 @@
   [restore-slash-caret-pos?]
   (when restore-slash-caret-pos?
     (reset! *slash-caret-pos nil))
-  (reset! *show-commands false)
+  (state/clear-editor-action!)
   (reset! *angle-bracket-caret-pos nil)
-  (reset! *show-block-commands false)
   (reset! *matched-commands @*initial-commands)
   (reset! *matched-block-commands (block-commands-map)))
 
@@ -476,7 +473,7 @@
                   (str "\n" value)
                   value)]
       (insert! input-id value option)
-      (reset! *show-commands false))))
+      (state/clear-editor-action!))))
 
 (defmethod handle-step :editor/cursor-back [[_ n]]
   (when-let [input-id (state/get-edit-input-id)]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -421,7 +421,9 @@
   [config page-name-in-block page-name redirect-page-name page-entity contents-page? children html-export? label]
   (let [tag? (:tag? config)]
     [:a
-     {:class (if tag? "tag" "page-ref")
+     {:class (cond-> (if tag? "tag" "page-ref")
+               (:property? config)
+               (str " page-property-key"))
       :data-ref page-name
       :on-mouse-down
       (fn [e]
@@ -1805,9 +1807,7 @@
   [config block k v]
   (let [date (and (= k :date) (date/get-locale-string (str v)))]
     [:div
-     [:a.page-property-key
-      {:href (rfe/href :page {:name (name k)})}
-      (name k)]
+     (page-cp (assoc config :property? true) {:block/name (name k)})
      [:span.mr-1 ":"]
      (cond
        (int? v)

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1805,7 +1805,9 @@
   [config block k v]
   (let [date (and (= k :date) (date/get-locale-string (str v)))]
     [:div
-     [:span.page-property-key.font-medium (name k)]
+     [:a.page-property-key
+      {:href (rfe/href :page {:name (name k)})}
+      (name k)]
      [:span.mr-1 ":"]
      (cond
        (int? v)

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1807,7 +1807,7 @@
   [config block k v]
   (let [date (and (= k :date) (date/get-locale-string (str v)))]
     [:div
-     (page-cp (assoc config :property? true) {:block/name (name k)})
+     (page-cp (assoc config :property? true) {:block/name (subs (str k) 1)})
      [:span.mr-1 ":"]
      (cond
        (int? v)

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1896,12 +1896,12 @@
                            (do
                              (reset! show? false)
                              (reset! commands/*current-command nil)
-                             (state/set-editor-show-date-picker! false)
+                             (state/clear-editor-action!)
                              (state/set-timestamp-block! nil))
                            (do
                              (reset! show? true)
                              (reset! commands/*current-command typ)
-                             (state/set-editor-show-date-picker! true)
+                             (state/set-editor-action! :datepicker)
                              (state/set-timestamp-block! {:block block
                                                           :typ typ
                                                           :show? show?}))))}

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -188,7 +188,7 @@
 .block-left-menu {
     background-color: var(--ls-secondary-background-color);
     background: linear-gradient(90deg, var(--ls-primary-background-color) 0%, var(--ls-secondary-background-color) 100%);
-    
+
     .commands-button {
         overflow: hidden;
         max-width: 40px;
@@ -613,7 +613,12 @@ a.cloze-revealed {
 }
 
 .page-property-key {
+  @apply font-medium;
   color: var(--ls-secondary-text-color);
+}
+
+.page-property-key:hover {
+    background-color: var(--ls-selection-background-color);
 }
 
 .block-parents a {

--- a/src/main/frontend/components/datetime.cljs
+++ b/src/main/frontend/components/datetime.cljs
@@ -147,7 +147,7 @@
                                    (contains? #{"deadline" "scheduled"}
                                               (string/lower-case current-command)))
         date (state/sub :date-picker/date)]
-    (when (state/sub :editor/show-date-picker?)
+    (when (= :datepicker (state/sub :editor/action))
       [:div#date-time-picker.flex.flex-row {:on-click (fn [e] (util/stop e))
                                             :on-mouse-down (fn [e] (.stopPropagation e))}
        (ui/datepicker

--- a/src/main/frontend/components/datetime.cljs
+++ b/src/main/frontend/components/datetime.cljs
@@ -106,7 +106,7 @@
       (reset! show? false)))
   (clear-timestamp!)
   (state/set-editor-show-date-picker! false)
-  (commands/restore-state false))
+  (commands/restore-state))
 
 (rum/defc time-repeater < rum/reactive
   (mixins/event-mixin

--- a/src/main/frontend/components/datetime.cljs
+++ b/src/main/frontend/components/datetime.cljs
@@ -105,7 +105,6 @@
     (when show?
       (reset! show? false)))
   (clear-timestamp!)
-  (state/set-editor-show-date-picker! false)
   (commands/restore-state))
 
 (rum/defc time-repeater < rum/reactive
@@ -164,7 +163,7 @@
                                                (util/format "[[%s]]" journal)
                                                format
                                                nil)
-               (state/set-editor-show-date-picker! false)
+               (state/clear-editor-action!)
                (reset! commands/*current-command nil))))})
        (when deadline-or-schedule?
          (time-repeater))])))

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -262,6 +262,7 @@
                (when (>= current-pos (+ start-idx 2))
                  (subs edit-content (+ start-idx 2) current-pos))
                "")
+            q (string/triml q)
             matched-values (editor-handler/get-matched-property-values property q)
             non-exist-handler (fn [_state]
                                 ((editor-handler/property-value-on-chosen-handler id q) nil))]

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -232,12 +232,9 @@
 (rum/defc property-search < rum/reactive
   {:will-unmount (fn [state] (reset! editor-handler/*selected-text nil) state)}
   [id]
-  (let [pos (:pos (:pos (state/get-editor-action-data)))
-        input (gdom/getElement id)]
+  (let [input (gdom/getElement id)]
     (when input
-      (let [current-pos (cursor/pos input)
-            edit-content (state/sub [:editor/content id])
-            q (:searching-property (editor-handler/get-searching-property input))
+      (let [q (:searching-property (editor-handler/get-searching-property input))
             matched-properties (editor-handler/get-matched-properties q)
             q-property (string/replace (string/lower-case q) #"\s+" "-")
             non-exist-handler (fn [_state]
@@ -254,8 +251,7 @@
 (rum/defc property-value-search < rum/reactive
   {:will-unmount (fn [state] (reset! editor-handler/*selected-text nil) state)}
   [id]
-  (let [pos (:pos (:pos (state/get-editor-action-data)))
-        property (:property (state/get-editor-action-data))
+  (let [property (:property (state/get-editor-action-data))
         input (gdom/getElement id)]
     (when (and input
                (not (string/blank? property)))

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -234,7 +234,8 @@
   [id]
   (let [input (gdom/getElement id)]
     (when input
-      (let [q (:searching-property (editor-handler/get-searching-property input))
+      (let [q (or (:searching-property (editor-handler/get-searching-property input))
+                  "")
             matched-properties (editor-handler/get-matched-properties q)
             q-property (string/replace (string/lower-case q) #"\s+" "-")
             non-exist-handler (fn [_state]

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -248,7 +248,7 @@
          matched-properties
          {:on-chosen (editor-handler/property-on-chosen-handler id q)
           :on-enter non-exist-handler
-          :empty-placeholder [:div.text-gray-500.px-4.py-2.text-sm "Search for a property"]
+          :empty-placeholder [:div.px-4.py-2.text-sm (str "Create a new property: " q)]
           :header [:div.px-4.py-2.text-sm.font-medium "Matched properties: "]
           :item-render (fn [property] property)
           :class       "black"})))))

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -219,7 +219,7 @@
                "")
             matched-templates (editor-handler/get-matched-templates q)
             non-exist-handler (fn [_state]
-                                (state/set-editor-show-template-search! false))]
+                                (state/clear-editor-action!))]
         (ui/auto-complete
          matched-templates
          {:on-chosen   (editor-handler/template-on-chosen-handler id)

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -1341,6 +1341,21 @@
                 [(get m :template) e]))
          (into {}))))
 
+(defn get-all-properties
+  []
+  (let [properties (d/q
+                     '[:find [?p ...]
+                       :where
+                       [_ :block/properties ?p]]
+                     (conn/get-db))
+        properties (remove (fn [m] (or (empty? m)
+                                       (and (= 1 (count m))
+                                            (= :id (first (keys m)))))) properties)]
+    (->> (map keys properties)
+         (apply concat)
+         distinct
+         sort)))
+
 (defn get-template-by-name
   [name]
   (when (string? name)

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -1370,6 +1370,7 @@
        pred)
      (map (fn [x] (if (coll? x) x [x])))
      (apply concat)
+     (map str)
      (remove string/blank?)
      (distinct)
      (sort))))

--- a/src/main/frontend/extensions/zotero/handler.cljs
+++ b/src/main/frontend/extensions/zotero/handler.cljs
@@ -41,7 +41,7 @@
 
 (defn handle-command-zotero
   [id page-name]
-  (state/set-editor-show-zotero! false)
+  (state/clear-editor-action!)
   (editor-handler/insert-command! id (str "[[" page-name "]]") nil {}))
 
 (defn- create-abstract-note!

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -522,8 +522,7 @@
 
 (defn clear-when-saved!
   []
-  (state/clear-editor-action!)
-  (commands/restore-state true))
+  (commands/restore-state))
 
 (defn get-state
   []
@@ -1347,13 +1346,7 @@
     nil)
 
   (when restore?
-    (let [restore-slash-caret-pos? (if (and
-                                        (seq? command-output)
-                                        (= :editor/click-hidden-file-input
-                                           (ffirst command-output)))
-                                     false
-                                     true)]
-      (commands/restore-state restore-slash-caret-pos?))))
+    (commands/restore-state)))
 
 (defn get-asset-file-link
   [format url file-name image?]
@@ -2096,9 +2089,8 @@
 (defn property-value-on-chosen-handler
   [element-id q]
   (fn [property-value]
-    (when-let [input (gdom/getElement element-id)]
-      (commands/insert! element-id (or property-value q)
-                        {:last-pattern q}))
+    (commands/insert! element-id (or property-value q)
+                      {:last-pattern q})
     (state/clear-editor-action!)))
 
 (defn parent-is-page?
@@ -2616,14 +2608,14 @@
            (= (util/nth-safe value (dec current-pos)) (state/get-editor-command-trigger)))
       (do
         (util/stop e)
-        (commands/restore-state true)
+        (commands/restore-state)
         (delete-and-update input (dec current-pos) current-pos))
 
       (and (> current-pos 1)
            (= (util/nth-safe value (dec current-pos)) commands/angle-bracket))
       (do
         (util/stop e)
-        (commands/restore-state true)
+        (commands/restore-state)
         (delete-and-update input (dec current-pos) current-pos))
 
       ;; pair

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2082,9 +2082,9 @@
         (cursor/move-cursor-to input (+ end-index 2))
         (commands/insert! element-id (str (or property q) "::")
                           {:last-pattern (str searching-property "::")})
-        (state/set-editor-action! :property-value-search)
         (state/set-editor-action-data! {:property (or property q)
-                                        :pos (cursor/pos input)})))))
+                                        :pos (cursor/get-caret-pos input)})
+        (state/set-editor-action! :property-value-search)))))
 
 (defn property-value-on-chosen-handler
   [element-id q]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2080,17 +2080,22 @@
     (when-let [input (gdom/getElement element-id)]
       (let [{:keys [end-index searching-property]} (get-searching-property input)]
         (cursor/move-cursor-to input (+ end-index 2))
-        (commands/insert! element-id (str (or property q) "::")
+        (commands/insert! element-id (str (or property q) ":: ")
                           {:last-pattern (str searching-property "::")})
-        (state/set-editor-action-data! {:property (or property q)
-                                        :pos (cursor/get-caret-pos input)})
-        (state/set-editor-action! :property-value-search)))))
+        (state/clear-editor-action!)
+        (js/setTimeout (fn []
+                         (let [pos (let [input (gdom/getElement element-id)]
+                                     (cursor/get-caret-pos input))]
+                           (state/set-editor-action-data! {:property (or property q)
+                                                           :pos pos})
+                           (state/set-editor-action! :property-value-search)))
+                       50)))))
 
 (defn property-value-on-chosen-handler
   [element-id q]
   (fn [property-value]
-    (commands/insert! element-id (or property-value q)
-                      {:last-pattern q})
+    (commands/insert! element-id (str ":: " (or property-value q))
+                      {:last-pattern (str ":: " q)})
     (state/clear-editor-action!)))
 
 (defn parent-is-page?

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1773,8 +1773,7 @@
 (defn close-autocomplete-if-outside
   [input]
   (when (and input
-             (or (state/get-editor-action)
-                 (state/get-editor-show-page-search-hashtag?))
+             (state/get-editor-action)
              (not (wrapped-by? input "[[" "]]")))
     (when (get-search-q)
       (let [value (gobj/get input "value")
@@ -1787,9 +1786,7 @@
                     (string/includes? between "]")
                     (string/includes? between "(")
                     (string/includes? between ")")))
-          (state/set-editor-show-block-search! false)
-          (state/set-editor-show-page-search! false)
-          (state/set-editor-show-page-search-hashtag! false))))))
+          (state/clear-editor-action!))))))
 
 (defn resize-image!
   [block-id metadata full_text size]
@@ -2800,11 +2797,8 @@
                (= c (util/nth-safe value (dec (dec current-pos))) " "))
           (state/clear-editor-action!)
 
-          (and (= c " ")
-               (or (= (util/nth-safe value (dec (dec current-pos))) "#")
-                   (not (state/get-editor-show-page-search?))
-                   (and (state/get-editor-show-page-search?)
-                        (not= (util/nth-safe value current-pos) "]"))))
+          (and (state/get-editor-show-page-search-hashtag?)
+               (= c " "))
           (state/set-editor-show-page-search-hashtag! false)
 
           :else

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2993,14 +2993,18 @@
   "shortcut cut action:
   * when in selection mode, cut selected blocks
   * when in edit mode with text selected, cut selected text
-  * otherwise same as delete shortcut"
+  * otherwise nothing need to be handled."
   [e]
   (cond
     (state/selection?)
     (shortcut-cut-selection e)
 
-    (state/editing?)
-    (keydown-backspace-handler true e)))
+    (and (state/editing?) (util/input-text-selected?
+                           (gdom/getElement (state/get-edit-input-id))))
+    (keydown-backspace-handler true e)
+
+    :else
+    nil))
 
 (defn delete-selection
   [e]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1848,7 +1848,7 @@
       (do
         (cursor/move-cursor-backward input 2)
         (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)})
-        (state/set-editor-show-property-search! true))
+        (state/set-editor-action! :property-search))
 
       (and
        (not= :property-search (state/get-editor-action))
@@ -1856,7 +1856,7 @@
            (wrapped-by? input "\n" "::")))
       (do
         (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)})
-        (state/set-editor-show-property-search! true))
+        (state/set-editor-action! :property-search))
 
       (and (= last-input-char commands/colon) (= :property-search (state/get-editor-action)))
       (state/clear-editor-action!)
@@ -1867,7 +1867,7 @@
 (defn block-on-chosen-handler
   [_input id q format]
   (fn [chosen _click?]
-    (state/set-editor-show-block-search! false)
+    (state/clear-editor-action!)
     (let [uuid-string (str (:block/uuid chosen))]
 
       ;; block reference
@@ -1890,7 +1890,7 @@
 (defn block-non-exist-handler
   [input]
   (fn []
-    (state/set-editor-show-block-search! false)
+    (state/clear-editor-action!)
     (cursor/move-cursor-forward input 2)))
 
 (defn- paste-block-cleanup
@@ -2299,7 +2299,7 @@
                             :check-fn (fn [_ _ _]
                                         (state/set-editor-action-data! {:pos new-pos})
                                         (commands/handle-step [:editor/search-page]))}))]
-        (state/set-editor-show-page-search! false)
+        (state/clear-editor-action!)
         (let [selection (get-selection-and-format)
               {:keys [selection-start selection-end selection]} selection]
           (if selection
@@ -2332,7 +2332,7 @@
                              :check-fn     (fn [_ _ _]
                                              (state/set-editor-action-data! {:pos new-pos})
                                              (commands/handle-step [:editor/search-block]))}))]
-        (state/set-editor-show-block-search! false)
+        (state/clear-editor-action!)
         (if-let [embed-ref (thingatpt/embed-macro-at-point input)]
           (let [{:keys [raw-content start end]} embed-ref]
             (delete-and-update input start end)
@@ -2638,10 +2638,10 @@
         (commands/delete-pair! id)
         (cond
           (and (= deleted "[") (state/get-editor-show-page-search?))
-          (state/set-editor-show-page-search! false)
+          (state/clear-editor-action!)
 
           (and (= deleted "(") (state/get-editor-show-block-search?))
-          (state/set-editor-show-block-search! false)
+          (state/clear-editor-action!)
 
           :else
           nil))
@@ -2649,7 +2649,7 @@
       ;; deleting hashtag
       (and (= deleted "#") (state/get-editor-show-page-search-hashtag?))
       (do
-        (state/set-editor-show-page-search-hashtag! false)
+        (state/clear-editor-action!)
         (delete-and-update input (dec current-pos) current-pos))
 
       ;; just delete
@@ -2729,7 +2729,7 @@
         (and (= key "#")
              (and (> pos 0)
                   (= "#" (util/nth-safe value (dec pos)))))
-        (state/set-editor-show-page-search-hashtag! false)
+        (state/clear-editor-action!)
 
         (and (contains? (set/difference (set (keys reversed-autopair-map))
                                         #{"`"})
@@ -2831,7 +2831,7 @@
 
           (and (state/get-editor-show-page-search-hashtag?)
                (= c " "))
-          (state/set-editor-show-page-search-hashtag! false)
+          (state/clear-editor-action!)
 
           :else
           (when (and (not editor-action) (not non-enter-processed?))

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -240,13 +240,21 @@
         (util/replace-ignore-case (str " " old-tag " ") (str " " new-tag " "))
         (util/replace-ignore-case (str " " old-tag "$") (str " " new-tag)))))
 
+(defn- replace-property-ref!
+  [content old-name new-name]
+  (let [new-name (keyword (string/replace (string/lower-case new-name) #"\s+" "_"))
+        old-property (str old-name "::")
+        new-property (str (name new-name) "::")]
+    (util/replace-ignore-case content old-property new-property)))
+
 (defn- replace-old-page!
   "Unsanitized names"
   [content old-name new-name]
   (when (and (string? content) (string? old-name) (string? new-name))
     (-> content
         (replace-page-ref! old-name new-name)
-        (replace-tag-ref! old-name new-name))))
+        (replace-tag-ref! old-name new-name)
+        (replace-property-ref! old-name new-name))))
 
 (defn- walk-replace-old-page!
   "Unsanitized names"
@@ -264,6 +272,9 @@
                      (if (= f old-name)
                        new-name
                        (replace-old-page! f old-name new-name))
+
+                     (and (keyword f) (= (name f) old-name))
+                     (keyword (string/replace (string/lower-case new-name) #"\s+" "_"))
 
                      :else
                      f))

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -73,7 +73,7 @@
    (let [p (common-handler/get-page-default-properties title)
          ps (merge p properties)
          content (page-property/insert-properties format "" ps)
-         refs (gp-block/get-page-refs-from-properties properties
+         refs (gp-block/get-page-refs-from-properties format properties
                                                       (db/get-db (state/get-current-repo))
                                                       (state/get-date-formatter))]
      {:block/uuid (db/new-block-id)

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -242,7 +242,7 @@
 
 (defn- replace-property-ref!
   [content old-name new-name]
-  (let [new-name (keyword (string/replace (string/lower-case new-name) #"\s+" "_"))
+  (let [new-name (keyword (string/replace (string/lower-case new-name) #"\s+" "-"))
         old-property (str old-name "::")
         new-property (str (name new-name) "::")]
     (util/replace-ignore-case content old-property new-property)))
@@ -274,7 +274,7 @@
                        (replace-old-page! f old-name new-name))
 
                      (and (keyword f) (= (name f) old-name))
-                     (keyword (string/replace (string/lower-case new-name) #"\s+" "_"))
+                     (keyword (string/replace (string/lower-case new-name) #"\s+" "-"))
 
                      :else
                      f))
@@ -380,6 +380,7 @@
                                   {:block/uuid       uuid
                                    :block/content    content
                                    :block/properties properties
+                                   :block/properties-order (map first properties)
                                    :block/refs (rename-update-block-refs! (:block/refs block) (:db/id page) (:db/id to-page))
                                    :block/path-refs (rename-update-block-refs! (:block/path-refs block) (:db/id page) (:db/id to-page))})))) blocks)
                       (remove nil?))]
@@ -568,7 +569,8 @@
           (rename-namespace-pages! repo old-name new-name))
         (rename-nested-pages old-name new-name))
       (when (string/blank? new-name)
-        (notification/show! "Please use a valid name, empty name is not allowed!" :error)))))
+        (notification/show! "Please use a valid name, empty name is not allowed!" :error)))
+    (ui-handler/re-render-root!)))
 
 (defn- split-col-by-element
   [col element]

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -691,15 +691,17 @@
   [input id _q pos format]
   (let [current-pos (cursor/pos input)
         edit-content (state/sub [:editor/content id])
+        action (state/get-editor-action)
+        hashtag? (= action :page-search-hashtag)
         q (or
            @editor-handler/*selected-text
-           (when (state/sub :editor/show-page-search-hashtag?)
+           (when hashtag?
              (gp-util/safe-subs edit-content pos current-pos))
            (when (> (count edit-content) current-pos)
              (gp-util/safe-subs edit-content pos current-pos)))]
-    (if (state/sub :editor/show-page-search-hashtag?)
+    (if hashtag?
       (fn [chosen _click?]
-        (state/set-editor-show-page-search! false)
+        (state/clear-editor-action!)
         (let [wrapped? (= "[[" (gp-util/safe-subs edit-content (- pos 2) pos))
               chosen (if (string/starts-with? chosen "New page: ") ;; FIXME: What if a page named "New page: XXX"?
                        (subs chosen 10)
@@ -721,7 +723,7 @@
                                            :end-pattern (when wrapped? "]]")
                                            :forward-pos forward-pos})))
       (fn [chosen _click?]
-        (state/set-editor-show-page-search! false)
+        (state/clear-editor-action!)
         (let [chosen (if (string/starts-with? chosen "New page: ")
                        (subs chosen 10)
                        chosen)

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -683,7 +683,7 @@
 ;; Editor
 (defn page-not-exists-handler
   [input id q current-pos]
-  (state/set-editor-show-page-search! false)
+  (state/clear-editor-action!)
   (if (state/org-mode-file-link? (state/get-current-repo))
     (let [page-ref-text (get-page-ref-text q)
           value (gobj/get input "value")

--- a/src/main/frontend/search.cljs
+++ b/src/main/frontend/search.cljs
@@ -172,7 +172,19 @@
        (if (string/blank? q)
          properties
          (let [result (fuzzy-search properties q :limit limit)]
-          (vec result)))))))
+           (vec result)))))))
+
+(defn property-value-search
+  ([property q]
+   (property-value-search property q 10))
+  ([property q limit]
+   (let [q (clean-str q)
+         result (db-model/get-property-values (keyword property))]
+     (when (seq result)
+       (if (string/blank? q)
+         result
+         (let [result (fuzzy-search result q :limit limit)]
+           (vec result)))))))
 
 (defn sync-search-indice!
   [repo tx-report]

--- a/src/main/frontend/search.cljs
+++ b/src/main/frontend/search.cljs
@@ -3,6 +3,7 @@
             [clojure.string :as string]
             [logseq.graph-parser.config :as gp-config]
             [frontend.db :as db]
+            [frontend.db.model :as db-model]
             [frontend.regex :as regex]
             [frontend.search.browser :as search-browser]
             [frontend.search.db :as search-db :refer [indices]]
@@ -160,6 +161,18 @@
      (when (seq templates)
        (let [result (fuzzy-search (keys templates) q :limit limit)]
          (vec (select-keys templates result)))))))
+
+(defn property-search
+  ([q]
+   (property-search q 10))
+  ([q limit]
+   (let [q (clean-str q)
+         properties (map name (db-model/get-all-properties))]
+     (when (seq properties)
+       (if (string/blank? q)
+         properties
+         (let [result (fuzzy-search properties q :limit limit)]
+          (vec result)))))))
 
 (defn sync-search-indice!
   [repo tx-report]

--- a/src/main/frontend/search.cljs
+++ b/src/main/frontend/search.cljs
@@ -156,35 +156,38 @@
   ([q]
    (template-search q 10))
   ([q limit]
-   (let [q (clean-str q)
-         templates (db/get-all-templates)]
-     (when (seq templates)
-       (let [result (fuzzy-search (keys templates) q :limit limit)]
-         (vec (select-keys templates result)))))))
+   (when q
+     (let [q (clean-str q)
+           templates (db/get-all-templates)]
+       (when (seq templates)
+         (let [result (fuzzy-search (keys templates) q :limit limit)]
+           (vec (select-keys templates result))))))))
 
 (defn property-search
   ([q]
    (property-search q 10))
   ([q limit]
-   (let [q (clean-str q)
-         properties (map name (db-model/get-all-properties))]
-     (when (seq properties)
-       (if (string/blank? q)
-         properties
-         (let [result (fuzzy-search properties q :limit limit)]
-           (vec result)))))))
+   (when q
+     (let [q (clean-str q)
+           properties (map name (db-model/get-all-properties))]
+       (when (seq properties)
+         (if (string/blank? q)
+           properties
+           (let [result (fuzzy-search properties q :limit limit)]
+             (vec result))))))))
 
 (defn property-value-search
   ([property q]
    (property-value-search property q 10))
   ([property q limit]
-   (let [q (clean-str q)
-         result (db-model/get-property-values (keyword property))]
-     (when (seq result)
-       (if (string/blank? q)
-         result
-         (let [result (fuzzy-search result q :limit limit)]
-           (vec result)))))))
+   (when q
+     (let [q (clean-str q)
+           result (db-model/get-property-values (keyword property))]
+       (when (seq result)
+         (if (string/blank? q)
+           result
+           (let [result (fuzzy-search result q :limit limit)]
+             (vec result))))))))
 
 (defn sync-search-indice!
   [repo tx-report]

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -626,21 +626,12 @@
 (defn set-editor-show-template-search!
   [value]
   (set-editor-action! (when value :template-search)))
-(defn get-editor-show-template-search?
-  []
-  (= (get-editor-action) :template-search))
 (defn set-editor-show-property-search!
   [value]
   (set-editor-action! (when value :property-search)))
-(defn get-editor-show-property-search?
-  []
-  (= (get-editor-action) :property-search))
 (defn set-editor-show-date-picker!
   [value]
   (set-editor-action! (when value :datepicker)))
-(defn get-editor-show-date-picker?
-  []
-  (= (get-editor-action) :datepicker))
 (defn set-editor-show-input!
   [value]
   (if value

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -588,7 +588,6 @@
 
 (defn set-editor-action!
   [value]
-  (js/console.trace)
   (set-state! :editor/action value))
 
 (defn set-editor-action-data!

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -598,6 +598,10 @@
   []
   (:editor/action @state))
 
+(defn get-editor-action-data
+  []
+  (:editor/action-data @state))
+
 (defn set-editor-show-page-search!
   [value]
   (set-editor-action! (when value :page-search)))
@@ -635,7 +639,7 @@
   [value]
   (if value
     (do
-      (set-editor-action-data! value)
+      (set-editor-action-data! (assoc (get-editor-action-data) :options value))
       (set-editor-action! :input))
     (do
       (set-editor-action! nil)
@@ -651,8 +655,6 @@
   []
   (when-not (get-editor-action) (set-editor-action! :block-commands)))
 
-
-
 (defn set-editor-show-zotero!
   [value]
   (set-state! :editor/show-zotero value))
@@ -660,9 +662,7 @@
 (defn clear-editor-action!
   []
   (swap! state (fn [state]
-                 (assoc state
-                        :editor/action nil
-                        :editor/action-data nil))))
+                 (assoc state :editor/action nil))))
 
 (defn set-edit-input-id!
   [input-id]

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -97,12 +97,9 @@
      :config                                {}
      :block/component-editing-mode?         false
      :editor/draw-mode?                     false
-     :editor/show-page-search?              false
-     :editor/show-page-search-hashtag?      false
-     :editor/show-date-picker?              false
+     :editor/action                         nil
+     :editor/action-data                    nil
      ;; With label or other data
-     :editor/show-input                     nil
-     :editor/show-zotero                    false
      :editor/last-saved-cursor              nil
      :editor/editing?                       nil
      :editor/in-composition?                false
@@ -589,63 +586,83 @@
   [value]
   (set-state! :search/mode value))
 
+(defn set-editor-action!
+  [value]
+  (set-state! :editor/action value))
+
+(defn set-editor-action-data!
+  [value]
+  (set-state! :editor/action-data value))
+
+(defn get-editor-action
+  []
+  (:editor/action @state))
+
 (defn set-editor-show-page-search!
   [value]
-  (set-state! :editor/show-page-search? value))
+  (set-editor-action! (when value :page-search)))
 
 (defn get-editor-show-page-search?
   []
-  (get @state :editor/show-page-search?))
+  (= (get-editor-action) :page-search))
 
 (defn set-editor-show-page-search-hashtag!
   [value]
-  (set-state! :editor/show-page-search? value)
-  (set-state! :editor/show-page-search-hashtag? value))
+  (set-editor-action! (when value :page-search-hashtag)))
+
 (defn get-editor-show-page-search-hashtag?
   []
-  (get @state :editor/show-page-search-hashtag?))
+  (= (get-editor-action) :page-search-hashtag))
 (defn set-editor-show-block-search!
   [value]
-  (set-state! :editor/show-block-search? value))
+  (set-editor-action! (when value :block-search)))
 (defn get-editor-show-block-search?
   []
-  (get @state :editor/show-block-search?))
+  (= (get-editor-action) :block-search))
 (defn set-editor-show-template-search!
   [value]
-  (set-state! :editor/show-template-search? value))
+  (set-editor-action! (when value :template-search)))
 (defn get-editor-show-template-search?
   []
-  (get @state :editor/show-template-search?))
+  (= (get-editor-action) :template-search))
 (defn set-editor-show-date-picker!
   [value]
-  (set-state! :editor/show-date-picker? value))
+  (set-editor-action! (when value :datepicker)))
 (defn get-editor-show-date-picker?
   []
-  (get @state :editor/show-date-picker?))
+  (= (get-editor-action) :datepicker))
 (defn set-editor-show-input!
   [value]
-  (set-state! :editor/show-input value))
+  (if value
+    (do
+      (set-editor-action-data! value)
+      (set-editor-action! :input))
+    (do
+      (set-editor-action! nil)
+      (set-editor-action-data! nil))))
 (defn get-editor-show-input
   []
-  (get @state :editor/show-input))
+  (when (= (get-editor-action) :input)
+    (get @state :editor/action-data)))
+(defn set-editor-show-commands!
+  []
+  (when-not (get-editor-action) (set-editor-action! :commands)))
+(defn set-editor-show-block-commands!
+  []
+  (when-not (get-editor-action) (set-editor-action! :block-commands)))
+
 
 
 (defn set-editor-show-zotero!
   [value]
   (set-state! :editor/show-zotero value))
 
-;; TODO: refactor, use one state
-(defn clear-editor-show-state!
+(defn clear-editor-action!
   []
   (swap! state (fn [state]
                  (assoc state
-                        :editor/show-input nil
-                        :editor/show-zotero false
-                        :editor/show-date-picker? false
-                        :editor/show-block-search? false
-                        :editor/show-template-search? false
-                        :editor/show-page-search? false
-                        :editor/show-page-search-hashtag? false))))
+                        :editor/action nil
+                        :editor/action-data nil))))
 
 (defn set-edit-input-id!
   [input-id]

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -629,6 +629,12 @@
 (defn get-editor-show-template-search?
   []
   (= (get-editor-action) :template-search))
+(defn set-editor-show-property-search!
+  [value]
+  (set-editor-action! (when value :property-search)))
+(defn get-editor-show-property-search?
+  []
+  (= (get-editor-action) :property-search))
 (defn set-editor-show-date-picker!
   [value]
   (set-editor-action! (when value :datepicker)))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -588,6 +588,7 @@
 
 (defn set-editor-action!
   [value]
+  (js/console.trace)
   (set-state! :editor/action value))
 
 (defn set-editor-action-data!

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -602,36 +602,18 @@
   []
   (:editor/action-data @state))
 
-(defn set-editor-show-page-search!
-  [value]
-  (set-editor-action! (when value :page-search)))
-
 (defn get-editor-show-page-search?
   []
   (= (get-editor-action) :page-search))
 
-(defn set-editor-show-page-search-hashtag!
-  [value]
-  (set-editor-action! (when value :page-search-hashtag)))
-
 (defn get-editor-show-page-search-hashtag?
   []
   (= (get-editor-action) :page-search-hashtag))
-(defn set-editor-show-block-search!
-  [value]
-  (set-editor-action! (when value :block-search)))
+
 (defn get-editor-show-block-search?
   []
   (= (get-editor-action) :block-search))
-(defn set-editor-show-template-search!
-  [value]
-  (set-editor-action! (when value :template-search)))
-(defn set-editor-show-property-search!
-  [value]
-  (set-editor-action! (when value :property-search)))
-(defn set-editor-show-date-picker!
-  [value]
-  (set-editor-action! (when value :datepicker)))
+
 (defn set-editor-show-input!
   [value]
   (if value
@@ -651,10 +633,6 @@
 (defn set-editor-show-block-commands!
   []
   (when-not (get-editor-action) (set-editor-action! :block-commands)))
-
-(defn set-editor-show-zotero!
-  [value]
-  (set-state! :editor/show-zotero value))
 
 (defn clear-editor-action!
   []

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -397,11 +397,13 @@
            get-group-name
            empty-placeholder
            item-render
-           class]}]
+           class
+           header]}]
   (let [current-idx (get state ::current-idx)]
     [:div#ui__ac {:class class}
      (if (seq matched)
        [:div#ui__ac-inner.hide-scrollbar
+        (when header header)
         (for [[idx item] (medley/indexed matched)]
           [:<>
            {:key idx}

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -65,10 +65,7 @@
                             (plugin-handler/hook-plugin-editor :input-selection-end (bean/->js e)))))))
                 state)}
   [{:keys [on-change] :as props}]
-  (let [skip-composition? (or
-                           (state/sub :editor/show-page-search?)
-                           (state/sub :editor/show-block-search?)
-                           (state/sub :editor/show-template-search?))
+  (let [skip-composition? (state/sub :editor/action)
         on-composition (fn [e]
                          (if skip-composition?
                            (on-change e)

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -312,6 +312,11 @@
   (when input
     (.-selectionEnd input)))
 
+(defn input-text-selected?
+  [input]
+  (not= (get-selection-start input)
+        (get-selection-end input)))
+
 (defn get-selection-direction
   [input]
   (when input

--- a/src/main/frontend/util/cursor.cljs
+++ b/src/main/frontend/util/cursor.cljs
@@ -111,9 +111,10 @@
 (defn beginning-of-line?
   [input]
   (let [[content pos] (get-input-content&pos input)]
-    (or (zero? pos)
-        (when-let [pre-char (subs content (dec pos) pos)]
-          (= pre-char \newline)))))
+    (when content
+      (or (zero? pos)
+         (when-let [pre-char (subs content (dec pos) pos)]
+           (= pre-char \newline))))))
 
 (defn move-cursor-to-line-end
   [input]

--- a/src/main/frontend/util/text.cljs
+++ b/src/main/frontend/util/text.cljs
@@ -86,19 +86,21 @@
 
 (defn get-string-all-indexes
   "Get all indexes of `value` in the string `s`."
-  [s value]
-  (loop [acc []
-         i 0]
-    (if-let [i (string/index-of s value i)]
-      (recur (conj acc i) (+ i (count value)))
-      acc)))
+  [s value before?]
+  (if (= value "")
+    (if before? [0] [(dec (count s))])
+    (loop [acc []
+          i 0]
+     (if-let [i (string/index-of s value i)]
+       (recur (conj acc i) (+ i (count value)))
+       acc))))
 
 (defn wrapped-by?
   "`pos` must be wrapped by `before` and `and` in string `value`, e.g. ((a|b))"
   [value pos before end]
-  (let [before-matches (->> (get-string-all-indexes value before)
+  (let [before-matches (->> (get-string-all-indexes value before true)
                             (map (fn [i] [i :before])))
-        end-matches (->> (get-string-all-indexes value end)
+        end-matches (->> (get-string-all-indexes value end false)
                          (map (fn [i] [i :end])))
         indexes (sort-by first (concat before-matches end-matches [[pos :between]]))
         ks (map second indexes)

--- a/src/main/frontend/util/text.cljs
+++ b/src/main/frontend/util/text.cljs
@@ -86,7 +86,7 @@
 
 (defn get-string-all-indexes
   "Get all indexes of `value` in the string `s`."
-  [s value before?]
+  [s value {:keys [before?] :or {before? true}}]
   (if (= value "")
     (if before? [0] [(dec (count s))])
     (loop [acc []
@@ -98,9 +98,9 @@
 (defn wrapped-by?
   "`pos` must be wrapped by `before` and `and` in string `value`, e.g. ((a|b))"
   [value pos before end]
-  (let [before-matches (->> (get-string-all-indexes value before true)
+  (let [before-matches (->> (get-string-all-indexes value before {:before? true})
                             (map (fn [i] [i :before])))
-        end-matches (->> (get-string-all-indexes value end false)
+        end-matches (->> (get-string-all-indexes value end {:before? false})
                          (map (fn [i] [i :end])))
         indexes (sort-by first (concat before-matches end-matches [[pos :between]]))
         ks (map second indexes)

--- a/src/test/frontend/db/query_dsl_test.cljs
+++ b/src/test/frontend/db/query_dsl_test.cljs
@@ -394,7 +394,7 @@ tags: other
                 (dsl-query "(or [[tag2]] [[page 3]])")))
         "OR query with nonexistent page should return meaningful results")
 
-    (is (= ["foo:: bar\n" "b1 [[page 1]] #tag2" "b3"]
+    (is (= ["b1 [[page 1]] #tag2" "foo:: bar\n" "b3"]
            (->> (dsl-query "(not [[page 2]])")
                 ;; Only filter to page1 to get meaningful results
                 (filter #(= "page1" (get-in % [:block/page :block/name])))

--- a/src/test/frontend/util/text_test.cljs
+++ b/src/test/frontend/util/text_test.cljs
@@ -23,11 +23,11 @@
 (deftest get-string-all-indexes
   []
   (are [x y] (= x y)
-    (text-util/get-string-all-indexes "[[hello]] [[world]]" "[[")
+    (text-util/get-string-all-indexes "[[hello]] [[world]]" "[[" true)
     [0 10]
 
-    (text-util/get-string-all-indexes "abc abc ab" "ab")
+    (text-util/get-string-all-indexes "abc abc ab" "ab" true)
     [0 4 8]
 
-    (text-util/get-string-all-indexes "a.c a.c ab" "a.")
+    (text-util/get-string-all-indexes "a.c a.c ab" "a." true)
     [0 4]))

--- a/src/test/frontend/util/text_test.cljs
+++ b/src/test/frontend/util/text_test.cljs
@@ -23,11 +23,11 @@
 (deftest get-string-all-indexes
   []
   (are [x y] (= x y)
-    (text-util/get-string-all-indexes "[[hello]] [[world]]" "[[" true)
+    (text-util/get-string-all-indexes "[[hello]] [[world]]" "[[" {})
     [0 10]
 
-    (text-util/get-string-all-indexes "abc abc ab" "ab" true)
+    (text-util/get-string-all-indexes "abc abc ab" "ab" {})
     [0 4 8]
 
-    (text-util/get-string-all-indexes "a.c a.c ab" "a." true)
+    (text-util/get-string-all-indexes "a.c a.c ab" "a." {})
     [0 4]))


### PR DESCRIPTION
This PR addressed several parts:
1. Simplify states for the editor modal, including the current `:editor/action` and its corresponding data (e.g. slash position, input options, etc.)
2. Adds auto-complete support for block properties
3. Adds auto-complete support for block property values
4. Each property will be treated as a "block" too, which enables property blocks in the linked references

Demo:
https://www.loom.com/share/27804e1bcd7b4e4bbf71ec14956c42fe