### PR TITLE
fix(editor): skip empty block when cycle todo

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -756,7 +756,8 @@
                    (remove nil?))]
       (doseq [id ids]
         (let [block (db/pull [:block/uuid id])]
-          (set-marker block))))))
+          (when (not-empty (:block/content block))
+            (set-marker block)))))))
 
 (defn cycle-todo!
   []


### PR DESCRIPTION
Avoid cycle todo of empty block:

The original BUG:

https://user-images.githubusercontent.com/72891/185789719-974cd786-0534-4afe-83cf-1c858a2b4874.mov

Fixed:


https://user-images.githubusercontent.com/72891/185789726-59755655-a035-4b39-9c6b-679b8069d7e4.mov


