### PR TITLE
Improve backtick autopairing

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2720,9 +2720,15 @@
         (do (util/stop e)
             (autopair input-id "(" format nil))
 
+        ;; If you type `xyz`, the last backtick should close the first and not add another autopair
+        ;; If you type several backticks in a row, each one should autopair to accommodate multiline code (```)        
         (contains? (set (keys autopair-map)) key)
-        (do (util/stop e)
-            (autopair input-id key format nil))
+        (do (let [curr (get-current-input-char input)
+                  prev (util/nth-safe value (dec pos))]
+            (util/stop e) 
+            (if (and (= key "`") (= "`" curr) (not= "`" prev))
+              (cursor/move-cursor-forward input)
+              (autopair input-id key format nil))))
 
         (and hashtag? (or (zero? pos) (re-matches #"\s" (get value (dec pos)))))
         (do

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2723,12 +2723,12 @@
         ;; If you type `xyz`, the last backtick should close the first and not add another autopair
         ;; If you type several backticks in a row, each one should autopair to accommodate multiline code (```)        
         (contains? (set (keys autopair-map)) key)
-        (do (let [curr (get-current-input-char input)
+        (let [curr (get-current-input-char input)
                   prev (util/nth-safe value (dec pos))]
             (util/stop e) 
             (if (and (= key "`") (= "`" curr) (not= "`" prev))
               (cursor/move-cursor-forward input)
-              (autopair input-id key format nil))))
+              (autopair input-id key format nil)))
 
         (and hashtag? (or (zero? pos) (re-matches #"\s" (get value (dec pos)))))
         (do

--- a/src/main/frontend/util/text.cljs
+++ b/src/main/frontend/util/text.cljs
@@ -66,7 +66,7 @@
       result)))
 
 (defn surround-by?
-  "`pos` must be surrounded by `before` and `and` in string `value`, e.g. ((|))"
+  "`pos` must be surrounded by `before` and `end` in string `value`, e.g. ((|))"
   [value pos before end]
   (let [start-pos (if (= :start before) 0 (- pos (count before)))
         end-pos (if (= :end end) (count value) (+ pos (count end)))]
@@ -97,7 +97,7 @@
        acc))))
 
 (defn wrapped-by?
-  "`pos` must be wrapped by `before` and `and` in string `value`, e.g. ((a|b))"
+  "`pos` must be wrapped by `before` and `end` in string `value`, e.g. ((a|b))"
   [value pos before end]
   ;; Increment 'before' matches by (length of before string - 0.5) to make them be just before the cursor position they precede.
   ;; Increment 'after' matches by 0.5 to make them be just after the cursor position they follow.


### PR DESCRIPTION
## Before
Currently, if you type a backtick and then some text and then another backtick, the last backtick is autopaired and more backticks spawn. It looks like this:
<img src="https://user-images.githubusercontent.com/13837978/187013039-d519bc3a-daa3-4eb0-a05f-fafab478f7b8.gif" width=30% height=30%>

That's annoying because to close the backtick, you can't type a backtick. You need to use the mouse or the arrow keys or jump to the end of the line with a shortcut.

## After
With these code changes, it looks like this:
<img src="https://user-images.githubusercontent.com/13837978/187013102-ceec3252-44b4-4e30-bae4-bc49e1fd6914.gif" width=30% height=30%>

## Caveat
But we also need to keep in mind that 3 backticks in a row have a special meaning so autopairing makes sense if you're typing several backticks in a row. So that behavior is unchanged and looks like this:
<img src="https://user-images.githubusercontent.com/13837978/187013232-7e6e8472-0f6e-4747-bc47-e31a3ba93d67.gif" width=30% height=30%>

#4380 #4516 