### PR TITLE
Dev: Enable two disabled kondo linters and bump kondo deps

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,4 +1,13 @@
-{:linters
+{:ns-groups [{:pattern "frontend.components.*" :name all-components}]
+
+ :config-in-ns
+ ;; :used-underscored-binding is turned off for components because of false positive
+ ;; for rum/defcs and _state.
+ {all-components {:linters {:used-underscored-binding {:level :off}}}
+  ;; false positive with match/match and _
+  frontend.handler.paste {:linters {:used-underscored-binding {:level :off}}}}
+
+ :linters
  {:unresolved-symbol {:exclude [goog.DEBUG
                                 goog.string.unescapeEntities
                                 ;; TODO:lint: Fix when fixing all type hints
@@ -39,12 +48,15 @@
              logseq.graph-parser.util gp-util
              logseq.graph-parser.property gp-property
              logseq.graph-parser.config gp-config
-             logseq.graph-parser.date-time-util date-time-util
              logseq.graph-parser.util.page-ref page-ref
-             logseq.graph-parser.util.block-ref block-ref}}}
+             logseq.graph-parser.util.block-ref block-ref
+             logseq.graph-parser.date-time-util date-time-util}}
+
+  :namespace-name-mismatch {:level :warning}
+  :used-underscored-binding {:level :warning}}
 
  :hooks {:analyze-call {rum.core/defc hooks.rum/defc
-                        rum.core/defcs hooks.rum/defcs}}
+                         rum.core/defcs hooks.rum/defcs}}
  :lint-as {promesa.core/let clojure.core/let
            promesa.core/loop clojure.core/loop
            promesa.core/recur clojure.core/recur

--- a/deps.edn
+++ b/deps.edn
@@ -47,5 +47,5 @@
                   :main-opts   ["-m" "shadow.cljs.devtools.cli"]}
 
            ;; Use :replace-deps for tools. See https://github.com/clj-kondo/clj-kondo/issues/1536#issuecomment-1013006889
-           :clj-kondo {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2022.05.31"}}
+           :clj-kondo {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2022.09.08"}}
                        :main-opts  ["-m" "clj-kondo.main"]}}}

--- a/deps/db/deps.edn
+++ b/deps/db/deps.edn
@@ -3,5 +3,5 @@
  {datascript/datascript {:mvn/version "1.3.8"}}
  :aliases
  {:clj-kondo
-  {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2022.05.31"}}
+  {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2022.09.08"}}
    :main-opts  ["-m" "clj-kondo.main"]}}}

--- a/deps/graph-parser/deps.edn
+++ b/deps/graph-parser/deps.edn
@@ -20,5 +20,5 @@
                       org.clojure/clojurescript {:mvn/version "1.11.54"}}
          :main-opts ["-m" "cljs-test-runner.main"]}
 
-  :clj-kondo {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2022.05.31"}}
+  :clj-kondo {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2022.09.08"}}
               :main-opts  ["-m" "clj-kondo.main"]}}}

