### PR TITLE
Dev: Centralize uses of block-ref, page-ref and property strings

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -32,7 +32,8 @@
              logseq.graph-parser.util gp-util
              logseq.graph-parser.property gp-property
              logseq.graph-parser.config gp-config
-             logseq.graph-parser.date-time-util date-time-util}}}
+             logseq.graph-parser.date-time-util date-time-util
+             logseq.graph-parser.util.page-ref page-ref}}}
 
  :hooks {:analyze-call {rum.core/defc hooks.rum/defc
                         rum.core/defcs hooks.rum/defcs}}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -33,7 +33,8 @@
              logseq.graph-parser.property gp-property
              logseq.graph-parser.config gp-config
              logseq.graph-parser.date-time-util date-time-util
-             logseq.graph-parser.util.page-ref page-ref}}}
+             logseq.graph-parser.util.page-ref page-ref
+             logseq.graph-parser.util.block-ref block-ref}}}
 
  :hooks {:analyze-call {rum.core/defc hooks.rum/defc
                         rum.core/defcs hooks.rum/defcs}}

--- a/deps/graph-parser/.carve/ignore
+++ b/deps/graph-parser/.carve/ignore
@@ -8,3 +8,5 @@ logseq.graph-parser.property/register-built-in-properties
 logseq.graph-parser.block/left-and-right-parens
 ;; API
 logseq.graph-parser.block/->block-ref
+;; API
+logseq.graph-parser.block/block-ref?

--- a/deps/graph-parser/.carve/ignore
+++ b/deps/graph-parser/.carve/ignore
@@ -4,3 +4,7 @@ logseq.graph-parser.cli/parse-graph
 logseq.graph-parser.mldoc/ast-export-markdown
 ;; API
 logseq.graph-parser.property/register-built-in-properties
+;; API
+logseq.graph-parser.block/left-and-right-parens
+;; API
+logseq.graph-parser.block/->block-ref

--- a/deps/graph-parser/.carve/ignore
+++ b/deps/graph-parser/.carve/ignore
@@ -12,3 +12,9 @@ logseq.graph-parser.block/->block-ref
 logseq.graph-parser.block/block-ref?
 ;; API
 logseq.graph-parser.block/get-all-block-ref-ids
+;; API
+logseq.graph-parser.util.page-ref/left-and-right-brackets
+;; API
+logseq.graph-parser.util.page-ref/->page-ref
+;; API
+logseq.graph-parser.util.page-ref/get-page-name!

--- a/deps/graph-parser/.carve/ignore
+++ b/deps/graph-parser/.carve/ignore
@@ -5,13 +5,13 @@ logseq.graph-parser.mldoc/ast-export-markdown
 ;; API
 logseq.graph-parser.property/register-built-in-properties
 ;; API
-logseq.graph-parser.block/left-and-right-parens
+logseq.graph-parser.util.block-ref/left-and-right-parens
 ;; API
-logseq.graph-parser.block/->block-ref
+logseq.graph-parser.util.block-ref/->block-ref
 ;; API
-logseq.graph-parser.block/block-ref?
+logseq.graph-parser.util.block-ref/block-ref?
 ;; API
-logseq.graph-parser.block/get-all-block-ref-ids
+logseq.graph-parser.util.block-ref/get-all-block-ref-ids
 ;; API
 logseq.graph-parser.util.page-ref/left-and-right-brackets
 ;; API

--- a/deps/graph-parser/.carve/ignore
+++ b/deps/graph-parser/.carve/ignore
@@ -10,3 +10,5 @@ logseq.graph-parser.block/left-and-right-parens
 logseq.graph-parser.block/->block-ref
 ;; API
 logseq.graph-parser.block/block-ref?
+;; API
+logseq.graph-parser.block/get-all-block-ref-ids

--- a/deps/graph-parser/.clj-kondo/config.edn
+++ b/deps/graph-parser/.clj-kondo/config.edn
@@ -10,6 +10,7 @@
              logseq.graph-parser.property gp-property
              logseq.graph-parser.config gp-config
              logseq.graph-parser.date-time-util date-time-util
-             logseq.graph-parser.util.page-ref page-ref}}}
+             logseq.graph-parser.util.page-ref page-ref
+             logseq.graph-parser.util.block-ref block-ref}}}
  :skip-comments true
  :output {:progress true}}

--- a/deps/graph-parser/.clj-kondo/config.edn
+++ b/deps/graph-parser/.clj-kondo/config.edn
@@ -9,6 +9,7 @@
              logseq.graph-parser.util gp-util
              logseq.graph-parser.property gp-property
              logseq.graph-parser.config gp-config
-             logseq.graph-parser.date-time-util date-time-util}}}
+             logseq.graph-parser.date-time-util date-time-util
+             logseq.graph-parser.util.page-ref page-ref}}}
  :skip-comments true
  :output {:progress true}}

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -10,7 +10,8 @@
             [logseq.graph-parser.property :as gp-property]
             [logseq.graph-parser.text :as text]
             [logseq.graph-parser.utf8 :as utf8]
-            [logseq.graph-parser.util :as gp-util]))
+            [logseq.graph-parser.util :as gp-util]
+            [logseq.graph-parser.util.page-ref :as page-ref]))
 
 (defn heading-block?
   [block]
@@ -87,7 +88,7 @@ of block-ref?"
 
                   (and
                    (= typ "Search")
-                   (text/page-ref? value)
+                   (page-ref/page-ref? value)
                    (text/page-ref-un-brackets! value))
 
                   (and

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -32,6 +32,26 @@
                   "")))
          (string/join))))
 
+(def left-parens "Opening characters for block-ref" "((")
+(def right-parens "Closing characters for block-ref" "))")
+(def left-and-right-parens "Opening and closing characters for block-ref"
+  (str left-parens right-parens))
+
+(defn block-ref-string?
+  [s]
+  (and (string/starts-with? s left-parens)
+       (string/ends-with? s right-parens)))
+
+(defn ->block-ref
+  "Creates block ref string given id"
+  [block-id]
+  (str left-parens block-id right-parens))
+
+(defn block-ref->block-id
+  "Extracts block id from block-ref string e.g. ((123)) -> 123."
+  [s]
+  (subs s 2 (- (count s) 2)))
+
 (defn- get-page-reference
   [block supported-formats]
   (let [page (cond
@@ -111,9 +131,8 @@
                         (let [{:keys [name arguments]} (second block)]
                           (when (and (= name "embed")
                                      (string? (first arguments))
-                                     (string/starts-with? (first arguments) "((")
-                                     (string/ends-with? (first arguments) "))"))
-                            (subs (first arguments) 2 (- (count (first arguments)) 2))))
+                                     (block-ref-string? (first arguments)))
+                            (block-ref->block-id (first arguments))))
 
                         (and (vector? block)
                              (= "Link" (first block))

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -36,8 +36,31 @@
 (def right-parens "Closing characters for block-ref" "))")
 (def left-and-right-parens "Opening and closing characters for block-ref"
   (str left-parens right-parens))
+(def block-ref-re #"\(\(([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})\)\)")
 
-(defn block-ref-string?
+(defn get-all-block-ref-ids
+  [content]
+  (map second (re-seq block-ref-re content)))
+
+(defn get-block-ref-id
+  "Extracts block id from block-ref using regex"
+  [s]
+  (second (re-matches block-ref-re s)))
+
+(defn get-string-block-ref-id
+  "Extracts block id from block-ref by stripping parens e.g. ((123)) -> 123.
+  This is a less strict version of get-block-ref-id"
+  [s]
+  (subs s 2 (- (count s) 2)))
+
+(defn block-ref?
+  "Determines if string is block ref using regex"
+  [s]
+  (boolean (get-block-ref-id s)))
+
+(defn string-block-ref?
+  "Determines if string is block ref by checking parens. This is less strict version
+of block-ref?"
   [s]
   (and (string/starts-with? s left-parens)
        (string/ends-with? s right-parens)))
@@ -46,11 +69,6 @@
   "Creates block ref string given id"
   [block-id]
   (str left-parens block-id right-parens))
-
-(defn block-ref->block-id
-  "Extracts block id from block-ref string e.g. ((123)) -> 123."
-  [s]
-  (subs s 2 (- (count s) 2)))
 
 (defn- get-page-reference
   [block supported-formats]
@@ -111,7 +129,7 @@
 
                :else
                nil)]
-    (text/block-ref-un-brackets! page)))
+    (when page (or (get-block-ref-id page) page))))
 
 (defn- get-block-reference
   [block]
@@ -131,8 +149,8 @@
                         (let [{:keys [name arguments]} (second block)]
                           (when (and (= name "embed")
                                      (string? (first arguments))
-                                     (block-ref-string? (first arguments)))
-                            (block-ref->block-id (first arguments))))
+                                     (string-block-ref? (first arguments)))
+                            (get-string-block-ref-id (first arguments))))
 
                         (and (vector? block)
                              (= "Link" (first block))
@@ -140,7 +158,9 @@
                         (if (= "id" (:protocol (second (:url (second block)))))
                           (:link (second (:url (second block))))
                           (let [id (second (:url (second block)))]
-                            (text/block-ref-un-brackets! id)))
+                            ;; these can be maps
+                            (when (string? id)
+                              (or (get-block-ref-id id) id))))
 
                         :else
                         nil)]

--- a/deps/graph-parser/src/logseq/graph_parser/property.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/property.cljs
@@ -6,6 +6,8 @@
             [goog.string :as gstring]
             [goog.string.format]))
 
+(def colons "Property delimiter for markdown mode" "::")
+
 (defn properties-ast?
   [block]
   (and
@@ -77,7 +79,7 @@
                                            compare-k (keyword (string/lower-case k))
                                            k (if (contains? #{:id :custom_id :custom-id} compare-k) "id" k)
                                            k (if (contains? #{:last-modified-at} compare-k) "updated-at" k)]
-                                       (str k ":: " (string/trim v)))
+                                       (str k colons " " (string/trim v)))
                                      text)))))
               after (subvec lines (inc end-idx))
               lines (concat before middle after)]

--- a/deps/graph-parser/src/logseq/graph_parser/text.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/text.cljs
@@ -34,17 +34,6 @@
    (string/starts-with? s "[[")
    (string/ends-with? s "]]")))
 
