### PR TITLE
fix: incorrect ordering for simple query table ordered by date

### DIFF
--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -59,7 +59,7 @@ and handles unexpected failure."
   "Normalizes supported formats such as dates and percentages."
   ([block]
    (->> [normalize-as-percentage normalize-as-date identity]
-        (map #(% block))
+        (map #(% (if (set? block) (first block) block)))
         (remove nil?)
         (first))))
 

--- a/src/test/frontend/format/block_test.cljs
+++ b/src/test/frontend/format/block_test.cljs
@@ -9,6 +9,12 @@
          "2022-08-12T00:00:00Z"
 
          "2022-08-12T00:00:00Z"
+         "2022-08-12T00:00:00Z"
+
+         #{"Aug 12th, 2022"}
+         "2022-08-12T00:00:00Z"
+
+         #{"2022-08-12T00:00:00Z"}
          "2022-08-12T00:00:00Z")))
 
 (deftest test-normalize-percentage
@@ -21,7 +27,10 @@
          0
 
          "-5%"
-         -0.05)))
+         -0.05
+
+         #{"50%"}
+         0.5)))
 
 (deftest test-random-values
   (testing "random values should not be processed"


### PR DESCRIPTION
Fixes #6955 

Pagelinks are treated as sets with one Element [[abc]] => #{abc} 
but the normalize functions expected strings. 

The solution was extracting the first element if the supplied block is a set.

Also added tests for this scenario