### PR TITLE
Page bottom refs blocks

### DIFF
--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -178,7 +178,7 @@
   [repo tag]
   (let [pages (db/get-tag-pages repo tag)]
     (when (seq pages)
-      [:div.references.mt-6.flex-1.flex-row
+      [:div.references.page-tags.mt-6.flex-1.flex-row
        [:div.content
         (ui/foldable
          [:h2.font-bold.opacity-50 (util/format "Pages tagged with \"%s\"" tag)]

--- a/src/main/frontend/components/reference.cljs
+++ b/src/main/frontend/components/reference.cljs
@@ -229,7 +229,7 @@
                      frequencies)]
       (reset! *ref-pages ref-pages)
       (when (or (seq filter-state) (> filter-n 0))
-        [:div.references.flex-1.flex-row
+        [:div.references.page-linked.flex-1.flex-row
          [:div.content.pt-6
           (references-cp page-name filters filters-atom filter-state total filter-n filtered-ref-blocks' *ref-pages)]]))))
 
@@ -272,7 +272,7 @@
   (let [n-ref (get state ::n-ref)]
     (when page-name
       (let [page-name (string/lower-case page-name)]
-        [:div.references.mt-6.flex-1.flex-row
+        [:div.references.page-unlinked.mt-6.flex-1.flex-row
          [:div.content.flex-1
           (ui/foldable
            [:h2.font-medium


### PR DESCRIPTION
More consistency in page bottom reference blocks (tagged, linked, unlinked) classnames (same as https://github.com/logseq/logseq/blob/master/src/main/frontend/components/hierarchy.cljs#L43 has).