### PR TITLE
Fix: stuck re-index when there're multiple whiteboards have the same UUID

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/extract.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/extract.cljc
@@ -16,7 +16,8 @@
             [logseq.graph-parser.config :as gp-config]
             #?(:org.babashka/nbb [logseq.graph-parser.log :as log]
                :default [lambdaisland.glogi :as log])
-            [logseq.graph-parser.whiteboard :as gp-whiteboard]))
+            [logseq.graph-parser.whiteboard :as gp-whiteboard]
+            [medley.core :as medley]))
 
 (defn- filepath->page-name
   [filepath]
@@ -209,6 +210,12 @@
   [file content {:keys [verbose] :or {verbose true}}]
   (let [_ (when verbose (println "Parsing start: " file))
         {:keys [pages blocks]} (gp-util/safe-read-string content)
+        blocks (map
+                 (fn [block]
+                   (-> block
+                       (medley/dissoc-in [:block/parent :block/name])
+                       (medley/dissoc-in [:block/left :block/name])))
+                 blocks)
         serialized-page (first pages)
         ;; whiteboard edn file should normally have valid :block/original-name, :block/name, :block/uuid
         page-name (-> (or (:block/name serialized-page)

--- a/deps/graph-parser/src/logseq/graph_parser/extract.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/extract.cljc
@@ -16,8 +16,7 @@
             [logseq.graph-parser.config :as gp-config]
             #?(:org.babashka/nbb [logseq.graph-parser.log :as log]
                :default [lambdaisland.glogi :as log])
-            [logseq.graph-parser.whiteboard :as gp-whiteboard]
-            [medley.core :as medley]))
+            [logseq.graph-parser.whiteboard :as gp-whiteboard]))
 
 (defn- filepath->page-name
   [filepath]
@@ -213,8 +212,8 @@
         blocks (map
                  (fn [block]
                    (-> block
-                       (medley/dissoc-in [:block/parent :block/name])
-                       (medley/dissoc-in [:block/left :block/name])))
+                       (gp-util/dissoc-in [:block/parent :block/name])
+                       (gp-util/dissoc-in [:block/left :block/name])))
                  blocks)
         serialized-page (first pages)
         ;; whiteboard edn file should normally have valid :block/original-name, :block/name, :block/uuid

--- a/deps/graph-parser/src/logseq/graph_parser/util.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/util.cljs
@@ -167,3 +167,23 @@
     (catch :default e
       (log/error :parse/read-string-failed e)
       {})))
+
+;; Copied from Medley
+;; https://github.com/weavejester/medley/blob/d1e00337cf6c0843fb6547aadf9ad78d981bfae5/src/medley/core.cljc#L22
+(defn dissoc-in
+  "Dissociate a value in a nested associative structure, identified by a sequence
+  of keys. Any collections left empty by the operation will be dissociated from
+  their containing structures."
+  ([m ks]
+   (if-let [[k & ks] (seq ks)]
+     (if (seq ks)
+       (let [v (dissoc-in (get m k) ks)]
+         (if (empty? v)
+           (dissoc m k)
+           (assoc m k v)))
+       (dissoc m k))
+     m))
+  ([m ks & kss]
+   (if-let [[ks' & kss] (seq kss)]
+     (recur (dissoc-in m ks) ks' kss)
+     (dissoc-in m ks))))

--- a/src/main/frontend/handler/common/file.cljs
+++ b/src/main/frontend/handler/common/file.cljs
@@ -9,7 +9,8 @@
             [logseq.graph-parser :as graph-parser]
             [logseq.graph-parser.util :as gp-util]
             [logseq.graph-parser.config :as gp-config]
-            [lambdaisland.glogi :as log]))
+            [lambdaisland.glogi :as log]
+            [clojure.string :as string]))
 
 (defn- page-exists-in-another-file
   "Conflict of files towards same page"
@@ -73,3 +74,9 @@
                                             :supported-formats (gp-config/supported-formats)}
                                            (when (some? verbose) {:verbose verbose}))})]
      (:tx (graph-parser/parse-file (db/get-db repo-url false) file content options)))))
+
+(defn whiteboard?
+  "Whether a file is a whiteboard. "
+  [path]
+  (and (string/includes? path "whiteboards/")
+       (string/ends-with? path ".edn")))

--- a/src/main/frontend/handler/common/file.cljs
+++ b/src/main/frontend/handler/common/file.cljs
@@ -8,9 +8,7 @@
             [frontend.mobile.util :as mobile-util]
             [logseq.graph-parser :as graph-parser]
             [logseq.graph-parser.util :as gp-util]
