### PR TITLE
fix missing references and filters ux enhancements

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2416,7 +2416,7 @@
         *navigating-block (get state ::navigating-block)
         navigating-block (rum/react *navigating-block)
         navigated? (and (not= (:block/uuid block) navigating-block) navigating-block)
-        block (if (or navigated? custom-query?)
+        block (if navigated?
                 (let [block (db/pull [:block/uuid navigating-block])
                       blocks (db/get-paginated-blocks repo (:db/id block)
                                                       {:scoped-block-id (:db/id block)})
@@ -3322,28 +3322,6 @@
    (cond-> option
      (:document/mode? config) (assoc :class "doc-mode"))
    (cond
-     (and (:ref? config) (:group-by-page? config))
-     [:div.flex.flex-col
-      (let [blocks (sort-by (comp :block/journal-day first) > blocks)]
-        (for [[page parent-blocks] blocks]
-         (ui/lazy-visible
-          (fn []
-            (let [alias? (:block/alias? page)
-                  page (db/entity (:db/id page))]
-              [:div.my-2 (cond-> {:key (str "page-" (:db/id page))}
-                           (:ref? config)
-                           (assoc :class "color-level px-2 sm:px-7 py-2 rounded"))
-               (ui/foldable
-                [:div
-                 (page-cp config page)
-                 (when alias? [:span.text-sm.font-medium.opacity-50 " Alias"])]
-                (for [block parent-blocks]
-                  (let [block' (update block :block/children tree/non-consecutive-blocks->vec-tree)]
-                    (rum/with-key
-                      (breadcrumb-with-container block' config)
-                      (:db/id block'))))
-                {:debug-id page})])))))]
-
      (and (:custom-query? config) (:group-by-page? config))
      [:div.flex.flex-col
       (let [blocks (sort-by (comp :block/journal-day first) > blocks)]
@@ -3366,6 +3344,28 @@
                      (:db/id block)))
                  {:debug-id page
                   :trigger-once? false})])))))]
+
+     (and (:ref? config) (:group-by-page? config))
+     [:div.flex.flex-col
+      (let [blocks (sort-by (comp :block/journal-day first) > blocks)]
+        (for [[page parent-blocks] blocks]
+         (ui/lazy-visible
+          (fn []
+            (let [alias? (:block/alias? page)
+                  page (db/entity (:db/id page))]
+              [:div.my-2 (cond-> {:key (str "page-" (:db/id page))}
+                           (:ref? config)
+                           (assoc :class "color-level px-2 sm:px-7 py-2 rounded"))
+               (ui/foldable
+                [:div
+                 (page-cp config page)
+                 (when alias? [:span.text-sm.font-medium.opacity-50 " Alias"])]
+                (for [block parent-blocks]
+                  (let [block' (update block :block/children tree/non-consecutive-blocks->vec-tree)]
+                    (rum/with-key
+                      (breadcrumb-with-container block' config)
+                      (:db/id block'))))
+                {:debug-id page})])))))]
 
      (and (:group-by-page? config)
           (vector? (first blocks)))

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2144,13 +2144,10 @@
       [:div.more (ui/icon "dots-circle-horizontal" {:style {:fontSize 16}})])]])
 
 (rum/defcs block-content-or-editor < rum/reactive
-  {:init (fn [state]
-           (let [[config block] (:rum/args state)
-                 inline-block-refs-hide? (not= (:id config) (str (:block/uuid block)))]
-             (assoc state ::hide-block-refs? (atom inline-block-refs-hide?))))}
+  (rum/local true ::hide-block-refs?)
   [state config {:block/keys [uuid format] :as block} edit-input-id block-id heading-level edit?]
   (let [*hide-block-refs? (get state ::hide-block-refs?)
-        hide-block-refs? (rum/react *hide-block-refs?)
+        hide-block-refs? @*hide-block-refs?
         editor-box (get config :editor-box)
         editor-id (str "editor-" edit-input-id)
         slide? (:slide? config)

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -3322,23 +3322,24 @@
    (cond
      (and (:ref? config) (:group-by-page? config))
      [:div.flex.flex-col
-      (for [[page parent-blocks] blocks]
-        (ui/lazy-visible
-         (fn []
-           (let [alias? (:block/alias? page)
-                 page (db/entity (:db/id page))]
-             [:div.my-2 (cond-> {:key (str "page-" (:db/id page))}
-                          (:ref? config)
-                          (assoc :class "color-level px-2 sm:px-7 py-2 rounded"))
-              (ui/foldable
-               [:div
-                (page-cp config page)
-                (when alias? [:span.text-sm.font-medium.opacity-50 " Alias"])]
-               (for [block parent-blocks]
-                 (rum/with-key
-                   (breadcrumb-with-container block config)
-                   (:db/id block)))
-               {:debug-id page})]))))]
+      (let [blocks (sort-by (comp :block/journal-day first) > blocks)]
+        (for [[page parent-blocks] blocks]
+         (ui/lazy-visible
+          (fn []
+            (let [alias? (:block/alias? page)
+                  page (db/entity (:db/id page))]
+              [:div.my-2 (cond-> {:key (str "page-" (:db/id page))}
+                           (:ref? config)
+                           (assoc :class "color-level px-2 sm:px-7 py-2 rounded"))
+               (ui/foldable
+                [:div
+                 (page-cp config page)
+                 (when alias? [:span.text-sm.font-medium.opacity-50 " Alias"])]
+                (for [block parent-blocks]
+                  (rum/with-key
+                    (breadcrumb-with-container block config)
+                    (:db/id block)))
+                {:debug-id page})])))))]
 
      (and (:custom-query? config) (:group-by-page? config))
      [:div.flex.flex-col

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2144,9 +2144,13 @@
       [:div.more (ui/icon "dots-circle-horizontal" {:style {:fontSize 16}})])]])
 
 (rum/defcs block-content-or-editor < rum/reactive
-  (rum/local true :hide-block-refs?)
+  {:init (fn [state]
+           (let [[config block] (:rum/args state)
+                 inline-block-refs-hide? (not= (:id config) (str (:block/uuid block)))]
+             (assoc state ::hide-block-refs? (atom inline-block-refs-hide?))))}
   [state config {:block/keys [uuid format] :as block} edit-input-id block-id heading-level edit?]
-  (let [*hide-block-refs? (get state :hide-block-refs?)
+  (let [*hide-block-refs? (get state ::hide-block-refs?)
+        hide-block-refs? (rum/react *hide-block-refs?)
         editor-box (get config :editor-box)
         editor-id (str "editor-" edit-input-id)
         slide? (:slide? config)
@@ -2202,7 +2206,7 @@
 
            (block-refs-count block *hide-block-refs?)]]
 
-         (when (and (not @*hide-block-refs?) (> refs-count 0))
+         (when (and (not hide-block-refs?) (> refs-count 0))
            (let [refs-cp (state/get-component :block/linked-references)]
              (refs-cp uuid)))]))))
 

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2559,7 +2559,7 @@
   (let [repo (state/get-current-repo)
         ref? (:ref? config)
         custom-query? (boolean (:custom-query? config))]
-    (if (and ref? (not custom-query?) (not (:ref-query-child? config)))
+    (if (and (or ref? custom-query?) (not (:ref-query-child? config)))
       (ui/lazy-visible
        (fn [] (block-container-inner state repo config block)))
       (block-container-inner state repo config block))))
@@ -2943,7 +2943,8 @@
    (ui/block-error "Query Error:" {:content (:query q)})
    (ui/lazy-visible
     (fn [] (custom-query* config q))
-    {:debug-id q})))
+    {:debug-id q
+     :trigger-once? false})))
 
 (defn admonition
   [config type result]
@@ -3363,7 +3364,8 @@
                    (rum/with-key
                      (breadcrumb-with-container block config)
                      (:db/id block)))
