### PR TITLE
Fix: Allow custom protocols

### DIFF
--- a/src/main/frontend/security.cljs
+++ b/src/main/frontend/security.cljs
@@ -2,7 +2,8 @@
   "Provide security focused fns like preventing XSS attacks"
   (:require ["dompurify" :as DOMPurify]))
 
-(def sanitization-options (clj->js {:ADD_TAGS ["iframe"]}))
+(def sanitization-options (clj->js {:ADD_TAGS ["iframe"]
+                                    :ALLOW_UNKNOWN_PROTOCOLS true}))
 
 (defn sanitize-html
   [html]


### PR DESCRIPTION
Since we allow custom protocols on markdown links, it makes sense to also allow them on HTML and Hiccup.
We can find a better way to handle both later (related discussion here https://github.com/logseq/logseq/pull/6967)

We can test this by creating a hiccup link with a custom protocol 
`[:a {:href "skype://"} "skype link"]`

Resolves https://github.com/logseq/logseq/issues/7206