### PR TITLE
fix: force /private part on iOS

### DIFF
--- a/src/main/frontend/fs/capacitor_fs.cljs
+++ b/src/main/frontend/fs/capacitor_fs.cljs
@@ -212,10 +212,13 @@
                       (error-handler error)
                       (log/error :write-file-failed error)))))))))
 
-(defn remove-private-part
-  "iOS sometimes return the private part."
+(defn ios-force-include-private
+  "iOS sometimes return paths without the private part."
   [path]
-  (string/replace path "///private/" "///"))
+  (if (string/includes? path "///private/")
+    path
+    (let [[prefix others] (string/split path "///")]
+      (str prefix "///private/" others))))
 
 (defn normalize-file-protocol-path [dir path]
   (let [dir             (some-> dir (string/replace #"/+$" ""))
@@ -249,7 +252,9 @@
                 :else
                 (let [path' (safe-encode-url path)]
                   (str dir "/" path')))]
-    (remove-private-part path')))
+    (if (mobile-util/native-ios?)
+      (ios-force-include-private path')
+      path')))
 
 (defn- local-container-path?
   "Check whether `path' is logseq's container `localDocumentsPath' on iOS"

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -570,7 +570,7 @@
         payload (-> event
                     (js->clj :keywordize-keys true)
                     (update :path (fn [path]
-                                    (when (string? path) (capacitor-fs/remove-private-part path)))))]
+                                    (when (string? path) (capacitor-fs/ios-force-include-private path)))))]
     (fs-watcher/handle-changed! type payload)
     (when (file-sync-handler/enable-sync?)
      (sync/file-watch-handler type payload))))


### PR DESCRIPTION
Re-index needed.

This fixed two bugs:
1. unsaved changes will be overwritten when restarting the app.
2. full sync instead of incremental sync