### PR TITLE
fix: Renaming the homepage makes it no longer the homepage

### DIFF
--- a/e2e-tests/whiteboards.spec.ts
+++ b/e2e-tests/whiteboards.spec.ts
@@ -63,7 +63,7 @@ test('draw a rectangle', async ({ page }) => {
 
     await page.keyboard.press('8')
 
-    await page.mouse.move(bounds.x, bounds.y);
+    await page.mouse.move(bounds.x + 5, bounds.y + 5);
     await page.mouse.down();
 
     await page.mouse.move(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2);

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -464,6 +464,11 @@
         (when (and file (not journal?))
           (rename-file! file new-file-name-body (fn [] nil)))
 
+
+        (let [home (get (state/get-config) :default-home {})]
+          (when (= old-page-name (string/lower-case (get home :page "")))
+            (config-handler/set-config! :default-home (assoc home :page new-name))))
+
         (rename-update-refs! page old-original-name new-name)
 
         (outliner-file/sync-to-file page))


### PR DESCRIPTION
Closes #6907. 
Fixed by checking wether the renamed page is the homepage and then setting it to the new page name.

Added a e2e-test for this usecase. This caused the whiteboard e2e-test to become flaky on my machine. The fix was to draw the whiteboard rectangle 5 pixel from the origin. I couldn't find any other way to fix it, as I don't think my changes should've interfered with the whiteboard