### PR TITLE
Dev: Use catch :default for default error handling in cljs

### DIFF
--- a/src/electron/electron/configs.cljs
+++ b/src/electron/electron/configs.cljs
@@ -15,7 +15,7 @@
     (.ensureFileSync fs cfg-path)
     (let [body (.toString (.readFileSync fs cfg-path))]
       (if (seq body) (reader/read-string body) {}))
-    (catch js/Error e
+    (catch :default e
       (js/console.error :cfg-error e)
       {})))
 
@@ -23,7 +23,7 @@
   [cfg]
   (try
     (.writeFileSync fs cfg-path (pr-str cfg)) cfg
-    (catch js/Error e
+    (catch :default e
       (js/console.error :cfg-error e))))
 
 (defn set-item!

--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -166,7 +166,7 @@
                (fn [_ type & args]
                  (try
                    (js-invoke app type args)
-                   (catch js/Error e
+                   (catch :default e
                      (logger/error (str call-app-channel " " e))))))
 
       (.handle call-win-channel
@@ -174,7 +174,7 @@
                  (let [win (get-win-from-sender e)]
                    (try
                      (js-invoke win type args)
-                     (catch js/Error e
+                     (catch :default e
                        (logger/error (str call-win-channel " " e))))))))
 
     #(do (clear-win-effects!)
@@ -276,7 +276,7 @@
                                      (try
                                        (fs-watcher/close-watcher!)
                                        (search/close!)
-                                       (catch js/Error e
+                                       (catch :default e
                                          (logger/error "window-all-closed" e)))
                                      (.quit app)))
       (.on app "ready"

--- a/src/electron/electron/git.cljs
+++ b/src/electron/electron/git.cljs
@@ -46,7 +46,7 @@
   (try
     (let [p (.join path (state/get-graph-path) ".git")]
       (.isDirectory (fs/statSync p)))
-    (catch js/Error _e
+    (catch :default _e
       nil)))
 
 (defn remove-dot-git-file!
@@ -66,7 +66,7 @@
                      (string/includes? content ".logseq/")
                      (not (fs/existsSync dir-path)))
             (fs/unlinkSync p)))))
-    (catch js/Error e
+    (catch :default e
       (log-error e))))
 
 (defn init!

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -233,7 +233,7 @@
         (when-let [sync-meta (and (not (string/blank? root))
                                   (.toString (.readFileSync fs txid-path)))]
           (reader/read-string sync-meta))))
-    (catch js/Error e
+    (catch :default e
       (js/console.debug "[read txid meta] #" root (.-message e)))))
 
 (defmethod handle :inflateGraphsInfo [_win [_ graphs]]
@@ -316,7 +316,7 @@
       (let [path (path/join path dir)]
         (try
           (fs-extra/removeSync path)
-          (catch js/Error e
+          (catch :default e
             (logger/error "Clear cache:" e)))))
     (utils/send-to-renderer window "redirect" {:payload {:to :home}})))
 
@@ -352,7 +352,7 @@
                  (try
                    (and (fs-extra/pathExistsSync url)
                         (fs-extra/pathExistsSync (path/join url "package.json")))
-                   (catch js/Error _e false)))))
+                   (catch :default _e false)))))
 
 (defmethod handle :relaunchApp []
   (.relaunch app) (.quit app))
@@ -623,7 +623,7 @@
                    ;; exception -
                    ;; https://www.electronjs.org/docs/latest/breaking-changes#behavior-changed-sending-non-js-objects-over-ipc-now-throws-an-exception
                    (bean/->js (handle (or (utils/get-win-from-sender event) window) message)))
