### PR TITLE
chore(deps): update electron 19.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
         "codemirror": "5.58.1",
         "d3-force": "3.0.0",
         "diff": "5.0.0",
-        "electron": "19.0.10",
+        "electron": "19.0.12",
         "electron-dl": "3.3.0",
         "fs": "0.0.1-security",
         "fs-extra": "9.1.0",

--- a/resources/package.json
+++ b/resources/package.json
@@ -12,7 +12,7 @@
     "electron:make": "electron-forge make",
     "electron:make-macos-arm64": "electron-forge make --platform=darwin --arch=arm64",
     "electron:publish:github": "electron-forge publish",
-    "rebuild:better-sqlite3": "electron-rebuild -v 19.0.10 -f -w better-sqlite3",
+    "rebuild:better-sqlite3": "electron-rebuild -v 19.0.12 -f -w better-sqlite3",
     "postinstall": "install-app-deps"
   },
   "config": {
@@ -47,13 +47,13 @@
     "@electron-forge/maker-rpm": "^6.0.0-beta.57",
     "@electron-forge/maker-squirrel": "^6.0.0-beta.57",
     "@electron-forge/maker-zip": "^6.0.0-beta.57",
-    "electron": "19.0.10",
+    "electron": "19.0.12",
     "electron-builder": "^22.11.7",
     "electron-forge-maker-appimage": "trusktr/electron-forge-maker-appimage#patch-1",
     "electron-rebuild": "3.2.5"
   },
   "resolutions": {
-    "**/electron": "19.0.10",
+    "**/electron": "19.0.12",
     "**/node-gyp": "9.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2554,10 +2554,10 @@ electron-to-chromium@^1.4.84:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.87.tgz#1aeacfa50b2fbf3ecf50a78fbebd8f259d4fe208"
   integrity sha512-EXXTtDHFUKdFVkCnhauU7Xp8wmFC1ZG6GK9a1BeI2vvNhy61IwfNPo/CRexhf7mh4ajxAHJPind62BzpzVUeuQ==
 
-electron@19.0.10:
-  version "19.0.10"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-19.0.10.tgz#4d2f03f307fbb70a295ff419112130b75661eda9"
-  integrity sha512-EiWtPWdD7CzkRkp1cw7t0N9W2qhI5XZOudHX7daOh5wI076nsdV2dtlAf/XyTHhPNoKR5qhTWrSnYL9PY6D1vg==
+electron@19.0.12:
+  version "19.0.12"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-19.0.12.tgz#73d11cc2a3e4dbcd61fdc1c39561e7a7911046e9"
+  integrity sha512-GOvG0t2NCeJYIfmC3g/dnEAQ71k3nQDbRVqQhpi2YbsYMury0asGJwqnVAv2uZQEwCwSx4XOwOQARTFEG/msWw==
   dependencies:
     "@electron/get" "^1.14.1"
     "@types/node" "^16.11.26"


### PR DESCRIPTION
This electron minor version release fixed a bug in wayland rendering for Linux desktops.

Fixes #5010 