### PR TITLE
Fix: shortcut alignment on command palette

### DIFF
--- a/src/main/frontend/components/command_palette.cljs
+++ b/src/main/frontend/components/command_palette.cljs
@@ -29,7 +29,7 @@
      [:span.col-span-3 desc]
      [:div.col-span-1.justify-end.tip.flex
       (when (and (keyword? id) (namespace id))
-        [:code.opacity-20.bg-transparent (namespace id)])
+        [:code.opacity-50.bg-transparent (namespace id)])
       (when-not (string/blank? first-shortcut)
         [:code.ml-1 first-shortcut])]]))
 

--- a/src/main/frontend/components/command_palette.cljs
+++ b/src/main/frontend/components/command_palette.cljs
@@ -29,7 +29,7 @@
      [:span.col-span-3 desc]
      [:div.col-span-1.justify-end.tip.flex
       (when (and (keyword? id) (namespace id))
-        [:code.opacity-50.bg-transparent (namespace id)])
+        [:code.opacity-40.bg-transparent (namespace id)])
       (when-not (string/blank? first-shortcut)
         [:code.ml-1 first-shortcut])]]))
 

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -160,7 +160,7 @@
      (dissoc options :only-child?) child]
     [:a.flex.justify-between.px-4.py-2.text-sm.transition.ease-in-out.duration-150.cursor.menu-link
      options
-     [:span.w-full child]
+     [:span.flex-1 child]
      (when shortcut
        [:span.ml-1 (render-keyboard-shortcut shortcut)])]))
 

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -160,7 +160,7 @@
      (dissoc options :only-child?) child]
     [:a.flex.justify-between.px-4.py-2.text-sm.transition.ease-in-out.duration-150.cursor.menu-link
      options
-     [:span child]
+     [:span.w-full child]
      (when shortcut
        [:span.ml-1 (render-keyboard-shortcut shortcut)])]))
 


### PR DESCRIPTION
This fixes the alignment of the shortcuts on our command palette. I also increased the opacity of namespace to make it readable.

![Screenshot from 2022-10-18 13-57-17](https://user-images.githubusercontent.com/10744960/196411518-a1c17876-99ea-467d-8445-85042a6f2d88.png)