-                 (catch js/Error e
+                 (catch :default e
                    (when-not (contains? #{"mkdir" "stat"} (nth args-js 0))
                      (logger/error "IPC error: " {:event event
                                                   :args args-js}

--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -98,7 +98,7 @@
   (try
     (when (fs/existsSync path)
       (.toString (fs/readFileSync path)))
-    (catch js/Error e
+    (catch :default e
       (logger/error "Read file:" e))))
 
 (defn get-focused-window
@@ -109,7 +109,7 @@
   [^js evt]
   (try
     (.fromWebContents BrowserWindow (.-sender evt))
-    (catch js/Error _
+    (catch :default _
       nil)))
 
 (defn send-to-renderer

--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -111,7 +111,7 @@
 (defn- open-default-app!
   [url default-open]
   (let [URL (.-URL URL)
-        parsed-url (try (URL. url) (catch js/Error _ nil))]
+        parsed-url (try (URL. url) (catch :default _ nil))]
     (if (and parsed-url (contains? #{"https:" "http:" "mailto:"} (.-protocol parsed-url)))
       (.openExternal shell url)
       (when default-open (default-open url)))))

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1209,7 +1209,7 @@
              f (sci/eval-string fn-string)]
          (when (fn? f)
            (try (f query-result)
-                (catch js/Error e
+                (catch :default e
                   (js/console.error e)))))))
    [:span.warning
     (util/format "{{function %s}}" (first arguments))]))
@@ -2814,7 +2814,7 @@
                                    :colgroup
                                    (repeat number col-elem))))
                               col_groups)
-                        (catch js/Error _e
+                        (catch :default _e
                           []))
         head (when header
                [:thead (tr :th header)])
@@ -3042,7 +3042,7 @@
                (and (seq result) view-f)
                (let [result (try
                               (sci/call-fn view-f result)
-                              (catch js/Error error
+                              (catch :default error
                                 (log/error :custom-view-failed {:error error
                                                                 :result result})
                                 [:div "Custom view failed: "
@@ -3318,7 +3318,7 @@
 
       :else
       "")
-    (catch js/Error e
+    (catch :default e
       (println "Convert to html failed, error: " e)
       "")))
 

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -484,7 +484,7 @@
    (fn [state]
      (when-not (:editor/on-paste? @state/state)
        (try (editor-handler/handle-last-input)
-            (catch js/Error _e
+            (catch :default _e
               nil)))
      (state/set-state! :editor/on-paste? false)
      state)}

--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -677,5 +677,5 @@
 
           (state/pub-event! [:file-sync/onboarding-tip type])
           (state/set-state! [:file-sync/onboarding-state (keyword type)] true)))
-      (catch js/Error e
+      (catch :default e
         (js/console.warn "[onboarding SKIP] " (name type) e)))))

--- a/src/main/frontend/date.cljs
+++ b/src/main/frontend/date.cljs
@@ -66,7 +66,7 @@
     (->> (tf/parse (tf/formatters :date-time-no-ms) s)
         (t/to-default-time-zone)
         (tf/unparse (tf/formatter "MMM do, yyyy")))
-    (catch js/Error _e
+    (catch :default _e
       nil)))
 
 (def custom-formatter-2 (tf/formatter "yyyy-MM-dd-HH-mm-ss"))
@@ -112,7 +112,7 @@
 (defn journal-name-s [s]
   (try
     (journal-name (tf/parse (tf/formatter "yyyy-MM-dd") s))
-    (catch js/Error _e
+    (catch :default _e
       (log/info :parse-journal-date {:message  "Unable to parse date to journal name, skipping."
                                      :date-str s})
       nil)))
@@ -168,7 +168,7 @@
    (fn [formatter]
      (try
        (tf/parse (tf/formatter formatter) s)
-       (catch js/Error _e
+       (catch :default _e
          false)))
    (journal-title-formatters)))
 

