### PR TITLE
feat(settings): add plugin id to buttons and panel

### DIFF
--- a/src/main/frontend/components/plugins.cljs
+++ b/src/main/frontend/components/plugins.cljs
@@ -964,12 +964,13 @@
       (when nav?
         [:aside.md:w-64 {:style {:min-width "10rem"}}
          (let [plugins (plugin-handler/get-enabled-plugins-if-setting-schema)]
-           [:ul
+           [:ul.settings-plugin-list
             (for [{:keys [id name title icon]} plugins]
               [:li
                {:class (util/classnames [{:active (= id focused)}])}
-               [:a.flex.items-center
-                {:on-click #(do (state/set-state! :plugin/focused-settings id))}
+               [:a.flex.items-center.settings-plugin-item
+                {:data-id id
+                 :on-click #(do (state/set-state! :plugin/focused-settings id))}
                 (if (and icon (not (string/blank? icon)))
                   [:img.icon {:src icon}]
                   svg/folder)
@@ -977,6 +978,7 @@
 
       [:article
        [:div.panel-wrap
+        {:data-id focused}
         (when-let [^js pl (and focused (= @*cache focused)
                                (plugin-handler/get-plugin-inst focused))]
           (ui/catch-error

--- a/src/main/frontend/components/plugins_settings.cljs
+++ b/src/main/frontend/components/plugins_settings.cljs
@@ -79,7 +79,7 @@
     [:div.pl-1 (edit-settings-file pid nil)]]])
 
 (rum/defc render-item-heading
-  [{:keys [title]}]
+  [{:keys [key title]}]
 
   [:div.heading-item
    {:data-key key}

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -653,23 +653,24 @@
      [:div.cp__settings-inner.md:flex
 
       [:aside.md:w-64 {:style {:min-width "10rem"}}
-       [:ul
-        (for [[label text icon]
-              [[:general (t :settings-page/tab-general) (ui/icon "adjustments" {:style {:font-size 20}})]
-               [:editor (t :settings-page/tab-editor) (ui/icon "writing" {:style {:font-size 20}})]
+       [:ul.settings-menu
+        (for [[label id text icon]
+              [[:general "general" (t :settings-page/tab-general) (ui/icon "adjustments" {:style {:font-size 20}})]
+               [:editor "editor" (t :settings-page/tab-editor) (ui/icon "writing" {:style {:font-size 20}})]
                (when-not (mobile-util/native-platform?)
-                 [:git (t :settings-page/tab-version-control) (ui/icon "history" {:style {:font-size 20}})])
-               [:advanced (t :settings-page/tab-advanced) (ui/icon "bulb" {:style {:font-size 20}})]
+                 [:git "git" (t :settings-page/tab-version-control) (ui/icon "history" {:style {:font-size 20}})])
+               [:advanced "advanced" (t :settings-page/tab-advanced) (ui/icon "bulb" {:style {:font-size 20}})]
                (when plugins-of-settings
-                 [:plugins-setting (t :settings-of-plugins) (ui/icon "puzzle")])]]
+                 [:plugins-setting "plugins" (t :settings-of-plugins) (ui/icon "puzzle")])]]
 
           (when label
-            [:li
+            [:li.settings-menu-item
              {:key      text
               :class    (util/classnames [{:active (= label (first @*active))}])
               :on-click #(reset! *active [label (first @*active)])}
 
-             [:a.flex.items-center
+             [:a.flex.items-center.settings-menu-link
+             {:data-id id}
               icon
               [:strong text]]]))]]
 


### PR DESCRIPTION
Add `data-id` to settings items, plugins items and plugin settings panel to target and rule own plugin for features and needs: styles, event listeners, etc...