### PR TITLE
Update develop-logseq.md to include required static install

### DIFF
--- a/docs/develop-logseq.md
+++ b/docs/develop-logseq.md
@@ -49,7 +49,7 @@ yarn watch
 # Wait until watch reports `Build Completed.` for `:electron` and `:app`.
 # Then, run the following command in a different shell.
 # If you have opened desktop logseq, you should close it. Otherwise, this command will fail.
-yarn dev-electron-app
+(cd static && yarn install) && yarn dev-electron-app
 ```
 
 Alternatively, run `bb dev:electron-start` to do this step with one command. To


### PR DESCRIPTION
To run `dev-electron-app`, one must run `yarn install` in the `static` folder after `yarn watch`. This adds that to the dev readme.

I ran into this after not having a required dependency when I was getting back into logseq development after having not done so since before Sync came out.