### PR TITLE
Fix: Disallow tags as property names

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/property.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/property.cljs
@@ -17,9 +17,11 @@
 
 (defn valid-property-name?
   [s]
-  [:pre (string? s)]
+  {:pre [(string? s)]}
   (and (gp-util/valid-edn-keyword? s)
-       (not (re-find #"[\"|^|(|)|{|}]+" s))))
+       (not (re-find #"[\"|^|(|)|{|}]+" s))
+       ;; Disallow tags as property names
+       (not (re-find #"^:#" s))))
 
 (defn properties-ast?
   [block]

--- a/deps/graph-parser/test/logseq/graph_parser_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser_test.cljs
@@ -284,13 +284,14 @@
   (let [conn (ldb/start-conn)
         properties {"foo" "valid"
                     "[[foo]]" "invalid"
-                    "some,prop" "invalid"}
+                    "some,prop" "invalid"
+                    "#blarg" "invalid"}
         body (str (gp-property/->block-content properties)
                   "\n- " (gp-property/->block-content properties))]
     (graph-parser/parse-file conn "foo.md" body {})
 
     (is (= [{:block/properties {:foo "valid"}
-             :block/invalid-properties #{"[[foo]]" "some,prop"}}]
+             :block/invalid-properties #{"[[foo]]" "some,prop" "#blarg"}}]
            (->> (d/q '[:find (pull ?b [*])
                        :in $
                        :where
@@ -303,7 +304,7 @@
         "Has correct (in)valid block properties")
 
     (is (= [{:block/properties {:foo "valid"}
-             :block/invalid-properties #{"[[foo]]" "some,prop"}}]
+             :block/invalid-properties #{"[[foo]]" "some,prop" "#blarg"}}]
            (->> (d/q '[:find (pull ?b [*])
                        :in $
                        :where [?b :block/properties] [?b :block/name]]


### PR DESCRIPTION
Fixes bugs seen in #6753. This is consistent with https://github.com/logseq/logseq/commit/066496089fdd2f1c749909d2e552d780ce5cd416. Eventually we may want to share validation logic between property names and page names