### PR TITLE
Another fix for page bouncing for lazy loading

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2895,7 +2895,8 @@
   (ui/catch-error
    (ui/block-error "Query Error:" {:content (:query q)})
    (ui/lazy-visible
-    (fn [] (custom-query* config q)))))
+    (fn [] (custom-query* config q))
+    "custom-query")))
 (defn admonition
   [config type result]
   (when-let [icon (case (string/lower-case (name type))

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2897,6 +2897,7 @@
    (ui/lazy-visible
     (fn [] (custom-query* config q))
     "custom-query")))
+
 (defn admonition
   [config type result]
   (when-let [icon (case (string/lower-case (name type))

--- a/src/main/frontend/components/journal.cljs
+++ b/src/main/frontend/components/journal.cljs
@@ -56,7 +56,7 @@
 
       (if today?
         (blocks-cp repo page format)
-        (ui/lazy-visible (fn [] (blocks-cp repo page format))))
+        (ui/lazy-visible (fn [] (blocks-cp repo page format)) page))
 
       {})
 

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -925,18 +925,19 @@
   ([content-fn]
    (lazy-visible content-fn nil))
   ([content-fn _debug-id]
-   (let [[hasBeenSeen setHasBeenSeen] (rum/use-state false)
-        [last-changed-time set-last-changed-time!] (rum/use-state nil)
-        inViewState (useInView #js {:rootMargin "100px"
-                                    :onChange (fn [in-view? entry]
-                                                (let [self-top (.-top (.-boundingClientRect entry))
-                                                      in-view? (or in-view? (<= self-top 0))
-                                                      time' (util/time-ms)]
-                                                  (when (or in-view?
-                                                            (nil? last-changed-time)
-                                                            (> (- time' last-changed-time) 50))
-                                                    (set-last-changed-time! time')
-                                                    (setHasBeenSeen in-view?))))})
-        ref (.-ref inViewState)]
-    (lazy-visible-inner hasBeenSeen content-fn ref)))
-  )
+   (if (or (util/mobile?) (mobile-util/native-platform?))
+     (content-fn)
+     (let [[hasBeenSeen setHasBeenSeen] (rum/use-state false)
+           [last-changed-time set-last-changed-time!] (rum/use-state nil)
+           inViewState (useInView #js {:rootMargin "100px"
+                                       :onChange (fn [in-view? entry]
+                                                   (let [self-top (.-top (.-boundingClientRect entry))
+                                                         in-view? (or in-view? (<= self-top 0))
+                                                         time' (util/time-ms)]
+                                                     (when (or in-view?
+                                                               (nil? last-changed-time)
+                                                               (> (- time' last-changed-time) 50))
+                                                       (set-last-changed-time! time')
+                                                       (setHasBeenSeen in-view?))))})
+           ref (.-ref inViewState)]
+       (lazy-visible-inner hasBeenSeen content-fn ref)))))

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -932,11 +932,12 @@
            inViewState (useInView #js {:rootMargin "100px"
                                        :onChange (fn [in-view? entry]
                                                    (let [self-top (.-top (.-boundingClientRect entry))
-                                                         in-view? (or in-view? (<= self-top 0))
                                                          time' (util/time-ms)]
                                                      (when (or in-view?
-                                                               (nil? last-changed-time)
-                                                               (> (- time' last-changed-time) 50))
+                                                               (and
+                                                                (nil? last-changed-time)
+                                                                (> (- time' last-changed-time) 50)
+                                                                (<= self-top 0)))
                                                        (set-last-changed-time! time')
                                                        (setHasBeenSeen in-view?))))})
            ref (.-ref inViewState)]

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -922,12 +922,21 @@
          [:div.h-2.bg-base-4.rounded]]]]])])
 
 (rum/defc lazy-visible
-  [content-fn]
-  (let [[hasBeenSeen setHasBeenSeen] (rum/use-state false)
+  ([content-fn]
+   (lazy-visible content-fn nil))
+  ([content-fn _debug-id]
+   (let [[hasBeenSeen setHasBeenSeen] (rum/use-state false)
+        [last-changed-time set-last-changed-time!] (rum/use-state nil)
         inViewState (useInView #js {:rootMargin "100px"
-                                    :onChange (fn [v entry]
+                                    :onChange (fn [in-view? entry]
                                                 (let [self-top (.-top (.-boundingClientRect entry))
-                                                      v (if v v (if (> self-top 0) false true))]
-                                                  (setHasBeenSeen v)))})
+                                                      in-view? (or in-view? (<= self-top 0))
+                                                      time' (util/time-ms)]
+                                                  (when (or in-view?
+                                                            (nil? last-changed-time)
+                                                            (> (- time' last-changed-time) 50))
+                                                    (set-last-changed-time! time')
+                                                    (setHasBeenSeen in-view?))))})
         ref (.-ref inViewState)]
     (lazy-visible-inner hasBeenSeen content-fn ref)))
+  )


### PR DESCRIPTION
The root cause of page bouncing on the journals page is because of lazy rendered empty linked references.
The fix is to not render empty references at all.

Also, the last time when in-view's state changes will be recorded to prevent loop switching between the lazy loading placeholder and the real content.

related to #5972