### PR TITLE
fix: search or editor frozen caused by large text

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1968,7 +1968,7 @@
 
 (defn- block-content-on-mouse-down
   [e block block-id content edit-input-id]
-  (when-not (util/base64-image-included? content)
+  (when-not (> (count content) (state/block-content-max-length (state/get-current-repo)))
     (.stopPropagation e)
     (let [target (gobj/get e "target")
           button (gobj/get e "buttons")
@@ -2098,6 +2098,9 @@
        (merge attrs))
 
      [:<>
+      (when (> (count content) (state/block-content-max-length (state/get-current-repo)))
+        [:div.warning.text-sm
+         "Large block will not be editable or searchable to not slow down the app, please use another editor to edit this block."])
       [:div.flex.flex-row.justify-between.block-content-inner
        [:div.flex-1.w-full
         (cond

--- a/src/main/frontend/search/db.cljs
+++ b/src/main/frontend/search/db.cljs
@@ -14,7 +14,7 @@
   "Convert a block to the index for searching"
   [{:block/keys [uuid page content] :as block}]
   (when-let [content (util/search-normalize content (state/enable-search-remove-accents?))]
-    (when-not (util/base64-image-included? content)
+    (when-not (> (count content) (state/block-content-max-length (state/get-current-repo)))
       {:id (:db/id block)
        :uuid (str uuid)
        :page page

--- a/src/main/frontend/search/db.cljs
+++ b/src/main/frontend/search/db.cljs
@@ -14,10 +14,11 @@
   "Convert a block to the index for searching"
   [{:block/keys [uuid page content] :as block}]
   (when-let [content (util/search-normalize content (state/enable-search-remove-accents?))]
-    {:id (:db/id block)
-     :uuid (str uuid)
-     :page page
-     :content content}))
+    (when-not (util/base64-image-included? content)
+      {:id (:db/id block)
+       :uuid (str uuid)
+       :page page
+       :content content})))
 
 (defn build-blocks-indice
   ;; TODO: Remove repo effects fns further up the call stack. db fns need standardization on taking connection

--- a/src/main/frontend/search/node.cljs
+++ b/src/main/frontend/search/node.cljs
@@ -3,20 +3,22 @@
             [electron.ipc :as ipc]
             [frontend.search.db :as search-db]
             [frontend.search.protocol :as protocol]
-            [promesa.core :as p]))
+            [promesa.core :as p]
+            [frontend.util :as util]))
 
 (defrecord Node [repo]
   protocol/Engine
   (query [_this q opts]
     (p/let [result (ipc/ipc "search-blocks" repo q opts)
             result (bean/->clj result)]
-      (map (fn [{:keys [content uuid page]}]
-             {:block/uuid uuid
-              :block/content content
-              :block/page page}) result)))
+      (keep (fn [{:keys [content uuid page]}]
+              (when-not (util/base64-image-included? content)
+                {:block/uuid uuid
+                 :block/content content
+                 :block/page page})) result)))
   (cache-stale? [_this repo]
-                ;; only FTS require cache validating
-                (ipc/ipc "searchVersionChanged?" repo))
+    ;; only FTS require cache validating
+    (ipc/ipc "searchVersionChanged?" repo))
   (rebuild-blocks-indice! [_this]
     (let [indice (search-db/build-blocks-indice repo)]
       (ipc/ipc "rebuild-blocks-indice" repo indice)))

--- a/src/main/frontend/search/node.cljs
+++ b/src/main/frontend/search/node.cljs
@@ -4,7 +4,7 @@
             [frontend.search.db :as search-db]
             [frontend.search.protocol :as protocol]
             [promesa.core :as p]
-            [frontend.util :as util]))
+            [frontend.state :as state]))
 
 (defrecord Node [repo]
   protocol/Engine
@@ -12,7 +12,7 @@
     (p/let [result (ipc/ipc "search-blocks" repo q opts)
             result (bean/->clj result)]
       (keep (fn [{:keys [content uuid page]}]
-              (when-not (util/base64-image-included? content)
+              (when-not (> (count content) (state/block-content-max-length repo))
                 {:block/uuid uuid
                  :block/content content
                  :block/page page})) result)))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -857,40 +857,9 @@
   []
   (or (not @publishing?) (:publishing/enable-editing? (get-config))))
 
