### PR TITLE
fix(whiteboard): some more ux issues

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/extract.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/extract.cljc
@@ -222,11 +222,11 @@
   (let [_ (when verbose (println "Parsing start: " file))
         {:keys [pages blocks]} (gp-util/safe-read-string content)
         blocks (map
-                 (fn [block]
-                   (-> block
-                       (gp-util/dissoc-in [:block/parent :block/name])
-                       (gp-util/dissoc-in [:block/left :block/name])))
-                 blocks)
+                (fn [block]
+                  (-> block
+                      (gp-util/dissoc-in [:block/parent :block/name])
+                      (gp-util/dissoc-in [:block/left :block/name])))
+                blocks)
         serialized-page (first pages)
         ;; whiteboard edn file should normally have valid :block/original-name, :block/name, :block/uuid
         page-name (-> (or (:block/name serialized-page)

--- a/src/main/frontend/components/whiteboard.css
+++ b/src/main/frontend/components/whiteboard.css
@@ -105,6 +105,7 @@ h1.title.whiteboard-dashboard-title {
 
 input.tl-text-input {
   border: none;
+  padding: 0;
 
   &:focus {
     box-shadow: none;

--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -153,7 +153,7 @@
    By default it will be placed next to the given shape id"
   [block-uuid source-shape & {:keys [link? bottom?]}]
   (let [app (state/active-tldraw-app)
-        api (.-api app)
+        ^js api (.-api app)
         point (-> (.getShapeById app source-shape)
                   (.-bounds)
                   ((fn [bounds] (if bottom?

--- a/src/main/frontend/modules/outliner/file.cljs
+++ b/src/main/frontend/modules/outliner/file.cljs
@@ -23,6 +23,7 @@
     :block/format
     :block/created-at
     :block/updated-at
+    :block/collapsed?
     {:block/page      [:block/uuid]}
     {:block/left      [:block/uuid]}
     {:block/parent    [:block/uuid]}])
@@ -33,6 +34,7 @@
     (dissoc block
             :db/id
             :block/uuid ;; shape block uuid is read from properties
+            :block/collapsed?
             :block/content
             :block/format
             :block/left

--- a/src/main/frontend/modules/shortcut/before.cljs
+++ b/src/main/frontend/modules/shortcut/before.cljs
@@ -33,7 +33,5 @@
   [f]
   (fn [e]
     (when (or (contains? #{:srs :page-histories} (state/get-modal-id))
-              (not (state/block-component-editing?))
-              ;; when in whiteboard mode and editing a logseq block
-              (and (state/active-tldraw-app) (state/tldraw-editing-logseq-block?)))
+              (not (state/block-component-editing?)))
       (f e))))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1429,7 +1429,8 @@ Similar to re-frame subscriptions"
 
 (defn active-tldraw-app
   []
-  ^js js/window.tln)
+  (when-let [tldraw-el (.closest js/document.activeElement ".logseq-tldraw[data-tlapp]")]
+    (gobj/get js/window.tlapps (.. tldraw-el -dataset -tlapp))))
 
 (defn tldraw-editing-logseq-block?
   []
@@ -1622,9 +1623,14 @@ Similar to re-frame subscriptions"
   [args]
   (set-state! :editor/args args))
 
+(defn whiteboard-active-but-not-editing-portal?
+  []
+  (and (active-tldraw-app) (not (tldraw-editing-logseq-block?))))
+
 (defn block-component-editing?
   []
-  (:block/component-editing-mode? @state))
+  (or (:block/component-editing-mode? @state)
+      (whiteboard-active-but-not-editing-portal?)))
 
 (defn set-block-component-editing-mode!
   [value]

--- a/tldraw/apps/tldraw-logseq/src/app.tsx
+++ b/tldraw/apps/tldraw-logseq/src/app.tsx
@@ -7,6 +7,7 @@ import {
   TLReactCallbacks,
   TLReactComponents,
   TLReactToolConstructor,
+  useApp,
 } from '@tldraw/react'
 import * as React from 'react'
 import { AppUI } from './components/AppUI'
@@ -61,6 +62,20 @@ interface LogseqTldrawProps {
   onPersist?: TLReactCallbacks<Shape>['onPersist']
 }
 
+const AppImpl = () => {
+  const ref = React.useRef<HTMLDivElement>(null)
+  const app = useApp()
+  return (
+    <ContextMenu collisionRef={ref}>
+      <div ref={ref} className="logseq-tldraw logseq-tldraw-wrapper" data-tlapp={app.uuid}>
+        <AppCanvas components={components}>
+          <AppUI />
+        </AppCanvas>
+      </div>
+    </ContextMenu>
+  )
+}
+
 const AppInner = ({
   onPersist,
   model,
@@ -69,7 +84,6 @@ const AppInner = ({
   const onDrop = useDrop()
   const onPaste = usePaste()
   const onQuickAdd = useQuickAdd()
-  const ref = React.useRef<HTMLDivElement>(null)
 
   const onPersistOnDiff: TLReactCallbacks<Shape>['onPersist'] = React.useCallback(
     (app, info) => {
@@ -91,13 +105,7 @@ const AppInner = ({
       model={model}
       {...rest}
     >
-      <ContextMenu collisionRef={ref}>
-        <div ref={ref} className="logseq-tldraw logseq-tldraw-wrapper">
-          <AppCanvas components={components}>
-            <AppUI />
-          </AppCanvas>
-        </div>
-      </ContextMenu>
+      <AppImpl />
     </AppProvider>
   )
 }

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
@@ -887,7 +887,7 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
   validateProps = (props: Partial<LogseqPortalShapeProps>) => {
     if (props.size !== undefined) {
       const scale = levelToScale[this.props.scaleLevel ?? 'md']
-      props.size[0] = Math.max(props.size[0], 240 * scale)
+      props.size[0] = Math.max(props.size[0], 60 * scale)
       props.size[1] = Math.max(props.size[1], HEADER_HEIGHT * scale)
     }
     return withClampedStyles(this, props)

--- a/tldraw/apps/tldraw-logseq/src/lib/tools/LogseqPortalTool/states/CreatingState.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/tools/LogseqPortalTool/states/CreatingState.tsx
@@ -68,5 +68,6 @@ export class CreatingState extends TLToolState<
       this.app.deleteShapes([this.creatingShape.id])
       this.app.setEditingShape()
     }
+    this.creatingShape = undefined
   }
 }

--- a/tldraw/packages/core/src/lib/TLApp/TLApp.ts
+++ b/tldraw/packages/core/src/lib/TLApp/TLApp.ts
@@ -17,7 +17,7 @@ import type {
   TLSubscriptionEventName,
 } from '../../types'
 import { AlignType, DistributeType } from '../../types'
-import { BoundsUtils, createNewLineBinding, isNonNullable, KeyUtils } from '../../utils'
+import { BoundsUtils, createNewLineBinding, isNonNullable, KeyUtils, uniqueId } from '../../utils'
 import type { TLShape, TLShapeConstructor, TLShapeModel } from '../shapes'
 import { TLApi } from '../TLApi'
 import { TLCursors } from '../TLCursors'
@@ -69,7 +69,8 @@ export class TLApp<
   }
 
   keybindingRegistered = false
-
+  uuid = uniqueId()
+  
   static id = 'app'
   static initial = 'select'
 

--- a/tldraw/packages/core/src/lib/TLApp/TLApp.ts
+++ b/tldraw/packages/core/src/lib/TLApp/TLApp.ts
@@ -7,30 +7,29 @@ import { action, computed, makeObservable, observable, toJS, transaction } from 
 import { GRID_SIZE } from '../../constants'
 import type {
   TLAsset,
-  TLEventMap,
-  TLShortcut,
-  TLSubscription,
-  TLSubscriptionEventName,
   TLCallback,
-  TLSubscriptionEventInfo,
-  TLStateEvents,
+  TLEventMap,
   TLEvents,
-  TLHandle,
+  TLShortcut,
+  TLStateEvents,
+  TLSubscription,
+  TLSubscriptionEventInfo,
+  TLSubscriptionEventName,
 } from '../../types'
 import { AlignType, DistributeType } from '../../types'
-import { KeyUtils, BoundsUtils, isNonNullable, createNewLineBinding } from '../../utils'
+import { BoundsUtils, createNewLineBinding, isNonNullable, KeyUtils } from '../../utils'
 import type { TLShape, TLShapeConstructor, TLShapeModel } from '../shapes'
 import { TLApi } from '../TLApi'
 import { TLCursors } from '../TLCursors'
 
 import { TLHistory } from '../TLHistory'
 import { TLInputs } from '../TLInputs'
-import { type TLPageModel, TLPage } from '../TLPage'
+import { TLPage, type TLPageModel } from '../TLPage'
 import { TLSettings } from '../TLSettings'
 import { TLRootState } from '../TLState'
 import type { TLToolConstructor } from '../TLTool'
 import { TLViewport } from '../TLViewport'
-import { TLSelectTool, TLMoveTool } from '../tools'
+import { TLMoveTool, TLSelectTool } from '../tools'
 
 export interface TLDocumentModel<S extends TLShape = TLShape, A extends TLAsset = TLAsset> {
   // currentPageId: string
@@ -324,6 +323,7 @@ export class TLApp<
     this.setSelectedShapes(this.selectedShapesArray.filter(shape => !ids.has(shape.id)))
     const removedShapes = this.currentPage.removeShapes(...shapes)
     if (removedShapes) this.notify('delete-shapes', removedShapes)
+    this.selectedTool.transition('idle')
     this.persist()
     return this
   }

--- a/tldraw/packages/core/src/lib/TLApp/TLApp.ts
+++ b/tldraw/packages/core/src/lib/TLApp/TLApp.ts
@@ -170,6 +170,7 @@ export class TLApp<
         keys: ['del', 'backspace'],
         fn: () => {
           this.api.deleteShapes()
+          this.selectedTool.transition('idle')
         },
       },
     ]
@@ -323,7 +324,6 @@ export class TLApp<
     this.setSelectedShapes(this.selectedShapesArray.filter(shape => !ids.has(shape.id)))
     const removedShapes = this.currentPage.removeShapes(...shapes)
     if (removedShapes) this.notify('delete-shapes', removedShapes)
-    this.selectedTool.transition('idle')
     this.persist()
     return this
   }

--- a/tldraw/packages/react/src/hooks/useSetup.ts
+++ b/tldraw/packages/react/src/hooks/useSetup.ts
@@ -2,7 +2,7 @@ import * as React from 'react'
 import type { TLAppPropsWithApp, TLAppPropsWithoutApp } from '../components'
 import type { TLReactApp, TLReactShape } from '../lib'
 
-declare const window: Window & { tln?: TLReactApp<any> }
+declare const window: Window & { tlapps?: Record<string, TLReactApp<any>> }
 
 export function useSetup<
   S extends TLReactShape = TLReactShape,
@@ -27,11 +27,16 @@ export function useSetup<
     const unsubs: (() => void)[] = []
     if (!app) return
     app.history.reset()
-    if (typeof window !== undefined) window['tln'] = app
+    if (typeof window !== undefined) {
+      window['tlapps'] = window['tlapps'] || {}
+      window['tlapps'][app.uuid] = app
+    }
     if (onMount) onMount(app, null)
     return () => {
       unsubs.forEach(unsub => unsub())
-      window['tln'] = undefined
+      if (typeof window !== undefined && window['tlapps']) {
+        delete window['tlapps'][app.uuid]
+      }
     }
   }, [app])
 


### PR DESCRIPTION
- [x] [fix(whiteboard): quick add style](https://github.com/logseq/logseq/pull/7102/commits/418713f7d6b4535c50ba76f3fd7e4f289edf1cd0)
- [x] [fix(whiteboard): state issue after deleting shapes](https://github.com/logseq/logseq/pull/7102/commits/c6b12f6f5fa0a74ef0be6d85dc3bcf0319376d5a)
- [x] [fix(whiteboard): portal shape min size](https://github.com/logseq/logseq/pull/7102/commits/fbc24aedf07d3b09685e1f1aaedd633d362ca67d)
- [x] [fix(whiteboard): some shortcut conflicting issues](https://github.com/logseq/logseq/pull/7102/commits/b5ccfe0eb739dbf23792cfb505ff6691c9f55ec6)
- [x] [fix(whiteboard): persisting whiteboard block collapsed state](https://github.com/logseq/logseq/pull/7102/commits/08334c8eafd70d82222a29e4f5151a2833be8c8d)

It seems block collapsing state of the first root block of a portal shape will not work due to `frontend.components.block/root-block?`. I am not sure what is the best way to fix that 🤔
<img width="493" alt="image" src="https://user-images.githubusercontent.com/584378/197705117-d093c1d4-ac4a-431c-af9d-17355a003d13.png">

