### PR TITLE
iOS: Continue recording audio when phone sleeps (Fixes #6407)

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -78,6 +78,10 @@
 			<string>ANY</string>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
Previously, the voice recorder would silently stop recording the moment that the phone locked.

Apple's documentation doesn't directly say this, but it looks like a prerequisite for recording background audio is enabling background audio playback: https://developer.apple.com/documentation/xcode/configuring-background-execution-modes

Fixes #6407 

cc @cnrpman 