### PR TITLE
fix(search): cannot batch insert to search db

### DIFF
--- a/src/main/frontend/search.cljs
+++ b/src/main/frontend/search.cljs
@@ -96,7 +96,7 @@
       (when-not (string/blank? q)
         (protocol/query engine q option)))))
 
-(defn transact-blocks!
+(defn- transact-blocks!
   [repo data]
   (when-let [engine (get-engine repo)]
     (protocol/transact-blocks! engine data)))
@@ -237,7 +237,8 @@
                 blocks-to-add (->> (filter (fn [block]
                                              (contains? blocks-to-add-set (:db/id block)))
                                            blocks-result)
-                                   (map search-db/block->index))
+                                   (map search-db/block->index)
+                                   (remove nil?))
                 blocks-to-remove-set (->> (remove :added blocks)
                                           (map :e)
                                           (set))]


### PR DESCRIPTION
When re-index, Electron main process error:

```
RangeError: Too many parameter values were provided
    at /Users/..../Repos/logseq/.shadow-cljs/builds/electron/dev/out/cljs-runtime/electron/search.cljs:150:39
    at insert-many (/Users/...../Repos/logseq/static/node_modules/better-sqlite3/lib/methods/transaction.js:65:24)
```
The incoming blocks-to-add has a nil in coll.

Introduced in https://github.com/logseq/logseq/pull/6455

`block->index` now becomes nil-able. should filter out all nil values.

Caused by diff of:
https://github.com/logseq/logseq/pull/6455/files#diff-e7fd16ab702eff86ec25cb18638b6fe514d4d527d80bba84f9af4918319dfa01R16-R22
<img width="839" alt="image" src="https://user-images.githubusercontent.com/72891/189033393-3b49e172-fcf1-4b40-ab47-52b682007e0c.png">

