### PR TITLE
Enhance: Whiteboards

### DIFF
--- a/tldraw/apps/tldraw-logseq/build.mjs
+++ b/tldraw/apps/tldraw-logseq/build.mjs
@@ -2,6 +2,7 @@
 /* eslint-disable no-undef */
 import 'zx/globals'
 import fs from 'fs'
+import path from 'path'
 
 // Build with [tsup](https://tsup.egoist.sh)
 await $`tsup`
@@ -16,4 +17,7 @@ Object.assign(glob, {
 
 fs.writeFileSync('dist/package.json', JSON.stringify(glob, null, 2))
 
-await $`ln -f ${__dirname}/dist/index.js ${__dirname}/../../../src/js/tldraw-logseq.js`
+const dest = path.join(__dirname, '/../../../src/js/tldraw-logseq.js')
+
+fs.unlinkSync(dest)
+fs.linkSync(path.join(__dirname, '/dist/index.js'), dest)

--- a/tldraw/apps/tldraw-logseq/src/components/ContextBar/ContextBar.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextBar/ContextBar.tsx
@@ -43,7 +43,10 @@ const _ContextBar: TLContextBarComponent<Shape> = ({ shapes, offsets, hidden }) 
         <div
           ref={rContextBar}
           className="tl-contextbar"
-          style={{ pointerEvents: hidden ? 'none' : 'all' }}
+          style={{
+            visibility: hidden ? 'hidden' : 'visible',
+            pointerEvents: hidden ? 'none' : 'all'
+          }}
         >
           {Actions.map((Action, idx) => (
             <React.Fragment key={idx}>

--- a/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
@@ -40,6 +40,17 @@ export const ContextMenu = observer(function ContextMenu({
             <>
               <ReactContextMenu.Item
                 className="tl-context-menu-button"
+                onClick={() => runAndTransition(app.cut)}
+              >
+                Cut
+                <div className="tl-context-menu-right-slot">
+                  <span className="keyboard-shortcut">
+                    <code>{MOD_KEY}</code> <code>X</code>
+                  </span>
+                </div>
+              </ReactContextMenu.Item>
+              <ReactContextMenu.Item
+                className="tl-context-menu-button"
                 onClick={() => runAndTransition(app.copy)}
               >
                 Copy

--- a/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
@@ -19,17 +19,18 @@ export const ContextMenu = observer(function ContextMenu({
   const app = useApp()
   const rContent = React.useRef<HTMLDivElement>(null)
 
+  const runAndTransition = (f: Function) => {
+    f()
+    app.transition('select')
+  }
+
   return (
-    <ReactContextMenu.Root
-      onOpenChange={state => {
-        if (!state) app.transition('select')
-      }}
-    >
+    <ReactContextMenu.Root>
       <ReactContextMenu.Trigger>{children}</ReactContextMenu.Trigger>
       <ReactContextMenu.Content
         className="tl-context-menu"
         ref={rContent}
-        onEscapeKeyDown={preventDefault}
+        onEscapeKeyDown={()=> app.transition('select')}
         collisionBoundary={collisionRef.current}
         asChild
         tabIndex={-1}
@@ -37,7 +38,7 @@ export const ContextMenu = observer(function ContextMenu({
         <div>
           {app.selectedShapes?.size > 0 && (
             <>
-              <ReactContextMenu.Item className="tl-context-menu-button" onClick={() => app.copy()}>
+              <ReactContextMenu.Item className="tl-context-menu-button" onClick={() => runAndTransition(app.copy)}>
                 Copy
                 <div className="tl-context-menu-right-slot">
                   <span className="keyboard-shortcut">
@@ -47,7 +48,7 @@ export const ContextMenu = observer(function ContextMenu({
               </ReactContextMenu.Item>
             </>
           )}
-          <ReactContextMenu.Item className="tl-context-menu-button" onClick={() => app.paste()}>
+          <ReactContextMenu.Item className="tl-context-menu-button" onClick={() => runAndTransition(app.paste)}>
             Paste
             <div className="tl-context-menu-right-slot">
               <span className="keyboard-shortcut">
@@ -58,7 +59,7 @@ export const ContextMenu = observer(function ContextMenu({
           <ReactContextMenu.Separator className="menu-separator" />
           <ReactContextMenu.Item
             className="tl-context-menu-button"
-            onClick={() => app.api.selectAll()}
+            onClick={() => runAndTransition(app.api.selectAll)}
           >
             Select all
             <div className="tl-context-menu-right-slot">
@@ -70,7 +71,7 @@ export const ContextMenu = observer(function ContextMenu({
           {app.selectedShapes?.size > 1 && (
             <ReactContextMenu.Item
               className="tl-context-menu-button"
-              onClick={() => app.api.deselectAll()}
+              onClick={() => runAndTransition(app.api.deselectAll)}
             >
               Deselect all
             </ReactContextMenu.Item>
@@ -79,7 +80,7 @@ export const ContextMenu = observer(function ContextMenu({
             <>
               <ReactContextMenu.Item
                 className="tl-context-menu-button"
-                onClick={() => app.api.deleteShapes()}
+                onClick={() => runAndTransition(app.api.deleteShapes)}
               >
                 Delete
                 <div className="tl-context-menu-right-slot">
@@ -93,13 +94,13 @@ export const ContextMenu = observer(function ContextMenu({
                   <ReactContextMenu.Separator className="menu-separator" />
                   <ReactContextMenu.Item
                     className="tl-context-menu-button"
-                    onClick={() => app.flipHorizontal()}
+                    onClick={() => runAndTransition(app.flipHorizontal)}
                   >
                     Flip horizontally
                   </ReactContextMenu.Item>
                   <ReactContextMenu.Item
                     className="tl-context-menu-button"
-                    onClick={() => app.flipVertical()}
+                    onClick={() => runAndTransition(app.flipVertical)}
                   >
                     Flip vertically
                   </ReactContextMenu.Item>
@@ -108,7 +109,7 @@ export const ContextMenu = observer(function ContextMenu({
               <ReactContextMenu.Separator className="menu-separator" />
               <ReactContextMenu.Item
                 className="tl-context-menu-button"
-                onClick={() => app.bringToFront()}
+                onClick={() => runAndTransition(app.bringToFront)}
               >
                 Move to front
                 <div className="tl-context-menu-right-slot">
@@ -119,7 +120,7 @@ export const ContextMenu = observer(function ContextMenu({
               </ReactContextMenu.Item>
               <ReactContextMenu.Item
                 className="tl-context-menu-button"
-                onClick={() => app.sendToBack()}
+                onClick={() => runAndTransition(app.sendToBack)}
               >
                 Move to back
                 <div className="tl-context-menu-right-slot">

--- a/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
@@ -60,7 +60,7 @@ export const ContextMenu = observer(function ContextMenu({
             className="tl-context-menu-button"
             onClick={() => app.api.selectAll()}
           >
-            Select All
+            Select all
             <div className="tl-context-menu-right-slot">
               <span className="keyboard-shortcut">
                 <code>{MOD_KEY}</code> <code>A</code>
@@ -72,7 +72,7 @@ export const ContextMenu = observer(function ContextMenu({
               className="tl-context-menu-button"
               onClick={() => app.api.deselectAll()}
             >
-              Deselect All
+              Deselect all
             </ReactContextMenu.Item>
           )}
           {app.selectedShapes?.size > 0 && (
@@ -95,13 +95,13 @@ export const ContextMenu = observer(function ContextMenu({
                     className="tl-context-menu-button"
                     onClick={() => app.flipHorizontal()}
                   >
-                    Flip Horizontally
+                    Flip horizontally
                   </ReactContextMenu.Item>
                   <ReactContextMenu.Item
                     className="tl-context-menu-button"
                     onClick={() => app.flipVertical()}
                   >
-                    Flip Vertically
+                    Flip vertically
                   </ReactContextMenu.Item>
                 </>
               )}
@@ -110,7 +110,7 @@ export const ContextMenu = observer(function ContextMenu({
                 className="tl-context-menu-button"
                 onClick={() => app.bringToFront()}
               >
-                Move to Front
+                Move to front
                 <div className="tl-context-menu-right-slot">
                   <span className="keyboard-shortcut">
                     <code>⇧</code> <code>]</code>

--- a/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
@@ -30,7 +30,7 @@ export const ContextMenu = observer(function ContextMenu({
       <ReactContextMenu.Content
         className="tl-context-menu"
         ref={rContent}
-        onEscapeKeyDown={()=> app.transition('select')}
+        onEscapeKeyDown={() => app.transition('select')}
         collisionBoundary={collisionRef.current}
         asChild
         tabIndex={-1}
@@ -38,7 +38,10 @@ export const ContextMenu = observer(function ContextMenu({
         <div>
           {app.selectedShapes?.size > 0 && (
             <>
-              <ReactContextMenu.Item className="tl-context-menu-button" onClick={() => runAndTransition(app.copy)}>
+              <ReactContextMenu.Item
+                className="tl-context-menu-button"
+                onClick={() => runAndTransition(app.copy)}
+              >
                 Copy
                 <div className="tl-context-menu-right-slot">
                   <span className="keyboard-shortcut">
@@ -48,7 +51,10 @@ export const ContextMenu = observer(function ContextMenu({
               </ReactContextMenu.Item>
             </>
           )}
-          <ReactContextMenu.Item className="tl-context-menu-button" onClick={() => runAndTransition(app.paste)}>
+          <ReactContextMenu.Item
+            className="tl-context-menu-button"
+            onClick={() => runAndTransition(app.paste)}
+          >
             Paste
             <div className="tl-context-menu-right-slot">
               <span className="keyboard-shortcut">

--- a/tldraw/apps/tldraw-logseq/src/components/ZoomMenu/ZoomMenu.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ZoomMenu/ZoomMenu.tsx
@@ -24,14 +24,15 @@ export const ZoomMenu = observer(function ZoomMenu(): JSX.Element {
           onSelect={preventEvent}
           onClick={app.api.zoomToFit}
         >
-          Zoom to Fit <div className="tl-zoom-menu-right-slot"></div>
+          Zoom to fit
+          <div className="tl-zoom-menu-right-slot"></div>
         </DropdownMenuPrimitive.Item>
         <DropdownMenuPrimitive.Item
           className="menu-link tl-zoom-menu-dropdown-item"
           onSelect={preventEvent}
           onClick={app.api.zoomToSelection}
         >
-          Zoom to Selection{' '}
+          Zoom to selection
           <div className="tl-zoom-menu-right-slot">
             <span className="keyboard-shortcut">
               <code>{MOD_KEY}</code> <code>-</code>
@@ -43,7 +44,7 @@ export const ZoomMenu = observer(function ZoomMenu(): JSX.Element {
           onSelect={preventEvent}
           onClick={app.api.zoomIn}
         >
-          Zoom In{' '}
+          Zoom in
           <div className="tl-zoom-menu-right-slot">
             <span className="keyboard-shortcut">
               <code>{MOD_KEY}</code> <code>+</code>
@@ -55,7 +56,7 @@ export const ZoomMenu = observer(function ZoomMenu(): JSX.Element {
           onSelect={preventEvent}
           onClick={app.api.zoomOut}
         >
-          Zoom Out{' '}
+          Zoom out
           <div className="tl-zoom-menu-right-slot">
             <span className="keyboard-shortcut">
               <code>{MOD_KEY}</code> <code>-</code>
@@ -67,7 +68,7 @@ export const ZoomMenu = observer(function ZoomMenu(): JSX.Element {
           onSelect={preventEvent}
           onClick={app.api.resetZoom}
         >
-          Reset Zoom{' '}
+          Reset zoom
           <div className="tl-zoom-menu-right-slot">
             <span className="keyboard-shortcut">
               <code>⇧</code> <code>0</code>

--- a/tldraw/apps/tldraw-logseq/src/components/ZoomMenu/ZoomMenu.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ZoomMenu/ZoomMenu.tsx
@@ -25,7 +25,11 @@ export const ZoomMenu = observer(function ZoomMenu(): JSX.Element {
           onClick={app.api.zoomToFit}
         >
           Zoom to fit
-          <div className="tl-zoom-menu-right-slot"></div>
+          <div className="tl-zoom-menu-right-slot">
+            <span className="keyboard-shortcut">
+              <code>1</code>
+            </span>
+          </div>
         </DropdownMenuPrimitive.Item>
         <DropdownMenuPrimitive.Item
           className="menu-link tl-zoom-menu-dropdown-item"
@@ -35,7 +39,7 @@ export const ZoomMenu = observer(function ZoomMenu(): JSX.Element {
           Zoom to selection
           <div className="tl-zoom-menu-right-slot">
             <span className="keyboard-shortcut">
-              <code>{MOD_KEY}</code> <code>-</code>
+              <code>⇧</code> <code>1</code>
             </span>
           </div>
         </DropdownMenuPrimitive.Item>

--- a/tldraw/packages/core/src/lib/TLApp/TLApp.ts
+++ b/tldraw/packages/core/src/lib/TLApp/TLApp.ts
@@ -96,7 +96,11 @@ export class TLApp<
         fn: () => this.api.resetZoom(),
       },
       {
-        keys: 'mod+-',
+        keys: '1',
+        fn: () => this.api.zoomToFit(),
+      },
+      {
+        keys: 'shift+1',
         fn: () => this.api.zoomToSelection(),
       },
       {
@@ -110,6 +114,10 @@ export class TLApp<
       {
         keys: 'mod+z',
         fn: () => this.undo(),
+      },
+      {
+        keys: 'mod+x',
+        fn: () => this.cut(),
       },
       {
         keys: 'mod+shift+z',
@@ -435,6 +443,11 @@ export class TLApp<
         files: fileList ? Array.from(fileList) : undefined,
       })
     }
+  }
+
+  cut = () => {
+    this.copy()
+    this.api.deleteShapes()
   }
 
   dropFiles = (files: FileList, point?: number[]) => {

--- a/tldraw/packages/core/src/lib/TLApp/TLApp.ts
+++ b/tldraw/packages/core/src/lib/TLApp/TLApp.ts
@@ -819,7 +819,7 @@ export class TLApp<
   }
 
   readonly onWheel: TLEvents<S, K>['wheel'] = (info, e) => {
-    if (e.ctrlKey) {
+    if (e.ctrlKey || this.isIn('select.contextMenu')) {
       return
     }
 

--- a/tldraw/packages/core/src/lib/TLApp/TLApp.ts
+++ b/tldraw/packages/core/src/lib/TLApp/TLApp.ts
@@ -708,6 +708,7 @@ export class TLApp<
     return (
       !ctrlKey &&
       this.isInAny('select.idle', 'select.hoveringSelectionHandle') &&
+      !this.isIn('select.contextMenu') &&
       selectedShapesArray.length > 0 &&
       !selectedShapesArray.every(shape => shape.hideContextBar)
     )

--- a/tldraw/packages/react/src/components/ContextBarContainer/ContextBarContainer.tsx
+++ b/tldraw/packages/react/src/components/ContextBarContainer/ContextBarContainer.tsx
@@ -52,10 +52,6 @@ export const ContextBarContainer = observer(function ContextBarContainer<S exten
     height: screenBounds.height,
   }
 
-  const inView =
-    BoundsUtils.boundsContain(vpBounds, screenBounds) ||
-    BoundsUtils.boundsCollide(vpBounds, screenBounds)
-
   return (
     <div
       ref={rBounds}


### PR DESCRIPTION
- Replace `ls` with `fs.linkSync` to allow running the build script on windows
- Introduce cut command
- Fix zoom to fit and zoom to selection shortcuts (1->zoom to fit, Shift+1 -> zoom to selection)
- Update zoom menu labels (it looks like prettier added some empty string)
- Fix state management of context menu
- Hide context bar when the context menu is active (`useDebouncedValue` introduced [here](https://github.com/logseq/logseq/pull/5341/commits/a4979c495bb35097fe981d4934716502914779f6) delays the visibility switch)
- Fix context menu labels
- Block zooming and panning when the context menu is active