### PR TITLE
don't enter editing when click query table

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1926,7 +1926,8 @@
    (and (util/sup? target)
         (dom/has-class? target "fn"))
    (dom/has-class? target "image-resize")
-   (dom/closest target "a")))
+   (dom/closest target "a")
+   (dom/closest target ".dsl-query")))
 
 (defn- block-content-on-mouse-down
   [e block block-id _content edit-input-id]


### PR DESCRIPTION
tiny fix for query table on mobile: don't enter editing state when clicking it.