### PR TITLE
feat: support locale sensitive string comparisons for table sorting

### DIFF
--- a/src/main/frontend/components/query_table.cljs
+++ b/src/main/frontend/components/query_table.cljs
@@ -46,16 +46,9 @@
     (.localeCompare x y)
     (< x y)))
 
-(defn- locale-compare-desc
-  "Use locale specific descedent comparison for strings and general comparison for others."
-  [x y]
-  (if (and (string? x) (string? y))
-    (.localeCompare y x)
-    (> x y)))
-
 (defn- sort-result [result {:keys [sort-by-column sort-desc?]}]
   (if (some? sort-by-column)
-    (let [comp (if sort-desc? locale-compare-desc locale-compare)]
+    (let [comp (if sort-desc? #(locale-compare %2 %1) locale-compare)]
       (sort-by (fn [item]
                  (block/normalize-block (sort-by-fn sort-by-column item)))
                comp

--- a/src/main/frontend/components/query_table.cljs
+++ b/src/main/frontend/components/query_table.cljs
@@ -43,7 +43,7 @@
   "Use locale specific comparison for strings and general comparison for others."
   [x y]
   (if (and (string? x) (string? y))
-    (.localeCompare x y)
+    (.localeCompare x y (.language js/navigator))
     (< x y)))
 
 (defn- sort-result [result {:keys [sort-by-column sort-desc?]}]

--- a/src/main/frontend/components/query_table.cljs
+++ b/src/main/frontend/components/query_table.cljs
@@ -39,9 +39,23 @@
     (:block/name item)
     (get-in item [:block/properties sort-by-column])))
 
+(defn- locale-compare
+  "Use locale specific comparison for strings and general comparison for others."
+  [x y]
+  (if (and (string? x) (string? y))
+    (.localeCompare x y)
+    (< x y)))
+
+(defn- locale-compare-desc
+  "Use locale specific descedent comparison for strings and general comparison for others."
+  [x y]
+  (if (and (string? x) (string? y))
+    (.localeCompare y x)
+    (> x y)))
+
 (defn- sort-result [result {:keys [sort-by-column sort-desc?]}]
   (if (some? sort-by-column)
-    (let [comp (if sort-desc? > <)]
+    (let [comp (if sort-desc? locale-compare-desc locale-compare)]
       (sort-by (fn [item]
                  (block/normalize-block (sort-by-fn sort-by-column item)))
                comp

--- a/src/test/frontend/components/query_table_test.cljs
+++ b/src/test/frontend/components/query_table_test.cljs
@@ -49,4 +49,12 @@
 
          {:sort-desc? false :sort-by-column :title}
          [{:title "abc"} {:title "cde"}]
-         [{:title "abc"} {:title "cde"}])))
+         [{:title "abc"} {:title "cde"}]
+
+         {:sort-desc? true :sort-by-column :title}
+         [{:title "意志"} {:title "圆圈"}]
+         [{:title "圆圈"} {:title "意志"}]
+
+         {:sort-desc? false :sort-by-column :title}
+         [{:title "圆圈"} {:title "意志"}]
+         [{:title "意志"} {:title "圆圈"}])))


### PR DESCRIPTION
Added support for locale sensitive sorting for query tables. E.g, in Chinese, "圆圈" should be placed after "意志" according to pinyin order.

I'm not too familiar with Clojure and ClojureScript, can you help revise? Hope I implemented it right.