### PR TITLE
fix(ui): dsl-query style

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1146,7 +1146,7 @@
 ;;;; Macro component render functions
 (defn- macro-query-cp
   [config arguments]
-  [:div.dsl-query.overflow-x-hidden.pr-3.sm:pr-0
+  [:div.dsl-query.pr-3.sm:pr-0
    (let [query (->> (string/join ", " arguments)
                     (string/trim))]
      (when-not (string/blank? query)


### PR DESCRIPTION
It should work like this:
- Before
![微信图片_20220721150111](https://user-images.githubusercontent.com/55137994/180150550-85efc876-825c-4293-9210-12a11b22b205.jpg)
- After
![微信图片_20220721150123](https://user-images.githubusercontent.com/55137994/180150574-0dcafd81-6ef0-43f5-a521-75386aa69a93.jpg)

