### PR TITLE
fix: error while backup global config under windows

### DIFF
--- a/src/main/frontend/fs/watcher_handler.cljs
+++ b/src/main/frontend/fs/watcher_handler.cljs
@@ -88,7 +88,7 @@
                          (string/trim (or (state/get-default-journal-template) "")))
                       (= (string/trim content) "-")
                       (= (string/trim content) "*")))
-            (handle-add-and-change! repo path content db-content mtime true))
+            (handle-add-and-change! repo path content db-content mtime (not global-dir))) ;; no backup for global dir
 
           (and (= "unlink" type)
                (db/file-exists? repo path))


### PR DESCRIPTION
Error: Path contains invalid characters: C:\Users\xxxx\Works\mynotes\logseq\bak\C:\Users\xxxx\.logseq\config\config****