### PR TITLE
fix(editor): do not wrap space when pasting <code>

### DIFF
--- a/src/main/frontend/extensions/html_parser.cljs
+++ b/src/main/frontend/extensions/html_parser.cljs
@@ -170,9 +170,7 @@
 
                                    (string? (first children))
                                    (let [pattern (config/get-code format)]
-                                     (str " "
-                                          pattern (map-join children) pattern
-                                          " "))
+                                     (str pattern (map-join children) pattern))
 
                                    ;; skip monospace style, since it has more complex children
                                    :else


### PR DESCRIPTION
Avoid adding redundant space around a `<code>` element.
Comparing the following two blocks:

<img width="290" alt="image" src="https://user-images.githubusercontent.com/72891/203459048-0491804c-c4fd-4dab-9274-eb81ceba2969.png">
