### PR TITLE
fix(watcher): avoid calling delete too early

### DIFF
--- a/ios/App/App/FsWatcher.swift
+++ b/ios/App/App/FsWatcher.swift
@@ -48,10 +48,12 @@ public class FsWatcher: CAPPlugin, PollingWatcherDelegate {
         // NOTE: Event in js {dir path content stat{mtime}}
         switch event {
         case .Unlink:
-            self.notifyListeners("watcher", data: ["event": "unlink",
-                                                   "dir": baseUrl?.description as Any,
-                                                   "path": url.description,
-                                                  ])
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.notifyListeners("watcher", data: ["event": "unlink",
+                                                       "dir": self.baseUrl?.description as Any,
+                                                       "path": url.description,
+                                                      ])
+            }
         case .Add, .Change:
             var content: String? = nil
             if url.shouldNotifyWithContent() {

--- a/src/electron/electron/fs_watcher.cljs
+++ b/src/electron/electron/fs_watcher.cljs
@@ -82,8 +82,11 @@
              (fn [path]
                (publish-file-event! dir path "change")))
         (.on dir-watcher "unlink"
+             ;; delay 500ms for syncing disks
              (fn [path]
-               (publish-file-event! dir path "unlink")))
+               (js/setTimeout #(when (not (fs/existsSync path))
+                                 (publish-file-event! dir path "unlink"))
+                              500)))
         (.on dir-watcher "error"
              (fn [path]
                (println "Watch error happened: "


### PR DESCRIPTION
This resolves compatibility with both syncthing and git auto commit enabled.

Fix #6005 
Fix #5841 
Fix #5999