### PR TITLE
Fix: page properties not reading property-pages config

### DIFF
--- a/deps/db/package.json
+++ b/deps/db/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "devDependencies": {
-    "@logseq/nbb-logseq": "^0.5.103"
+    "@logseq/nbb-logseq": "^0.6.125"
   }
 }

--- a/deps/db/yarn.lock
+++ b/deps/db/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@logseq/nbb-logseq@^0.5.103":
-  version "0.5.103"
-  resolved "https://registry.yarnpkg.com/@logseq/nbb-logseq/-/nbb-logseq-0.5.103.tgz#1084380cd54c92ca8cc94a8934cc777206e45cc0"
-  integrity sha512-V9UW0XrCaaadHUc6/Hp9wfGpQqkzqzoqnDGeSVZkWR6l3QwyqGi9mkhnhVcfTwAvxIfOgrfz93GcaeepV4pYNA==
+"@logseq/nbb-logseq@^0.6.125":
+  version "0.6.125"
+  resolved "https://registry.yarnpkg.com/@logseq/nbb-logseq/-/nbb-logseq-0.6.125.tgz#197dbb01040f9cfdf7040399b9fbed9b862dee5b"
+  integrity sha512-1UB4Urt6O95Cwwni68B/f05x+wsL+ju+dCGLE47WTvF9F8WQwhiADfWhMbFOt35ImswLSzM1rgVGIMIj0g6fkQ==
   dependencies:
     import-meta-resolve "^1.1.1"
 

