### PR TITLE
fix: page names are URIencoded on Android pad / iPad devices

### DIFF
--- a/src/main/frontend/config.cljs
+++ b/src/main/frontend/config.cljs
@@ -128,6 +128,12 @@
       formats))))
 
 (def mobile?
+  "Triggering condition: Mobile phones
+   *** Warning!!! ***
+   For UX logic only! Don't use for FS logic
+   iPad / Android Pad doesn't trigger!
+   
+   Same as config/mobile?"
   (when-not util/node-test?
     (util/safe-re-find #"Mobi" js/navigator.userAgent)))
 

--- a/src/main/frontend/handler/common/file.cljs
+++ b/src/main/frontend/handler/common/file.cljs
@@ -69,7 +69,7 @@
                                             :date-formatter (state/get-date-formatter)
                                             :block-pattern (config/get-block-pattern (gp-util/get-format file))
                                             :supported-formats (gp-config/supported-formats)
-                                            :uri-encoded? (boolean (util/mobile?))
+                                            :uri-encoded? (boolean (mobile-util/native-platform?))
                                             :filename-format (state/get-filename-format repo-url)}
                                            (when (some? verbose) {:verbose verbose}))})]
      (:tx (graph-parser/parse-file (db/get-db repo-url false) file content options)))))

--- a/src/main/frontend/handler/conversion.cljs
+++ b/src/main/frontend/handler/conversion.cljs
@@ -58,6 +58,8 @@
 ;;   - the special rule in `is-manual-title-prop?`
 (defonce supported-filename-formats [:triple-lowbar :legacy])
 
