### PR TITLE
WIP: double queare bracket in title

### DIFF
--- a/deps/graph-parser/test/logseq/graph_parser/text_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/text_test.cljs
@@ -101,7 +101,11 @@
   (testing "parse-property with quoted strings"
     (are [k v y] (= (parse-property k v {}) y)
          :tags "\"foo, bar\"" "\"foo, bar\""
-         :tags "\"[[foo]], [[bar]]\"" "\"[[foo]], [[bar]]\"")))
+         :tags "\"[[foo]], [[bar]]\"" "\"[[foo]], [[bar]]\""))
+  
+  (testing "parse title property with square bracket"
+    (are [k v y] (= (parse-property k v {}) y)
+      :title "[[Jan 11th, 2022]] 21:26" "\"[[Jan 11th, 2022]] 21:26\"")))
 
 
 #_(cljs.test/test-ns 'logseq.graph-parser.text-test)

--- a/src/test/frontend/db/name_sanity_test.cljs
+++ b/src/test/frontend/db/name_sanity_test.cljs
@@ -23,7 +23,7 @@
       (is (= file-name' file-name))
       (is (= file-name'' file-name)))))
 
-(deftest ^:focus page-name-sanitization-tests
+(deftest page-name-sanitization-tests
   (test-page-name "Some.Content!")
   (test-page-name "More _/_ Con tents")
   (test-page-name "More _________/________ Con tents")


### PR DESCRIPTION
In a rare case that using `[[]]` in page's title property, like
> title:: [[Jan 11th, 2022]] 12:42

The parsing result will return a map:
![image](https://user-images.githubusercontent.com/9862022/195623992-7ccfacb7-1b09-4897-95e1-ceca3d39d6eb.png)

Another example by adding page reference in somewhere `[[[[aldsfkd]] a.b/c.d]]` and click in to check the page property
![image](https://user-images.githubusercontent.com/9862022/195630578-7048f7ce-4d51-411c-8a8c-c8169559cf72.png)


We need to decide if this is the supported usage of the `title` property, and what's the expected behavior.

---

Currently this PR provides a graph parser test case for the buggy parsing