### PR TITLE
feat: page-level full-text-search

### DIFF
--- a/e2e-tests/page-search.spec.ts
+++ b/e2e-tests/page-search.spec.ts
@@ -39,7 +39,7 @@ import { IsMac, createRandomPage, newBlock, newInnerBlock, randomString, lastBlo
 
   await page.waitForTimeout(500)
   const results = await page.$$('#ui__ac-inner>div')
-  expect(results.length).toEqual(3) // 2 blocks + 1 page
+  expect(results.length).toEqual(5) // 2 blocks + 1 page + 2 page content
   await page.keyboard.press("Escape")
   await page.keyboard.press("Escape")
 })

--- a/e2e-tests/page-search.spec.ts
+++ b/e2e-tests/page-search.spec.ts
@@ -37,11 +37,12 @@ import { IsMac, createRandomPage, newBlock, newInnerBlock, randomString, lastBlo
   await page.waitForSelector('[placeholder="Search or create page"]')
   await page.fill('[placeholder="Search or create page"]', 'Einführung in die Allgemeine Sprachwissenschaft' + rand)
 
-  await page.waitForTimeout(500)
+  await page.waitForTimeout(2000) // wait longer for search contents to render
   const results = await page.$$('#ui__ac-inner>div')
-  expect(results.length).toEqual(5) // 2 blocks + 1 page + 2 page content
+  expect(results.length).toBeGreaterThan(3) // 2 blocks + 1 page + 2 page content
   await page.keyboard.press("Escape")
   await page.keyboard.press("Escape")
+  await page.waitForTimeout(1000) // wait for modal disappear
 })
 
 async function alias_test(page: Page, page_name: string, search_kws: string[]) {

--- a/libs/src/LSPlugin.ts
+++ b/libs/src/LSPlugin.ts
@@ -311,6 +311,13 @@ export interface IPluginSearchServiceHooks {
       files?: Array<SearchFileItem>
     }>
 
+  onQueryPage: (
+    graph: string,
+    key: string,
+    opts: Partial<{}>
+  ) => Promise<unknown>
+
+  onPagesChanged: (graph: string, data: any) => Promise<void>
   onIndiceInit: (graph: string) => Promise<SearchIndiceInitStatus>
   onIndiceReset: (graph: string) => Promise<void>
   onBlocksChanged: (graph: string, changes: { added: Array<SearchBlockItem>, removed: Array<BlockEntity> }) => Promise<void>

--- a/libs/src/modules/LSPlugin.Search.ts
+++ b/libs/src/modules/LSPlugin.Search.ts
@@ -37,6 +37,8 @@ export class LSPluginSearchService {
             return data
           }
         },
+        queryPage: { f: 'onQueryPage', args: ['graph', 'q', true], reply: true },
+        transactPages: { f: 'onPagesChanged', args: ['graph', 'data'] },
         rebuildBlocksIndice: { f: 'onIndiceInit', args: ['graph', 'blocks'] },
         transactBlocks: { f: 'onBlocksChanged', args: ['graph', 'data'] },
         truncateBlocks: { f: 'onIndiceReset', args: ['graph'] },

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -289,6 +289,9 @@
 (defmethod handle :search-blocks [_window [_ repo q opts]]
   (search/search-blocks repo q opts))
 
