### PR TITLE
fix: unlink wrong graphs

### DIFF
--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -135,7 +135,9 @@
                 (when-let [GraphUUID (get (async/<! (file-sync-handler/create-graph graph-name)) 2)]
                   (async/<! (fs-sync/<sync-start))
                   (state/set-state! [:ui/loading? :graph/create-remote?] false)
-                  ;; update existing repo
+                  ;; update both local && remote graphs
+                  (state/add-remote-graph! {:GraphUUID GraphUUID
+                                            :GraphName graph-name})
                   (state/set-repos! (map (fn [r]
                                            (if (= (:url r) repo)
                                              (assoc r

--- a/src/main/frontend/components/repo.cljs
+++ b/src/main/frontend/components/repo.cljs
@@ -85,10 +85,11 @@
                                                              (file-sync/load-session-graphs)
                                                              (state/set-state! [:ui/loading? :remove/remote-graph GraphUUID] false)))}))]
                                      (state/set-modal! (confirm-fn)))
-                                   (do
+                                   (let [current-repo (state/get-current-repo)]
                                      (repo-handler/remove-repo! repo)
-                                     (file-sync/load-session-graphs)
-                                     (state/pub-event! [:graph/unlinked]))))}
+                                     (state/pub-event! [:graph/unlinked repo current-repo])
+                                     (when only-cloud?
+                                       (file-sync/load-session-graphs)))))}
                     (if only-cloud? "Remove" "Unlink")])])]]))
 
 (rum/defc repos < rum/reactive

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -194,7 +194,6 @@
   {:pre [(int? latest-txid) (>= latest-txid 0)]}
   (-> (p/let [_ (persist-var/-reset-value! graphs-txid [user-uuid graph-uuid latest-txid] repo)
               _ (persist-var/persist-save graphs-txid)]
-        (state/pub-event! [:graph/refresh])
         (when (state/developer-mode?) (assert-local-txid<=remote-txid)))
       p->c))
 

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -113,15 +113,11 @@
       (route-handler/redirect-to-home!)))
   (when-let [dir-name (config/get-repo-dir repo)]
     (fs/watch-dir! dir-name))
-  (repo-handler/refresh-repos!)
   (file-sync-restart!))
 
 (defmethod handle :graph/unlinked [repo current-repo]
   (when (= (:url repo) current-repo)
     (file-sync-restart!)))
-
-(defmethod handle :graph/refresh [_]
-  (repo-handler/refresh-repos!))
 
 ;; FIXME: awful multi-arty function.
 ;; Should use a `-impl` function instead of the awful `skip-ios-check?` param with nested callback.
@@ -141,7 +137,6 @@
          (fs/watch-dir! dir-name))
        (srs/update-cards-due-count!)
        (state/pub-event! [:graph/ready graph])
-       (repo-handler/refresh-repos!)
        (file-sync-restart!)))))
 
 ;; Parameters for the `persist-db` function, to show the notification messages

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -116,9 +116,9 @@
   (repo-handler/refresh-repos!)
   (file-sync-restart!))
 
-(defmethod handle :graph/unlinked [_]
-  (repo-handler/refresh-repos!)
-  (file-sync-restart!))
+(defmethod handle :graph/unlinked [repo current-repo]
+  (when (= (:url repo) current-repo)
+    (file-sync-restart!)))
 
 (defmethod handle :graph/refresh [_]
   (repo-handler/refresh-repos!))

