### PR TITLE
Refactor/graph separated state

### DIFF
--- a/src/main/electron/listener.cljs
+++ b/src/main/electron/listener.cljs
@@ -54,8 +54,7 @@
   (js/window.apis.on "file-sync-progress"
                      (fn [data]
                        (let [payload (bean/->clj data)]
-                         (state/set-state! [:file-sync/progress (:graphUUID payload) (:file payload)] payload)
-                         nil)))
+                         (state/set-state! [:file-sync/graph-state (:graphUUID payload) :file-sync/progress (:file payload)] payload))))
 
   (js/window.apis.on "notification"
                      (fn [data]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -206,7 +206,7 @@
                         *loading? (::loading? state)
                         *exist? (::exist? state)]
                     (when (and sync-on? asset-file? (false? @*exist?))
-                      (let [sync-state (state/sub [:file-sync/sync-state (state/get-current-repo)])
+                      (let [sync-state (state/get-file-sync-state (state/get-current-file-sync-graph-uuid))
                             downloading-files (:current-remote->local-files sync-state)
                             contain-url? (and (seq downloading-files)
                                               (some #(string/ends-with? src %) downloading-files))]
@@ -220,7 +220,7 @@
                             (reset! *loading? false))))))
                   state)}
   [state src content-fn]
-  (let [_ (state/sub [:file-sync/sync-state (state/get-current-repo)])
+  (let [_ (state/sub-file-sync-state (state/get-current-file-sync-graph-uuid))
         exist? @(::exist? state)
         loading? @(::loading? state)
         asset-file? (::asset-file? state)

--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -324,8 +324,11 @@
         enabled-progress-panel? (util/electron?)
         current-repo            (state/get-current-repo)
         creating-remote-graph?  (state/sub [:ui/loading? :graph/create-remote?])
-        sync-state              (state/get-file-sync-state (state/get-current-file-sync-graph-uuid))
-        sync-progress           (state/sub [:file-sync/progress (second @fs-sync/graphs-txid)])
+        current-graph-id        (state/get-current-file-sync-graph-uuid)
+        sync-state              (state/get-file-sync-state current-graph-id)
+        sync-progress           (state/sub [:file-sync/graph-state
+                                            current-graph-id
+                                            :file-sync/progress])
         _                       (rum/react file-sync-handler/refresh-file-sync-component)
         synced-file-graph?      (file-sync-handler/synced-file-graph? current-repo)
         uploading-files         (sort-files (:current-local->remote-files sync-state))

--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -360,7 +360,7 @@
                                  (fn []
                                    (when-not (file-sync-handler/current-graph-sync-on?)
                                      (async/go
-                                       (let [graphs-txid (fs-sync/get-graphs-txid)]
+                                       (let [graphs-txid fs-sync/graphs-txid]
                                          (async/<! (p->c (persist-var/-load graphs-txid)))
                                          (cond
                                            @*beta-unavailable?
@@ -376,7 +376,9 @@
                                                 (second @graphs-txid)
                                                 (fs-sync/graph-sync-off? (second @graphs-txid))
                                                 (async/<! (fs-sync/<check-remote-graph-exists (second @graphs-txid))))
-                                           (fs-sync/sync-start)
+                                           (do
+                                             (prn "sync start")
+                                             (fs-sync/sync-start))
 
                                            ;; remote graph already has been deleted, clear repos first, then create-remote-graph
                                            synced-file-graph?  ; <check-remote-graph-exists -> false

--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -326,7 +326,7 @@
         enabled-progress-panel? (util/electron?)
         current-repo            (state/get-current-repo)
         creating-remote-graph?  (state/sub [:ui/loading? :graph/create-remote?])
-        current-graph-id        (state/get-current-file-sync-graph-uuid)
+        current-graph-id        (state/sub-current-file-sync-graph-uuid)
         sync-state              (state/sub-file-sync-state current-graph-id)
         sync-progress           (state/sub [:file-sync/graph-state
                                             current-graph-id
@@ -516,11 +516,7 @@
             (when (and
                    (not enabled-progress-panel?)
                    synced-file-graph? queuing?)
-              [:div.head-ctls (sync-now)])
-
-            ;(when config/dev?
-            ;  [:strong.debug-status (str status)])
-            ]}))])))
+              [:div.head-ctls (sync-now)])]}))])))
 
 (rum/defc pick-local-graph-for-sync [graph]
   [:div.cp__file-sync-related-normal-modal

--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -324,7 +324,7 @@
         enabled-progress-panel? (util/electron?)
         current-repo            (state/get-current-repo)
         creating-remote-graph?  (state/sub [:ui/loading? :graph/create-remote?])
-        sync-state              (state/sub [:file-sync/sync-state current-repo])
+        sync-state              (state/get-file-sync-state (state/get-current-file-sync-graph-uuid))
         sync-progress           (state/sub [:file-sync/progress (second @fs-sync/graphs-txid)])
         _                       (rum/react file-sync-handler/refresh-file-sync-component)
         synced-file-graph?      (file-sync-handler/synced-file-graph? current-repo)
@@ -367,8 +367,8 @@
                                          nil
 
                                          (and synced-file-graph?
-                                              (fs-sync/graph-sync-off? current-repo)
                                               (second @fs-sync/graphs-txid)
+                                              (fs-sync/graph-sync-off? (second @fs-sync/graphs-txid))
                                               (async/<! (fs-sync/<check-remote-graph-exists (second @fs-sync/graphs-txid))))
                                          (do
                                            (prn "sync start")

--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -360,7 +360,7 @@
                                  (fn []
                                    (when-not (file-sync-handler/current-graph-sync-on?)
                                      (async/go
-                                       (let [graphs-txid fs-sync/graphs-txid]
+                                       (let [graphs-txid (fs-sync/get-graphs-txid)]
                                          (async/<! (p->c (persist-var/-load graphs-txid)))
                                          (cond
                                            @*beta-unavailable?
@@ -376,9 +376,7 @@
                                                 (second @graphs-txid)
                                                 (fs-sync/graph-sync-off? (second @graphs-txid))
                                                 (async/<! (fs-sync/<check-remote-graph-exists (second @graphs-txid))))
-                                           (do
-                                             (prn "sync start")
-                                             (fs-sync/sync-start))
+                                           (fs-sync/sync-start)
 
                                            ;; remote graph already has been deleted, clear repos first, then create-remote-graph
                                            synced-file-graph?  ; <check-remote-graph-exists -> false

--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -178,7 +178,9 @@
 
 (rum/defc last-synced-cp < rum/reactive
   []
-  (let [last-synced-at (state/sub [:file-sync/last-synced-at (state/get-current-repo)])
+  (let [last-synced-at (state/sub [:file-sync/graph-state
+                                   (state/get-current-file-sync-graph-uuid)
+                                   :file-sync/last-synced-at])
         last-synced-at (if last-synced-at
                          (util/time-ago (tc/from-long (* last-synced-at 1000)))
                          "just now")]

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -182,13 +182,7 @@
 (def ws-addr config/WS-URL)
 
 ;; Warning: make sure to `persist-var/-load` graphs-txid before using it.
-(def graphs-txid (persist-var/persist-var nil "graphs-txid"))
-
-(defn get-graphs-txid
-  [graph-uuid]
-  ;; (when graph-uuid
-  ;;   (get @state/state [:file-sync/graph-state graph-uuid ]))
-  )
+(defonce graphs-txid (persist-var/persist-var nil "graphs-txid"))
 
 (declare assert-local-txid<=remote-txid)
 (defn <update-graphs-txid!
@@ -2970,8 +2964,7 @@
                     (offer! full-sync-chan true)))))
             (catch :default e
               (prn "Sync start error: ")
-              (log/error :exception e)))))))
-  )
+              (log/error :exception e))))))))
 
 ;;; ### some add-watches
 

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -2857,10 +2857,6 @@
     (reset! current-sm-graph-uuid graph-uuid)
     (sync-manager user-uuid graph-uuid base-path repo txid *sync-state)))
 
