### PR TITLE
Fix sync stops when there's filenames with reserved chars

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/extract.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/extract.cljc
@@ -24,7 +24,7 @@
     (let [result (first (gp-util/split-last "." file-name))
           ext (string/lower-case (gp-util/get-file-ext filepath))]
       (if (or (gp-config/mldoc-support? ext) (= "edn" ext))
-        (js/decodeURIComponent (string/replace result "." "/"))
+        (gp-util/safe-decode-uri-component (string/replace result "." "/"))
         result))))
 
 (defn- get-page-name

--- a/deps/graph-parser/src/logseq/graph_parser/util.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/util.cljs
@@ -11,9 +11,8 @@
   [uri]
   (try
     (js/decodeURIComponent uri)
-    (catch :default e
-      (println "decodeURIComponent failed: " uri)
-      (js/console.error e)
+    (catch :default _
+      (log/error :decode-uri-component-failed uri)
       uri)))
 
 (defn safe-url-decode

--- a/deps/graph-parser/src/logseq/graph_parser/util.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/util.cljs
@@ -7,12 +7,19 @@
             [clojure.walk :as walk]
             [logseq.graph-parser.log :as log]))
 
+(defn safe-decode-uri-component
+  [uri]
+  (try
+    (js/decodeURIComponent uri)
+    (catch :default e
+      (println "decodeURIComponent failed: " uri)
+      (js/console.error e)
+      uri)))
+
 (defn safe-url-decode
   [string]
   (if (string/includes? string "%")
-    (try (some-> string str (js/decodeURIComponent))
-         (catch :default _
-           string))
+    (some-> string str safe-decode-uri-component)
     string))
 
 (defn path-normalize
@@ -220,7 +227,8 @@
 ;; Source: https://github.com/logseq/logseq/blob/e7110eea6790eda5861fdedb6b02c2a78b504cd9/deps/graph-parser/src/logseq/graph_parser/extract.cljc#L35
 (defn legacy-title-parsing
   [file-name-body]
-  (js/decodeURIComponent (string/replace file-name-body "." "/")))
+  (let [title (string/replace file-name-body "." "/")]
+    (or (safe-decode-uri-component title) title)))
 
 ;; Register sanitization / parsing fns in:
 ;; logseq.graph-parser.util (parsing only)

--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -77,7 +77,7 @@
                       [STATIC_URL js/__dirname])
 
            path' (.-pathname url')
-           path' (js/decodeURIComponent path')
+           path' (utils/safe-decode-uri-component path')
            path' (.join path ROOT path')]
 
        (callback #js {:path path'}))))

--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -154,3 +154,12 @@
 (defn normalize-lc
   [s]
   (normalize (string/lower-case s)))
+
+(defn safe-decode-uri-component
+  [uri]
+  (try
+    (js/decodeURIComponent uri)
+    (catch :default e
+      (println "decodeURIComponent failed: " uri)
+      (js/console.error e)
+      uri)))

--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -159,7 +159,6 @@
   [uri]
   (try
     (js/decodeURIComponent uri)
-    (catch :default e
+    (catch :default _
       (println "decodeURIComponent failed: " uri)
-      (js/console.error e)
       uri)))

--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -123,7 +123,7 @@
           new-win-handler
           (fn [e url]
             (let [url (if (string/starts-with? url "file:")
-                        (js/decodeURIComponent url) url)
+                        (utils/safe-decode-uri-component url) url)
                   url (if-not win32? (string/replace url "file://" "") url)]
               (logger/info "new-window" url)
               (if (some #(string/includes?

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -836,7 +836,7 @@
   [label]
   (when (and (= 1 (count label))
              (string? (last (first label))))
-    (js/decodeURIComponent (last (first label)))))
+    (gp-util/safe-decode-uri-component (last (first label)))))
 
 (defn- get-page
   [label]

--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -29,7 +29,8 @@
             [rum.core :as rum]
             [cljs-time.core :as t]
             [cljs-time.coerce :as tc]
-            [goog.functions :refer [debounce]]))
+            [goog.functions :refer [debounce]]
+            [logseq.graph-parser.util :as gp-util]))
 
 (declare maybe-onboarding-show)
 (declare open-icloud-graph-clone-picker)
