### PR TITLE
Fix: Property completion for hidden properties and property ordering

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -198,7 +198,6 @@
   [format properties user-config]
   (when (seq properties)
     (let [properties (seq properties)
-          properties (into {} properties)
           page-refs (get-page-ref-names-from-properties format properties user-config)
           properties (->> properties
                           (map (fn [[k v]]
@@ -512,7 +511,7 @@
                                 :content content
                                 :level 1
                                 :properties properties
-                                :properties-order properties-order
+                                :properties-order (vec properties-order)
                                 :refs property-refs
                                 :pre-block? true
                                 :unordered true
@@ -548,7 +547,7 @@
                 (assoc :properties (:properties properties))
 
                 (seq (:properties-order properties))
-                (assoc :properties-order (:properties-order properties)))
+                (assoc :properties-order (vec (:properties-order properties))))
         block (if (get-in block [:properties :collapsed])
                 (-> (assoc block :collapsed? true)
                     (update :properties (fn [m] (dissoc m :collapsed)))

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1845,8 +1845,8 @@
   [config block]
   (let [properties (walk/keywordize-keys (:block/properties block))
         properties-order (:block/properties-order block)
-        properties (apply dissoc properties (property/built-in-properties))
-        properties-order (remove (property/built-in-properties) properties-order)
+        properties (apply dissoc properties (property/hidden-properties))
+        properties-order (remove (property/hidden-properties) properties-order)
         pre-block? (:block/pre-block? block)
         properties (if pre-block?
                      (let [repo (state/get-current-repo)

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -177,7 +177,7 @@
      result
      {:on-chosen   chosen-handler
       :on-enter    non-exist-block-handler
-      :empty-placeholder   [:div.text-gray-500.pl-4.pr-4 "Search for a block"]
+      :empty-placeholder   [:div.text-gray-500.pl-4.pr-4 (t :editor/block-search)]
       :item-render (fn [{:block/keys [page uuid]}]  ;; content returned from search engine is normalized
                      (let [page (or (:block/original-name page)
                                     (:block/name page))

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -1384,7 +1384,6 @@
     (->> (map keys properties)
          (apply concat)
          distinct
-         (remove #{:id})
          sort)))
 
 (defn get-property-values

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -384,7 +384,7 @@
         block (update block :block/refs remove-non-existed-refs!)
         block (attach-page-properties-if-exists! block)
         new-properties (merge
-                        (select-keys properties (property/built-in-properties))
+                        (select-keys properties (property/hidden-properties))
                         (:block/properties block))]
     (-> block
         (dissoc :block/top?

--- a/src/main/frontend/search.cljs
+++ b/src/main/frontend/search.cljs
@@ -11,6 +11,7 @@
             [frontend.search.protocol :as protocol]
             [frontend.state :as state]
             [frontend.util :as util]
+            [frontend.util.property :as property]
             [goog.object :as gobj]
             [promesa.core :as p]))
 
@@ -169,7 +170,9 @@
   ([q limit]
    (when q
      (let [q (clean-str q)
-           properties (map name (db-model/get-all-properties))]
+           properties (->> (db-model/get-all-properties)
+                           (remove (property/hidden-properties))
+                           (map name))]
        (when (seq properties)
          (if (string/blank? q)
            properties


### PR DESCRIPTION
This PR fixes #6192 and fixes #4907 , two property issues. #4907 was caused by accidental clobbering of the sorted properties map before a block is saved