### PR TITLE
fix: clicking sync icon restarts the file sync

### DIFF
--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -182,7 +182,7 @@
 
         status                 (:state sync-state)
         status                 (or (nil? status) (keyword (name status)))
-        off?                   (or (nil? sync-state) (fs-sync/sync-state--stopped? sync-state))
+        off?                   (file-sync-handler/sync-off? sync-state)
         full-syncing?          (contains? #{:local->remote-full-sync :remote->local-full-sync} status)
         syncing?               (or full-syncing? (contains? #{:local->remote :remote->local} status))
         idle?                  (contains? #{:idle} status)
@@ -211,6 +211,7 @@
                                     nil
 
                                     (and synced-file-graph?
+                                         (file-sync-handler/graph-sync-off? current-repo)
                                          (second @fs-sync/graphs-txid)
                                          (async/<! (fs-sync/<check-remote-graph-exists (second @fs-sync/graphs-txid))))
                                     (fs-sync/sync-start)

--- a/src/main/frontend/handler/file_sync.cljs
+++ b/src/main/frontend/handler/file_sync.cljs
@@ -205,3 +205,11 @@
 (defn reset-user-state! []
   (vreset! *beta-unavailable? false)
   (state/set-state! :file-sync/onboarding-state nil))
+
+(defn sync-off?
+  [sync-state]
+  (or (nil? sync-state) (sync/sync-state--stopped? sync-state)))
+
+(defn graph-sync-off?
+  [graph]
+  (sync-off? (state/get-file-sync-state graph)))


### PR DESCRIPTION
This can result in app crash when clicking the icon multiple times.