### PR TITLE
test: enable Node-test on namespaces with dependency on hickory

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -70,7 +70,9 @@
          :closure-defines {frontend.util/NODETEST true}
          :devtools        {:enabled false}
          ;; disable :static-fns to allow for with-redefs and repl development
-         :compiler-options {:static-fns false}
+         :compiler-options {:static-fns false
+         ;; For custom conditional reading, see https://shadow-cljs.github.io/docs/UsersGuide.html#_conditional_reading
+                            :reader-features #{:node-test}}
          :main            frontend.test.frontend-node-test-runner/main}
 
   :publishing {:target        :browser

--- a/src/main/frontend/extensions/hickory.cljc
+++ b/src/main/frontend/extensions/hickory.cljc
@@ -1,0 +1,12 @@
+(ns frontend.extensions.hickory
+  "A shim for conditional reading of the hickory lib in Node,
+   which requires DOM"
+  (:require #?(:node-test [lambdaisland.glogi :as log]
+               :default   [hickory.core :as hickory])))
+
+#?(:node-test (defn html->hiccup
+                [html]
+                (log/error :exception "Calling hickory from Node test environment is not expected!"))
+   :default (defn html->hiccup
+              [html]
+              (hickory/as-hiccup (hickory/parse html))))

--- a/src/main/frontend/extensions/html_parser.cljs
+++ b/src/main/frontend/extensions/html_parser.cljs
@@ -4,7 +4,7 @@
             [clojure.walk :as walk]
             [frontend.config :as config]
             [frontend.util :as util]
