### PR TITLE
fix: issue #7366 render custom html element as hiccup not working

### DIFF
--- a/e2e-tests/sanitization.spec.ts
+++ b/e2e-tests/sanitization.spec.ts
@@ -37,3 +37,12 @@ test('custom hiccup should not spawn any dialogs', async ({ page, block }) => {
 
   expect(true).toBeTruthy()
 })
+
+test('"is" attribute should be allowed for plugin purposes', async ({ page, block }) => {
+  await createRandomPage(page)
+
+  await page.keyboard.type('[:div {:is "custom-element" :id "custom-element-id"}]', { delay: 5 })
+  await block.enterNext()
+
+  await expect(page.locator('#custom-element-id')).toHaveAttribute('is', 'custom-element');
+})

--- a/src/main/frontend/security.cljs
+++ b/src/main/frontend/security.cljs
@@ -3,7 +3,8 @@
   (:require ["dompurify" :as DOMPurify]))
 
 (def sanitization-options (clj->js {:ADD_TAGS ["iframe"]
-                                    :ALLOW_UNKNOWN_PROTOCOLS true}))
+                                    :ALLOW_UNKNOWN_PROTOCOLS true
+                                    :ALLOWED_ATTR ["is"]}))
 
 (defn sanitize-html
   [html]

--- a/src/main/frontend/security.cljs
+++ b/src/main/frontend/security.cljs
@@ -3,8 +3,8 @@
   (:require ["dompurify" :as DOMPurify]))
 
 (def sanitization-options (clj->js {:ADD_TAGS ["iframe"]
-                                    :ALLOW_UNKNOWN_PROTOCOLS true
-                                    :ALLOWED_ATTR ["is"]}))
+                                    :ADD_ATTR ["is"]
+                                    :ALLOW_UNKNOWN_PROTOCOLS true }))
 
 (defn sanitize-html
   [html]


### PR DESCRIPTION
dompurify remove `is` attribute from generated html from hiccup. I Add extra option into `sanitization-options` to allow `is` attribute.