@@ -78,7 +79,7 @@
 
      [:div.folder-tip.flex.flex-col.items-center
       [:h3
-       [:span (ui/icon "folder") [:label.pl-0.5 (js/decodeURIComponent graph-name)]]]
+       [:span (ui/icon "folder") [:label.pl-0.5 (gp-util/safe-decode-uri-component graph-name)]]]
       [:h4.px-6 (config/get-string-repo-dir repo)]
 
       (when (not (string/blank? selected-path))
@@ -441,7 +442,7 @@
 
              (map (fn [f] {:title [:div.file-item
                                    {:key (str "downloading-" f)}
-                                   (js/decodeURIComponent f)]
+                                   (gp-util/safe-decode-uri-component f)]
                            :key   (str "downloading-" f)
                            :icon  (if enabled-progress-panel?
                                     (let [progress (get sync-progress f)
@@ -460,13 +461,17 @@
                                 path (fs-sync/relative-path e)]
                             {:title [:div.file-item
                                      {:key (str "queue-" path)}
-                                     (js/decodeURIComponent path)]
+                                     (try
+                                       (gp-util/safe-decode-uri-component path)
+                                       (catch :default e
+                                         (prn "Wrong path: " path)
+                                         path))]
                              :key   (str "queue-" path)
                              :icon  (ui/icon icon)})) (take 10 queuing-files))
 
              (map (fn [f] {:title [:div.file-item
                                    {:key (str "uploading-" f)}
-                                   (js/decodeURIComponent f)]
+                                   (gp-util/safe-decode-uri-component f)]
                            :key   (str "uploading-" f)
                            :icon  (if enabled-progress-panel?
                                     (let [progress (get sync-progress f)
@@ -489,7 +494,7 @@
                                                         (if page-name
                                                           (rfe/push-state :page {:name page-name})
                                                           (rfe/push-state :file {:path full-path})))}
-                                           [:span.file-sync-item (js/decodeURIComponent (:path f))]
+                                           [:span.file-sync-item (gp-util/safe-decode-uri-component (:path f))]
                                            [:div.opacity-50 (ui/humanity-time-ago (:time f) nil)]]})))
                             (take 10 history-files)))))
 

--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -463,7 +463,7 @@
                                      {:key (str "queue-" path)}
                                      (try
                                        (gp-util/safe-decode-uri-component path)
-                                       (catch :default e
+                                       (catch :default _
                                          (prn "Wrong path: " path)
                                          path))]
                              :key   (str "queue-" path)

--- a/src/main/frontend/config.cljs
+++ b/src/main/frontend/config.cljs
@@ -359,7 +359,7 @@
                  "Local"))
          (->> (string/split repo-dir "Documents/")
               last
-              js/decodeURIComponent
+              gp-util/safe-decode-uri-component
               (str "/" (string/capitalize app-name) "/")))
     (get-repo-dir repo-dir)))
 

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -464,11 +464,14 @@
    (boolean)))
 
 (defn- filter-files-with-reserved-chars
+  "Skip downloading file paths with reserved chars."
   [files]
   (let [reserved-files (filter
                         #(fs-util/include-reserved-chars? (-relative-path %))
                         files)]
     (when (seq reserved-files)
+      (state/pub-event! [:ui/notify-skipped-downloading-files
+                         (map -relative-path reserved-files)])
       (prn "Skipped downloading those file paths with reserved chars: "
            (map -relative-path reserved-files))
       )

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -723,7 +723,7 @@
     (ui/button
       "Upgrade filename format"
       :on-click (fn []
-                  (state/close-modal!)
+                  (notification/clear-all!)
                   (state/set-modal!
                   (fn [_] (conversion-component/files-breaking-changed))
                   {:id :filename-format-panel :center? true})))

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -749,7 +749,7 @@
       [:p
        "Check " [:a {:href "https://docs.logseq.com/#/page/logseq%20file%20and%20folder%20naming%20rules"
                      :target "_blank"}
-                 "https://docs.logseq.com/#/page/logseq%20file%20and%20folder%20naming%20rules"]
+                 "Logseq file and folder naming rules"]
        " for more details."]
       [:p
        "To solve this problem, we suggest you upgrade the filename format (on Settings > Advanced > Filename format > click EDIT button) in other devices to avoid more potential bugs."]]]]

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -716,9 +716,9 @@
 
      [:div
       [:p
-       "We suggest you upgrading now to avoid some potential bugs."]
+       "We suggest you upgrade now to avoid some potential bugs."]
       [:p
-       "For example, the files below have reserved characters that make them unable to be synced on some platforms."]]
+       "For example, the files below have reserved characters can't be synced on some platforms."]]
      ]
     (ui/button
       "Upgrade filename format"
@@ -730,6 +730,29 @@
     [:ol.my-2
      (for [path paths]
        [:li path])]]
