### PR TITLE
fix(page): title has height 0 when length of editing title is 0

### DIFF
--- a/src/main/frontend/components/page.css
+++ b/src/main/frontend/components/page.css
@@ -293,6 +293,10 @@ a.page-title {
 .page-title-sizer-wrapper {
   @apply w-full;
 
+  :empty::before {
+    content: '\200b';
+  }
+
   > .title {
     @apply w-full pointer-events-none overflow-hidden overflow-ellipsis;
   }


### PR DESCRIPTION
I figure out that the `<span>` of title has height 0 when it has no content while editing the title.

Reference: https://stackoverflow.com/questions/8692041/minimum-height-for-div-or-span-with-empty-element

## Before

https://user-images.githubusercontent.com/28241963/198179783-df0a38ad-8394-49cb-aae7-d9f321d7dedd.mp4

## After

https://user-images.githubusercontent.com/28241963/198179815-8c4262d2-4b7b-4ad3-a09a-1a9ec222a136.mp4
