### PR TITLE
Adding tests for rounding errors

### DIFF
--- a/src/test/frontend/extensions/calc_test.cljc
+++ b/src/test/frontend/extensions/calc_test.cljc
@@ -96,7 +96,14 @@
       0.0  "acos(cos(0))"
       5.0  "2 * log(10) + 3"
       1.0  "-2 * log(10) + 3"
-      10.0 "ln(1) + 10")))
+      10.0 "ln(1) + 10"))
+  (testing "avoiding rounding errors"
+    (are [value expr] (= value (run expr))
+      3.3 "1.1 + 2.2"
+      2.2 "3.3 - 1.1"
+      0.0001 "1/10000"
+      1e-7 "1/10000000"
+      )))
 
 (deftest variables
   (testing "variables can be remembered"


### PR DESCRIPTION
Just some tests for the new behavior of https://github.com/logseq/logseq/pull/5374.