### PR TITLE
improve UX design: click the plugin title to open README

### DIFF
--- a/src/main/frontend/components/plugins.cljs
+++ b/src/main/frontend/components/plugins.cljs
@@ -277,9 +277,7 @@
                 :updating        installing-or-updating?
                 :has-new-version new-version}])}
 
-     [:div.l.link-block.cursor-pointer
-      {:on-click #(plugin-handler/open-readme!
-                   url item (if repo remote-readme-display local-markdown-display))}
+     [:div.l
       (if (and icon (not (string/blank? icon)))
         [:img.icon {:src (if market? (plugin-handler/pkg-asset id icon) icon)}]
         svg/folder)
@@ -290,7 +288,10 @@
      [:div.r
       [:h3.head.text-xl.font-bold.pt-1.5
 
-       [:span name]
+       [:span.l.link-block.cursor-pointer 
+        {:on-click #(plugin-handler/open-readme!
+                     url item (if repo remote-readme-display local-markdown-display))}
+        name]
        (when (not market?) [:sup.inline-block.px-1.text-xs.opacity-50 version])]
 
       [:div.desc.text-xs.opacity-70

--- a/src/main/frontend/components/plugins.cljs
+++ b/src/main/frontend/components/plugins.cljs
@@ -261,6 +261,12 @@
                  (js-invoke js/LSPluginCore (if disabled? "enable" "disable") id))
                true)]])
 
+(defn open-plugin-readme! 
+  [url item repo]
+  #(plugin-handler/open-readme!
+    url item (if repo remote-readme-display local-markdown-display))
+  )
+
 (rum/defc plugin-item-card < rum/static
   [t {:keys [id name title version url description author icon iir repo sponsors] :as item}
    disabled? market? *search-key has-other-pending?
@@ -277,7 +283,8 @@
                 :updating        installing-or-updating?
                 :has-new-version new-version}])}
 
-     [:div.l
+     [:div.l.link-block.cursor-pointer
+      {:on-click (open-plugin-readme! url item repo)}
       (if (and icon (not (string/blank? icon)))
         [:img.icon {:src (if market? (plugin-handler/pkg-asset id icon) icon)}]
         svg/folder)
@@ -288,9 +295,8 @@
      [:div.r
       [:h3.head.text-xl.font-bold.pt-1.5
 
-       [:span.l.link-block.cursor-pointer 
-        {:on-click #(plugin-handler/open-readme!
-                     url item (if repo remote-readme-display local-markdown-display))}
+       [:span.l.link-block.cursor-pointer
+        {:on-click (open-plugin-readme! url item repo)}
         name]
        (when (not market?) [:sup.inline-block.px-1.text-xs.opacity-50 version])]
 

--- a/src/main/frontend/components/plugins.cljs
+++ b/src/main/frontend/components/plugins.cljs
@@ -261,7 +261,7 @@
                  (js-invoke js/LSPluginCore (if disabled? "enable" "disable") id))
                true)]])
 
-(defn open-plugin-readme! 
+(defn get-open-plugin-readme-handler
   [url item repo]
   #(plugin-handler/open-readme!
     url item (if repo remote-readme-display local-markdown-display))
@@ -284,7 +284,7 @@
                 :has-new-version new-version}])}
 
      [:div.l.link-block.cursor-pointer
-      {:on-click (open-plugin-readme! url item repo)}
+      {:on-click (get-open-plugin-readme-handler url item repo)}
       (if (and icon (not (string/blank? icon)))
         [:img.icon {:src (if market? (plugin-handler/pkg-asset id icon) icon)}]
         svg/folder)
@@ -296,7 +296,7 @@
       [:h3.head.text-xl.font-bold.pt-1.5
 
        [:span.l.link-block.cursor-pointer
-        {:on-click (open-plugin-readme! url item repo)}
+        {:on-click (get-open-plugin-readme-handler url item repo)}
         name]
        (when (not market?) [:sup.inline-block.px-1.text-xs.opacity-50 version])]
 


### PR DESCRIPTION
Currently, users only are able to open the README page by clicking the plugin icon, which is counterintuitive and is not consistent with many existing tools. I didn't find the feature even after using Logseq for one year and I kept clicking the GitHub icon on the right side to open the website to see the README.

This commit moves the on-click function to the title instead of the plugin icon to improve the user experience.