### PR TITLE
Guide developer to use logseq.UI.showMsg

### DIFF
--- a/libs/src/LSPlugin.ts
+++ b/libs/src/LSPlugin.ts
@@ -386,7 +386,7 @@ export interface IAppProxy {
   queryElementRect: (selector: string) => Promise<DOMRectReadOnly | null>
 
   /**
-   * @deprecated
+   * @deprecated Use `logseq.UI.showMsg` instead
    * @param content
    * @param status
    */


### PR DESCRIPTION
`logseq.App.showMsg` is deprecated, add new api in the deprecated tag so new users can get to know.