### PR TITLE
feat: find in page on electron

### DIFF
--- a/src/electron/electron/find_in_page.cljs
+++ b/src/electron/electron/find_in_page.cljs
@@ -1,0 +1,12 @@
+(ns electron.find-in-page
+  (:require [electron.window :as win]))
+
+(defn find!
+  [^js window search option]
+  (when window
+    (.findInPage ^js (.-webContents window) search option)))
+
+(defn clear!
+  [^js window]
+  (when window
+    (.stopFindInPage ^js (.-webContents window) "clearSelection")))

--- a/src/electron/electron/find_in_page.cljs
+++ b/src/electron/electron/find_in_page.cljs
@@ -1,10 +1,16 @@
 (ns electron.find-in-page
-  (:require [electron.window :as win]))
+  (:require [electron.utils :as utils]
+            [cljs-bean.core :as bean]))
 
 (defn find!
   [^js window search option]
   (when window
-    (.findInPage ^js (.-webContents window) search option)))
+    (let [contents ^js (.-webContents window)]
+      (.findInPage contents search option)
+      (.on contents "found-in-page"
+           (fn [_event result]
+             (utils/send-to-renderer window "foundInPage" (bean/->clj result))))
+      true)))
 
 (defn clear!
   [^js window]

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -21,7 +21,8 @@
             [electron.plugin :as plugin]
             [electron.window :as win]
             [electron.file-sync-rsapi :as rsapi]
-            [electron.backup-file :as backup-file]))
+            [electron.backup-file :as backup-file]
+            [electron.find-in-page :as find]))
 
 (defmulti handle (fn [_window args] (keyword (first args))))
 
@@ -535,6 +536,12 @@
   (when-let [f (:window/once-persist-done @state/state)]
     (f)
     (state/set-state! :window/once-persist-done nil)))
+
+(defmethod handle :find-in-page [^js win [_ search option]]
+  (find/find! win search (bean/->js option)))
+
+(defmethod handle :clear-find-in-page [^js win [_]]
+  (find/clear! win))
 
 (defn set-ipc-handler! [window]
   (let [main-channel "main"]

--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -159,7 +159,3 @@
         (.off win "enter-full-screen")
         (.off win "leave-full-screen")))
     #()))
-
-(defn get-active-window
-  []
-  (.getFocusedWindow BrowserWindow))

