### PR TITLE
fix(editor): fix internal-paste

### DIFF
--- a/src/main/frontend/handler/common.cljs
+++ b/src/main/frontend/handler/common.cljs
@@ -8,15 +8,10 @@
             [frontend.db :as db]
             [frontend.state :as state]
             [frontend.util :as util]
-            [frontend.util.property :as property]
             [goog.object :as gobj]
             ["ignore" :as Ignore]
             [lambdaisland.glogi :as log]
             [borkdude.rewrite-edn :as rewrite]))
-
-(defn copy-to-clipboard-without-id-property!
-  [format raw-text html]
-  (util/copy-to-clipboard! (property/remove-id-property format raw-text) html))
 
 (defn config-with-document-mode
   [config]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -995,9 +995,10 @@
           [top-level-block-uuids content] (compose-copied-blocks-contents repo ids)
           block (db/entity [:block/uuid (first ids)])]
       (when block
-        (let [html (export/export-blocks-as-html repo top-level-block-uuids)]
-          (common-handler/copy-to-clipboard-without-id-property! (:block/format block) content (when html? html)))
-        (state/set-copied-blocks! content (get-all-blocks-by-ids repo top-level-block-uuids))
+        (let [html (export/export-blocks-as-html repo top-level-block-uuids)
+              content (property/remove-id-property (:block/format block) content)]
+          (util/copy-to-clipboard! content (when html? html))
+          (state/set-copied-blocks! content (get-all-blocks-by-ids repo top-level-block-uuids)))
         (notification/show! "Copied!" :success)))))
 
 (defn copy-block-refs
@@ -1209,9 +1210,10 @@
           ;; TODO: support org mode
           [_top-level-block-uuids md-content] (compose-copied-blocks-contents repo [block-id])
           html (export/export-blocks-as-html repo [block-id])
-          sorted-blocks (tree/get-sorted-block-and-children repo (:db/id block))]
+          sorted-blocks (tree/get-sorted-block-and-children repo (:db/id block))
+          md-content (property/remove-id-property (:block/format block) md-content)]
       (state/set-copied-blocks! md-content sorted-blocks)
-      (common-handler/copy-to-clipboard-without-id-property! (:block/format block) md-content html)
+      (util/copy-to-clipboard!  md-content html)
       (delete-block-aux! block true))))
 
 (defn clear-last-selected-block!


### PR DESCRIPTION
Close #6229.

Record precise copied block content to pass the internal-paste check:

https://github.com/logseq/logseq/blob/0c19a02a2da9c33544b29a7bc16a24fbfb49be1f/src/main/frontend/handler/paste.cljs#L71

The `remove-property` (accidentally?) remove the tailing newlines, which failed the internal-paste check.

After hours of struggling, I still failed to add an e2e-test for this change. It seems like copy block in e2e-test don't set the HTML content into clipboard.