### PR TITLE
Add heading in plugin settings

### DIFF
--- a/libs/src/LSPlugin.ts
+++ b/libs/src/LSPlugin.ts
@@ -228,7 +228,7 @@ export type SimpleCommandKeybinding = {
 
 export type SettingSchemaDesc = {
   key: string
-  type: 'string' | 'number' | 'boolean' | 'enum' | 'object'
+  type: 'string' | 'number' | 'boolean' | 'enum' | 'object' | 'heading'
   default: string | number | boolean | Array<any> | object | null
   title: string
   description: string // support markdown

--- a/src/main/frontend/components/plugins.css
+++ b/src/main/frontend/components/plugins.css
@@ -465,6 +465,12 @@
         right: 8px;
       }
 
+      .heading-item {
+        margin: 12px 12px 6px;
+        font-weight: bold;
+        border-bottom: 1px solid var(--ls-border-color, #738694);
+      }
+
       .desc-item {
         padding: 12px 12px 6px;
 
@@ -783,7 +789,7 @@
         max-height: 80vh;
         overflow-y: auto;
       }
-      
+
       .menu-link {
         padding: 3px 5px;
       }

--- a/src/main/frontend/components/plugins_settings.cljs
+++ b/src/main/frontend/components/plugins_settings.cljs
@@ -74,6 +74,12 @@
     [:small.pl-1.flex-1 description]
     [:div.pl-1 (edit-settings-file pid nil)]]])
 
+(rum/defc render-item-heading
+  [{:keys [title]}]
+
+  [:div.heading-item
+   [:h2 title]])
+
 (rum/defc settings-container
   [schema ^js pl]
   (let [^js _settings (.-settings pl)
@@ -107,6 +113,7 @@
            #{:boolean} (render-item-toggle val desc update-setting!)
            #{:enum} (render-item-enum val desc update-setting!)
            #{:object} (render-item-object val desc pid)
+           #{:heading} (render-item-heading desc)
 
            [:p (str "#Not Handled#" key)]))]
 


### PR DESCRIPTION
For plugins with a lot of settings would be good to have "visual splitting" into sections.
Added new settings type - `heading`

```js
  {
    key: "bannerHeading",
    title: "Banner settings",
    type: "heading"
  },
```

![image](https://user-images.githubusercontent.com/137919/177801745-1981dec6-26d5-4cf4-81e6-19739b442350.png)
