### PR TITLE
Prefer text type on dnd

### DIFF
--- a/tldraw/apps/tldraw-logseq/src/hooks/usePaste.ts
+++ b/tldraw/apps/tldraw-logseq/src/hooks/usePaste.ts
@@ -150,8 +150,8 @@ export function usePaste() {
       async function tryCreateShapesFromDataTransfer(dataTransfer: DataTransfer) {
         return tryCreateShapeHelper(
           tryCreateShapeFromFiles,
-          tryCreateShapeFromTextHTML,
           tryCreateShapeFromTextPlain,
+          tryCreateShapeFromTextHTML,
           tryCreateShapeFromBlockUUID
         )(dataTransfer)
       }


### PR DESCRIPTION
When we drag and drop a selected area, we should probably use the `text/plain` data type by default. `tryCreateShapeFromIframeString` would automatically create an iframe if we drag a link (or a youtube video), and it would also filter out unneeded info. The downside is that some of the information that is only available on `text/html` might be useful (e.g. anchor elements).

[2022-09-19 12-10-40.webm](https://user-images.githubusercontent.com/10744960/190992397-bed36fc7-0db6-44ba-9ef9-78ea78ca1447.webm)