--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -118,7 +118,7 @@
 (defn setup-window-listeners!
   [^js win]
   (when win
-    (let [web-contents (. win -webContents)          
+    (let [web-contents (. win -webContents)
           new-win-handler
           (fn [e url]
             (let [url (if (string/starts-with? url "file:")
@@ -140,7 +140,7 @@
 
           context-menu-handler
           (context-menu/setup-context-menu! win)]
-      
+
       (doto web-contents
         (.on "new-window" new-win-handler)
         (.on "will-navigate" will-navigate-handler))
@@ -159,3 +159,7 @@
         (.off win "enter-full-screen")
         (.off win "leave-full-screen")))
     #()))
+
+(defn get-active-window
+  []
+  (.getFocusedWindow BrowserWindow))

--- a/src/main/electron/listener.cljs
+++ b/src/main/electron/listener.cljs
@@ -17,7 +17,8 @@
             [frontend.ui :as ui]
             [frontend.handler.notification :as notification]
             [frontend.handler.repo :as repo-handler]
-            [frontend.handler.user :as user]))
+            [frontend.handler.user :as user]
+            [dommy.core :as dom]))
 
 (defn persist-dbs!
   []
@@ -128,7 +129,7 @@
                      (fn [data]
                        (let [data' (bean/->clj data)]
                          (state/set-state! [:ui/find-in-page :matches] data')
-                         (state/set-state! [:ui/find-in-page :searching?] false)
+                         (dom/remove-style! (dom/by-id "search-in-page-input") :visibility)
                          (ui/focus-element "search-in-page-input")
                          true)))
 

--- a/src/main/electron/listener.cljs
+++ b/src/main/electron/listener.cljs
@@ -128,6 +128,8 @@
                      (fn [data]
                        (let [data' (bean/->clj data)]
                          (state/set-state! [:ui/find-in-page :matches] data')
+                         (state/set-state! [:ui/find-in-page :searching?] false)
+                         (ui/focus-element "search-in-page-input")
                          true)))
 
   (js/window.apis.on "loginCallback"

--- a/src/main/electron/listener.cljs
+++ b/src/main/electron/listener.cljs
@@ -124,6 +124,12 @@
                                        :on-error   error-f}]
                          (repo-handler/persist-db! repo handlers))))
 
+  (js/window.apis.on "foundInPage"
+                     (fn [data]
+                       (let [data' (bean/->clj data)]
+                         (state/set-state! [:ui/find-in-search :matches] data')
+                         true)))
+
   (js/window.apis.on "loginCallback"
                      (fn [code]
                        (user/login-callback code)))

--- a/src/main/electron/listener.cljs
+++ b/src/main/electron/listener.cljs
@@ -130,6 +130,7 @@
                        (let [data' (bean/->clj data)]
                          (state/set-state! [:ui/find-in-page :matches] data')
                          (dom/remove-style! (dom/by-id "search-in-page-input") :visibility)
+                         (dom/set-text! (dom/by-id "search-in-page-placeholder") "")
                          (ui/focus-element "search-in-page-input")
                          true)))
 

--- a/src/main/electron/listener.cljs
+++ b/src/main/electron/listener.cljs
@@ -127,7 +127,7 @@
   (js/window.apis.on "foundInPage"
                      (fn [data]
                        (let [data' (bean/->clj data)]
-                         (state/set-state! [:ui/find-in-search :matches] data')
+                         (state/set-state! [:ui/find-in-page :matches] data')
                          true)))
 
   (js/window.apis.on "loginCallback"

--- a/src/main/frontend/components/find_in_page.cljs
+++ b/src/main/frontend/components/find_in_page.cljs
@@ -25,7 +25,8 @@
       [:div.text-sm.absolute.top-2.right-0.py-2.px-4
        (:activeMatchOrdinal matches 0)
        "/"
-       total]))])
+       total]))
+   [:div#search-in-page-placeholder.absolute.top-2.left-0.p-2.sm:text-sm]])
 
 (rum/defc search-inner < rum/static
   (mixins/event-mixin

--- a/src/main/frontend/components/find_in_page.cljs
+++ b/src/main/frontend/components/find_in_page.cljs
@@ -25,7 +25,7 @@
   (when (and (= (.-code e) "Enter")
              (not (state/editing?)))
     (let [shift? (.-shiftKey e)]
-      (state/set-state! [:ui/find-in-search :backward?] shift?)
+      (state/set-state! [:ui/find-in-page :backward?] shift?)
       (search-handler/electron-find-in-page!))))
 
 (rum/defc search-inner <
@@ -50,7 +50,7 @@
       :placeholder "Find in page"
       :on-change (fn [e]
                    (let [value (util/evalue e)]
-                     (state/set-state! [:ui/find-in-search :q] value)
+                     (state/set-state! [:ui/find-in-page :q] value)
                      (if (string/blank? value)
                        (search-handler/electron-exit-find-in-page!)
                        (debounced-search))))}]]
@@ -62,7 +62,7 @@
    (ui/button
      (ui/icon "caret-up" {:style {:font-size 18}})
      :on-click (fn []
-                 (state/set-state! [:ui/find-in-search :backward?] true)
+                 (state/set-state! [:ui/find-in-page :backward?] true)
                  (search-handler/electron-find-in-page!))
      :intent "link"
      :small? true)
@@ -70,7 +70,7 @@
    (ui/button
      (ui/icon "caret-down" {:style {:font-size 18}})
      :on-click (fn []
-                 (state/set-state! [:ui/find-in-search :backward?] false)
+                 (state/set-state! [:ui/find-in-page :backward?] false)
                  (search-handler/electron-find-in-page!))
      :intent "link"
      :small? true)
@@ -84,6 +84,6 @@
 
 (rum/defc search < rum/reactive
   []
-  (let [{:keys [active?] :as opt} (state/sub :ui/find-in-search)]
+  (let [{:keys [active?] :as opt} (state/sub :ui/find-in-page)]
     (when active?
       (search-inner opt))))

--- a/src/main/frontend/components/find_in_page.cljs
+++ b/src/main/frontend/components/find_in_page.cljs
@@ -47,6 +47,7 @@
                 (debounced-search))
     :intent "link"
     :small? true
+    :title "Match case"
     :class (str (when match-case? "active ") "text-lg"))
 
    (ui/button

--- a/src/main/frontend/components/find_in_page.cljs
+++ b/src/main/frontend/components/find_in_page.cljs
@@ -5,11 +5,12 @@
             [frontend.util :as util]
             [frontend.handler.search :as search-handler :refer [debounced-search]]
             [goog.dom :as gdom]
-            [frontend.mixins :as mixins]))
+            [frontend.mixins :as mixins]
+            [clojure.string :as string]))
 
 (rum/defc search-input
-  [q]
-  [:div.flex.w-48
+  [q matches]
+  [:div.flex.w-48.relative
    [:input#search-in-page-input.form-input.block.sm:text-sm.sm:leading-5.my-2.border-none.mr-4.outline-none
     {:auto-focus true
      :placeholder "Find in page"
@@ -18,7 +19,13 @@
      :on-change (fn [e]
                   (let [value (util/evalue e)]
                     (state/set-state! [:ui/find-in-page :q] value)
-                    (debounced-search)))}]])
+                    (debounced-search)))}]
+   (when-not (string/blank? q)
+     (when-let [total (:matches matches)]
+      [:div.text-sm.absolute.top-2.right-0.py-2.px-4
+       (:activeMatchOrdinal matches 0)
+       "/"
+       total]))])
 
 (rum/defc search-inner < rum/static
   (mixins/event-mixin
@@ -31,12 +38,7 @@
   [{:keys [matches match-case? q]}]
   [:div#search-in-page.flex.flex-row.absolute.top-2.right-4.shadow-lg.px-2.py-1.faster-fade-in.items-center
 
-   (search-input q)
-
-   [:div.px-4.text-sm.opacity-80
-    (:activeMatchOrdinal matches 0)
-    "/"
-    (:matches matches 0)]
+   (search-input q matches)
 
    (ui/button
     (ui/icon "letter-case")

--- a/src/main/frontend/components/find_in_page.cljs
+++ b/src/main/frontend/components/find_in_page.cljs
@@ -42,8 +42,8 @@
       :node (gdom/getElement "search-in-page")
       :on-hide (fn []
                  (search-handler/electron-exit-find-in-page!)))))
-  [{:keys [q backward?]}]
-  [:div#search-in-page.flex.flex-row.absolute.top-2.right-4.shadow-lg.px-2.py-1.faster-fade-in
+  [{:keys [matches]}]
+  [:div#search-in-page.flex.flex-row.absolute.top-2.right-4.shadow-lg.px-2.py-1.faster-fade-in.items-center
    [:div.flex
     [:input#search-in-page-input.form-input.block.w-48.sm:text-sm.sm:leading-5.my-2.border-none.mr-4.outline-none
      {:auto-focus true
@@ -51,7 +51,14 @@
       :on-change (fn [e]
                    (let [value (util/evalue e)]
                      (state/set-state! [:ui/find-in-search :q] value)
-                     (debounced-search)))}]]
+                     (if (string/blank? value)
+                       (search-handler/electron-exit-find-in-page!)
+                       (debounced-search))))}]]
+   [:div.px-4.text-sm.opacity-80
+    (:activeMatchOrdinal matches 0)
+    "/"
+    (:matches matches 0)]
+
    (ui/button
      (ui/icon "caret-up" {:style {:font-size 18}})
      :on-click (fn []

--- a/src/main/frontend/components/find_in_page.cljs
+++ b/src/main/frontend/components/find_in_page.cljs
@@ -1,0 +1,82 @@
+(ns frontend.components.find-in-page
+  (:require [rum.core :as rum]
+            [frontend.ui :as ui]
+            [frontend.state :as state]
+            [frontend.util :as util]
+            [frontend.handler.search :as search-handler]
+            [goog.dom :as gdom]
+            [goog.functions :refer [debounce]]
+            [frontend.mixins :as mixins]
+            [clojure.string :as string]))
+
+(defn focus-input!
+  []
+  (when-let [element ^js (gdom/getElement "search-in-page-input")]
+    (.focus element)))
+
+(defn find-in-page!
+  []
+  (search-handler/electron-find-in-page! focus-input!))
+
+(defonce debounced-search (debounce find-in-page! 500))
+
+(defn- enter-to-search
+  [e]
+  (when (and (= (.-code e) "Enter")
+             (not (state/editing?)))
+    (let [shift? (.-shiftKey e)]
+      (state/set-state! [:ui/find-in-search :backward?] shift?)
+      (search-handler/electron-find-in-page!))))
+
+(rum/defc search-inner <
+  {:did-mount (fn [state]
+                (js/document.addEventListener "keyup" enter-to-search)
+                state)
+   :will-unmount (fn [state]
+                   (js/document.removeEventListener "keyup" enter-to-search)
+                   state)}
+  (mixins/event-mixin
+   (fn [state]
+     (mixins/hide-when-esc-or-outside
+      state
+      :node (gdom/getElement "search-in-page")
+      :on-hide (fn []
+                 (search-handler/electron-exit-find-in-page!)))))
+  [{:keys [q backward?]}]
+  [:div#search-in-page.flex.flex-row.absolute.top-2.right-4.shadow-lg.px-2.py-1.faster-fade-in
+   [:div.flex
+    [:input#search-in-page-input.form-input.block.w-48.sm:text-sm.sm:leading-5.my-2.border-none.mr-4.outline-none
+     {:auto-focus true
+      :placeholder "Find in page"
+      :on-change (fn [e]
+                   (let [value (util/evalue e)]
+                     (state/set-state! [:ui/find-in-search :q] value)
+                     (debounced-search)))}]]
+   (ui/button
+     (ui/icon "caret-up" {:style {:font-size 18}})
+     :on-click (fn []
+                 (state/set-state! [:ui/find-in-search :backward?] true)
+                 (search-handler/electron-find-in-page!))
+     :intent "link"
+     :small? true)
+
+   (ui/button
+     (ui/icon "caret-down" {:style {:font-size 18}})
+     :on-click (fn []
+                 (state/set-state! [:ui/find-in-search :backward?] false)
+                 (search-handler/electron-find-in-page!))
+     :intent "link"
+     :small? true)
+
+   (ui/button
+     [:span.px-1 "X"]
+     :on-click (fn []
+                 (search-handler/electron-exit-find-in-page!))
+     :intent "link"
+     :small? true)])
+
+(rum/defc search < rum/reactive
+  []
+  (let [{:keys [active?] :as opt} (state/sub :ui/find-in-search)]
+    (when active?
+      (search-inner opt))))

--- a/src/main/frontend/components/find_in_page.css
+++ b/src/main/frontend/components/find_in_page.css
@@ -6,7 +6,8 @@
       box-shadow: none;
   }
 
-  .ui__button[intent='link'], .ui__button[intent='link']:focus {
+  .ui__button[intent='link'],
+  .ui__button[intent='link']:focus {
       border-color: none;
   }
 

--- a/src/main/frontend/components/find_in_page.css
+++ b/src/main/frontend/components/find_in_page.css
@@ -1,0 +1,16 @@
+#search-in-page {
+  z-index: 999;
+  background-color: var(--ls-primary-background-color);
+
+  .form-input:focus {
+      box-shadow: none;
+  }
+
+  .ui__button[intent='link'], .ui__button[intent='link']:focus {
+      border-color: none;
+  }
+
+  .ui__button {
+      margin-top: 0;
+  }
+}

--- a/src/main/frontend/components/find_in_page.css
+++ b/src/main/frontend/components/find_in_page.css
@@ -13,5 +13,9 @@
 
   .ui__button {
       margin-top: 0;
+
+      &.active {
+        color: var(--ls-link-text-color);
+      }
   }
 }

