### PR TITLE
Fix: Avoid repo-config db timing bugs by no longer depending on db [WIP]

### DIFF
--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -114,7 +114,7 @@
   ([graph skip-ios-check?]
    (if (and (mobile-util/native-ios?) (not skip-ios-check?))
      (state/pub-event! [:validate-appId graph-switch graph])
-     (do
+     (p/do!
        (state/set-current-repo! graph)
        ;; load config
        (repo-config-handler/restore-repo-config! graph)

--- a/src/main/frontend/handler/file.cljs
+++ b/src/main/frontend/handler/file.cljs
@@ -126,7 +126,7 @@
                        (ui-handler/add-style-if-exists!)
 
                        (= path (config/get-repo-config-path repo))
-                       (p/let [_ (repo-config-handler/restore-repo-config! repo content)]
+                       (p/let [_ (repo-config-handler/restore-repo-config! repo)]
                          (state/pub-event! [:shortcut/refresh]))
 
                        (and (config/global-config-enabled?) (= path (global-config-handler/global-config-path)))

--- a/src/main/frontend/handler/global_config.cljs
+++ b/src/main/frontend/handler/global_config.cljs
@@ -53,7 +53,7 @@
 (defn start
   "This component has four responsibilities on start:
 - Fetch root-dir for later use with config paths
-- Manage ui state of global config
+- Set ui state of global config by reading its file
 - Create a global config dir and file if it doesn't exist
 - Start a file watcher for global config dir if it's not already started.
   Watcher ensures client db is seeded with correct file data."

--- a/src/main/frontend/handler/repo_config.cljs
+++ b/src/main/frontend/handler/repo_config.cljs
@@ -3,19 +3,15 @@
   This component only concerns itself with one user-facing repo config file,
   logseq/config.edn. In the future it may manage more files. This component
   depends on a repo."
-  (:require [frontend.db :as db]
-            [frontend.config :as config]
+  (:require [frontend.config :as config]
             [frontend.state :as state]
             [frontend.handler.common :as common-handler]
             [frontend.handler.common.file :as file-common-handler]
             [cljs.reader :as reader]
             [frontend.fs :as fs]
             [promesa.core :as p]
-            [frontend.spec :as spec]))
-
-(defn- get-repo-config-content
-  [repo-url]
-  (db/get-file repo-url (config/get-repo-config-path)))
+            [frontend.spec :as spec]
+            ["path" :as path]))
 
 (defn read-repo-config
   "Converts file content to edn and handles read failure by backing up file and
@@ -34,31 +30,36 @@
     (state/set-config! repo-url config)
     config))
 
+(defn- repo-config-dir
+  [repo-url]
+  (path/join (config/get-repo-dir repo-url) config/app-name))
+
 (defn create-config-file-if-not-exists
   "Creates a default logseq/config.edn if it doesn't exist"
   [repo-url]
   (spec/validate :repos/url repo-url)
   (let [repo-dir (config/get-repo-dir repo-url)
-        app-dir config/app-name
-        dir (str repo-dir "/" app-dir)]
+        dir (repo-config-dir repo-url)]
     (p/let [_ (fs/mkdir-if-not-exists dir)]
            (let [default-content config/config-default-content
-                  path (str app-dir "/" config/config-file)]
-             (p/let [file-exists? (fs/create-if-not-exists repo-url repo-dir (str app-dir "/" config/config-file) default-content)]
+                 path (path/join config/app-name config/config-file)]
+             (p/let [file-exists? (fs/create-if-not-exists repo-url repo-dir path default-content)]
                     (when-not file-exists?
                       (file-common-handler/reset-file! repo-url path default-content)
                       (set-repo-config-state! repo-url default-content)))))))
 
+
 (defn restore-repo-config!
   "Sets repo config state from db"
-  ([repo-url]
-   (restore-repo-config! repo-url (get-repo-config-content repo-url)))
-  ([repo-url config-content]
-   (set-repo-config-state! repo-url config-content)))
+  [repo-url]
+  (p/let [config-dir (repo-config-dir repo-url)
+          config-path (path/join config-dir config/config-file)
+          config-content (fs/read-file config-dir config-path)]
+         (set-repo-config-state! repo-url config-content)))
 
 (defn start
-  "This component only has one reponsibility on start, to manage db and ui state
-  from repo config. It does not manage the repo directory, logseq/, as that is
-  loosely done by repo-handler"
+  "This component only has one reponsibility on start, set ui state of repo
+  config by reading the config file. It does not manage the repo directory,
+  logseq/, as that is loosely done by repo-handler"
   [{:keys [repo]}]
   (restore-repo-config! repo))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1311,12 +1311,14 @@ Similar to re-frame subscriptions"
 
 (defn set-config!
   [repo-url value]
-  (when value (set-state! [:config repo-url] value)))
+  {:pre [(some? value)]}
+  (set-state! [:config repo-url] value))
 
 (defn set-global-config!
   [value]
+  {:pre [(some? value)]}
   ;; Placed under :config so cursors can work seamlessly
-  (when value (set-config! ::global-config value)))
+  (set-config! ::global-config value))
 
 (defn get-wide-mode?
   []

--- a/src/test/frontend/test/helper.clj
+++ b/src/test/frontend/test/helper.clj
@@ -5,4 +5,4 @@
   `(let [repo# (frontend.state/get-current-repo)]
      (frontend.state/set-config! repo# ~config)
      ~@body
-     (frontend.state/set-config! repo# nil)))
+     (frontend.state/set-config! repo# {})))


### PR DESCRIPTION
Follow up to https://github.com/logseq/logseq/pull/6706#discussion_r969432802. This was the same approach we took with global-config in #6531