### PR TITLE
Fix: Whiteboards portal issues

### DIFF
--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -380,36 +380,38 @@
                             block-id (d/attr target "blockid")
                             {:keys [block block-ref]} (state/sub :block-ref/context)
                             {:keys [page]} (state/sub :page-title/context)]
-                        (cond
-                          page
-                          (do
+                        ;; TODO: Find a better way to handle this on whiteboards
+                        (when-not (.closest target ".logseq-tldraw")
+                          (cond
+                            page
+                            (do
+                              (common-handler/show-custom-context-menu!
+                               e
+                               (page-title-custom-context-menu-content page))
+                              (state/set-state! :page-title/context nil))
+
+                            block-ref
+                            (do
+                              (common-handler/show-custom-context-menu!
+                               e
+                               (block-ref-custom-context-menu-content block block-ref))
+                              (state/set-state! :block-ref/context nil))
+
+                            (and (state/selection?) (not (d/has-class? target "bullet")))
                             (common-handler/show-custom-context-menu!
                              e
-                             (page-title-custom-context-menu-content page))
-                            (state/set-state! :page-title/context nil))
+                             (custom-context-menu-content))
 
-                          block-ref
-                          (do
-                            (common-handler/show-custom-context-menu!
-                             e
-                             (block-ref-custom-context-menu-content block block-ref))
-                            (state/set-state! :block-ref/context nil))
+                            (and block-id (parse-uuid block-id))
+                            (let [block (.closest target ".ls-block")]
+                              (when block
+                                (util/select-highlight! [block]))
+                              (common-handler/show-custom-context-menu!
+                               e
+                               (block-context-menu-content target (uuid block-id))))
 
-                          (and (state/selection?) (not (d/has-class? target "bullet")))
-                          (common-handler/show-custom-context-menu!
-                           e
-                           (custom-context-menu-content))
-
-                          (and block-id (parse-uuid block-id))
-                          (let [block (.closest target ".ls-block")]
-                            (when block
-                              (util/select-highlight! [block]))
-                            (common-handler/show-custom-context-menu!
-                            e
-                            (block-context-menu-content target (uuid block-id))))
-
-                          :else
-                          nil))))))
+                            :else
+                            nil)))))))
   [id {:keys [hiccup]}]
   [:div {:id id}
    (if hiccup

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -17,6 +17,7 @@
             [frontend.handler.image :as image-handler]
             [frontend.handler.notification :as notification]
             [frontend.handler.page :as page-handler]
+            [frontend.handler.whiteboard :as whiteboard-handler]
             [frontend.mixins :as mixins]
             [frontend.state :as state]
             [frontend.ui :as ui]
@@ -381,7 +382,7 @@
                             {:keys [block block-ref]} (state/sub :block-ref/context)
                             {:keys [page]} (state/sub :page-title/context)]
                         ;; TODO: Find a better way to handle this on whiteboards
-                        (when-not (.closest target ".logseq-tldraw")
+                        (when-not (whiteboard-handler/inside-portal? target)
                           (cond
                             page
                             (do

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -76,8 +76,8 @@
                       (or (not= page-name old-page-name)
                           (not= hiccup old-hiccup)
                           (not= block-uuid old-block-uuid))))}
-  [page-name _blocks hiccup sidebar? _block-uuid]
-  [:div.page-blocks-inner {:style {:margin-left (if sidebar? 0 -20)}}
+  [page-name _blocks hiccup sidebar? whiteboard? _block-uuid]
+  [:div.page-blocks-inner {:style {:margin-left (if (or sidebar? whiteboard?) 0 -20)}}
    (rum/with-key
      (content/content page-name
                       {:hiccup   hiccup
@@ -124,7 +124,7 @@
                                   (date/journal-title->int (date/today))))
                      (state/pub-event! [:journal/insert-template page-name])))
                  state)}
-  [repo page-e {:keys [sidebar?] :as config}]
+  [repo page-e {:keys [sidebar? whiteboard?] :as config}]
   (when page-e
     (let [page-name (or (:block/name page-e)
                         (str (:block/uuid page-e)))
@@ -147,7 +147,7 @@
               hiccup-config (common-handler/config-with-document-mode hiccup-config)
               hiccup (component-block/->hiccup page-blocks hiccup-config {})]
           [:div
-           (page-blocks-inner page-name page-blocks hiccup sidebar? block-id)
+           (page-blocks-inner page-name page-blocks hiccup sidebar? whiteboard? block-id)
            (when-not config/publishing?
              (let [args (if block-id
                           {:block-uuid block-id}
@@ -435,7 +435,7 @@
                _ (and block? page (reset! *current-block-page (:block/name (:block/page page))))
                _ (when (and block? (not page))
                    (route-handler/redirect-to-page! @*current-block-page))]
-           (page-blocks-cp repo page {:sidebar? sidebar?}))]])
+           (page-blocks-cp repo page {:sidebar? sidebar? :whiteboard? whiteboard?}))]])
 
        (when today?
          (today-queries repo today? sidebar?))

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
@@ -72,7 +72,7 @@ const LogseqTypeTag = ({
 
 const LogseqPortalShapeHeader = observer(
   ({ type, children }: { type: 'P' | 'B'; children: React.ReactNode }) => {
-    return <div className="tl-logseq-portal-header">{children}</div>
+    return <div className={`tl-logseq-portal-header tl-logseq-portal-header-${type === "P" ? "page" : "block"}`}>{children}</div>
   }
 )
 

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
@@ -152,7 +152,7 @@ const CircleButton = ({
   }, [active])
 
   return (
-    <div
+    <button
       data-active={active}
       data-recently-changed={recentlyChanged}
       style={style}
@@ -163,7 +163,7 @@ const CircleButton = ({
         {otherIcon && <TablerIcon name={otherIcon} />}
         <TablerIcon name={icon} />
       </div>
-    </div>
+    </button>
   )
 }
 

--- a/tldraw/apps/tldraw-logseq/src/styles.css
+++ b/tldraw/apps/tldraw-logseq/src/styles.css
@@ -662,18 +662,25 @@ button.tl-select-input-trigger {
 
   height: 40px;
   flex-shrink: 0;
-  background: linear-gradient(0deg, transparent, var(--ls-tertiary-background-color));
+
   color: var(--ls-title-text-color);
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
+  background: var(--ls-tertiary-background-color);
   padding: 0 1rem;
   gap: 0.5em;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
 
+  &.tl-logseq-portal-header-block {
+    background: linear-gradient(0deg, transparent, var(--ls-tertiary-background-color));
+  }
+
+
   .page-ref {
     color: var(--ls-title-text-color);
+    background: var(--ls-tertiary-background-color));
   }
 
   .breadcrumb {

--- a/tldraw/apps/tldraw-logseq/src/styles.css
+++ b/tldraw/apps/tldraw-logseq/src/styles.css
@@ -476,7 +476,7 @@ button.tl-select-input-trigger {
     transform: translateY(-100%);
   }
 
-  &[data-active='false']:hover {
+  &[data-active='false']:hover:not([data-recently-changed='true']) {
     .tie {
       transform: translateY(0);
 
@@ -499,7 +499,7 @@ button.tl-select-input-trigger {
       }
     }
 
-    &:hover {
+    &:hover:not([data-recently-changed='true']) {
       color: var(--ls-primary-text-color);
       background-color: var(--ls-secondary-background-color);
 
@@ -516,12 +516,6 @@ button.tl-select-input-trigger {
   i.tie {
     transition: transform 0.2s ease-in-out;
     transition-delay: 0;
-  }
-
-  &[data-recently-changed='true'] {
-    i.tie {
-      transition-delay: 0.5s;
-    }
   }
 
   .tl-circle-button-icons-wrapper[data-icons-count='2'] {


### PR DESCRIPTION
- [x] Fix block overflow https://github.com/logseq/logseq/pull/7097/commits/dfa245061d870346d8e3494c67b52e9143759eec ![Screenshot from 2022-10-25 18-02-02](https://user-images.githubusercontent.com/10744960/197810201-dd9f9aee-818d-425f-bb2d-6966d6c469e6.png)
- [x] Use gradient bg on header for blocks and solid fro pages  https://github.com/logseq/logseq/pull/7097/commits/b5b56a82053a7a2228ce3d0aee5a9a2380220d50
- [x] Fix circle button css transition issue (still not perfect) https://github.com/logseq/logseq/pull/7097/commits/9fe9555f1785d22472c487adb01ee2afc47b3b4f
- [x] Disable block context menu on whiteboards https://github.com/logseq/logseq/pull/7097/commits/6a80351a5fe1bab350a946a9a0a12a4cc1664967. We should probably allow both in the future, but coordinating them might be tricky. Also [this](https://github.com/logseq/logseq/pull/7097/files#diff-c1412ecb2eed7eddf860eb6d10439dbe6f0f620d89fdfae92e73c1693f9e15a1R384) feels dirty, but I couldn't find a way to properly stop the event propagation. Any suggestions?