-(defn clear-graph-progress!
-  [graph-uuid]
-  (state/set-state! [:file-sync/progress graph-uuid] {}))
-
 (defn <sync-stop []
   (go
     (when-let [sm ^SyncManager (state/get-file-sync-manager (state/get-current-file-sync-graph-uuid))]
@@ -2870,9 +2866,7 @@
 
       (<! (-stop! sm))
 
-      (println "[SyncManager" (:graph-uuid sm) "]" "stopped")
-
-      (clear-graph-progress! (:graph-uuid sm)))
+      (println "[SyncManager" (:graph-uuid sm) "]" "stopped"))
 
     (reset! current-sm-graph-uuid nil)))
 
@@ -2948,7 +2942,6 @@
             (try
               (when-not (get @*sync-starting? graph-uuid)
                 (swap! *sync-starting? assoc graph-uuid true)
-                (clear-graph-progress! graph-uuid)
 
                 (when-some [sm (sync-manager-singleton current-user-uuid graph-uuid
                                                        (config/get-repo-dir repo) repo

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -2863,7 +2863,7 @@
 
 (defn <sync-stop []
   (go
-    (when-let [sm ^SyncManager (state/get-file-sync-manager)]
+    (when-let [sm ^SyncManager (state/get-file-sync-manager (state/get-current-file-sync-graph-uuid))]
       (println "[SyncManager" (:graph-uuid sm) "]" "stopping")
 
       (state/clear-file-sync-state! (:graph-uuid sm))
@@ -2871,14 +2871,14 @@
       (<! (-stop! sm))
 
       (println "[SyncManager" (:graph-uuid sm) "]" "stopped")
-      (state/set-file-sync-manager nil)
+
       (clear-graph-progress! (:graph-uuid sm)))
 
     (reset! current-sm-graph-uuid nil)))
 
 (defn sync-need-password!
   []
-  (when-let [sm ^SyncManager (state/get-file-sync-manager)]
+  (when-let [sm ^SyncManager (state/get-file-sync-manager (state/get-current-file-sync-graph-uuid))]
     (.need-password sm)))
 
 (defn check-graph-belong-to-current-user

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -181,35 +181,28 @@
 
 (def ws-addr config/WS-URL)
 
+;; Warning: make sure to `persist-var/-load` graphs-txid before using it.
+(def graphs-txid (persist-var/persist-var nil "graphs-txid"))
+
 (defn get-graphs-txid
-  ([]
-   (let [result (persist-var/persist-var nil "graphs-txid")]
-     (p/let [_ (persist-var/-load result)]
-       (when-let [graph-uuid (second @result)]
-         (state/set-state! [:file-sync/graph-state graph-uuid :graphs-txid] result)))
-     result))
-  ([graph-uuid]
-   (when graph-uuid
-     (let [result (get-in @state/state [:file-sync/graph-state graph-uuid :graphs-txid]
-                          (get-graphs-txid))]
-       (persist-var/-load result)
-       result))))
+  [graph-uuid]
+  ;; (when graph-uuid
+  ;;   (get @state/state [:file-sync/graph-state graph-uuid ]))
+  )
 
 (declare assert-local-txid<=remote-txid)
 (defn <update-graphs-txid!
   [latest-txid graph-uuid user-uuid repo]
   {:pre [(int? latest-txid) (>= latest-txid 0)]}
-  (let [graphs-txid (get-graphs-txid graph-uuid)]
-    (-> (p/let [_ (persist-var/-reset-value! graphs-txid [user-uuid graph-uuid latest-txid] repo)
-               _ (persist-var/persist-save graphs-txid)]
-         (state/pub-event! [:graph/refresh])
-         (when (state/developer-mode?) (assert-local-txid<=remote-txid)))
-       p->c)))
+  (-> (p/let [_ (persist-var/-reset-value! graphs-txid [user-uuid graph-uuid latest-txid] repo)
+              _ (persist-var/persist-save graphs-txid)]
+        (state/pub-event! [:graph/refresh])
+        (when (state/developer-mode?) (assert-local-txid<=remote-txid)))
+      p->c))
 
-(defn clear-graphs-txid! [graph-uuid]
-  (when-let [graphs-txid (get-graphs-txid graph-uuid)]
-    (persist-var/-reset-value! graphs-txid nil (state/get-current-repo))
-    (persist-var/persist-save graphs-txid)))
+(defn clear-graphs-txid! [repo]
+  (persist-var/-reset-value! graphs-txid nil repo)
+  (persist-var/persist-save graphs-txid))
 
 (defn- ws-ping-loop [ws]
   (go-loop []
@@ -1373,11 +1366,10 @@
 
 (defn- assert-local-txid<=remote-txid
   []
-  (let [graphs-txid (get-graphs-txid)]
-    (when-let [local-txid (last @graphs-txid)]
-     (go (let [remote-txid (:TXId (<! (<get-remote-graph remoteapi nil (second @graphs-txid))))]
-           (assert (<= local-txid remote-txid)
-                   [@graphs-txid local-txid remote-txid]))))))
+  (when-let [local-txid (last @graphs-txid)]
+    (go (let [remote-txid (:TXId (<! (<get-remote-graph remoteapi nil (second @graphs-txid))))]
+          (assert (<= local-txid remote-txid)
+                  [@graphs-txid local-txid remote-txid])))))
 
 (defn- get-local-files-checksum
   [graph-uuid base-path relative-paths]
@@ -2934,7 +2926,7 @@
 
 (defn graph-encrypted?
   []
-  (when-let [graph-uuid (state/get-current-file-sync-graph-uuid)]
+  (when-let [graph-uuid (second @graphs-txid)]
     (get-pwd graph-uuid)))
 
 (declare network-online-cursor)
@@ -2944,8 +2936,7 @@
 (defn sync-start []
   (let [*sync-state                 (atom (sync-state))
         current-user-uuid           (user/user-uuid)
-        repo                        (state/get-current-repo)
-        graphs-txid                 (get-graphs-txid)]
+        repo                        (state/get-current-repo)]
     (go
       (<! (<sync-stop))
       (when (and (graph-sync-off? repo) @network-online-cursor)
@@ -2964,7 +2955,7 @@
                                                        txid *sync-state)]
                   (when (check-graph-belong-to-current-user current-user-uuid user-uuid)
                     (if-not (<! (<check-remote-graph-exists graph-uuid)) ; remote graph has been deleted
-                      (clear-graphs-txid! graph-uuid)
+                      (clear-graphs-txid! repo)
                       (do
                         (state/set-file-sync-state graph-uuid @*sync-state)
                         (state/set-file-sync-manager graph-uuid sm)

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -2934,48 +2934,48 @@
 ;; Prevent starting of multiple sync managers
 (def *sync-starting? (atom {}))
 (defn sync-start []
-  (let [*sync-state                 (atom (sync-state))
-        current-user-uuid           (user/user-uuid)
-        repo                        (state/get-current-repo)]
-    (go
-      (<! (<sync-stop))
+  (go
+    (let [*sync-state                 (atom (sync-state))
+          current-user-uuid           (user/user-uuid)
+          ;; put @graph-uuid & get-current-repo together,
+          ;; prevent to get older repo dir and current graph-uuid.
+          _                           (<! (p->c (persist-var/-load graphs-txid)))
+          [user-uuid graph-uuid txid] @graphs-txid
+          repo                        (state/get-current-repo)]
       (when (and (graph-sync-off? repo) @network-online-cursor)
-        (<! (p->c (persist-var/-load graphs-txid)))
-        (let [[user-uuid graph-uuid txid] @graphs-txid]
-          (when (and user-uuid graph-uuid txid
-                     (user/logged-in?)
-                     repo
-                     (not (config/demo-graph? repo)))
-            (try
-              (when-not (get @*sync-starting? graph-uuid)
-                (swap! *sync-starting? assoc graph-uuid true)
+        (when (and user-uuid graph-uuid txid
+                   (user/logged-in?)
+                   repo
+                   (not (config/demo-graph? repo)))
+          (try
+            (when-not (get @*sync-starting? graph-uuid)
+              (swap! *sync-starting? assoc graph-uuid true)
+              (when-some [sm (sync-manager-singleton current-user-uuid graph-uuid
+                                                     (config/get-repo-dir repo) repo
+                                                     txid *sync-state)]
+                (when (check-graph-belong-to-current-user current-user-uuid user-uuid)
+                  (if-not (<! (<check-remote-graph-exists graph-uuid)) ; remote graph has been deleted
+                    (clear-graphs-txid! repo)
+                    (do
+                      (state/set-file-sync-state graph-uuid @*sync-state)
+                      (state/set-file-sync-manager graph-uuid sm)
 
-                (when-some [sm (sync-manager-singleton current-user-uuid graph-uuid
-                                                       (config/get-repo-dir repo) repo
-                                                       txid *sync-state)]
-                  (when (check-graph-belong-to-current-user current-user-uuid user-uuid)
-                    (if-not (<! (<check-remote-graph-exists graph-uuid)) ; remote graph has been deleted
-                      (clear-graphs-txid! repo)
-                      (do
-                        (state/set-file-sync-state graph-uuid @*sync-state)
-                        (state/set-file-sync-manager graph-uuid sm)
+                      ;; update global state when *sync-state changes
+                      (add-watch *sync-state ::update-global-state
+                                 (fn [_ _ _ n]
+                                   (state/set-file-sync-state graph-uuid n)))
 
-                        ;; update global state when *sync-state changes
-                        (add-watch *sync-state ::update-global-state
-                                   (fn [_ _ _ n]
-                                     (state/set-file-sync-state graph-uuid n)))
+                      (state/set-state! [:file-sync/graph-state :current-graph-uuid] graph-uuid)
 
-                        (state/set-state! [:file-sync/graph-state :current-graph-uuid] graph-uuid)
+                      (.start sm)
 
-                        (.start sm)
-
-                        (offer! remote->local-full-sync-chan true)
-                        (offer! full-sync-chan true)
-                        (swap! *sync-starting? assoc graph-uuid false))))))
-              (catch :default e
-                (prn "Sync start error: ")
-                (log/error :exception e)
-                (swap! *sync-starting? assoc graph-uuid false)))))))))
+                      (offer! remote->local-full-sync-chan true)
+                      (offer! full-sync-chan true)
+                      (swap! *sync-starting? assoc graph-uuid false))))))
+            (catch :default e
+              (prn "Sync start error: ")
+              (log/error :exception e)
+              (swap! *sync-starting? assoc graph-uuid false))))))))
 
 ;;; ### some add-watches
 

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -2865,6 +2865,9 @@
   (go
     (when-let [sm ^SyncManager (state/get-file-sync-manager)]
       (println "[SyncManager" (:graph-uuid sm) "]" "stopping")
+
+      (state/clear-file-sync-state! (:graph-uuid sm))
+
       (<! (-stop! sm))
       (swap! state/state assoc :file-sync/sync-state {})
       (println "[SyncManager" (:graph-uuid sm) "]" "stopped")
@@ -2955,7 +2958,7 @@
                       (clear-graphs-txid! repo)
                       (do
                         (state/set-file-sync-state repo @*sync-state)
-                        (state/set-file-sync-manager sm)
+                        (state/set-file-sync-manager graph-uuid sm)
 
                         ;; update global state when *sync-state changes
                         (add-watch *sync-state ::update-global-state

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -184,6 +184,12 @@
 ;; Warning: make sure to `persist-var/-load` graphs-txid before using it.
 (def graphs-txid (persist-var/persist-var nil "graphs-txid"))
 
+(defn get-graphs-txid
+  [graph-uuid]
+  ;; (when graph-uuid
+  ;;   (get @state/state [:file-sync/graph-state graph-uuid ]))
+  )
+
 (declare assert-local-txid<=remote-txid)
 (defn <update-graphs-txid!
   [latest-txid graph-uuid user-uuid repo]
@@ -264,6 +270,7 @@
        :api-name api-name
        :body body})))
 
+;; For debug
 (def *on-flying-request
   "requests not finished"
   (atom #{}))
@@ -2956,7 +2963,7 @@
                         ;; update global state when *sync-state changes
                         (add-watch *sync-state ::update-global-state
                                    (fn [_ _ _ n]
-                                     (state/set-file-sync-state repo n)))
+                                     (state/set-file-sync-state graph-uuid n)))
 
                         (state/set-state! [:file-sync/graph-state :current-graph-uuid] graph-uuid)
 

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -2958,9 +2958,9 @@
                                    (fn [_ _ _ n]
                                      (state/set-file-sync-state repo n)))
 
-                        (.start sm)
-
                         (state/set-state! [:file-sync/graph-state :current-graph-uuid] graph-uuid)
+
+                        (.start sm)
 
                         (offer! remote->local-full-sync-chan true)
                         (offer! full-sync-chan true)

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -108,6 +108,8 @@
     (if empty-graph?
       (route-handler/redirect! {:to :import :query-params {:from "picker"}})
       (route-handler/redirect-to-home!)))
+  (when-let [dir-name (config/get-repo-dir repo)]
+    (fs/watch-dir! dir-name))
   (repo-handler/refresh-repos!)
   (file-sync-restart!))
 

--- a/src/main/frontend/handler/file_sync.cljs
+++ b/src/main/frontend/handler/file_sync.cljs
@@ -74,7 +74,7 @@
         (notification/show! (str "Delete graph failed: " graph-uuid) :warning)
         (do
           (when same-graph?
-            (sync/clear-graphs-txid! (state/get-current-repo))
+            (sync/clear-graphs-txid! graph-uuid)
             (swap! refresh-file-sync-component not))
           (notification/show! (str "Graph deleted") :success))))))
 

--- a/src/main/frontend/handler/file_sync.cljs
+++ b/src/main/frontend/handler/file_sync.cljs
@@ -29,7 +29,7 @@
 
 (defn current-graph-sync-on?
   []
-  (when-let [sync-state (state/sub [:file-sync/sync-state (state/get-current-repo)])]
+  (when-let [sync-state (state/sub-file-sync-state (state/get-current-file-sync-graph-uuid))]
     (not (sync/sync-state--stopped? sync-state))))
 
 (defn synced-file-graph?

--- a/src/main/frontend/handler/file_sync.cljs
+++ b/src/main/frontend/handler/file_sync.cljs
@@ -195,7 +195,7 @@
         (case event
           (list :finished-local->remote :finished-remote->local)
           (do
-            (sync/clear-graph-progress! (second @sync/graphs-txid))
+            (state/clear-file-sync-progress! (state/get-current-file-sync-graph-uuid))
             (state/set-state! :file-sync/start {})
             (state/set-state! [:file-sync/last-synced-at (state/get-current-repo)]
                               (:epoch data)))

--- a/src/main/frontend/handler/file_sync.cljs
+++ b/src/main/frontend/handler/file_sync.cljs
@@ -199,7 +199,8 @@
             (state/set-state! [:file-sync/graph-state current-uuid :file-sync/last-synced-at] (:epoch data)))
 
           :start
-          (state/set-state! [:file-sync/graph-state current-uuid :file-sync/start-time] data)
+          (when-let [current-uuid (state/get-current-file-sync-graph-uuid)]
+            (state/set-state! [:file-sync/graph-state current-uuid :file-sync/start-time] data))
 
           nil)
 

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1796,6 +1796,10 @@ Similar to re-frame subscriptions"
   []
   (get-in @state [:file-sync/graph-state :current-graph-uuid]))
 
+(defn sub-current-file-sync-graph-uuid
+  []
+  (sub [:file-sync/graph-state :current-graph-uuid]))
+
 (defn reset-parsing-state!
   []
   (set-state! [:graph/parsing-state (get-current-repo)] {}))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -237,10 +237,9 @@
                                                 {:welcome false})
      :file-sync/remote-graphs               {:loading false :graphs nil}
 
-     ;; graph-uuid -> {}
+     ;; graph-uuid -> [:current-graph-uuid :file-sync/sync-manager :file-sync/sync-state]
      :file-sync/graph-state                 {}
 
-     :file-sync/sync-state                  nil
      :file-sync/sync-uploading-files        nil
      :file-sync/sync-downloading-files      nil
      :file-sync/set-remote-graph-password-result {}
@@ -1773,15 +1772,21 @@ Similar to re-frame subscriptions"
 (defn clear-file-sync-state! [graph-uuid]
   (set-state! [:file-sync/graph-state graph-uuid] nil))
 
-(defn set-file-sync-state [graph v]
+(defn set-file-sync-state [graph-uuid v]
   (when v (s/assert :frontend.fs.sync/sync-state v))
-  (set-state! [:file-sync/sync-state graph] v))
+  (set-state! [:file-sync/graph-state graph-uuid :file-sync/sync-state] v))
 
 (defn get-file-sync-state
-  ([]
-   (get-file-sync-state (get-current-repo)))
-  ([repo]
-   (get-in @state [:file-sync/sync-state repo])))
+  [graph-uuid]
+  (get-in @state [:file-sync/graph-state graph-uuid :file-sync/sync-state]))
+
+(defn sub-file-sync-state
+  [graph-uuid]
+  (sub [:file-sync/graph-state graph-uuid :file-sync/sync-state]))
+
+(defn get-current-file-sync-graph-uuid
+  []
+  (get-in @state [:file-sync/graph-state :current-graph-uuid]))
 
 (defn reset-parsing-state!
   []

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -236,15 +236,15 @@
      :file-sync/onboarding-state            (or (storage/get :file-sync/onboarding-state)
                                                 {:welcome false})
      :file-sync/remote-graphs               {:loading false :graphs nil}
+     :file-sync/set-remote-graph-password-result {}
 
      ;; graph-uuid -> [:current-graph-uuid :file-sync/sync-manager :file-sync/sync-state]
-     :file-sync/graph-state                 {}
+     :file-sync/graph-state                 {:current-graph-uuid nil
+                                             :file-sync/sync-manager nil
+                                             :file-sync/sync-state nil
+                                             ;; {file-path -> payload}
+                                             :file-sync/progress nil}
 
-     :file-sync/sync-uploading-files        nil
-     :file-sync/sync-downloading-files      nil
-     :file-sync/set-remote-graph-password-result {}
-     ;; graph-uuid -> {file-path -> payload}
-     :file-sync/progress                    {}
      :file-sync/start                       {}
      ;; graph -> epoch
      :file-sync/last-synced-at              {}
@@ -629,13 +629,15 @@ Similar to re-frame subscriptions"
   [path value]
   (if (vector? path)
     (swap! state assoc-in path value)
-    (swap! state assoc path value)))
+    (swap! state assoc path value))
+  nil)
 
 (defn update-state!
   [path f]
   (if (vector? path)
     (swap! state update-in path f)
-    (swap! state update path f)))
+    (swap! state update path f))
+  nil)
 
 ;; State getters and setters
 ;; =========================