+(defmethod handle :search-pages [_window [_ repo q opts]]
+  (search/search-pages repo q opts))
+
 (defmethod handle :rebuild-indice [_window [_ repo block-data page-data]]
   (search/truncate-blocks-table! repo)
   ;; unneeded serialization
@@ -299,6 +302,7 @@
 
 (defmethod handle :transact-blocks [_window [_ repo data]]
   (let [{:keys [blocks-to-remove-set blocks-to-add]} data]
+    ;; Order matters! Same id will delete then upsert sometimes.
     (when (seq blocks-to-remove-set)
       (search/delete-blocks! repo blocks-to-remove-set))
     (when (seq blocks-to-add)
@@ -307,6 +311,7 @@
 
 (defmethod handle :transact-pages [_window [_ repo data]]
   (let [{:keys [pages-to-remove-set pages-to-add]} data]
+    ;; Order matters! Same id will delete then upsert sometimes.
     (when (seq pages-to-remove-set)
       (search/delete-pages! repo pages-to-remove-set))
     (when (seq pages-to-add)

--- a/src/electron/electron/search.cljs
+++ b/src/electron/electron/search.cljs
@@ -254,12 +254,20 @@
          (take limit)
          (vec))))))
 
+(defn- search-pages-res-unpack
+  [arr]
+  (let [[rowid uuid content snippet] arr]
+    {:id      rowid
+     :uuid    uuid
+     :content content
+     :snippet snippet}))
+
 (defn- search-pages-aux
   [database sql input limit]
   (let [stmt (prepare database sql)]
-    (js->clj
-     (.all ^object stmt  input limit)
-     :keywordize-keys true)))
+    (map search-pages-res-unpack (-> (.raw ^object stmt)
+                                     (.all input limit)
+                                     (js->clj)))))
 
 (defn search-pages
   [repo q {:keys [limit]}]

--- a/src/electron/electron/search.cljs
+++ b/src/electron/electron/search.cljs
@@ -288,9 +288,8 @@
             ;; the 2nd column in pages_fts (content)
             ;; pfts_2lqh is a key for retrieval
             ;; highlight and snippet only works for some matching with high rank
-            highlight-aux "highlight(pages_fts, 1, '$pfts_2lqh>$', '$<pfts_2lqh$')"
             snippet-aux "snippet(pages_fts, 1, '$pfts_2lqh>$', '$<pfts_2lqh$', '...', 32)"
-            select (str "select rowid, uuid, " highlight-aux ", " snippet-aux " from pages_fts where ")
+            select (str "select rowid, uuid, content, " snippet-aux " from pages_fts where ")
             match-sql (str select
                            " content match ? order by rank limit ?")
             non-match-sql (str select
@@ -299,7 +298,8 @@
          (concat
           (search-pages-aux database match-sql match-input limit)
           (search-pages-aux database non-match-sql non-match-input limit))
-         (distinct)
+         ;; distinct by :id
+         (group-by :id) (vals) (map first)
          (take limit)
          (vec))))))
 

--- a/src/electron/electron/search.cljs
+++ b/src/electron/electron/search.cljs
@@ -181,7 +181,7 @@
 (defn delete-pages!
   [repo ids]
   (when-let [db (get-db repo)]
-    (let [sql (str "DELETE from blocks WHERE id IN " (clj-list->sql ids))
+    (let [sql (str "DELETE from pages WHERE id IN " (clj-list->sql ids))
           stmt (prepare db sql)]
       (.run ^object stmt))))
 

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2497,12 +2497,14 @@
 (rum/defc breadcrumb-separator [] [:span.mx-2.opacity-50 "➤"])
 
 (defn breadcrumb
+  "block-id - uuid of the target block of breadcrumb. page uuid is also acceptable"
   [config repo block-id {:keys [show-page? indent? end-separator? level-limit _navigating-block]
                          :or {show-page? true
                               level-limit 3}
                          :as opts}]
   (let [parents (db/get-block-parents repo block-id (inc level-limit))
-        page (db/get-block-page repo block-id)
+        page (or (db/get-block-page repo block-id) ;; only return for block uuid
+                 (model/query-block-by-uuid block-id)) ;; return page entity when received page uuid
         page-name (:block/name page)
         page-original-name (:block/original-name page)
         show? (or (seq parents) show-page? page-name)

--- a/src/main/frontend/components/search.cljs
+++ b/src/main/frontend/components/search.cljs
@@ -189,6 +189,21 @@
         (println "[Error] Block page missing: "
                  {:block-id block-uuid
                   :block (db/pull [:block/uuid block-uuid])})))
+
+    :page-content
+    (let [page-uuid (uuid (:block/uuid data))
+          page (model/get-block-by-uuid page-uuid)
+          page-name (:block/name page)]
+      (if page
+        (cond
+          (model/whiteboard-page? page-name)
+          (route/redirect-to-whiteboard! page-name)
+          :else
+          (route/redirect-to-page! page-name))
+        ;; search indice outdated
+        (println "[Error] page missing: "
+                 {:page-uuid page-uuid
+                  :page page})))
     nil)
   (state/close-modal!))
 
@@ -204,6 +219,19 @@
          repo
          (:db/id page)
          :page)))