--- a/src/main/frontend/components/search.cljs
+++ b/src/main/frontend/components/search.cljs
@@ -271,7 +271,7 @@
     [:div "Recent search:"]
     (ui/with-shortcut :go/search-in-page "bottom"
       [:div.flex-row.flex.align-items
-       [:div.mr-2 "Search in page:"]
+       [:div.mr-2 "Search blocks in page:"]
        [:div {:style {:margin-top 3}}
         (ui/toggle in-page-search?
                    (fn [_value]

--- a/src/main/frontend/components/sidebar.cljs
+++ b/src/main/frontend/components/sidebar.cljs
@@ -12,6 +12,7 @@
             [frontend.components.svg :as svg]
             [frontend.components.theme :as theme]
             [frontend.components.widgets :as widgets]
+            [frontend.components.find-in-page :as find-in-page]
             [frontend.config :as config]
             [frontend.context.i18n :refer [t]]
             [frontend.db :as db]
@@ -71,7 +72,7 @@
   (let [original-name (db-model/get-page-original-name name)]
     [:a {:on-click (fn [e]
                      (let [name (util/safe-page-name-sanity-lc name)
-                           source-page (db-model/get-alias-source-page (state/get-current-repo) name) 
+                           source-page (db-model/get-alias-source-page (state/get-current-repo) name)
                            name (if (empty? source-page) name (:block/name source-page))]
                        (if (gobj/get e "shiftKey")
                          (when-let [page-entity (if (empty? source-page) (db/entity [:block/name name]) source-page)]
@@ -332,6 +333,9 @@
                     :route-match route-match})
 
      [:div#main-content-container.scrollbar-spacing.w-full.flex.justify-center.flex-row
+
+      (when (util/electron?)
+        (find-in-page/search))
 
       (when show-action-bar?
         (action-bar/action-bar))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2907,8 +2907,9 @@
 
 (defn- cut-blocks-and-clear-selections!
   [copy?]
-  (cut-selection-blocks copy?)
-  (clear-selection!))
+  (when-not (get-in @state/state [:ui/find-in-page :active?])
+    (cut-selection-blocks copy?)
+    (clear-selection!)))
 
 (defn shortcut-copy-selection
   [_e]

--- a/src/main/frontend/handler/search.cljs
+++ b/src/main/frontend/handler/search.cljs
@@ -54,7 +54,7 @@
    (electron-find-in-page! nil))
   ([on-success]
    (when (util/electron?)
-     (let [{:keys [active? backward? q]} (:ui/find-in-search @state/state)
+     (let [{:keys [active? backward? q]} (:ui/find-in-page @state/state)
            option (cond->
                     {}
 
@@ -63,7 +63,7 @@
 
                     backward?
                     (assoc :forward false))]
-       (when-not active? (state/set-state! [:ui/find-in-search :active?] true))
+       (when-not active? (state/set-state! [:ui/find-in-page :active?] true))
        (when-not (string/blank? q)
          (ipc/ipc "find-in-page" q option)
          (when on-success
@@ -75,7 +75,7 @@
   (when (util/electron?)
     (ipc/ipc "clear-find-in-page")
     (when clear-state?
-      (state/set-state! :ui/find-in-search nil))))
+      (state/set-state! :ui/find-in-page nil))))
 
 (defn clear-search!
   ([]

--- a/src/main/frontend/handler/search.cljs
+++ b/src/main/frontend/handler/search.cljs
@@ -76,6 +76,12 @@
       (when-not (string/blank? q)
         (dom/set-style! (dom/by-id "search-in-page-input")
                         :visibility "hidden")
+        (when (> (count q) 1)
+          (dom/set-html! (dom/by-id "search-in-page-placeholder")
+                         (util/format
+                          "<span><span>%s</span><span style=\"margin-left: -4px;\">%s</span></span>"
+                          (first q)
+                          (str " " (subs q 1)))))
         (ipc/ipc "find-in-page" q option)))))
 
 (defonce debounced-search (debounce electron-find-in-page! 500))

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -249,6 +249,10 @@
                                                 (editor-handler/escape-editing)
                                                 (route-handler/go-to-search! :global))}
 
+   :go/electron-find-in-page       {:binding "mod+f"
+                                    :fn      #(when (util/electron?)
+                                                (search-handler/electron-find-in-page!))}
+
    :go/journals                    {:binding "g j"
                                     :fn      route-handler/go-to-journals!}
 
@@ -501,6 +505,7 @@
                           :ui/toggle-brackets
                           :go/search-in-page
                           :go/search
+                          :go/electron-find-in-page
                           :go/backward
                           :go/forward
                           :search/re-index
@@ -553,6 +558,7 @@
     :editor/select-all-blocks
     :go/search
     :go/search-in-page
+    :go/electron-find-in-page
     :editor/undo
     :editor/redo
     :editor/copy

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -251,7 +251,7 @@
 
    :go/electron-find-in-page       {:binding "mod+f"
                                     :fn      #(when (util/electron?)
-                                                (search-handler/electron-find-in-page!))}
+                                                (search-handler/open-find-in-page!))}
 
    :go/journals                    {:binding "g j"
                                     :fn      route-handler/go-to-journals!}

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -253,6 +253,16 @@
                                     :fn      #(when (util/electron?)
                                                 (search-handler/open-find-in-page!))}
 
+   :go/electron-jump-to-the-next {:binding ["enter" "mod+g"]
+                                    :fn      (fn [_state _e]
+                                               (when (util/electron?)
+                                                 (search-handler/loop-find-in-page! false)))}
+
+   :go/electron-jump-to-the-previous {:binding ["shift+enter" "mod+shift+g"]
+                                             :fn      (fn [_state _e]
+                                                        (when (util/electron?)
+                                                          (search-handler/loop-find-in-page! true)))}
+
    :go/journals                    {:binding "g j"
                                     :fn      route-handler/go-to-journals!}
 
@@ -284,7 +294,7 @@
    :graph/open                     {:fn      #(do
                                                 (editor-handler/escape-editing)
                                                 (state/set-state! :ui/open-select :graph-open))
-                                    :binding "mod+shift+g"}
+                                    :binding "alt+shift+g"}
 
    :graph/remove                   {:fn      #(do
                                                 (editor-handler/escape-editing)
@@ -506,6 +516,8 @@
                           :go/search-in-page
                           :go/search
                           :go/electron-find-in-page
+                          :go/electron-jump-to-the-next
+                          :go/electron-jump-to-the-previous
                           :go/backward
                           :go/forward
                           :search/re-index
@@ -559,6 +571,8 @@
     :go/search
     :go/search-in-page
     :go/electron-find-in-page
+    :go/electron-jump-to-the-next
+    :go/electron-jump-to-the-previous
     :editor/undo
     :editor/redo
     :editor/copy

--- a/src/main/frontend/modules/shortcut/dicts.cljc
+++ b/src/main/frontend/modules/shortcut/dicts.cljc
@@ -77,6 +77,7 @@
    :editor/zoom-out                "Zoom out editing block / Backwards otherwise"
    :ui/toggle-brackets             "Toggle whether to display brackets"
    :go/search-in-page              "Search in the current page"
+   :go/electron-find-in-page       "Find in page"
    :go/search                      "Full text search"
    :go/journals                    "Go to journals"
    :go/backward                    "Backwards"

--- a/src/main/frontend/modules/shortcut/dicts.cljc
+++ b/src/main/frontend/modules/shortcut/dicts.cljc
@@ -78,6 +78,8 @@
    :ui/toggle-brackets             "Toggle whether to display brackets"
    :go/search-in-page              "Search in the current page"
    :go/electron-find-in-page       "Find in page"
+   :go/electron-jump-to-the-next   "Jump to the next match to your Find bar search"
+   :go/electron-jump-to-the-previous "Jump to the previous match to your Find bar search"
    :go/search                      "Full text search"
    :go/journals                    "Go to journals"
    :go/backward                    "Backwards"

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -231,7 +231,7 @@
 
      :encryption/graph-parsing?             false
 
-     :ui/find-in-search                     nil
+     :ui/find-in-page                     nil
      })))
 
 ;; block uuid -> {content(String) -> ast}

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -230,6 +230,8 @@
      :file-sync/download-init-progress      nil
 
      :encryption/graph-parsing?             false
