### PR TITLE
Ensure "css" and "js" are writable during export.

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -118,6 +118,17 @@
                            (fn [part]
                              (. fs copy (path/join app-path part) (path/join static-dir part)))
                            ["css" "fonts" "icons" "img" "js"])))
+                ;;
+                ;; The "css" and "js" directories are copied from the app bundle,
+                ;; which could be on a read-only file system. Ensure they can be
+                ;; written to so that the rest of the export succeeds.
+                ;;
+                ;;   https://github.com/logseq/logseq/issues/5848
+                ;;   https://github.com/logseq/logseq/issues/6880
+                ;;
+                _ (p/all (map (fn [part]
+                                (. fs chmod (path/join static-dir part) 0755))
+                              ["css" "js"]))
                 export-css (if (fs/existsSync export-css-path) (. fs readFile export-css-path) "")
                 _ (. fs writeFile (path/join static-dir "css" "export.css")  export-css)
                 custom-css (if (fs/existsSync custom-css-path) (. fs readFile custom-css-path) "")


### PR DESCRIPTION
This is the bare minimum needed to fix "Export graph" work when the application is installed on a read-only file system (like NixOS).

Please let me know if you'd like a test. I feel any such test would need to be end-to-end including making some directories read-only so would like to know if I should invest the effort before doing so.

Resolves https://github.com/logseq/logseq/issues/5848 and https://github.com/logseq/logseq/issues/6880.