### PR TITLE
fix: invalid property fixes

### DIFF
--- a/deps/db/package.json
+++ b/deps/db/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "devDependencies": {
-    "@logseq/nbb-logseq": "^0.6.125"
+    "@logseq/nbb-logseq": "^0.7.133"
   }
 }

--- a/deps/db/yarn.lock
+++ b/deps/db/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@logseq/nbb-logseq@^0.6.125":
-  version "0.6.125"
-  resolved "https://registry.yarnpkg.com/@logseq/nbb-logseq/-/nbb-logseq-0.6.125.tgz#197dbb01040f9cfdf7040399b9fbed9b862dee5b"
-  integrity sha512-1UB4Urt6O95Cwwni68B/f05x+wsL+ju+dCGLE47WTvF9F8WQwhiADfWhMbFOt35ImswLSzM1rgVGIMIj0g6fkQ==
+"@logseq/nbb-logseq@^0.7.133":
+  version "0.7.133"
+  resolved "https://registry.yarnpkg.com/@logseq/nbb-logseq/-/nbb-logseq-0.7.133.tgz#793492c6f0bc3089f394795052ca0b8503018161"
+  integrity sha512-eraxs2j1HT4RjxYCB51Rlb3KBx5oihIKoFueB1QHZYnMOwPMLIn6iMzHvyGyEGweqp422PcdDXfK3Nl4iTw/wA==
   dependencies:
     import-meta-resolve "^1.1.1"
 

