### PR TITLE
fix: cancel previous requests when sync needs to download/upload

### DIFF
--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -500,9 +500,6 @@
           ;; options
           {:outer-header
            [:<>
-            (ui/button "stop syncing"
-                       :on-click (fn []
-                                   (fs-sync/rsapi-cancel-all-requests)))
             (when (util/electron?)
               (indicator-progress-pane
                sync-state sync-progress

--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -306,11 +306,8 @@
            (ui/icon "chevron-left" {:style {:font-size 24}}))])]]))
 
 (defn- sort-files
-  [progress files]
-  (sort-by (fn [f]
-             (let [percent (or (:percent (get progress f)) 0)]
-               (if (= percent 100) -1 percent)))
-           > files))
+  [files]
+  (sort-by (fn [f] (or (:size f) 0)) > files))
 
 (rum/defcs ^:large-vars/cleanup-todo indicator <
   rum/reactive
@@ -331,8 +328,8 @@
         sync-progress           (state/sub [:file-sync/progress (second @fs-sync/graphs-txid)])
         _                       (rum/react file-sync-handler/refresh-file-sync-component)
         synced-file-graph?      (file-sync-handler/synced-file-graph? current-repo)
-        uploading-files         (sort-files sync-progress (:current-local->remote-files sync-state))
-        downloading-files       (sort-files sync-progress (:current-remote->local-files sync-state))
+        uploading-files         (sort-files (:current-local->remote-files sync-state))
+        downloading-files       (sort-files (:current-remote->local-files sync-state))
         queuing-files           (:queued-local->remote-files sync-state)
         history-files           (:history sync-state)
         status                  (:state sync-state)

--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -528,7 +528,6 @@
    [:h1.mb-5.text-2xl.text-center.font-bold "Sync a remote graph to local"]
 
    [:div.folder-tip.flex.flex-col.items-center
-    {:style {:border-bottom-right-radius 0 :border-bottom-left-radius 0}}
     [:h3
      [:span.flex.space-x-2.leading-none.pb-1
       (ui/icon "cloud-lock")
@@ -537,44 +536,46 @@
       [:span (ui/icon "folder")]]]
     [:h4.px-2.-mb-1.5 [:strong "UUID: "] (:GraphUUID graph)]]
 
-   [:div.-mt-1
-    (ui/button
-      "Open a local directory"
-      :class "w-full rounded-t-none py-4"
-      :on-click #(do
-                   (state/close-modal!)
-                   (fs-sync/<sync-stop)
-                   (->
-                    (page-handler/ls-dir-files!
-                     (fn [{:keys [url]}]
-                       (file-sync-handler/init-remote-graph url graph)
-                       (js/setTimeout (fn [] (repo-handler/refresh-repos!)) 200))
+   (ui/button
+     "Open a local directory"
+     :class "block w-full py-4 mt-4"
+     :on-click #(do
+                  (state/close-modal!)
+                  (fs-sync/<sync-stop)
+                  (->
+                   (page-handler/ls-dir-files!
+                    (fn [{:keys [url]}]
+                      (file-sync-handler/init-remote-graph url graph)
+                      (js/setTimeout (fn [] (repo-handler/refresh-repos!)) 200))
 
-                     {:empty-dir?-or-pred
-                      (fn [ret]
-                        (let [empty-dir? (nil? (second ret))]
-                          (if-let [root (first ret)]
+                    {:empty-dir?-or-pred
+                     (fn [ret]
+                       (let [empty-dir? (nil? (second ret))]
+                         (if-let [root (first ret)]
 
-                            ;; verify directory
-                            (-> (if empty-dir?
-                                  (p/resolved nil)
-                                  (if (util/electron?)
-                                    (ipc/ipc :readGraphTxIdInfo root)
-                                    (fs-util/read-graphs-txid-info root)))
+                           ;; verify directory
+                           (-> (if empty-dir?
+                                 (p/resolved nil)
+                                 (if (util/electron?)
+                                   (ipc/ipc :readGraphTxIdInfo root)
+                                   (fs-util/read-graphs-txid-info root)))
 
-                                (p/then (fn [^js info]
-                                          (when (and (not empty-dir?)
-                                                     (or (nil? info)
-                                                         (nil? (second info))
-                                                         (not= (second info) (:GraphUUID graph))))
-                                            (if (js/confirm "This directory is not empty, are you sure to sync the remote graph to it? Make sure to back up the directory first.")
-                                              (p/resolved nil)
-                                              (throw (js/Error. nil)))))))
+                               (p/then (fn [^js info]
+                                         (when (and (not empty-dir?)
+                                                    (or (nil? info)
+                                                        (nil? (second info))
+                                                        (not= (second info) (:GraphUUID graph))))
+                                           (if (js/confirm "This directory is not empty, are you sure to sync the remote graph to it? Make sure to back up the directory first.")
+                                             (p/resolved nil)
+                                             (throw (js/Error. nil)))))))
 
-                            ;; cancel pick a directory
-                            (throw (js/Error. nil)))))})
-                    (p/catch (fn [])))))
-    [:p.text-xs.opacity-50.px-1 (ui/icon "alert-circle") " An empty directory or an existing remote graph!"]]])
+                           ;; cancel pick a directory
+                           (throw (js/Error. nil)))))})
+                   (p/catch (fn [])))))
+
+   [:div.text-xs.opacity-50.px-1.flex-row.flex.items-center.p-2
+    (ui/icon "alert-circle")
+    [:span.ml-1 " An empty directory or an existing remote graph!"]]])
 
 (defn pick-dest-to-sync-panel [graph]
   (fn []

--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -525,16 +525,8 @@
   [:div.cp__file-sync-related-normal-modal
    [:div.flex.justify-center.pb-4 [:span.icon-wrap (ui/icon "cloud-download")]]
 
-   [:h1.mb-5.text-2xl.text-center.font-bold "Sync a remote graph to local"]
-
-   [:div.folder-tip.flex.flex-col.items-center
-    [:h3
-     [:span.flex.space-x-2.leading-none.pb-1
-      (ui/icon "cloud-lock")
-      [:span (:GraphName graph)]
-      [:span.scale-75 (ui/icon "arrow-right")]
-      [:span (ui/icon "folder")]]]
-    [:h4.px-2.-mb-1.5 [:strong "UUID: "] (:GraphUUID graph)]]
+   [:h1.mb-5.text-2xl.text-center.font-bold (util/format "Sync graph \"%s\" to local"
+                                                         (:GraphName graph))]
 
    (ui/button
      "Open a local directory"

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -162,12 +162,13 @@
      state/set-state! :sync-graph/init? false)))
 
 (defmethod handle :graph/switch [[_ graph opts]]
-  (if (or (not (false? (get @outliner-file/*writes-finished? graph)))
-          (:sync-graph/init? @state/state))
-    (graph-switch-on-persisted graph opts)
-    (notification/show!
-     "Please wait seconds until all changes are saved for the current graph."
-     :warning)))
+  (let [opts (if (false? (:persist? opts)) opts (assoc opts :persist? true))]
+    (if (or (not (false? (get @outliner-file/*writes-finished? graph)))
+           (:sync-graph/init? @state/state))
+      (graph-switch-on-persisted graph opts)
+     (notification/show!
+      "Please wait seconds until all changes are saved for the current graph."
+      :warning))))
 
 (defmethod handle :graph/pick-dest-to-sync [[_ graph]]
   (state/set-modal!

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -233,24 +233,24 @@
 
      ;; file-sync
      :file-sync/jstour-inst                   nil
-     :file-sync/remote-graphs               {:loading false :graphs nil}
-     :file-sync/sync-manager                nil
-     :file-sync/sync-state-manager          nil
-     :file-sync/sync-state                  nil
-     :file-sync/sync-uploading-files        nil
-     :file-sync/sync-downloading-files      nil
      :file-sync/onboarding-state            (or (storage/get :file-sync/onboarding-state)
                                                 {:welcome false})
 
-     :encryption/graph-parsing?             false
-
-     :ui/loading?                           {}
+     :file-sync/remote-graphs               {:loading false :graphs nil}
+     :file-sync/sync-manager                nil
+     :file-sync/sync-state                  nil
+     :file-sync/sync-uploading-files        nil
+     :file-sync/sync-downloading-files      nil
      :file-sync/set-remote-graph-password-result {}
      ;; graph-uuid -> {file-path -> payload}
      :file-sync/progress                    {}
      :file-sync/start                       {}
      ;; graph -> epoch
      :file-sync/last-synced-at              {}
+
+     :encryption/graph-parsing?             false
+
+     :ui/loading?                           {}
      :feature/enable-sync?                  (storage/get :logseq-sync-enabled)
 
      :file/rename-event-chan                (async/chan 100)


### PR DESCRIPTION
This can avoid running multiple downloads/uploads at the same time.