+;; In case of recovering this check in future
+#_:clj-kondo/ignore
 (defn- is-manual-title-prop?
   "If it's an user defined title property instead of the generated one"
   [format file-body prop-title]
@@ -74,14 +76,12 @@
   ;;   and it includes reserved characters, format config change / file renaming is required. 
   ;;   It's about user's own data management decision and should be handled
   ;;   by user manually.
-  ;; Don't rename page that with a custom setup `title` property
-  (when (not (is-manual-title-prop? old-format file-body prop-title))
-      ;; the 'expected' title of the user when updating from the previous format, or title will be broken in new format
-    (or (when (and (nil? prop-title)
-                   (not= old-format new-format))
-          (calc-previous-name old-format new-format file-body))
+  ;; the 'expected' title of the user when updating from the previous format, or title will be broken in new format
+  (or (when (and (nil? prop-title)
+                 (not= old-format new-format))
+        (calc-previous-name old-format new-format file-body))
       ;; if no break-change conversion triggered, check if file name is in an informal / outdated style.
-        (calc-current-name new-format file-body prop-title))))
+      (calc-current-name new-format file-body prop-title)))
 
 (defn calc-rename-target
   "Return the renaming status and new file body to recover the original title of the file in previous version. 

--- a/src/main/frontend/handler/conversion.cljs
+++ b/src/main/frontend/handler/conversion.cljs
@@ -4,7 +4,8 @@
   "For conversion logic between old version and new version"
   (:require [logseq.graph-parser.util :as gp-util]
             [frontend.util.fs :as fs-util]
-            [frontend.handler.config :refer [set-config!]]))
+            [frontend.handler.config :refer [set-config!]]
+            [frontend.util :as util]))
 
 (defn write-filename-format!
   "Return:
@@ -77,11 +78,16 @@
   ;;   It's about user's own data management decision and should be handled
   ;;   by user manually.
   ;; the 'expected' title of the user when updating from the previous format, or title will be broken in new format
-  (or (when (and (nil? prop-title)
-                 (not= old-format new-format))
-        (calc-previous-name old-format new-format file-body))
-      ;; if no break-change conversion triggered, check if file name is in an informal / outdated style.
-      (calc-current-name new-format file-body prop-title)))
+  (let [ret (or (when (and (nil? prop-title)
+                           (not= old-format new-format))
+                  (calc-previous-name old-format new-format file-body))
+                 ;; if no break-change conversion triggered, check if file name is in an informal / outdated style.
+                (calc-current-name new-format file-body prop-title))]
+    (when (and ret
+               ;; Return only when the target is different from the original file body, not only capitalization difference
+               (not= (util/page-name-sanity-lc (:target ret))
+                     (util/page-name-sanity-lc file-body)))
+      ret)))
 
 (defn calc-rename-target
   "Return the renaming status and new file body to recover the original title of the file in previous version. 

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -88,6 +88,10 @@
 
 #?(:cljs
    (defn mobile?
+       "Triggering condition: Mobile phones
+        *** Warning!!! ***
+        For UX logic only! Don't use for FS logic
+        iPad / Android Pad doesn't trigger!"
      []
      (when-not node-test?
        (safe-re-find #"Mobi" js/navigator.userAgent))))

--- a/src/test/frontend/db/name_sanity_test.cljs
+++ b/src/test/frontend/db/name_sanity_test.cljs
@@ -102,6 +102,7 @@
 (deftest rename-tests
   ;; z: new title structure; x: old ver title; y: title property (if available)
   (are [x y z] (= z (#'conversion-handler/calc-rename-target-impl :legacy :triple-lowbar x y))
+    "aaBBcc"      "aabbcc"        nil
     "aaa.bbb.ccc" "aaa/bbb/ccc"   {:status :informal,
                                    :target "aaa___bbb___ccc",
                                    :old-title "aaa/bbb/ccc",

--- a/src/test/frontend/db/name_sanity_test.cljs
+++ b/src/test/frontend/db/name_sanity_test.cljs
@@ -114,13 +114,28 @@
                                    :target "aa%3F%23___bbb___ccc",
                                    :old-title "aa?#/bbb/ccc",
                                    :changed-title "aa?#/bbb/ccc"}
-    "aa?#.bbb.ccc" "aa__/bbb/ccc" nil
-    "aaa__bbb__ccc" "aaa/bbb/ccc" nil
-    "aaa__bbb__cccon" "aaa/bbb/cccon" nil
+    "aa?#.bbb.ccc" "aa__/bbb/ccc" {:status :informal,
+                                   :target "aa_%5F___bbb___ccc",
+                                   :old-title "aa__/bbb/ccc",
+                                   :changed-title "aa__/bbb/ccc"}
+    "aaa__bbb__ccc" "aaa/bbb/ccc" {:status :informal,
+                                   :target "aaa___bbb___ccc",
+                                   :old-title "aaa/bbb/ccc",
+                                   :changed-title "aaa/bbb/ccc"}
+    "aaa__bbb__cccon" "aaa/bbb/cccon" {:status :informal,
+                                       :target "aaa___bbb___cccon",
+                                       :old-title "aaa/bbb/cccon",
+                                       :changed-title "aaa/bbb/cccon"}
     "aaa__bbb__ccc" nil               nil
     "aaa_bbb_ccc"   nil               nil
-    "aaa.bbb.ccc"   "adbcde/aks/sdf"  nil
-    "a__.bbb.ccc"   "adbcde/aks/sdf"  nil
+    "aaa.bbb.ccc"   "adbcde/aks/sdf"  {:status :informal,
+                                       :target "adbcde___aks___sdf",
+                                       :old-title "adbcde/aks/sdf",
+                                       :changed-title "adbcde/aks/sdf"}
+    "a__.bbb.ccc"   "adbcde/aks/sdf"  {:status :informal,
+                                       :target "adbcde___aks___sdf",
+                                       :old-title "adbcde/aks/sdf",
+                                       :changed-title "adbcde/aks/sdf"}
     "CON" "CON" {:status :informal,
                  :target "CON___",
                  :old-title "CON",


### PR DESCRIPTION
### page names are URIencoded on Android pad / iPad devices
Fix #7188 #7259

### remove the manually modified `title::` property check of the conversion UI
Why remove the check?
The "manually set title property" might be introduced by unconscious behavior of users, like renaming the filename with reserved characters. 
We should force rename to avoid any possibility of breaking  cross platform file sync 
Close #7204 

### don't suggest filename conversion when it only has capitalization difference
macOS's FSEvent doesn't fire `add` when renaming files between capitalization