### PR TITLE
fix: href asset is not loaded on Electron

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -197,10 +197,8 @@
                             asset-path (gp-config/remove-asset-protocol src)]
                         (if (string/blank? asset-path)
                           (reset! *exist? false)
-                          (-> (fs/file-exists? "" asset-path)
-                              (p/then
-                               (fn [exist?]
-                                 (reset! *exist? (boolean exist?))))))
+                          (p/let [exist? (fs/file-or-href-exists? "" asset-path)]
+                            (reset! *exist? (boolean exist?))))
                         (assoc state ::asset-path asset-path ::asset-file? true))
                       state)))
    :will-update (fn [state]
@@ -314,8 +312,10 @@
           :title   title}
          metadata)]
        [:.asset-overlay]
-       (let [image-src (string/replace src #"^assets://" "")]
+       (let [image-src (string/replace src #"^assets://" "")
+             _ (prn "image-src:" image-src)]
          [:.asset-action-bar {:aria-hidden "true"}
+          ;; the image path bar
           (when (util/electron?)
             [:button.asset-action-btn.text-left
              {:title (t (if local? :asset/show-in-folder :asset/open-in-browser))

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -312,8 +312,7 @@
           :title   title}
          metadata)]
        [:.asset-overlay]
-       (let [image-src (string/replace src #"^assets://" "")
-             _ (prn "image-src:" image-src)]
+       (let [image-src (string/replace src #"^assets://" "")]
          [:.asset-action-bar {:aria-hidden "true"}
           ;; the image path bar
           (when (util/electron?)

--- a/src/main/frontend/fs.cljs
+++ b/src/main/frontend/fs.cljs
@@ -14,7 +14,8 @@
             [promesa.core :as p]
             [frontend.db :as db]
             [clojure.string :as string]
-            [frontend.state :as state]))
+            [frontend.state :as state]
+            [logseq.graph-parser.util :as gp-util]))
 
 (defonce nfs-record (nfs/->Nfs))
 (defonce bfs-record (bfs/->Bfs))
@@ -215,6 +216,15 @@
    (stat dir path)
    (fn [stat] (not (nil? stat)))
    (fn [_e] false)))
+
+(defn file-or-href-exists?
+  "It not only accept path, but also href (url encoded path)"
+  [dir href]
+  (p/let [exist? (file-exists? dir href)
+          decoded-href   (gp-util/safe-decode-uri-component href)
+          decoded-exist? (when (not= decoded-href href)
+                           (file-exists? dir decoded-href))]
+    (or exist? decoded-exist?)))
 
 (defn dir-exists?
   [dir]


### PR DESCRIPTION
**Before the fix, URLencoded href (the `%20` in path) is not accepted, though the asset exists in the decoded form (`../assets/IMG_9072 2.PNG`)**
`**00:28** [[quick capture]]: ![IMG_9072%202](../assets/IMG_9072%202.PNG)`
<img width="314" alt="image" src="https://user-images.githubusercontent.com/9862022/200881231-a95dda12-f539-4818-9592-31199d63ba47.png">
(Image doesn't show)
`**00:28** [[quick capture]]: ![IMG_9072%202](../assets/IMG_9072 2.PNG)`
<img width="761" alt="image" src="https://user-images.githubusercontent.com/9862022/200881447-074dc21c-fe61-4923-bc56-8699a859acc1.png">
(Image shows up)
**After the fix, URLencoded href (the `%20` in path) is also accepted**
`**00:28** [[quick capture]]: ![IMG_9072%202](../assets/IMG_9072%202.PNG)`
<img width="795" alt="image" src="https://user-images.githubusercontent.com/9862022/200880632-4a2d6538-ba48-4d4b-a4ef-1713318ec367.png">
(Image shows up)
