### PR TITLE
fix(whiteboard): dnd missing uuid issue

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -3228,7 +3228,6 @@
         :else
         (let [language (if (contains? #{"edn" "clj" "cljc" "cljs"} language) "clojure" language)]
           [:div {:ref (fn [el]
-                        (println "(whiteboard-handler/inside-portal el)" (whiteboard-handler/inside-portal? el))
                         (set-inside-portal? (and el (whiteboard-handler/inside-portal? el))))}
            (cond
              (nil? inside-portal?) nil

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1937,7 +1937,7 @@
           (when (= block-type :whiteboard-shape) [:span.mr-1 (ui/icon "whiteboard-element" {:extension? true})])
           (when (and
                  (or config/publishing? (util/electron?))
-                 (not= block-type :default))
+                 (not (#{:default :whiteboard-shape} block-type)))
             (let [area? (= :area (keyword (:hl-type properties)))]
               [:div.prefix-link
                {:on-mouse-down (fn [^js e]

--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -199,9 +199,9 @@
     (db-utils/transact! [tx])
     uuid))
 
-(defn inside-portal
+(defn inside-portal?
   [target]
-  (dom/closest target ".tl-logseq-cp-container"))
+  (some? (dom/closest target ".tl-logseq-cp-container")))
 
 (defn closest-shape
   [target]

--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -9,7 +9,8 @@
             [frontend.modules.outliner.file :as outliner-file]
             [frontend.state :as state]
             [frontend.util :as util]
-            [logseq.graph-parser.whiteboard :as gp-whiteboard]))
+            [logseq.graph-parser.whiteboard :as gp-whiteboard]
+            [frontend.handler.editor :as editor-handler]))
 
 (defn shape->block [shape page-name idx]
   (let [properties {:ls-type :whiteboard-shape
@@ -150,6 +151,7 @@
                                   [(.-minX bounds) (+ 64 (.-maxY bounds))]
                                   [(+ 64 (.-maxX bounds)) (.-minY bounds)]))))
         shape (->logseq-portal-shape block-uuid point)]
+    (when (uuid? block-uuid) (editor-handler/set-blocks-id! [block-uuid]))
     (.createShapes api (clj->js shape))
     (when link?
       (.createNewLineBinding api source-shape (:id shape)))))

--- a/src/main/frontend/modules/shortcut/before.cljs
+++ b/src/main/frontend/modules/shortcut/before.cljs
@@ -32,9 +32,8 @@
 (defn enable-when-not-component-editing!
   [f]
   (fn [e]
-    (when (and (or (contains? #{:srs :page-histories} (state/get-modal-id))
-                   (not (state/block-component-editing?)))
-               ;; should not enable when in whiteboard mode, but not editing a logseq block
-               (not (and (state/active-tldraw-app)
-                         (not (state/tldraw-editing-logseq-block?)))))
+    (when (or (contains? #{:srs :page-histories} (state/get-modal-id))
+              (not (state/block-component-editing?))
+              ;; when in whiteboard mode and editing a logseq block
+              (and (state/active-tldraw-app) (state/tldraw-editing-logseq-block?)))
       (f e))))

--- a/tldraw/apps/tldraw-logseq/src/hooks/usePaste.ts
+++ b/tldraw/apps/tldraw-logseq/src/hooks/usePaste.ts
@@ -223,6 +223,8 @@ export function usePaste() {
             allSelectedBlocks && allSelectedBlocks?.length > 1
               ? allSelectedBlocks.map(b => b.uuid)
               : [text]
+          // ensure all uuid in blockUUIDs is persisted
+          window.logseq?.api?.set_blocks_id?.(blockUUIDs)
           const tasks = blockUUIDs.map(uuid => tryCreateLogseqPortalShapesFromString(`((${uuid}))`))
           const newShapes = (await Promise.all(tasks)).flat().filter(isNonNullable)
           return newShapes.map((s, idx) => {


### PR DESCRIPTION
- [x] fix: shapes created via dnd/clicking block ref may result in "target is missing" issue
- [x] fix: remove `?p` marker for shape reference
- [x] fix: fallback codemirror to hljs for code blocks in whiteboard because of compatibility issue (https://github.com/codemirror/dev/issues/324) 