### PR TITLE
fix: add local conflicted versions on mobile

### DIFF
--- a/src/main/frontend/fs.cljs
+++ b/src/main/frontend/fs.cljs
@@ -53,8 +53,12 @@
   (protocol/mkdir-recur! (get-fs dir) dir))
 
 (defn readdir
-  [dir]
-  (protocol/readdir (get-fs dir) dir))
+  [dir & {:keys [path-only?]}]
+  (p/let [result (protocol/readdir (get-fs dir) dir)
+          result (bean/->clj result)]
+    (if (and path-only? (map? (first result)))
+      (map :uri result)
+      result)))
 
 (defn unlink!
   "Should move the path to logseq/recycle instead of deleting it."

--- a/src/main/frontend/fs/capacitor_fs.cljs
+++ b/src/main/frontend/fs/capacitor_fs.cljs
@@ -111,14 +111,16 @@
       (p/resolved (= (string/trim disk-content) (string/trim db-content))))))
 
 (def backup-dir "logseq/bak")
+(def version-file-dir "logseq/version-files/local")
+
 (defn- get-backup-dir
-  [repo-dir path ext]
+  [repo-dir path bak-dir ext]
   (let [relative-path (-> path
                           (string/replace (re-pattern (str "^" (gstring/regExpEscape repo-dir)))
                                           "")
                           (string/replace (re-pattern (str "(?i)" (gstring/regExpEscape (str "." ext)) "$"))
                                           ""))]
-    (util/safe-path-join repo-dir (str backup-dir "/" relative-path))))
+    (util/safe-path-join repo-dir (str bak-dir "/" relative-path))))
 
 (defn- truncate-old-versioned-files!
   "reserve the latest 6 version files"
@@ -130,10 +132,18 @@
             (.deleteFile Filesystem (clj->js {:path (:uri file)})))
           old-versioned-files)))
 
+;; TODO: move this to FS protocol
 (defn backup-file
-  [repo-dir path content ext]
-  (let [backup-dir (get-backup-dir repo-dir path ext)
-        new-path (str backup-dir "/" (string/replace (.toISOString (js/Date.)) ":" "_") "." ext)]
+  "backup CONTENT under DIR :backup-dir or :version-file-dir
+  :backup-dir = `backup-dir`
+  :version-file-dir = `version-file-dir`"
+  [repo dir path content]
+  {:pre [(contains? #{:backup-dir :version-file-dir} dir)]}
+  (let [ext (util/get-file-ext path)
+        dir (case dir
+               :backup-dir (get-backup-dir repo path backup-dir ext)
+               :version-file-dir (get-backup-dir repo path version-file-dir ext))
+        new-path (util/safe-path-join dir (str (string/replace (.toISOString (js/Date.)) ":" "_") "." ext))]
     (<write-file-with-utf8 new-path content)
     (truncate-old-versioned-files! backup-dir)))
 
@@ -191,7 +201,7 @@
                  mtime (-> (js->clj stat :keywordize-keys true)
                            :mtime)]
            (when-not contents-matched?
-             (backup-file repo-dir path disk-content ext))
+             (backup-file repo-dir :backup-dir path disk-content))
            (db/set-file-last-modified-at! repo path mtime)
            (p/let [content (if (encrypt/encrypted-db? (state/get-current-repo))
                              (encrypt/decrypt content)

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -29,7 +29,8 @@
             [medley.core :refer [dedupe-by]]
             [rum.core :as rum]
             [promesa.core :as p]
-            [lambdaisland.glogi :as log]))
+            [lambdaisland.glogi :as log]
+            [frontend.fs.capacitor-fs :as capacitor-fs]))
 
 ;;; ### Commentary
 ;; file-sync related local files/dirs:
@@ -659,7 +660,8 @@
   (<delete-remote-files [this graph-uuid base-path filepaths local-txid] "return err or txid")
   (<encrypt-fnames [this graph-uuid fnames])
   (<decrypt-fnames [this graph-uuid fnames])
-  (<cancel-all-requests [this]))
+  (<cancel-all-requests [this])
+  (<add-new-version [this repo path content]))
 
 (defprotocol IRemoteAPI
   (<user-info [this] "user info")
@@ -805,7 +807,10 @@
                                                (ex-info "decrypt-failed" {:fnames fnames} (ex-cause r))
                                                (js->clj r)))))
   (<cancel-all-requests [_]
-    (p->c (ipc/ipc "cancel-all-requests"))))
+    (p->c (ipc/ipc "cancel-all-requests")))
+
+  (<add-new-version [_this repo path content]
+    (p->c (ipc/ipc "addVersionFile" (config/get-local-dir repo) path content))))
 
 (deftype ^:large-vars/cleanup-todo CapacitorAPI [^:mutable graph-uuid' ^:mutable private-key ^:mutable public-key']
   IToken
@@ -936,7 +941,9 @@
             (ex-info "decrypt-failed" {:fnames fnames} (ex-cause r))
             (get (js->clj r) "value")))))
   (<cancel-all-requests [_]
-    (p->c (.cancelAllRequests mobile-util/file-sync))))
+    (p->c (.cancelAllRequests mobile-util/file-sync)))
+  (<add-new-version [_this repo path content]
+    (p->c (capacitor-fs/backup-file repo :version-file-dir path content))))
 
 (def rsapi (cond
              (util/electron?)
@@ -950,6 +957,10 @@
 
              :else
              nil))
