### PR TITLE
WIP Fix block selection logic

### DIFF
--- a/e2e-tests/basic.spec.ts
+++ b/e2e-tests/basic.spec.ts
@@ -86,6 +86,46 @@ test('delete and backspace', async ({ page, block }) => {
 })
 
 
+test('moving cursor between blocks', async ({ page, block }) => {
+  await createRandomPage(page)
+
+  // add 5 blocks
+  await block.mustFill('line 1')
+  await block.enterNext()
+  await block.mustFill('line 2')
+  await block.enterNext()
+  expect(await block.indent()).toBe(true)
+  await block.mustFill('line 3')
+  await block.enterNext()
+  await block.mustFill('line 4')
+  expect(await block.indent()).toBe(true)
+  await block.enterNext()
+  await page.waitForTimeout(30)
+  await block.mustFill('line 5')
+  expect(await block.unindent()).toBe(true)
+  expect(await block.unindent()).toBe(true)
+
+  // Moving up with keyboard
+  await page.keyboard.press('ArrowUp')
+  await expect(await page.locator('.block-editor textarea')).toHaveText('line 4')
+  await page.keyboard.press('ArrowUp')
+  await expect(await page.locator('.block-editor textarea')).toHaveText('line 3')
+  await page.keyboard.press('ArrowUp')
+  await expect(await page.locator('.block-editor textarea')).toHaveText('line 2')
+  await page.keyboard.press('ArrowUp')
+  await expect(await page.locator('.block-editor textarea')).toHaveText('line 1')
+
+  // Moving down with keyboard
+  await page.keyboard.press('ArrowDown')
+  await expect(page.locator('.block-editor textarea')).toHaveText('line 2')
+  await page.keyboard.press('ArrowDown')
+  await expect(page.locator('.block-editor textarea')).toHaveText('line 3')
+  await page.keyboard.press('ArrowDown')
+  await expect(page.locator('.block-editor textarea')).toHaveText('line 4')
+  await page.keyboard.press('ArrowDown')
+  await expect(page.locator('.block-editor textarea')).toHaveText('line 5')
+})
+
 test('selection', async ({ page, block }) => {
   await createRandomPage(page)
 

--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -177,6 +177,7 @@ export const test = base.extend<LogseqFixtures>({
       waitForSelectedBlocks: async (total: number): Promise<void> => {
         // NOTE: `nth=` counts from 0.
         await page.waitForSelector(`.ls-block.selected >> nth=${total - 1}`, { timeout: 1000 })
+        await page.waitForSelector(`.ls-block.selected >> nth=${total}`, { state: 'detached', timeout: 1000 })
       },
       escapeEditing: async (): Promise<void> => {
         await page.keyboard.press('Escape')

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1947,9 +1947,9 @@
     (if (and meta? (not (state/get-edit-input-id)))
       (do
         (util/stop e)
-        (state/conj-selection-block! (gdom/getElement block-id) :down)
-        (when (and block-id (not (state/get-selection-start-block)))
-          (state/set-selection-start-block! block-id)))
+        (state/conj-selection-block! (util/get-block-by-id block-id) :down)
+        (when (and block-id (not (state/get-selection-start-block-id)))
+          (state/set-selection-start-block-id! block-id)))
       (when (contains? #{1 0} button)
         (when-not (target-forbidden-edit? target)
           (cond
@@ -1986,7 +1986,7 @@
                   (f)
                   (js/setTimeout f 5))
 
-                (when block-id (state/set-selection-start-block! block-id))))))))))
+                (when block-id (state/set-selection-start-block-id! block-id))))))))))
 
 (rum/defc dnd-separator-wrapper < rum/reactive
   [block block-id slide? top? block-content?]
@@ -2328,7 +2328,7 @@
   [event uuid target-block *move-to]
   (util/stop event)
   (when-not (dnd-same-block? uuid)
-    (let [block-uuids (state/get-selection-block-ids)
+    (let [block-uuids (state/get-selection-block-uuids)
           lookup-refs (map (fn [id] [:block/uuid id]) block-uuids)
           selected (db/pull-many (state/get-current-repo) '[*] lookup-refs)
           blocks (if (seq selected) selected [@*dragging-block])]
@@ -2463,7 +2463,7 @@
         edit? (state/sub [:editor/editing? edit-input-id])
         card? (string/includes? data-refs-self "\"card\"")
         review-cards? (:review-cards? config)
-        selected-blocks (set (state/get-selection-block-ids))
+        selected-blocks (set (state/get-selection-block-uuids))
         selected? (contains? selected-blocks uuid)]
     [:div.ls-block
      (cond->

--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -310,6 +310,7 @@
     (when (= (:data-lang attr) "calc")
       (calc/results (:calc-atom state)))]])
 
+;; TODO: Maybe use html id all the way through this
 ;; Focus into the CodeMirror editor rather than the normal "raw" editor
 (defmethod commands/handle-step :codemirror/focus [[_]]
   ;; This requestAnimationFrame is necessary because, for some reason, when you
@@ -325,7 +326,7 @@
     (state/clear-edit!)
     (js/setTimeout
      (fn []
-       (let [block-node (util/get-first-block-by-id block-uuid)
+       (let [block-node (util/get-first-block-by-uuid block-uuid)
              textarea-ref (.querySelector block-node "textarea")]
          (when-let [codemirror-ref (gobj/get textarea-ref codemirror-ref-name)]
            (.focus codemirror-ref))))


### PR DESCRIPTION
This fixes a few issues:
- Fixes #5870 Moving up/down while multiple blocks are selected now selects the one block up/down from the last block that was added to the selection (or the first/last block if you hit the top/bottom of the list). This mirrors the behavior of Finder, which I find nice and intuitive. Previous behavior was that it would just jump to the top/bottom of the list.
- (mentioned [here](https://github.com/logseq/logseq/issues/5870#issuecomment-1204082555)) If you press up/down after indenting a block, it now moves the selection correctly. The old behavior was that it would jump to the beginning/end of the list, because the new block has a different DOM reference than before it was indented.

To accomplish this, I reworked many of the selection functions to use the HTML `id` attribute as the identifier for comparison between blocks (eg for indexOf in a list of blocks), instead of a DOM element reference. DOM element references can become invalid if React renders since the last one was saved, so this new approach should be much more reliable.

There are some other places that might also be updated in this fashion, but they weren't directly related to the changes I was making.

Still WIP because I have a few TODOs left in the code, and it's late.