--- a/deps/graph-parser/package.json
+++ b/deps/graph-parser/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "devDependencies": {
-    "@logseq/nbb-logseq": "^0.5.103"
+    "@logseq/nbb-logseq": "^0.6.125"
   },
   "dependencies": {
     "mldoc": "^1.3.9"

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -480,8 +480,8 @@
       (d/squuid)))
 
 (defn get-page-refs-from-properties
-  [format properties db date-formatter]
-  (let [page-refs (get-page-ref-names-from-properties format properties {})]
+  [format properties db date-formatter user-config]
+  (let [page-refs (get-page-ref-names-from-properties format properties user-config)]
     (map (fn [page] (page-name->map page true db true date-formatter)) page-refs)))
 
 (defn- with-page-block-refs
@@ -493,7 +493,7 @@
           (update :refs (fn [col] (remove nil? col)))))
 
 (defn- with-pre-block-if-exists
-  [blocks body pre-block-properties encoded-content {:keys [supported-formats db date-formatter]}]
+  [blocks body pre-block-properties encoded-content {:keys [supported-formats db date-formatter user-config]}]
   (let [first-block (first blocks)
         format (or (:block/format first-block) :markdown)
         first-block-start-pos (get-in first-block [:block/meta :start_pos])
@@ -506,7 +506,7 @@
                    (let [content (utf8/substring encoded-content 0 first-block-start-pos)
                          {:keys [properties properties-order]} pre-block-properties
                          id (get-custom-id-or-new-id {:properties properties})
-                         property-refs (->> (get-page-refs-from-properties format properties db date-formatter)
+                         property-refs (->> (get-page-refs-from-properties format properties db date-formatter user-config)
                                             (map :block/original-name))
                          block {:uuid id
                                 :content content

--- a/deps/graph-parser/src/logseq/graph_parser/extract.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/extract.cljc
@@ -190,9 +190,6 @@
          (map (partial apply merge))
          (with-block-uuid))))
 
-#?(:org.babashka/nbb
-   (alter-var-root #'gp-mldoc/parse-property (constantly text/parse-property))
-   :default
-   ;; TODO: Properly fix this circular dependency:
-   ;; mldoc/->edn > text/parse-property > mldoc/link? ->mldoc/inline->edn + mldoc/default-config
-   (set! gp-mldoc/parse-property text/parse-property))
+;; TODO: Properly fix this circular dependency:
+;; mldoc/->edn > text/parse-property > mldoc/link? ->mldoc/inline->edn + mldoc/default-config
+(set! gp-mldoc/parse-property text/parse-property)

--- a/deps/graph-parser/test/logseq/graph_parser/extract_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/extract_test.cljs
@@ -1,19 +1,19 @@
 (ns logseq.graph-parser.extract-test
-  (:require [cljs.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is are]]
             [logseq.graph-parser.extract :as extract]
             [clojure.pprint :as pprint]))
 
 (defn- extract
   [text]
   (let [{:keys [blocks]} (extract/extract "a.md" text {:block-pattern "-"})
-          lefts (map (juxt :block/parent :block/left) blocks)]
+        lefts (map (juxt :block/parent :block/left) blocks)]
     (if (not= (count lefts) (count (distinct lefts)))
       (do
         (pprint/pprint (map (fn [x] (select-keys x [:block/uuid :block/level :block/content :block/left])) blocks))
         (throw (js/Error. ":block/parent && :block/left conflicts")))
       (mapv :block/content blocks))))
 
-(deftest test-extract
+(deftest extract-blocks-for-headings
   []
   (is (= ["a" "b" "c"]
          (extract
@@ -40,6 +40,21 @@
     - h
   - i
 - j"))))
+
+(deftest extract-blocks-with-property-pages-config
+  []
+  (are [extract-args expected-refs]
+       (= expected-refs
+          (->> (apply extract/extract extract-args)
+               :blocks
+               (mapcat #(->> % :block/refs (map :block/name)))
+               set))
+
+       ["a.md" "foo:: #bar\nbaz:: #bing" {:block-pattern "-" :user-config {:property-pages/enabled? true}}]
+       #{"bar" "bing" "foo" "baz"}
+
+       ["a.md" "foo:: #bar\nbaz:: #bing" {:block-pattern "-" :user-config {:property-pages/enabled? false}}]
+       #{"bar" "bing"}))
 
 (deftest test-regression-1902
   []

--- a/deps/graph-parser/yarn.lock
+++ b/deps/graph-parser/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@logseq/nbb-logseq@^0.5.103":
-  version "0.5.103"
-  resolved "https://registry.yarnpkg.com/@logseq/nbb-logseq/-/nbb-logseq-0.5.103.tgz#1084380cd54c92ca8cc94a8934cc777206e45cc0"
-  integrity sha512-V9UW0XrCaaadHUc6/Hp9wfGpQqkzqzoqnDGeSVZkWR6l3QwyqGi9mkhnhVcfTwAvxIfOgrfz93GcaeepV4pYNA==
+"@logseq/nbb-logseq@^0.6.125":
+  version "0.6.125"
+  resolved "https://registry.yarnpkg.com/@logseq/nbb-logseq/-/nbb-logseq-0.6.125.tgz#197dbb01040f9cfdf7040399b9fbed9b862dee5b"
+  integrity sha512-1UB4Urt6O95Cwwni68B/f05x+wsL+ju+dCGLE47WTvF9F8WQwhiADfWhMbFOt35ImswLSzM1rgVGIMIj0g6fkQ==
   dependencies:
     import-meta-resolve "^1.1.1"
 

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -660,9 +660,11 @@
 (defn properties-block
   [properties format page]
   (let [content (property/insert-properties format "" properties)
-        refs (gp-block/get-page-refs-from-properties format properties
+        refs (gp-block/get-page-refs-from-properties format
+                                                     properties
                                                      (db/get-db (state/get-current-repo))
-                                                     (state/get-date-formatter))]
+                                                     (state/get-date-formatter)
+                                                     (state/get-config))]
     {:block/pre-block? true
      :block/uuid (db/new-block-id)
      :block/properties properties

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -74,9 +74,11 @@
    (let [p (common-handler/get-page-default-properties title)
          ps (merge p properties)
          content (page-property/insert-properties format "" ps)
-         refs (gp-block/get-page-refs-from-properties format properties
+         refs (gp-block/get-page-refs-from-properties format
+                                                      properties
                                                       (db/get-db (state/get-current-repo))
-                                                      (state/get-date-formatter))]
+                                                      (state/get-date-formatter)
+                                                      (state/get-config))]
      {:block/uuid (db/new-block-id)
       :block/properties ps
       :block/properties-order (keys ps)


### PR DESCRIPTION
This PR fixes #6124 from which I was able to confirm that page property pages (not block property pages) weren't being deleted when the property-pages config was turned off. This PR also bumps to the latest nbb-logseq. The source of the bug was [what I was worried about from the last PR](https://github.com/logseq/logseq/pull/6024#discussion_r921582161). With this fix, I am now able to delete all property pages with `:property-pages/enable? false` and then re-indexing my graph twice