### PR TITLE
fix(whiteboard): pasting text in block portal shapes

### DIFF
--- a/src/main/frontend/components/page_menu.cljs
+++ b/src/main/frontend/components/page_menu.cljs
@@ -57,7 +57,8 @@
   [page-name]
   (when-let [page-name (or
                         page-name
-                        (state/get-current-page))]
+                        (state/get-current-page)
+                        (state/get-current-whiteboard))]
     (let [page-name (util/page-name-sanity-lc page-name)
           repo (state/sub :git/current-repo)
           page (db/entity repo [:block/name page-name])

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -697,7 +697,13 @@ Similar to re-frame subscriptions"
 
 (defn get-current-page
   []
-  (when (#{:page :whiteboard} (get-current-route))
+  (when (= :page (get-current-route))
+    (get-in (get-route-match)
+            [:path-params :name])))
+
+(defn get-current-whiteboard
+  []
+  (when (= :whiteboard (get-current-route))
     (get-in (get-route-match)
             [:path-params :name])))
 

--- a/tldraw/apps/tldraw-logseq/src/hooks/usePaste.ts
+++ b/tldraw/apps/tldraw-logseq/src/hooks/usePaste.ts
@@ -1,5 +1,4 @@
 import {
-  BoundsUtils,
   getSizeFromSrc,
   isNonNullable,
   TLAsset,
@@ -174,6 +173,7 @@ export function usePaste() {
               asset.type === 'video' ? VideoShape.defaultProps : ImageShape.defaultProps
             const newShape = {
               ...defaultProps,
+              id: uniqueId(),
               // TODO: Should be place near the last edited shape
               assetId: asset.id,
               opacity: 1,
@@ -372,8 +372,9 @@ export function usePaste() {
       })
 
       app.wrapUpdate(() => {
-        if (assetsToClone.length > 0) {
-          app.createAssets(assetsToClone)
+        const allAssets = [...imageAssetsToCreate, ...assetsToClone]
+        if (allAssets.length > 0) {
+          app.createAssets(allAssets)
         }
         if (newShapes.length > 0) {
           app.createShapes(newShapes)
@@ -389,6 +390,10 @@ export function usePaste() {
         app.setSelectedShapes(allShapesToAdd.map(s => s.id))
         app.selectedTool.transition('idle') // clears possible editing states
         app.cursors.setCursor(TLCursor.Default)
+
+        if (fromDrop) {
+          app.packIntoRectangle()
+        }
       })
     },
     []


### PR DESCRIPTION
- fix: pasting texts into portal shapes not working. This is due to a regression in a5e01895c. Supporting `get-current-page` for whiteboard route breaks https://github.com/logseq/logseq/blob/b09fe61e86a64580faa9c6fb3a90cb54cf2f63db/src/main/frontend/handler/paste.cljs#L118-L150
- fix: pasting image assets are not correctly handled. Also, dropping multiple assets will also pack them into a rect.


https://user-images.githubusercontent.com/584378/200510135-dbd97aec-6790-42fc-9f49-e66d33770d9c.mp4

