### PR TITLE
Always render the invalid block ref regardless of contents

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -857,7 +857,7 @@
 (rum/defc block-reference < rum/reactive
   db-mixins/query
   [config id label]
-  (when-let [block-id (parse-uuid id)]
+  (if-let [block-id (parse-uuid id)]
     (let [db-id (:db/id (db/pull [:block/uuid block-id]))
           block (when db-id (db/pull-block db-id))
           block-type (keyword (get-in block [:block/properties :ls-type]))
@@ -927,7 +927,10 @@
                         :delay       [1000, 100]} inner)
              inner)])
         [:span.warning.mr-1 {:title "Block ref invalid"}
-         (block-ref/->block-ref id)]))))
+         (block-ref/->block-ref id)]))
+  [:span.warning.mr-1 {:title "Block ref invalid"}
+    (block-ref/->block-ref id)]
+))
 
 (defn inline-text
   ([format v]


### PR DESCRIPTION
I have a plugin where I would like to render a custom component on top of block references that would typically be invalid. An example:
<img width="617" alt="Screen Shot 2022-11-01 at 1 33 15 PM" src="https://user-images.githubusercontent.com/7143571/199299716-afbcc90a-5537-422b-ae41-25b95319f9d7.png">

Notice how the top block reference is custom - it's a uuid followed by a `:` and another id. Allowing this to render as invalid will make it easier for me to create a mutation observer in my plugin that watches for this component and renders the desired content instead.

The screenshot above is with the changes introduced in this PR. Without this PR, this is what renders instead:
<img width="526" alt="Screen Shot 2022-11-01 at 1 35 40 PM" src="https://user-images.githubusercontent.com/7143571/199300157-45c9afb8-d915-4676-87ed-fceea336abf2.png">

Notice how that top block reference is now just missing, with no HTML content to watch for.