-            [logseq.graph-parser.config :as gp-config]
-            [lambdaisland.glogi :as log]
-            [clojure.string :as string]))
+            [logseq.graph-parser.config :as gp-config]))
 
 (defn- page-exists-in-another-file
   "Conflict of files towards same page"

--- a/src/main/frontend/handler/common/file.cljs
+++ b/src/main/frontend/handler/common/file.cljs
@@ -74,9 +74,3 @@
                                             :supported-formats (gp-config/supported-formats)}
                                            (when (some? verbose) {:verbose verbose}))})]
      (:tx (graph-parser/parse-file (db/get-db repo-url false) file content options)))))
-
-(defn whiteboard?
-  "Whether a file is a whiteboard. "
-  [path]
-  (and (string/includes? path "whiteboards/")
-       (string/ends-with? path ".edn")))

--- a/src/main/frontend/handler/common/file.cljs
+++ b/src/main/frontend/handler/common/file.cljs
@@ -39,41 +39,37 @@
   ([repo-url file content]
    (reset-file! repo-url file content {}))
   ([repo-url file content {:keys [verbose] :as options}]
-   (try
-     (let [electron-local-repo? (and (util/electron?)
-                                     (config/local-db? repo-url))
-           file (cond
-                  (and electron-local-repo?
-                       util/win32?
-                       (utils/win32 file))
-                  file
+   (let [electron-local-repo? (and (util/electron?)
+                                   (config/local-db? repo-url))
+         file (cond
+                (and electron-local-repo?
+                     util/win32?
+                     (utils/win32 file))
+                file
 
-                  (and electron-local-repo? (or
-                                             util/win32?
-                                             (not= "/" (first file))))
-                  (str (config/get-repo-dir repo-url) "/" file)
+                (and electron-local-repo? (or
+                                           util/win32?
+                                           (not= "/" (first file))))
+                (str (config/get-repo-dir repo-url) "/" file)
 
-                  (and (mobile-util/native-android?) (not= "/" (first file)))
-                  file
+                (and (mobile-util/native-android?) (not= "/" (first file)))
+                file
 
-                  (and (mobile-util/native-ios?) (not= "/" (first file)))
-                  file
+                (and (mobile-util/native-ios?) (not= "/" (first file)))
+                file
 
-                  :else
-                  file)
-           file (gp-util/path-normalize file)
-           new? (nil? (db/entity [:file/path file]))
-           options (merge (dissoc options :verbose)
-                          {:new? new?
-                           :delete-blocks-fn (partial get-delete-blocks repo-url)
-                           :extract-options (merge
-                                             {:user-config (state/get-config)
-                                              :date-formatter (state/get-date-formatter)
-                                              :page-name-order (state/page-name-order)
-                                              :block-pattern (config/get-block-pattern (gp-util/get-format file))
-                                              :supported-formats (gp-config/supported-formats)}
-                                             (when (some? verbose) {:verbose verbose}))})]
-       (:tx (graph-parser/parse-file (db/get-db repo-url false) file content options)))
-     (catch :default e
-       (prn "Reset file failed " {:file file})
-       (log/error :exception e)))))
+                :else
+                file)
+         file (gp-util/path-normalize file)
+         new? (nil? (db/entity [:file/path file]))
+         options (merge (dissoc options :verbose)
+                        {:new? new?
+                         :delete-blocks-fn (partial get-delete-blocks repo-url)
+                         :extract-options (merge
+                                           {:user-config (state/get-config)
+                                            :date-formatter (state/get-date-formatter)
+                                            :page-name-order (state/page-name-order)
+                                            :block-pattern (config/get-block-pattern (gp-util/get-format file))
+                                            :supported-formats (gp-config/supported-formats)}
+                                           (when (some? verbose) {:verbose verbose}))})]
+     (:tx (graph-parser/parse-file (db/get-db repo-url false) file content options)))))

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -58,7 +58,8 @@
             [goog.dom :as gdom]
             [logseq.db.schema :as db-schema]
             [promesa.core :as p]
-            [rum.core :as rum]))
+            [rum.core :as rum]
+            [logseq.graph-parser.config :as gp-config]))
 
 ;; TODO: should we move all events here?
 
