### PR TITLE
fix: Scheduled date picker always points to today, regardless of a previous date

### DIFF
--- a/e2e-tests/basic.spec.ts
+++ b/e2e-tests/basic.spec.ts
@@ -230,12 +230,20 @@ test('invalid page props #3944', async ({ page, block }) => {
 })
 
 test('Scheduled date picker should point to the already specified Date #6985', async({page,block})=>{
-  await createRandomPage(page);
-  await block.mustFill('testTask \n SCHEDULED: <2000-05-06 Sat>');
-  await block.enterNext();
+  await createRandomPage(page)
+
+  await block.mustFill('testTask \n SCHEDULED: <2000-05-06 Sat>')
+  await block.enterNext()
+  await page.waitForTimeout(500)
+  await block.escapeEditing()
 
   // Open date picker
-  await page.click('a.opacity-80');
-  expect(page.locator('text=May 2000')).toBeVisible();
-  expect(page.locator('td:has-text("6").active')).toBeVisible();
+  await page.click('a.opacity-80')
+  await page.waitForTimeout(500)
+  expect(page.locator('text=May 2000')).toBeVisible()
+  expect(page.locator('td:has-text("6").active')).toBeVisible()
+
+  // Close date picker
+  await page.click('a.opacity-80')
+  await page.waitForTimeout(500)
 })

--- a/e2e-tests/basic.spec.ts
+++ b/e2e-tests/basic.spec.ts
@@ -228,3 +228,14 @@ test('invalid page props #3944', async ({ page, block }) => {
   // Force rendering property block
   await block.enterNext()
 })
+
+test('Scheduled date picker should point to the already specified Date #6985', async({page,block})=>{
+  await createRandomPage(page);
+  await block.mustFill('testTask \n SCHEDULED: <2000-05-06 Sat>');
+  await block.enterNext();
+
+  // Open date picker
+  await page.click('a.opacity-80');
+  expect(page.locator('text=May 2000')).toBeVisible();
+  expect(page.locator('td:has-text("6").active')).toBeVisible();
+})

--- a/src/main/frontend/components/datetime.cljs
+++ b/src/main/frontend/components/datetime.cljs
@@ -136,7 +136,7 @@
                (reset! *timestamp {:time ""
                                    :repeater {}}))
              (when-not (:date-picker/date @state/state)
-               (state/set-state! :date-picker/date (t/today))))
+               (state/set-state! :date-picker/date (get ts :date (t/today)))))
            state)
    :will-unmount (fn [state]
                    (clear-timestamp!)


### PR DESCRIPTION
fixes  #6985 
![grafik](https://user-images.githubusercontent.com/68823230/201649617-7c5ac8f0-6548-4558-b078-68ace7524a9f.png)
Datepicker now opens on the previously specified day if editing a task

Also added a e2e-test for this 