### PR TITLE
Fix: Persist zoom level on app close

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -317,6 +317,7 @@
                                   (when @*quit-dirty? ;; when not updating
                                     (.preventDefault e)
                                     (let [web-contents (. win -webContents)]
+                                      (.send web-contents "persist-zoom-level" (.getZoomLevel web-contents))
                                       (.send web-contents "persistent-dbs"))
                                     (async/go
                                       (let [_ (async/<! state/persistent-dbs-chan)]

--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -146,7 +146,7 @@
         (.on "new-window" new-win-handler)
         (.on "will-navigate" will-navigate-handler)
         (.on "did-start-navigation" #(.send web-contents "persist-zoom-level" (.getZoomLevel web-contents)))
-        (.on "did-navigate-in-page" #(.send web-contents "restore-zoom-level")))
+        (.on "page-title-updated" #(.send web-contents "restore-zoom-level")))
 
       (doto win
         (.on "enter-full-screen" #(.send web-contents "full-screen" "enter"))


### PR DESCRIPTION
On https://github.com/logseq/logseq/pull/6617 we introduced a way to persist the zoom level when we navigate.
It also makes sense to persist the zoom level when we close the app, and restore it when we reopen logseq.

Resolves https://github.com/logseq/logseq/issues/6719

**Notes for reviewers**
- There are two `on window close` event handlers, one for the main and one for non-main windows. We persist the zoom level on main. I am not sure if there is a reason to add this to the other handler as well. Ideally, we would like to hook on something like [zoom-changed](https://www.electronjs.org/docs/latest/api/web-contents#event-zoom-changed), but this is triggered exclusively when we use the mouse wheel.
- I tried using `did-finish-load`, `dom-ready` and some other related events to restore the zoom level when the app is initially loaded. Strangely, the only event that was consistently fired on application load was `page-title-updated`,.which is also fired on `did-navigate-in-page`, so I replaced the event. Although it does seem to cover our cases, it feels a little weird to use that.