@@ -705,7 +706,7 @@
         [:div
          [:p
           (str "It seems that another whiteboard file already have the ID \"" id
-               "\", you can fix it by change replace the ID in this file with another UUID.")]
+               "\". You can fix it by changing the ID in this file with another UUID.")]
          [:p
           "Or, let me"
           (ui/button "Fix"
@@ -731,7 +732,7 @@
                         (for [[file error] parse-errors]
                           (let [data (ex-data error)]
                             (cond
-                             (and (file-common-handler/whiteboard? file)
+                             (and (gp-config/whiteboard? file)
                                   (= :transact/upsert (:error data))
                                   (uuid? (last (:assertion data))))
                              (rum/with-key (file-id-conflict-item repo file data) file)

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -705,7 +705,7 @@
          [:div.ml-1 "Resolved"]]
         [:div
          [:p
-          (str "It seems that another whiteboard file already have the ID \"" id
+          (str "It seems that another whiteboard file already has the ID \"" id
                "\". You can fix it by changing the ID in this file with another UUID.")]
          [:p
           "Or, let me"

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -737,9 +737,12 @@
                              (rum/with-key (file-id-conflict-item repo file data) file)
 
                              :else
-                             [:li.my-1 {:key file}
-                              [:a {:on-click #(js/window.apis.openPath file)} file]
-                              [:p (.-message error)]])))]
+                             (do
+                               (state/pub-event! [:instrument {:type :file/parse-and-load-error
+                                                               :payload error}])
+                               [:li.my-1 {:key file}
+                                [:a {:on-click #(js/window.apis.openPath file)} file]
+                                [:p (.-message error)]]))))]
                        [:p "Don't forget to re-index your graph when all the conflicts are resolved."]]
                       :status :error}]))
 

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -40,7 +40,6 @@
             [frontend.handler.search :as search-handler]
             [frontend.handler.ui :as ui-handler]
             [frontend.handler.user :as user-handler]
-            [frontend.handler.common.file :as file-common-handler]
             [frontend.handler.web.nfs :as nfs-handler]
             [frontend.mobile.core :as mobile]
             [frontend.mobile.util :as mobile-util]
@@ -739,8 +738,8 @@
 
                              :else
                              [:li.my-1 {:key file}
-                              [:p file]
-                              [:p (str error)]])))]
+                              [:a {:on-click #(js/window.apis.openPath file)} file]
+                              [:p (.-message error)]])))]
                        [:p "Don't forget to re-index your graph when all the conflicts are resolved."]]
                       :status :error}]))
 

