### PR TITLE
feat: select element on context menu

### DIFF
--- a/tldraw/packages/core/src/lib/tools/TLSelectTool/states/ContextMenuState.ts
+++ b/tldraw/packages/core/src/lib/tools/TLSelectTool/states/ContextMenuState.ts
@@ -3,7 +3,8 @@ import type { TLShape } from '../../../shapes'
 import type { TLApp } from '../../../TLApp'
 import { TLToolState } from '../../../TLToolState'
 import type { TLSelectTool } from '../TLSelectTool'
-import type { TLEvents, TLSelectionHandle, TLEventMap, TLEventSelectionInfo } from '../../../../types'
+import type { TLEvents, TLEventMap, TLEventInfo } from '../../../../types'
+import { TLTargetType } from '../../../../types'
 
 export class ContextMenuState<
   S extends TLShape,
@@ -13,10 +14,21 @@ export class ContextMenuState<
 > extends TLToolState<S, K, R, P> {
   static id = 'contextMenu'
 
-  handle?: TLSelectionHandle
+  onEnter = (info: TLEventInfo<S>) => {
+    const {
+      selectedIds,
+      selectedShapes,
+      inputs: { shiftKey },
+    } = this.app
 
-  onEnter = (info: TLEventSelectionInfo) => {
-    this.handle = info.handle
+    if (info.type === TLTargetType.Shape && !selectedShapes.has(info.shape)) {
+      if (shiftKey) {
+        this.app.setSelectedShapes([...Array.from(selectedIds.values()), info.shape.id])
+        return
+      }
+
+      this.app.setSelectedShapes([info.shape])
+    }
   }
 
   onPointerDown: TLEvents<S>['pointer'] = () => {

--- a/tldraw/packages/core/src/lib/tools/TLSelectTool/states/IdleState.ts
+++ b/tldraw/packages/core/src/lib/tools/TLSelectTool/states/IdleState.ts
@@ -47,7 +47,7 @@ export class IdleState<
     } = this.app
 
     if (event.button === 2) {
-      this.tool.transition('contextMenu')
+      this.tool.transition('contextMenu', info)
       return
     }
 
@@ -56,6 +56,7 @@ export class IdleState<
       this.tool.transition('pointingCanvas')
       return
     }
+
 
     switch (info.type) {
       case TLTargetType.Selection: {


### PR DESCRIPTION
When we right click on an element to trigger the context menu, we should also select the hovered element.
Holding `Shift` when we right click, enables multi-selection as a bonus.