### PR TITLE
fix(sync): api calls fail when network offline

### DIFF
--- a/src/main/frontend/handler.cljs
+++ b/src/main/frontend/handler.cljs
@@ -195,6 +195,7 @@
   (render)
   (i18n/start)
   (instrument/init)
+  (state/set-online! js/navigator.onLine)
   (set-network-watcher!)
 
   (util/indexeddb-check?


### PR DESCRIPTION
- set :network/online? in state when init
- won't sync-start if network offline
- if auth-refresh-token failed, won't clear id-token&access-token (if they aren't expired)