### PR TITLE
Small fix in documentation for browser development.

### DIFF
--- a/docs/develop-logseq.md
+++ b/docs/develop-logseq.md
@@ -30,7 +30,7 @@ Then open the browser <http://localhost:3001>.
 yarn release
 ```
 
-The released files will be at `resources/` directory.
+The released files will be at `static/` directory.
 
 ## Desktop app development
 


### PR DESCRIPTION
**Disclaimer:**
This is my first PR to Logseq so please forgive me if I've misunderstood something about the repo that makes this PR incorrect.

**Summary**:
The changes to the docs in this PR now direct users to the static/ directory for released files instead of resources/ for browser development.

**Details:**
When I look at the `release` script in `package.json` I can see that it runs `gulp:build` script first. `gulp:build` in turn runs `gulp build`. Following the command into `gulpfile.js` I can see that the build script runs:

```
exports.build = gulp.series(common.clean, common.syncResourceFile, common.syncAssetFiles, css.buildCSS)
```

Each of the functions that are used in `gulp.series` output files to `outputPath = path.join(__dirname, 'static')`. This is the static directory and not the resources directory.

I sense checked this with the `Dockerfile` which, as its final step, has to move the files from static into public.
```
# Build for static resources
RUN git clone https://github.com/logseq/logseq.git &&  cd /data/logseq && yarn && yarn release && mv ./static ./public
```
