### PR TITLE
Fix: block-uuid on page-reference

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -745,8 +745,9 @@
       (draw-component {:file file :block-uuid block-uuid}))))
 
 (rum/defc page-reference < rum/reactive
-  [html-export? s {:keys [nested-link? block-uuid id] :as config} label]
+  [html-export? s {:keys [nested-link? id] :as config} label]
   (let [show-brackets? (state/show-brackets?)
+        block-uuid (:block/uuid config)
         contents-page? (= "contents" (string/lower-case (str id)))]
     (if (string/ends-with? s ".excalidraw")
       [:div.draw {:on-click (fn [e]


### PR DESCRIPTION
Introduced [here](https://github.com/logseq/logseq/commit/aed9527f5a7520cb744181cc522bb7d3d6ffeac2#diff-39e448dcea9d6d637136848eddca673106911b12f656627ab14923fb3fa72322R622)

Resolves  
> Another thing I noticed was that nothing was happening when I clicked on the edit block option. I am guessing this should take me to the block text in Logseq. Am I missing something? Other buttons like Zen mode etc are working fine.

on https://github.com/logseq/logseq/issues/7034
The edit button doesn't work because `block-uuid` is `nil`

