### PR TITLE
refactor: unify heading UX for both markdown and org mode

### DIFF
--- a/deps/db/src/logseq/db/schema.cljs
+++ b/deps/db/src/logseq/db/schema.cljs
@@ -62,9 +62,6 @@
    ;; first block that's not a heading or unordered list
    :block/pre-block? {}
 
-   ;; heading's level (the block must be a heading)
-   :block/heading-level {}
-
    ;; scheduled day
    :block/scheduled {}
 
@@ -116,7 +113,6 @@
     :block/deadline
     :block/repeated?
     :block/pre-block?
-    :block/heading-level
     :block/type
     :block/properties
     :block/properties-order

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -542,13 +542,12 @@
     (with-path-refs blocks)))
 
 (defn- with-heading-property
-  [properties markdown-heading? size]
+  [properties markdown-heading? size level]
   (let [properties (if markdown-heading?
                      (assoc properties :heading size)
                      properties)]
     (if (true? (:heading properties))
-      ;; default-level 2
-      (assoc properties :heading 2)
+      (assoc properties :heading (min 6 level))
       properties)))
 
 (defn- construct-block
@@ -571,7 +570,7 @@
                            :meta pos-meta)
                     (dissoc :size))
                 (or (seq (:properties properties)) markdown-heading?)
