### PR TITLE
ehhancement: Prevent Ctrl+A from selecting the whole document

### DIFF
--- a/src/main/frontend/components/page.css
+++ b/src/main/frontend/components/page.css
@@ -385,3 +385,7 @@ html.is-native-ios {
   line-height: normal;
   background-color: var(--ls-quaternary-background-color);
 }
+
+.references {
+  user-select: none;
+}

--- a/src/main/frontend/components/sidebar.css
+++ b/src/main/frontend/components/sidebar.css
@@ -267,6 +267,7 @@
     width: 100%;
     padding: 14px;
     background-image: linear-gradient(transparent, var(--ls-primary-background-color));
+    user-select: none;
 
     @screen sm {
       background-image: linear-gradient(transparent, var(--ls-secondary-background-color));

--- a/src/main/frontend/components/sidebar.css
+++ b/src/main/frontend/components/sidebar.css
@@ -504,6 +504,7 @@ html[data-theme='dark'] {
   transition: width 0.3s;
   background-color: var(--ls-secondary-background-color, #d8e1e8);
   position: relative;
+  user-select: none;
 
   .resizer {
     @apply absolute top-0 bottom-0;


### PR DESCRIPTION
Currently in Logseq when you press Ctrl-A (or Meta-A on macOS), the whole page is selected. This behavior is useless and nobody would expect this.

This PR enhances Ctrl+A to be more intuitive:
1. ~~When in the selection mode, all blocks are selected.~~ Removed due to bugs.
2. When in the editing mode, all text in the block is selected.
3. Global Ctrl+A does nothing.