### PR TITLE
fix: add timestamps for whiteboard blocks

### DIFF
--- a/src/main/frontend/db/utils.cljs
+++ b/src/main/frontend/db/utils.cljs
@@ -87,7 +87,6 @@
   ([repo-url tx-data]
    (transact! repo-url tx-data nil))
   ([repo-url tx-data tx-meta]
-   (frontend.util/pprint tx-data)
    (when-not config/publishing?
      (let [tx-data (->> (gp-util/remove-nils tx-data)
                         (remove nil?))]

--- a/src/main/frontend/db/utils.cljs
+++ b/src/main/frontend/db/utils.cljs
@@ -87,6 +87,7 @@
   ([repo-url tx-data]
    (transact! repo-url tx-data nil))
   ([repo-url tx-data tx-meta]
+   (frontend.util/pprint tx-data)
    (when-not config/publishing?
      (let [tx-data (->> (gp-util/remove-nils tx-data)
                         (remove nil?))]

--- a/src/main/frontend/modules/outliner/file.cljs
+++ b/src/main/frontend/modules/outliner/file.cljs
@@ -21,6 +21,8 @@
     :block/uuid
     :block/content
     :block/format
+    :block/created-at
+    :block/updated-at
     {:block/page      [:block/uuid]}
     {:block/left      [:block/uuid]}
     {:block/parent    [:block/uuid]}])


### PR DESCRIPTION
This PR adds timestamps for whiteboard blocks too (pages are supported already). Timestamps could enable some really interesting usages, e.g., reviewing the blocks created on the same day, which blocks have been modified recently, etc.