-                (assoc :properties (with-heading-property (:properties properties) markdown-heading? (:size block))
+                (assoc :properties (with-heading-property (:properties properties) markdown-heading? (:size block) (:level block))
                        :properties-text-values (:properties-text-values properties)
                        :properties-order (vec (:properties-order properties)))
 

--- a/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
@@ -115,10 +115,9 @@
             :block/priority 4
             :block/deadline 1
             :block/collapsed? 22
-            :block/heading-level 60
             :block/repeated? 1}
            (->> [:block/scheduled :block/priority :block/deadline :block/collapsed?
-                 :block/heading-level :block/repeated?]
+                 :block/repeated?]
                 (map (fn [attr]
                        [attr
                         (ffirst (d/q [:find (list 'count '?b) :where ['?b attr]]

--- a/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
@@ -100,7 +100,8 @@
             :updated-at 47 :created-at 47
             :card-last-score 6 :card-repeats 6 :card-next-schedule 6
             :card-last-interval 6 :card-ease-factor 6 :card-last-reviewed 6
-            :alias 6 :logseq.macro-arguments 94 :logseq.macro-name 94}
+            :alias 6 :logseq.macro-arguments 94 :logseq.macro-name 94
+            :heading 64}
            (get-top-block-properties db))
         "Counts for top block properties")
 
@@ -141,7 +142,7 @@
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
     (is (= 211 (count files)) "Correct file count")
-    (is (= 42070 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 42006 (count (d/datoms db :eavt))) "Correct datoms count")
 
     (is (= 3600
            (ffirst

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1839,7 +1839,7 @@
 (declare block-content)
 
 (defn build-block-title
-  [config {:block/keys [title marker pre-block? properties level heading-level]
+  [config {:block/keys [title marker pre-block? properties]
            :as t}]
   (let [config (assoc config :block t)
         slide? (boolean (:slide? config))
@@ -1856,14 +1856,9 @@
         priority (priority-cp t)
         tags (block-tags-cp t)
         bg-color (:background-color properties)
-        heading-level (or (and heading-level
-                               (<= heading-level 6)
-                               heading-level)
-                          (and (get properties :heading)
-                               (<= level 6)
-                               level))
-        elem (if heading-level
-               (keyword (str "h" heading-level
+        heading (:heading properties)
+        elem (if heading
+               (keyword (str "h" heading
                              (when block-ref? ".inline")))
                :span.inline)]
     (->elem
@@ -2289,7 +2284,7 @@
 
 (rum/defcs block-content-or-editor < rum/reactive
   (rum/local true ::hide-block-refs?)
-  [state config {:block/keys [uuid format] :as block} edit-input-id block-id heading-level edit?]
+  [state config {:block/keys [uuid format] :as block} edit-input-id block-id edit?]
   (let [*hide-block-refs? (get state ::hide-block-refs?)
         hide-block-refs? @*hide-block-refs?
         editor-box (get config :editor-box)
@@ -2307,7 +2302,6 @@
                      :block-id uuid
                      :block-parent-id block-id
                      :format format
-                     :heading-level heading-level
                      :on-hide (fn [value event]
                                 (when (= event :esc)
                                   (editor-handler/save-block! (editor-handler/get-state) value)
@@ -2574,7 +2568,7 @@
         block (if ref?
                 (merge block (db/pull-block (:db/id block)))
                 block)
-        {:block/keys [uuid children pre-block? top? refs heading-level level format content properties]} block
+        {:block/keys [uuid children pre-block? top? refs level format content properties]} block
         config (if navigated? (assoc config :id (str navigating-block)) config)
         block (merge block (block/parse-title-and-body uuid format pre-block? content))
         blocks-container-id (:blocks-container-id config)
@@ -2583,7 +2577,7 @@
         config (if (nil? (:query-result config))
                  (assoc config :query-result (atom nil))
                  config)
-        heading? (or (:heading properties) (and heading-level (<= heading-level 6)))
+        heading? (:heading properties)
         *control-show? (get state ::control-show?)
         db-collapsed? (util/collapsed? block)
         collapsed? (cond
@@ -2665,7 +2659,7 @@
       (when @*show-left-menu?
         (block-left-menu config block))
 
-      (block-content-or-editor config block edit-input-id block-id heading-level edit?)
+      (block-content-or-editor config block edit-input-id block-id edit?)
 
       (when @*show-right-menu?
         (block-right-menu config block edit?))]

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -84,7 +84,7 @@
      :on-click editor-handler/copy-block-embeds}
     "Copy block embeds"
     nil)
-   
+
    [:hr.menu-separator]
 
    (ui/menu-link
@@ -100,8 +100,7 @@
    "#787f97"
    "#978626"
    "#49767b"
-   "#264c9b"
-   "#793e3e"])
+   "#264c9b"])
 
 (defonce *template-including-parent? (atom nil))
 
@@ -163,22 +162,36 @@
 (rum/defc ^:large-vars/cleanup-todo block-context-menu-content
   [_target block-id]
     (when-let [block (db/entity [:block/uuid block-id])]
-      (let [properties (:block/properties block)
-            heading? (true? (:heading properties))]
+      (let [format (:block/format block)]
         [:.menu-links-wrapper
-         [:div.flex-row.flex.justify-between.pb-2.pt-1.px-2
-          [:div.flex-row.flex.justify-between
+         [:div.flex.flex-row.justify-between.pb-2.pt-1.px-2.items-center
+          [:div.flex.flex-row.justify-between.flex-1
            (for [color block-background-colors]
              [:a.m-2.shadow-sm
               {:on-click (fn [_e]
                            (editor-handler/set-block-property! block-id "background-color" color))}
-              [:div.heading-bg {:style {:background-color color}}]])
-           [:a.m-2.shadow-sm
-            {:title    (t :remove-background)
-             :on-click (fn [_e]
-                         (editor-handler/remove-block-property! block-id "background-color"))}
-            [:div.heading-bg.remove "-"]]]]
-         
+              [:div.heading-bg {:style {:background-color color}}]])]
+          [:a.m-2.shadow-sm
+           {:title    (t :remove-background)
+            :on-click (fn [_e]
+                        (editor-handler/remove-block-property! block-id "background-color"))}
+           [:div.heading-bg.remove "-"]]]
+
+         [:div.flex.flex-row.justify-between.pb-2.pt-1.px-2.items-center
+          [:div.flex.flex-row.justify-between.flex-1
+           (for [i (range 1 7)]
+             (ui/button
+               (str "H" i)
+               :on-click (fn [_e]
+                           (editor-handler/set-heading! block-id format i))
+               :intent "link"
+               :small? true))]
+          [:a.m-2
+           {:title    (t :remove-heading)
+            :on-click (fn [_e]
+                        (editor-handler/remove-heading! block-id format))}
+           [:div.heading-bg.remove "-"]]]
+
          [:hr.menu-separator]
 
          (ui/menu-link
@@ -231,17 +244,6 @@
           nil)
 
          [:hr.menu-separator]
-
-         (ui/menu-link
-          {:key      "Convert heading"
-           :on-click (fn [_e]
-                       (if heading?
-                         (editor-handler/remove-block-property! block-id :heading)
-                         (editor-handler/set-block-property! block-id :heading true)))}
-          (if heading?
-            "Convert back to a block"
-            "Convert to a heading")
-          nil)
 
          (block-template block-id)
 

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -170,27 +170,29 @@
              [:a.m-2.shadow-sm
               {:on-click (fn [_e]
                            (editor-handler/set-block-property! block-id "background-color" color))}
-              [:div.heading-bg {:style {:background-color color}}]])]
-          [:a.m-2.shadow-sm
-           {:title    (t :remove-background)
-            :on-click (fn [_e]
-                        (editor-handler/remove-block-property! block-id "background-color"))}
-           [:div.heading-bg.remove "-"]]]
+              [:div.heading-bg {:style {:background-color color}}]])
+           [:a.m-2.shadow-sm
+            {:title    (t :remove-background)
+             :on-click (fn [_e]
+                         (editor-handler/remove-block-property! block-id "background-color"))}
+            [:div.heading-bg.remove "-"]]]]
 
          [:div.flex.flex-row.justify-between.pb-2.pt-1.px-2.items-center
           [:div.flex.flex-row.justify-between.flex-1
            (for [i (range 1 7)]
              (ui/button
-               (str "H" i)
-               :on-click (fn [_e]
-                           (editor-handler/set-heading! block-id format i))
-               :intent "link"
-               :small? true))]
-          [:a.m-2
-           {:title    (t :remove-heading)
+              (str "H" i)
+              :on-click (fn [_e]
+                          (editor-handler/set-heading! block-id format i))
+              :intent "link"
+              :small? true))
+           (ui/button
+            "H-"
+            :title (t :remove-heading)
             :on-click (fn [_e]
-                        (editor-handler/remove-heading! block-id format))}
-           [:div.heading-bg.remove "-"]]]
+                        (editor-handler/remove-heading! block-id format))
+            :intent "link"
+            :small? true)]]
 
          [:hr.menu-separator]
 

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -568,7 +568,7 @@
 
 (rum/defcs box < rum/reactive
   {:init (fn [state]
-           (assoc state ::heading-level (:heading-level (first (:rum/args state)))
+           (assoc state
                   ::id (str (random-uuid))))
    :did-mount (fn [state]
                 (state/set-editor-args! (:rum/args state))

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -54,7 +54,6 @@
     :block/created-at
     :block/updated-at
     :block/file
-    :block/heading-level
     {:block/page [:db/id :block/name :block/original-name :block/journal-day]}
     {:block/_parent ...}])
 

--- a/src/main/frontend/dicts.cljc
+++ b/src/main/frontend/dicts.cljc
@@ -283,6 +283,7 @@
         :white "Light"
         :dark "Dark"
         :remove-background "Remove background"
+        :remove-heading "Remove heading"
         :open "Open"
         :open-a-directory "Open a local directory"
         :user/delete-account "Delete account"

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1940,7 +1940,6 @@
                                   (property/insert-properties format content props))
                     ast (mldoc/->edn content* (gp-mldoc/default-config format))
                     blocks (block/extract-blocks ast content* format {})
-                    _ (prn {:block (first blocks)})
                     fst-block (first blocks)
                     fst-block (if (and keep-uuid? (uuid? (:uuid block)))
                                 (assoc fst-block :block/uuid (:uuid block))

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -611,6 +611,10 @@
            template
            {:target page}))))))
 
+(defmethod handle :editor/set-org-mode-heading [[_ block heading]]
+  (when-let [id (:block/uuid block)]
+    (editor-handler/set-heading! id :org heading)))
+
 (defmethod handle :file-sync-graph/restore-file [[_ graph page-entity content]]
   (when (db/get-db graph)
     (let [file (:block/file page-entity)]

--- a/src/main/frontend/handler/export.cljs
+++ b/src/main/frontend/handler/export.cljs
@@ -482,7 +482,6 @@
          [:block/id
           :block/page-name
           :block/properties
-          :block/heading-level
           :block/format
           :block/children
           :block/content]))})