-(def block-ref-re #"\(\(([a-zA-z0-9]{8}-[a-zA-z0-9]{4}-[a-zA-z0-9]{4}-[a-zA-z0-9]{4}-[a-zA-z0-9]{12})\)\)")
-
-(defn get-block-ref
-  [s]
-  (and (string? s)
-       (second (re-matches block-ref-re s))))
-
-(defn block-ref?
-  [s]
-  (boolean (get-block-ref s)))
-
 (defonce page-ref-re #"\[\[(.*?)\]\]")
 
 (defonce page-ref-re-2 #"(\[\[.*?\]\])")
@@ -54,13 +43,6 @@
 (defn page-ref-un-brackets!
   [s]
   (or (get-page-name s) s))
-
-(defn block-ref-un-brackets!
-  [s]
-  (when (string? s)
-    (if (block-ref? s)
-      (subs s 2 (- (count s) 2))
-      s)))
 
 ;; E.g "Foo Bar"
 (defn sep-by-comma

--- a/deps/graph-parser/src/logseq/graph_parser/text.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/text.cljs
@@ -4,11 +4,8 @@
             [clojure.string :as string]
             [clojure.set :as set]
             [logseq.graph-parser.mldoc :as gp-mldoc]
-            [logseq.graph-parser.util :as gp-util]))
-
-(def page-ref-re-0 #"\[\[(.*)\]\]")
-(def org-page-ref-re #"\[\[(file:.*)\]\[.+?\]\]")
-(def markdown-page-ref-re #"\[(.*)\]\(file:.*\)")
+            [logseq.graph-parser.util :as gp-util]
+            [logseq.graph-parser.util.page-ref :as page-ref :refer [right-brackets]]))
 
 (defn get-file-basename
   [path]
@@ -16,7 +13,14 @@
     ;; Same as util/node-path.name
     (.-name (path/parse (string/replace path "+" "/")))))
 
+(def page-ref-re-0 #"\[\[(.*)\]\]")
+(def org-page-ref-re #"\[\[(file:.*)\]\[.+?\]\]")
+(def markdown-page-ref-re #"\[(.*)\]\(file:.*\)")
+
 (defn get-page-name
+  "Extracts page names from format-specific page-refs e.g. org/md specific and
+  logseq page-refs. Only call in contexts where format-specific page-refs are
+  used. For logseq page-refs use page-ref/get-page-name"
   [s]
   (and (string? s)
        (or (when-let [[_ label _path] (re-matches markdown-page-ref-re s)]
@@ -26,19 +30,6 @@
                      (string/replace "." "/")))
            (-> (re-matches page-ref-re-0 s)
                second))))
-
-(defn page-ref?
-  [s]
-  (and
-   (string? s)
-   (string/starts-with? s "[[")
-   (string/ends-with? s "]]")))
-
-(defonce page-ref-re #"\[\[(.*?)\]\]")
-
-(defonce page-ref-re-2 #"(\[\[.*?\]\])")
-
-(def page-ref-re-without-nested #"\[\[([^\[\]]+)\]\]")
 
 (defn page-ref-un-brackets!
   [s]
@@ -64,18 +55,18 @@
 (defn- not-matched-nested-pages
   [s]
   (and (string? s)
-       (> (count (re-seq #"\[\[" s))
-          (count (re-seq #"\]\]" s)))))
+       (> (count (re-seq page-ref/left-brackets-re s))
+          (count (re-seq page-ref/right-brackets-re s)))))
 
 (defn- ref-matched?
   [s]
-  (let [x (re-seq #"\[\[" s)
-        y (re-seq #"\]\]" s)]
+  (let [x (re-seq page-ref/left-brackets-re s)
+        y (re-seq page-ref/right-brackets-re s)]
     (and (> (count x) 0) (= (count x) (count y)))))
 
 (defn get-nested-page-name
   [page-name]
-  (when-let [first-match (re-find page-ref-re-without-nested page-name)]
+  (when-let [first-match (re-find page-ref/page-ref-without-nested-re page-name)]
     (second first-match)))
 
 (defn- concat-nested-pages
@@ -83,7 +74,7 @@
   (first
    (reduce (fn [[acc not-matched-s] s]
              (cond
-               (and not-matched-s (= s "]]"))
+               (and not-matched-s (= s right-brackets))
                (let [s' (str not-matched-s s)]
                  (if (ref-matched? s')
                    [(conj acc s') nil]
@@ -118,30 +109,31 @@
 
      (and (string? s)
             ;; Either a page ref, a tag or a comma separated collection
-            (or (gp-util/safe-re-find page-ref-re s)
+            (or (gp-util/safe-re-find page-ref/page-ref-re s)
                 (gp-util/safe-re-find #"[\,|，|#|\"]+" s)))
      (let [result (->> (sep-by-quotes s)
                        (mapcat
                         (fn [s]
                           (when-not (gp-util/wrapped-by-quotes? (string/trim s))
-                            (string/split s page-ref-re-2))))
+                            (string/split s page-ref/page-ref-outer-capture-re))))
                        (mapcat (fn [s]
                                  (cond
                                    (gp-util/wrapped-by-quotes? s)
                                    nil
 
-                                   (string/includes? (string/trimr s) "]],")
-                                   (let [idx (string/index-of s "]],")]
+                                   (string/includes? (string/trimr s)
+                                                     (str right-brackets ","))
+                                   (let [idx (string/index-of s (str right-brackets ","))]
                                      [(subs s 0 idx)
-                                      "]]"
+                                      right-brackets
                                       (subs s (+ idx 3))])
 
                                    :else
                                    [s])))
                        (remove #(= % ""))
-                       (mapcat (fn [s] (if (string/ends-with? s "]]")
+                       (mapcat (fn [s] (if (string/ends-with? s right-brackets)
                                          [(subs s 0 (- (count s) 2))
-                                          "]]"]
+                                          right-brackets]
                                          [s])))
                        concat-nested-pages
                        (remove string/blank?)
@@ -150,7 +142,7 @@
                                    (gp-util/wrapped-by-quotes? s)
                                    nil
 
-                                   (page-ref? s)
+                                   (page-ref/page-ref? s)
                                    [(if un-brackets? (page-ref-un-brackets! s) s)]
 
                                    :else

--- a/deps/graph-parser/src/logseq/graph_parser/util/block_ref.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/util/block_ref.cljs
@@ -1,0 +1,41 @@
+(ns logseq.graph-parser.util.block-ref
+  "General purpose vars and util fns for block-refs"
+  (:require [clojure.string :as string]))
+
+(def left-parens "Opening characters for block-ref" "((")
+(def right-parens "Closing characters for block-ref" "))")
+(def left-and-right-parens "Opening and closing characters for block-ref"
+  (str left-parens right-parens))
+(def block-ref-re #"\(\(([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})\)\)")
+
+(defn get-all-block-ref-ids
+  [content]
+  (map second (re-seq block-ref-re content)))
+
+(defn get-block-ref-id
+  "Extracts block id from block-ref using regex"
+  [s]
+  (second (re-matches block-ref-re s)))
+
+(defn get-string-block-ref-id
+  "Extracts block id from block-ref by stripping parens e.g. ((123)) -> 123.
+  This is a less strict version of get-block-ref-id"
+  [s]
+  (subs s 2 (- (count s) 2)))
+
+(defn block-ref?
+  "Determines if string is block ref using regex"
+  [s]
+  (boolean (get-block-ref-id s)))
+
+(defn string-block-ref?
+  "Determines if string is block ref by checking parens. This is less strict version
+of block-ref?"
+  [s]
+  (and (string/starts-with? s left-parens)
+       (string/ends-with? s right-parens)))
+
+(defn ->block-ref
+  "Creates block ref string given id"
+  [block-id]
+  (str left-parens block-id right-parens))

--- a/deps/graph-parser/src/logseq/graph_parser/util/page_ref.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/util/page_ref.cljs
@@ -1,0 +1,39 @@
+(ns logseq.graph-parser.util.page-ref
+  "General purpose vars and util fns for page-ref. Currently this only handles
+a logseq page-ref e.g. [[page name]]"
+  (:require [clojure.string :as string]))
+
+(def left-brackets "Opening characters for page-ref" "[[")
+(def right-brackets "Closing characters for page-ref" "]]")
+(def left-and-right-brackets "Opening and closing characters for page-ref"
+  (str left-brackets right-brackets))
+
+;; common regular expressions
+(def left-brackets-re #"\[\[")
+(def right-brackets-re #"\]\]")
+(def page-ref-re "Inner capture and doesn't match nested brackets" #"\[\[(.*?)\]\]")
+(def page-ref-outer-capture-re #"(\[\[.*?\]\])")
+(def page-ref-without-nested-re "Matches most inner nested brackets" #"\[\[([^\[\]]+)\]\]")
+(def page-ref-any-re "Inner capture that matches anything between brackets" #"\[\[(.*)\]\]")
+
+(defn page-ref?
+  "Determines if string is page-ref. Avoid using with format-specific page-refs e.g. org"
+  [s]
+  (and (string/starts-with? s left-brackets)
+       (string/ends-with? s right-brackets)))
+
+(defn ->page-ref
+  "Create a page ref given a page name"
+  [page-name]
+  (str left-brackets page-name right-brackets))
+
+(defn get-page-name
+  "Extracts page-name from page-ref string"
+  [s]
+  (second (re-matches page-ref-any-re s)))
+
+(defn get-page-name!
+  "Extracts page-name from page-ref and fall back to arg. Useful for when user
+  input may (not) be a page-ref"
+  [s]
+  (or (get-page-name s) s))

--- a/deps/graph-parser/test/logseq/graph_parser/nbb_test_runner.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/nbb_test_runner.cljs
@@ -7,6 +7,7 @@
             [logseq.graph-parser.property-test]
             [logseq.graph-parser.extract-test]
             [logseq.graph-parser.cli-test]
+            [logseq.graph-parser.util.page-ref-test]
             [logseq.graph-parser-test]))
 
 (defmethod cljs.test/report [:cljs.test/default :end-run-tests] [m]
@@ -21,4 +22,5 @@
                'logseq.graph-parser.block-test
                'logseq.graph-parser.extract-test
                'logseq.graph-parser.cli-test
+               'logseq.graph-parser.util.page-ref-test
                'logseq.graph-parser-test))

--- a/deps/graph-parser/test/logseq/graph_parser/text_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/text_test.cljs
@@ -26,14 +26,6 @@
          "[logseq/page](file:./logseq.page.md)" "logseq/page"
          "[logseq/page](file:./pages/logseq.page.md)" "logseq/page"))
 
-(deftest page-ref?
-  []
-  (are [x y] (= (text/page-ref? x) y)
-    "[[page]]" true
-    "[[another page]]" true
-    "[single bracket]" false
-    "no brackets" false))
-
 (deftest page-ref-un-brackets!
   []
   (are [x y] (= (text/page-ref-un-brackets! x) y)

--- a/deps/graph-parser/test/logseq/graph_parser/util/page_ref_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/util/page_ref_test.cljs
@@ -7,5 +7,6 @@
   (are [x y] (= (page-ref/page-ref? x) y)
        "[[page]]" true
        "[[another page]]" true
+       "[[some [[nested]] page]]" true
        "[single bracket]" false
        "no brackets" false))

--- a/deps/graph-parser/test/logseq/graph_parser/util/page_ref_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/util/page_ref_test.cljs
@@ -1,0 +1,11 @@
+(ns logseq.graph-parser.util.page-ref-test
+  (:require [logseq.graph-parser.util.page-ref :as page-ref]
+            [cljs.test :refer [are deftest]]))
+
+(deftest page-ref?
+  []
+  (are [x y] (= (page-ref/page-ref? x) y)
+       "[[page]]" true
+       "[[another page]]" true
+       "[single bracket]" false
+       "no brackets" false))

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -18,6 +18,7 @@
             [logseq.graph-parser.util :as gp-util]
             [logseq.graph-parser.config :as gp-config]
             [logseq.graph-parser.block :as gp-block]
+            [logseq.graph-parser.property :as gp-property]
             [goog.dom :as gdom]
             [goog.object :as gobj]
             [promesa.core :as p]))
@@ -345,8 +346,8 @@
                                              (string/starts-with? last-pattern "[[")))
                                     (and s (string/starts-with? s "{{embed"))
                                     (and last-pattern
-                                         (or (string/ends-with? last-pattern "::")
-                                             (string/starts-with? last-pattern "::")))))))]
+                                         (or (string/ends-with? last-pattern gp-property/colons)
+                                             (string/starts-with? last-pattern gp-property/colons)))))))]
                    (if (and space? (string/starts-with? last-pattern "#[["))
                      false
                      space?))

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -17,9 +17,9 @@
             [frontend.util.property :as property]
             [logseq.graph-parser.util :as gp-util]
             [logseq.graph-parser.config :as gp-config]
-            [logseq.graph-parser.block :as gp-block]
             [logseq.graph-parser.property :as gp-property]
             [logseq.graph-parser.util.page-ref :as page-ref]
+            [logseq.graph-parser.util.block-ref :as block-ref]
             [goog.dom :as gdom]
             [goog.object :as gobj]
             [promesa.core :as p]))
@@ -221,7 +221,7 @@
     [["Page reference" [[:editor/input page-ref/left-and-right-brackets {:backward-pos 2}]
                         [:editor/search-page]] "Create a backlink to a page"]
      ["Page embed" (embed-page) "Embed a page here"]
-     ["Block reference" [[:editor/input gp-block/left-and-right-parens {:backward-pos 2}]
+     ["Block reference" [[:editor/input block-ref/left-and-right-parens {:backward-pos 2}]
                          [:editor/search-block :reference]] "Create a backlink to a block"]
      ["Block embed" (embed-block) "Embed a block here" "Embed a block here"]
      ["Link" (link-steps) "Create a HTTP link"]
@@ -343,7 +343,7 @@
                                    (or
                                     (and s
                                          (string/ends-with? s "(")
-                                         (or (string/starts-with? last-pattern gp-block/left-parens)
+                                         (or (string/starts-with? last-pattern block-ref/left-parens)
                                              (string/starts-with? last-pattern page-ref/left-brackets)))
                                     (and s (string/starts-with? s "{{embed"))
                                     (and last-pattern

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -17,6 +17,7 @@
             [frontend.util.property :as property]
             [logseq.graph-parser.util :as gp-util]
             [logseq.graph-parser.config :as gp-config]
+            [logseq.graph-parser.block :as gp-block]
             [goog.dom :as gdom]
             [goog.object :as gobj]
             [promesa.core :as p]))
@@ -218,7 +219,7 @@
     [["Page reference" [[:editor/input "[[]]" {:backward-pos 2}]
                         [:editor/search-page]] "Create a backlink to a page"]
      ["Page embed" (embed-page) "Embed a page here"]
-     ["Block reference" [[:editor/input "(())" {:backward-pos 2}]
+     ["Block reference" [[:editor/input gp-block/left-and-right-parens {:backward-pos 2}]
                          [:editor/search-block :reference]] "Create a backlink to a block"]
      ["Block embed" (embed-block) "Embed a block here" "Embed a block here"]
      ["Link" (link-steps) "Create a HTTP link"]
@@ -340,7 +341,7 @@
                                    (or
                                     (and s
                                          (string/ends-with? s "(")
-                                         (or (string/starts-with? last-pattern "((")
+                                         (or (string/starts-with? last-pattern gp-block/left-parens)
                                              (string/starts-with? last-pattern "[[")))
                                     (and s (string/starts-with? s "{{embed"))
                                     (and last-pattern

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -19,6 +19,7 @@
             [logseq.graph-parser.config :as gp-config]
             [logseq.graph-parser.block :as gp-block]
             [logseq.graph-parser.property :as gp-property]
+            [logseq.graph-parser.util.page-ref :as page-ref]
             [goog.dom :as gdom]
             [goog.object :as gobj]
             [promesa.core :as p]))
@@ -217,7 +218,7 @@
   (->>
    (concat
     ;; basic
-    [["Page reference" [[:editor/input "[[]]" {:backward-pos 2}]
+    [["Page reference" [[:editor/input page-ref/left-and-right-brackets {:backward-pos 2}]
                         [:editor/search-page]] "Create a backlink to a page"]
      ["Page embed" (embed-page) "Embed a page here"]
      ["Block reference" [[:editor/input gp-block/left-and-right-parens {:backward-pos 2}]
@@ -276,7 +277,7 @@
      ["Draw" (fn []
                (let [file (draw/file-name)
                      path (str gp-config/default-draw-directory "/" file)
-                     text (util/format "[[%s]]" path)]
+                     text (page-ref/->page-ref path)]
                  (p/let [_ (draw/create-draw-with-default-content path)]
                    (println "draw file created, " path))
                  text)) "Draw a graph with Excalidraw"]
@@ -343,7 +344,7 @@
                                     (and s
                                          (string/ends-with? s "(")
                                          (or (string/starts-with? last-pattern gp-block/left-parens)
-                                             (string/starts-with? last-pattern "[[")))
+                                             (string/starts-with? last-pattern page-ref/left-brackets)))
                                     (and s (string/starts-with? s "{{embed"))
                                     (and last-pattern
                                          (or (string/ends-with? last-pattern gp-property/colons)
@@ -381,7 +382,7 @@
         (state/set-block-content-and-last-pos! id new-value new-pos)
         (cursor/move-cursor-to input
                                (if (and (or backward-pos forward-pos)
-                                        (not= end-pattern "]]"))
+                                        (not= end-pattern page-ref/right-brackets))
                                  new-pos
                                  (inc new-pos)))))))
 

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -787,7 +787,7 @@
                         :delay       [1000, 100]} inner)
              inner)])
         [:span.warning.mr-1 {:title "Block ref invalid"}
-         (util/format "((%s))" id)]))))
+         (gp-block/->block-ref id)]))))
 
 (defn inline-text
   ([format v]
@@ -1120,12 +1120,9 @@
         (when-not (string/blank? page-name)
           (page-embed (assoc config :link-depth (inc link-depth)) page-name)))
 
-      (and (string/starts-with? a "((")
-           (string/ends-with? a "))"))
-      (when-let [s (-> (string/replace a "((" "")
-                       (string/replace "))" "")
-                       string/trim)]
-        (when-let [id (some-> s string/trim parse-uuid)]
+      (gp-block/block-ref-string? a)
+      (when-let [s (-> gp-block/block-ref->block-id string/trim)]
+        (when-let [id (some-> s parse-uuid)]
           (block-embed (assoc config :link-depth (inc link-depth)) id)))
 
       :else                         ;TODO: maybe collections?
@@ -2155,9 +2152,8 @@
         editor-id (str "editor-" edit-input-id)
         slide? (:slide? config)
         trimmed-content (string/trim (:block/content block))
-        block-reference-only? (and (string/starts-with? trimmed-content "((")
-                                   (re-find (re-pattern util/uuid-pattern) trimmed-content)
-                                   (string/ends-with? trimmed-content "))"))]
+        block-reference-only? (and (gp-block/block-ref-string? trimmed-content)
+                                   (re-find (re-pattern util/uuid-pattern) trimmed-content))]
     (if (and edit? editor-box)
       [:div.editor-wrapper {:id editor-id}
        (ui/catch-error

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -930,8 +930,8 @@
          (not= \* (last s)))
     (->elem :a {:on-click #(route-handler/jump-to-anchor! (mldoc/anchorLink (subs s 1)))} (subs s 1))
 
-    (text/block-ref? s)
-    (let [id (text/get-block-ref s)]
+    (gp-block/block-ref? s)
+    (let [id (gp-block/get-block-ref-id s)]
       (block-reference config id label))
 
     (not (string/includes? s "."))
@@ -1120,8 +1120,8 @@
         (when-not (string/blank? page-name)
           (page-embed (assoc config :link-depth (inc link-depth)) page-name)))
 
-      (gp-block/block-ref-string? a)
-      (when-let [s (-> gp-block/block-ref->block-id string/trim)]
+      (gp-block/string-block-ref? a)
+      (when-let [s (-> gp-block/get-string-block-ref-id string/trim)]
         (when-let [id (some-> s parse-uuid)]
           (block-embed (assoc config :link-depth (inc link-depth)) id)))
 
@@ -2152,8 +2152,7 @@
         editor-id (str "editor-" edit-input-id)
         slide? (:slide? config)
         trimmed-content (string/trim (:block/content block))
-        block-reference-only? (and (gp-block/block-ref-string? trimmed-content)
-                                   (re-find (re-pattern util/uuid-pattern) trimmed-content))]
+        block-reference-only? (gp-block/block-ref? trimmed-content)]
     (if (and edit? editor-box)
       [:div.editor-wrapper {:id editor-id}
        (ui/catch-error

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -65,6 +65,7 @@
             [logseq.graph-parser.text :as text]
             [logseq.graph-parser.util :as gp-util]
             [logseq.graph-parser.util.page-ref :as page-ref]
+            [logseq.graph-parser.util.block-ref :as block-ref]
             [medley.core :as medley]
             [promesa.core :as p]
             [reitit.frontend.easy :as rfe]
@@ -788,7 +789,7 @@
                         :delay       [1000, 100]} inner)
              inner)])
         [:span.warning.mr-1 {:title "Block ref invalid"}
-         (gp-block/->block-ref id)]))))
+         (block-ref/->block-ref id)]))))
 
 (defn inline-text
   ([format v]
@@ -931,8 +932,8 @@
          (not= \* (last s)))
     (->elem :a {:on-click #(route-handler/jump-to-anchor! (mldoc/anchorLink (subs s 1)))} (subs s 1))
 
-    (gp-block/block-ref? s)
-    (let [id (gp-block/get-block-ref-id s)]
+    (block-ref/block-ref? s)
+    (let [id (block-ref/get-block-ref-id s)]
       (block-reference config id label))
 
     (not (string/includes? s "."))
@@ -1120,8 +1121,8 @@
         (when-not (string/blank? page-name)
           (page-embed (assoc config :link-depth (inc link-depth)) page-name)))
 
-      (gp-block/string-block-ref? a)
-      (when-let [s (-> gp-block/get-string-block-ref-id string/trim)]
+      (block-ref/string-block-ref? a)
+      (when-let [s (-> block-ref/get-string-block-ref-id string/trim)]
         (when-let [id (some-> s parse-uuid)]
           (block-embed (assoc config :link-depth (inc link-depth)) id)))
 
@@ -2152,7 +2153,7 @@
         editor-id (str "editor-" edit-input-id)
         slide? (:slide? config)
         trimmed-content (string/trim (:block/content block))
-        block-reference-only? (gp-block/block-ref? trimmed-content)]
+        block-reference-only? (block-ref/block-ref? trimmed-content)]
     (if (and edit? editor-box)
       [:div.editor-wrapper {:id editor-id}
        (ui/catch-error

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -22,6 +22,7 @@
             [frontend.ui :as ui]
             [frontend.util :as util]
             [logseq.graph-parser.util :as gp-util]
+            [logseq.graph-parser.block :as gp-block]
             [frontend.util.url :as url-util]
             [goog.dom :as gdom]
             [goog.object :as gobj]
@@ -207,7 +208,7 @@
           (ui/menu-link
            {:key      "Copy block ref"
             :on-click (fn [_e]
-                        (editor-handler/copy-block-ref! block-id #(str "((" % "))")))}
+                        (editor-handler/copy-block-ref! block-id gp-block/->block-ref))}
            "Copy block ref")
 
           (ui/menu-link

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -22,7 +22,7 @@
             [frontend.ui :as ui]
             [frontend.util :as util]
             [logseq.graph-parser.util :as gp-util]
-            [logseq.graph-parser.block :as gp-block]
+            [logseq.graph-parser.util.block-ref :as block-ref]
             [frontend.util.url :as url-util]
             [goog.dom :as gdom]
             [goog.object :as gobj]
@@ -208,7 +208,7 @@
           (ui/menu-link
            {:key      "Copy block ref"
             :on-click (fn [_e]
-                        (editor-handler/copy-block-ref! block-id gp-block/->block-ref))}
+                        (editor-handler/copy-block-ref! block-id block-ref/->block-ref))}
            "Copy block ref")
 
           (ui/menu-link

--- a/src/main/frontend/components/datetime.cljs
+++ b/src/main/frontend/components/datetime.cljs
@@ -10,7 +10,8 @@
             [frontend.ui :as ui]
             [frontend.util :as util]
             [frontend.mixins :as mixins]
-            [rum.core :as rum]))
+            [rum.core :as rum]
+            [logseq.graph-parser.util.page-ref :as page-ref]))
 
 (defonce default-timestamp-value {:time ""
                                   :repeater {}})
@@ -160,7 +161,7 @@
              (when-not deadline-or-schedule?
                ;; similar to page reference
                (editor-handler/insert-command! id
-                                               (util/format "[[%s]]" journal)
+                                               (page-ref/->page-ref journal)
                                                format
                                                nil)
                (state/clear-editor-action!)

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -23,6 +23,7 @@
             [frontend.util.cursor :as cursor]
             [frontend.util.keycode :as keycode]
             [logseq.graph-parser.util :as gp-util]
+            [logseq.graph-parser.property :as gp-property]
             [goog.dom :as gdom]
             [promesa.core :as p]
             [react-draggable]
@@ -262,7 +263,8 @@
                (not (string/blank? property)))
       (let [current-pos (cursor/pos input)
             edit-content (state/sub [:editor/content id])
-            start-idx (string/last-index-of (subs edit-content 0 current-pos) "::")
+            start-idx (string/last-index-of (subs edit-content 0 current-pos)
+                                            gp-property/colons)
             q (or
                (when (>= current-pos (+ start-idx 2))
                  (subs edit-content (+ start-idx 2) current-pos))

--- a/src/main/frontend/components/shortcut.cljs
+++ b/src/main/frontend/components/shortcut.cljs
@@ -8,6 +8,7 @@
             [frontend.extensions.latex :as latex]
             [frontend.extensions.highlight :as highlight]
             [logseq.graph-parser.block :as gp-block]
+            [logseq.graph-parser.util.page-ref :as page-ref]
             [rum.core :as rum]))
 
 (rum/defcs customize-shortcut-dialog-inner <
@@ -98,7 +99,7 @@
      [:td.text-right [:code "<"]]]
     [:tr
      [:td.text-left (t :help/reference-autocomplete)]
-     [:td.text-right [:code "[[]]"]]]
+     [:td.text-right [:code page-ref/left-and-right-brackets]]]
     [:tr
      [:td.text-left (t :help/block-reference)]
      [:td.text-right [:code gp-block/left-and-right-parens]]]

--- a/src/main/frontend/components/shortcut.cljs
+++ b/src/main/frontend/components/shortcut.cljs
@@ -7,6 +7,7 @@
             [frontend.ui :as ui]
             [frontend.extensions.latex :as latex]
             [frontend.extensions.highlight :as highlight]
+            [logseq.graph-parser.block :as gp-block]
             [rum.core :as rum]))
 
 (rum/defcs customize-shortcut-dialog-inner <
@@ -100,7 +101,7 @@
      [:td.text-right [:code "[[]]"]]]
     [:tr
      [:td.text-left (t :help/block-reference)]
-     [:td.text-right [:code "(())"]]]
+     [:td.text-right [:code gp-block/left-and-right-parens]]]
     [:tr
      [:td.text-left (t :command.editor/open-link-in-sidebar)]
      [:td.text-right (ui/render-keyboard-shortcut ["shift" "click"])]]

--- a/src/main/frontend/components/shortcut.cljs
+++ b/src/main/frontend/components/shortcut.cljs
@@ -7,7 +7,7 @@
             [frontend.ui :as ui]
             [frontend.extensions.latex :as latex]
             [frontend.extensions.highlight :as highlight]
-            [logseq.graph-parser.block :as gp-block]
+            [logseq.graph-parser.util.block-ref :as block-ref]
             [logseq.graph-parser.util.page-ref :as page-ref]
             [rum.core :as rum]))
 
@@ -102,7 +102,7 @@
      [:td.text-right [:code page-ref/left-and-right-brackets]]]
     [:tr
      [:td.text-left (t :help/block-reference)]
-     [:td.text-right [:code gp-block/left-and-right-parens]]]
+     [:td.text-right [:code block-ref/left-and-right-parens]]]
     [:tr
      [:td.text-left (t :command.editor/open-link-in-sidebar)]
      [:td.text-right (ui/render-keyboard-shortcut ["shift" "click"])]]

--- a/src/main/frontend/db/query_dsl.cljs
+++ b/src/main/frontend/db/query_dsl.cljs
@@ -14,6 +14,7 @@
             [logseq.db.rules :as rules]
             [frontend.template :as template]
             [logseq.graph-parser.text :as text]
+            [logseq.graph-parser.util.page-ref :as page-ref]
             [frontend.util.text :as text-util]
             [frontend.util :as util]))
 
@@ -60,8 +61,8 @@
       (= "tomorrow" input)
       (db-utils/date->int (t/plus (t/today) (t/days 1)))
 
-      (text/page-ref? input)
-      (let [input (-> (text/page-ref-un-brackets! input)
+      (page-ref/page-ref? input)
+      (let [input (-> (page-ref/get-page-name input)
                       (string/replace ":" "")
                       (string/capitalize))]
         (when (date/valid-journal-title? input)
@@ -92,8 +93,8 @@
       (= "tomorrow" input)
       (tc/to-long (t/plus (t/today) (t/days 1)))
 
-      (text/page-ref? input)
-      (let [input (-> (text/page-ref-un-brackets! input)
+      (page-ref/page-ref? input)
+      (let [input (-> (page-ref/get-page-name input)
                       (string/replace ":" "")
                       (string/capitalize))]
         (when (date/valid-journal-title? input)
@@ -298,7 +299,7 @@
                (rest e))
         tags (map (comp string/lower-case name) tags)]
     (when (seq tags)
-      (let [tags (set (map (comp text/page-ref-un-brackets! string/lower-case name) tags))]
+      (let [tags (set (map (comp page-ref/get-page-name! string/lower-case name) tags))]
         {:query (list 'page-tags '?p tags)
          :rules [:page-tags]}))))
 
@@ -342,14 +343,14 @@
 
 (defn- build-page
   [e]
-  (let [page-name (text/page-ref-un-brackets! (str (first (rest e))))
+  (let [page-name (page-ref/get-page-name! (str (first (rest e))))
         page-name (util/page-name-sanity-lc page-name)]
     {:query (list 'page '?b page-name)
      :rules [:page]}))
 
 (defn- build-namespace
   [e]
-  (let [page-name (text/page-ref-un-brackets! (str (first (rest e))))
+  (let [page-name (page-ref/get-page-name! (str (first (rest e))))
         page (util/page-name-sanity-lc page-name)]
     (when-not (string/blank? page)
       {:query (list 'namespace '?p page)
@@ -357,7 +358,7 @@
 
 (defn- build-page-ref
   [e]
-  (let [page-name (-> (text/page-ref-un-brackets! e)
+  (let [page-name (-> (page-ref/get-page-name! e)
                       (util/page-name-sanity-lc))]
     {:query (list 'page-ref '?b page-name)
      :rules [:page-ref]}))
@@ -381,7 +382,7 @@ Some bindings in this fn:
    ; {:post [(or (nil? %) (map? %))]}
    (let [fe (first e)
          fe (when fe (symbol (string/lower-case (name fe))))
-         page-ref? (text/page-ref? e)]
+         page-ref? (page-ref/page-ref? e)]
      (when (or (and page-ref?
                     (not (contains? #{'page-property 'page-tags} (:current-filter env))))
                (contains? #{'between 'property 'todo 'task 'priority 'sort-by 'page} fe)
@@ -442,20 +443,21 @@ Some bindings in this fn:
 
 (defn- pre-transform
   [s]
-  (some-> s
-          (string/replace text/page-ref-re "\"[[$1]]\"")
-          (string/replace text-util/between-re
-                          (fn [[_ x]]
-                            (->> (string/split x #" ")
-                                 (remove string/blank?)
-                                 (map (fn [x]
-                                        (if (or (contains? #{"+" "-"} (first x))
-                                                (and (util/safe-re-find #"\d" (first x))
-                                                     (some #(string/ends-with? x %) ["y" "m" "d" "h" "min"])))
-                                          (keyword (name x))
-                                          x)))
-                                 (string/join " ")
-                                 (util/format "(between %s)"))))))
+  (let [quoted-page-ref (str "\"" page-ref/left-brackets "$1" page-ref/right-brackets "\"")]
+    (some-> s
+            (string/replace page-ref/page-ref-re quoted-page-ref)
+            (string/replace text-util/between-re
+                            (fn [[_ x]]
+                              (->> (string/split x #" ")
+                                   (remove string/blank?)
+                                   (map (fn [x]
+                                          (if (or (contains? #{"+" "-"} (first x))
+                                                  (and (util/safe-re-find #"\d" (first x))
+                                                       (some #(string/ends-with? x %) ["y" "m" "d" "h" "min"])))
+                                            (keyword (name x))
+                                            x)))
+                                   (string/join " ")
+                                   (util/format "(between %s)")))))))
 
 (defn- add-bindings!
   [form q]
@@ -482,7 +484,7 @@ Some bindings in this fn:
       or?
       (cond
         (->> (flatten form)
-             (remove text/page-ref?)
+             (remove (every-pred string? page-ref/page-ref?))
              (some string?))            ; block full-text search
         (concat [['?b :block/content '?content]] [q])
 
@@ -499,7 +501,7 @@ Some bindings in this fn:
   [s]
   (when (and (string? s)
              (not (string/blank? s)))
-    (let [s (if (= \# (first s)) (util/format "[[%s]]" (subs s 1)) s)
+    (let [s (if (= \# (first s)) (page-ref/->page-ref (subs s 1)) s)
           form (some-> s
                        (pre-transform)
                        (reader/read-string))

--- a/src/main/frontend/db/query_react.cljs
+++ b/src/main/frontend/db/query_react.cljs
@@ -10,7 +10,7 @@
             [frontend.debug :as debug]
             [frontend.extensions.sci :as sci]
             [frontend.state :as state]
-            [logseq.graph-parser.text :as text]
+            [logseq.graph-parser.util.page-ref :as page-ref]
             [frontend.util :as util]
             [frontend.date :as date]
             [lambdaisland.glogi :as log]))
@@ -44,8 +44,8 @@
           days (parse-long (re-find #"^\d+" input))]
       (date->int (t/plus (t/today) (t/days days))))
 
-    (and (string? input) (text/page-ref? input))
-    (-> (text/page-ref-un-brackets! input)
+    (and (string? input) (page-ref/page-ref? input))
+    (-> (page-ref/get-page-name input)
         (string/lower-case))
 
     :else
@@ -81,7 +81,7 @@
 
 (defn- resolve-query
   [query]
-  (let [page-ref? #(and (string? %) (text/page-ref? %))]
+  (let [page-ref? #(and (string? %) (page-ref/page-ref? %))]
     (walk/postwalk
      (fn [f]
        (cond
@@ -100,7 +100,7 @@
          (let [[x y] (rest f)
                [page-ref sym] (if (page-ref? x) [x y] [y x])
                page-ref (string/lower-case page-ref)]
-           (list 'contains? sym (text/page-ref-un-brackets! page-ref)))
+           (list 'contains? sym (page-ref/get-page-name page-ref)))
 
          (and (vector? f)
               (= (first f) 'page-property)

--- a/src/main/frontend/diff.cljs
+++ b/src/main/frontend/diff.cljs
@@ -47,7 +47,7 @@
 
                       :else
                       (recur r1 t2 (inc i1) i2))))
-            current-line (text-util/get-current-line-by-pos markup pos)]
+            current-line (:line (text-util/get-current-line-by-pos markup pos))]
         (cond
           (= (util/nth-safe markup pos)
              (util/nth-safe markup (inc pos))

--- a/src/main/frontend/extensions/pdf/assets.cljs
+++ b/src/main/frontend/extensions/pdf/assets.cljs
@@ -11,6 +11,7 @@
             [frontend.state :as state]
             [frontend.util :as util]
             [logseq.graph-parser.config :as gp-config]
+            [logseq.graph-parser.block :as gp-block]
             [medley.core :as medley]
             [promesa.core :as p]
             [reitit.frontend.easy :as rfe]
@@ -213,7 +214,7 @@
 (defn copy-hl-ref!
   [highlight]
   (when-let [ref-block (create-ref-block! highlight)]
-    (util/copy-to-clipboard! (str "((" (:block/uuid ref-block) "))"))))
+    (util/copy-to-clipboard! (gp-block/->block-ref (:block/uuid ref-block)))))
 
 (defn open-block-ref!
   [block]

--- a/src/main/frontend/extensions/pdf/assets.cljs
+++ b/src/main/frontend/extensions/pdf/assets.cljs
@@ -11,7 +11,7 @@
             [frontend.state :as state]
             [frontend.util :as util]
             [logseq.graph-parser.config :as gp-config]
-            [logseq.graph-parser.block :as gp-block]
+            [logseq.graph-parser.util.block-ref :as block-ref]
             [medley.core :as medley]
             [promesa.core :as p]
             [reitit.frontend.easy :as rfe]
@@ -214,7 +214,7 @@
 (defn copy-hl-ref!
   [highlight]
   (when-let [ref-block (create-ref-block! highlight)]
-    (util/copy-to-clipboard! (gp-block/->block-ref (:block/uuid ref-block)))))
+    (util/copy-to-clipboard! (block-ref/->block-ref (:block/uuid ref-block)))))
 
 (defn open-block-ref!
   [block]

--- a/src/main/frontend/extensions/srs.cljs
+++ b/src/main/frontend/extensions/srs.cljs
@@ -4,6 +4,7 @@
             [frontend.db.query-react :as query-react]
             [frontend.util :as util]
             [logseq.graph-parser.property :as gp-property]
+            [logseq.graph-parser.util.page-ref :as page-ref]
             [frontend.util.property :as property]
             [frontend.util.drawer :as drawer]
             [frontend.util.persist-var :as persist-var]
@@ -264,7 +265,7 @@
                           query-string (if-not (or (string/blank? query-string)
                                                    (string/starts-with? query-string "(")
                                                    (string/starts-with? query-string "["))
-                                         (util/format "[[%s]]" (string/trim query-string))
+                                         (page-ref/->page-ref (string/trim query-string))
                                          query-string)
                           {:keys [query sort-by rules]} (query-dsl/parse query-string)
                           query* (util/concat-without-nil

--- a/src/main/frontend/extensions/zotero/extractor.cljs
+++ b/src/main/frontend/extensions/zotero/extractor.cljs
@@ -5,7 +5,8 @@
             [frontend.extensions.html-parser :as html-parser]
             [frontend.extensions.zotero.schema :as schema]
             [frontend.extensions.zotero.setting :as setting]
-            [frontend.util :as util]))
+            [frontend.util :as util]
+            [logseq.graph-parser.util.page-ref :as page-ref]))
 
 (defn item-type [item] (-> item :data :item-type))
 
@@ -64,8 +65,8 @@
 
 (defn date->journal [item]
   (if-let [date (-> item :meta :parsed-date
-                      (date/journal-name-s))]
-    (util/format "[[%s]]" date)
+                    (date/journal-name-s))]
+    (page-ref/->page-ref date)
     (-> item :data :date)))
 
 (defn wrap-in-doublequotes [m]
@@ -129,7 +130,7 @@
                                 :authors authors
                                 :tags tags
                                 :date date
-                                :item-type (util/format "[[%s]]" type))
+                                :item-type (page-ref/->page-ref type))
                          (dissoc :creators :abstract-note)
                          (rename-keys {:title :original-title})
                          (assoc :title (page-name item)))]

--- a/src/main/frontend/extensions/zotero/handler.cljs
+++ b/src/main/frontend/extensions/zotero/handler.cljs
@@ -8,7 +8,8 @@
             [frontend.state :as state]
             [frontend.handler.editor :as editor-handler]
             [frontend.handler.page :as page-handler]
-            [frontend.db :as db]))
+            [frontend.db :as db]
+            [logseq.graph-parser.util.page-ref :as page-ref]))
 
 (defn add [page-name type item]
   (go
@@ -42,7 +43,7 @@
 (defn handle-command-zotero
   [id page-name]
   (state/clear-editor-action!)
-  (editor-handler/insert-command! id (str "[[" page-name "]]") nil {}))
+  (editor-handler/insert-command! id (page-ref/->page-ref page-name) nil {}))
 
 (defn- create-abstract-note!
   [page-name abstract-note]

--- a/src/main/frontend/external/roam.cljs
+++ b/src/main/frontend/external/roam.cljs
@@ -5,7 +5,7 @@
             [clojure.walk :as walk]
             [clojure.string :as string]
             [goog.string :as gstring]
-            [logseq.graph-parser.block :as gp-block]
+            [logseq.graph-parser.util.block-ref :as block-ref]
             [logseq.graph-parser.util :as gp-util]
             [logseq.graph-parser.text :as text]))
 
@@ -31,7 +31,7 @@
   [text]
   (string/replace text uid-pattern (fn [[_ uid]]
                                      (let [id (get @uid->uuid uid uid)]
-                                       (gp-block/->block-ref id)))))
+                                       (block-ref/->block-ref id)))))
 
 (defn macro-transform
   [text]

--- a/src/main/frontend/external/roam.cljs
+++ b/src/main/frontend/external/roam.cljs
@@ -4,7 +4,8 @@
             [frontend.date :as date]
             [clojure.walk :as walk]
             [clojure.string :as string]
-            [frontend.util :as util]
+            [goog.string :as gstring]
+            [logseq.graph-parser.block :as gp-block]
             [logseq.graph-parser.util :as gp-util]
             [logseq.graph-parser.text :as text]))
 
@@ -30,7 +31,7 @@
   [text]
   (string/replace text uid-pattern (fn [[_ uid]]
                                      (let [id (get @uid->uuid uid uid)]
-                                       (str "((" id "))")))))
+                                       (gp-block/->block-ref id)))))
 
 (defn macro-transform
   [text]
@@ -38,7 +39,7 @@
                                        (let [[name arg] (gp-util/split-first ":" text)]
                                          (if name
                                            (let [name (text/page-ref-un-brackets! name)]
-                                             (util/format "{{%s %s}}" name arg))
+                                             (gstring/format "{{%s %s}}" name arg))
                                            original)))))
 
 (defn- fenced-code-transform
@@ -83,7 +84,7 @@
                              " -"))
         properties (when (contains? @all-refed-uids uid)
                      (str
-                      (util/format "id:: %s"
+                      (gstring/format "id:: %s"
                                    (str (get @uid->uuid uid)))
                       "\n"))]
     (if string
@@ -109,7 +110,7 @@
                  (let [journal? (date/valid-journal-title? title)
                        front-matter (if journal?
                                       ""
-                                      (util/format "---\ntitle: %s\n---\n\n" title))]
+                                      (gstring/format "---\ntitle: %s\n---\n\n" title))]
                    (str front-matter (transform text)))))]
     (when (and (not (string/blank? title))
                text)

--- a/src/main/frontend/fs/watcher_handler.cljs
+++ b/src/main/frontend/fs/watcher_handler.cljs
@@ -9,7 +9,7 @@
             [frontend.handler.repo :as repo-handler]
             [frontend.handler.ui :as ui-handler]
             [logseq.graph-parser.util :as gp-util]
-            [frontend.util.text :as text-util]
+            [logseq.graph-parser.block :as gp-block]
             [lambdaisland.glogi :as log]
             [electron.ipc :as ipc]
             [promesa.core :as p]
@@ -22,7 +22,7 @@
 (defn- set-missing-block-ids!
   [content]
   (when (string? content)
-    (doseq [block-id (text-util/extract-all-block-refs content)]
+    (doseq [block-id (gp-block/get-all-block-ref-ids content)]
       (when-let [block (try
                          (model/get-block-by-uuid block-id)
                          (catch js/Error _e

--- a/src/main/frontend/fs/watcher_handler.cljs
+++ b/src/main/frontend/fs/watcher_handler.cljs
@@ -9,7 +9,7 @@
             [frontend.handler.repo :as repo-handler]
             [frontend.handler.ui :as ui-handler]
             [logseq.graph-parser.util :as gp-util]
-            [logseq.graph-parser.block :as gp-block]
+            [logseq.graph-parser.util.block-ref :as block-ref]
             [lambdaisland.glogi :as log]
             [electron.ipc :as ipc]
             [promesa.core :as p]
@@ -22,7 +22,7 @@
 (defn- set-missing-block-ids!
   [content]
   (when (string? content)
-    (doseq [block-id (gp-block/get-all-block-ref-ids content)]
+    (doseq [block-id (block-ref/get-all-block-ref-ids content)]
       (when-let [block (try
                          (model/get-block-by-uuid block-id)
                          (catch js/Error _e

--- a/src/main/frontend/handler/dnd.cljs
+++ b/src/main/frontend/handler/dnd.cljs
@@ -3,7 +3,7 @@
             [frontend.modules.outliner.core :as outliner-core]
             [frontend.modules.outliner.tree :as tree]
             [frontend.modules.outliner.transaction :as outliner-tx]
-            [logseq.graph-parser.block :as gp-block]
+            [logseq.graph-parser.util.block-ref :as block-ref]
             [frontend.state :as state]))
 
 (defn move-blocks
@@ -23,7 +23,7 @@
                                             :id
                                             (str (:block/uuid first-block)))
         (editor-handler/api-insert-new-block!
-         (gp-block/->block-ref (:block/uuid first-block))
+         (block-ref/->block-ref (:block/uuid first-block))
          {:block-uuid (:block/uuid target-block)
           :sibling? (not nested?)
           :before? top?}))

--- a/src/main/frontend/handler/dnd.cljs
+++ b/src/main/frontend/handler/dnd.cljs
@@ -3,8 +3,8 @@
             [frontend.modules.outliner.core :as outliner-core]
             [frontend.modules.outliner.tree :as tree]
             [frontend.modules.outliner.transaction :as outliner-tx]
-            [frontend.state :as state]
-            [frontend.util :as util]))
+            [logseq.graph-parser.block :as gp-block]
+            [frontend.state :as state]))
 
 (defn move-blocks
   [^js event blocks target-block move-to]
@@ -23,7 +23,7 @@
                                             :id
                                             (str (:block/uuid first-block)))
         (editor-handler/api-insert-new-block!
-         (util/format "((%s))" (str (:block/uuid first-block)))
+         (gp-block/->block-ref (:block/uuid first-block))
          {:block-uuid (:block/uuid target-block)
           :sibling? (not nested?)
           :before? top?}))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1855,9 +1855,8 @@
 
       (and
        (not= :property-search (state/get-editor-action))
-       (when-let [current-line (text-util/get-current-line-by-pos (.-value input) (dec pos))]
-         (or (wrapped-by? current-line "" gp-property/colons)
-             (wrapped-by? current-line "\n" gp-property/colons))))
+       (let [{:keys [line start-pos]} (text-util/get-current-line-by-pos (.-value input) (dec pos))]
+         (text-util/wrapped-by? line (dec (- pos start-pos)) "" gp-property/colons)))
 
       (do
         (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)})
@@ -2697,7 +2696,7 @@
         (on-tab direction)))
     nil))
 
-(defn keydown-not-matched-handler
+(defn ^:large-vars/cleanup-todo keydown-not-matched-handler
   [format]
   (fn [e _key-code]
     (let [input-id (state/get-edit-input-id)
@@ -2711,6 +2710,10 @@
                        (surround-by? input "#" :end)
                        (= key "#"))]
       (cond
+        (and (contains? #{"ArrowLeft" "ArrowRight" "ArrowUp" "ArrowDown"} key)
+             (contains? #{:property-search :property-value-search} (state/get-editor-action)))
+        (state/clear-editor-action!)
+
         (and (util/event-is-composing? e true) ;; #3218
              (not hashtag?) ;; #3283 @Rime
              (not (state/get-editor-show-page-search-hashtag?))) ;; #3283 @MacOS pinyin

--- a/src/main/frontend/handler/export.cljs
+++ b/src/main/frontend/handler/export.cljs
@@ -24,6 +24,7 @@
             [logseq.graph-parser.mldoc :as gp-mldoc]
             [logseq.graph-parser.util :as gp-util]
             [logseq.graph-parser.block :as gp-block]
+            [logseq.graph-parser.util.page-ref :as page-ref]
             [promesa.core :as p]
             [frontend.handler.notification :as notification])
   (:import
@@ -160,11 +161,8 @@
                              (= "embed" (some-> (:name (second i))
                                                 (string/lower-case)))
                              (some-> (:arguments (second i))
-                                     (first)
-                                     (string/starts-with? "[["))
-                             (some-> (:arguments (second i))
-                                     (first)
-                                     (string/ends-with? "]]")))
+                                     first
+                                     page-ref/page-ref?))
                         (let [arguments (:arguments (second i))
                               page-ref (first arguments)
                               page-name (-> page-ref

--- a/src/main/frontend/handler/export.cljs
+++ b/src/main/frontend/handler/export.cljs
@@ -189,9 +189,9 @@
                                                 (string/lower-case)))
                              (some-> (:arguments (second i))
                                      (first)
-                                     gp-block/block-ref-string?))
+                                     gp-block/string-block-ref?))
                         (let [arguments (:arguments (second i))
-                              block-uuid (gp-block/block-ref->block-id (first arguments))]
+                              block-uuid (gp-block/get-string-block-ref-id (first arguments))]
                           (conj! result block-uuid)
                           i)
                         :else

--- a/src/main/frontend/handler/export.cljs
+++ b/src/main/frontend/handler/export.cljs
@@ -23,7 +23,7 @@
             [lambdaisland.glogi :as log]
             [logseq.graph-parser.mldoc :as gp-mldoc]
             [logseq.graph-parser.util :as gp-util]
-            [logseq.graph-parser.block :as gp-block]
+            [logseq.graph-parser.util.block-ref :as block-ref]
             [logseq.graph-parser.util.page-ref :as page-ref]
             [promesa.core :as p]
             [frontend.handler.notification :as notification])
@@ -187,9 +187,9 @@
                                                 (string/lower-case)))
                              (some-> (:arguments (second i))
                                      (first)
-                                     gp-block/string-block-ref?))
+                                     block-ref/string-block-ref?))
                         (let [arguments (:arguments (second i))
-                              block-uuid (gp-block/get-string-block-ref-id (first arguments))]
+                              block-uuid (block-ref/get-string-block-ref-id (first arguments))]
                           (conj! result block-uuid)
                           i)
                         :else

--- a/src/main/frontend/handler/export.cljs
+++ b/src/main/frontend/handler/export.cljs
@@ -23,6 +23,7 @@
             [lambdaisland.glogi :as log]
             [logseq.graph-parser.mldoc :as gp-mldoc]
             [logseq.graph-parser.util :as gp-util]
+            [logseq.graph-parser.block :as gp-block]
             [promesa.core :as p]
             [frontend.handler.notification :as notification])
   (:import
@@ -188,15 +189,9 @@
                                                 (string/lower-case)))
                              (some-> (:arguments (second i))
                                      (first)
-                                     (string/starts-with? "(("))
-                             (some-> (:arguments (second i))
-                                     (first)
-                                     (string/ends-with? "))")))
+                                     gp-block/block-ref-string?))
                         (let [arguments (:arguments (second i))
-                              block-ref (first arguments)
-                              block-uuid (-> block-ref
-                                             (subs 2)
-                                             (#(subs % 0 (- (count %) 2))))]
+                              block-uuid (gp-block/block-ref->block-id (first arguments))]
                           (conj! result block-uuid)
                           i)
                         :else

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -37,6 +37,7 @@
             [logseq.graph-parser.config :as gp-config]
             [logseq.graph-parser.block :as gp-block]
             [logseq.graph-parser.property :as gp-property]
+            [logseq.graph-parser.util.page-ref :as page-ref]
             [frontend.format.block :as block]
             [goog.functions :refer [debounce]]))
 
@@ -211,7 +212,7 @@
   "Unsanitized names"
   [content old-name new-name]
   (let [[original-old-name original-new-name] (map string/trim [old-name new-name])
-        [old-ref new-ref] (map #(util/format "[[%s]]" %) [old-name new-name])
+        [old-ref new-ref] (map page-ref/->page-ref [old-name new-name])
         [old-name new-name] (map #(if (string/includes? % "/")
                                     (string/replace % "/" ".")
                                     %)
@@ -455,8 +456,9 @@
   "Unsanitized names only"
   [old-ns-name new-ns-name]
   (let [repo            (state/get-current-repo)
-        nested-page-str (util/format "[[%s]]" (util/page-name-sanity-lc old-ns-name))
-        ns-prefix       (util/format "[[%s/" (util/page-name-sanity-lc old-ns-name))
+        nested-page-str (page-ref/->page-ref (util/page-name-sanity-lc old-ns-name))
+        ns-prefix-format-str (str page-ref/left-brackets "%s/")
+        ns-prefix       (util/format ns-prefix-format-str (util/page-name-sanity-lc old-ns-name))
         nested-pages    (db/get-pages-by-name-partition repo nested-page-str)
         nested-pages-ns (db/get-pages-by-name-partition repo ns-prefix)]
     (when nested-pages
@@ -465,8 +467,8 @@
         (let [old-page-title (or original-name name)
               new-page-title (string/replace
                               old-page-title
-                              (util/format "[[%s]]" old-ns-name)
-                              (util/format "[[%s]]" new-ns-name))]
+                              (page-ref/->page-ref old-ns-name)
+                              (page-ref/->page-ref new-ns-name))]
           (when (and old-page-title new-page-title)
             (p/do!
              (rename-page-aux old-page-title new-page-title false)
@@ -477,8 +479,8 @@
         (let [old-page-title (or original-name name)
               new-page-title (string/replace
                               old-page-title
-                              (util/format "[[%s/" old-ns-name)
-                              (util/format "[[%s/" new-ns-name))]
+                              (util/format ns-prefix-format-str old-ns-name)
+                              (util/format ns-prefix-format-str new-ns-name))]
           (when (and old-page-title new-page-title)
             (p/do!
              (rename-page-aux old-page-title new-page-title false)
@@ -637,7 +639,7 @@
           (util/format "[[file:%s][%s]]"
                        (util/get-relative-path edit-block-file-path ref-file-path)
                        page)))
-      (util/format "[[%s]]" page))))
+      (page-ref/->page-ref page))))
 
 (defn init-commands!
   []
@@ -690,7 +692,7 @@
   (if (state/org-mode-file-link? (state/get-current-repo))
     (let [page-ref-text (get-page-ref-text q)
           value (gobj/get input "value")
-          old-page-ref (util/format "[[%s]]" q)
+          old-page-ref (page-ref/->page-ref q)
           new-value (string/replace value
                                     old-page-ref
                                     page-ref-text)]
@@ -718,13 +720,13 @@
     (if hashtag?
       (fn [chosen _click?]
         (state/clear-editor-action!)
-        (let [wrapped? (= "[[" (gp-util/safe-subs edit-content (- pos 2) pos))
+        (let [wrapped? (= page-ref/left-brackets (gp-util/safe-subs edit-content (- pos 2) pos))
               prefix (str (t :new-page) ": ")
               chosen (if (string/starts-with? chosen prefix) ;; FIXME: What if a page named "New page: XXX"?
                        (string/replace-first chosen prefix "")
                        chosen)
               chosen (if (and (util/safe-re-find #"\s+" chosen) (not wrapped?))
-                       (util/format "[[%s]]" chosen)
+                       (page-ref/->page-ref chosen)
                        chosen)
               q (if @editor-handler/*selected-text "" q)
               [last-pattern forward-pos] (if wrapped?
@@ -732,12 +734,12 @@
                                            (if (= \# (first q))
                                              [(subs q 1) 1]
                                              [q 2]))
-              last-pattern (str "#" (when wrapped? "[[") last-pattern)]
+              last-pattern (str "#" (when wrapped? page-ref/left-brackets) last-pattern)]
           (editor-handler/insert-command! id
-                                          (str "#" (when wrapped? "[[") chosen)
+                                          (str "#" (when wrapped? page-ref/left-brackets) chosen)
                                           format
                                           {:last-pattern last-pattern
-                                           :end-pattern (when wrapped? "]]")
+                                           :end-pattern (when wrapped? page-ref/right-brackets)
                                            :forward-pos forward-pos})))
       (fn [chosen _click?]
         (state/clear-editor-action!)
@@ -749,9 +751,9 @@
           (editor-handler/insert-command! id
                                           page-ref-text
                                           format
-                                          {:last-pattern (str "[[" (if @editor-handler/*selected-text "" q))
-                                           :end-pattern "]]"
-                                           :postfix-fn   (fn [s] (util/replace-first "]]" s ""))
+                                          {:last-pattern (str page-ref/left-brackets (if @editor-handler/*selected-text "" q))
+                                           :end-pattern page-ref/right-brackets
+                                           :postfix-fn   (fn [s] (util/replace-first page-ref/right-brackets s ""))
                                            :forward-pos 3}))))))
 
 (defn create-today-journal!

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -36,6 +36,7 @@
             [logseq.graph-parser.util :as gp-util]
             [logseq.graph-parser.config :as gp-config]
             [logseq.graph-parser.block :as gp-block]
+            [logseq.graph-parser.property :as gp-property]
             [frontend.format.block :as block]
             [goog.functions :refer [debounce]]))
 
@@ -247,8 +248,8 @@
 (defn- replace-property-ref!
   [content old-name new-name]
   (let [new-name (keyword (string/replace (string/lower-case new-name) #"\s+" "-"))
-        old-property (str old-name "::")
-        new-property (str (name new-name) "::")]
+        old-property (str old-name gp-property/colons)
+        new-property (str (name new-name) gp-property/colons)]
     (util/replace-ignore-case content old-property new-property)))
 
 (defn- replace-old-page!

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -82,7 +82,7 @@
           (editor-handler/html-link-format! text)
 
           (and (text/block-ref? text)
-               (editor-handler/wrapped-by? input "((" "))"))
+               (editor-handler/wrapped-by? input gp-block/left-parens gp-block/right-parens))
           (commands/simple-insert! (state/get-edit-input-id) (text/get-block-ref text) nil)
 
           :else

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -5,6 +5,7 @@
             [logseq.graph-parser.util :as gp-util]
             [logseq.graph-parser.mldoc :as gp-mldoc]
             [logseq.graph-parser.block :as gp-block]
+            [logseq.graph-parser.util.block-ref :as block-ref]
             [clojure.string :as string]
             [frontend.util :as util]
             [frontend.handler.editor :as editor-handler]
@@ -80,9 +81,9 @@
                (not (string/blank? (util/get-selected-text))))
           (editor-handler/html-link-format! text)
 
-          (and (gp-block/block-ref? text)
-               (editor-handler/wrapped-by? input gp-block/left-parens gp-block/right-parens))
-          (commands/simple-insert! (state/get-edit-input-id) (gp-block/get-block-ref-id text) nil)
+          (and (block-ref/block-ref? text)
+               (editor-handler/wrapped-by? input block-ref/left-parens block-ref/right-parens))
+          (commands/simple-insert! (state/get-edit-input-id) (block-ref/get-block-ref-id text) nil)
 
           :else
           ;; from external

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -15,7 +15,6 @@
             ["/frontend/utils" :as utils]
             [frontend.commands :as commands]
             [cljs.core.match :refer [match]]
-            [logseq.graph-parser.text :as text]
             [frontend.handler.notification :as notification]
             [frontend.util.text :as text-util]
             [frontend.format.mldoc :as mldoc]
@@ -81,9 +80,9 @@
                (not (string/blank? (util/get-selected-text))))
           (editor-handler/html-link-format! text)
 
-          (and (text/block-ref? text)
+          (and (gp-block/block-ref? text)
                (editor-handler/wrapped-by? input gp-block/left-parens gp-block/right-parens))
-          (commands/simple-insert! (state/get-edit-input-id) (text/get-block-ref text) nil)
+          (commands/simple-insert! (state/get-edit-input-id) (gp-block/get-block-ref-id text) nil)
 
           :else
           ;; from external

--- a/src/main/frontend/mobile/action_bar.cljs
+++ b/src/main/frontend/mobile/action_bar.cljs
@@ -11,6 +11,7 @@
    [goog.dom :as gdom]
    [goog.object :as gobj]
    [rum.core :as rum]
+   [logseq.graph-parser.block :as gp-block]
    [frontend.mobile.util :as mobile-util]))
 
 (defn- action-command
@@ -63,7 +64,7 @@
         (action-command "cut" "Cut" #(editor-handler/cut-selection-blocks true))
         (action-command "trash" "Delete" #(editor-handler/delete-block-aux! block true))
         (action-command "registered" "Copy ref"
-                        (fn [_event] (editor-handler/copy-block-ref! uuid #(str "((" % "))"))))
+                        (fn [_event] (editor-handler/copy-block-ref! uuid gp-block/->block-ref)))
         (action-command "link" "Copy url"
                         (fn [_event] (let [current-repo (state/get-current-repo)
                                            tap-f (fn [block-id]
@@ -74,5 +75,3 @@
                           (fn [_event]
                             (let [current-repo (state/get-current-repo)]
                               (state/sidebar-add-block! current-repo uuid :block-ref)))))]])))
-
-

--- a/src/main/frontend/mobile/action_bar.cljs
+++ b/src/main/frontend/mobile/action_bar.cljs
@@ -11,7 +11,7 @@
    [goog.dom :as gdom]
    [goog.object :as gobj]
    [rum.core :as rum]
-   [logseq.graph-parser.block :as gp-block]
+   [logseq.graph-parser.util.block-ref :as block-ref]
    [frontend.mobile.util :as mobile-util]))
 
 (defn- action-command
@@ -64,7 +64,7 @@
         (action-command "cut" "Cut" #(editor-handler/cut-selection-blocks true))
         (action-command "trash" "Delete" #(editor-handler/delete-block-aux! block true))
         (action-command "registered" "Copy ref"
-                        (fn [_event] (editor-handler/copy-block-ref! uuid gp-block/->block-ref)))
+                        (fn [_event] (editor-handler/copy-block-ref! uuid block-ref/->block-ref)))
         (action-command "link" "Copy url"
                         (fn [_event] (let [current-repo (state/get-current-repo)
                                            tap-f (fn [block-id]

--- a/src/main/frontend/mobile/intent.cljs
+++ b/src/main/frontend/mobile/intent.cljs
@@ -17,6 +17,7 @@
             [lambdaisland.glogi :as log]
             [logseq.graph-parser.config :as gp-config]
             [logseq.graph-parser.mldoc :as gp-mldoc]
+            [logseq.graph-parser.util.page-ref :as page-ref]
             [promesa.core :as p]))
 
 (defn- handle-received-text [result]
@@ -89,7 +90,7 @@
                 (.copy Filesystem (clj->js {:from url :to path}))
                 (fn [error]
                   (log/error :copy-file-error {:error error})))
-          url (util/format "[[%s]]" title)
+          url (page-ref/->page-ref title)
           template (get-in (state/get-config)
                            [:quick-capture-templates :text]
                            "**{time}** [[quick capture]]: {url}")]

--- a/src/main/frontend/template.cljs
+++ b/src/main/frontend/template.cljs
@@ -2,17 +2,16 @@
   (:require [clojure.string :as string]
             [frontend.date :as date]
             [frontend.state :as state]
-            [frontend.util :as util]))
+            [logseq.graph-parser.util.page-ref :as page-ref]))
 
 (defn- variable-rules
   []
-  {"today" (util/format "[[%s]]" (date/today))
-   "yesterday" (util/format "[[%s]]" (date/yesterday))
-   "tomorrow" (util/format "[[%s]]" (date/tomorrow))
+  {"today" (page-ref/->page-ref (date/today))
+   "yesterday" (page-ref/->page-ref (date/yesterday))
+   "tomorrow" (page-ref/->page-ref (date/tomorrow))
    "time" (date/get-current-time)
-   "current page" (util/format "[[%s]]"
-                               (or (state/get-current-page)
-                                   (date/today)))})
+   "current page" (page-ref/->page-ref (or (state/get-current-page)
+                                           (date/today)))})
 
 ;; TODO: programmable
 ;; context information, date, current page
@@ -31,5 +30,5 @@
                          (let [;; NOTE: This following cannot handle timezones
                                ;; date (tc/to-local-date-time nld)
                                date (doto (goog.date.DateTime.) (.setTime (.getTime nld)))]
-                           (util/format "[[%s]]" (date/journal-name date)))
+                           (page-ref/->page-ref (date/journal-name date)))
                          match))))))

--- a/src/main/frontend/util/property.cljs
+++ b/src/main/frontend/util/property.cljs
@@ -7,6 +7,7 @@
             [logseq.graph-parser.util :as gp-util]
             [logseq.graph-parser.mldoc :as gp-mldoc]
             [logseq.graph-parser.property :as gp-property :refer [properties-start properties-end]]
+            [logseq.graph-parser.util.page-ref :as page-ref]
             [frontend.format.mldoc :as mldoc]
             [logseq.graph-parser.text :as text]
             [frontend.util.cursor :as cursor]))
@@ -325,7 +326,7 @@
                (some->>
                 (seq v)
                 (distinct)
-                (map (fn [item] (util/format "[[%s]]" (text/page-ref-un-brackets! item))))
+                (map (fn [item] (page-ref/->page-ref (text/page-ref-un-brackets! item))))
                 (string/join ", "))
                v)]
        (insert-property format content k v)))

--- a/src/main/frontend/util/text.cljs
+++ b/src/main/frontend/util/text.cljs
@@ -122,7 +122,3 @@
             (string/join "/" parts)
             (last parts))
           js/decodeURI))))
-
-(defn extract-all-block-refs
-  [content]
-  (map second (re-seq #"\(\(([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})\)\)" content)))

--- a/src/main/frontend/util/text.cljs
+++ b/src/main/frontend/util/text.cljs
@@ -59,9 +59,10 @@
         result (reduce (fn [acc line]
                          (let [new-pos (+ acc (count line))]
                            (if (>= new-pos pos)
-                             (reduced line)
+                             (reduced {:line line
+                                       :start-pos acc})
                              (inc new-pos)))) 0 lines)]
-    (when (string? result)
+    (when (map? result)
       result)))
 
 (defn surround-by?

--- a/src/main/frontend/util/thingatpt.cljs
+++ b/src/main/frontend/util/thingatpt.cljs
@@ -5,6 +5,7 @@
             [frontend.config :as config]
             [logseq.graph-parser.text :as text]
             [logseq.graph-parser.property :as gp-property]
+            [logseq.graph-parser.block :as gp-block]
             [cljs.reader :as reader]
             [goog.object :as gobj]))
 
@@ -46,7 +47,7 @@
          :end line-end-pos}))))
 
 (defn block-ref-at-point [& [input]]
-  (when-let [block-ref (thing-at-point ["((" "))"] input " ")]
+  (when-let [block-ref (thing-at-point [gp-block/left-parens gp-block/right-parens] input " ")]
     (when-let [uuid (uuid (:raw-content block-ref))]
       (assoc block-ref
              :type "block-ref"

--- a/src/main/frontend/util/thingatpt.cljs
+++ b/src/main/frontend/util/thingatpt.cljs
@@ -6,6 +6,7 @@
             [logseq.graph-parser.text :as text]
             [logseq.graph-parser.property :as gp-property]
             [logseq.graph-parser.block :as gp-block]
+            [logseq.graph-parser.util.page-ref :as page-ref]
             [cljs.reader :as reader]
             [goog.object :as gobj]))
 
@@ -54,7 +55,7 @@
              :link uuid))))
 
 (defn page-ref-at-point [& [input]]
-  (when-let [page-ref (thing-at-point ["[[" "]]"] input)]
+  (when-let [page-ref (thing-at-point [page-ref/left-brackets page-ref/right-brackets] input)]
     (assoc page-ref
            :type "page-ref"
            :link (text/get-page-name

--- a/src/main/frontend/util/thingatpt.cljs
+++ b/src/main/frontend/util/thingatpt.cljs
@@ -86,14 +86,14 @@
           (case (state/get-preferred-format) ;; TODO fix me to block's format
             :org (thing-at-point ":" input "\n")
             (when-let [line (:raw-content (line-at-point input))]
-              (let [key (first (string/split line "::"))
+              (let [key (first (string/split line gp-property/colons))
                     line-beginning-pos (cursor/line-beginning-pos input)
                     pos-in-line (- (cursor/pos input) line-beginning-pos)]
-                (when (<= 0 pos-in-line (+ (count key) (count "::")))
-                  {:full-content (str key "::")
+                (when (<= 0 pos-in-line (+ (count key) (count gp-property/colons)))
+                  {:full-content (str key gp-property/colons)
                    :raw-content key
                    :start line-beginning-pos
-                   :end (+ line-beginning-pos (count (str key "::")))}))))]
+                   :end (+ line-beginning-pos (count (str key gp-property/colons)))}))))]
       (assoc property :type "property-key"))))
 
 (defn get-list-item-indent&bullet [line]

--- a/src/main/frontend/util/thingatpt.cljs
+++ b/src/main/frontend/util/thingatpt.cljs
@@ -5,7 +5,7 @@
             [frontend.config :as config]
             [logseq.graph-parser.text :as text]
             [logseq.graph-parser.property :as gp-property]
-            [logseq.graph-parser.block :as gp-block]
+            [logseq.graph-parser.util.block-ref :as block-ref]
             [logseq.graph-parser.util.page-ref :as page-ref]
             [cljs.reader :as reader]
             [goog.object :as gobj]))
@@ -48,7 +48,7 @@
          :end line-end-pos}))))
 
 (defn block-ref-at-point [& [input]]
-  (when-let [block-ref (thing-at-point [gp-block/left-parens gp-block/right-parens] input " ")]
+  (when-let [block-ref (thing-at-point [block-ref/left-parens block-ref/right-parens] input " ")]
     (when-let [uuid (uuid (:raw-content block-ref))]
       (assoc block-ref
              :type "block-ref"

--- a/src/test/frontend/util/property_test.cljs
+++ b/src/test/frontend/util/property_test.cljs
@@ -71,12 +71,20 @@
       "** hello\n\na:: b")))
 
 (deftest test-get-property-keys
-  (are [x y] (= x y)
-    (property/get-property-keys :org "hello\n:PROPERTIES:\n:x1: y1\n:x2: y2\n:END:\n")
-    ["X1" "X2"]
+  (testing "org mode"
+    (are [x y] (= x y)
+        (property/get-property-keys :org "hello\n:PROPERTIES:\n:x1: y1\n:x2: y2\n:END:\n")
+        ["X1" "X2"]
 
-    (property/get-property-keys :org "hello\n:PROPERTIES:\n:END:\n")
-    nil))
+        (property/get-property-keys :org "hello\n:PROPERTIES:\n:END:\n")
+        nil))
+  (testing "markdown mode"
+    (are [x y] (= x y)
+        (property/get-property-keys :markdown "hello\nx1:: y1\nx2:: y2\n")
+        ["X1" "X2"]
+
+        (property/get-property-keys :markdown "hello\n")
+        nil)))
 
 (deftest test-insert-property
   (are [x y] (= x y)


### PR DESCRIPTION
This PR centralizes uses of block-ref, page-ref and property strings per [this task](https://quire.io/w/Logseq-_team_dedicated_to_sport_of_knowledge/1123/Move_special_link_and_property_strings_to_graph...?sublist=Cycle_10_End_2022-08-05&view=board). This should make it easier for us to reference these concepts and transform their text throughout the app. The new namespaces are `logseq.graph-parser.util.{page-ref,block-ref}`. I could also put these under `logseq.graph-parser.text.{page-ref,block-ref}` if that's more intuitive for the team.

I noticed that tags e.g. `#` and md/org links and page-refs are also hardcoded but didn't want to make this PR too big. I'll put that to a task for some other day