### PR TITLE
Fix: Container scrolling on sidebar editing

### DIFF
--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -40,8 +40,13 @@
        (-write writer (str "\"" (.toString sym) "\"")))))
 
 #?(:cljs (defonce ^js node-path utils/nodePath))
-#?(:cljs (defn app-scroll-container-node []
-           (gdom/getElement "main-content-container")))
+#?(:cljs (defn app-scroll-container-node
+           ([]
+            (gdom/getElement "main-content-container"))
+           ([el]
+            (if (.closest el "#main-content-container")
+              (app-scroll-container-node)
+              (gdom/getElementByClass "sidebar-item-list")))))
 
 #?(:cljs
    (defn safe-re-find
@@ -1300,7 +1305,7 @@
              header-height (-> (gdom/getElementByClass "cp__header")
                                .-clientHeight)
 
-             main-node   (app-scroll-container-node)
+             main-node   (app-scroll-container-node el)
              scroll-top  (.-scrollTop main-node)
 
              current-pos (get-selection-start el)
@@ -1326,7 +1331,7 @@
 
            (< cursor-y header-height)
            (let [_ (.scrollIntoView el true)
-                 main-node (app-scroll-container-node)
+                 main-node (app-scroll-container-node el)
                  scroll-top (.-scrollTop main-node)]
              (set! (.-scrollTop main-node) (- scroll-top (/ vw-height 4))))
 


### PR DESCRIPTION
While activating/deactivating/editing a block, we are calling `util/scroll-editor-cursor` which calculates and sets the `scrollTop` of  `#main-content-container`. The problem is that we might be editing a block within the sidebar. To fix this, we can pass the editing element ref to `app-scroll-container-node` and check if `#main-content-container` is a parent element using [closest](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest). If not, the scrolling parent should be the `.sidebar-item-list`.

**To consistently reproduce the issue, you need to edit a bock at the bottom of the right sidebar and have a long scrollable  page loaded on the main container.**

Resolves https://github.com/logseq/logseq/issues/6470 