### PR TITLE
Fix mobile backup path

### DIFF
--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -359,7 +359,7 @@
                                 (p/resolved nil)
                                 (if (util/electron?)
                                   (ipc/ipc :readGraphTxIdInfo root)
-                                  (fs-util/read-graph-txid-info root)))
+                                  (fs-util/read-graphs-txid-info root)))
 
                               (p/then (fn [^js info]
                                         (when (and (not empty-dir?)

--- a/src/main/frontend/fs/capacitor_fs.cljs
+++ b/src/main/frontend/fs/capacitor_fs.cljs
@@ -2,6 +2,7 @@
   (:require ["@capacitor/filesystem" :refer [Encoding Filesystem]]
             [cljs-bean.core :as bean]
             [clojure.string :as string]
+            [goog.string :as gstring]
             [frontend.config :as config]
             [frontend.db :as db]
             [frontend.encrypt :as encrypt]
@@ -126,11 +127,11 @@
 (def backup-dir "logseq/bak")
 (defn- get-backup-dir
   [repo-dir path ext]
-  (let [path (if (string/starts-with? path "file://")
-               (subs path 7)
-               path)
-        relative-path (-> (string/replace path repo-dir "")
-                          (string/replace (str "." ext) ""))]
+  (let [relative-path (-> path
+                          (string/replace (re-pattern (str "^" (gstring/regExpEscape repo-dir)))
+                                          "")
+                          (string/replace (re-pattern (str "(?i)" (gstring/regExpEscape (str "." ext)) "$"))
+                                          ""))]
     (util/safe-path-join repo-dir (str backup-dir "/" relative-path))))
 
 (defn- truncate-old-versioned-files!

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -1423,7 +1423,7 @@
               r)))))))
 
 (defn apply-filetxns-partitions
-  "won't call update-graph-txid! when *txid is nil"
+  "won't call update-graphs-txid! when *txid is nil"
   [*sync-state user-uuid graph-uuid base-path filetxns-partitions repo *txid *stopped *paused]
   (assert (some? *sync-state))
 

--- a/src/main/frontend/handler/web/nfs.cljs
+++ b/src/main/frontend/handler/web/nfs.cljs
@@ -185,8 +185,8 @@
                                 (assoc file :file/content content))) markup-files))
                 (p/then (fn [result]
                           (p/let [files (map #(dissoc % :file/file) result)
-                                  graph-txid-meta (util-fs/read-graph-txid-info dir-name)
-                                  graph-uuid (and (vector? graph-txid-meta) (second graph-txid-meta))]
+                                  graphs-txid-meta (util-fs/read-graphs-txid-info dir-name)
+                                  graph-uuid (and (vector? graphs-txid-meta) (second graphs-txid-meta))]
                             (if-let [exists-graph (state/get-sync-graph-by-uuid graph-uuid)]
                               (state/pub-event!
                                [:notification/show

--- a/src/main/frontend/util/fs.cljs
+++ b/src/main/frontend/util/fs.cljs
@@ -17,44 +17,44 @@
   "Ignore path for ls-dir-files-with-handler! and reload-dir!"
   [dir path]
   (let [ignores ["." ".recycle" "node_modules" "logseq/bak"
-                    "logseq/version-files" "logseq/graphs-txid.edn"]]
+                 "logseq/version-files" "logseq/graphs-txid.edn"]]
     (when (string? path)
-     (or
-      (some #(string/starts-with? path (str dir "/" %)) ignores)
-      (some #(string/includes? path (str "/" % "/")) ignores)
-      (some #(string/ends-with? path %)
-            [".DS_Store" "logseq/graphs-txid.edn" "logseq/broken-config.edn"])
+      (or
+       (some #(string/starts-with? path (str dir "/" %)) ignores)
+       (some #(string/includes? path (str "/" % "/")) ignores)
+       (some #(string/ends-with? path %)
+             [".DS_Store" "logseq/graphs-txid.edn" "logseq/broken-config.edn"])
       ;; hidden directory or file
-      (let [relpath (path/relative dir path)]
-        (or (re-find #"/\.[^.]+" relpath)
-            (re-find #"^\.[^.]+" relpath)))
-      (let [path (string/lower-case path)]
-        (and
-         (not (string/blank? (path/extname path)))
-         (not
-          (some #(string/ends-with? path %)
-                [".md" ".markdown" ".org" ".js" ".edn" ".css"]))))))))
+       (let [relpath (path/relative dir path)]
+         (or (re-find #"/\.[^.]+" relpath)
+             (re-find #"^\.[^.]+" relpath)))
+       (let [path (string/lower-case path)]
+         (and
+          (not (string/blank? (path/extname path)))
+          (not
+           (some #(string/ends-with? path %)
+                 [".md" ".markdown" ".org" ".js" ".edn" ".css"]))))))))
 
-(defn read-graph-txid-info
+(defn read-graphs-txid-info
   [root]
   (when (string? root)
     (-> (p/let [txid-str (fs/read-file root "logseq/graphs-txid.edn")
                 txid-meta (and txid-str (reader/read-string txid-str))]
-               txid-meta)
+          txid-meta)
         (p/catch
-          (fn [^js e]
-            (js/console.error "[fs read txid data error]" e))))))
+         (fn [^js e]
+           (js/console.error "[fs read txid data error]" e))))))
 
 (defn inflate-graphs-info
   [graphs]
   (if (seq graphs)
     (p/all (for [{:keys [root] :as graph} graphs]
-             (p/let [sync-meta (read-graph-txid-info root)]
-                    (if sync-meta
-                      (assoc graph
-                             :sync-meta sync-meta
-                             :GraphUUID (second sync-meta))
-                      graph))))
+             (p/let [sync-meta (read-graphs-txid-info root)]
+               (if sync-meta
+                 (assoc graph
+                        :sync-meta sync-meta
+                        :GraphUUID (second sync-meta))
+                 graph))))
     []))
 
 (defn read-repo-file

--- a/src/main/frontend/util/persist_var.cljs
+++ b/src/main/frontend/util/persist_var.cljs
@@ -55,12 +55,13 @@
 
   ISave
   (-save [_]
-    (when-not (config/demo-graph?)
+    (if (config/demo-graph?)
+      (p/resolved nil)
       (let [path (load-path location)
             repo (state/get-current-repo)
             content (str (get-in @*value [repo :value]))
             dir (config/get-repo-dir repo)]
-        (fs/write-file! repo dir path content nil))))
+        (fs/write-file! repo dir path content {:skip-compare? true}))))
 
   IDeref
   (-deref [_this]


### PR DESCRIPTION
- more robust mobile backup path calculating
- rename graph-txid to graphs-txid, avoid misleading
- do not backup persist_var when save
