### PR TITLE
feat: x-callback-url getCurrentURL [WIP]

### DIFF
--- a/src/electron/electron/url.cljs
+++ b/src/electron/electron/url.cljs
@@ -68,6 +68,11 @@
                                                   :title title
                                                   :content content} win))
 
+      (= action "/getCurrentURL")
+      (let [[x-success x-error] (get-URL-decoded-params parsed-url ["x-success" "x-error"])]
+        (send-to-focused-renderer "handleGetCurrentURL" {:x-success x-success
+                                                         :x-error?   x-error} win))
+
       :else
       (send-to-focused-renderer "notification" {:type "error"
                                                 :payload (str "Unimplemented x-callback-url action: `"

--- a/src/main/electron/listener.cljs
+++ b/src/main/electron/listener.cljs
@@ -15,6 +15,7 @@
             [datascript.core :as d]
             [electron.ipc :as ipc]
             [frontend.ui :as ui]
+            [frontend.util.url :as url-util]
             [frontend.handler.notification :as notification]
             [frontend.handler.repo :as repo-handler]
             [frontend.handler.user :as user]))
@@ -149,6 +150,24 @@
                            (editor-handler/api-insert-new-block! content {:page page
                                                                           :edit-block? false
                                                                           :replace-empty-target? true})))))
+
+  (js/window.apis.on "handleGetCurrentURL"
+                     (fn [args]
+                       (let [{:keys  [x-success x-error?]} (bean/->clj args)
+                             repo (state/get-current-repo)
+                             ;; may reuse the following logic for other api services
+                             edit-block-id   (some-> (state/get-edit-block) (:block/uuid))
+                             select-block-id (first (state/get-selection-block-ids))
+                             cur-page-id     (some-> (state/get-current-page) (db-model/get-page) (:block/uuid))
+                             uuid            (or edit-block-id select-block-id cur-page-id)
+
+                             url     (when uuid
+                                       (url-util/encode-param (url-util/get-logseq-graph-uuid-url nil repo uuid)))
+                             target  (if (and x-error? (nil? url))
+                                       x-error?
+                                       (str x-success url))]
+                         (js/setTimeout #(js/window.open target) 100) ;; Magic, don't remove the timeout, even 1ms works. Why?
+                         )))
 
   (js/window.apis.on "openNewWindowOfGraph"
                      ;; Handle open new window in renderer, until the destination graph doesn't rely on setting local storage

--- a/src/main/frontend/utils.js
+++ b/src/main/frontend/utils.js
@@ -276,6 +276,7 @@ export const writeClipboard = ({text, html}) => {
             }
             promise_written = navigator.clipboard.write(data)
         } else {
+            // mainly for E2E environment on Github CI @ Ubuntu
             console.debug("Degraded copy without `ClipboardItem` support:", text)
             promise_written = navigator.clipboard.writeText(text)
         }


### PR DESCRIPTION
Add x-callback-url `/getCurrentURL` per https://twitter.com/HookProductvT/status/1516116386442932224 requested

How to test (manual): 
a good way is use quickCapture url as success callback
logseq://x-callback-url/getCurrentURL?x-success=logseq%3A%2F%2Fx-callback-url%2FquickCapture%3Ftitle%3DCurrentURL%26url%3D&x-error=logseq%3A%2F%2Fx-callback-url%2FquickCapture%3Ftitle%3DNoURLforCurrentPosition%26url%3Dhttp%3A%2F%2Fabout%3Ablank