### PR TITLE
feat: show theme plugin settings under "Plugin Settings"

### DIFF
--- a/src/main/frontend/handler/plugin.cljs
+++ b/src/main/frontend/handler/plugin.cljs
@@ -163,7 +163,7 @@
 
 (defn get-enabled-plugins-if-setting-schema
   []
-  (when-let [plugins (seq (state/get-enabled?-installed-plugins false nil true))]
+  (when-let [plugins (seq (state/get-all-enabled?-installed-plugins nil true))]
     (filter #(has-setting-schema? (:id %)) plugins)))
 
 (defn setup-install-listener!

--- a/src/main/frontend/handler/plugin.cljs
+++ b/src/main/frontend/handler/plugin.cljs
@@ -163,7 +163,7 @@
 
 (defn get-enabled-plugins-if-setting-schema
   []
-  (when-let [plugins (seq (state/get-all-enabled?-installed-plugins nil true))]
+  (when-let [plugins (seq (state/get-all-enabled?-installed-plugins))]
     (filter #(has-setting-schema? (:id %)) plugins)))
 
 (defn setup-install-listener!

--- a/src/main/frontend/handler/plugin.cljs
+++ b/src/main/frontend/handler/plugin.cljs
@@ -163,7 +163,7 @@
 
 (defn get-enabled-plugins-if-setting-schema
   []
-  (when-let [plugins (seq (state/get-all-enabled?-installed-plugins))]
+  (when-let [plugins (seq (state/get-enabled?-installed-plugins false nil true true))]
     (filter #(has-setting-schema? (:id %)) plugins)))
 
 (defn setup-install-listener!

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1753,21 +1753,19 @@ Similar to re-frame subscriptions"
   (when-let [id (and id (keyword id))]
     (get-in @state [:plugin/installed-plugins id])))
 
-(defn get-all-enabled?-installed-plugins
-  ([enabled? include-unpacked?]
-   (filterv
-     #(and (if include-unpacked? true (:iir %))
-           (if-not (boolean? enabled?) true (= (not enabled?) (boolean (get-in % [:settings :disabled])))))
-     (vals (:plugin/installed-plugins @state)))))
-
 (defn get-enabled?-installed-plugins
-  ([theme?] (get-enabled?-installed-plugins theme? true false))
-  ([theme? enabled? include-unpacked?]
+  ([theme?] (get-enabled?-installed-plugins theme? true false false))
+  ([theme? enabled? include-unpacked? include-all?]
    (filterv
      #(and (if include-unpacked? true (:iir %))
            (if-not (boolean? enabled?) true (= (not enabled?) (boolean (get-in % [:settings :disabled]))))
-           (= (boolean theme?) (:theme %)))
+           (or include-all? (= (boolean theme?) (:theme %))))
      (vals (:plugin/installed-plugins @state)))))
+
+(defn get-all-enabled?-installed-plugins
+  ([] (get-all-enabled?-installed-plugins true true))
+  ([enabled? include-unpacked?]
+   (get-enabled?-installed-plugins nil enabled? include-unpacked? true)))
 
 (defn lsp-enabled?-or-theme
   []

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1762,11 +1762,6 @@ Similar to re-frame subscriptions"
            (or include-all? (= (boolean theme?) (:theme %))))
      (vals (:plugin/installed-plugins @state)))))
 
-(defn get-all-enabled?-installed-plugins
-  ([] (get-all-enabled?-installed-plugins true true))
-  ([enabled? include-unpacked?]
-   (get-enabled?-installed-plugins nil enabled? include-unpacked? true)))
-
 (defn lsp-enabled?-or-theme
   []
   (:plugin/enabled @state))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1753,6 +1753,13 @@ Similar to re-frame subscriptions"
   (when-let [id (and id (keyword id))]
     (get-in @state [:plugin/installed-plugins id])))
 
+(defn get-all-enabled?-installed-plugins
+  ([enabled? include-unpacked?]
+   (filterv
+     #(and (if include-unpacked? true (:iir %))
+           (if-not (boolean? enabled?) true (= (not enabled?) (boolean (get-in % [:settings :disabled])))))
+     (vals (:plugin/installed-plugins @state)))))
+
 (defn get-enabled?-installed-plugins
   ([theme?] (get-enabled?-installed-plugins theme? true false))
   ([theme? enabled? include-unpacked?]


### PR DESCRIPTION
This change will allow theme plugins to show in the list under _Settings > Plugin Settings_ if they register settings schema using `logseq.useSettingsSchema(settings)` same as how non-theme plugins do.

This will enable theme designers to give users customization options within the theme design guidelines like accent color, hide/unhide elements, etc. 

I have shared context and additional info in a feature request at [discuss](https://discuss.logseq.com/t/theme-plugin-settings/12280). Discord [conversation](https://discord.com/channels/725182569297215569/752845138148982877/1039251172156002324) related to this.

Thanks!