--- a/src/main/frontend/handler/file.cljs
+++ b/src/main/frontend/handler/file.cljs
@@ -116,7 +116,7 @@
                           [:db/retract page-id :block/tags]]
                          opts)))
                    (file-common-handler/reset-file! repo path content (merge opts
-                                                         (when (some? verbose) {:verbose verbose}))))
+                                                                             (when (some? verbose) {:verbose verbose}))))
                  (db/set-file-content! repo path content opts))]
     (util/p-handle (write-file!)
                    (fn [_]

--- a/src/main/frontend/handler/repo.cljs
+++ b/src/main/frontend/handler/repo.cljs
@@ -28,6 +28,7 @@
             [frontend.db.persist :as db-persist]
             [logseq.graph-parser.util :as gp-util]
             [logseq.graph-parser :as graph-parser]
+            [logseq.graph-parser.config :as gp-config]
             [electron.ipc :as ipc]
             [cljs-bean.core :as bean]
             [clojure.core.async :as async]
@@ -248,7 +249,7 @@
       (async/go-loop [tx []]
         (if-let [item (async/<! chan)]
           (let [[idx file] item
-                whiteboard? (file-common-handler/whiteboard? (:file/path file))
+                whiteboard? (gp-config/whiteboard? (:file/path file))
                 yield-for-ui? (or (not large-graph?)
                                   (zero? (rem idx 10))
                                   (<= (- total idx) 10)

--- a/src/main/frontend/handler/repo.cljs
+++ b/src/main/frontend/handler/repo.cljs
@@ -212,6 +212,18 @@
   (when re-render?
     (ui-handler/re-render-root! re-render-opts))
   (state/pub-event! [:graph/added repo-url opts])
+  (let [parse-errors (get-in @state/state [:graph/parsing-state repo-url :failed-parsing-files])]
+    (when (seq parse-errors)
+     (state/pub-event! [:notification/show
+                        {:content
+                         [:div
+                          [:h2 "Oops, those files are failed to imported to your graph:"]
+                          [:ul
+                           (for [[file error] parse-errors]
+                             [:li
+                              [:p file]
+                              [:p (str error)]])]]
+                         :status :error}])))
   (state/reset-parsing-state!)
   (state/set-loading-files! repo-url false)
   (async/offer! graph-added-chan true))

--- a/src/main/frontend/modules/file/core.cljs
+++ b/src/main/frontend/modules/file/core.cljs
@@ -139,7 +139,7 @@
         file-path (-> (db-utils/entity file-db-id) :file/path)]
     (if (and (string? file-path) (not-empty file-path))
       (let [new-content (if (= "whiteboard" (:block/type page-block))
-                          (pr-str {:blocks (map remove-transit-ids tree)
+                          (pr-str {:blocks tree
                                    :pages (list (remove-transit-ids page-block))})
                           (tree->file-content tree {:init-level init-level}))
             files [[file-path new-content]]

--- a/src/main/frontend/modules/outliner/file.cljs
+++ b/src/main/frontend/modules/outliner/file.cljs
@@ -21,21 +21,22 @@
     :block/uuid
     :block/content
     :block/format
-    {:block/page      [:block/name :block/uuid]}
-    {:block/left      [:block/name :block/uuid]}
-    {:block/parent    [:block/name :block/uuid]}])
+    {:block/page      [:block/uuid]}
+    {:block/left      [:block/uuid]}
+    {:block/parent    [:block/uuid]}])
 
 (defn- cleanup-whiteboard-block
   [block]
   (if (get-in block [:block/properties :ls-type] false)
     (dissoc block
+            :db/id
             :block/uuid ;; shape block uuid is read from properties
             :block/content
             :block/format
             :block/left
             :block/page
             :block/parent) ;; these are auto-generated for whiteboard shapes
-    (dissoc block :block/page)))
+    (dissoc block :db/id :block/page)))
 
 
 (defn do-write-file!
@@ -46,7 +47,7 @@
         blocks-count (model/get-page-blocks-count repo page-db-id)]
     (if (or (and (> blocks-count 500)
                  (not (state/input-idle? repo {:diff 3000}))) ;; long page
-            ;; when this whiteboard page is just being updated 
+            ;; when this whiteboard page is just being updated
             (and whiteboard? (not (state/whiteboard-page-idle? repo page-block))))
       (async/put! (state/get-file-write-chan) [repo page-db-id])
       (let [pull-keys (if whiteboard? whiteboard-blocks-pull-keys-with-persisted-ids '[*])

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -223,35 +223,32 @@
 (rum/defc notification-content
   [state content status uid]
   (when (and content status)
-    (let [[color-class svg]
+    (let [svg
           (case status
             :success
-            ["text-gray-900 dark:text-gray-300 "
-             [:svg.h-6.w-6.text-green-400
-              {:stroke "currentColor", :viewBox "0 0 24 24", :fill "none"}
-              [:path
-               {:d               "M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                :stroke-width    "2"
-                :stroke-linejoin "round"
-                :stroke-linecap  "round"}]]]
+            [:svg.h-6.w-6.text-green-400
+             {:stroke "currentColor", :viewBox "0 0 24 24", :fill "none"}
+             [:path
+              {:d               "M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+               :stroke-width    "2"
+               :stroke-linejoin "round"
+               :stroke-linecap  "round"}]]
             :warning
-            ["text-gray-900 dark:text-gray-300 "
-             [:svg.h-6.w-6.text-yellow-500
-              {:stroke "currentColor", :viewBox "0 0 24 24", :fill "none"}
-              [:path
-               {:d               "M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                :stroke-width    "2"
-                :stroke-linejoin "round"
-                :stroke-linecap  "round"}]]]
+            [:svg.h-6.w-6.text-yellow-500
+             {:stroke "currentColor", :viewBox "0 0 24 24", :fill "none"}
+             [:path
+              {:d               "M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+               :stroke-width    "2"
+               :stroke-linejoin "round"
+               :stroke-linecap  "round"}]]
 
-            ["text-red-500"
-             [:svg.h-6.w-6.text-red-500
-              {:view-box "0 0 20 20", :fill "currentColor"}
-              [:path
-               {:clip-rule "evenodd"
-                :d
-                "M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
-                :fill-rule "evenodd"}]]])]
+            [:svg.h-6.w-6.text-red-500
+             {:view-box "0 0 20 20", :fill "currentColor"}
+             [:path
+              {:clip-rule "evenodd"
+               :d
+               "M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
+               :fill-rule "evenodd"}]])]
       [:div.ui__notifications-content
        {:style
         (when (or (= state "exiting")
@@ -271,8 +268,7 @@
            [:div.flex-shrink-0
             svg]
            [:div.ml-3.w-0.flex-1
-            [:div.text-sm.leading-5.font-medium.whitespace-pre-line {:style {:margin 0}
-                                                                     :class color-class}
+            [:div.text-sm.leading-5.font-medium.whitespace-pre-line {:style {:margin 0}}
              content]]
            [:div.ml-4.flex-shrink-0.flex
             [:button.inline-flex.text-gray-400.focus:outline-none.focus:text-gray-500.transition.ease-in-out.duration-150.notification-close-button


### PR DESCRIPTION
This PR fixed the issue that re-index can be stuck if there're multiple whiteboard pages that have the same UUID.

Some changes:
1. re-index will continue even if some files fail to parse or load to db.
2. all the errors will be notified when re-index is finished
3. for each error, users can either click the file path to fix it themselves, or click the `Fix` button to replace the UUID.

Demo: https://www.loom.com/share/148330aac0864c279707293a3a9d9baf