-                 {:debug-id page})])))))]
+                 {:debug-id page
+                  :trigger-once? false})])))))]
 
      (and (:group-by-page? config)
           (vector? (first blocks)))

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -3340,9 +3340,10 @@
                  (page-cp config page)
                  (when alias? [:span.text-sm.font-medium.opacity-50 " Alias"])]
                 (for [block parent-blocks]
-                  (rum/with-key
-                    (breadcrumb-with-container block config)
-                    (:db/id block)))
+                  (let [block' (update block :block/children tree/non-consecutive-blocks->vec-tree)]
+                    (rum/with-key
+                      (breadcrumb-with-container block' config)
+                      (:db/id block'))))
                 {:debug-id page})])))))]
 
      (and (:custom-query? config) (:group-by-page? config))

--- a/src/main/frontend/components/journal.cljs
+++ b/src/main/frontend/components/journal.cljs
@@ -59,7 +59,8 @@
         (blocks-cp repo page)
         (ui/lazy-visible
          (fn [] (blocks-cp repo page))
-         {:debug-id (str "journal-blocks " page)}))
+         {:trigger-once? false
+          :debug-id (str "journal-blocks " page)}))
 
       {})
 

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -142,7 +142,7 @@
               hiccup-config (common-handler/config-with-document-mode hiccup-config)
               hiccup (component-block/->hiccup page-blocks hiccup-config {})]
           [:div
-           (page-blocks-inner page-name page-blocks hiccup sidebar? block-id (or block-id page-name))
+           (page-blocks-inner page-name page-blocks hiccup sidebar? block-id)
            (when-not config/publishing?
              (let [args (if block-id
                           {:block-uuid block-id}

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -142,7 +142,7 @@
               hiccup-config (common-handler/config-with-document-mode hiccup-config)
               hiccup (component-block/->hiccup page-blocks hiccup-config {})]
           [:div
-           (page-blocks-inner page-name page-blocks hiccup sidebar? block-id)
+           (page-blocks-inner page-name page-blocks hiccup sidebar? block-id (or block-id page-name))
            (when-not config/publishing?
              (let [args (if block-id
                           {:block-uuid block-id}
@@ -394,10 +394,11 @@
          (tagged-pages repo page-name))
 
        ;; referenced blocks
-       [:div {:key "page-references"}
-        (rum/with-key
-          (reference/references route-page-name)
-          (str route-page-name "-refs"))]
+       (when-not block?
+         [:div {:key "page-references"}
+          (rum/with-key
+            (reference/references route-page-name)
+            (str route-page-name "-refs"))])
 
        (when-not block?
          [:div

--- a/src/main/frontend/components/query_table.cljs
+++ b/src/main/frontend/components/query_table.cljs
@@ -10,7 +10,8 @@
             [frontend.util.property :as property]
             [frontend.format.block :as block]
             [medley.core :as medley]
-            [rum.core :as rum]))
+            [rum.core :as rum]
+            [frontend.modules.outliner.tree :as tree]))
 
 ;; TODO: extract to table utils
 (defn- sort-result-by
@@ -82,7 +83,8 @@
   (rum/local false ::select?)
   [state config current-block result {:keys [page?]} map-inline page-cp ->elem inline-text]
   (when current-block
-    (let [p-sort-by (keyword (get-in current-block [:block/properties :query-sort-by]))
+    (let [result (tree/filter-top-level-blocks result)
+          p-sort-by (keyword (get-in current-block [:block/properties :query-sort-by]))
           p-desc? (get-in current-block [:block/properties :query-sort-desc])
           select? (get state ::select?)
           *sort-by-item (get state ::sort-by-item)

--- a/src/main/frontend/components/reference.cljs
+++ b/src/main/frontend/components/reference.cljs
@@ -181,24 +181,15 @@
           repo (state/get-current-repo)
           filters-atom (get state ::filters)
           filter-state (rum/react filters-atom)
-          block-id (parse-uuid page-name)
-          id (if block-id
-               (:db/id (db/pull [:block/uuid block-id]))
-               (:db/id page-entity))
-          ref-blocks (if block-id
-                       (db/get-block-referenced-blocks block-id)
-                       (db/get-page-referenced-blocks page-name))
-          aliases (when-not block-id (db/page-alias-set repo page-name))
-          top-level-blocks (if block-id
-                             ref-blocks
-                             (filter (fn [b] (some aliases (set (map :db/id (:block/refs b))))) ref-blocks))
+          id (:db/id page-entity)
+          ref-blocks (db/get-page-referenced-blocks page-name)
+          aliases (db/page-alias-set repo page-name)
+          top-level-blocks (filter (fn [b] (some aliases (set (map :db/id (:block/refs b))))) ref-blocks)
           top-level-blocks-ids (set (map :db/id top-level-blocks))
           filters (when (seq filter-state)
                     (-> (group-by second filter-state)
                         (update-vals #(map first %))))
-          filtered-ref-blocks (if block-id
-                                ref-blocks
-                                (block-handler/filter-blocks ref-blocks filters))
+          filtered-ref-blocks (block-handler/filter-blocks ref-blocks filters)
           total (count top-level-blocks)
           filtered-top-blocks (filter (fn [b] (top-level-blocks-ids (:db/id b))) filtered-ref-blocks)
           filter-n (count filtered-top-blocks)

--- a/src/main/frontend/components/reference.cljs
+++ b/src/main/frontend/components/reference.cljs
@@ -232,8 +232,7 @@
    (ui/lazy-visible
     (fn []
       (references* page-name))
-    {:trigger-once? true
-     :debug-id (str page-name " references")})))
+    {:debug-id (str page-name " references")})))
 
 (rum/defcs unlinked-references-aux
   < rum/reactive db-mixins/query

--- a/src/main/frontend/components/reference.cljs
+++ b/src/main/frontend/components/reference.cljs
@@ -14,7 +14,6 @@
             [frontend.ui :as ui]
             [frontend.util :as util]
             [rum.core :as rum]
-            [clojure.set :as set]
             [frontend.modules.outliner.tree :as tree]))
 
 (defn- frequencies-sort
@@ -26,8 +25,7 @@
   [:div.flex.gap-1.flex-wrap
    (for [[ref-name ref-count] filtered-references]
      (when ref-name
-       (let [lc-reference (string/lower-case ref-name)
-             filtered (get filters lc-reference)]
+       (let [lc-reference (string/lower-case ref-name)]
          (ui/button
            [:span
             ref-name
@@ -111,7 +109,7 @@
                       {:hiccup ref-hiccup})]))
 
 (rum/defc references-inner
-  [page-name filters filtered-ref-blocks top-level-ids]
+  [page-name filters filtered-ref-blocks]
   [:div.references-blocks
    (let [ref-hiccup (block/->hiccup filtered-ref-blocks
                                     {:id page-name
@@ -177,11 +175,9 @@
   (when page-name
     (let [page-name (string/lower-case page-name)
           *ref-pages (::ref-pages state)
-          page-entity (db/entity [:block/name page-name])
           repo (state/get-current-repo)
           filters-atom (get state ::filters)
           filter-state (rum/react filters-atom)
-          id (:db/id page-entity)
           ref-blocks (db/get-page-referenced-blocks page-name)
           aliases (db/page-alias-set repo page-name)
           top-level-blocks (filter (fn [b] (some aliases (set (map :db/id (:block/refs b))))) ref-blocks)

--- a/src/main/frontend/components/reference.cljs
+++ b/src/main/frontend/components/reference.cljs
@@ -194,7 +194,7 @@
           ref-blocks (db/get-page-referenced-blocks page-name)
           page-id (:db/id (db/entity repo [:block/name page-name]))
           aliases (db/page-alias-set repo page-name)
-          aliases-exclude-self (remove #{page-id} aliases)
+          aliases-exclude-self (set (remove #{page-id} aliases))
           top-level-blocks (filter (fn [b] (some aliases (set (map :db/id (:block/refs b))))) ref-blocks)
           top-level-blocks-ids (set (map :db/id top-level-blocks))
           filters (when (seq filter-state)

--- a/src/main/frontend/components/reference.css
+++ b/src/main/frontend/components/reference.css
@@ -10,3 +10,7 @@
   padding-left: 0.5rem;
   align-items: center;
 }
+
+.references-blocks .breadcrumb {
+  margin-left: 1.5rem;
+}

--- a/src/main/frontend/components/reference.css
+++ b/src/main/frontend/components/reference.css
@@ -14,3 +14,7 @@
 .references-blocks .breadcrumb {
   margin-left: 1.5rem;
 }
+
+.ls-filters {
+    max-width: 704px;
+}

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -1219,25 +1219,6 @@
           :entities
           (remove (fn [block] (= page-id (:db/id (:block/page block)))))))))))
 
-(defn get-linked-references-count
-  [id]
-  (when-let [block (db-utils/entity id)]
-    (let [repo (state/get-current-repo)
-          page? (:block/name block)
-          result (if page?
-                   (let [pages (page-alias-set repo (:block/name block))]
-                     @(react/q repo [:frontend.db.react/refs-count id] {}
-                        '[:find [?block ...]
-                          :in $ [?ref-page ...] ?id
-                          :where
-                          [?block :block/refs ?ref-page]
-                          [?block :block/page ?p]
-                          [(not= ?p ?id)]]
-                        pages
-                        id))
-                   (:block/_refs block))]
-      (count result))))
-
 (defn get-date-scheduled-or-deadlines
   [journal-title]
   (when-let [date (date/journal-title->int journal-title)]

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -1205,7 +1205,8 @@
          (->>
           (react/q repo
             [:frontend.db.react/refs page-id]
-            {:query-fn (fn []
+            {:use-cache? false
+             :query-fn (fn []
                          (let [entities (mapcat (fn [id]
                                                   (:block/_path-refs (db-utils/entity id))) pages)
                                blocks (map (fn [e] {:block/parent (:block/parent e)
@@ -1216,15 +1217,7 @@
             nil)
           react
           :entities
-          (remove (fn [block] (= page-id (:db/id (:block/page block)))))
-          db-utils/group-by-page
-          (map (fn [[k blocks]]
-                 (let [k (if (contains? aliases (:db/id k))
-                           {:db/id (:db/id k)
-                            :block/alias? true
-                            :block/journal-day (:block/journal-day k)}
-                           k)]
-                   [k blocks])))))))))
+          (remove (fn [block] (= page-id (:db/id (:block/page block)))))))))))
 
 (defn get-linked-references-count
   [id]

--- a/src/main/frontend/db/react.cljs
+++ b/src/main/frontend/db/react.cljs
@@ -33,10 +33,6 @@
 ;; ::refs
 ;; get BLOCKS referencing PAGE or BLOCK
 (s/def ::refs (s/tuple #(= ::refs %) int?))
-;; ::refs-count
-;; get refs count
-(s/def ::refs-count int?)
-
 ;; custom react-query
 (s/def ::custom any?)
 
@@ -46,7 +42,6 @@
                                 :journals ::journals
                                 :page<-pages ::page<-pages
                                 :refs ::refs
-                                :refs-count ::refs-count
                                 :custom ::custom))
 
 (s/def ::affected-keys (s/coll-of ::react-query-keys))
@@ -260,9 +255,7 @@
                                 blocks [[::block (:db/id block)]]
                                 path-refs (:block/path-refs block)
                                 path-refs' (mapcat (fn [ref]
-                                                     [
-                                                      ;; [::refs-count (:db/id ref)]
-                                                      [::refs (:db/id ref)]]) path-refs)
+                                                     [[::refs (:db/id ref)]]) path-refs)
                                 page-blocks (when page-id
                                               [[::page-blocks page-id]])]
                             (concat blocks page-blocks path-refs')))
@@ -270,9 +263,7 @@
 
                        (mapcat
                         (fn [ref]
-                          [
-                           ;; [::refs-count (:db/id entity)]
-                           [::refs ref]])
+                          [[::refs ref]])
                         refs)
 
                        (when-let [current-page-id (:db/id (get-current-page))]

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -13,9 +13,7 @@
    [frontend.state :as state]
    [frontend.util :as util]
    [goog.dom :as gdom]
-   [logseq.graph-parser.block :as gp-block]
-   [frontend.modules.instrumentation.posthog :as posthog]
-   [cljs-bean.core :as bean]))
+   [logseq.graph-parser.block :as gp-block]))
 
 ;;  Fns
 

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -251,7 +251,7 @@
 
 (defn get-blocks-refed-pages
   [aliases ref-blocks]
-  (let [refs (->> (mapcat (fn [b] (conj (:block/refs b) (:block/page b))) ref-blocks)
+  (let [refs (->> (mapcat (fn [b] (conj (:block/path-refs b) (:block/page b))) ref-blocks)
                   distinct
                   (remove #(aliases (:db/id %))))]
     (keep (fn [ref]
@@ -275,6 +275,6 @@
                     (seq (set/intersection exclude-ids ids)))))
 
         (seq include-ids)
-        (remove (fn [block]
+        (filter (fn [block]
                   (let [ids (set (map :db/id (:block/path-refs block)))]
-                    (empty? (set/intersection include-ids ids)))))))))
+                    (set/subset? include-ids ids))))))))

--- a/src/main/frontend/modules/outliner/pipeline.cljs
+++ b/src/main/frontend/modules/outliner/pipeline.cljs
@@ -6,8 +6,7 @@
             [frontend.db.model :as db-model]
             [frontend.db.react :as react]
             [frontend.db :as db]
-            [clojure.set :as set]
-            [datascript.core :as d]))
+            [clojure.set :as set]))
 
 (defn updated-page-hook
   [_tx-report page]

--- a/src/main/frontend/modules/outliner/pipeline.cljs
+++ b/src/main/frontend/modules/outliner/pipeline.cljs
@@ -6,7 +6,8 @@
             [frontend.db.model :as db-model]
             [frontend.db.react :as react]
             [frontend.db :as db]
-            [clojure.set :as set]))
+            [clojure.set :as set]
+            [datascript.core :as d]))
 
 (defn updated-page-hook
   [_tx-report page]
@@ -21,12 +22,9 @@
 ;; 1. For each changed block, new-refs = its page + :block/refs + parents :block/refs
 ;; 2. Its children' block/path-refs might need to be updated too.
 (defn compute-block-path-refs
-  [tx-meta blocks]
+  [{:keys [tx-meta]} blocks]
   (let [repo (state/get-current-repo)
-        blocks (remove :block/name blocks)
-        blocks (if (= (:outliner-op tx-meta) :insert-blocks)
-                 (butlast blocks)
-                 blocks)]
+        blocks (remove :block/name blocks)]
     (when (:outliner-op tx-meta)
       (when (react/path-refs-need-recalculated? tx-meta)
         (let [*computed-ids (atom #{})]
@@ -44,13 +42,15 @@
                             refs-changed? (not= old-refs new-refs)
                             children (db-model/get-block-children-ids repo (:block/uuid block))
                             children-refs (map (fn [id]
-                                                 {:db/id (:db/id (db/entity [:block/uuid id]))
-                                                  :block/path-refs (concat
-                                                                    (map :db/id (:block/path-refs (db/entity id)))
-                                                                    new-refs)}) children)]
+                                                 (let [entity (db/entity [:block/uuid id])]
+                                                   {:db/id (:db/id entity)
+                                                    :block/path-refs (concat
+                                                                      (map :db/id (:block/path-refs entity))
+                                                                      new-refs)})) children)]
                         (swap! *computed-ids set/union (set (cons (:block/uuid block) children)))
                         (util/concat-without-nil
-                         [(when (and refs-changed? (seq new-refs))
+                         [(when (and (seq new-refs)
+                                     refs-changed?)
                             {:db/id (:db/id block)
                              :block/path-refs new-refs})]
                          children-refs))))
@@ -66,7 +66,7 @@
             repo (state/get-current-repo)
             refs-tx (util/profile
                      "Compute path refs: "
-                     (set (compute-block-path-refs (:tx-meta tx-report) blocks)))
+                     (set (compute-block-path-refs tx-report blocks)))
             truncate-refs-tx (map (fn [m] [:db/retract (:db/id m) :block/path-refs]) refs-tx)
             tx (util/concat-without-nil truncate-refs-tx refs-tx)
             tx-report' (if (seq tx)

--- a/src/main/frontend/modules/outliner/tree.cljs
+++ b/src/main/frontend/modules/outliner/tree.cljs
@@ -84,14 +84,19 @@
       (assoc root' :block/children children)
       root')))
 
+(defn block-entity->map
+  [e]
+  {:db/id (:db/id e)
+   :block/uuid (:block/uuid e)
+   :block/parent {:db/id (:db/id (:block/parent e))}
+   :block/left {:db/id (:db/id (:block/left e))}
+   :block/page (:block/page e)
+   :block/refs (:block/refs e)})
+
 (defn non-consecutive-blocks->vec-tree
   "`blocks` need to be in the same page."
   [blocks]
-  (let [blocks (map (fn [e] {:db/id (:db/id e)
-                             :block/uuid (:block/uuid e)
-                             :block/parent {:db/id (:db/id (:block/parent e))}
-                             :block/left {:db/id (:db/id (:block/left e))}
-                             :block/page {:db/id (:db/id (:block/page e))}}) blocks)
+  (let [blocks (map block-entity->map blocks)
         parent->children (group-by :block/parent blocks)
         id->blocks (zipmap (map :db/id blocks) blocks)
         top-level-blocks (filter #(nil?

--- a/src/main/frontend/modules/outliner/tree.cljs
+++ b/src/main/frontend/modules/outliner/tree.cljs
@@ -93,16 +93,20 @@
    :block/page (:block/page e)
    :block/refs (:block/refs e)})
 
+(defn filter-top-level-blocks
+  [blocks]
+  (let [id->blocks (zipmap (map :db/id blocks) blocks)]
+    (filter #(nil?
+              (id->blocks
+               (:db/id (:block/parent (id->blocks (:db/id %)))))) blocks)))
+
 (defn non-consecutive-blocks->vec-tree
   "`blocks` need to be in the same page."
   [blocks]
   (let [blocks (map block-entity->map blocks)
-        parent->children (group-by :block/parent blocks)
-        id->blocks (zipmap (map :db/id blocks) blocks)
-        top-level-blocks (filter #(nil?
-                                   (id->blocks
-                                    (:db/id (:block/parent (id->blocks (:db/id %)))))) blocks)
-        top-level-blocks' (model/try-sort-by-left top-level-blocks (:block/parent (first top-level-blocks)))]
+        top-level-blocks (filter-top-level-blocks blocks)
+        top-level-blocks' (model/try-sort-by-left top-level-blocks (:block/parent (first top-level-blocks)))
+        parent->children (group-by :block/parent blocks)]
     (map #(tree parent->children %) top-level-blocks')))
 
 (defn- sort-blocks-aux

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -147,7 +147,7 @@
 
 (defn button
   [text & {:keys [background href class intent on-click small? large?]
-           :or {small? false large? false}
+           :or   {small? false large? false}
            :as   option}]
   (let [klass (when-not intent ".bg-indigo-600.hover:bg-indigo-700.focus:border-indigo-700.active:bg-indigo-700.text-center")
         klass (if background (string/replace klass "indigo" background) klass)

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -936,24 +936,17 @@
   ([content-fn]
    (lazy-visible content-fn nil))
   ([content-fn {:keys [trigger-once? _debug-id]
-                :or {trigger-once? false}}]
+                :or {trigger-once? true}}]
    (if (or (util/mobile?) (mobile-util/native-platform?))
      (content-fn)
      (let [[visible? set-visible!] (rum/use-state false)
-           [last-changed-time set-last-changed-time!] (rum/use-state nil)
            inViewState (useInView #js {:rootMargin "100px"
                                        :triggerOnce trigger-once?
                                        :onChange (fn [in-view? entry]
-                                                   (let [self-top (.-top (.-boundingClientRect entry))
-                                                         time' (util/time-ms)]
-                                                     (when (and
-                                                            (or (and (not visible?) in-view?)
-                                                                ;; hide only the components below the current top for better ux
-                                                                (and visible? (not in-view?) (> self-top 0)))
-                                                            (or (nil? last-changed-time)
-                                                                (and (some? last-changed-time)
-                                                                     (> (- time' last-changed-time) 50))))
-                                                       (set-last-changed-time! time')
+                                                   (let [self-top (.-top (.-boundingClientRect entry))]
+                                                     (when (or (and (not visible?) in-view?)
+                                                               ;; hide only the components below the current top for better ux
+                                                               (and visible? (not in-view?) (> self-top 0)))
                                                        (set-visible! in-view?))))})
            ref (.-ref inViewState)]
        (lazy-visible-inner visible? content-fn ref)))))


### PR DESCRIPTION
This PR does:

1. fix wrong page refs count in filters
2. fix children's `block/path-refs` are cleared when updating their parent
3. improve performance for linked references
4. remove reactive query ::refs-count
5. add includes and excludes to filters
6. fix #6406 https://github.com/logseq/logseq/pull/6423/commits/cf3a2a668523c0bd3812e19db02396783597321f
7. fix the issue that lazy components are not rendered sometimes