### PR TITLE
fix: modal not respond to enter keydown

### DIFF
--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -565,6 +565,7 @@
      (ui/button
       (t :yes)
       :autoFocus "on"
+      :class "ui__modal-enter"
       :large? true
       :on-click (fn []
                   (state/close-modal!)

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -639,7 +639,9 @@
        [:div.mt-5.sm:mt-4.sm:flex.sm:flex-row-reverse
         [:span.flex.w-full.rounded-md.shadow-sm.sm:ml-3.sm:w-auto
          [:button.inline-flex.justify-center.w-full.rounded-md.border.border-transparent.px-4.py-2.bg-indigo-600.text-base.leading-6.font-medium.text-white.shadow-sm.hover:bg-indigo-500.focus:outline-none.focus:border-indigo-700.focus:shadow-outline-indigo.transition.ease-in-out.duration-150.sm:text-sm.sm:leading-5
-          {:type     "button"
+          {:type     "button" 
+           :autoFocus "on"
+           :class "ui__modal-enter"
            :on-click #(and (fn? on-confirm)
                            (on-confirm % {:close-fn close-fn
                                           :sub-selected (and *sub-checkbox-selected @*sub-checkbox-selected)}))}


### PR DESCRIPTION
## Background

Button Yes in modal of refresh and page renaming are not respond to enter key-press

<img width="823" alt="image" src="https://user-images.githubusercontent.com/28241963/196210315-596c075d-dde9-421f-ac3a-85bae955bda9.png">

<img width="771" alt="image" src="https://user-images.githubusercontent.com/28241963/196210362-4c8646ff-cc3b-4582-813f-6a258a7f4581.png">

## Solution

I have dived into this project and imitated the way this code segment is written: https://github.com/logseq/logseq/blob/9bd0b0b22107753cae12bf3f78e0369aa2e3ee93/src/main/frontend/handler/events.cljs#L478-L479

And then apply it to the codes which is modified in the commit of this PR.

## Behavior after fix

Button Yes in modal mentioned in Background are now respond to enter key-press :)
