### PR TITLE
replace whiteboard printing with ugly print #7168

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ pom.xml.asc
 node_modules/
 static/
 tmp
+cljs-test-runner-out
 
 .cpcache/
 /src/gen

--- a/deps.edn
+++ b/deps.edn
@@ -47,6 +47,11 @@
                                 org.clojars.knubie/cljs-run-test {:mvn/version "1.0.1"}}
                   :main-opts   ["-m" "shadow.cljs.devtools.cli"]}
 
+           :bench {:extra-paths ["src/bench/"]
+                   :extra-deps {olical/cljs-test-runner {:mvn/version "3.8.0"}
+                                fipp/fipp {:mvn/version "0.6.26"}}
+                   :main-opts ["-m" "cljs-test-runner.main" "-d" "src/bench" "-n" "frontend.benchmark-test-runner"]}
+
            ;; Use :replace-deps for tools. See https://github.com/clj-kondo/clj-kondo/issues/1536#issuecomment-1013006889
            :clj-kondo {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2022.10.14"}}
                        :main-opts  ["-m" "clj-kondo.main"]}}}

--- a/src/bench/frontend/benchmark_test_runner.cljs
+++ b/src/bench/frontend/benchmark_test_runner.cljs
@@ -4,7 +4,7 @@
             [frontend.macros :refer [slurped]]
             [frontend.modules.file.uprint :as up]
             [clojure.pprint :as pprint]
-            [clojure.test :refer [run-tests deftest testing]]
+            [clojure.test :refer [deftest testing]]
             [fipp.edn :as fipp]))
 
 (def onboarding

--- a/src/bench/frontend/benchmark_test_runner.cljs
+++ b/src/bench/frontend/benchmark_test_runner.cljs
@@ -1,0 +1,28 @@
+(ns frontend.benchmark-test-runner
+  "Runs a benchmark"
+  (:require [clojure.edn :as edn]
+            [frontend.macros :refer [slurped]]
+            [frontend.modules.file.uprint :as up]
+            [clojure.pprint :as pprint]
+            [clojure.test :refer [run-tests deftest testing]]
+            [fipp.edn :as fipp]))
+
+(def onboarding
+  (edn/read-string (slurped "resources/whiteboard/onboarding.edn")))
+
+(deftest test-pp-str
+  (testing "pp-str benchmark"
+    (simple-benchmark []
+                      (with-out-str (pprint/pprint onboarding))
+                      10)
+    (simple-benchmark []
+                      (with-out-str (fipp/pprint onboarding))
+                      10)
+    (simple-benchmark []
+                      (up/ugly-pr-str onboarding)
+                      10)
+    (simple-benchmark []
+                      (pr-str onboarding)
+                      10)
+    ;; uncomment to see the output
+    #_(println (up/ugly-pr-str onboarding))))

--- a/src/bench/frontend/macros.cljc
+++ b/src/bench/frontend/macros.cljc
@@ -1,6 +1,5 @@
 (ns frontend.macros
-  #?(:cljs (:require-macros [frontend.macros])
-     :clj (:require [clojure.edn :as edn])))
+  #?(:cljs (:require-macros [frontend.macros])))
 
 #?(:clj
    (defmacro slurped

--- a/src/bench/frontend/macros.cljc
+++ b/src/bench/frontend/macros.cljc
@@ -1,0 +1,9 @@
+(ns frontend.macros
+  #?(:cljs (:require-macros [frontend.macros])
+     :clj (:require [clojure.edn :as edn])))
+
+#?(:clj
+   (defmacro slurped
+     "Like slurp, but at compile time"
+     [filename]
+     (slurp filename)))

--- a/src/main/frontend/modules/file/core.cljs
+++ b/src/main/frontend/modules/file/core.cljs
@@ -4,6 +4,7 @@
             [frontend.date :as date]
             [frontend.db :as db]
             [frontend.db.utils :as db-utils]
+            [frontend.modules.file.uprint :as up]
             [frontend.state :as state]
             [frontend.util.property :as property]
             [frontend.util.fs :as fs-util]
@@ -140,7 +141,7 @@
         file-path (-> (db-utils/entity file-db-id) :file/path)]
     (if (and (string? file-path) (not-empty file-path))
       (let [new-content (if (= "whiteboard" (:block/type page-block))
-                          (pr-str {:blocks tree
+                          (up/ugly-pr-str {:blocks tree
                                    :pages (list (remove-transit-ids page-block))})
                           (tree->file-content tree {:init-level init-level}))
             files [[file-path new-content]]

--- a/src/main/frontend/modules/file/uprint.cljs
+++ b/src/main/frontend/modules/file/uprint.cljs
@@ -4,9 +4,9 @@
   (pr-sequential-writer
     writer
     (fn [e w opts]
-      (do (print-one (key e) w opts)
-          (-write w \space)
-          (print-one (val e) w opts)))
+      (print-one (key e) w opts)
+      (-write w \space)
+      (print-one (val e) w opts))
     (str prefix "\n{") \newline "}"
     opts (seq m)))
 

--- a/src/main/frontend/modules/file/uprint.cljs
+++ b/src/main/frontend/modules/file/uprint.cljs
@@ -1,0 +1,17 @@
+(ns frontend.modules.file.uprint)
+
+(defn print-prefix-map* [prefix m print-one writer opts]
+  (pr-sequential-writer
+    writer
+    (fn [e w opts]
+      (do (print-one (key e) w opts)
+          (-write w \space)
+          (print-one (val e) w opts)))
+    (str prefix "{") \newline "}"
+    opts (seq m)))
+
+(defn ugly-pr-str
+  "Ugly printing fast, with newline per block"
+  [x]
+  (with-redefs [print-prefix-map print-prefix-map*]
+    (pr-str x)))

--- a/src/main/frontend/modules/file/uprint.cljs
+++ b/src/main/frontend/modules/file/uprint.cljs
@@ -7,11 +7,11 @@
       (do (print-one (key e) w opts)
           (-write w \space)
           (print-one (val e) w opts)))
-    (str prefix "{") \newline "}"
+    (str prefix "\n{") \newline "}"
     opts (seq m)))
 
 (defn ugly-pr-str
-  "Ugly printing fast, with newline per block"
+  "Ugly printing fast, with newlines so that git diffs are smaller"
   [x]
   (with-redefs [print-prefix-map print-prefix-map*]
     (pr-str x)))


### PR DESCRIPTION
Prints fast with newlines

clojure -M:test:bench

```
Testing frontend.benchmark-test-runner
[], (with-out-str (pprint/pprint onboarding)), 10 runs, 2950 msecs 
[], (with-out-str (fipp/pprint onboarding)), 10 runs, 2447 msecs 
[], (up/ugly-pr-str onboarding), 10 runs, 94 msecs 
[], (pr-str onboarding), 10 runs, 82 msecs
```