### PR TITLE
Enhance/api block UUID

### DIFF
--- a/src/main/logseq/api.cljs
+++ b/src/main/logseq/api.cljs
@@ -66,7 +66,7 @@
     (uuid s)
 
     :else
-    (throw (js/Error. (str s " is not a valid UUID.")))))
+    (throw (js/Error. (str s " is not a valid UUID string.")))))
 
 (defn- parse-hiccup-ui
   [input]

--- a/src/main/logseq/api.cljs
+++ b/src/main/logseq/api.cljs
@@ -56,6 +56,18 @@
           (uuid? a) (str a)
           :else a)) input))))
 
+(defn- uuid-or-throw-error
+  [s]
+  (cond
+    (uuid? s)
+    s
+
+    (util/uuid-string? s)
+    (uuid s)
+
+    :else
+    (throw (js/Error. (str s " is not a valid UUID.")))))
+
 (defn- parse-hiccup-ui
   [input]
   (when (string? input)
@@ -506,19 +518,19 @@
 
 (defn ^:export open_in_right_sidebar
   [block-uuid]
-  (editor-handler/open-block-in-sidebar! (uuid block-uuid)))
+  (editor-handler/open-block-in-sidebar! (uuid-or-throw-error block-uuid)))
 
 (defn ^:export new_block_uuid []
   (str (db/new-block-id)))
 
 (def ^:export select_block
   (fn [block-uuid]
-    (when-let [block (db-model/get-block-by-uuid block-uuid)]
+    (when-let [block (db-model/get-block-by-uuid (uuid-or-throw-error block-uuid))]
       (editor-handler/select-block! (:block/uuid block)) nil)))
 
 (def ^:export edit_block
   (fn [block-uuid ^js opts]
-    (when-let [block-uuid (and block-uuid (uuid block-uuid))]
+    (when-let [block-uuid (and block-uuid (uuid-or-throw-error block-uuid))]
       (when-let [block (db-model/query-block-by-uuid block-uuid)]
         (let [{:keys [pos] :or {pos :max}} (bean/->clj opts)]
           (editor-handler/edit-block! block pos block-uuid))))))
@@ -528,14 +540,11 @@
     (let [{:keys [before sibling focus isPageBlock customUUID properties]} (bean/->clj opts)
           page-name (and isPageBlock block-uuid-or-page-name)
           custom-uuid (or customUUID (:id properties))
+          custom-uuid (when custom-uuid (uuid-or-throw-error custom-uuid))
           edit-block? (if (nil? focus) true focus)
-          _ (when (not (string/blank? custom-uuid))
-              (when-not (util/uuid-string? custom-uuid)
-                (throw (js/Error.
-                        (util/format "Illegal custom block UUID pattern (%s)." custom-uuid))))
-              (when (db-model/query-block-by-uuid custom-uuid)
-                (throw (js/Error.
-                        (util/format "Custom block UUID already exists (%s)." custom-uuid)))))
+          _ (when (and custom-uuid (db-model/query-block-by-uuid custom-uuid))
+              (throw (js/Error.
+                      (util/format "Custom block UUID already exists (%s)." custom-uuid))))
           block-uuid (if isPageBlock nil (uuid block-uuid-or-page-name))
           block-uuid' (if (and (not sibling) before block-uuid)
                         (let [block (db/entity [:block/uuid block-uuid])
@@ -560,14 +569,14 @@
                        :before?     before?
                        :edit-block? edit-block?
                        :page        page-name
-                       :custom-uuid (uuid custom-uuid)
+                       :custom-uuid custom-uuid
                        :properties  (merge properties
                                            (when custom-uuid {:id custom-uuid}))})]
       (bean/->js (normalize-keyword-for-json new-block)))))
 
 (def ^:export insert_batch_block
   (fn [block-uuid ^js batch-blocks ^js opts]
-    (when-let [block (db-model/query-block-by-uuid block-uuid)]
+    (when-let [block (db-model/query-block-by-uuid (uuid-or-throw-error block-uuid))]
       (when-let [bb (bean/->clj batch-blocks)]
         (let [bb (if-not (vector? bb) (vector bb) bb)
               {:keys [sibling]} (bean/->clj opts)
@@ -580,17 +589,17 @@
     (let [includeChildren true
           repo (state/get-current-repo)]
       (editor-handler/delete-block-aux!
-        {:block/uuid (uuid block-uuid) :repo repo} includeChildren)
+       {:block/uuid (uuid-or-throw-error block-uuid) :repo repo} includeChildren)
       nil)))
 
 (def ^:export update_block
   (fn [block-uuid content ^js _opts]
     (let [repo (state/get-current-repo)
           edit-input (state/get-edit-input-id)
-          editing? (and edit-input (string/ends-with? edit-input block-uuid))]
+          editing? (and edit-input (string/ends-with? edit-input (str block-uuid)))]
       (if editing?
         (state/set-edit-content! edit-input content)
-        (editor-handler/save-block! repo (uuid block-uuid) content))
+        (editor-handler/save-block! repo (uuid-or-throw-error block-uuid) content))
       nil)))
 
 (def ^:export move_block
@@ -605,15 +614,15 @@
 
                     :else
                     nil)
-          src-block (db-model/query-block-by-uuid (uuid src-block-uuid))
-          target-block (db-model/query-block-by-uuid (uuid target-block-uuid))]
+          src-block (db-model/query-block-by-uuid (uuid-or-throw-error src-block-uuid))
+          target-block (db-model/query-block-by-uuid (uuid-or-throw-error target-block-uuid))]
       (editor-dnd-handler/move-blocks nil [src-block] target-block move-to) nil)))
 
 (def ^:export get_block
   (fn [id-or-uuid ^js opts]
     (when-let [block (cond
                        (number? id-or-uuid) (db-utils/pull id-or-uuid)
-                       (string? id-or-uuid) (db-model/query-block-by-uuid id-or-uuid))]
+                       (string? id-or-uuid) (db-model/query-block-by-uuid (uuid-or-throw-error id-or-uuid)))]
       (when-not (contains? block :block/name)
         (when-let [uuid (:block/uuid block)]
           (let [{:keys [includeChildren]} (bean/->clj opts)
@@ -640,47 +649,47 @@
 
 (def ^:export get_previous_sibling_block
   (fn [block-uuid]
-    (when-let [block (db-model/query-block-by-uuid block-uuid)]
+    (when-let [block (db-model/query-block-by-uuid (uuid-or-throw-error block-uuid))]
       (let [{:block/keys [parent left]} block
             block (when-not (= parent left) (db-utils/pull (:db/id left)))]
         (and block (bean/->js (normalize-keyword-for-json block)))))))
 
 (def ^:export get_next_sibling_block
   (fn [block-uuid]
-    (when-let [block (db-model/query-block-by-uuid block-uuid)]
+    (when-let [block (db-model/query-block-by-uuid (uuid-or-throw-error block-uuid))]
       (when-let [right-siblings (outliner/get-right-siblings (outliner/->Block block))]
         (bean/->js (normalize-keyword-for-json (:data (first right-siblings))))))))
 
 (def ^:export set_block_collapsed
   (fn [block-uuid ^js opts]
-    (when-let [block (db-model/get-block-by-uuid block-uuid)]
-      (let [opts       (bean/->clj opts)
-            opts       (if (or (string? opts) (boolean? opts)) {:flag opts} opts)
-            {:keys [flag]} opts
-            block-uuid (uuid block-uuid)
-            flag       (if (= "toggle" flag)
-                         (not (util/collapsed? block))
-                         (boolean flag))]
-        (if flag (editor-handler/collapse-block! block-uuid)
-          (editor-handler/expand-block! block-uuid))
-        nil))))
+    (let [block-uuid (uuid-or-throw-error block-uuid)]
+      (when-let [block (db-model/get-block-by-uuid block-uuid)]
+       (let [opts       (bean/->clj opts)
+             opts       (if (or (string? opts) (boolean? opts)) {:flag opts} opts)
+             {:keys [flag]} opts
+             flag       (if (= "toggle" flag)
+                          (not (util/collapsed? block))
+                          (boolean flag))]
+         (if flag (editor-handler/collapse-block! block-uuid)
+             (editor-handler/expand-block! block-uuid))
+         nil)))))
 
 (def ^:export upsert_block_property
   (fn [block-uuid key value]
-    (editor-handler/set-block-property! (uuid block-uuid) key value)))
+    (editor-handler/set-block-property! (uuid-or-throw-error block-uuid) key value)))
 
 (def ^:export remove_block_property
   (fn [block-uuid key]
-    (editor-handler/remove-block-property! (uuid block-uuid) key)))
+    (editor-handler/remove-block-property! (uuid-or-throw-error block-uuid) key)))
 
 (def ^:export get_block_property
   (fn [block-uuid key]
-    (when-let [block (db-model/query-block-by-uuid block-uuid)]
+    (when-let [block (db-model/query-block-by-uuid (uuid-or-throw-error block-uuid))]
       (get (:block/properties block) (keyword key)))))
 
 (def ^:export get_block_properties
   (fn [block-uuid]
-    (when-let [block (db-model/query-block-by-uuid block-uuid)]
+    (when-let [block (db-model/query-block-by-uuid (uuid-or-throw-error block-uuid))]
       (bean/->js (normalize-keyword-for-json (:block/properties block))))))
 
 (def ^:export get_current_page_blocks_tree


### PR DESCRIPTION
Logseq api should throw an error if there is an invalid block-uuid string.
Also, make sure UUIDs are converted already when passing to cljs.

Related to #7375.
