### PR TITLE
fix: roam export error caused by typo

### DIFF
--- a/src/main/frontend/external/roam_export.cljs
+++ b/src/main/frontend/external/roam_export.cljs
@@ -23,10 +23,10 @@
 (defn uuid->uid-map []
   (let [db (db/get-db (state/get-current-repo))]
     (->>
-     (d/q db '[:find (pull ?r [:block/uuid])
-               :in $
-               :where
-               [?b :block/refs ?r]])
+     (d/q '[:find (pull ?r [:block/uuid])
+            :in $
+            :where
+            [?b :block/refs ?r]] db)
      (map (comp :block/uuid first))
      (distinct)
      (map (fn [uuid] [uuid (nano-id)]))


### PR DESCRIPTION
Fix #4502 

Fix Issue: export graph to roam json is broken
reported in https://discord.com/channels/725182569297215569/735747000649252894/1008418884459708459