+
+     :ui/find-in-search                     nil
      })))
 
 ;; block uuid -> {content(String) -> ast}

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -146,7 +146,7 @@
    opts))
 
 (defn button
-  [text & {:keys [background href class intent on-click small? large?]
+  [text & {:keys [background href class intent on-click small? large? title]
            :or   {small? false large? false}
            :as   option}]
   (let [klass (when-not intent ".bg-indigo-600.hover:bg-indigo-700.focus:border-indigo-700.active:bg-indigo-700.text-center")
@@ -156,6 +156,7 @@
     [:button.ui__button
      (merge
       {:type  "button"
+       :title title
        :class (str (util/hiccup->class klass) " " class)}
       (dissoc option :background :class :small? :large?)
       (when href
@@ -253,6 +254,11 @@
 (defn main-node
   []
   (gdom/getElement "main-content-container"))
+
+(defn focus-element
+  [element]
+  (when-let [element ^js (gdom/getElement element)]
+    (.focus element)))
 
 (defn get-scroll-top []
   (.-scrollTop (main-node)))

--- a/src/main/frontend/ui.css
+++ b/src/main/frontend/ui.css
@@ -243,6 +243,10 @@ html.is-mobile {
     @apply text-white;
   }
 
+  &.active {
+    color: var(--ls-link-text-color);
+  }
+
   &[intent='logseq'] {
     @apply focus:border-gray-500 dark:hover:text-gray-200;
 

--- a/src/main/frontend/ui.css
+++ b/src/main/frontend/ui.css
@@ -243,10 +243,6 @@ html.is-mobile {
     @apply text-white;
   }
 
-  &.active {
-    color: var(--ls-link-text-color);
-  }
-
   &[intent='logseq'] {
     @apply focus:border-gray-500 dark:hover:text-gray-200;
 


### PR DESCRIPTION
Demo: https://www.loom.com/share/036276f228f74db2b5b6c0a19365a076

- [x] search result including count
- [x] clear search result when blank input

Some caveats:
1. Electron findInPage will cause focus loss, it doesn't provide a way to [ignore inputs or specified elements](https://github.com/electron/electron/issues/11444).
2. The input element itself is counted in the search result too.
3. Can't focus after clearing the search input.

Fixes #4605 