### PR TITLE
chore: bump version 0.8.4

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "com.logseq.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 37
-        versionName "0.8.3"
+        versionCode 38
+        versionName "0.8.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/resources/package.json
+++ b/resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Logseq",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "main": "electron.js",
   "author": "Logseq",
   "license": "AGPL-3.0",

--- a/src/main/frontend/version.cljs
+++ b/src/main/frontend/version.cljs
@@ -1,3 +1,3 @@
 (ns frontend.version)
 
-(defonce version "0.8.3")
+(defonce version "0.8.4")


### PR DESCRIPTION
This release is to fix android platforms.

iOS App version is still pending at 0.8.3.