### PR TITLE
fix(windows): update rsapi, use static link

### DIFF
--- a/resources/package.json
+++ b/resources/package.json
@@ -37,7 +37,7 @@
     "https-proxy-agent": "5.0.0",
     "@sentry/electron": "2.5.1",
     "posthog-js": "1.10.2",
-    "@logseq/rsapi": "0.0.48",
+    "@logseq/rsapi": "0.0.50",
     "electron-deeplink": "1.0.10",
     "abort-controller": "3.0.0"
   },


### PR DESCRIPTION
Fix https://github.com/logseq/logseq/issues/6756
Fix https://github.com/logseq/logseq/issues/6727
Fix https://github.com/logseq/logseq/issues/6698
Fix https://github.com/logseq/logseq/issues/5362
