### PR TITLE
Fixes shift+click on "all pages" launching a new browser window

### DIFF
--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -1050,6 +1050,7 @@
                                              (swap! *checks update idx not))})]
 
                 [:td.name [:a {:on-click (fn [e]
+                                          (.preventDefault e)
                                            (let [repo (state/get-current-repo)]
                                              (when (gobj/get e "shiftKey")
                                                (state/sidebar-add-block!


### PR DESCRIPTION
**Summary**:
Fixes #5976 - Fixes shift+click on items in "all pages" launching a new browser window.

**Details**:
Because the items in `all pages` are `<a>` tags, their default behaviour (when doing a shift+click) is to open a new browser window. I've added `preventDefault` to these tags to stop that from happening.