### PR TITLE
fix: keep the favorites item when publishing

### DIFF
--- a/src/main/frontend/components/sidebar.cljs
+++ b/src/main/frontend/components/sidebar.cljs
@@ -262,7 +262,7 @@
            :active (and (not srs-open?) (= route-name :all-pages))
            :icon   "files"})]]
 
-      (when (and left-sidebar-open? (not config/publishing?)) (favorites t))
+      (when left-sidebar-open? (favorites t))
 
       (when (and left-sidebar-open? (not config/publishing?)) (recent-pages t))
 


### PR DESCRIPTION
Hi @cnrpman , keep the `config/publishing?` is true as we discussed. Sorry for introducing some bugs for this project.  