### PR TITLE
fix(excalidraw): grid mode status not correctly shown

### DIFF
--- a/src/main/frontend/extensions/excalidraw.cljs
+++ b/src/main/frontend/extensions/excalidraw.cljs
@@ -89,7 +89,7 @@
         [:a.mr-2 {:on-click #(swap! *view-mode? not)}
          (util/format "View Mode (%s)" (if @*view-mode? "ON" "OFF"))]
         [:a.mr-2 {:on-click #(swap! *grid-mode? not)}
-         (util/format "Grid Mode (%s)" (if @*view-mode? "ON" "OFF"))]
+         (util/format "Grid Mode (%s)" (if @*grid-mode? "ON" "OFF"))]
         [:a.mr-2 {:on-click #(when-let [block (db/pull [:block/uuid block-uuid])]
                                (editor-handler/edit-block! block :max block-uuid))}
          "Edit Block"]]


### PR DESCRIPTION
## Background

Grid mode status not correctly shown because of a small typo of `grid-mode`.

## Before 


https://user-images.githubusercontent.com/28241963/195325910-fbdd1d51-e2aa-4258-8b76-7da8e50f5a52.mp4

## After

https://user-images.githubusercontent.com/28241963/195325881-cecf5c9a-06dc-4642-b67d-ff1428d02c4d.mp4

