### PR TITLE
fix #7283: customUUID not converted to UUID type

### DIFF
--- a/src/main/logseq/api.cljs
+++ b/src/main/logseq/api.cljs
@@ -558,7 +558,7 @@
                        :sibling?    sibling?
                        :before?     before?
                        :page        page-name
-                       :custom-uuid custom-uuid
+                       :custom-uuid (uuid custom-uuid)
                        :properties  (merge properties
                                            (when custom-uuid {:id custom-uuid}))})]
       (bean/->js (normalize-keyword-for-json new-block)))))


### PR DESCRIPTION
Took us only about 4 hours to figure out, but we found the fix :tada: 

We found that the only other usage of the custom-uuid argument 
in assets / `ensure-ref-block!` already passes a uuid, 
so we chose to convert in the calling api. 

Closes #7283

<!--
Thank you for the pull request. Please provide a description. Screenshots and gifs are appreciated for UX enhancements, new features and bug fixes!

For bug fixes and new features, please include tests and possibly benchmarks.
-->
