### PR TITLE
Fix format property reference when org mode

### DIFF
--- a/deps/graph-parser/.carve/ignore
+++ b/deps/graph-parser/.carve/ignore
@@ -34,3 +34,5 @@ logseq.graph-parser.property/property-value-from-content
 logseq.graph-parser.whiteboard/page-block->tldr-page
 ;; API
 logseq.graph-parser/get-blocks-to-delete
+;; Future use & be unified with markdown colon
+logseq.graph-parser.property/colons-org

--- a/deps/graph-parser/src/logseq/graph_parser/property.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/property.cljs
@@ -7,7 +7,11 @@
             [goog.string.format]))
 
 (def colons "Property delimiter for markdown mode" "::")
-
+(defn colons-org 
+  "Property delimiter for org mode"
+  [property]
+  (str ":" property ":"))
+ 
 (defn ->block-content
   "Creates a block content string from properties map"
   [properties]


### PR DESCRIPTION
Fix #7127 

# Description
The code seemed not to take into account the fact that the user can select the `org` mode, and that in that mode the delimiters for a property are a semicolon at the beginning and one at the end (if I'm not misunderstood).
So in order to add this case but not to break old code, I opted for the creation of a small function `colons-org` defined right below `colons` and by propagating the info about the `format` we can then choose the right property delimiter depending on the format.

Here a video of the flow, now fixed:
[Uploading Screencast from 2022-11-17 12-17-25.webm…]()
  