### PR TITLE
Fix: File links creating garbage pages

### DIFF
--- a/deps/graph-parser/test/logseq/graph_parser_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser_test.cljs
@@ -328,4 +328,21 @@
                        @conn)
                   (map (comp :block/name first))
                   (remove built-in-pages)
+                  set)))))
+
+  (testing "for file and web uris"
+    (let [conn (ldb/start-conn)
+          built-in-pages (set (map string/lower-case default-db/built-in-pages-names))]
+      (graph-parser/parse-file conn
+                               "foo.md"
+                               (str "- [Filename.txt](file:///E:/test/Filename.txt)\n"
+                                    "- [example](https://example.com)")
+                               {})
+      (is (= #{"foo"}
+             (->> (d/q '[:find (pull ?b [*])
+                         :in $
+                         :where [?b :block/name]]
+                       @conn)
+                  (map (comp :block/name first))
+                  (remove built-in-pages)
                   set))))))


### PR DESCRIPTION
Fixes #6034, #6618 and  #6930 . Looks like behavior was introduced [awhile ago](https://github.com/logseq/logseq/commit/986bb201c7430f84e1cbadb535a865bae1f0fafd#diff-5caa002eb84518fbfaa4afa600ecd7fc3fb59a485193f826aff2efa46cc54d97)