### PR TITLE
fix: don't start sync if not logged in or it's not a remote graph

### DIFF
--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -237,8 +237,7 @@
 
        ["Upload an asset" [[:editor/click-hidden-file-input :id]] "Upload file types like image, pdf, docx, etc.)"]
 
-       (state/deprecated-logged?)
-       ["Upload an image" [[:editor/click-hidden-file-input :id]]]
+       ;; ["Upload an image" [[:editor/click-hidden-file-input :id]]]
        )]
 
     (markdown-headings)

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -2712,10 +2712,13 @@
     (go
       ;; stop previous sync
       (<! (<sync-stop))
-      (when-some [sm (sync-manager-singleton current-user-uuid graph-uuid
-                                             (config/get-repo-dir repo) repo
-                                             txid *sync-state)]
-        (when (and repo (not (config/demo-graph? repo)))
+      (when (and user-uuid graph-uuid txid
+                 (user/logged-in?)
+                 repo
+                 (not (config/demo-graph? repo)))
+        (when-some [sm (sync-manager-singleton current-user-uuid graph-uuid
+                                               (config/get-repo-dir repo) repo
+                                               txid *sync-state)]
           ;; 1. if remote graph has been deleted, clear graphs-txid.edn
           ;; 2. if graphs-txid.edn's content isn't [user-uuid graph-uuid txid], clear it
           (if (not= 3 (count @graphs-txid))

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -1544,8 +1544,7 @@
   [type {:keys [dir path _content stat] :as _payload}]
   (when-let [current-graph (state/get-current-repo)]
     (when (string/ends-with? current-graph dir)
-      (when-not (some-> (state/get-file-sync-state current-graph)
-                        sync-state--stopped?)
+      (when-not (sync-state--stopped? (state/get-file-sync-state current-graph))
         (when (or (:mtime stat) (= type "unlink"))
           (go
             (let [path (remove-dir-prefix dir path)
@@ -1976,8 +1975,9 @@
       add-history? (update :history add-history-items paths now))))
 
 (defn sync-state--stopped?
+  "Graph syncing is stopped or not enabled"
   [sync-state]
-  (= ::stop (:state sync-state)))
+  (or (nil? sync-state) (= ::stop (:state sync-state))))
 
 ;;; ### remote->local syncer & local->remote syncer
 

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1055,11 +1055,6 @@
   []
   (:me @state))
 
-(defn deprecated-logged?
-  "Whether the user has logged in."
-  []
-  false)
-
 (defn set-db-restoring!
   [value]
   (set-state! :db/restoring? value))


### PR DESCRIPTION
Previously, sync will be started when user is not logged in or the current graph is not a remote graph.