### PR TITLE
feat: show youtube thumb images in preview

### DIFF
--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/ImageShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/ImageShape.tsx
@@ -101,6 +101,7 @@ export class ImageShape extends TLImageShape<ImageShapeProps> {
           <img
             src={make_asset_url ? make_asset_url(asset.src) : asset.src}
             draggable={false}
+            loading="lazy"
             style={{
               position: 'relative',
               top: -t,

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/YouTubeShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/YouTubeShape.tsx
@@ -3,8 +3,6 @@ import { TLBoxShape, TLBoxShapeProps } from '@tldraw/core'
 import { HTMLContainer, TLComponentProps } from '@tldraw/react'
 import { action, computed } from 'mobx'
 import { observer } from 'mobx-react-lite'
-import { TablerIcon } from '../../components/icons'
-
 import { withClampedStyles } from './style-props'
 
 export interface YouTubeShapeProps extends TLBoxShapeProps {

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/YouTubeShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/YouTubeShape.tsx
@@ -3,6 +3,8 @@ import { TLBoxShape, TLBoxShapeProps } from '@tldraw/core'
 import { HTMLContainer, TLComponentProps } from '@tldraw/react'
 import { action, computed } from 'mobx'
 import { observer } from 'mobx-react-lite'
+import { TablerIcon } from '../../components/icons'
+
 import { withClampedStyles } from './style-props'
 
 export interface YouTubeShapeProps extends TLBoxShapeProps {
@@ -128,5 +130,44 @@ export class YouTubeShape extends TLBoxShape<YouTubeShapeProps> {
       props.size[1] = Math.max(props.size[0] * this.aspectRatio, 1)
     }
     return withClampedStyles(this, props)
+  }
+
+  getShapeSVGJsx() {
+    // Do not need to consider the original point here
+    const bounds = this.getBounds()
+    const embedId = this.embedId
+
+    if (embedId) {
+      return (
+        <>
+          <foreignObject width={bounds.width} height={bounds.height}>
+            <img
+              src={`https://img.youtube.com/vi/${embedId}/mqdefault.jpg`}
+              draggable={false}
+              loading="lazy"
+              className="rounded-lg relative pointer-events-none w-full h-full grayscale-[50%]"
+            />
+            <div className="absolute top-0 left-0 w-full h-full flex items-center justify-center">
+              <svg
+                width="240"
+                height="240"
+                viewBox="0 0 15 15"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M4.76447 3.12199C5.63151 3.04859 6.56082 3 7.5 3C8.43918 3 9.36849 3.04859 10.2355 3.12199C11.2796 3.21037 11.9553 3.27008 12.472 3.39203C12.9425 3.50304 13.2048 3.64976 13.4306 3.88086C13.4553 3.90618 13.4902 3.94414 13.5133 3.97092C13.7126 4.20149 13.8435 4.4887 13.918 5.03283C13.9978 5.6156 14 6.37644 14 7.52493C14 8.66026 13.9978 9.41019 13.9181 9.98538C13.8439 10.5206 13.7137 10.8061 13.5125 11.0387C13.4896 11.0651 13.4541 11.1038 13.4296 11.1287C13.2009 11.3625 12.9406 11.5076 12.4818 11.6164C11.9752 11.7365 11.3143 11.7942 10.2878 11.8797C9.41948 11.9521 8.47566 12 7.5 12C6.52434 12 5.58052 11.9521 4.7122 11.8797C3.68572 11.7942 3.02477 11.7365 2.51816 11.6164C2.05936 11.5076 1.7991 11.3625 1.57037 11.1287C1.54593 11.1038 1.51035 11.0651 1.48748 11.0387C1.28628 10.8061 1.15612 10.5206 1.08193 9.98538C1.00221 9.41019 1 8.66026 1 7.52493C1 6.37644 1.00216 5.6156 1.082 5.03283C1.15654 4.4887 1.28744 4.20149 1.48666 3.97092C1.5098 3.94414 1.54468 3.90618 1.56942 3.88086C1.7952 3.64976 2.05752 3.50304 2.52796 3.39203C3.04473 3.27008 3.7204 3.21037 4.76447 3.12199ZM0 7.52493C0 5.28296 0 4.16198 0.729985 3.31713C0.766457 3.27491 0.815139 3.22194 0.854123 3.18204C1.63439 2.38339 2.64963 2.29744 4.68012 2.12555C5.56923 2.05028 6.52724 2 7.5 2C8.47276 2 9.43077 2.05028 10.3199 2.12555C12.3504 2.29744 13.3656 2.38339 14.1459 3.18204C14.1849 3.22194 14.2335 3.27491 14.27 3.31713C15 4.16198 15 5.28296 15 7.52493C15 9.74012 15 10.8477 14.2688 11.6929C14.2326 11.7348 14.1832 11.7885 14.1444 11.8281C13.3629 12.6269 12.3655 12.71 10.3709 12.8763C9.47971 12.9505 8.50782 13 7.5 13C6.49218 13 5.52028 12.9505 4.62915 12.8763C2.63446 12.71 1.63712 12.6269 0.855558 11.8281C0.816844 11.7885 0.767442 11.7348 0.731221 11.6929C0 10.8477 0 9.74012 0 7.52493ZM5.25 5.38264C5.25 5.20225 5.43522 5.08124 5.60041 5.15369L10.428 7.27105C10.6274 7.35853 10.6274 7.64147 10.428 7.72895L5.60041 9.84631C5.43522 9.91876 5.25 9.79775 5.25 9.61736V5.38264Z"
+                  fill="#D10014"
+                  fill-rule="evenodd"
+                  clip-rule="evenodd"
+                ></path>
+              </svg>
+            </div>
+          </foreignObject>
+        </>
+      )
+    } else {
+      return super.getShapeSVGJsx({})
+    }
   }
 }

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/YouTubeShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/YouTubeShape.tsx
@@ -166,8 +166,7 @@ export class YouTubeShape extends TLBoxShape<YouTubeShapeProps> {
           </foreignObject>
         </>
       )
-    } else {
-      return super.getShapeSVGJsx({})
     }
+    return super.getShapeSVGJsx({})
   }
 }


### PR DESCRIPTION
Turns out it is pretty easy to get a youtube video's thumbnail image. See https://gist.github.com/iredun/a9681c46d3d74e03fb35d9ebf198b83d

<img width="671" alt="image" src="https://user-images.githubusercontent.com/584378/199174084-e87bf738-e1ee-464e-8f07-cc10308cfc22.png">
