### PR TITLE
fix click not working on cards preview mode

### DIFF
--- a/src/main/frontend/extensions/srs.cljs
+++ b/src/main/frontend/extensions/srs.cljs
@@ -441,9 +441,7 @@
         [:div.ls-card.content
          {:class (when (or preview? modal?)
                    (str (util/hiccup->class ".flex.flex-col.resize.overflow-y-auto")
-                        (when modal? " modal-cards")))
-          :on-mouse-down (fn [e]
-                           (util/stop e))}
+                        (when modal? " modal-cards")))}
          (let [repo (state/get-current-repo)]
            [:div {:style {:margin-top 20}}
             (component-block/breadcrumb {} repo root-block-id {})])


### PR DESCRIPTION
fix #6013. Introduced in https://github.com/logseq/logseq/commit/71727845043dbccf5a23a5463b3ef159d126ab2b