### PR TITLE
Fix: Declare two built-in org properties

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/property.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/property.cljs
@@ -33,7 +33,9 @@
 (defn editable-built-in-properties
   "Properties used by logseq that user can edit"
   []
-  (into #{:title :icon :template :template-including-parent :public :filters :exclude-from-graph-view}
+  (into #{:title :icon :template :template-including-parent :public :filters :exclude-from-graph-view
+          ;; org-mode only
+          :macro :filetags}
         editable-linkable-built-in-properties))
 
 (defn hidden-built-in-properties

--- a/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
@@ -67,7 +67,7 @@
 " md-config {})))
       "Src example with leading whitespace"))
 
-(deftest properties-test
+(deftest md-properties-test
   (are [x y] (= [["Properties" y] nil]
                 (first (gp-mldoc/->edn x md-config {})))
 
@@ -97,6 +97,28 @@
           {:start_pos 0, :end_pos 17}]
          (first (gp-mldoc/->edn "term
 : definition" md-config {})))))
+
+(defn- parse-properties
+  [text]
+  (->> (gp-mldoc/->edn text (gp-mldoc/default-config :org) {})
+       (filter #(= "Properties" (ffirst %)))
+       ffirst
+       second))
+
+(deftest org-properties-test
+  []
+  (testing "just title"
+    (let [content "#+TITLE:   some title   "
+          props (parse-properties content)]
+      (is (= "some title   " (:title props)))))
+
+  (testing "filetags"
+    (let [content "#+FILETAGS:   :tag1:tag2:@tag:
+#+TAGS: tag3
+body"
+          props (parse-properties content)]
+      (is ["@tag" "tag1" "tag2"] (sort (:filetags props)))
+      (is ["@tag" "tag1" "tag2" "tag3"] (sort (:tags props))))))
 
 (deftest ^:integration test->edn
   (let [graph-dir "test/docs"


### PR DESCRIPTION
`:filetags` and `:macro` are two org properties that are recognized by the graph-parser. This declares them so that they behave like other built-in properties. While testing this I was surprised to see none of the formats for multiple tags are supported - https://orgmode.org/manual/Setting-Tags.html