### PR TITLE
fix(mobile): show url-decoded filenames when re-indexing

### DIFF
--- a/src/main/frontend/components/sidebar.cljs
+++ b/src/main/frontend/components/sidebar.cljs
@@ -461,13 +461,17 @@
   (let [finished (or (:finished state) 0)
         total (:total state)
         width (js/Math.round (* (.toFixed (/ finished total) 2) 100))
+        file-basename (util/node-path.basename
+                       (:current-parsing-file state))
+        display-filename (if (mobile-util/native-platform?)
+                           (js/decodeURIComponent file-basename)
+                           file-basename)
         left-label [:div.flex.flex-row.font-bold
                     (t :parsing-files)
                     [:div.hidden.md:flex.flex-row
                      [:span.mr-1 ": "]
                      [:div.text-ellipsis-wrapper {:style {:max-width 300}}
-                      (util/node-path.basename
-                       (:current-parsing-file state))]]]]
+                      display-filename]]]]
     (ui/progress-bar-with-label width left-label (str finished "/" total))))
 
 (rum/defc main-content < rum/reactive db-mixins/query


### PR DESCRIPTION
Displayed filenames should be URL-decoded on mobile platforms, instead of something like %XX%XX....%XX.md