### PR TITLE
feat: added property exclude-in-graph

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/property.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/property.cljs
@@ -33,7 +33,7 @@
 (defn editable-built-in-properties
   "Properties used by logseq that user can edit"
   []
-  (into #{:title :icon :template :template-including-parent :public :filters}
+  (into #{:title :icon :template :template-including-parent :public :filters :exclude-from-graph-view}
         editable-linkable-built-in-properties))
 
 (defn hidden-built-in-properties

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -433,17 +433,20 @@
 (defonce *journal? (atom nil))
 (defonce *orphan-pages? (atom true))
 (defonce *builtin-pages? (atom nil))
+(defonce *excluded-pages? (atom true))
 
 (rum/defc ^:large-vars/cleanup-todo graph-filters < rum/reactive
   [graph settings n-hops]
-  (let [{:keys [journal? orphan-pages? builtin-pages?]
+  (let [{:keys [journal? orphan-pages? builtin-pages? excluded-pages?]
          :or {orphan-pages? true}} settings
         journal?' (rum/react *journal?)
         orphan-pages?' (rum/react *orphan-pages?)
         builtin-pages?' (rum/react *builtin-pages?)
+        excluded-pages?' (rum/react *excluded-pages?)
         journal? (if (nil? journal?') journal? journal?')
         orphan-pages? (if (nil? orphan-pages?') orphan-pages? orphan-pages?')
         builtin-pages? (if (nil? builtin-pages?') builtin-pages? builtin-pages?')
+        excluded-pages? (if (nil? excluded-pages?') excluded-pages? excluded-pages?')
         set-setting! (fn [key value]
                        (let [new-settings (assoc settings key value)]
                          (config-handler/set-config! :graph/settings new-settings)))
@@ -509,6 +512,15 @@
                                (reset! *builtin-pages? value)
                                (set-setting! :builtin-pages? value)))
                            true)]]
+              [:div.flex.items-center.justify-between.mb-2
+               [:span "Excluded pages"]
+               [:div.mt-1
+                (ui/toggle excluded-pages?
+                           (fn []
+                             (let [value (not excluded-pages?)]
+                               (reset! *excluded-pages? value)
+                               (set-setting! :excluded-pages? value)))
+                           true)]]              
               (when (seq focus-nodes)
                 [:div.flex.flex-col.mb-2
                  [:p {:title "N hops from selected nodes"}

--- a/src/main/frontend/handler/graph.cljs
+++ b/src/main/frontend/handler/graph.cljs
@@ -98,7 +98,7 @@
 
            pages-after-exclude-filter (cond->> pages-after-journal-filter
                                         (not excluded-pages?)
-                                        (remove (fn [p] (=  true (:exclude-in-graph (:block/properties p))))))
+                                        (remove (fn [p] (=  true (:exclude-from-graph-view (:block/properties p))))))
 
             links (concat (seq relation)
                           (seq tagged-pages)

--- a/src/main/frontend/handler/graph.cljs
+++ b/src/main/frontend/handler/graph.cljs
@@ -81,7 +81,7 @@
      :links links}))
 
 (defn build-global-graph
-  [theme {:keys [journal? orphan-pages? builtin-pages?]}]
+  [theme {:keys [journal? orphan-pages? builtin-pages? excluded-pages?]}]
   (let [dark? (= "dark" theme)
         current-page (or (:block/name (db/get-current-page)) "")]
     (when-let [repo (state/get-current-repo)]
@@ -95,12 +95,17 @@
             pages-after-journal-filter (if-not journal?
                                          (remove :block/journal? full-pages)
                                          full-pages)
+
+           pages-after-exclude-filter (cond->> pages-after-journal-filter
+                                        (not excluded-pages?)
+                                        (remove (fn [p] (=  true (:exclude-in-graph (:block/properties p))))))
+
             links (concat (seq relation)
                           (seq tagged-pages)
                           (seq namespaces))
             linked (set (flatten links))
             build-in-pages (set (map string/lower-case default-db/built-in-pages-names))
-            nodes (cond->> (map :block/name pages-after-journal-filter)
+            nodes (cond->> (map :block/name pages-after-exclude-filter)
                     (not builtin-pages?)
                     (remove (fn [p] (contains? build-in-pages (string/lower-case p))))
                     (not orphan-pages?)


### PR DESCRIPTION
- Like this thread [#1312](https://discuss.logseq.com/t/option-to-ignore-certain-nodes-in-the-graph/1312), I added the ability to exclude a page in "global graph" by adding the property exclude-in-graph:: true
	- added property exclude-in-graph
	- added settings paramenter :excluded-pages
	- added "Excluded pages" toggle in in graph filters

EDIT: for the moment the display of the "page graph"  remains unchanged