-            [hickory.core :as hickory]))
+            [frontend.extensions.hickory :as hickory]))
 
 (defonce *inside-pre? (atom false))
 (defn- hiccup-without-style
@@ -273,7 +273,7 @@
 (defn convert
   [format html]
   (when-not (string/blank? html)
-    (let [hiccup (hickory/as-hiccup (hickory/parse html))
+    (let [hiccup (hickory/html->hiccup html)
           decoded-hiccup (html-decode-hiccup hiccup)]
       (hiccup->doc format decoded-hiccup))))
 

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -60,6 +60,8 @@
       nil)))
 
 (defn- try-parse-as-json
+  "Result is not only to be an Object.
+   Maybe JSON types like string, number, boolean, null, array"
   [text]
   (try (js/JSON.parse text)
        (catch :default _ #js{})))

--- a/src/test/frontend/extensions/zotero/extractor_test.cljs
+++ b/src/test/frontend/extensions/zotero/extractor_test.cljs
@@ -1,39 +1,41 @@
 ;; FIXME
 ;; https://github.com/davidsantiago/hickory/issues/17
 ;; hictory doesnt work in Node
-;; (ns frontend.extensions.zotero.extractor-test
-;;   (:require [clojure.edn :as edn]
-;;             [clojure.test :as test :refer [deftest is testing]]
-;;             [shadow.resource :as rc]
-;;             [clojure.string :as str]
-;;             [frontend.extensions.zotero.extractor :as extractor]))
+;; 2022.10.17 Fixed via frontend.extensions.hickory
+;; TODO fix the remaining cases
+(ns frontend.extensions.zotero.extractor-test
+  (:require [clojure.edn :as edn]
+            [clojure.test :as test :refer [deftest is testing]]
+            [shadow.resource :as rc]
+            ;; [clojure.string :as str]
+            [frontend.extensions.zotero.extractor :as extractor]))
 
-;; (def data
-;;   (-> (rc/inline "fixtures/zotero.edn")
-;;       (edn/read-string)))
+(def data
+  (-> (rc/inline "fixtures/zotero.edn")
+      (edn/read-string)))
 
-;; (deftest extract-test
-;;   (testing "journal article"
-;;     (let [{:keys [page-name properties]}
-;;           (extractor/extract (:journal-article-sample-1 data))]
+(deftest extract-test
+  (testing "journal article"
+    (let [{:keys [page-name properties]}
+          (extractor/extract (:journal-article-sample-1 data))]
 
-;;       (testing "page name prefer citation key"
-;;         (is (= "@efroniHowCombineTreeSearch2019" page-name)))
+      (testing "page name prefer citation key"
+        (is (= "@efroniHowCombineTreeSearch2019" page-name)))
 
-;;       (testing "convert date"
-;;         (is (= "[[Feb 17th, 2019]]" (-> properties :date))))
+      (testing "convert date"
+        (is (= "[[Feb 17th, 2019]]" (-> properties :date))))
 
-;;       (testing "convert date"
-;;         (is (= "[[Feb 17th, 2019]]" (-> properties :date))))
+      (testing "convert date"
+        (is (= "[[Feb 17th, 2019]]" (-> properties :date))))
 
-;;       (testing "original title"
-;;         (is (= "How to Combine Tree-Search Methods in Reinforcement Learning" (-> properties :original-title))))
+      (testing "original title"
+        (is (= "How to Combine Tree-Search Methods in Reinforcement Learning" (-> properties :original-title))))
 
-;;       (testing "double quote when containing comma"
-;;         (is (= "\"arXiv:1809.01843 [cs, stat]\"" (-> properties :publication-title))))
+      (testing "double quote when containing comma"
+        (is (= "\"arXiv:1809.01843 [cs, stat]\"" (-> properties :publication-title))))
 
-;;       (testing "skip when containing newline"
-;;         (is (nil? (-> properties :extra))))))
+      (testing "skip when containing newline"
+        (is (nil? (-> properties :extra))))))
 
 ;;   (testing "another journal article"
 ;;     (let [{:keys [page-name properties]}
@@ -47,27 +49,29 @@
 ;;       (testing "tags"
 ;;         (is (= 17 tags)))))
 
-;;   (testing "book"
-;;     (let [{:keys [page-name properties]}
-;;           (extractor/extract (:book-sample-1 data))]
+  (testing "book"
+    (let [{:keys [page-name properties]}
+          (extractor/extract (:book-sample-1 data))]
 
-;;       (testing "page name"
-;;         (is (= "@1984" page-name)))
+      (testing "page name"
+        (is (= "@1984" page-name)))
 
-;;       (testing "author"
-;;         (is (= "[[George Orwell]]" (-> properties :authors))))
+      (testing "author"
+        (is (= '("George Orwell") (-> properties :authors))))
 
-;;       (testing "preserve unparsable date"
-;;         (is (= "1984" (-> properties :date))))))
+      (testing "preserve unparsable date"
+        (is (= "1984" (-> properties :date))))))
 
-;;   (testing "newpaper article"
-;;     (let [{:keys [page-name properties]}
-;;           (extractor/extract (:newspaper-article-sample-1 data))]
-;;       (is (= "A Letter to Our Readers About Digital Subscriptions" (-> properties :original-title)))
+  (testing "newpaper article"
+    (let [{:keys [_page-name properties]}
+          (extractor/extract (:newspaper-article-sample-1 data))]
+      (is (= "A Letter to Our Readers About Digital Subscriptions" (-> properties :original-title)))
 
-;;       (testing "use parsed date when possible"
-;;         (is (= "[[Mar 28th, 2011]]" (-> properties :date))))))
+      (testing "use parsed date when possible"
+        (is (= "[[Mar 28th, 2011]]" (-> properties :date))))))
 
+;; 2022.10.18. Should be deprecated since Hickory is invalid in Node test
 ;;   (testing "note"
 ;;     (let [result (extractor/extract (:note-sample-1 data))]
-;;       (is (str/starts-with? result "This study shows")))))
+;;       (is (str/starts-with? result "This study shows"))))
+  )

--- a/src/test/frontend/extensions/zotero/extractor_test.cljs
+++ b/src/test/frontend/extensions/zotero/extractor_test.cljs
@@ -1,13 +1,9 @@
 ;; FIXME
-;; https://github.com/davidsantiago/hickory/issues/17
-;; hictory doesnt work in Node
-;; 2022.10.17 Fixed via frontend.extensions.hickory
-;; TODO fix the remaining cases
+;; this test is not focusable (unable to feed :node-test as reading feature?)
 (ns frontend.extensions.zotero.extractor-test
   (:require [clojure.edn :as edn]
             [clojure.test :as test :refer [deftest is testing]]
             [shadow.resource :as rc]
-            ;; [clojure.string :as str]
             [frontend.extensions.zotero.extractor :as extractor]))
 
 (def data
@@ -37,17 +33,20 @@
       (testing "skip when containing newline"
         (is (nil? (-> properties :extra))))))
 
-;;   (testing "another journal article"
-;;     (let [{:keys [page-name properties]}
-;;           (extractor/extract (:journal-article-sample-2 data))
-;;           authors (count (re-seq #"\[\[" (-> properties :authors)))
-;;           tags    (count (re-seq #"\[\[" (-> properties :tags)))]
+  (testing "another journal article"
+    (let [{:keys [_page-name properties]}
+          (extractor/extract (:journal-article-sample-2 data))
+          authors (count (-> properties :authors))
+          tags    (count (-> properties :tags))]
 
-;;       (testing "authors"
-;;         (is (= 8 authors)))
+      (testing "authors"
+        (is (= 8 authors)))
 
-;;       (testing "tags"
-;;         (is (= 17 tags)))))
+      (testing "tags"
+        (prn (-> properties :tags))
+        ;; tags split by `,` are counted into different tags
+        ;; https://github.com/logseq/logseq/commit/435c2110bcc2d30ed743ba31375450f1a705b00b
+        (is (= 20 tags)))))
 
   (testing "book"
     (let [{:keys [page-name properties]}
@@ -71,7 +70,8 @@
         (is (= "[[Mar 28th, 2011]]" (-> properties :date))))))
 
 ;; 2022.10.18. Should be deprecated since Hickory is invalid in Node test
+;; Skip until we find an alternative
 ;;   (testing "note"
 ;;     (let [result (extractor/extract (:note-sample-1 data))]
 ;;       (is (str/starts-with? result "This study shows"))))
-  )
+)

--- a/src/test/frontend/handler/paste_test.cljs
+++ b/src/test/frontend/handler/paste_test.cljs
@@ -1,0 +1,32 @@
+(ns frontend.handler.paste-test
+  (:require [cljs.test :refer [deftest are]]
+            [goog.object :as gobj]
+            [frontend.handler.paste :as paste-handler]))
+
+(deftest try-parse-as-json-result-parse-test
+  (are [x y] (let [result (#'paste-handler/try-parse-as-json x)
+                   obj-result (if (object? result) result #js{})]
+               (gobj/get obj-result "foo") ;; This op shouldn't throw
+               (gobj/getValueByKeys obj-result "foo" "bar") ;; This op shouldn't throw
+               (gobj/equals result y))
+    "{\"number\": 1234}" #js{:number 1234}
+    "1234" 1234
+    "null" nil
+    "true" true
+    "[1234, 5678]" #js[1234 5678]
+    ;; invalid JSON
+    "{number: 1234}" #js{}))
+
+(deftest try-parse-as-json-result-get-test
+  (are [x y z] (let [result (#'paste-handler/try-parse-as-json x)
+                     obj-result (if (object? result) result #js{})]
+                 (and (gobj/equals (gobj/get obj-result "foo") y)
+                      (gobj/equals (gobj/getValueByKeys obj-result "foo" "bar") z)))
+    "{\"foo\": {\"bar\": 1234}}" #js{:bar 1234} 1234
+    "{\"number\": 1234}" nil nil
+    "1234" nil nil
+    "null" nil nil
+    "true" nil nil
+    "[{\"number\": 1234}]" nil nil
+    ;; invalid JSON
+    "{number: 1234}" nil nil))


### PR DESCRIPTION
This PR was to fix the pasting issue of writeboard (addressed in #7002 )
Now the paste issue fix is removed.

This PR now
1. **Enables test on `frontend.handler.paste`** which was blocked by the dependency on `hickory`, and provides some trivial tests in `src/test/frontend.handler.paste_test`
2. Recovers `src/test/frontend.extensions.zotero.extractor-test` which was also blocked previously.