### PR TITLE
fix(build): use npx to run tsup

### DIFF
--- a/tldraw/apps/tldraw-logseq/build.mjs
+++ b/tldraw/apps/tldraw-logseq/build.mjs
@@ -5,7 +5,7 @@ import fs from 'fs'
 import path from 'path'
 
 // Build with [tsup](https://tsup.egoist.sh)
-await $`tsup`
+await $`npx tsup`
 
 // Prepare package.json file
 const packageJson = fs.readFileSync('package.json', 'utf8')


### PR DESCRIPTION
This fixes a build error on Windows(PowerShell).

```console
> yarn
yarn install v1.22.19
[1/4] Resolving packages...
success Already up-to-date.
$ yarn tldraw:build
yarn run v1.22.19
$ cd tldraw && yarn
[1/4] Resolving packages...
success Already up-to-date.
$ yarn build
$ cd apps/tldraw-logseq && yarn build
[1/4] Resolving packages...
success Already up-to-date.
$ zx build.mjs
$ tsup
tsup : The term 'tsup' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:1
+ tsup
+ ~~~~
    + CategoryInfo          : ObjectNotFound: (tsup:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```