--- a/src/main/frontend/db.cljs
+++ b/src/main/frontend/db.cljs
@@ -160,7 +160,7 @@
           _ (swap! conns assoc db-name db-conn)
           _ (when stored
               (let [stored-db (try (string->db stored)
-                                   (catch js/Error _e
+                                   (catch :default _e
                                      (js/console.warn "Invalid graph cache")
                                      (d/empty-db db-schema/schema)))
                     attached-db (d/db-with stored-db

--- a/src/main/frontend/db/outliner.cljs
+++ b/src/main/frontend/db/outliner.cljs
@@ -5,7 +5,7 @@
   [conn id]
   (try
     (d/pull @conn '[*] id)
-    (catch js/Error _e nil)))
+    (catch :default _e nil)))
 
 ;; key [:block/children parent-id]
 

--- a/src/main/frontend/db/query_react.cljs
+++ b/src/main/frontend/db/query_react.cljs
@@ -72,12 +72,12 @@
         (if-let [f (sci/eval-string (pr-str result-transform))]
           (try
             (sci/call-fn f result)
-            (catch js/Error e
+            (catch :default e
               (log/error :sci/call-error e)
               result))
           result)
         result))
-    (catch js/Error e
+    (catch :default e
       (log/error :query/failed e))))
 
 (defn- resolve-query

--- a/src/main/frontend/db/react.cljs
+++ b/src/main/frontend/db/react.cljs
@@ -348,7 +348,7 @@
                        (if (and custom? (not custom-query?))
                          (async/put! (state/get-reactive-custom-queries-chan) [f query])
                          (f)))
-                     (catch js/Error e
+                     (catch :default e
                        (js/console.error e)))))))))))))
 
 (defn set-key-value
@@ -378,7 +378,7 @@
             (do
               (async/<! (async/timeout 2000))
               (async/put! chan [f query])))
-          (catch js/Error error
+          (catch :default error
             (let [type :custom-query/failed]
               (js/console.error (str type "\n" query))
               (js/console.error error)))))

--- a/src/main/frontend/db/utils.cljs
+++ b/src/main/frontend/db/utils.cljs
@@ -66,7 +66,7 @@
        (d/pull db
                selector
                eid)
-       (catch js/Error _e
+       (catch :default _e
          nil)))))
 
 (defn pull-many
@@ -78,7 +78,7 @@
    (when-let [db (conn/get-db repo)]
      (try
        (d/pull-many db selector eids)
-       (catch js/Error e
+       (catch :default e
          (js/console.error e))))))
 
 (defn transact!

--- a/src/main/frontend/diff.cljs
+++ b/src/main/frontend/diff.cljs
@@ -68,6 +68,6 @@
 
           :else
           pos))
-      (catch js/Error e
+      (catch :default e
         (log/error :diff/find-position {:error e})
         (count markup)))))

--- a/src/main/frontend/extensions/excalidraw.cljs
+++ b/src/main/frontend/extensions/excalidraw.cljs
@@ -26,7 +26,7 @@
   (when-not (string/blank? text)
     (try
       (js/JSON.parse text)
-      (catch js/Error e
+      (catch :default e
         (println "from json error:")
         (js/console.dir e)
         (notification/show!

--- a/src/main/frontend/extensions/graph/pixi.cljs
+++ b/src/main/frontend/extensions/graph/pixi.cljs
@@ -176,13 +176,13 @@
           simulation                                                                (layout! nodes-js links-js)]
       (doseq [node nodes-js]
         (try (.addNode graph (.-id node) node)
-          (catch js/Error e
+          (catch :default e
             (js/console.error e))))
       (doseq [link links-js]
         (let [source (.-id (.-source link))
               target (.-id (.-target link))]
           (try (.addEdge graph source target link)
-            (catch js/Error e
+            (catch :default e
               (js/console.error e)))))
       (when-let [container-ref (:ref state)]
         (let [pixi-graph (new (.-PixiGraph Pixi-Graph)
@@ -199,6 +199,6 @@
             (register-handlers-fn pixi-graph))
           (set-up-listeners! pixi-graph)
           (.on simulation "tick" (tick! pixi-graph graph nodes-js links-js)))))
-    (catch js/Error e
+    (catch :default e
       (js/console.error e)))
   state)

--- a/src/main/frontend/extensions/latex.cljs
+++ b/src/main/frontend/extensions/latex.cljs
@@ -24,7 +24,7 @@
                               :throwOnError false
                               :strict false}))
 
-      (catch js/Error e
+      (catch :default e
         (js/console.error e)))))
 
 (defn- load-and-render!

--- a/src/main/frontend/extensions/pdf/utils.cljs
+++ b/src/main/frontend/extensions/pdf/utils.cljs
@@ -173,13 +173,13 @@
   []
   (try
     (js-invoke js/window.lsPdfViewer "nextPage")
-    (catch js/Error _e nil)))
+    (catch :default _e nil)))
 
 (defn prev-page
   []
   (try
     (js-invoke js/window.lsPdfViewer "previousPage")
-    (catch js/Error _e nil)))
+    (catch :default _e nil)))
 
 (comment
  (fix-selection-text-breakline "this is a\ntest paragraph")

--- a/src/main/frontend/extensions/sci.cljs
+++ b/src/main/frontend/extensions/sci.cljs
@@ -17,7 +17,7 @@
                                    'isNaN js/isNaN
                                    'log js/console.log
                                    'pprint util/pp-str}})
-    (catch js/Error e
+    (catch :default e
       (println "Query: sci eval failed:")
       (js/console.error e))))
 