+   :warning
+   false))
+
+(defmethod handle :ui/notify-skipped-downloading-files [[_ paths]]
+  (notification/show!
+   [:div
+    [:div.mb-4
+     [:div.font-semibold.mb-4.text-xl "It seems that you're using the old filename format."]
+     [:p
+      "The files below that have reserved characters can't be saved on this device."]
+     [:div.overflow-y-auto.max-h-96
+      [:ol.my-2
+       (for [path paths]
+         [:li path])]]
+
+     [:div
+      [:p
+       "Check " [:a {:href "https://docs.logseq.com/#/page/logseq%20file%20and%20folder%20naming%20rules"
+                     :target "_blank"}
+                 "https://docs.logseq.com/#/page/logseq%20file%20and%20folder%20naming%20rules"]
+       " for more details."]
+      [:p
+       "To solve this problem, we suggest you upgrade the filename format (on Settings > Advanced > Filename format > click EDIT button) in other devices to avoid more potential bugs."]]]]
    :warning
    false))
 

--- a/src/main/frontend/handler/file_sync.cljs
+++ b/src/main/frontend/handler/file_sync.cljs
@@ -13,7 +13,8 @@
             [frontend.handler.user :as user]
             [frontend.fs :as fs]
             [cljs-time.coerce :as tc]
-            [cljs-time.core :as t]))
+            [cljs-time.core :as t]
+            [logseq.graph-parser.util :as gp-util]))
 
 (def *beta-unavailable? (volatile! false))
 
@@ -150,7 +151,7 @@
     (when-let [path (:file/path (db/entity file-id))]
       (let [base-path (config/get-repo-dir (state/get-current-repo))
             base-path (if (string/starts-with? base-path "file://")
-                        (js/decodeURIComponent base-path)
+                        (gp-util/safe-decode-uri-component base-path)
                         base-path)
             path*     (string/replace-first (string/replace-first path base-path "") #"^/" "")]
         (go

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -69,7 +69,7 @@
 (defn- get-whiteboard-tldr-from-text
   [text]
   (when-let [matched-text (util/safe-re-find #"<whiteboard-tldr>(.*)</whiteboard-tldr>" text)]
-    (try-parse-as-json (js/decodeURIComponent (second matched-text)))))
+    (try-parse-as-json (gp-util/safe-decode-uri-component (second matched-text)))))
 
 (defn- get-whiteboard-shape-refs-text
   [text]

--- a/src/main/frontend/mobile/intent.cljs
+++ b/src/main/frontend/mobile/intent.cljs
@@ -77,12 +77,12 @@
     (-> (string/replace template "{time}" time)
         (string/replace "{url}" (or url "")))))
 
-(defn- embed-text-file 
-  "Store external content with url into Logseq repo" 
+(defn- embed-text-file
+  "Store external content with url into Logseq repo"
   [url title]
   (p/let [time (date/get-current-time)
           title (some-> (or title (path/basename url))
-                        js/decodeURIComponent
+                        gp-util/safe-decode-uri-component
                         util/node-path.name
                         ;; make the title more user friendly
                         gp-util/page-name-sanity)
@@ -148,7 +148,7 @@
 
                       :else
                       (if (mobile-util/native-ios?)
-                        (js/decodeURIComponent v)
+                        (gp-util/safe-decode-uri-component v)
                         v))])))
 
 (defn handle-result [result]

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -506,7 +506,7 @@
    (defn safe-path-join [prefix & paths]
      (let [path (apply node-path.join (cons prefix paths))]
        (if (and (electron?) (gstring/caseInsensitiveStartsWith path "file://"))
-         (js/decodeURIComponent (subs path 7))
+         (gp-util/safe-decode-uri-component (subs path 7))
          path))))
 
 (defn trim-safe

--- a/src/main/frontend/util/fs.cljs
+++ b/src/main/frontend/util/fs.cljs
@@ -74,7 +74,7 @@
   (re-pattern (str "[" multiplatform-reserved-chars "]+")))
 
 (defn include-reserved-chars?
-  "Includes reserved charcters that would broken FS"
+  "Includes reserved characters that would broken FS"
   [s]
   (util/safe-re-find reserved-chars-pattern s))
 


### PR DESCRIPTION
This PR will notify users to switch to the new filename format when there're file paths that have some reserved chars.
It also skips downloading those files and notifies users to update the filename format on other devices.

This PR fixed two issues:
1. Sync stops because there're filenames with reserved chars.
2. `js/decodeURIComponent` is not safe to use, for example, `(js/decodeURIComponent "% 20")` will throws a `URI malformed` error. 