### PR TITLE
Fix: 3 user actions broken by global-config in mobile or web

### DIFF
--- a/src/main/frontend/handler/file.cljs
+++ b/src/main/frontend/handler/file.cljs
@@ -95,7 +95,9 @@
   (let [original-content (db/get-file repo path)
         write-file! (if from-disk?
                       #(p/resolved nil)
-                      #(let [path-dir (if (= (path/dirname path) (global-config-handler/global-config-dir))
+                      #(let [path-dir (if (and
+                                            (config/global-config-enabled?)
+                                            (= (path/dirname path) (global-config-handler/global-config-dir)))
                                         (global-config-handler/global-config-dir)
                                         (config/get-repo-dir repo))]
                          (fs/write-file! repo path-dir path content
@@ -122,7 +124,7 @@
                        (p/let [_ (repo-config-handler/restore-repo-config! repo)]
                          (state/pub-event! [:shortcut/refresh]))
 
-                       (= path (global-config-handler/global-config-path))
+                       (and (config/global-config-enabled?) (= path (global-config-handler/global-config-path)))
                        (p/let [_ (global-config-handler/restore-global-config!)]
                          (state/pub-event! [:shortcut/refresh]))
 
@@ -131,7 +133,8 @@
 
                      (when re-render-root? (ui-handler/re-render-root!)))
                    (fn [error]
-                     (when (= path (global-config-handler/global-config-path))
+                     (when (and (config/global-config-enabled?)
+                                (= path (global-config-handler/global-config-path)))
                        (state/pub-event! [:notification/show
                                          {:content (str "Failed to write to file " path)
                                           :status :error}]))

--- a/src/main/frontend/handler/global_config.cljs
+++ b/src/main/frontend/handler/global_config.cljs
@@ -34,24 +34,21 @@
 
 (defn- create-global-config-file-if-not-exists
   [repo-url]
-  (when (not-empty @root-dir)
-   (let [config-dir (global-config-dir)
+  (let [config-dir (global-config-dir)
         config-path (global-config-path)]
     (p/let [_ (fs/mkdir-if-not-exists config-dir)
             file-exists? (fs/create-if-not-exists repo-url config-dir config-path default-content)]
            (when-not file-exists?
              (file-common-handler/reset-file! repo-url config-path default-content)
-             (set-global-config-state! default-content))))))
+             (set-global-config-state! default-content)))))
 
 (defn restore-global-config!
   "Sets global config state from config file"
   []
-  (if (not-empty @root-dir)
-    (let [config-dir (global-config-dir)
-          config-path (global-config-path)]
-      (p/let [config-content (fs/read-file config-dir config-path)]
-        (set-global-config-state! config-content)))
-    (set-global-config-state! default-content)))
+  (let [config-dir (global-config-dir)
+        config-path (global-config-path)]
+    (p/let [config-content (fs/read-file config-dir config-path)]
+      (set-global-config-state! config-content))))
 
 (defn start
   "This component has four responsibilities on start:

--- a/src/main/frontend/handler/repo.cljs
+++ b/src/main/frontend/handler/repo.cljs
@@ -408,7 +408,8 @@
    (state/set-db-restoring! true)
    (db/restore-graph! repo)
    (repo-config-handler/restore-repo-config! repo)
-   (global-config-handler/restore-global-config!)
+   (when (config/global-config-enabled?)
+     (global-config-handler/restore-global-config!))
     ;; Don't have to unlisten the old listener, as it will be destroyed with the conn
    (db/listen-and-persist! repo)
    (state/pub-event! [:shortcut/refresh])

--- a/src/main/frontend/handler/web/nfs.cljs
+++ b/src/main/frontend/handler/web/nfs.cljs
@@ -338,14 +338,16 @@
                                        (fn [path handle]
                                          (when nfs?
                                            (swap! path-handles assoc path handle))))
-                         global-dir (global-config-handler/global-config-dir)
-                         global-files-result (if (config/global-config-enabled?)
-                                               (fs/get-files global-dir (constantly nil))
-                                               [])
                          new-local-files (-> (->db-files mobile-native? electron? dir-name local-files-result)
                                              (remove-ignore-files dir-name nfs?))
-                         new-global-files (-> (->db-files mobile-native? electron? global-dir global-files-result)
-                                              (remove-ignore-files global-dir nfs?))
+                         new-global-files (if (config/global-config-enabled?)
+                                            (p/let [global-files-result (fs/get-files
+                                                                          (global-config-handler/global-config-dir)
+                                                                          (constantly nil))
+                                                    global-files (-> (->db-files mobile-native? electron? (global-config-handler/global-config-dir) global-files-result)
+                                                  (remove-ignore-files (global-config-handler/global-config-dir) nfs?))]
+                                              global-files)
+                                            (p/resolved []))
                          new-files (concat new-local-files new-global-files)
 
                          _ (when nfs?


### PR DESCRIPTION
This fixes 3 user actions which were buggy or failing with mobile or web, which I introduced in #6531. I have tested these fixes work on android. If someone can test iOS that would be helpful. The user actions that were buggy were re-indexing graph, switching graphs and editing config.edn