### PR TITLE
Fix: Title bar drag region

### DIFF
--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -166,17 +166,17 @@
         custom-home-page? (and (state/custom-home-page?)
                                (= (state/sub-default-home-page) (state/get-current-page)))
         sync-enabled? (file-sync-handler/enable-sync?)]
-    [:div.cp__header#head
+    [:div.cp__header.drag-region#head
      {:class           (util/classnames [{:electron-mac   electron-mac?
                                           :native-ios     (mobile-util/native-ios?)
                                           :native-android (mobile-util/native-android?)}])
       :on-double-click (fn [^js e]
                          (when-let [target (.-target e)]
                            (when (and (util/electron?)
-                                      (.. target -classList (contains "cp__header")))
+                                      (.. target -classList (contains "drag-region")))
                              (js/window.apis.toggleMaxOrMinActiveWindow))))
       :style           {:fontSize  50}}
-     [:div.l.flex
+     [:div.l.flex.drag-region
       (when-not (mobile-util/native-platform?)
         [left-menu
          (when current-repo ;; this is for the Search button
@@ -196,7 +196,7 @@
              {:title "Go back" :on-click #(js/window.history.back)}
              (ui/icon "chevron-left" {:size 26})])))]
 
-     [:div.r.flex
+     [:div.r.flex.drag-region
       (when (and current-repo
                  (not (config/demo-graph? current-repo))
                  (user-handler/alpha-or-beta-user?))

--- a/src/main/frontend/components/header.css
+++ b/src/main/frontend/components/header.css
@@ -1,8 +1,6 @@
 .cp__header {
   @apply z-10;
 
-  -webkit-app-region: drag;
-
   padding-top: var(--ls-headbar-inner-top-padding);
   height: calc(var(--ls-headbar-height) + var(--ls-headbar-inner-top-padding));
   display: flex;
@@ -13,7 +11,6 @@
   top: 0;
   left: 0;
   right: 0;
-  user-select: none;
   line-height: 1;
   white-space: nowrap;
 
@@ -350,4 +347,9 @@ html.is-zoomed-native-ios {
     --ls-headbar-inner-top-padding: 8px;
     --ls-headbar-height: 2.5rem;
   }
+}
+
+.drag-region {
+  user-select: none;
+  -webkit-app-region: drag;
 }


### PR DESCRIPTION
Double click handling was limited to `.cp__header`.
A `drag-region` class was added to allow toggling the maximized state on multiple regions.
I also moved the drag related rules under this class.

Resolves https://github.com/logseq/logseq/issues/7380