--- a/src/main/frontend/extensions/srs.cljs
+++ b/src/main/frontend/extensions/srs.cljs
@@ -558,7 +558,7 @@
               count (count result)]
           (reset! cards-total count)
           count)))
-    (catch js/Error e
+    (catch :default e
       (js/console.error e) 0)))
 
 (declare cards)

--- a/src/main/frontend/format/mldoc.cljs
+++ b/src/main/frontend/format/mldoc.cljs
@@ -45,7 +45,7 @@
       {}
       (let [[headers blocks] (-> content (parse-opml) (gp-util/json->clj))]
         [headers (gp-mldoc/collect-page-properties blocks config)]))
-    (catch js/Error e
+    (catch :default e
       (log/error :edn/convert-failed e)
       [])))
 

--- a/src/main/frontend/fs/watcher_handler.cljs
+++ b/src/main/frontend/fs/watcher_handler.cljs
@@ -24,7 +24,7 @@
     (doseq [block-id (block-ref/get-all-block-ref-ids content)]
       (when-let [block (try
                          (model/get-block-by-uuid block-id)
-                         (catch js/Error _e
+                         (catch :default _e
                            nil))]
         (let [id-property (:id (:block/properties block))]
           (when-not (= (str id-property) (str block-id))

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -234,7 +234,7 @@
 
             :else
             nil))
-        (catch js/Error e
+        (catch :default e
           (js/console.error e))
         (finally
           (reset! *show-left-menu? false)

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -293,7 +293,7 @@
                           :else
                           content)]
         new-content)
-      (catch js/Error _e
+      (catch :default _e
         content))
     content))
 
@@ -1292,7 +1292,7 @@
                       (not= (string/trim db-content-without-heading)
                             (string/trim value)))
                  (save-block-aux! db-block value opts))))