@@ -1771,6 +1773,12 @@ Similar to re-frame subscriptions"
 
 (defn clear-file-sync-state! [graph-uuid]
   (set-state! [:file-sync/graph-state graph-uuid] nil))
+
+(defn clear-file-sync-progress! [graph-uuid]
+  (set-state! [:file-sync/graph-state
+               graph-uuid
+               :file-sync/progress]
+              nil))
 
 (defn set-file-sync-state [graph-uuid v]
   (when v (s/assert :frontend.fs.sync/sync-state v))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -243,11 +243,9 @@
                                              :file-sync/sync-manager nil
                                              :file-sync/sync-state nil
                                              ;; {file-path -> payload}
-                                             :file-sync/progress nil}
-
-     :file-sync/start                       {}
-     ;; graph -> epoch
-     :file-sync/last-synced-at              {}
+                                             :file-sync/progress nil
+                                             :file-sync/start-time nil
+                                             :file-sync/last-synced-at nil}
 
      :encryption/graph-parsing?             false
 

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -235,9 +235,11 @@
      :file-sync/jstour-inst                   nil
      :file-sync/onboarding-state            (or (storage/get :file-sync/onboarding-state)
                                                 {:welcome false})
-
      :file-sync/remote-graphs               {:loading false :graphs nil}
