### PR TITLE
fix: make the title of sidebar item clickable. #4983

### DIFF
--- a/src/main/frontend/components/right_sidebar.cljs
+++ b/src/main/frontend/components/right_sidebar.cljs
@@ -127,8 +127,8 @@
            [:div.flex.flex-col
             [:div.flex.flex-row.justify-between
              [:div.flex.flex-row.justify-center
+              {:on-click #(state/sidebar-block-toggle-collapse! db-id)}
               [:a.opacity-50.hover:opacity-100.flex.items-center.pr-1
-               {:on-click #(state/sidebar-block-toggle-collapse! db-id)}
                (ui/rotating-arrow collapse?)]
               [:div.ml-1.font-medium
                title]]


### PR DESCRIPTION
fix #4983. make the title clickable.