### PR TITLE
fix: quick capture across desktops

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -43,6 +43,8 @@
                    :win    win})))
 
 (defn open-url-handler
+  "win - the main window instance (first renderer process)
+   url - the input URL"
   [win url]
   (.info logger "open-url" (str {:url url}))
 

--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -6,7 +6,7 @@
             [cljs-bean.core :as bean]
             ["electron" :refer [app BrowserWindow]]))
 
-(defonce *win (atom nil))
+(defonce *win (atom nil)) ;; The main window
 (defonce mac? (= (.-platform js/process) "darwin"))
 (defonce win32? (= (.-platform js/process) "win32"))
 (defonce linux? (= (.-platform js/process) "linux"))
@@ -112,13 +112,21 @@
 
 (defn send-to-renderer
   "Notice: pass the `window` parameter if you can. Otherwise, the message
-  will not be received if there's no focused window."
+  will not be received if there's no focused window.
+   Use `send-to-focused-renderer` instead if you want to set a window for fallback"
   ([kind payload]
    (send-to-renderer (get-focused-window) kind payload))
   ([window kind payload]
    (when window
      (.. ^js window -webContents
          (send (name kind) (bean/->js payload))))))
+
+(defn send-to-focused-renderer
+  "Try to send to focused window. If no focused window, fallback to the `fallback-win`"
+  ([kind payload fallback-win]
+   (let [focused-win (get-focused-window)
+         win         (if focused-win focused-win fallback-win)]
+     (send-to-renderer win kind payload))))
 
 (defn get-graph-dir
   "required by all internal state in the electron section"


### PR DESCRIPTION
Fix https://github.com/logseq/logseq/issues/5959
In multiple desktop case, there will be no `focused window` exists for sometime.
No much idea about how to define a "focus window" in macOS for Electron, but should have a fallback window assigned.
Thus, add function `send-to-focused-renderer`
https://github.com/cnrpman/logseq/blob/70f7bd53bd876f5508262a6b2d8e3ad50649f661/src/electron/electron/utils.cljs#L124-L125