### PR TITLE
fix(style): cursor of restart text

### DIFF
--- a/src/main/frontend/components/header.css
+++ b/src/main/frontend/components/header.css
@@ -90,7 +90,6 @@
 
     a.restart {
       position: relative;
-      cursor: pointer !important;
       display: flex;
       align-items: center;
 
@@ -102,6 +101,7 @@
       > strong {
         display: inline-block;
         padding-left: 2px;
+        cursor: pointer;
       }
     }
   }


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

As the title. The `cursor: pointer !important` in the `.restart` class won't work because there still has another CSS rule to limit all buttons or links in the header to be `cursor: default`.

https://github.com/logseq/logseq/blob/808215dda84587578bd5c601e9049274747faad4/src/main/frontend/components/header.css#L213