### PR TITLE
Refactor: page search hashtag

### DIFF
--- a/e2e-tests/editor.spec.ts
+++ b/e2e-tests/editor.spec.ts
@@ -29,6 +29,41 @@ test('hashtag and quare brackets in same line #4178', async ({ page }) => {
   )
 })
 
+test('hashtag search page auto-complete', async ({ page, block }) => {
+  await createRandomPage(page)
+
+  await block.activeEditing(0)
+
+  await page.type('textarea >> nth=0', '#', { delay: 100 })
+  await page.waitForSelector('text="Search for a page"', { state: 'visible' })
+  await page.keyboard.press('Escape', { delay: 50 })
+
+  await block.mustFill("done")
+
+  await enterNextBlock(page)
+  await page.type('textarea >> nth=0', 'Some#', { delay: 100 })
+  await page.waitForSelector('text="Search for a page"', { state: 'visible' })
+  await page.keyboard.press('Escape', { delay: 50 })
+
+  await block.mustFill("done")
+
+  await enterNextBlock(page)
+  await page.type('textarea >> nth=0', 'Some #', { delay: 100 })
+  await page.waitForSelector('text="Search for a page"', { state: 'visible' })
+  await page.keyboard.press('Escape', { delay: 50 })
+
+  await block.mustFill("done")
+
+  await enterNextBlock(page)
+  await page.type('textarea >> nth=0', 'SomeInner', { delay: 100 })
+  for (let i = 0; i < 5; i++) {
+    await page.press('textarea >> nth=0', 'ArrowLeft', { delay: 50 })
+  }
+  await page.type('textarea >> nth=0', '#', { delay: 50 })
+  await page.waitForSelector('text="Search for a page"', { state: 'visible' })
+  await page.keyboard.press('Escape', { delay: 50 })
+})
+
 test('disappeared children #4814', async ({ page, block }) => {
   await createRandomPage(page)
 

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -28,6 +28,7 @@
 ;; TODO: move to frontend.handler.editor.commands
 
 (defonce angle-bracket "<")
+(defonce hashtag "#")
 (defonce colon ":")
 (defonce *current-command (atom nil))
 

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -181,7 +181,7 @@
      result
      {:on-chosen   chosen-handler
       :on-enter    non-exist-block-handler
-      :empty-placeholder   [:div.text-gray-500.pl-4.pr-4 (t :editor/block-search)]
+      :empty-placeholder   [:div.text-gray-500.text-sm.px-4.py-2 (t :editor/block-search)]
       :item-render (fn [{:block/keys [page uuid]}]  ;; content returned from search engine is normalized
                      (let [page (or (:block/original-name page)
                                     (:block/name page))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1847,7 +1847,9 @@
       (state/clear-editor-action!)
 
       ;; Open "Search page or New page" auto-complete
-      (= last-input-char commands/hashtag)
+      (and (= last-input-char commands/hashtag)
+           ;; Only trigger at beginning of line or before whitespace
+           (or (= 1 pos) (contains? #{" " "\t"} (get (.-value input) (- pos 2)))))
       (do
         (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)})
         (state/set-editor-last-pos! pos)
@@ -3249,7 +3251,7 @@
         repo (state/get-current-repo)
         value (boolean value)]
     (when repo
-      (save-current-block!) ;; Save the input contents before collapsing 
+      (save-current-block!) ;; Save the input contents before collapsing
       (outliner-tx/transact! ;; Save the new collapsed state as an undo transaction (if it changed)
         {:outliner-op :collapse-expand-blocks}
         (doseq [block-id block-ids]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1759,7 +1759,7 @@
 
   (handle-command-input-close id))
 
-(defn close-autocomplete-if-outside
+(defn- close-autocomplete-if-outside
   [input]
   (when (and input
              (contains? #{:page-search :page-search-hashtag :block-search} (state/get-editor-action))
@@ -1813,7 +1813,9 @@
     ;; TODO: is it cross-browser compatible?
     ;; (not= (gobj/get native-e "inputType") "insertFromPaste")
     (cond
-      (= last-input-char (state/get-editor-command-trigger))
+      ;; By default, "/" is also used as namespace separator in Logseq.
+      (and (= last-input-char (state/get-editor-command-trigger))
+           (not (contains? #{:page-search-hashtag} (state/sub :editor/action))))
       (do
         (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)})
         (commands/reinit-matched-commands!)
@@ -1843,6 +1845,13 @@
 
       (and (= last-input-char commands/colon) (= :property-search (state/get-editor-action)))
       (state/clear-editor-action!)
+
+      ;; Open "Search page or New page" auto-complete
+      (= last-input-char commands/hashtag)
+      (do
+        (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)})
+        (state/set-editor-last-pos! pos)
+        (state/set-editor-action! :page-search-hashtag))
 
       :else
       nil)))
@@ -2659,6 +2668,7 @@
     nil))
 
 (defn ^:large-vars/cleanup-todo keydown-not-matched-handler
+  "NOTE: Keydown cannot be used on Android platform"
   [format]
   (fn [e _key-code]
     (let [input-id (state/get-edit-input-id)
@@ -2734,14 +2744,6 @@
             (if (and (= key "`") (= "`" curr) (not= "`" prev))
               (cursor/move-cursor-forward input)
               (autopair input-id key format nil)))
-
-        (and hashtag? (or (zero? pos) (re-matches #"\s" (get value (dec pos)))))
-        (do
-          (commands/handle-step [:editor/search-page-hashtag])
-          (if (= key "#")
-            (state/set-editor-last-pos! (inc (cursor/pos input))) ;; In keydown handler, the `#` is not inserted yet.
-            (state/set-editor-last-pos! (cursor/pos input)))
-          (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)}))
 
         (let [sym "$"]
           (and (= key sym)

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -45,56 +45,6 @@
           "[[https://github.com/logseq/logseq][logseq]] is #awesome :)" 0 editor/url-regex))
       "Finds url in org link correctly"))
 
-(defn- keydown-not-matched-handler
-  "Spied version of editor/keydown-not-matched-handler"
-  [{:keys [value key format cursor-pos] :or {key "#" format "markdown"}}]
-  ;; Reset editor action in order to test result
-  (state/set-editor-action! nil)
-  ;; Default cursor pos to end of line
-  (let [pos (or cursor-pos (count value))]
-    (with-redefs [util/get-selected-text (constantly false)
-                  state/get-input (constantly #js {:value value})
-                  cursor/pos (constantly pos)
-                  cursor/get-caret-pos (constantly {})]
-      ((editor/keydown-not-matched-handler format)
-       #js {:key key} nil))))
-
-(deftest keydown-not-matched-handler-test
-  (testing "Tag autocompletion"
-    (keydown-not-matched-handler {:value "Some words "})
-    (is (= :page-search-hashtag (state/get-editor-action))
-        "Autocomplete tags if starting new word")
-
-    (keydown-not-matched-handler {:value ""})
-    (is (= :page-search-hashtag (state/get-editor-action))
-        "Autocomplete tags if starting a new line")
-
-    (keydown-not-matched-handler {:value "Some words" :cursor-pos 0})
-    (is (= :page-search-hashtag (state/get-editor-action))
-        "Autocomplete tags if there is are existing words and cursor is at start of line")
-
-    (keydown-not-matched-handler {:value "Some words" :cursor-pos 5})
-    (is (= :page-search-hashtag (state/get-editor-action))
-        "Autocomplete tags if there is whitespace before cursor")
-
-    (keydown-not-matched-handler {:value "String"})
-    (is (= nil (state/get-editor-action))
-        "Don't autocomplete tags if at end of word")
-
-    (keydown-not-matched-handler {:value "String" :cursor-pos 3})
-    (is (= nil (state/get-editor-action))
-        "Don't autocomplete tags if in middle of word")
-
-    (keydown-not-matched-handler {:value "`One backtick "})
-    (is (= :page-search-hashtag (state/get-editor-action))
-        "Autocomplete tags if only one backtick")
-
-    (keydown-not-matched-handler {:value "`String#gsub and String`"
-                                  :cursor-pos (dec (count "`String#gsub and String`"))})
-    (is (= nil (state/get-editor-action))
-        "Don't autocomplete tags within backticks")
-    (state/set-editor-action! nil)))
-
 (defn- set-marker
   "Spied version of editor/set-marker"
   [marker content format]

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -96,24 +96,45 @@
     (handle-last-input-handler {:value "first \nfoo::bar"
                                 :cursor-pos (dec (count "first "))})
     (is (= nil (state/get-editor-action))
-        "Don't autocomplete properties if typing in a block where properties already exist")
+        "Don't autocomplete properties if typing in a block where properties already exist"))
 
+  (testing "Tag autocompletion"
     (handle-last-input-handler {:value "#"
                                 :cursor-pos 1})
     (is (= :page-search-hashtag (state/get-editor-action))
-        "Page search if only hashtags has been typed")
-
-    (handle-last-input-handler {:value "foo bar#"
-                                :cursor-pos 8})
-    (is (= :page-search-hashtag (state/get-editor-action))
-        "Page search if hashtags has been typed as EOL")
+        "Page search if only hashtag has been typed")
 
     (handle-last-input-handler {:value "foo #"
                                 :cursor-pos 5})
     (is (= :page-search-hashtag (state/get-editor-action))
-        "Page search if hashtags has been typed after a space")
+        "Page search if hashtag has been typed at EOL")
 
-    (handle-last-input-handler {:value "foo#bar"
-                                :cursor-pos 4})
+    (handle-last-input-handler {:value "#Some words"
+                                :cursor-pos 1})
     (is (= :page-search-hashtag (state/get-editor-action))
-        "Page search if hashtags has been typed in the middle of a line")))
+        "Page search if hashtag is at start of line and there are existing words")
+
+    (handle-last-input-handler {:value "foo #"
+                                :cursor-pos 5})
+    (is (= :page-search-hashtag (state/get-editor-action))
+        "Page search if hashtag is at EOL and after a space")
+
+    (handle-last-input-handler {:value "foo #bar"
+                                :cursor-pos 5})
+    (is (= :page-search-hashtag (state/get-editor-action))
+        "Page search if hashtag is in middle of line and after a space")
+
+    (handle-last-input-handler {:value "String#" :cursor-pos 7})
+    (is (= nil (state/get-editor-action))
+        "No page search if hashtag has been typed at end of a word")
+
+    (handle-last-input-handler {:value "foo#bar" :cursor-pos 4})
+    (is (= nil (state/get-editor-action))
+        "No page search if hashtag is in middle of word")
+
+    (handle-last-input-handler {:value "`String#gsub and String#`"
+                                :cursor-pos (dec (count "`String#gsub and String#`"))})
+    (is (= nil (state/get-editor-action))
+        "No page search within backticks"))
+  ;; Reset state
+  (state/set-editor-action! nil))

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -1,7 +1,6 @@
 (ns frontend.handler.editor-test
   (:require [frontend.handler.editor :as editor]
             [clojure.test :refer [deftest is testing are]]
-            [frontend.util :as util]
             [frontend.state :as state]
             [frontend.util.cursor :as cursor]))
 

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -96,4 +96,24 @@
     (handle-last-input-handler {:value "first \nfoo::bar"
                                 :cursor-pos (dec (count "first "))})
     (is (= nil (state/get-editor-action))
-        "Don't autocomplete properties if typing in a block where properties already exist")))
+        "Don't autocomplete properties if typing in a block where properties already exist")
+
+    (handle-last-input-handler {:value "#"
+                                :cursor-pos 1})
+    (is (= :page-search-hashtag (state/get-editor-action))
+        "Page search if only hashtags has been typed")
+
+    (handle-last-input-handler {:value "foo bar#"
+                                :cursor-pos 8})
+    (is (= :page-search-hashtag (state/get-editor-action))
+        "Page search if hashtags has been typed as EOL")
+
+    (handle-last-input-handler {:value "foo #"
+                                :cursor-pos 5})
+    (is (= :page-search-hashtag (state/get-editor-action))
+        "Page search if hashtags has been typed after a space")
+
+    (handle-last-input-handler {:value "foo#bar"
+                                :cursor-pos 4})
+    (is (= :page-search-hashtag (state/get-editor-action))
+        "Page search if hashtags has been typed in the middle of a line")))


### PR DESCRIPTION
Fix #7305

- move `#` handler from keyup to `:did-update` (for Android platform)
- Typing `/` after `#blah` page search no longer triggers inline command popup (Now it will keep searching/creating namespace pages)
- Minor style fix of  search block auto-complete - `((|))`
- [x] unit tests

