### PR TITLE
Fix: Remove hidden task properties that weren't used 

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/property.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/property.cljs
@@ -28,10 +28,6 @@
    (contains? #{"Property_Drawer" "Properties"}
               (first block))))
 
-(def markers
-  #{"now" "later" "todo" "doing" "done" "wait" "waiting"
-    "canceled" "cancelled" "started" "in-progress"})
-
 ;; Built-in properties are properties that logseq uses for its features. Most of
 ;; these properties are hidden from the user but a few like the editable ones
 ;; are visible for the user to edit.
@@ -61,8 +57,9 @@
      :created-at :updated-at :last-modified-at :created_at :last_modified_at
      :query-table :query-properties :query-sort-by :query-sort-desc :ls-type
      :hl-type :hl-page :hl-stamp :hl-color :logseq.macro-name :logseq.macro-arguments
-     :logseq.tldraw.page :logseq.tldraw.shape}
-   (set (map keyword markers))
+     :logseq.tldraw.page :logseq.tldraw.shape
+     ; task markers
+     :todo :doing :now :later :done}
    @built-in-extended-properties))
 
 (defonce properties-start ":PROPERTIES:")

--- a/src/main/frontend/util/marker.cljs
+++ b/src/main/frontend/util/marker.cljs
@@ -6,10 +6,10 @@
 (defn marker-pattern [format]
   (re-pattern
    (str "^" (if (= format :markdown) "(#+\\s+)?" "(\\*+\\s+)?")
-        "(NOW|LATER|TODO|DOING|DONE|WAITING|WAIT|CANCELED|CANCELLED|STARTED|IN-PROGRESS)?\\s?")))
+        "(NOW|LATER|TODO|DOING|DONE|WAITING|WAIT|CANCELED|CANCELLED|IN-PROGRESS)?\\s?")))
 
 (def bare-marker-pattern
-  #"(NOW|LATER|TODO|DOING|DONE|WAITING|WAIT|CANCELED|CANCELLED|STARTED|IN-PROGRESS){1}\s+")
+  #"(NOW|LATER|TODO|DOING|DONE|WAITING|WAIT|CANCELED|CANCELLED|IN-PROGRESS){1}\s+")
 
 (defn add-or-update-marker
   [content format marker]


### PR DESCRIPTION
Fixes #6902. Can see that the removed task properties weren't used in https://github.com/logseq/logseq/commit/b63aa2c03c7bf576c59d687b5370d7c89fabb730