### PR TITLE
Fix: Resizer position

### DIFF
--- a/src/main/frontend/components/sidebar.css
+++ b/src/main/frontend/components/sidebar.css
@@ -461,9 +461,7 @@ html[data-theme='dark'] {
     width: 0 !important;
 
     @screen lg {
-      .resizer {
-        left: -4px;
-      }
+      width: 4px !important;
     }
   }
 


### PR DESCRIPTION
Increase the width of the closed sidebar instead of setting a negative left position
on the resizer.

Resolves https://github.com/logseq/logseq/issues/6770