-     :file-sync/sync-manager                nil
+
+     ;; graph-uuid -> {}
+     :file-sync/graph-state                 {}
+
      :file-sync/sync-state                  nil
      :file-sync/sync-uploading-files        nil
      :file-sync/sync-downloading-files      nil
@@ -1761,14 +1763,19 @@ Similar to re-frame subscriptions"
 (defn get-auth-refresh-token []
   (:auth/refresh-token @state))
 
-(defn set-file-sync-manager [v]
-  (set-state! :file-sync/sync-manager v))
+(defn set-file-sync-manager [graph-uuid v]
+  (when (and graph-uuid v)
+    (set-state! [:file-sync/graph-state graph-uuid :file-sync/sync-manager] v)))
+
+(defn get-file-sync-manager [graph-uuid]
+  (get-in @state [:file-sync/graph-state graph-uuid :file-sync/sync-manager]))
+
+(defn clear-file-sync-state! [graph-uuid]
+  (set-state! [:file-sync/graph-state graph-uuid] nil))
+
 (defn set-file-sync-state [graph v]
   (when v (s/assert :frontend.fs.sync/sync-state v))
   (set-state! [:file-sync/sync-state graph] v))
-
-(defn get-file-sync-manager []
-  (:file-sync/sync-manager @state))
 
 (defn get-file-sync-state
   ([]

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -238,14 +238,16 @@
      :file-sync/remote-graphs               {:loading false :graphs nil}
      :file-sync/set-remote-graph-password-result {}
 
-     ;; graph-uuid -> [:current-graph-uuid :file-sync/sync-manager :file-sync/sync-state]
+     ;; graph-uuid -> {:graphs-txid {}
+     ;;                :file-sync/sync-manager {}
+     ;;                :file-sync/sync-state {}
+     ;;                ;; {file-path -> payload}
+     ;;                :file-sync/progress {}
+     ;;                :file-sync/start-time {}
+     ;;                :file-sync/last-synced-at {}}
      :file-sync/graph-state                 {:current-graph-uuid nil
-                                             :file-sync/sync-manager nil
-                                             :file-sync/sync-state nil
-                                             ;; {file-path -> payload}
-                                             :file-sync/progress nil
-                                             :file-sync/start-time nil
-                                             :file-sync/last-synced-at nil}
+                                             ;; graph-uuid -> ...
+                                             }
 
      :encryption/graph-parsing?             false
 


### PR DESCRIPTION
This PR groups several states related to file-sync into `:file-sync/graph-state` for better state management to prevent more bugs in the future.

State 1: [file-sync/sync-manager](https://github.com/logseq/logseq/pull/6854/commits/b072dc8862802abb446280b835af619795fa6a09)
State 2: [file-sync/sync-state](https://github.com/logseq/logseq/pull/6854/commits/8b5663a73bc02de9902a4e13d140e8a54002afba)
State 3: [file-sync/progress](https://github.com/logseq/logseq/pull/6854/commits/6c9c3f95f6af9b486e5e6c7689980b38efa33d4d)
State 4: [start-time and last-synced-at](https://github.com/logseq/logseq/pull/6854/commits/0b6ba534d5222f5a4e8a68bf01718d21a649a321)
State 5: [graphs-txid](https://github.com/logseq/logseq/pull/6854/commits/adc5b81d933b7230e84eed83454bfc44c995d243)

It also [fixed](https://github.com/logseq/logseq/pull/6854/commits/2041564fec9c431302e11ced834386d485e899b6) a bug that the file watcher is not started when adding a new graph.