### PR TITLE
fix(plugin): enter to break line not work for textarea settings item

### DIFF
--- a/src/main/frontend/components/plugins_settings.cljs
+++ b/src/main/frontend/components/plugins_settings.cljs
@@ -29,6 +29,7 @@
        {:class        (util/classnames [{:form-input (not (contains? #{:color :range} input-as))}])
         :type         (name input-as)
         :defaultValue (or val default)
+        :on-key-down  #(.stopPropagation %)
         :on-change    (debounce #(update-setting! key (util/evalue %)) 1000)}])]])
 
 (rum/defc render-item-toggle


### PR DESCRIPTION
### Before

https://user-images.githubusercontent.com/1779837/194833854-cf815ceb-bafe-4aef-b45a-df90d7f94f04.mp4

### After

https://user-images.githubusercontent.com/1779837/194833894-410d00a2-78e0-4769-a867-a5f9b66326ba.mp4

