### PR TITLE
fix(android): key code nil sometimes

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2780,7 +2780,8 @@
             value (gobj/get input "value")
             c (util/nth-safe value (dec current-pos))
             [key-code k code is-processed?]
-            (if (and (mobile-util/native-android?)
+            (if (and c
+                     (mobile-util/native-android?)
                      (or (= key-code 229)
                          (= key-code 0)))
               [(.charCodeAt value (dec current-pos))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/72891/193062430-04a28d1f-029f-442e-b3b8-6b8216d63400.png)

Introduced in ClojureScript upgrade. parse-long fails when `nil` passed.