--- a/src/main/frontend/handler/file_sync.cljs
+++ b/src/main/frontend/handler/file_sync.cljs
@@ -49,7 +49,8 @@
                (string? r))
         (let [tx-info [0 r (user/user-uuid) (state/get-current-repo)]]
           (<! (apply sync/<update-graphs-txid! tx-info))
-          (swap! refresh-file-sync-component not) tx-info)
+          (swap! refresh-file-sync-component not)
+          tx-info)
         (do
           (state/set-state! [:ui/loading? :graph/create-remote?] false)
           (cond

--- a/src/main/frontend/handler/repo.cljs
+++ b/src/main/frontend/handler/repo.cljs
@@ -341,13 +341,14 @@
 (defn remove-repo!
   [{:keys [url] :as repo}]
   (let [delete-db-f (fn []
-                      (let [graph-exists? (db/get-db url)]
+                      (let [graph-exists? (db/get-db url)
+                            current-repo (state/get-current-repo)]
                         (db/remove-conn! url)
                         (db-persist/delete-graph! url)
                         (search/remove-db! url)
                         (state/delete-repo! repo)
                         (when graph-exists? (ipc/ipc "graphUnlinked" repo))
-                        (when (= (state/get-current-repo) url)
+                        (when (= current-repo url)
                           (state/set-current-repo! (:url (first (state/get-repos)))))))]
     (when (or (config/local-db? url) (= url "local"))
       (-> (p/let [_ (idb/clear-local-db! url)] ; clear file handles

--- a/src/main/frontend/handler/repo.cljs
+++ b/src/main/frontend/handler/repo.cljs
@@ -498,7 +498,7 @@
   [local-repos remote-repos]
   (when-let [repos' (seq (concat (map #(if-let [sync-meta (seq (:sync-meta %))]
                                          (assoc % :GraphUUID (second sync-meta)) %)
-                                      local-repos)
+                                   local-repos)
                                  (some->> remote-repos
                                           (map #(assoc % :remote? true)))))]
     (let [repos' (group-by :GraphUUID repos')
@@ -515,7 +515,7 @@
   [url]
   (when-let [graphs (seq (and url (combine-local-&-remote-graphs
                                     (state/get-repos)
-                                    (state/get-remote-repos))))]
+                                    (state/get-remote-graphs))))]
     (first (filter #(when-let [url' (:url %)]
                       (= url url')) graphs))))
 
@@ -524,7 +524,7 @@
   (p/let [repos (get-repos)
           repos' (combine-local-&-remote-graphs
                   repos
-                  (state/get-remote-repos))]
+                  (state/get-remote-graphs))]
     (state/set-repos! repos')
     repos'))
 

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -711,7 +711,7 @@ Similar to re-frame subscriptions"
       (when-not (mobile-util/native-platform?)
         "local")))
 
-(defn get-remote-repos
+(defn get-remote-graphs
   []
   (get-in @state [:file-sync/remote-graphs :graphs]))
 
@@ -719,6 +719,22 @@ Similar to re-frame subscriptions"
   [uuid]
   (when-let [graphs (seq (get-in @state [:file-sync/remote-graphs :graphs]))]
     (some #(when (= (:GraphUUID %) (str uuid)) %) graphs)))
+
+(defn delete-remote-graph!
+  [repo]
+  (swap! state update-in [:file-sync/remote-graphs :graphs]
+         (fn [repos]
+           (remove #(and
+                     (:GraphUUID repo)
+                     (:GraphUUID %)
+                     (= (:GraphUUID repo) (:GraphUUID %))) repos))))
+
+(defn add-remote-graph!
+  [repo]
+  (swap! state update-in [:file-sync/remote-graphs :graphs]
+         (fn [repos]
+           (->> (conj repos repo)
+                (distinct)))))
 
 (defn get-repos
   []

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -762,7 +762,10 @@ Similar to re-frame subscriptions"
   (swap! state update-in [:me :repos]
          (fn [repos]
            (->> (remove #(or (= (:url repo) (:url %))
-                             (= (:GraphUUID repo) (:GraphUUID %))) repos)
+                             (and
+                              (:GraphUUID repo)
+                              (:GraphUUID %)
+                              (= (:GraphUUID repo) (:GraphUUID %)))) repos)
                 (util/distinct-by :url)))))
 
 (defn set-timestamp-block!


### PR DESCRIPTION
Fix:
1. unlink a graph can unlink others.
2. remove a remote graph doesn't remove it from the graph list sometimes.