### PR TITLE
fix: race condition on creating zotero profile

### DIFF
--- a/src/main/frontend/extensions/zotero/setting.cljs
+++ b/src/main/frontend/extensions/zotero/setting.cljs
@@ -1,5 +1,6 @@
 (ns frontend.extensions.zotero.setting
   (:require [clojure.string :as str]
+            [promesa.core :as p]
             [frontend.handler.config :as config-handler]
             [frontend.state :as state]
             [frontend.storage :as storage]))
@@ -46,8 +47,10 @@
 
 (defn set-profile [profile]
   (storage/set :zotero/setting-profile profile)
-  (when-not (contains? (all-profiles) profile)
-    (add-profile name)))
+  (p/let [has-item? (p/then (js/setTimeout 1000) ;; Wait 1000 ms for profile to be applied on config
+                            #(contains? (all-profiles) profile))]
+    (when-not has-item?
+      (add-profile profile))))
 
 (defn remove-profile [profile]
   (let [settings (dissoc (sub-zotero-config) profile)]


### PR DESCRIPTION
The update to config via `set-config` has some latency to be listen by `sub-config`, which causes race condition. (The latency may be introduced by the global config PR)
The race condition triggered a legacy bug in the zotero implementation.

The solution is adding timeout between `set-config` and `sub-config`

Fix #6861 
Fix #7092 
Fix #7103 