### PR TITLE
fix: use name to detect default theme

### DIFF
--- a/src/main/frontend/components/theme.cljs
+++ b/src/main/frontend/components/theme.cljs
@@ -27,7 +27,7 @@
           (.add cls "dark")
           (.remove cls "dark"))
         (ui/apply-custom-theme-effect! theme)
-        (plugin-handler/hook-plugin-app :theme-mode-changed {:mode theme} nil))
+        (plugin-handler/hook-plugin-app :theme-mode-changed {:mode theme}))
      [theme])
 
     (rum/use-effect!

--- a/src/main/frontend/handler/plugin.cljs
+++ b/src/main/frontend/handler/plugin.cljs
@@ -632,8 +632,8 @@
                                                           (when mode
                                                             (state/set-custom-theme! mode theme)
                                                             (state/set-theme-mode! mode))
-                                                          (hook-plugin-app :theme-changed theme)
-                                                          (state/set-state! :plugin/selected-theme url))))
+                                                          (state/set-state! :plugin/selected-theme url)
+                                                          (hook-plugin-app :theme-changed theme))))
 
                                 (.on "reset-custom-theme" (fn [^js themes]
                                                             (let [themes       (bean/->clj themes)

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -366,10 +366,12 @@
 (defn apply-custom-theme-effect! [theme]
   (when config/lsp-enabled?
     (when-let [custom-theme (state/sub [:ui/custom-theme (keyword theme)])]
-      (when-let [url (:url custom-theme)]
+      ;; If the name is nil, the user has not set a custom theme (initially {:mode light/dark}).
+      ;; The url is not used because the default theme does not have an url.
+      (when-let [name (:name custom-theme)]
         (js/LSPluginCore.selectTheme (bean/->js custom-theme)
-                                     (bean/->js {:emit true}))
-        (state/set-state! :plugin/selected-theme url)))))
+                                     (bean/->js {:emit false}))
+        (state/set-state! :plugin/selected-theme (:url custom-theme))))))
 
 (defn setup-system-theme-effect!
   []

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -368,7 +368,7 @@
     (when-let [custom-theme (state/sub [:ui/custom-theme (keyword theme)])]
       ;; If the name is nil, the user has not set a custom theme (initially {:mode light/dark}).
       ;; The url is not used because the default theme does not have an url.
-      (when-let [name (:name custom-theme)]
+      (if (some? (:name custom-theme))
         (js/LSPluginCore.selectTheme (bean/->js custom-theme)
                                      (bean/->js {:emit false}))
         (state/set-state! :plugin/selected-theme (:url custom-theme))))))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1595,9 +1595,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001370:
-  version "1.0.30001393"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001393.tgz#1aa161e24fe6af2e2ccda000fc2b94be0b0db356"
-  integrity sha512-N/od11RX+Gsk+1qY/jbPa0R6zJupEa0lxeBG598EbrtblxVCTJsQwbRBm6+V+rxpc5lHKdsXb9RY83cZIPLseA==
+  version "1.0.30001431"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz"
+  integrity sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==
 
 capacitor-voice-recorder@4.0.0:
   version "4.0.0"


### PR DESCRIPTION
From #5434.

In `apply-custom-theme-effect!`, the previous code used `url` to detect if the user was using a custom theme, which would cause problems (do not execute selectTheme) because the default themes did not have `url`.

https://github.com/logseq/logseq/blob/a939767aaf5720ec68c1ca00cc589dd85718995f/src/main/frontend/components/plugins.cljs#L47

This problem will occur when the user has set only one theme (e.g. set a custom light theme but uses the default dark theme). So I change the code to use `name` to detect if the user has set a custom theme (see more details in code comments).

### Misc

This PR also updates the caniuse-lite.