+
+(defn add-new-version-file
+  [repo path content]
+  (<add-new-version rsapi repo path content))
 
 (defn <rsapi-cancel-all-requests []
   (go
@@ -1309,11 +1320,6 @@
             (swap! *get-graph-encrypt-keys-memoize-cache conj [graph-uuid r]))
           r))))
 
-(defn add-new-version-file
-  [repo path content]
-  ;; TODO @leizhe mobile implementation
-  (ipc/ipc "addVersionFile" (config/get-local-dir repo) path content))
-
 (defn- is-journals-or-pages?
   [filetxn]
   (let [rel-path (relative-path filetxn)]
@@ -1454,7 +1460,7 @@
               r (<! (<with-pause update-local-files-ch *paused))]
           (doseq [[filetxn origin-db-content] txn->db-content-vec]
             (when (<! (need-add-version-file? filetxn origin-db-content))
-              (add-new-version-file repo (relative-path filetxn) origin-db-content)
+              (<! (<add-new-version rsapi repo (relative-path filetxn) origin-db-content))
               (put-sync-event! {:event :created-local-version-file
                                 :data {:graph-uuid graph-uuid
                                        :repo repo

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -640,7 +640,8 @@
   (when (db/get-db graph)
     (let [file (:block/file page-entity)]
       (when-let [path (:file/path file)]
-        (when (not= content (:file/content file))
+        (when (and (not= content (:file/content file))
+                   (:file/content file))
           (sync/add-new-version-file graph path (:file/content file)))
         (p/let [_ (file-handler/alter-file graph
                                            path

--- a/src/main/frontend/handler/file_sync.cljs
+++ b/src/main/frontend/handler/file_sync.cljs
@@ -131,17 +131,9 @@
                                      (#(js->clj % :keywordize-keys true))
                                      ((juxt :dir :name))
                                      (apply path/join base-path))
-            version-file-paths* (<! (p->c (fs/readdir version-files-dir)))]
-        (when-not (instance? ExceptionInfo version-file-paths*)
-          (let [version-file-paths
-                (filterv
-                 ;; filter dir
-                 (fn [dir-or-file]
-                   (-> (path/parse dir-or-file)
-                       (js->clj :keywordize-keys true)
-                       :ext
-                       seq))
-                 (js->clj (<! (p->c (fs/readdir version-files-dir)))))]
+            version-file-paths (<! (p->c (fs/readdir version-files-dir :path-only? true)))]
+        (when-not (instance? ExceptionInfo version-file-paths)
+          (when (seq version-file-paths)
             (mapv
              (fn [path]
                (let [create-time


### PR DESCRIPTION
Previously, the local file will not be added to local history if there was any conflict when syncing with the server, which can result in data-loss.