### PR TITLE
chore(build): file-sync production env as default

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -32,7 +32,7 @@
                                                 :redef false}}
         :closure-defines  {goog.debug.LOGGING_ENABLED       true
                            frontend.config/ENABLE-PLUGINS   #shadow/env ["ENABLE_PLUGINS"   :as :bool :default true]
-                           frontend.config/ENABLE-FILE-SYNC-PRODUCTION #shadow/env ["ENABLE_FILE_SYNC_PRODUCTION" :as :bool :default false]}
+                           frontend.config/ENABLE-FILE-SYNC-PRODUCTION #shadow/env ["ENABLE_FILE_SYNC_PRODUCTION" :as :bool :default true]}
 
         ;; NOTE: electron, browser/mobile-app use different asset-paths.
         ;;   For browser/mobile-app devs, assets are located in /static/js(via HTTP root).


### PR DESCRIPTION
CC @kanru 

The current Flatpak build didn't set `ENABLE_FILE_SYNC_PRODUCTION` as `true`.
So the App will use file-sync development environment as default.

This PR set production environment as default. eliminate the need of setting `ENABLE_FILE_SYNC_PRODUCTION`

Changes for Developers:

When doing local development on file-sync, you might need to set 
`ENABLE_FILE_SYNC_PRODUCTION=false`