### PR TITLE
Refactor inline html markup element conversion

### DIFF
--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -1078,36 +1078,29 @@ mark {
 }
 
 /* inline code */
-:not(pre):not(mark) > code {
+:not(pre) > code {
   border-radius: 3px;
   font-size: 0.9em;
+  font-style: normal;
   font-family: MonoLisa, 'Fira Code', Monaco, Menlo, Consolas, 'COURIER NEW',
     monospace;
-  padding: 3px 5px !important;
+  letter-spacing: 0;
+  word-spacing: -0.15em;
+  text-rendering: optimizeSpeed;
 }
 
 :not(pre):not(mark) > code {
-  font-style: normal;
-  letter-spacing: 0;
-  word-spacing: -0.15em;
-  -webkit-border-radius: var(--ls-border-radius-low);
-  border-radius: var(--ls-border-radius-low);
   line-height: 1.45;
-  text-rendering: optimizeSpeed;
+  padding: 3px 5px !important;
+  border-radius: var(--ls-border-radius-low);
+  -webkit-border-radius: var(--ls-border-radius-low);
 }
 
 mark > code {
-  font-style: normal;
-  letter-spacing: 0;
   padding: 0;
-  word-spacing: -0.15em;
   line-height: inherit !important;
-  text-rendering: optimizeSpeed;
   background: #fef3ac !important;
   color: #262626 !important;
-  font-size: 0.9em;
-  font-family: MonoLisa, 'Fira Code', Monaco, Menlo, Consolas, 'COURIER NEW',
-    monospace;
 }
 
 b > code {

--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -253,9 +253,6 @@ pre.code {
   color: var(--ls-primary-text-color, #f8f8f2);
 }
 
-:not(pre) > code {
-}
-
 dl {
   margin: 1rem 0;
 }
@@ -305,19 +302,6 @@ video {
 ::-moz-selection {
   background: var(--ls-selection-background-color);
   color: var(--ls-primary-text-color);
-}
-
-:not(pre) > code {
-  font-style: normal !important;
-  letter-spacing: 0;
-  padding: 0.1em 0.4em;
-  word-spacing: -0.15em;
-  -webkit-border-radius: var(--ls-border-radius-low);
-  border-radius: var(--ls-border-radius-low);
-  color: var(--ls-page-inline-code-color);
-  background-color: var(--ls-page-inline-code-bg-color, #eee);
-  line-height: 1.45;
-  text-rendering: optimizeSpeed;
 }
 
 /* endregion */
@@ -1088,19 +1072,50 @@ mark {
 }
 
 /* block references */
-
 .block-ref .block-ref {
   padding: 6px 5px;
   border: none;
 }
 
 /* inline code */
-:not(pre) > code {
+:not(pre):not(mark) > code {
   border-radius: 3px;
   font-size: 0.9em;
   font-family: MonoLisa, 'Fira Code', Monaco, Menlo, Consolas, 'COURIER NEW',
     monospace;
   padding: 3px 5px !important;
+}
+
+:not(pre):not(mark) > code {
+  font-style: normal;
+  letter-spacing: 0;
+  word-spacing: -0.15em;
+  -webkit-border-radius: var(--ls-border-radius-low);
+  border-radius: var(--ls-border-radius-low);
+  line-height: 1.45;
+  text-rendering: optimizeSpeed;
+}
+
+mark > code {
+  font-style: normal;
+  letter-spacing: 0;
+  padding: 0;
+  word-spacing: -0.15em;
+  line-height: inherit !important;
+  text-rendering: optimizeSpeed;
+  background: #fef3ac !important;
+  color: #262626 !important;
+  font-size: 0.9em;
+  font-family: MonoLisa, 'Fira Code', Monaco, Menlo, Consolas, 'COURIER NEW',
+    monospace;
+}
+
+b > code {
+  font-weight: bold !important;
+}
+
+i > code {
+  font-style: italic !important;
 }
 
 a {

--- a/src/main/frontend/config.cljs
+++ b/src/main/frontend/config.cljs
@@ -124,7 +124,7 @@
       :org
       "/"
       :markdown
-      "_"
+      "*"
       "")))
 (defn get-underline
   [format]
@@ -132,8 +132,8 @@
     (case format
       :org
       "_"
-      :markdown
-      "__"
+      :markdown ;; no underline for markdown
+      ""
       "")))
 (defn get-strike-through
   [format]


### PR DESCRIPTION
- support marked code, bold code, italic code
- better handling of HTML inline markup element
- fix wrong markup symbols for markdown

CSS tested against:
<img width="291" alt="image" src="https://user-images.githubusercontent.com/72891/177756240-16ff12fa-150b-4602-a8bc-bd47116124d0.png">
