### PR TITLE
fix: navigation with multiple selected blocks

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2440,7 +2440,10 @@
       (state/exit-editing-and-set-selected-blocks! [block]))))
 
 (defn- select-up-down [direction]
-  (let [selected (first (state/get-selection-blocks))
+  (let [selected-blocks (state/get-selection-blocks)
+        selected (case direction
+                   :up (first selected-blocks)
+                   :down (last selected-blocks))
         f (case direction
             :up util/get-prev-block-non-collapsed
             :down util/get-next-block-non-collapsed)
@@ -3069,7 +3072,7 @@
         (state/editing?)
         (keydown-up-down-handler direction)
 
-        (and (state/selection?) (== 1 (count (state/get-selection-blocks))))
+        (state/selection?)
         (select-up-down direction)
 
         :else


### PR DESCRIPTION
Fix #5448

At the moment, after selecting multiple blocks:

- `up`/`down` navigation highlights the block at the top/bottom of the page. This behavior, particularly on long page, is very annoying
- `left`/`right` navigation does nothing

This PR solves the "problem" in the following way:

- If `up`/`ctrl+p` is pressed, the previous block of the first selected block is highlighted
- If `down`/`ctrl+n` is pressed, the next block of the last selected block is highlighted
- If `left` is pressed, cursor is placed at the beginning of the first selected block
- If `right` is pressed, cursor is placed at the end of the last selected block

In this way, the behavior of single and multiple block selection is similar.