### PR TITLE
Fix: Up/down arrow navigation

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3096,7 +3096,8 @@
 
         (state/selection?)
         (select-up-down direction)
-
+        
+        ;; if there is an edit-input-id set, we are probably still on editing mode, that is not fully initialized
         (not (state/get-edit-input-id))
         (select-first-last direction)))
     nil))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3097,7 +3097,7 @@
         (state/selection?)
         (select-up-down direction)
 
-        :else
+        (not (state/get-edit-input-id))
         (select-first-last direction)))
     nil))
 


### PR DESCRIPTION
Resolves https://github.com/logseq/logseq/issues/6697

As stated on the original issue
> This doesn't happen on macOS (probably related to built-in event throttling differences). The frontend.state/editing? predicate returns false after 4-5 consequent events, because (gdom/getElement id) of get-input fails. Adding a custom 50ms throttle to the event seems to fix this, but I am not sure if that's the best approach.

I think trying to solve this by throttling the event is not great, and might lead to unexpected results. The root problem is that `state/editing?`should return `true`, but the dom element can't be selected yet. If `(state/get-edit-input-id)` is set but the element does not exist, we are on a transitioning state, so we simply do nothing. Calling `select-first-last` (which calls `exit-editing-and-set-selected-blocks!`) when it shouldn't, was causing the switch to select mode. My understanding is that in this case we are using it to select the first or the last block.

I also found a way to reproduce the issue on macOS. You can go to `Settings->Keyboard` and set `Key Repeat` and `Delay Until Repeat` to fast. Then follow the steps described on https://github.com/logseq/logseq/issues/6697. That verifies that the difference is just the default throttling behavior of the operating system. The event is not fired fast enough with the default settings on macOS.

@ reviewers 
This is a one-liner fix, but please take a look at the original issue and the description above, to verify that the reasoning makes sense.