### PR TITLE
Shift click on “Journals” opens latest in the right sidebar

### DIFF
--- a/src/main/frontend/components/sidebar.cljs
+++ b/src/main/frontend/components/sidebar.cljs
@@ -245,7 +245,10 @@
             :active           (and (not srs-open?)
                                    (or (= route-name :all-journals) (= route-name :home)))
             :title            (t :left-side-bar/journals)
-            :on-click-handler route-handler/go-to-journals!
+            :on-click-handler (fn [e]
+                                (if (gobj/get e "shiftKey")
+                                  (route-handler/sidebar-journals!)
+                                  (route-handler/go-to-journals!)))
             :icon             "calendar"})))
 
         (when (state/enable-flashcards? (state/get-current-repo))

--- a/src/main/frontend/handler/route.cljs
+++ b/src/main/frontend/handler/route.cljs
@@ -9,6 +9,7 @@
             [frontend.state :as state]
             [logseq.graph-parser.text :as text]
             [frontend.util :as util]
+            [goog.object :as gobj]
             [reitit.frontend.easy :as rfe]))
 
 (defn redirect!
@@ -137,13 +138,20 @@
   (state/pub-event! [:go/search]))
 
 (defn go-to-journals!
-  []
-  (state/set-journals-length! 3)
-  (let [route (if (state/custom-home-page?)
-                :all-journals
-                :home)]
-    (redirect! {:to route}))
-  (util/scroll-to-top))
+  [e]
+  (if (gobj/get e "shiftKey")           ;TODO pretty sure this test should be sidebar.cljs
+    (do
+      (state/sidebar-add-block!
+       (state/get-current-repo)
+       (:db/id (db/get-page (date/today)))
+       :page))
+    (do
+      (state/set-journals-length! 3)
+      (let [route (if (state/custom-home-page?)
+                    :all-journals
+                    :home)]
+        (redirect! {:to route}))
+      (util/scroll-to-top))))
 
 (defn- redirect-to-file!
   [page]

--- a/src/main/frontend/handler/route.cljs
+++ b/src/main/frontend/handler/route.cljs
@@ -9,7 +9,6 @@
             [frontend.state :as state]
             [logseq.graph-parser.text :as text]
             [frontend.util :as util]
-            [goog.object :as gobj]
             [reitit.frontend.easy :as rfe]))
 
 (defn redirect!
@@ -137,21 +136,21 @@
     (state/set-search-mode! search-mode))
   (state/pub-event! [:go/search]))
 
+(defn sidebar-journals!
+  []
+  (state/sidebar-add-block!
+   (state/get-current-repo)
+   (:db/id (db/get-page (date/today)))
+   :page))
+
 (defn go-to-journals!
-  [e]
-  (if (gobj/get e "shiftKey")           ;TODO pretty sure this test should be sidebar.cljs
-    (do
-      (state/sidebar-add-block!
-       (state/get-current-repo)
-       (:db/id (db/get-page (date/today)))
-       :page))
-    (do
-      (state/set-journals-length! 3)
-      (let [route (if (state/custom-home-page?)
-                    :all-journals
-                    :home)]
-        (redirect! {:to route}))
-      (util/scroll-to-top))))
+  []
+  (state/set-journals-length! 3)
+  (let [route (if (state/custom-home-page?)
+                :all-journals
+                :home)]
+    (redirect! {:to route}))
+  (util/scroll-to-top))
 
 (defn- redirect-to-file!
   [page]


### PR DESCRIPTION
I requested this about a year ago: https://discuss.logseq.com/t/shift-click-on-journals-should-open-latest-in-the-sidebar/3631 . Seems like a pretty straightforward new minor feature, but very useful.

This is my first logseq PR so be gentle please.