### PR TITLE
fix(editor): missing trailing content when pasting inline code

### DIFF
--- a/src/main/frontend/extensions/html_parser.cljs
+++ b/src/main/frontend/extensions/html_parser.cljs
@@ -171,7 +171,7 @@
                                    (string? (first children))
                                    (let [pattern (config/get-code format)]
                                      (str " "
-                                          (str pattern (first children) pattern)
+                                          pattern (map-join children) pattern
                                           " "))
 
                                    ;; skip monospace style, since it has more complex children


### PR DESCRIPTION
To reproduce, copy from the following HTML. The resulted inline code will omit all content after the first `<wbr>`  tag.

```html
<p>
<span><code data-v-88c637be="">BGApp<wbr data-v-88c637be="">Refresh<wbr data-v-88c637be="">Task</code></span><span ><span> </span>is for short-duration tasks that expect quick results, such as downloading a stock quote.<span> </span></span><span><code data-v-88c637be="">BGProcessing<wbr data-v-88c637be="">Task</code></span><span><span> </span>is for tasks that might be time-consuming, such as downloading a large file or synchronizing data. Your app can use one or both of these.</span>
</p>
```

