### PR TITLE
fix(api): return non transferable value for plugin api

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1252,7 +1252,8 @@
 
       ;; if different direction, keep clear until one left
     (state/selection?)
-    (clear-last-selected-block!)))
+    (clear-last-selected-block!))
+  nil)
 
 (defn on-select-block
   [direction]
@@ -3053,7 +3054,8 @@
         (select-up-down direction)
 
         :else
-        (select-first-last direction)))))
+        (select-first-last direction)))
+    nil))
 
 (defn shortcut-select-up-down [direction]
   (fn [e]


### PR DESCRIPTION
Reproduced plugin: https://github.com/vipzhicheng/logseq-plugin-vim-shortcuts

<img width="1391" alt="CleanShot 2022-07-19 at 13 54 47@2x" src="https://user-images.githubusercontent.com/1779837/179675701-86fcf87a-b422-4819-9dd9-2031deab3ab5.png">
