### PR TITLE
Dev: bump clj-kondo and hickory

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -5,10 +5,13 @@
  ;; for rum/defcs and _state.
  {all-components {:linters {:used-underscored-binding {:level :off}}}
   ;; false positive with match/match and _
-  frontend.handler.paste {:linters {:used-underscored-binding {:level :off}}}}
+  frontend.handler.paste {:linters {:used-underscored-binding {:level :off}}}
+  frontend.db {:linters {:aliased-namespace-symbol
+                         {:exclude [frontend.db.conn frontend.db.react logseq.db.default]}}}}
 
  :linters
- {:unresolved-symbol {:exclude [goog.DEBUG
+ {:aliased-namespace-symbol {:level :warning}
+  :unresolved-symbol {:exclude [goog.DEBUG
                                 goog.string.unescapeEntities
                                 ;; TODO:lint: Fix when fixing all type hints
                                 object]}
@@ -20,7 +23,10 @@
                              frontend.util/node-path.name]}
 
   :consistent-alias
-  {:aliases {datascript.core d
+  {:aliases {cljs.reader reader
+             cljs-time.core t
+             cljs-time.coerce tc
+             datascript.core d
              datascript.transit dt
              datascript.db ddb
              electron.ipc ipc

--- a/deps.edn
+++ b/deps.edn
@@ -18,8 +18,8 @@
   cljs-drag-n-drop/cljs-drag-n-drop     {:mvn/version "0.1.0"}
   cljs-http/cljs-http                   {:mvn/version "0.1.46"}
   org.babashka/sci                      {:mvn/version "0.3.2"}
-  hickory/hickory                       {:git/url "https://github.com/logseq/hickory"
-                                         :sha     "86baee0319a66b7921719a5d2345e09734b23650"}
+  hickory/hickory                       {:git/url "https://github.com/clj-commons/hickory"
+                                         :sha     "a308fafdf1e0483087a105544f2cb190cc3289b0"}
   hiccups/hiccups                       {:mvn/version "0.3.0"}
   tongue/tongue                         {:mvn/version "0.4.4"}
   org.clojure/core.async                {:mvn/version "1.3.610"}

--- a/deps.edn
+++ b/deps.edn
@@ -48,5 +48,5 @@
                   :main-opts   ["-m" "shadow.cljs.devtools.cli"]}
 
            ;; Use :replace-deps for tools. See https://github.com/clj-kondo/clj-kondo/issues/1536#issuecomment-1013006889
-           :clj-kondo {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2022.09.08"}}
+           :clj-kondo {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2022.10.14"}}
                        :main-opts  ["-m" "clj-kondo.main"]}}}

--- a/deps/db/deps.edn
+++ b/deps/db/deps.edn
@@ -3,5 +3,5 @@
  {datascript/datascript {:mvn/version "1.3.8"}}
  :aliases
  {:clj-kondo
-  {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2022.09.08"}}
+  {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2022.10.14"}}
    :main-opts  ["-m" "clj-kondo.main"]}}}

--- a/deps/graph-parser/.clj-kondo/config.edn
+++ b/deps/graph-parser/.clj-kondo/config.edn
@@ -1,5 +1,9 @@
 {:linters
- {:consistent-alias
+ {:aliased-namespace-symbol {:level :warning}
+  :namespace-name-mismatch {:level :warning}
+  :used-underscored-binding {:level :warning}
+
+  :consistent-alias
   {:aliases {clojure.string string
              datascript.core d
              logseq.graph-parser graph-parser

--- a/deps/graph-parser/deps.edn
+++ b/deps/graph-parser/deps.edn
@@ -19,5 +19,5 @@
                       org.clojure/clojurescript {:mvn/version "1.11.54"}}
          :main-opts ["-m" "cljs-test-runner.main"]}
 
-  :clj-kondo {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2022.09.08"}}
+  :clj-kondo {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2022.10.14"}}
               :main-opts  ["-m" "clj-kondo.main"]}}}

--- a/deps/graph-parser/test/logseq/graph_parser/nbb_test_runner.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/nbb_test_runner.cljs
@@ -12,8 +12,8 @@
             [logseq.graph-parser.util.file-name-test]
             [logseq.graph-parser-test]))
 
-(defmethod cljs.test/report [:cljs.test/default :end-run-tests] [m]
-  (when-not (cljs.test/successful? m)
+(defmethod t/report [:cljs.test/default :end-run-tests] [m]
+  (when-not (t/successful? m)
     (set! (.-exitCode js/process) 1)))
 
 ;; run this function with: nbb-logseq -m logseq.test.nbb-test-runner/run-tests

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -443,8 +443,6 @@
     (set-up-key-down! state format)
     (set-up-key-up! state input input-id)))
 
-(def starts-with? clojure.string/starts-with?)
-
 (defn get-editor-style-class
   "Get textarea css class according to it's content"
   [content format]
@@ -459,17 +457,17 @@
      (case format
        :markdown
        (cond
-         (starts-with? content "# ") "h1"
-         (starts-with? content "## ") "h2"
-         (starts-with? content "### ") "h3"
-         (starts-with? content "#### ") "h4"
-         (starts-with? content "##### ") "h5"
-         (starts-with? content "###### ") "h6"
-         (and (starts-with? content "---\n") (.endsWith content "\n---")) "page-properties"
+         (string/starts-with? content "# ") "h1"
+         (string/starts-with? content "## ") "h2"
+         (string/starts-with? content "### ") "h3"
+         (string/starts-with? content "#### ") "h4"
+         (string/starts-with? content "##### ") "h5"
+         (string/starts-with? content "###### ") "h6"
+         (and (string/starts-with? content "---\n") (.endsWith content "\n---")) "page-properties"
          :else "normal-block")
        ;; other formats
        (cond
-         (and (starts-with? content "---\n") (.endsWith content "\n---")) "page-properties"
+         (and (string/starts-with? content "---\n") (.endsWith content "\n---")) "page-properties"
          :else "normal-block")))))
 
 (defn editor-row-height-unchanged?

--- a/src/main/frontend/components/shortcut.cljs
+++ b/src/main/frontend/components/shortcut.cljs
@@ -48,7 +48,7 @@
 (rum/defc shortcut-col [k binding configurable? action-name]
   (let [conflict?         (dh/potential-conflict? k)
         displayed-binding (dh/binding-for-display k binding)
-        disabled?         (clojure.string/includes? displayed-binding "system default")]
+        disabled?         (str/includes? displayed-binding "system default")]
     (if (not configurable?)
       [:td.text-right displayed-binding]
       [:td.text-right

--- a/src/main/frontend/rum.cljs
+++ b/src/main/frontend/rum.cljs
@@ -57,7 +57,7 @@
           ;; a valid html element tag is used, using sablono
           vector->react-elems (fn [[key val]]
                                 (if (sequential? val)
-                                  [key (daiquiri.interpreter/interpret val)]
+                                  [key (interpreter/interpret val)]
                                   [key val]))
           new-options (into {}
                             (if skip-opts-transform?
@@ -123,7 +123,7 @@
   "Returns a function that can be used to register a callback
    that will be called when the user clicks outside the given dom node"
   [handler & {:keys [capture? event]
-              :or {capture? false 
+              :or {capture? false
                    event "click"}}] ;; could be "mousedown" or "click"
   (let [[ref set-ref] (rum/use-state nil)]
     (rum/use-effect!

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -751,13 +751,13 @@
 #?(:cljs
    (defn react
      [ref]
-     (if rum.core/*reactions*
+     (if rum/*reactions*
        (rum/react ref)
        @ref)))
 
 (defn time-ms
   []
-  #?(:cljs (tc/to-long (cljs-time.core/now))))
+  #?(:cljs (tc/to-long (t/now))))
 
 ;; Returns the milliseconds representation of the provided time, in the local timezone.
 ;; For example, if you run this function at 10pm EDT in the EDT timezone on May 31st,

--- a/src/main/frontend/util/persist_var.cljs
+++ b/src/main/frontend/util/persist_var.cljs
@@ -42,7 +42,7 @@
                              (fs/read-file dir path)))
                          (fn [content]
                            (when (not-empty content)
-                             (try (cljs.reader/read-string content)
+                             (try (reader/read-string content)
                                   (catch :default e
                                     (println (util/format "read persist-var failed: %s" (load-path location)))
                                     (js/console.dir e)))))


### PR DESCRIPTION
- Bump clj-kondo as it has added a couple new linters and fixed some bugs.
- Bump hickory to use the [original version](https://github.com/clj-commons/hickory/commits/master) as it now has a deps.edn (which was our only reason for the fork) and also includes a dependency bump to patch a security vulnerability with jsoup