--- a/src/main/electron/listener.cljs
+++ b/src/main/electron/listener.cljs
@@ -166,7 +166,7 @@
                      ;; Handle open new window in renderer, until the destination graph doesn't rely on setting local storage
                      ;; No db cache persisting ensured. Should be handled by the caller
                      (fn [repo]
-                       (ui-handler/open-new-window! nil repo))))
+                       (ui-handler/open-new-window! repo))))
 
 (defn listen!
   []

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -207,9 +207,9 @@
                         *exist? (::exist? state)]
                     (when (and sync-on? asset-file? (false? @*exist?))
                       (let [sync-state (state/sub [:file-sync/sync-state (state/get-current-repo)])
-                            _downloading-files (:current-remote->local-files sync-state)
-                            contain-url? (and (seq _downloading-files)
-                                              (some #(string/ends-with? src %) _downloading-files))]
+                            downloading-files (:current-remote->local-files sync-state)
+                            contain-url? (and (seq downloading-files)
+                                              (some #(string/ends-with? src %) downloading-files))]
                         (cond
                           (and (not @*loading?) contain-url?)
                           (reset! *loading? true)
@@ -247,8 +247,8 @@
   (let [images (js/document.querySelectorAll ".asset-container img")
         images (to-array images)
         images (if-not (= (count images) 1)
-                 (let [^js _image (.closest (.-target e) ".asset-container")
-                       image (. _image querySelector "img")]
+                 (let [^js image (.closest (.-target e) ".asset-container")
+                       image (. image querySelector "img")]
                    (->> images
                         (sort-by (juxt #(.-y %) #(.-x %)))
                         (split-with (complement #{image}))

--- a/src/main/frontend/components/encryption.cljs
+++ b/src/main/frontend/components/encryption.cljs
@@ -266,11 +266,11 @@
 (defn input-password
   ([repo-url close-fn] (input-password repo-url close-fn {:type :local}))
   ([repo-url close-fn opts]
-   (fn [_close-fn]
+   (fn [close-fn']
      (let [close-fn' (if (fn? close-fn)
                        #(do (close-fn %)
-                            (_close-fn))
-                       _close-fn)]
+                            (close-fn'))
+                       close-fn')]
        (input-password-inner repo-url close-fn' opts)))))
 
 (rum/defcs encryption-setup-dialog-inner

--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -414,7 +414,7 @@
        [:div.p-4 (ui/loading "Loading...")]
        (for [version version-files]
          (let [version-uuid (get-version-key version)
-               _local?      (some? (:relative-path version))]
+               local?      (some? (:relative-path version))]
            [:div.version-list-item {:key version-uuid}
             [:a.item-link.block.fade-link.flex.justify-between
              {:title    version-uuid
@@ -427,7 +427,7 @@
                (or (:CreateTime version)
                    (:create-time version)) nil)]
              [:small.opacity-50.translate-y-1
-              (if _local?
+              (if local?
                 [:<> (ui/icon "git-commit") " local"]
                 [:<> (ui/icon "cloud") " remote"])]]])))]))
 

--- a/src/main/frontend/components/plugins_settings.cljs
+++ b/src/main/frontend/components/plugins_settings.cljs
@@ -87,18 +87,18 @@
 
 (rum/defc settings-container
   [schema ^js pl]
-  (let [^js _settings (.-settings pl)
+  (let [^js settings (.-settings pl)
         pid (.-id pl)
-        [settings, set-settings] (rum/use-state (bean/->clj (.toJSON _settings)))
-        update-setting! (fn [k v] (.set _settings (name k) (bean/->js v)))]
+        [settings, set-settings] (rum/use-state (bean/->clj (.toJSON settings)))
+        update-setting! (fn [k v] (.set settings (name k) (bean/->js v)))]
 
     (rum/use-effect!
       (fn []
         (let [on-change (fn [^js s]
                           (when-let [s (bean/->clj s)]
                             (set-settings s)))]
-          (.on _settings "change" on-change)
-          #(.off _settings "change" on-change)))
+          (.on settings "change" on-change)
+          #(.off settings "change" on-change)))
       [pid])
 
     (if (seq schema)

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -702,7 +702,7 @@
           (recur (dec n)))
         r))))
 
-(deftype RSAPI [^:mutable _graph-uuid ^:mutable _private-key ^:mutable _public-key]
+(deftype RSAPI [^:mutable graph-uuid' ^:mutable private-key' ^:mutable public-key']
   IToken
   (<get-token [this]
     (go
@@ -714,15 +714,15 @@
       (state/get-auth-id-token)))
 
   IRSAPI
-  (rsapi-ready? [_ graph-uuid] (and (= graph-uuid _graph-uuid) _private-key _public-key))
+  (rsapi-ready? [_ graph-uuid] (and (= graph-uuid graph-uuid') private-key' public-key'))
   (<key-gen [_] (go (js->clj (<! (p->c (ipc/ipc "key-gen")))
                              :keywordize-keys true)))
   (<set-env [_ prod? private-key public-key graph-uuid]
     (when (not-empty private-key)
       (print (util/format "[%s] setting sync age-encryption passphrase..." graph-uuid)))
-    (set! _graph-uuid graph-uuid)
-    (set! _private-key private-key)
-    (set! _public-key public-key)
+    (set! graph-uuid' graph-uuid)
+    (set! private-key' private-key)
+    (set! public-key' public-key)
     (p->c (ipc/ipc "set-env" (if prod? "prod" "dev") private-key public-key)))
   (<get-local-all-files-meta [_ graph-uuid base-path]
     (go
@@ -786,7 +786,7 @@
                                     (js->clj r))))))
 
 
-(deftype ^:large-vars/cleanup-todo CapacitorAPI [^:mutable _graph-uuid ^:mutable _private-key ^:mutable _public-key]
+(deftype ^:large-vars/cleanup-todo CapacitorAPI [^:mutable graph-uuid' ^:mutable private-key ^:mutable public-key']
   IToken
   (<get-token [this]
     (go
@@ -798,15 +798,15 @@
       (state/get-auth-id-token)))
 
   IRSAPI
-  (rsapi-ready? [_ graph-uuid] (and (= graph-uuid _graph-uuid) _private-key _public-key))
+  (rsapi-ready? [_ graph-uuid] (and (= graph-uuid graph-uuid') private-key public-key'))
   (<key-gen [_]
     (go (let [r (<! (p->c (.keygen mobile-util/file-sync #js {})))]
           (-> r
               (js->clj :keywordize-keys true)))))
   (<set-env [_ prod? secret-key public-key graph-uuid]
-    (set! _graph-uuid graph-uuid)
-    (set! _private-key secret-key)
-    (set! _public-key public-key)
+    (set! graph-uuid' graph-uuid)
+    (set! private-key secret-key)
+    (set! public-key' public-key)
     (p->c (.setEnv mobile-util/file-sync (clj->js {:env (if prod? "prod" "dev")
                                                    :secretKey secret-key
                                                    :publicKey public-key}))))
@@ -2356,7 +2356,7 @@
  SyncManager [graph-uuid base-path *sync-state
               ^Local->RemoteSyncer local->remote-syncer ^Remote->LocalSyncer remote->local-syncer remoteapi
               ^:mutable ratelimit-local-changes-chan
-              *txid ^:mutable state ^:mutable _remote-change-chan ^:mutable _*ws *stopped? *paused?
+              *txid ^:mutable state ^:mutable remote-change-chan ^:mutable *ws *stopped? *paused?
               ^:mutable ops-chan
               ;; control chans
               private-full-sync-chan private-stop-sync-chan private-remote->local-sync-chan
@@ -2389,8 +2389,8 @@
 
   (start [this]
     (set! ops-chan (chan (async/dropping-buffer 10)))
-    (set! _*ws (atom nil))
-    (set! _remote-change-chan (ws-listen! graph-uuid _*ws))
+    (set! *ws (atom nil))
+    (set! remote-change-chan (ws-listen! graph-uuid *ws))
     (set! ratelimit-local-changes-chan (<ratelimit local->remote-syncer local-changes-revised-chan))
     (setup-local->remote! local->remote-syncer)
     (async/tap full-sync-mult private-full-sync-chan)
@@ -2406,7 +2406,7 @@
               private-remote->local-sync-chan {:remote->local true}
               private-full-sync-chan {:local->remote-full-sync true}
               private-pause-resume-chan ([v] (if v {:resume true} {:pause true}))
-              _remote-change-chan ([v] (println "remote change:" v) {:remote->local v})
+              remote-change-chan ([v] (println "remote change:" v) {:remote->local v})
               ratelimit-local-changes-chan ([v]
                                             (let [rest-v (util/drain-chan ratelimit-local-changes-chan)
                                                   vs     (cons v rest-v)]
@@ -2655,7 +2655,7 @@
     (go
       (when-not @*stopped?
         (vreset! *stopped? true)
-        (ws-stop! _*ws)
+        (ws-stop! *ws)
         (offer! private-stop-sync-chan true)
         (async/untap full-sync-mult private-full-sync-chan)
         (async/untap stop-sync-mult private-stop-sync-chan)

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -170,13 +170,13 @@
    (file-sync/pick-page-histories-panel graph-uuid page-name)
    {:id :page-histories :label "modal-page-histories"}))
 
-(defmethod handle :graph/open-new-window [[ev repo]]
+(defmethod handle :graph/open-new-window [[_ev repo]]
   (p/let [current-repo (state/get-current-repo)
           target-repo (or repo current-repo)
           _ (repo-handler/persist-db! current-repo persist-db-noti-m) ;; FIXME: redundant when opening non-current-graph window
           _ (when-not (= current-repo target-repo)
               (repo-handler/broadcast-persist-db! repo))]
-    (ui-handler/open-new-window! ev repo)))
+    (ui-handler/open-new-window! repo)))
 
 (defmethod handle :graph/migrated [[_ _repo]]
   (js/alert "Graph migrated."))

--- a/src/main/frontend/handler/ui.cljs
+++ b/src/main/frontend/handler/ui.cljs
@@ -298,9 +298,9 @@
 (defn open-new-window!
   "Open a new Electron window.
    No db cache persisting ensured. Should be handled by the caller."
-  ([_e]
-   (open-new-window! _e nil))
-  ([_e repo]
+  ([]
+   (open-new-window! nil))
+  ([repo]
    ;; TODO: find out a better way to open a new window with a different repo path. Using local storage for now
    ;; TODO: also write local storage with the current repo state, to make behavior consistent
    ;; then we can remove the `openNewWindowOfGraph` ipcMain call

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -85,14 +85,14 @@
     (textarea props)))
 
 (rum/defc dropdown-content-wrapper
-  < {:did-mount    (fn [_state]
+  < {:did-mount    (fn [state]
                      (let [k    (inc (count (state/sub :modal/dropdowns)))
-                           args (:rum/args _state)]
+                           args (:rum/args state)]
                        (state/set-state! [:modal/dropdowns k] (second args))
-                       (assoc _state ::k k)))
-     :will-unmount (fn [_state]
-                     (state/update-state! :modal/dropdowns #(dissoc % (::k _state)))
-                     _state)}
+                       (assoc state ::k k)))
+     :will-unmount (fn [state]
+                     (state/update-state! :modal/dropdowns #(dissoc % (::k state)))
+                     state)}
   [dropdown-state _close-fn content class]
   (let [class (or class
                   (util/hiccup->class "origin-top-right.absolute.right-0.mt-2"))]
@@ -287,8 +287,8 @@
   (let [time-fn (fn []
                   (try
                     (util/time-ago input)
-                    (catch js/Error _e
-                      (js/console.error _e)
+                    (catch js/Error e
+                      (js/console.error e)
                       input)))
         [time set-time] (rum/use-state (time-fn))]
 

--- a/src/main/frontend/util/cursor.cljs
+++ b/src/main/frontend/util/cursor.cljs
@@ -39,8 +39,8 @@
                  (util/nth-safe pos)
                  mock-char-pos
                  (assoc :rect rect))
-         (catch :default _e
-           (js/console.log "index error" _e)
+         (catch :default e
+           (js/console.log "index error" e)
            {:pos pos
             :rect rect
             :left js/Number.MAX_SAFE_INTEGER

--- a/src/main/logseq/api.cljs
+++ b/src/main/logseq/api.cljs
@@ -852,9 +852,9 @@
 
 (defn ^:export exper_request
   [pid ^js options]
-  (when-let [^js _pl (plugin-handler/get-plugin-inst pid)]
+  (when-let [^js pl (plugin-handler/get-plugin-inst pid)]
     (let [req-id (vreset! *request-k (inc @*request-k))
-          req-cb #(plugin-handler/request-callback _pl req-id %)]
+          req-cb #(plugin-handler/request-callback pl req-id %)]
       (-> (ipc/ipc :httpRequest req-id options)
           (p/then #(req-cb %))
           (p/catch #(req-cb %)))


### PR DESCRIPTION
This enables two clj-kondo linters that are disabled by default but are useful:
- `:used-underscored-binding` - We rely on `_` to communicate unused bindings. This ensures this is true for all bindings. This is helpful for code review where we don't always have the full context and for large PRs like file-sync
- `:namespace-name-mismatch` - catches typos with namespaces. I encountered a typo-ed test ns a couple months ago which should've been caught by this