### PR TITLE
fix: prompt to create a Logseq sync graph or normal graph on iOS

### DIFF
--- a/ios/App/App/FolderPicker.swift
+++ b/ios/App/App/FolderPicker.swift
@@ -18,13 +18,33 @@ public class FolderPicker: CAPPlugin, UIDocumentPickerDelegate {
         self._call = call
 
         DispatchQueue.main.async { [weak self] in
+
             let documentPicker = UIDocumentPickerViewController(
-                documentTypes: [String(kUTTypeFolder)],
-                in: UIDocumentPickerMode.open
+              documentTypes: [String(kUTTypeFolder)],
+              in: UIDocumentPickerMode.open
             )
+
+            // Set the initial directory.
+
+            if let path = call.getString("path") {
+                // guard let url = URL(string: path) else {
+                //     call.reject("can not parse url")
+                //     return
+                // }
+
+                guard let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
+
+                let url = documentDirectory.appendingPathComponent(path)
+
+                print("picked folder url = " + url.path)
+
+                documentPicker.directoryURL = url
+
+            }
 
             documentPicker.allowsMultipleSelection = false
             documentPicker.delegate = self
+
             documentPicker.modalPresentationStyle = UIModalPresentationStyle.fullScreen
 
             self?.bridge?.viewController?.present(

--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -534,7 +534,8 @@
                       (file-sync-handler/init-remote-graph url graph)
                       (js/setTimeout (fn [] (repo-handler/refresh-repos!)) 200))
 
-                    {:empty-dir?-or-pred
+                    {:sync-from-remote? true
+                     :empty-dir?-or-pred
                      (fn [ret]
                        (let [empty-dir? (nil? (second ret))]
                          (if-let [root (first ret)]

--- a/src/main/frontend/fs.cljs
+++ b/src/main/frontend/fs.cljs
@@ -157,9 +157,9 @@
     nfs-record))
 
 (defn open-dir
-  [ok-handler]
+  [dir ok-handler]
   (let [record (get-record)]
-    (p/let [result (protocol/open-dir record ok-handler)]
+    (p/let [result (protocol/open-dir record dir ok-handler)]
       (if (or (util/electron?)
               (mobile-util/native-platform?))
         (let [[dir & paths] (bean/->clj result)]

--- a/src/main/frontend/fs/bfs.cljs
+++ b/src/main/frontend/fs/bfs.cljs
@@ -30,7 +30,7 @@
     (js/window.pfs.rename old-path new-path))
   (stat [_this dir path]
     (js/window.pfs.stat (str dir path)))
-  (open-dir [_this _ok-handler]
+  (open-dir [_this _dir _ok-handler]
     nil)
   (get-files [_this _path-or-handle _ok-handler]
     nil)

--- a/src/main/frontend/fs/nfs.cljs
+++ b/src/main/frontend/fs/nfs.cljs
@@ -232,7 +232,7 @@
            :file/size (get-attr "size")
            :file/type (get-attr "type")}))
       (p/rejected "File not exists")))
-  (open-dir [_this ok-handler]
+  (open-dir [_this _dir ok-handler]
     (utils/openDirectory #js {:recursive true}
                          ok-handler))
   (get-files [_this path-or-handle ok-handler]

--- a/src/main/frontend/fs/node.cljs
+++ b/src/main/frontend/fs/node.cljs
@@ -83,8 +83,8 @@
                       (error-handler error)
                       (log/error :write-file-failed error)))))))))
 
-(defn- open-dir []
-  (p/let [dir-path (util/mocked-open-dir-path)
+(defn- open-dir [dir]
+  (p/let [dir-path (or dir (util/mocked-open-dir-path))
           result (if dir-path
                    (ipc/ipc "getFiles" dir-path)
                    (ipc/ipc "openDir" {}))]
@@ -121,8 +121,8 @@
   (stat [_this dir path]
     (let [path (concat-path dir path)]
       (ipc/ipc "stat" path)))
-  (open-dir [_this _ok-handler]
-    (open-dir))
+  (open-dir [_this dir _ok-handler]
+    (open-dir dir))
   (get-files [_this path-or-handle _ok-handler]
     (ipc/ipc "getFiles" path-or-handle))
   (watch-dir! [_this dir options]

--- a/src/main/frontend/fs/protocol.cljs
+++ b/src/main/frontend/fs/protocol.cljs
@@ -13,7 +13,7 @@
   (rename! [this repo old-path new-path])
   (copy! [this repo old-path new-path])
   (stat [this dir path])
-  (open-dir [this ok-handler])
+  (open-dir [this dir ok-handler])
   (get-files [this path-or-handle ok-handler])
   (watch-dir! [this dir options])
   (unwatch-dir! [this dir])

--- a/src/main/frontend/handler/web/nfs.cljs
+++ b/src/main/frontend/handler/web/nfs.cljs
@@ -122,18 +122,22 @@
 (defn ^:large-vars/cleanup-todo ls-dir-files-with-handler!
   "Read files from directory and setup repo (for the first time setup a repo)"
   ([ok-handler] (ls-dir-files-with-handler! ok-handler nil))
-  ([ok-handler {:keys [empty-dir?-or-pred dir-result-fn]}]
+  ([ok-handler {:keys [empty-dir?-or-pred dir-result-fn ios-logseq-sync?]}]
    (let [path-handles (atom {})
          electron? (util/electron?)
          mobile-native? (mobile-util/native-platform?)
          nfs? (and (not electron?)
                    (not mobile-native?))
-         *repo (atom nil)]
+         *repo (atom nil)
+         dir (when ios-logseq-sync?
+               ;; open Logseq's Documents folder
+               "")]
     ;; TODO: add ext filter to avoid loading .git or other ignored file handlers
      (->
       (p/let [result (if (fn? dir-result-fn)
                        (dir-result-fn {:path-handles path-handles :nfs? nfs?})
-                       (fs/open-dir (fn [path handle]
+                       (fs/open-dir dir
+                                    (fn [path handle]
                                       (when nfs?
                                         (swap! path-handles assoc path handle)))))
               _ (when-not (nil? empty-dir?-or-pred)


### PR DESCRIPTION
Previously, users can create a graph everywhere including the iCloud folder, which is both confusing and can cause unexpected data conflicts.

Another enhancement:
After the user confirms the "Use Logseq Sync for this new graph?" prompt, a remote graph will be created and start to sync automatically.

https://www.loom.com/share/69059969747c4b798a4c712c45e442d7