-           (catch js/Error error
+           (catch :default error
              (log/error :save-block-failed error))))))))
 
 (defn- clean-content!
@@ -1605,7 +1605,7 @@
               @commands/*initial-commands)
          (and last-command
               (commands/get-matched-commands last-command)))))
-    (catch js/Error e
+    (catch :default e
       (js/console.error e)
       nil)))
 
@@ -1625,7 +1625,7 @@
               (commands/get-matched-commands
                last-command
                (commands/block-commands-map))))))
-    (catch js/Error _error
+    (catch :default _error
       nil)))
 
 (defn auto-complete?

--- a/src/main/frontend/handler/editor/lifecycle.cljs
+++ b/src/main/frontend/handler/editor/lifecycle.cljs
@@ -20,7 +20,7 @@
 
     ;; try to close all opened dropdown menu
     (when-let [close-fns (vals (sub :modal/dropdowns))]
-      (try (doseq [f close-fns] (f)) (catch js/Error _e ())))
+      (try (doseq [f close-fns] (f)) (catch :default _e ())))
 
     (when-let [element (gdom/getElement id)]
       (.focus element)

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -678,7 +678,7 @@
       (let [payload (async/<! chan)]
         (try
           (handle payload)
-          (catch js/Error error
+          (catch :default error
             (let [type :handle-system-events/failed]
               (js/console.error (str type) (clj->js payload) "\n" error)
               (state/pub-event! [:instrument {:type    type

--- a/src/main/frontend/handler/external.cljs
+++ b/src/main/frontend/handler/external.cljs
@@ -118,7 +118,7 @@
     (try (page/create! title {:redirect?  false
                               :format     page-format
                               :uuid       uuid})
-         (catch js/Error e
+         (catch :default e
            (notification/show! (str "Error happens when creating page " title ":\n"
                                     e
                                     "\nSkipped and continue the remaining import.") :error)))
@@ -130,7 +130,7 @@
                                        {:target-block first-child
                                         :sibling?     true
                                         :keep-uuid?   true})
-             (catch js/Error e
+             (catch :default e
                (notification/show! (str "Error happens when creating block content of page " title "\n"
                                         e
                                         "\nSkipped and continue the remaining import.") :error))))))

--- a/src/main/frontend/handler/image.cljs
+++ b/src/main/frontend/handler/image.cljs
@@ -49,7 +49,7 @@
              (fn [error]
                (println "Can't read local image file: ")
                (js/console.dir error))))))
-      (catch js/Error _e
+      (catch :default _e
         nil))))
 
 (defn request-presigned-url

--- a/src/main/frontend/handler/metadata.cljs
+++ b/src/main/frontend/handler/metadata.cljs
@@ -23,7 +23,7 @@
         (let [metadata-str (or file-content default-metadata-str)
               metadata (try
                          (reader/read-string metadata-str)
-                         (catch js/Error e
+                         (catch :default e
                            (println "Parsing metadata.edn failed: ")
                            (js/console.dir e)
                            {}))

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -694,7 +694,7 @@
   (let [properties (db/get-page-properties page-name)
         properties-str (get properties :filters "{}")]
     (try (reader/read-string properties-str)
-         (catch js/Error e
+         (catch :default e
            (log/error :syntax/filters e)))))
 
 (defn save-filter!

--- a/src/main/frontend/handler/plugin.cljs
+++ b/src/main/frontend/handler/plugin.cljs
@@ -35,7 +35,7 @@
   [type & args]
   (try
     (apply js-invoke (aget js/window.logseq "api") type args)
-    (catch js/Error e (js/console.error e))))
+    (catch :default e (js/console.error e))))
 
 ;; state handlers
 (defonce central-endpoint "https://raw.githubusercontent.com/logseq/marketplace/master/")
@@ -153,7 +153,7 @@
   [id]
   (try
     (js/LSPluginCore.ensurePlugin (name id))
-    (catch js/Error _e
+    (catch :default _e
       nil)))
 
 (defn open-updates-downloading
@@ -431,7 +431,7 @@
                             matched)))
                       content)]
         (format/to-html content :markdown (gp-mldoc/default-config :markdown))))
-    (catch js/Error e
+    (catch :default e
       (log/error :parse-user-md-exception e)
       content)))
 
@@ -472,7 +472,7 @@
                    (bean/->js (normalize-keyword-for-json payload))
                    payload)
                  (if (keyword? plugin-id) (name plugin-id) plugin-id))
-      (catch js/Error e
+      (catch :default e
         (js/console.error "[Hook Plugin Err]" e)))))
 
 (defn hook-plugin-app

--- a/src/main/frontend/handler/repo.cljs
+++ b/src/main/frontend/handler/repo.cljs
@@ -163,7 +163,7 @@
                            (remove nil?))]
              (when (seq metadata)
                (db/transact! repo metadata {:new-graph? true}))))))
-     (catch js/Error e
+     (catch :default e
        (log/error :exception e)))))
 
 (defn update-pages-metadata!

--- a/src/main/frontend/handler/ui.cljs
+++ b/src/main/frontend/handler/ui.cljs
@@ -166,7 +166,7 @@
                         (try
                           (js/eval scripts)
                           (execed)
-                          (catch js/Error e
+                          (catch :default e
                             (js/console.error "[custom js]" e)))))))))))))))
 
 (defn toggle-wide-mode!

--- a/src/main/frontend/mixins.cljs
+++ b/src/main/frontend/mixins.cljs
@@ -50,7 +50,7 @@
           (listen state js/window "visibilitychange"
                   (fn [e]
                     (on-hide state e :visibilitychange))))))
-    (catch js/Error _e
+    (catch :default _e
       ;; TODO: Unable to find node on an unmounted component.
       nil)))
 

--- a/src/main/frontend/modules/datascript_report/core.cljs
+++ b/src/main/frontend/modules/datascript_report/core.cljs
@@ -8,7 +8,7 @@
   [db selector eid]
   (try
     (d/pull db selector eid)
-    (catch js/Error e
+    (catch :default e
       (js/console.error e)
       nil)))
 

--- a/src/main/frontend/modules/instrumentation/posthog.cljs
+++ b/src/main/frontend/modules/instrumentation/posthog.cljs
@@ -51,7 +51,7 @@
 (defn capture [id data]
   (try
     (posthog/capture (str id) (bean/->js data))
-    (catch js/Error e
+    (catch :default e
       (js/console.error e)
       ;; opt out or network issues
       nil)))

--- a/src/main/frontend/modules/outliner/datascript.cljc
+++ b/src/main/frontend/modules/outliner/datascript.cljc
@@ -76,6 +76,6 @@
                                        (map next))]
                  (assert (= (count left&parent-list) (count (distinct left&parent-list))) eids)))
              rs)
-           (catch js/Error e
+           (catch :default e
              (log/error :exception e)
              (throw e)))))))

--- a/src/main/frontend/modules/outliner/file.cljs
+++ b/src/main/frontend/modules/outliner/file.cljs
@@ -37,7 +37,7 @@
     (when-not config/publishing?
       (doseq [[repo page-id] (set pages)]
         (try (do-write-file! repo page-id)
-             (catch js/Error e
+             (catch :default e
                (notification/show!
                 [:div
                  [:p "Write file failed, please copy the changes to other editors in case of losing data."]

--- a/src/main/frontend/modules/shortcut/core.cljs
+++ b/src/main/frontend/modules/shortcut/core.cljs
@@ -66,7 +66,7 @@
            (try
              (log/debug :shortcut/register-shortcut {:id id :binding k})
              (.registerShortcut handler (util/keyname id) (dh/normalize-user-keyname k))
-             (catch js/Object e
+             (catch :default e
                (log/error :shortcut/register-shortcut {:id      id
                                                        :binding k
                                                        :error   e})

--- a/src/main/frontend/modules/shortcut/data_helper.cljs
+++ b/src/main/frontend/modules/shortcut/data_helper.cljs
@@ -166,7 +166,7 @@
           shortcut-m    (shortcut-map handler-id)
           parse-shortcut #(try
                            (KeyboardShortcutHandler/parseStringShortcut %)
-                           (catch js/Error e
+                           (catch :default e
                              (js/console.error "[shortcut/parse-error]" (str % " - " (.-message e)))))
           bindings      (->> (shortcut-binding k)
                              (map mod-key)

--- a/src/main/frontend/page.cljs
+++ b/src/main/frontend/page.cljs
@@ -17,7 +17,7 @@
   (try
     (comp
      (ui/setup-active-keystroke!))
-    (catch js/Error _e
+    (catch :default _e
       nil)))
 
 (rum/defc helpful-default-error-screen

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -289,7 +289,7 @@
   (let [time-fn (fn []
                   (try
                     (util/time-ago input)
-                    (catch js/Error e
+                    (catch :default e
                       (js/console.error e)
                       input)))
         [time set-time] (rum/use-state (time-fn))]
@@ -369,11 +369,11 @@
   []
   (let [^js schemaMedia (js/window.matchMedia "(prefers-color-scheme: dark)")]
     (try (.addEventListener schemaMedia "change" state/sync-system-theme!)
-         (catch js/Error _error
+         (catch :default _error
            (.addListener schemaMedia state/sync-system-theme!)))
     (state/sync-system-theme!)
     #(try (.removeEventListener schemaMedia "change" state/sync-system-theme!)
-          (catch js/Error _error
+          (catch :default _error
             (.removeListener schemaMedia state/sync-system-theme!)))))
 
 (defn set-global-active-keystroke [val]
@@ -894,7 +894,7 @@
                                   (html)
                                   [:div.px-2.py-1
                                    html]))
-                              (catch js/Error e
+                              (catch :default e
                                 (log/error :exception e)
                                 [:div])))
                           [:div {:key "tippy"} ""])))

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -568,12 +568,12 @@
      ([input text start end]
       (try
         (.setRangeText input text start end)
-        (catch js/Error _e
+        (catch :default _e
           nil)))
      ([input text start end select-mode]
       (try
         (.setRangeText input text start end select-mode)
-        (catch js/Error _e
+        (catch :default _e
           nil)))))
 
 #?(:cljs
@@ -587,7 +587,7 @@
            (let [^js splitter (GraphemeSplitter.)
                  ^js input (.splitGraphemes splitter input)]
              (- current-pos (.-length (.pop input))))
-           (catch js/Error e
+           (catch :default e
              (js/console.error e)
              (dec current-pos))))
        (dec current-pos))))
@@ -603,7 +603,7 @@
            (let [^js splitter (GraphemeSplitter.)
                  ^js input (.splitGraphemes splitter input)]
              (+ current-pos (.-length (.shift input))))
-           (catch js/Error e
+           (catch :default e
              (js/console.error e)
              (inc current-pos))))
        (inc current-pos))))
@@ -880,7 +880,7 @@
      [path]
      (try
        (js/window.apis.isAbsolutePath path)
-       (catch js/Error _
+       (catch :default _
          (utils/win32 path)))))
 
 (defn default-content-with-title

--- a/src/main/frontend/util/clock.cljs
+++ b/src/main/frontend/util/clock.cljs
@@ -77,7 +77,7 @@
               (str clock-in-log "\n")
               (str clock-out-log "\n"))))))
      content)
-    (catch js/Error _e
+    (catch :default _e
       content)))
 
 (defn clock-summary

--- a/src/main/frontend/util/drawer.cljs
+++ b/src/main/frontend/util/drawer.cljs
@@ -81,7 +81,7 @@
                       :else
                       content)]
         (string/trimr result))
-      (catch js/Error e
+      (catch :default e
         (js/console.error e)
         content))))
 

--- a/src/main/frontend/util/persist_var.cljs
+++ b/src/main/frontend/util/persist_var.cljs
@@ -41,7 +41,7 @@
                          (fn [content]
                            (when (not-empty content)
                              (try (cljs.reader/read-string content)
-                                  (catch js/Error e
+                                  (catch :default e
                                     (println (util/format "read persist-var failed: %s" (load-path location)))
                                     (js/console.dir e)))))
                          (fn [value]

--- a/src/main/logseq/api.cljs
+++ b/src/main/logseq/api.cljs
@@ -60,7 +60,7 @@
   (when (string? input)
     (try
       (sci/eval-string input {:preset :termination-safe})
-      (catch js/Error e
+      (catch :default e
         (js/console.error "[parse hiccup error]" e) input))))
 
 (defn ^:export install-plugin-hook


### PR DESCRIPTION
This is the encouraged practice for default error handling with cljs as `js/Error` won't catch everything that is thrown. See https://clojure.atlassian.net/browse/CLJS-661 and https://quire.io/w/Logseq-_team_dedicated_to_sport_of_knowledge/1377/Use_catch_default_for_default_error_handling?sublist=Cycle_14_End_2022-09-30&view=board for more info.

I see we also throw with `js/Error` over `ex-info`. Advantages of `ex-info` are having a finer grained catch and can add any metadata to the error. Something to keep in mind for future throws