-(defn set-editing!
-  ([edit-input-id content block cursor-range]
-   (set-editing! edit-input-id content block cursor-range true))
-  ([edit-input-id content block cursor-range move-cursor?]
-   (when (and edit-input-id block
-              (or
-                (publishing-enable-editing?)
-                (not @publishing?)))
-     (let [block-element (gdom/getElement (string/replace edit-input-id "edit-block" "ls-block"))
-           container (util/get-block-container block-element)
-           block (if container
-                   (assoc block
-                     :block/container (gobj/get container "id"))
-                   block)
-           content (string/trim (or content ""))]
-       (swap! state
-              (fn [state]
-                (-> state
-                    (assoc-in [:editor/content edit-input-id] content)
-                    (assoc
-                     :editor/block block
-                     :editor/editing? {edit-input-id true}
-                     :editor/last-key-code nil
-                     :cursor-range cursor-range))))
-       (when-let [input (gdom/getElement edit-input-id)]
-         (let [pos (count cursor-range)]
-           (when content
-             (util/set-change-value input content))
-
-           (when move-cursor?
-             (cursor/move-cursor-to input pos))
-
-           (when (or (util/mobile?) (mobile-util/native-platform?))
-             (set-state! :mobile/show-action-bar? false))))))))
+(defn block-content-max-length
+  [repo]
+  (or (:block/content-max-length (get (sub-config) repo)) 5000))
 
 (defn clear-edit!
   []
@@ -1542,6 +1511,47 @@
   ([blocks direction]
    (clear-edit!)
    (set-selection-blocks! blocks direction)))
+
+(defn set-editing!
+  ([edit-input-id content block cursor-range]
+   (set-editing! edit-input-id content block cursor-range true))
+  ([edit-input-id content block cursor-range move-cursor?]
+   (if (> (count content)
+          (block-content-max-length (get-current-repo)))
+     (let [elements (array-seq (js/document.getElementsByClassName (:block/uuid block)))]
+       (when (first elements)
+         (util/scroll-to-element (gobj/get (first elements) "id")))
+       (exit-editing-and-set-selected-blocks! elements))
+     (when (and edit-input-id block
+               (or
+                (publishing-enable-editing?)
+                (not @publishing?)))
+      (let [block-element (gdom/getElement (string/replace edit-input-id "edit-block" "ls-block"))
+            container (util/get-block-container block-element)
+            block (if container
+                    (assoc block
+                           :block/container (gobj/get container "id"))
+                    block)
+            content (string/trim (or content ""))]
+        (swap! state
+               (fn [state]
+                 (-> state
+                     (assoc-in [:editor/content edit-input-id] content)
+                     (assoc
+                      :editor/block block
+                      :editor/editing? {edit-input-id true}
+                      :editor/last-key-code nil
+                      :cursor-range cursor-range))))
+        (when-let [input (gdom/getElement edit-input-id)]
+          (let [pos (count cursor-range)]
+            (when content
+              (util/set-change-value input content))
+
+            (when move-cursor?
+              (cursor/move-cursor-to input pos))
+
+            (when (or (util/mobile?) (mobile-util/native-platform?))
+              (set-state! :mobile/show-action-bar? false)))))))))
 
 (defn remove-watch-state [key]
   (remove-watch state key))

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1347,4 +1347,4 @@
 #?(:cljs
    (defn base64-image-included?
      [content]
-     (string/includes? content "data:image/png;base64,")))
+     (safe-re-find #"data:image/[^;]+;base64" content)))

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1343,3 +1343,8 @@
                Math/floor
                int
                (#(str % " " (:name unit) (when (> % 1) "s") " ago"))))))))
+
+#?(:cljs
+   (defn base64-image-included?
+     [content]
+     (string/includes? content "data:image/png;base64,")))

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1343,8 +1343,3 @@
                Math/floor
                int
                (#(str % " " (:name unit) (when (> % 1) "s") " ago"))))))))
-
-#?(:cljs
-   (defn base64-image-included?
-     [content]
-     (safe-re-find #"data:image/[^;]+;base64" content)))

--- a/templates/config.edn
+++ b/templates/config.edn
@@ -119,6 +119,10 @@
  ;; Set this to `true` so that it's the same behaviour as the usual outliner mode.
  :shortcut/doc-mode-enter-for-new-block? false
 
+ ;; Block content larger than `search/text-max-length` will not be searchable
+ ;; or editable for performance.
+ :block/content-max-length 5000
+
  ;; Whether to show command doc on hover
  :ui/show-command-doc? true
 


### PR DESCRIPTION
This PR fixed the issue that searching and editing could be frozen because the block's content is too large.

It adds a new option `:block/content-max-length` which defaults to 5000 chars. Blocks larger than this max length will not be searchable or editable.

<img width="816" alt="CleanShot 2022-08-29 at 07 17 33@2x" src="https://user-images.githubusercontent.com/479169/187098701-78024b1a-56f0-482c-8ece-abae07dc464a.png">
