### PR TITLE
WIP fix: match CJK page titles affixed by digits

### DIFF
--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -1243,7 +1243,7 @@
 (defn- pattern [name]
   (re-pattern (str "(?i)(^|[^\\[#0-9a-zA-Z]|((^|[^\\[])\\[))"
                    (util/regex-escape name)
-                   (if (contains-cjk? name) "\\d*" nil)
+                   (if (contains-cjk? (util/regex-escape name)) "\\d*" nil)
                    "($|[^0-9a-zA-Z])")))
 
 (defn get-page-unlinked-references

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -1242,7 +1242,6 @@
 
 (defn- pattern [name]
   (re-pattern (str "(?i)(^|[^\\[#0-9a-zA-Z]|((^|[^\\[])\\[))"
-                   "^"
                    (util/regex-escape name)
                    (if (contains-cjk? (util/regex-escape name)) "\\d*" nil)
                    "($|[^0-9a-zA-Z])")))

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -1235,9 +1235,16 @@
              (sort-by-left-recursive)
              db-utils/group-by-page)))))
 
+(defn- contains-cjk?
+ "Checks if text contains character in unicode range for CJK and returns a boolean"
+ [text]
+  (boolean (re-find (re-pattern "[\\u3040-\\u30ff\\u3400-\\u4dbf\\u4e00-\\u9fff\\uf900-\\ufaff\\uff66-\\uff9f]") text)))
+
 (defn- pattern [name]
   (re-pattern (str "(?i)(^|[^\\[#0-9a-zA-Z]|((^|[^\\[])\\[))"
+                   "^"
                    (util/regex-escape name)
+                   (if (contains-cjk? (util/regex-escape name)) "\\d*" nil)
                    "($|[^0-9a-zA-Z])")))
 
 (defn get-page-unlinked-references

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -1243,7 +1243,7 @@
 (defn- pattern [name]
   (re-pattern (str "(?i)(^|[^\\[#0-9a-zA-Z]|((^|[^\\[])\\[))"
                    (util/regex-escape name)
-                   (if (contains-cjk? (util/regex-escape name)) "\\d*" nil)
+                   (if (contains-cjk? name) "\\d*" nil)
                    "($|[^0-9a-zA-Z])")))
 
 (defn get-page-unlinked-references


### PR DESCRIPTION
Closes #5975 

Clojure uses `java.util.regex.Pattern`. 

Essentially we would like to have an if/else check if the name is CJK, and determine the pattern based on that.

A way of doing so is checking if a CJK char exists in the text via the regex range:
`[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uff66-\uff9f]`

- U+3040 - U+30FF: hiragana and katakana (Japanese only)
- U+3400 - U+4DBF: CJK unified ideographs extension A (Chinese, Japanese, and Korean)
- U+4E00 - U+9FFF: CJK unified ideographs (Chinese, Japanese, and Korean)
- U+F900 - U+FAFF: CJK compatibility ideographs (Chinese, Japanese, and Korean)
- U+FF66 - U+FF9F: half-width katakana (Japanese only)
- U+3131 - U+D79D: Korean (NOT INCLUDED)

NOTE: Needs native testing.