### PR TITLE
Enhance: Property page enhancements

### DIFF
--- a/.github/workflows/graph-parser.yml
+++ b/.github/workflows/graph-parser.yml
@@ -83,7 +83,7 @@ jobs:
         run: clojure -M:test
 
       - name: Run nbb-logseq tests
-        run: yarn nbb-logseq -cp src:test:../db/src -m logseq.graph-parser.nbb-test-runner/run-tests
+        run: yarn test
 
       # In this job because it depends on an npm package
       - name: Load namespaces into nbb-logseq

--- a/deps/graph-parser/.carve/ignore
+++ b/deps/graph-parser/.carve/ignore
@@ -2,3 +2,5 @@
 logseq.graph-parser.cli/parse-graph
 ;; For CLI
 logseq.graph-parser.mldoc/ast-export-markdown
+;; API
+logseq.graph-parser.property/register-built-in-properties

--- a/deps/graph-parser/README.md
+++ b/deps/graph-parser/README.md
@@ -49,7 +49,7 @@ To see available options that can run specific tests or namespaces: `clojure -M:
 
 To run nbb-logseq tests:
 ```
-yarn nbb-logseq -cp src:test -m logseq.graph-parser.nbb-test-runner/run-tests
+yarn test
 ```
 
 ### Managing dependencies

--- a/deps/graph-parser/package.json
+++ b/deps/graph-parser/package.json
@@ -7,5 +7,8 @@
   },
   "dependencies": {
     "mldoc": "^1.3.9"
+  },
+  "scripts": {
+    "test": "nbb-logseq -cp src:test:../db/src -m logseq.graph-parser.nbb-test-runner/run-tests"
   }
 }

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -170,7 +170,8 @@
                                          (remove string/blank?)
                                          ;; Remove built-in properties as we don't want pages
                                          ;; created for them by default
-                                         (remove (set (map name (gp-property/built-in-properties))))
+                                         (remove (set (map name (into (gp-property/editable-built-in-properties)
+                                                                      (gp-property/hidden-built-in-properties)))))
                                          (distinct))]
     (->> (concat page-refs property-keys-page-refs)
          (remove string/blank?)

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -161,7 +161,7 @@
                    (remove (fn [[k _]]
                              (contains?
                               (set/union (disj (gp-property/editable-built-in-properties)
-                                               :alias :tags)
+                                               :alias :aliases :tags)
                                          (gp-property/hidden-built-in-properties))
                               (keyword k))))
                    (map last)

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -142,32 +142,35 @@
 (defn- get-page-ref-names-from-properties
   [format properties]
   (let [page-refs (->>
-                     properties
-                     (remove (fn [[k _]]
-                               (contains? #{:background-color :background_color} (keyword k))))
-                     (map last)
-                     (map (fn [v]
-                            (cond
-                              (and (string? v)
-                                   (not (gp-mldoc/link? format v)))
-                              (let [v (string/trim v)
-                                    result (text/split-page-refs-without-brackets v {:un-brackets? false})]
-                                (if (coll? result)
-                                  (map text/page-ref-un-brackets! result)
-                                  []))
+                   properties
+                   (remove (fn [[k _]]
+                             (contains? #{:background-color :background_color} (keyword k))))
+                   (map last)
+                   (map (fn [v]
+                          (cond
+                            (and (string? v)
+                                 (not (gp-mldoc/link? format v)))
+                            (let [v (string/trim v)
+                                  result (text/split-page-refs-without-brackets v {:un-brackets? false})]
+                              (if (coll? result)
+                                (map text/page-ref-un-brackets! result)
+                                []))
 
-                              (coll? v)
-                              (map (fn [s]
-                                     (when-not (and (string? v)
-                                                    (gp-mldoc/link? format v))
-                                       (text/page-ref-un-brackets! s))) v)
+                            (coll? v)
+                            (map (fn [s]
+                                   (when-not (and (string? v)
+                                                  (gp-mldoc/link? format v))
+                                     (text/page-ref-un-brackets! s))) v)
 
-                              :else
-                              nil)))
-                     (apply concat))
+                            :else
+                            nil)))
+                   (apply concat))
         property-keys-page-refs (some->> properties
                                          (map (comp name first))
                                          (remove string/blank?)
+                                         ;; Remove built-in properties as we don't want pages
+                                         ;; created for them by default
+                                         (remove (set (map name (gp-property/built-in-properties))))
                                          (distinct))]
     (->> (concat page-refs property-keys-page-refs)
          (remove string/blank?)

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -160,8 +160,9 @@
                    properties
                    (remove (fn [[k _]]
                              (contains?
-                              (set/union (disj (gp-property/editable-built-in-properties)
-                                               :alias :aliases :tags)
+                              (set/union (apply disj
+                                           (gp-property/editable-built-in-properties)
+                                           gp-property/editable-linkable-built-in-properties)
                                          (gp-property/hidden-built-in-properties))
                               (keyword k))))
                    (map last)
@@ -222,7 +223,7 @@
                                            k (keyword k)
                                            v (if (and
                                                   (string? v)
-                                                  (contains? #{:alias :aliases :tags} k))
+                                                  (contains? gp-property/editable-linkable-built-in-properties k))
                                                (set [v])
                                                v)
                                            v (if (coll? v) (set v) v)]

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -167,18 +167,13 @@
                    (map last)
                    (map (fn [v]
                           (cond
-                            (and (string? v) (not (string/blank? v)))
-                            (let [v (string/trim v)]
-                              (when-not (or (gp-mldoc/link? format v)
-                                            (= v "true")
-                                            (= v "false")
-                                            (parse-long v))
-                                (let [result (if (gp-util/wrapped-by-quotes? v)
-                                               (gp-util/unquote-string v)
-                                               (text/split-page-refs-without-brackets v {:un-brackets? false}))]
-                                  (if (coll? result)
-                                    (map text/page-ref-un-brackets! result)
-                                    [result]))))
+                            (and (string? v)
+                                 (not (gp-mldoc/link? format v)))
+                            (let [v (string/trim v)
+                                  result (text/split-page-refs-without-brackets v {:un-brackets? false})]
+                              (if (coll? result)
+                                (map text/page-ref-un-brackets! result)
+                                []))
 
                             (coll? v)
                             (map (fn [s]

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -158,7 +158,10 @@
   (let [page-refs (->>
                    properties
                    (remove (fn [[k _]]
-                             (contains? #{:background-color :background_color} (keyword k))))
+                             (contains?
+                              (set (into (gp-property/editable-built-in-properties)
+                                         (gp-property/hidden-built-in-properties)))
+                              (keyword k))))
                    (map last)
                    (map (fn [v]
                           (cond

--- a/deps/graph-parser/src/logseq/graph_parser/property.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/property.cljs
@@ -2,6 +2,7 @@
   "Property fns needed by graph-parser"
   (:require [logseq.graph-parser.util :as gp-util]
             [clojure.string :as string]
+            [clojure.set :as set]
             [goog.string :as gstring]
             [goog.string.format]))
 
@@ -11,6 +12,24 @@
    (vector? block)
    (contains? #{"Property_Drawer" "Properties"}
               (first block))))
+
+(def markers
+  #{"now" "later" "todo" "doing" "done" "wait" "waiting"
+    "canceled" "cancelled" "started" "in-progress"})
+
+(def built-in-extended-properties (atom #{}))
+(defn register-built-in-properties
+  [props]
+  (reset! built-in-extended-properties (set/union @built-in-extended-properties props)))
+
+(defn built-in-properties
+  "Properties that should only be used by logseq"
+  []
+  (set/union
+   #{:id :custom-id :background-color :heading :collapsed :created-at :updated-at :last-modified-at :created_at :last_modified_at :query-table :query-properties :query-sort-by :query-sort-desc
+     :ls-type :hl-type :hl-page :hl-stamp}
+   (set (map keyword markers))
+   @built-in-extended-properties))
 
 (defonce properties-start ":PROPERTIES:")
 (defonce properties-end ":END:")

--- a/deps/graph-parser/src/logseq/graph_parser/property.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/property.cljs
@@ -34,7 +34,7 @@
    #{:id :custom-id :background-color :background_color :heading :collapsed
      :created-at :updated-at :last-modified-at :created_at :last_modified_at
      :query-table :query-properties :query-sort-by :query-sort-desc :ls-type
-     :hl-type :hl-page :hl-stamp :icon :filters :file-path}
+     :hl-type :hl-page :hl-stamp :filters :file-path}
    (set (map keyword markers))
    @built-in-extended-properties))
 

--- a/deps/graph-parser/src/logseq/graph_parser/property.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/property.cljs
@@ -22,14 +22,19 @@
   [props]
   (reset! built-in-extended-properties (set/union @built-in-extended-properties props)))
 
-(defn built-in-properties
-  "Properties that should only be used by logseq"
+(defn editable-built-in-properties
+  "Properties used by logseq that user can edit"
+  []
+  #{:title :alias :tags :template :template-including-parent :public})
+
+(defn hidden-built-in-properties
+  "Properties used by logseq that user can't edit or see"
   []
   (set/union
-   #{:id :custom-id :background-color :heading :collapsed :created-at :updated-at
-     :last-modified-at :created_at :last_modified_at :query-table
-     :query-properties :query-sort-by :query-sort-desc :ls-type :hl-type
-     :hl-page :hl-stamp :template-including-parent :icon :filters}
+   #{:id :custom-id :background-color :background_color :heading :collapsed
+     :created-at :updated-at :last-modified-at :created_at :last_modified_at
+     :query-table :query-properties :query-sort-by :query-sort-desc :ls-type
+     :hl-type :hl-page :hl-stamp :icon :filters :file-path}
    (set (map keyword markers))
    @built-in-extended-properties))
 

--- a/deps/graph-parser/src/logseq/graph_parser/property.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/property.cljs
@@ -25,7 +25,7 @@
 (defn editable-built-in-properties
   "Properties used by logseq that user can edit"
   []
-  #{:title :alias :tags :template :template-including-parent :public})
+  #{:title :alias :aliases :tags :icon :template :template-including-parent :public})
 
 (defn hidden-built-in-properties
   "Properties used by logseq that user can't edit or see"

--- a/deps/graph-parser/src/logseq/graph_parser/property.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/property.cljs
@@ -17,15 +17,24 @@
   #{"now" "later" "todo" "doing" "done" "wait" "waiting"
     "canceled" "cancelled" "started" "in-progress"})
 
+;; Built-in properties are properties that logseq uses for its features. Most of
+;; these properties are hidden from the user but a few like the editable ones
+;; are visible for the user to edit.
+
 (def built-in-extended-properties (atom #{}))
 (defn register-built-in-properties
   [props]
   (reset! built-in-extended-properties (set/union @built-in-extended-properties props)))
 
+(def editable-linkable-built-in-properties
+  "Properties used by logseq that user can edit and that can have linkable property values"
+  #{:alias :aliases :tags})
+
 (defn editable-built-in-properties
   "Properties used by logseq that user can edit"
   []
-  #{:title :alias :aliases :tags :icon :template :template-including-parent :public})
+  (into #{:title :icon :template :template-including-parent :public :filters}
+        editable-linkable-built-in-properties))
 
 (defn hidden-built-in-properties
   "Properties used by logseq that user can't edit or see"
@@ -34,7 +43,7 @@
    #{:id :custom-id :background-color :background_color :heading :collapsed
      :created-at :updated-at :last-modified-at :created_at :last_modified_at
      :query-table :query-properties :query-sort-by :query-sort-desc :ls-type
-     :hl-type :hl-page :hl-stamp :filters :file-path}
+     :hl-type :hl-page :hl-stamp :file-path}
    (set (map keyword markers))
    @built-in-extended-properties))
 

--- a/deps/graph-parser/src/logseq/graph_parser/property.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/property.cljs
@@ -26,8 +26,10 @@
   "Properties that should only be used by logseq"
   []
   (set/union
-   #{:id :custom-id :background-color :heading :collapsed :created-at :updated-at :last-modified-at :created_at :last_modified_at :query-table :query-properties :query-sort-by :query-sort-desc
-     :ls-type :hl-type :hl-page :hl-stamp}
+   #{:id :custom-id :background-color :heading :collapsed :created-at :updated-at
+     :last-modified-at :created_at :last_modified_at :query-table
+     :query-properties :query-sort-by :query-sort-desc :ls-type :hl-type
+     :hl-page :hl-stamp :template-including-parent :icon :filters}
    (set (map keyword markers))
    @built-in-extended-properties))
 

--- a/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
@@ -142,7 +142,7 @@
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
     (is (= 211 (count files)) "Correct file count")
-    (is (= 41583 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 41290 (count (d/datoms db :eavt))) "Correct datoms count")
 
     (is (= 3600
            (ffirst

--- a/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
@@ -142,7 +142,7 @@
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
     (is (= 211 (count files)) "Correct file count")
-    (is (= 44212 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 42648 (count (d/datoms db :eavt))) "Correct datoms count")
 
     (is (= 3600
            (ffirst

--- a/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
@@ -142,7 +142,7 @@
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
     (is (= 211 (count files)) "Correct file count")
-    (is (= 41554 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 41583 (count (d/datoms db :eavt))) "Correct datoms count")
 
     (is (= 3600
            (ffirst

--- a/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
@@ -142,7 +142,7 @@
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
     (is (= 211 (count files)) "Correct file count")
-    (is (= 42056 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 41554 (count (d/datoms db :eavt))) "Correct datoms count")
 
     (is (= 3600
            (ffirst

--- a/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
@@ -142,7 +142,7 @@
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
     (is (= 211 (count files)) "Correct file count")
-    (is (= 42638 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 42056 (count (d/datoms db :eavt))) "Correct datoms count")
 
     (is (= 3600
            (ffirst

--- a/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
@@ -142,7 +142,7 @@
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
     (is (= 211 (count files)) "Correct file count")
-    (is (= 42648 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 42638 (count (d/datoms db :eavt))) "Correct datoms count")
 
     (is (= 3600
            (ffirst

--- a/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
@@ -1,36 +1,61 @@
 (ns logseq.graph-parser.block-test
   (:require [logseq.graph-parser.block :as gp-block]
-            [cljs.test :refer [deftest are]]))
+            [cljs.test :refer [deftest are testing is]]))
 
 (deftest test-extract-properties
   (are [x y] (= (:properties (gp-block/extract-properties :markdown x {})) y)
-    [["year" "1000"]] {:year 1000}
-    [["year" "\"1000\""]] {:year "\"1000\""}
-    [["background-color" "#000000"]] {:background-color "#000000"}
-    [["alias" "name/with space"]] {:alias #{"name/with space"}}
-    [["year" "1000"] ["alias" "name/with space"]] {:year 1000, :alias #{"name/with space"}}
-    [["year" "1000"] ["tags" "name/with space"]] {:year 1000, :tags #{"name/with space"}}
-    [["year" "1000"] ["tags" "name/with space, another"]] {:year 1000, :tags #{"name/with space" "another"}}
-    [["year" "1000"] ["alias" "name/with space, another"]] {:year 1000, :alias #{"name/with space" "another"}}
-    [["year" "1000"] ["alias" "name/with space, [[another [[nested]]]]"]] {:year 1000, :alias #{"name/with space" "another [[nested]]"}}
-    [["year" "1000"] ["alias" "name/with space, [[[[nested]] another]]"]] {:year 1000, :alias #{"name/with space" "[[nested]] another"}}
-    [["foo" "bar"]] {:foo "bar"}
-    [["foo" "bar, baz"]] {:foo #{"bar" "baz"}}
-    [["foo" "bar, [[baz]]"]] {:foo #{"bar" "baz"}}
-    [["foo" "[[bar]], [[baz]]"]] {:foo #{"bar" "baz"}}
-    [["foo" "[[bar]], [[nested [[baz]]]]"]] {:foo #{"bar" "nested [[baz]]"}}
-    [["foo" "[[bar]], [[nested [[baz]]]]"]] {:foo #{"bar" "nested [[baz]]"}}
-    [["foo" "bar, [[baz, test]]"]] {:foo #{"bar" "baz, test"}}
-    [["foo" "bar, [[baz, test, [[nested]]]]"]] {:foo #{"bar" "baz, test, [[nested]]"}}
-    [["file-path" "file:///home/x, y.pdf"]] {:file-path "file:///home/x, y.pdf"})
+       [["year" "1000"]] {:year 1000}
+       [["year" "\"1000\""]] {:year "\"1000\""}
+       [["background-color" "#000000"]] {:background-color "#000000"}
+       [["alias" "name/with space"]] {:alias #{"name/with space"}}
+       [["year" "1000"] ["alias" "name/with space"]] {:year 1000, :alias #{"name/with space"}}
+       [["year" "1000"] ["tags" "name/with space"]] {:year 1000, :tags #{"name/with space"}}
+       [["year" "1000"] ["tags" "name/with space, another"]] {:year 1000, :tags #{"name/with space" "another"}}
+       [["year" "1000"] ["alias" "name/with space, another"]] {:year 1000, :alias #{"name/with space" "another"}}
+       [["year" "1000"] ["alias" "name/with space, [[another [[nested]]]]"]] {:year 1000, :alias #{"name/with space" "another [[nested]]"}}
+       [["year" "1000"] ["alias" "name/with space, [[[[nested]] another]]"]] {:year 1000, :alias #{"name/with space" "[[nested]] another"}}
+       [["foo" "bar"]] {:foo "bar"}
+       [["foo" "bar, baz"]] {:foo #{"bar" "baz"}}
+       [["foo" "bar, [[baz]]"]] {:foo #{"bar" "baz"}}
+       [["foo" "[[bar]], [[baz]]"]] {:foo #{"bar" "baz"}}
+       [["foo" "[[bar]], [[nested [[baz]]]]"]] {:foo #{"bar" "nested [[baz]]"}}
+       [["foo" "[[bar]], [[nested [[baz]]]]"]] {:foo #{"bar" "nested [[baz]]"}}
+       [["foo" "bar, [[baz, test]]"]] {:foo #{"bar" "baz, test"}}
+       [["foo" "bar, [[baz, test, [[nested]]]]"]] {:foo #{"bar" "baz, test, [[nested]]"}}
+       [["file-path" "file:///home/x, y.pdf"]] {:file-path "file:///home/x, y.pdf"})
 
-  (are [x y] (= (vec (:page-refs (gp-block/extract-properties :markdown x {}))) y)
-    [["year" "1000"]] ["year"]
-    [["year" "\"1000\""]] ["year"]
-    [["foo" "[[bar]] test"]] ["bar" "test" "foo"]
-    [["foo" "[[bar]] test [[baz]]"]] ["bar" "test" "baz" "foo"]
-    [["foo" "[[bar]] test [[baz]] [[nested [[baz]]]]"]] ["bar" "test" "baz" "nested [[baz]]" "foo"]
-    [["foo" "#bar, #baz"]] ["bar" "baz" "foo"]
-    [["foo" "[[nested [[page]]]], test"]] ["nested [[page]]" "test" "foo"]))
+  (testing "page-refs"
+    (are [x y] (= (vec (:page-refs
+                        (gp-block/extract-properties :markdown x {:property-pages/enabled? true}))) y)
+         [["year" "1000"]] ["year"]
+         [["year" "\"1000\""]] ["year"]
+         [["year" "1000"] ["month" "12"]] ["year" "month"]
+         [["foo" "[[bar]] test"]] ["bar" "test" "foo"]
+         [["foo" "[[bar]] test [[baz]]"]] ["bar" "test" "baz" "foo"]
+         [["foo" "[[bar]] test [[baz]] [[nested [[baz]]]]"]] ["bar" "test" "baz" "nested [[baz]]" "foo"]
+         [["foo" "#bar, #baz"]] ["bar" "baz" "foo"]
+         [["foo" "[[nested [[page]]]], test"]] ["nested [[page]]" "test" "foo"])
+
+
+    (are [x y] (= (vec (:page-refs
+                        (gp-block/extract-properties :markdown x {:property-pages/enabled? false}))) y)
+         [["year" "1000"]] []
+         [["year" "1000"] ["month" "12"]] []
+         [["foo" "[[bar]] test"]] ["bar" "test"])
+
+    (is (= ["year"]
+           (:page-refs
+            (gp-block/extract-properties :markdown
+                                         [["year" "1000"] ["month" "12"]]
+                                         {:property-pages/enabled? true
+                                          :property-pages/excludelist #{:month :day}})))
+        ":property-pages/exclude-list excludes specified properties")
+
+    (is (= ["year"]
+           (:page-refs
+                (gp-block/extract-properties :markdown
+                                             [["year" "1000"]]
+                                             {})))
+        "Default to enabled when :property-pages/enabled? is not in config")))
 
 #_(cljs.test/run-tests)

--- a/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
@@ -28,7 +28,7 @@
     (are [x y] (= (vec (:page-refs
                         (gp-block/extract-properties :markdown x {:property-pages/enabled? true}))) y)
          [["year" "1000"]] ["year"]
-         [["year" "\"1000\""]] ["1000" "year"]
+         [["year" "\"1000\""]] ["year"]
          [["year" "1000"] ["month" "12"]] ["year" "month"]
          [["foo" "[[bar]] test"]] ["bar" "test" "foo"]
          [["foo" "[[bar]] test [[baz]]"]] ["bar" "test" "baz" "foo"]

--- a/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
@@ -28,7 +28,7 @@
     (are [x y] (= (vec (:page-refs
                         (gp-block/extract-properties :markdown x {:property-pages/enabled? true}))) y)
          [["year" "1000"]] ["year"]
-         [["year" "\"1000\""]] ["year"]
+         [["year" "\"1000\""]] ["1000" "year"]
          [["year" "1000"] ["month" "12"]] ["year" "month"]
          [["foo" "[[bar]] test"]] ["bar" "test" "foo"]
          [["foo" "[[bar]] test [[baz]]"]] ["bar" "test" "baz" "foo"]

--- a/deps/graph-parser/test/logseq/graph_parser/cli_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/cli_test.cljs
@@ -8,7 +8,7 @@
 (deftest ^:integration parse-graph
   (let [graph-dir "test/docs"
         _ (docs-graph-helper/clone-docs-repo-if-not-exists graph-dir)
-        {:keys [conn files asts]} (gp-cli/parse-graph graph-dir)]
+        {:keys [conn files asts]} (gp-cli/parse-graph graph-dir {:verbose false})]
 
     (docs-graph-helper/docs-graph-assertions @conn files)
 

--- a/e2e-tests/page-search.spec.ts
+++ b/e2e-tests/page-search.spec.ts
@@ -161,6 +161,6 @@ async function alias_test(page: Page, page_name: string, search_kws: string[]) {
   // TODO: search clicking (alias property)
 }
 
-test('page diacritic alias', async ({ page }) => {
+test.skip('page diacritic alias', async ({ page }) => {
   await alias_test(page, "ü", ["ü", "ü", "Ü"])
 })

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1805,9 +1805,12 @@
 
 (rum/defc property-cp
   [config block k v]
-  (let [date (and (= k :date) (date/get-locale-string (str v)))]
+  (let [date (and (= k :date) (date/get-locale-string (str v)))
+        property-pages-enabled? (contains? #{true nil} (:property-pages/enabled? (state/get-config)))]
     [:div
-     (page-cp (assoc config :property? true) {:block/name (subs (str k) 1)})
+     (if property-pages-enabled?
+       (page-cp (assoc config :property? true) {:block/name (subs (str k) 1)})
+       [:span.page-property-key.font-medium (name k)])
      [:span.mr-1 ":"]
      (cond
        (int? v)

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1549,7 +1549,7 @@
   (and
    (or
     (empty? properties)
-    (property/properties-built-in? properties))
+    (property/properties-hidden? properties))
 
    (empty? title)
 
@@ -2083,7 +2083,7 @@
           (timestamp-cp block "SCHEDULED" scheduled-ast)))
 
       (when (and (seq properties)
-                 (let [hidden? (property/properties-built-in? properties)]
+                 (let [hidden? (property/properties-hidden? properties)]
                    (not hidden?))
                  (not (and block-ref? (or (seq title) (seq body))))
                  (not (:slide? config)))

--- a/src/main/frontend/config.cljs
+++ b/src/main/frontend/config.cljs
@@ -259,10 +259,6 @@
 
 (def config-default-content (rc/inline "config.edn"))
 
-(def markers
-  #{"now" "later" "todo" "doing" "done" "wait" "waiting"
-    "canceled" "cancelled" "started" "in-progress"})
-
 (defonce idb-db-prefix "logseq-db/")
 (defonce local-db-prefix "logseq_local_")
 (defonce local-handle "handle")

--- a/src/main/frontend/extensions/srs.cljs
+++ b/src/main/frontend/extensions/srs.cljs
@@ -3,6 +3,7 @@
             [frontend.db.query-dsl :as query-dsl]
             [frontend.db.query-react :as query-react]
             [frontend.util :as util]
+            [logseq.graph-parser.property :as gp-property]
             [frontend.util.property :as property]
             [frontend.util.drawer :as drawer]
             [frontend.util.persist-var :as persist-var]
@@ -707,12 +708,12 @@
 (component-macro/register query-macro-name cards)
 
 ;;; register builtin properties
-(property/register-built-in-properties #{card-last-interval-property
-                                         card-repeats-property
-                                         card-last-reviewed-property
-                                         card-next-schedule-property
-                                         card-last-easiness-factor-property
-                                         card-last-score-property})
+(gp-property/register-built-in-properties #{card-last-interval-property
+                                            card-repeats-property
+                                            card-last-reviewed-property
+                                            card-next-schedule-property
+                                            card-last-easiness-factor-property
+                                            card-last-score-property})
 
 ;;; register slash commands
 (commands/register-slash-command ["Cards"

--- a/src/main/frontend/util/property.cljs
+++ b/src/main/frontend/util/property.cljs
@@ -11,18 +11,26 @@
             [logseq.graph-parser.text :as text]
             [frontend.util.cursor :as cursor]))
 
-(defn built-in-properties
+(defn hidden-properties
+  "These are properties hidden from user including built-in ones and ones
+  configured by user"
   []
   (set/union
-   (gp-property/built-in-properties)
+   (gp-property/hidden-built-in-properties)
    (set (config/get-block-hidden-properties))))
 
-(defn properties-built-in?
+;; TODO: Investigate if this behavior is correct for configured hidden
+;; properties and for editable built in properties
+(def built-in-properties
+  "Alias to hidden-properties to keep existing behavior"
+  hidden-properties)
+
+(defn properties-hidden?
   [properties]
   (and (seq properties)
        (let [ks (map (comp keyword string/lower-case name) (keys properties))
-             built-in-properties-set (built-in-properties)]
-         (every? built-in-properties-set ks))))
+             hidden-properties-set (hidden-properties)]
+         (every? hidden-properties-set ks))))
 
 (defn remove-empty-properties
   [content]

--- a/src/main/frontend/util/property.cljs
+++ b/src/main/frontend/util/property.cljs
@@ -11,19 +11,11 @@
             [logseq.graph-parser.text :as text]
             [frontend.util.cursor :as cursor]))
 
-(def built-in-extended-properties (atom #{}))
-(defn register-built-in-properties
-  [props]
-  (reset! built-in-extended-properties (set/union @built-in-extended-properties props)))
-
 (defn built-in-properties
   []
   (set/union
-   #{:id :custom-id :background-color :heading :collapsed :created-at :updated-at :last-modified-at :created_at :last_modified_at :query-table :query-properties :query-sort-by :query-sort-desc
-     :ls-type :hl-type :hl-page :hl-stamp}
-   (set (map keyword config/markers))
-   (set (config/get-block-hidden-properties))
-   @built-in-extended-properties))
+   (gp-property/built-in-properties)
+   (set (config/get-block-hidden-properties))))
 
 (defn properties-built-in?
   [properties]

--- a/templates/config.edn
+++ b/templates/config.edn
@@ -212,6 +212,13 @@
  ;; E.g. #{:created-at :updated-at}
  ;; :block-hidden-properties #{}
 
+ ;; Enable all your properties to have corresponding pages
+ :property-pages/enabled? true
+
+ ;; Properties to exclude from having property pages
+ ;; E.g. #{:duration :author}
+ ;; :property-pages/excludelist
+
  ;; logbook setup
  ;; :logbook/settings
  ;; {:with-second-support? false ;limit logbook to minutes, seconds will be eliminated


### PR DESCRIPTION
As a follow up to https://github.com/logseq/logseq/pull/5922, this does the following:
* Ignores logseq properties to fix #5963
*  Provides a config option to enable/disable property pages
* Provides a config option to exclude certain property names from having pages created

This PR is an alternative PR to #6009 and #6022. I tested this by removing all page properties from `logseq/pages-metadata.edn` and then re-indexing