--- a/src/main/frontend/mobile/action_bar.cljs
+++ b/src/main/frontend/mobile/action_bar.cljs
@@ -52,13 +52,6 @@
           (.scrollBy (util/app-scroll-container-node) #js {:top (- 10 delta)})))
       [:div.action-bar
        [:div.action-bar-commands
-        (when-not (= (:block/format block) :org)
-          (action-command "heading" "Heading"
-                          #(let [properties (:block/properties block)
-                                 heading?   (true? (:heading properties))]
-                             (if heading?
-                               (editor-handler/remove-block-property! uuid :heading)
-                               (editor-handler/set-block-property! uuid :heading true)))))
         (action-command "infinity" "Card" #(srs/make-block-a-card! (:block/uuid block)))
         (action-command "copy" "Copy" #(editor-handler/copy-selection-blocks false))
         (action-command "cut" "Cut" #(editor-handler/cut-selection-blocks true))

--- a/src/main/frontend/modules/file/core.cljs
+++ b/src/main/frontend/modules/file/core.cljs
@@ -29,13 +29,14 @@
     content))
 
 (defn transform-content
-  [{:block/keys [collapsed? format pre-block? unordered content heading-level left page parent]} level {:keys [heading-to-list?]}]
-  (let [content (or content "")
+  [{:block/keys [collapsed? format pre-block? unordered content left page parent properties]} level {:keys [heading-to-list?]}]
+  (let [heading (:heading properties)
+        markdown? (= :markdown format)
+        content (or content "")
         pre-block? (or pre-block?
                        (and (= page parent left) ; first block
-                            (= :markdown format)
+                            markdown?
                             (string/includes? (first (string/split-lines content)) ":: ")))
-        markdown? (= format :markdown)
         content (cond
                   pre-block?
                   (let [content (string/trim content)]
@@ -45,7 +46,7 @@
                   (let [markdown-top-heading? (and markdown?
                                                    (= parent page)
                                                    (not unordered)
-                                                   heading-level)
+                                                   heading)
                         [prefix spaces-tabs]
                         (cond
                           (= format :org)
@@ -57,10 +58,10 @@
                           ["" ""]
 
                           :else
-                          (let [level (if (and heading-to-list? heading-level)
-                                        (if (> heading-level 1)
-                                          (dec heading-level)
-                                          heading-level)
+                          (let [level (if (and heading-to-list? heading)
+                                        (if (> heading 1)
+                                          (dec heading)
+                                          heading)
                                         level)
                                 spaces-tabs (->>
                                              (repeat (dec level) (state/get-export-bullet-indentation))

--- a/src/main/frontend/ui.css
+++ b/src/main/frontend/ui.css
@@ -245,7 +245,7 @@ html.is-mobile {
 .ui__button {
   @apply flex items-center px-3 py-2 border border-transparent
   text-sm leading-4 font-medium rounded-md text-white
-  focus:outline-none transition ease-in-out duration-150 mt-1;
+  focus:outline-none transition ease-in-out duration-150;
 
   &:disabled {
     opacity: 0.5;


### PR DESCRIPTION
This PR unifies the UX to set and clear headings for Markdown and Org modes.
For org mode, a heading block will have a `:heading` property whose value ranges from 1 to 6 (h1 ~ h6).

Demo: https://www.loom.com/share/ae5a8cbb5c2c43979b9be518f687c433
