### PR TITLE
Plugin settings add data-key

### DIFF
--- a/src/main/frontend/components/plugins_settings.cljs
+++ b/src/main/frontend/components/plugins_settings.cljs
@@ -17,6 +17,7 @@
   [val {:keys [key type title default description inputAs]} update-setting!]
 
   [:div.desc-item.as-input
+   {:data-key key}
    [:h2 [:code key] (ui/icon "caret-right") [:strong title]]
 
    [:label.form-control
@@ -35,6 +36,7 @@
 
   (let [val (if (boolean? val) val (boolean default))]
     [:div.desc-item.as-toggle
+     {:data-key key}
      [:h2 [:code key] (ui/icon "caret-right") [:strong title]]
 
      [:label.form-control
@@ -51,6 +53,7 @@
                               :selected (contains? vals v)}) enumChoices)
         picker (keyword enumPicker)]
     [:div.desc-item.as-enum
+     {:data-key key}
      [:h2 [:code key] (ui/icon "caret-right") [:strong title]]
 
      [:div.form-control
@@ -68,6 +71,7 @@
   [_val {:keys [key title description _default]} pid]
 
   [:div.desc-item.as-object
+   {:data-key key}
    [:h2 [:code key] (ui/icon "caret-right") [:strong title]]
 
    [:div.form-control
@@ -78,6 +82,7 @@
   [{:keys [title]}]
 
   [:div.heading-item
+   {:data-key key}
    [:h2 title]])
 
 (rum/defc settings-container


### PR DESCRIPTION
Add `data-key` attribute to plugin settings item.

**Use case:**
Plugin settings (for ex. colors/bgs) for different modes (dark & light) should have **2x** sets of items for each mode 😒
To hide unneeded via CSS, they should have some identifier.

For ex.  plugin JS and CSS:
```js
const settingsArray: SettingSchemaDesc[] = [
  {
    key: "lightModeHeading",
    title: "Light mode settings",
    type: "heading"
  },
  {
    key: "lightDefaultlBgColor",
    title: "Default bg color",
    type: "string",
    description: "",
    default: "",
  },
  ...
  ... lot of "light" related settings
  ...
  {
    key: "darkModelHeading",
    title: "Dark mode settings",
    type: "heading"
  },
 ...
 ... lot of SAME settings, but for "dark"
 ...
```
```css
/* User in dark mode - hiding "light" mode items */
.dark-theme .cp__plugins-settings :is(.heading-item, .desc-item)[data-key^="light"] {
    display:none;
}
/* User in light mode - hiding "dark" mode items */
.light-theme .cp__plugins-settings :is(.heading-item, .desc-item)[data-key^="dark"] {
    display:none;
}
```