--- a/deps/graph-parser/package.json
+++ b/deps/graph-parser/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "devDependencies": {
-    "@logseq/nbb-logseq": "^0.6.125"
+    "@logseq/nbb-logseq": "^0.7.133"
   },
   "dependencies": {
     "mldoc": "^1.3.9"

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -211,7 +211,7 @@
                                              (string/replace " " "-")
                                              (string/replace "_" "-")
                                              (string/replace #"[\"|^|(|)|{|}]+" ""))]
-                                   (if (gp-util/valid-edn-keyword? (str ":" k))
+                                   (if (gp-property/valid-property-name? (str ":" k))
                                      (let [k (if (contains? #{"custom_id" "custom-id"} k)
                                                "id"
                                                k)

--- a/deps/graph-parser/src/logseq/graph_parser/extract.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/extract.cljc
@@ -42,12 +42,12 @@
 (defn- build-page-entity
   [properties file page-name page ref-tags {:keys [date-formatter db]}]
   (let [alias (:alias properties)
-        alias (if (string? alias) [alias] alias)
-        aliases (and alias
+        alias' (if (string? alias) [alias] alias)
+        aliases (and alias'
                      (seq (remove #(or (= page-name (gp-util/page-name-sanity-lc %))
                                        (string/blank? %)) ;; disable blank alias
-                                  alias)))
-        aliases (->>
+                                  alias')))
+        aliases' (->>
                  (map
                   (fn [alias]
                     (let [page-name (gp-util/page-name-sanity-lc alias)
@@ -65,17 +65,26 @@
                          :block/alias aliases}
                         {:block/name page-name})))
                   aliases)
-                 (remove nil?))]
+                 (remove nil?))
+        [*valid-properties *invalid-properties]
+        ((juxt filter remove)
+         (fn [[k _v]] (gp-property/valid-property-name? (str k))) properties)
+        valid-properties (into {} *valid-properties)
+        invalid-properties (set (map (comp name first) *invalid-properties))]
     (cond->
      (gp-util/remove-nils
       (assoc
        (gp-block/page-name->map page false db true date-formatter)
        :block/file {:file/path (gp-util/path-normalize file)}))
-     (seq properties)
-     (assoc :block/properties properties)
 
-     (seq aliases)
-     (assoc :block/alias aliases)
+     (seq valid-properties)
+     (assoc :block/properties valid-properties)
+
+     (seq invalid-properties)
+     (assoc :block/invalid-properties invalid-properties)
+
+     (seq aliases')
+     (assoc :block/alias aliases')
 
      (:tags properties)
      (assoc :block/tags (let [tags (:tags properties)

--- a/deps/graph-parser/src/logseq/graph_parser/property.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/property.cljs
@@ -21,6 +21,8 @@
   (second (re-find (re-pattern (str property colons "\\s+(.*)"))
                    content)))
 
+(def valid-property-name? gp-util/valid-edn-keyword?)
+
 (defn properties-ast?
   [block]
   (and

--- a/deps/graph-parser/src/logseq/graph_parser/util.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/util.cljs
@@ -150,11 +150,10 @@
     (normalize-format (keyword (string/lower-case (last (string/split file #"\.")))))))
 
 (defn valid-edn-keyword?
-  [k]
+  "Determine if string is a valid edn keyword"
+  [s]
   (try
-    (let [s (str k)]
-      (and (= \: (first s))
-           (edn/read-string (str "{" s " nil}"))))
-    true
+    (boolean (and (= \: (first s))
+                  (edn/read-string (str "{" s " nil}"))))
     (catch :default _
       false)))

--- a/deps/graph-parser/test/logseq/graph_parser/nbb_test_runner.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/nbb_test_runner.cljs
@@ -8,6 +8,7 @@
             [logseq.graph-parser.extract-test]
             [logseq.graph-parser.cli-test]
             [logseq.graph-parser.util.page-ref-test]
+            [logseq.graph-parser.util-test]
             [logseq.graph-parser-test]))
 
 (defmethod cljs.test/report [:cljs.test/default :end-run-tests] [m]
@@ -16,11 +17,13 @@
 
 ;; run this function with: nbb-logseq -m logseq.test.nbb-test-runner/run-tests
 (defn run-tests []
-  (t/run-tests 'logseq.graph-parser.mldoc-test
-               'logseq.graph-parser.text-test
-               'logseq.graph-parser.property-test
-               'logseq.graph-parser.block-test
-               'logseq.graph-parser.extract-test
-               'logseq.graph-parser.cli-test
-               'logseq.graph-parser.util.page-ref-test
-               'logseq.graph-parser-test))
+  (t/run-tests
+   'logseq.graph-parser.mldoc-test
+   'logseq.graph-parser.text-test
+   'logseq.graph-parser.property-test
+   'logseq.graph-parser.block-test
+   'logseq.graph-parser.extract-test
+   'logseq.graph-parser.cli-test
+   'logseq.graph-parser.util.page-ref-test
+   'logseq.graph-parser-test
+   'logseq.graph-parser.util-test))

--- a/deps/graph-parser/test/logseq/graph_parser/util_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/util_test.cljs
@@ -1,0 +1,14 @@
+(ns logseq.graph-parser.util-test
+  (:require [clojure.test :refer [deftest are]]
+            [logseq.graph-parser.util :as gp-util]))
+
+(deftest valid-edn-keyword?
+  (are [x y]
+       (= (gp-util/valid-edn-keyword? x) y)
+
+       ":foo-bar"  true
+       ":foo!"     true
+       ":foo,bar"  false
+       "4"         false
+       "foo bar"   false
+       "`property" false))

--- a/deps/graph-parser/test/logseq/graph_parser_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser_test.cljs
@@ -210,15 +210,30 @@
   (let [conn (ldb/start-conn)
         properties {"foo" "valid"
                     "[[foo]]" "invalid"
-                    "some,prop" "invalid"}]
-    (graph-parser/parse-file conn "foo.md" (gp-property/->block-content properties) {})
+                    "some,prop" "invalid"}
+        body (str (gp-property/->block-content properties)
+                  "\n- " (gp-property/->block-content properties))]
+    (graph-parser/parse-file conn "foo.md" body {})
 
     (is (= [{:block/properties {:foo "valid"}
              :block/invalid-properties #{"[[foo]]" "some,prop"}}]
            (->> (d/q '[:find (pull ?b [*])
                        :in $
-                       :where [?b :block/properties] [(missing? $ ?b :block/name)]]
+                       :where
+                       [?b :block/properties]
+                       [(missing? $ ?b :block/pre-block?)]
+                       [(missing? $ ?b :block/name)]]
                      @conn)
                 (map first)
                 (map #(select-keys % [:block/properties :block/invalid-properties]))))
-        "Has correct (in)valid block properties")))
+        "Has correct (in)valid block properties")
+
+    (is (= [{:block/properties {:foo "valid"}
+             :block/invalid-properties #{"[[foo]]" "some,prop"}}]
+           (->> (d/q '[:find (pull ?b [*])
+                       :in $
+                       :where [?b :block/properties] [?b :block/name]]
+                     @conn)
+                (map first)
+                (map #(select-keys % [:block/properties :block/invalid-properties]))))
+        "Has correct (in)valid page properties")))

--- a/deps/graph-parser/yarn.lock
+++ b/deps/graph-parser/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@logseq/nbb-logseq@^0.6.125":
-  version "0.6.125"
-  resolved "https://registry.yarnpkg.com/@logseq/nbb-logseq/-/nbb-logseq-0.6.125.tgz#197dbb01040f9cfdf7040399b9fbed9b862dee5b"
-  integrity sha512-1UB4Urt6O95Cwwni68B/f05x+wsL+ju+dCGLE47WTvF9F8WQwhiADfWhMbFOt35ImswLSzM1rgVGIMIj0g6fkQ==
+"@logseq/nbb-logseq@^0.7.133":
+  version "0.7.133"
+  resolved "https://registry.yarnpkg.com/@logseq/nbb-logseq/-/nbb-logseq-0.7.133.tgz#793492c6f0bc3089f394795052ca0b8503018161"
+  integrity sha512-eraxs2j1HT4RjxYCB51Rlb3KBx5oihIKoFueB1QHZYnMOwPMLIn6iMzHvyGyEGweqp422PcdDXfK3Nl4iTw/wA==
   dependencies:
     import-meta-resolve "^1.1.1"
 

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -457,7 +457,7 @@
                (str " page-property-key block-property"))
       :data-ref page-name
       :on-mouse-down (fn [e] (open-page-ref e page-name redirect-page-name page-name-in-block contents-page?))
-      :on-key-up (fn [e] ((when (= (.-key e) "Enter") 
+      :on-key-up (fn [e] ((when (= (.-key e) "Enter")
                            (open-page-ref e page-name redirect-page-name page-name-in-block contents-page?))))}
 
      (if (and (coll? children) (seq children))
@@ -1908,10 +1908,10 @@
   (when (seq invalid-properties)
     [:div.invalid-properties.mb-2
      [:div.warning {:title "Invalid properties"}
-      "Invalid property keys: "
+      "Invalid property names: "
       (for [p invalid-properties]
         [:button.p-1.mr-2 p])]
-     [:code "Property key begins with a non-numeric character and can contain alphanumeric characters and . * + ! - _ ? $ % & = < >. If -, + or . are the first character, the second character (if any) must be non-numeric."]]))
+     [:code "Property name begins with a non-numeric character and can contain alphanumeric characters and . * + ! - _ ? $ % & = < >. If -, + or . are the first character, the second character (if any) must be non-numeric."]]))
 
 (rum/defcs timestamp-cp < rum/reactive
   (rum/local false ::show?)

--- a/src/main/frontend/handler/export.cljs
+++ b/src/main/frontend/handler/export.cljs
@@ -25,6 +25,7 @@
             [logseq.graph-parser.util :as gp-util]
             [logseq.graph-parser.util.block-ref :as block-ref]
             [logseq.graph-parser.util.page-ref :as page-ref]
+            [logseq.graph-parser.property :as gp-property]
             [promesa.core :as p]
             [frontend.handler.notification :as notification])
   (:import
@@ -450,7 +451,7 @@
           (fn [properties]
             (when (seq properties)
               (->> (filter (fn [[k _v]]
-                             (gp-util/valid-edn-keyword? k)) properties)
+                             (gp-property/valid-property-name? (str k))) properties)
                    (into {}))))))
 
 (defn- blocks [db]


### PR DESCRIPTION
This is a follow up to #6477 that fixes and tweaks the following:
- Invalid properties were identified as valid properties e.g. "foo bar" or "4"
- Page properties were saving :invalid-properties as valid :properties. This would've effected queries since page properties are normally queried by page blocks
- Renamed "Property key" to "property name" since users don't know what keys are. Confirmed that our docs don't refer to keys anywhere

Also bumped to latest nbb-logseq