### PR TITLE
Fix: Linkable built in properties should not display as rich properties

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1878,7 +1878,9 @@
         user-config (state/get-config)
         ;; In this mode and when value is a set of refs, display full property text
         ;; because :block/properties value only contains refs but user wants to see text
-        v (if (and (:rich-property-values? user-config) (coll? value))
+        v (if (and (:rich-property-values? user-config)
+                   (coll? value)
+                   (not (contains? gp-property/editable-linkable-built-in-properties k)))
             (gp-property/property-value-from-content (name k) (:block/content block))
             value)
         property-pages-enabled? (contains? #{true nil} (:property-pages/enabled? user-config))]


### PR DESCRIPTION
Quick display fix for #6589. Linkable built in properties, alias and tags, are meant to be backwards compatible with `:rich-property-values` as they are special properties that have lots of pre-existing usage. Having `tags` not be backwards compatible would also break org-mode tags property