+    
+    :page-content
+    (let [page-uuid (uuid (:block/uuid data))
+          page (model/get-block-by-uuid page-uuid)]
+      (if page
+        (state/sidebar-add-block!
+         repo
+         (:db/id page)
+         :page)
+        ;; search indice outdated
+        (println "[Error] page missing: "
+                 {:page-uuid page-uuid
+                  :page page})))
 
     :block
     (let [block-uuid (uuid (:block/uuid data))

--- a/src/main/frontend/components/search.cljs
+++ b/src/main/frontend/components/search.cljs
@@ -67,10 +67,9 @@
   "Return hiccup of highlighted page content FTS result"
   [content q]
   (when-not (or (string/blank? content) (string/blank? q))
-    [:div (loop [content content
+    [:div (loop [content content ;; why recur? because there might be multiple matches
                  result  []]
-            (let [_ (prn "content" content "result" result)
-                  [b-cut hl-cut e-cut] (text-util/cut-by content "$pfts_2lqh>$" "$<pfts_2lqh$")
+            (let [[b-cut hl-cut e-cut] (text-util/cut-by content "$pfts_2lqh>$" "$<pfts_2lqh$")
                   hiccups-add [(when-not (string/blank? b-cut)
                                  [:span b-cut])
                                (when-not (string/blank? hl-cut)

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -785,6 +785,8 @@
         react)))))
 
 (defn get-page-blocks-no-cache
+  "Return blocks of the designated page, without using cache.
+   page - name / title of the page"
   ([page]
    (get-page-blocks-no-cache (state/get-current-repo) page nil))
   ([repo-url page]

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -1528,6 +1528,7 @@
             assets (get-assets datoms)]
         [@(d/conn-from-datoms datoms db-schema/schema) assets]))))
 
+;; Deprecated?
 (defn delete-blocks
   [repo-url files _delete-page?]
   (when (seq files)

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -274,6 +274,7 @@
   (db-utils/entity [:block/uuid (if (uuid? id) id (uuid id))]))
 
 (defn query-block-by-uuid
+  "Return block or page entity, depends on the uuid"
   [id]
   (db-utils/pull [:block/uuid (if (uuid? id) id (uuid id))]))
 

--- a/src/main/frontend/handler/search.cljs
+++ b/src/main/frontend/handler/search.cljs
@@ -44,12 +44,15 @@
                         (:db/id (db/entity repo [:block/name (util/page-name-sanity-lc page-db-id)]))
                         page-db-id)
            opts (if page-db-id (assoc opts :page (str page-db-id)) opts)]
-       (p/let [blocks (search/block-search repo q opts)]
+       (p/let [blocks (search/block-search repo q opts)
+               pages-content (search/page-content-search repo q opts)
+               _ (prn pages-content)]
          (let [result (merge
                        {:blocks blocks
                         :has-more? (= limit (count blocks))}
                        (when-not page-db-id
-                         {:pages (search/page-search q)
+                         {:pages-content pages-content
+                          :pages (search/page-search q)
                           :files (search/file-search q)}))
                search-key (if more? :search/more-result :search/result)]
            (swap! state/state assoc search-key result)

--- a/src/main/frontend/handler/search.cljs
+++ b/src/main/frontend/handler/search.cljs
@@ -45,8 +45,7 @@
                         page-db-id)
            opts (if page-db-id (assoc opts :page (str page-db-id)) opts)]
        (p/let [blocks (search/block-search repo q opts)
-               pages-content (search/page-content-search repo q opts)
-               _ (prn pages-content)]
+               pages-content (search/page-content-search repo q opts)]
          (let [result (merge
                        {:blocks blocks
                         :has-more? (= limit (count blocks))}

--- a/src/main/frontend/modules/datascript_report/core.cljs
+++ b/src/main/frontend/modules/datascript_report/core.cljs
@@ -13,6 +13,8 @@
       nil)))
 
 (defn get-entity-from-db-after-or-before
+  "Get the entity from db after if possible; otherwise get entity from db before
+   Useful for fetching deleted elements"
   [db-before db-after db-id]
   (let [r (safe-pull db-after '[*] db-id)]
     (if (= keys-of-deleted-entity (count r))
@@ -21,6 +23,7 @@
       r)))
 
 (defn get-blocks-and-pages
+  "Calculate updated blocks and pages based on the db-before and db-after from tx-report"
   [{:keys [db-before db-after tx-data tx-meta]}]
   (let [updated-db-ids (-> (mapv first tx-data) (set))
         result (reduce
@@ -39,6 +42,7 @@
                 {:blocks #{}
                  :pages #{}}
                 updated-db-ids)
+        ;; updated pages logged in tx-meta (usually from move op)
         tx-meta-pages (->> [(:from-page tx-meta) (:target-page tx-meta)]
                            (remove nil?)
                            (map #(get-entity-from-db-after-or-before db-before db-after %))

--- a/src/main/frontend/search.cljs
+++ b/src/main/frontend/search.cljs
@@ -10,7 +10,6 @@
             [frontend.search.agency :as search-agency]
             [frontend.search.db :as search-db :refer [indices]]
             [frontend.search.protocol :as protocol]
-            [frontend.modules.datascript-report.core :as ds-report]
             [frontend.state :as state]
             [frontend.util :as util]
             [frontend.util.property :as property]
@@ -262,12 +261,13 @@
                (get-pages-from-datoms-impl pages))))))
 
 (defn- get-indirect-pages
-  "Return the set of pages that will have content updated" 
+  "Return the set of pages that will have content updated"
   [tx-report]
   (let [data   (:tx-data tx-report)
         datoms (filter
                 (fn [datom]
-                  (contains? #{:file/content} (:a datom)))
+                  (and (:added datom)
+                       (contains? #{:file/content} (:a datom))))
                 data)]
     (when (seq datoms)
       (->> datoms
@@ -318,7 +318,7 @@
       (let [indice-pages   (map search-db/page->index updated-pages)
             invalid-set    (->> (map (fn [updated indiced] ;; get id of pages without valid page index
                                        (if indiced nil (:db/id updated)))
-                                     pages-to-add indice-pages)
+                                     updated-pages indice-pages)
                                 (remove nil?)
                                 set)
             pages-to-add   (->> indice-pages

--- a/src/main/frontend/search.cljs
+++ b/src/main/frontend/search.cljs
@@ -257,7 +257,7 @@
       (let [affected-pages   (-> (map :block/name updated-pages)
                                distinct)
             pages-to-add-set (filter db/page-exists? affected-pages)
-            pages-to-add     (->> (map search-db/page->index pages-to-add-set)
+            pages-to-add     (->> (map (partial search-db/page->index repo) pages-to-add-set)
                                   (remove nil?))
             pages-to-remove-set (remove db/page-exists? affected-pages)]
         (transact-pages! repo {:pages-to-remove-set pages-to-remove-set

--- a/src/main/frontend/search/agency.cljs
+++ b/src/main/frontend/search/agency.cljs
@@ -31,6 +31,13 @@
         (protocol/query e q opts))
       (protocol/query e1 q opts)))
 
+  (query-page [_this q opts]
+    (println "D:Search > Query-page contents:" repo q opts)
+    (let [[e1 e2] (get-registered-engines repo)]
+      (doseq [e e2]
+        (protocol/query-page e q opts))
+      (protocol/query-page e1 q opts)))
+
   (rebuild-blocks-indice! [_this]
     (println "D:Search > Initial blocks indice!:" repo)
     (let [[e1 e2] (get-registered-engines repo)]
@@ -42,6 +49,11 @@
     (println "D:Search > Transact blocks!:" repo)
     (doseq [e (get-flatten-registered-engines repo)]
       (protocol/transact-blocks! e data)))
+
+  (transact-pages! [_this data]
+    (println "D:Search > Transact pages!:" repo)
+    (doseq [e (get-flatten-registered-engines repo)]
+      (protocol/transact-pages! e data)))
 
   (truncate-blocks! [_this]
     (println "D:Search > Truncate blocks!" repo)

--- a/src/main/frontend/search/browser.cljs
+++ b/src/main/frontend/search/browser.cljs
@@ -51,6 +51,7 @@
                  (doseq [block blocks-to-add]
                    (.add indice (bean/->js block)))))
              indice)))
+  (transact-pages! [_this _data] nil) ;; Page index is not available with fuse.js until sufficient performance benchmarking
   (truncate-blocks! [_this]
     (swap! indices assoc-in [repo :blocks] nil))
   (remove-db! [_this]

--- a/src/main/frontend/search/browser.cljs
+++ b/src/main/frontend/search/browser.cljs
@@ -35,6 +35,7 @@
   protocol/Engine
   (query [_this q option]
     (p/promise (search-blocks repo q option)))
+  (query-page [_this _q _opt] nil) ;; Page index is not available with fuse.js until sufficient performance benchmarking
   (rebuild-blocks-indice! [_this]
     (let [indice (search-db/make-blocks-indice! repo)]
       (p/promise indice)))

--- a/src/main/frontend/search/db.cljs
+++ b/src/main/frontend/search/db.cljs
@@ -4,8 +4,7 @@
             [frontend.db :as db]
             [frontend.state :as state]
             [frontend.util :as util]
-            ["fuse.js" :as fuse]
-            [frontend.db.utils :as db-util]))
+            ["fuse.js" :as fuse]))
 
 ;; Notice: When breaking changes happen, bump version in src/electron/electron/search.cljs
 

--- a/src/main/frontend/search/db.cljs
+++ b/src/main/frontend/search/db.cljs
@@ -31,10 +31,9 @@
 (defn page->index
   "Convert a page name to the index for searching (page content level)
    Generate index based on the DB content AT THE POINT OF TIME"
-  [{:block/keys [uuid _name] :as page}]
+  [{:block/keys [uuid _original-name] :as page}]
   (when-let [content (some-> (:block/file page)
                              (:file/content))]
-    (prn "content: " content)
     (when-not (> (count content) (* (max-len) 10))
       {:id   (:db/id page)
        :uuid (str uuid)

--- a/src/main/frontend/search/db.cljs
+++ b/src/main/frontend/search/db.cljs
@@ -50,7 +50,7 @@
 (defn build-pages-indice 
   [repo]
   (->> (db/get-all-pages repo)
-       (map #(page->index (db/get-page %)))
+       (map page->index)
        (remove nil?)
        (bean/->js)))
 

--- a/src/main/frontend/search/db.cljs
+++ b/src/main/frontend/search/db.cljs
@@ -29,6 +29,16 @@
        (remove nil?)
        (bean/->js)))
 
+;; TODO Junyi: Finalize index code
+(defn build-pages-indice
+  ;; TODO: Remove repo effects fns further up the call stack. db fns need standardization on taking connection
+  #_:clj-kondo/ignore
+  [repo]
+  (->> (db/get-all-page-contents)
+       (map page->index)
+       (remove nil?)
+       (bean/->js)))
+
 (defn make-blocks-indice!
   [repo]
   (let [blocks (build-blocks-indice repo)
@@ -46,9 +56,11 @@
   [p] {:name (util/search-normalize p (state/enable-search-remove-accents?))
        :original-name p})
 
-(defn make-pages-indice!
-  "Build a page indice from scratch.
-   Incremental page indice is implemented in frontend.search.sync-search-indice!"
+(defn make-pages-title-indice!
+  "Build a page title indice from scratch.
+   Incremental page title indice is implemented in frontend.search.sync-search-indice!
+   Rename from the page indice since 10.25.2022, since this is only used for page title search.
+   From now on, page indice is talking about page content search."
   []
   (when-let [repo (state/get-current-repo)]
     (let [pages (->> (db/get-pages (state/get-current-repo))

--- a/src/main/frontend/search/db.cljs
+++ b/src/main/frontend/search/db.cljs
@@ -20,6 +20,12 @@
        :page page
        :content content})))
 
+;; TODO Junyi: Finalize index code
+(defn page->index
+  "Convert a page name to the index for searching (page content level)"
+  [page-name]
+  :no-op)
+
 (defn build-blocks-indice
   ;; TODO: Remove repo effects fns further up the call stack. db fns need standardization on taking connection
   #_:clj-kondo/ignore
@@ -29,12 +35,9 @@
        (remove nil?)
        (bean/->js)))
 
-;; TODO Junyi: Finalize index code
-(defn build-pages-indice
-  ;; TODO: Remove repo effects fns further up the call stack. db fns need standardization on taking connection
-  #_:clj-kondo/ignore
+(defn build-pages-indice 
   [repo]
-  (->> (db/get-all-page-contents)
+  (->> (db/get-all-pages repo)
        (map page->index)
        (remove nil?)
        (bean/->js)))

--- a/src/main/frontend/search/node.cljs
+++ b/src/main/frontend/search/node.cljs
@@ -23,8 +23,7 @@
       (keep (fn [{:keys [content snippet uuid]}]
               (when-not (> (count content) (* 10 (state/block-content-max-length repo)))
                 {:block/uuid uuid
-                 :snippet snippet
-                 :block/content content})) result)))
+                 :block/snippet snippet})) result)))
   (rebuild-blocks-indice! [_this]
     (let [blocks-indice (search-db/build-blocks-indice repo)
           pages-indice  (search-db/build-pages-indice repo)]

--- a/src/main/frontend/search/node.cljs
+++ b/src/main/frontend/search/node.cljs
@@ -20,9 +20,10 @@
   (query-page [_this q opts]
     (p/let [result (ipc/ipc "search-pages" repo q opts)
             result (bean/->clj result)]
-      (keep (fn [{:keys [content uuid]}]
+      (keep (fn [{:keys [content snippet uuid]}]
               (when-not (> (count content) (* 10 (state/block-content-max-length repo)))
                 {:block/uuid uuid
+                 :snippet snippet
                  :block/content content})) result)))
   (rebuild-blocks-indice! [_this]
     (let [blocks-indice (search-db/build-blocks-indice repo)

--- a/src/main/frontend/search/node.cljs
+++ b/src/main/frontend/search/node.cljs
@@ -18,11 +18,14 @@
                  :block/content content
                  :block/page page})) result)))
   (rebuild-blocks-indice! [_this]
-    (let [indice (search-db/build-blocks-indice repo)]
-      (ipc/ipc "rebuild-blocks-indice" repo indice)))
+    (let [blocks-indice (search-db/build-blocks-indice repo)
+          pages-indice  (search-db/build-pages-indice repo)]
+      (ipc/ipc "rebuild-indice" repo blocks-indice pages-indice)))
   (transact-blocks! [_this data]
     (ipc/ipc "transact-blocks" repo (bean/->js data)))
   (truncate-blocks! [_this]
-    (ipc/ipc "truncate-blocks" repo))
+    (ipc/ipc "truncate-indice" repo)) 
+  (transact-pages! [_this data]
+    (ipc/ipc "transact-pages" repo (bean/->js data)))
   (remove-db! [_this]
     (ipc/ipc "remove-db" repo)))

--- a/src/main/frontend/search/node.cljs
+++ b/src/main/frontend/search/node.cljs
@@ -17,6 +17,13 @@
                 {:block/uuid uuid
                  :block/content content
                  :block/page page})) result)))
+  (query-page [_this q opts]
+    (p/let [result (ipc/ipc "search-pages" repo q opts)
+            result (bean/->clj result)]
+      (keep (fn [{:keys [content uuid]}]
+              (when-not (> (count content) (* 10 (state/block-content-max-length repo)))
+                {:block/uuid uuid
+                 :block/content content})) result)))
   (rebuild-blocks-indice! [_this]
     (let [blocks-indice (search-db/build-blocks-indice repo)
           pages-indice  (search-db/build-pages-indice repo)]
@@ -24,7 +31,7 @@
   (transact-blocks! [_this data]
     (ipc/ipc "transact-blocks" repo (bean/->js data)))
   (truncate-blocks! [_this]
-    (ipc/ipc "truncate-indice" repo)) 
+    (ipc/ipc "truncate-indice" repo))
   (transact-pages! [_this data]
     (ipc/ipc "transact-pages" repo (bean/->js data)))
   (remove-db! [_this]

--- a/src/main/frontend/search/plugin.cljs
+++ b/src/main/frontend/search/plugin.cljs
@@ -23,6 +23,9 @@
   (query [_this q opts]
     (call-service! service "search:query" (merge {:q q} opts) true))
 
+  (query-page [_this q opts]
+    (call-service! service "search:queryPage" (merge {:q q} opts) true))
+
   (rebuild-blocks-indice! [_this]
    ;; Not pushing all data for performance temporarily
    ;;(let [blocks (search-db/build-blocks-indice repo)])
@@ -33,6 +36,12 @@
       (call-service! service "search:transactBlocks"
                      {:data {:added   blocks-to-add
                              :removed blocks-to-remove-set}})))
+
+  (transact-pages! [_this data]
+    (let [{:keys [pages-to-remove-set pages-to-add]} data]
+      (call-service! service "search:transactpages"
+                     {:data {:added   pages-to-add
+                             :removed pages-to-remove-set}})))
 
   (truncate-blocks! [_this]
     (call-service! service "search:truncateBlocks" {}))

--- a/src/main/frontend/search/plugin.cljs
+++ b/src/main/frontend/search/plugin.cljs
@@ -39,7 +39,7 @@
 
   (transact-pages! [_this data]
     (let [{:keys [pages-to-remove-set pages-to-add]} data]
-      (call-service! service "search:transactpages"
+      (call-service! service "search:transactPages"
                      {:data {:added   pages-to-add
                              :removed pages-to-remove-set}})))
 

--- a/src/main/frontend/search/protocol.cljs
+++ b/src/main/frontend/search/protocol.cljs
@@ -1,8 +1,9 @@
 (ns ^:no-doc frontend.search.protocol)
 
 (defprotocol Engine
-  (query [this q option])
-  (rebuild-blocks-indice! [this])
+  (query [this q option]) 
+  (rebuild-blocks-indice! [this]) ;; TODO: rename to rebuild-indice!
   (transact-blocks! [this data])
-  (truncate-blocks! [this])
+  (truncate-blocks! [this]) ;; TODO: rename to truncate-indice!
+  (transact-pages! [this data])
   (remove-db! [this]))

--- a/src/main/frontend/search/protocol.cljs
+++ b/src/main/frontend/search/protocol.cljs
@@ -2,6 +2,7 @@
 
 (defprotocol Engine
   (query [this q option]) 
+  (query-page [this q option])
   (rebuild-blocks-indice! [this]) ;; TODO: rename to rebuild-indice!
   (transact-blocks! [this data])
   (truncate-blocks! [this]) ;; TODO: rename to truncate-indice!

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -51,7 +51,7 @@
      :journals-length                       3
 
      :search/q                              ""
-     :search/mode                           :global
+     :search/mode                           :global  ;; inner page or full graph? {:page :global}
      :search/result                         nil
      :search/graph-filters                  []
      :search/engines                        {}

--- a/src/main/frontend/util/text.cljs
+++ b/src/main/frontend/util/text.cljs
@@ -120,7 +120,9 @@
 
 (defn cut-by
   "Cut string by specifid wrapping symbols, only match the first occurrence.
-     value - string to cut"
+     value - string to cut
+     before - cutting symbol (before)
+     end - cutting symbol (end)"
   [value before end]
   (let [b-pos (string/index-of value before)
         b-len (count before)]

--- a/src/main/frontend/util/text.cljs
+++ b/src/main/frontend/util/text.cljs
@@ -118,6 +118,24 @@
              []
              ks))))
 
+(defn cut-by
+  "Cut string by specifid wrapping symbols, only match the first occurrence.
+     value - string to cut"
+  [value before end]
+  (let [b-pos (string/index-of value before)
+        b-len (count before)]
+    (if b-pos
+      (let [b-cut (subs value 0 b-pos)
+            m-cut (subs value (+ b-pos b-len))
+            e-len (count end)
+            e-pos (string/index-of m-cut end)]
+        (if e-pos
+          (let [e-cut (subs m-cut (+ e-pos e-len))
+                m-cut (subs m-cut 0 e-pos)]
+            [b-cut m-cut e-cut])
+          [b-cut m-cut nil]))
+      [value nil nil])))
+
 (defn get-graph-name-from-path
   [path]
   (when (string? path)

--- a/src/test/frontend/util/text_test.cljs
+++ b/src/test/frontend/util/text_test.cljs
@@ -57,3 +57,37 @@
     '(false false false false false false true true true true true true)
     (map #(text-util/wrapped-by? "prop::value" % "::" "") (take 12 (range)))
     ))
+
+
+(deftest test-cut-by
+  []
+  (are [x y] (= x y)
+    ["" "" ""]
+    (text-util/cut-by "[[]]" "[[" "]]")
+
+    ["" "abc" ""]
+    (text-util/cut-by "[[abc]]" "[[" "]]")
+
+    ["012 " "6" " [[2]]"]
+    (text-util/cut-by "012 [[6]] [[2]]" "[[" "]]")
+
+    ["" "prop" "value"]
+    (text-util/cut-by "prop::value" "" "::")
+
+    ["prop" "" "value"]
+    (text-util/cut-by "prop::value" "::" "")
+
+    ["some" "content" "here"]
+    (text-util/cut-by "some $pfts>$content$pfts<$ here" "$pfts>$" "$pfts<$")
+
+    ["some" "content$pft" nil]
+    (text-util/cut-by "some $pfts>$content$pft" "$pfts>$" "$pfts<$")
+
+    ["some $pf" nil nil]
+    (text-util/cut-by "some $pf" "$pfts>$" "$pfts<$")
+
+    ["" "content" ""]
+    (text-util/cut-by "$pfts>$content$pfts<$" "$pfts>$" "$pfts<$")
+    
+    ["" "content$p" nil]
+    (text-util/cut-by "$pfts>$content$p" "$pfts>$" "$pfts<$")))

--- a/src/test/frontend/util/text_test.cljs
+++ b/src/test/frontend/util/text_test.cljs
@@ -77,10 +77,10 @@
     ["prop" "" "value"]
     (text-util/cut-by "prop::value" "::" "")
 
-    ["some" "content" "here"]
+    ["some " "content" " here"]
     (text-util/cut-by "some $pfts>$content$pfts<$ here" "$pfts>$" "$pfts<$")
 
-    ["some" "content$pft" nil]
+    ["some " "content$pft" nil]
     (text-util/cut-by "some $pfts>$content$pft" "$pfts>$" "$pfts<$")
 
     ["some $pf" nil nil]


### PR DESCRIPTION
Provides cross-block full-text-search ability

Schedule:
- [x] provides page-level search ability at search backend
  - [x] table work
  - [x] get affected page ids on block transaction
  - [x] upsert page rows
  - [x] DB transaction hook
  - [x] page index build-up
- [x] integrate into search UX
- [x] integrate into search plugin API

TODO
- [ ] integrate into whiteboard
- [ ] ~~refine search experience (ranking, search mode choosing)~~ in new PR

Preview:
![捕获2](https://user-images.githubusercontent.com/9862022/203626788-c5a9c889-7026-4b07-9e88-7307bedab189.PNG)
![捕获](https://user-images.githubusercontent.com/9862022/203626782-26e38ba0-f4d6-46d4-8c57-e204400be471.PNG)
![捕获](https://user-images.githubusercontent.com/9862022/203798953-a451d8d7-12fe-4fa7-8090-85dee2f23963.PNG)
![捕获](https://user-images.githubusercontent.com/9862022/203626952-98f955f4-8c35-4bd5-9074-6aa18c9742ac.PNG)

**How to play in REPL**
`(p/then (page-content-search (state/get-current-repo) "deep stuffs" {}) #(prn (map :block/uuid %)))`