### PR TITLE
fix(editor): handle delete image with no actual file

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -234,7 +234,7 @@
                                                   (editor-handler/delete-asset-of-block!
                                                    {:block-id    block-id
                                                     :local?      local?
-                                                    :delete-local? (first sub-selected)
+                                                    :delete-local? (and sub-selected (first sub-selected))
                                                     :repo        (state/get-current-repo)
                                                     :href        src
                                                     :title       title


### PR DESCRIPTION
When a image link is a data-url. The delete button icon fails with `false is not ISeq` error.

<img width="238" alt="image" src="https://user-images.githubusercontent.com/72891/186715519-bb9421cb-f83b-434b-b95b-28842ccaac73.png">
<img width="672" alt="image" src="https://user-images.githubusercontent.com/72891/186715703-fd1e6d4d-aaf0-4b4e-a220-747c3c4d418e.png">
