### PR TITLE
fix: Date sorting is nonsensical #6363 

### DIFF
--- a/src/main/frontend/components/query_table.cljs
+++ b/src/main/frontend/components/query_table.cljs
@@ -110,7 +110,7 @@
                   keys))
           desc? (desc? *desc? p-desc?)
           result (sort-result-by (fn [item]
-                                   (sort-by-fn sort-by-item item))
+                                   (block/normalize-block (sort-by-fn sort-by-item item)))
                                  desc?
                                  result)]
       [:div.overflow-x-auto {:on-mouse-down (fn [e] (.stopPropagation e))

--- a/src/main/frontend/date.cljs
+++ b/src/main/frontend/date.cljs
@@ -29,6 +29,7 @@
      "do MMMM yyyy"
      "MMM do, yyyy"
      "MMMM do, yyyy"
+     "MMMM do,yyyy"
      "E, dd-MM-yyyy"
      "E, dd.MM.yyyy"
      "E, MM/dd/yyyy"

--- a/src/main/frontend/date.cljs
+++ b/src/main/frontend/date.cljs
@@ -29,7 +29,6 @@
      "do MMMM yyyy"
      "MMM do, yyyy"
      "MMMM do, yyyy"
-     "MMMM do,yyyy"
      "E, dd-MM-yyyy"
      "E, dd.MM.yyyy"
      "E, MM/dd/yyyy"

--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -38,25 +38,26 @@ and handles unexpected failure."
    (page-name->map original-page-name with-id? true))
   ([original-page-name with-id? with-timestamp?]
    (gp-block/page-name->map original-page-name with-id? (db/get-db (state/get-current-repo)) with-timestamp? (state/get-date-formatter))))
-(defn- block-to-string 
-  "Convert block to string handling edge cases such as a,b,c being parsed as a set"
+
+(defn- block->string
+  "Convert block to string handling edge cases such as a, b, c being parsed as a set"
   ([block]
-   (if (set? block) (string/join "," block) (str block))))
+   (if (set? block) (string/join ", " block) (str block))))
 
 (defn- normalize-as-percentage
   ([block]
    (some->> block
-            block-to-string 
-            (re-matches #"(-?\d+\.?\d*)%") 
-            second 
+            block->string
+            (re-matches #"(-?\d+\.?\d*)%")
+            second
             (#(/ % 100)))))
 
 (defn- normalize-as-date
   ([block]
    (some->> block
-            block-to-string 
+            block->string
             date/valid?
-                        (tf/unparse date/custom-formatter))))
+            (tf/unparse date/custom-formatter))))
 
 (defn normalize-block
   "Normalizes supported formats such as dates and percentages."

--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -1,19 +1,18 @@
 (ns frontend.format.block
   "Block code needed by app but not graph-parser"
-  (:require
-   ["@sentry/react" :as Sentry]
-   [cljs-time.format :as tf]
-   [clojure.string :as string]
-   [frontend.config :as config]
-   [frontend.date :as date]
-   [frontend.db :as db]
-   [frontend.format :as format]
-   [frontend.handler.notification :as notification]
-   [frontend.state :as state]
-   [logseq.graph-parser.block :as gp-block]
-   [logseq.graph-parser.config :as gp-config]
-   [logseq.graph-parser.mldoc :as gp-mldoc]
-   [logseq.graph-parser.property :as gp-property]))
+  (:require ["@sentry/react" :as Sentry]
+            [cljs-time.format :as tf]
+            [clojure.string :as string]
+            [frontend.config :as config]
+            [frontend.date :as date]
+            [frontend.db :as db]
+            [frontend.format :as format]
+            [frontend.handler.notification :as notification]
+            [frontend.state :as state]
+            [logseq.graph-parser.block :as gp-block]
+            [logseq.graph-parser.config :as gp-config]
+            [logseq.graph-parser.mldoc :as gp-mldoc]
+            [logseq.graph-parser.property :as gp-property]))
 
 (defn extract-blocks
   "Wrapper around logseq.graph-parser.block/extract-blocks that adds in system state

--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -38,15 +38,10 @@ and handles unexpected failure."
   ([original-page-name with-id? with-timestamp?]
    (gp-block/page-name->map original-page-name with-id? (db/get-db (state/get-current-repo)) with-timestamp? (state/get-date-formatter))))
 
-(defn- block->string
-  "Convert block to string handling edge cases such as a, b, c being parsed as a set"
-  ([block]
-   (if (set? block) (string/join ", " block) (str block))))
-
 (defn- normalize-as-percentage
   ([block]
    (some->> block
-            block->string
+            str
             (re-matches #"(-?\d+\.?\d*)%")
             second
             (#(/ % 100)))))
@@ -54,7 +49,7 @@ and handles unexpected failure."
 (defn- normalize-as-date
   ([block]
    (some->> block
-            block->string
+            str
             date/valid?
             (tf/unparse date/custom-formatter))))
 

--- a/src/test/frontend/format/block_test.cljs
+++ b/src/test/frontend/format/block_test.cljs
@@ -1,5 +1,5 @@
 (ns frontend.format.block-test 
-  (:require [cljs.test :refer [deftest is testing are]]
+  (:require [cljs.test :refer [deftest testing are]]
             [frontend.format.block :as block]))
 
 (deftest test-normalize-date

--- a/src/test/frontend/format/block_test.cljs
+++ b/src/test/frontend/format/block_test.cljs
@@ -1,0 +1,43 @@
+(ns frontend.format.block-test 
+  (:require [cljs.test :refer [deftest is testing are]]
+            [frontend.format.block :as block]))
+
+(deftest test-normalize-date
+  (testing "normalize date values"
+    (are [x y] (= (block/normalize-block x) y)
+         "Aug 12th, 2022"
+         "2022-08-12T00:00:00Z"
+
+         "2022-08-12T00:00:00Z"
+         "2022-08-12T00:00:00Z")))
+
+(deftest test-normalize-percentage
+  (testing "normalize percentages"
+    (are [x y] (= (block/normalize-block x) y)
+         "50%"
+         0.5
+
+         "0%"
+         0
+
+         "-5%"
+         -0.05)))
+
+(deftest test-random-values
+  (testing "random values should not be processed"
+    
+    (are [x y] (= (block/normalize-block x) y)
+         "anreanre"
+         "anreanre"
+
+         ""
+         ""
+
+         "a.0%"
+         "a.0%"
+
+         "%"
+         "%"
+
+         "-%"
+         "-%")))

--- a/src/test/frontend/format/block_test.cljs
+++ b/src/test/frontend/format/block_test.cljs
@@ -25,7 +25,6 @@
 
 (deftest test-random-values
   (testing "random values should not be processed"
-    
     (are [x y] (= (block/normalize-block x) y)
          "anreanre"
          "anreanre"


### PR DESCRIPTION
Fixes #6363 
![grafik](https://user-images.githubusercontent.com/68823230/188328544-8d074184-d360-4273-aca1-38c69849287e.png)
![grafik](https://user-images.githubusercontent.com/68823230/188328754-3de109c2-78b9-4297-ba2e-a488260fdbb6.png)

The approach is to normalize the special formats such as 50% to 0.5 and then sort them with existing functionality. This allows interoperability ex. percentages with integers.
There are probably many more possible formats but I couldn't find a list of formats to support.

