### PR TITLE
Allow using config.edn to change if page redirect happens when inserting quick-capture

### DIFF
--- a/src/main/electron/listener.cljs
+++ b/src/main/electron/listener.cljs
@@ -1,29 +1,28 @@
 (ns electron.listener
   "System-component-like ns that defines listeners by event name to receive ipc
   messages from electron's main process"
-  (:require
-    [cljs-bean.core :as bean]
-    [clojure.string :as string]
-    [datascript.core :as d]
-    [dommy.core :as dom]
-    [electron.ipc :as ipc]
-    [frontend.config :as config]
-    [frontend.context.i18n :refer [t]]
-    [frontend.date :as date]
-    [frontend.db :as db]
-    [frontend.db.model :as db-model]
-    [frontend.fs.sync :as sync]
-    [frontend.fs.watcher-handler :as watcher-handler]
-    [frontend.handler.editor :as editor-handler]
-    [frontend.handler.file-sync :as file-sync-handler]
-    [frontend.handler.notification :as notification]
-    [frontend.handler.page :as page-handler]
-    [frontend.handler.repo :as repo-handler]
-    [frontend.handler.route :as route-handler]
-    [frontend.handler.ui :as ui-handler]
-    [frontend.handler.user :as user]
-    [frontend.state :as state]
-    [frontend.ui :as ui]))
+  (:require [cljs-bean.core :as bean]
+            [clojure.string :as string]
+            [datascript.core :as d]
+            [dommy.core :as dom]
+            [electron.ipc :as ipc]
+            [frontend.config :as config]
+            [frontend.context.i18n :refer [t]]
+            [frontend.date :as date]
+            [frontend.db :as db]
+            [frontend.db.model :as db-model]
+            [frontend.fs.sync :as sync]
+            [frontend.fs.watcher-handler :as watcher-handler]
+            [frontend.handler.editor :as editor-handler]
+            [frontend.handler.file-sync :as file-sync-handler]
+            [frontend.handler.notification :as notification]
+            [frontend.handler.repo :as repo-handler]
+            [frontend.handler.route :as route-handler]
+            [frontend.handler.ui :as ui-handler]
+            [frontend.handler.user :as user]
+            [frontend.state :as state]
+            [frontend.ui :as ui]
+            [frontend.handler.page :as page-handler]))
 
 
 (defn persist-dbs!
@@ -31,8 +30,8 @@
   ;; only persist current db!
   ;; TODO rename the function and event to persist-db
   (repo-handler/persist-db! {:before     #(notification/show!
-                                            (ui/loading (t :graph/persist))
-                                            :warning)
+                                           (ui/loading (t :graph/persist))
+                                           :warning)
                              :on-success #(ipc/ipc "persistent-dbs-saved")
                              :on-error   #(ipc/ipc "persistent-dbs-error")}))
 
@@ -41,9 +40,9 @@
   []
   ;; TODO: move "file-watcher" to electron.ipc.channels
   (js/window.apis.on
-    "persistent-dbs"
-    (fn [_req]
-      (persist-dbs!))))
+   "persistent-dbs"
+   (fn [_req]
+     (persist-dbs!))))
 
 
 (defn ^:large-vars/cleanup-todo listen-to-electron!
@@ -129,14 +128,14 @@
                      (fn [data]
                        (let [repo (bean/->clj data)
                              before-f #(notification/show!
-                                         (ui/loading (t :graph/persist))
-                                         :warning)
+                                        (ui/loading (t :graph/persist))
+                                        :warning)
                              after-f #(ipc/ipc "broadcastPersistGraphDone")
                              error-f (fn []
                                        (after-f)
                                        (notification/show!
-                                         (t :graph/persist-error)
-                                         :error))
+                                        (t :graph/persist-error)
+                                        :error))
                              handlers {:before     before-f
                                        :on-success after-f
                                        :on-error   error-f}]
@@ -162,8 +161,8 @@
                                                    [:quick-capture-options :insert-today]
                                                    false)
                              redirect-page? (get-in (state/get-config)
-                                                    [:quick-capture-options :redirect-page]
-                                                    false)
+                                                   [:quick-capture-options :redirect-page]
+                                                   false)
                              today-page (when (state/enable-journals?)
                                           (string/lower-case (date/today)))
                              page (if (or (= page "TODAY")
@@ -172,7 +171,7 @@
                                     (or (not-empty page)
                                         (state/get-current-page)
                                         today-page))
-                             page (or page "quick capture") ; default to quick capture page, if journals are not enabled
+                             page (or page "quick capture") ;; default to quick capture page, if journals are not enabled
                              format (db/get-page-format page)
                              time (date/get-current-time)
                              text (or (and content (not-empty (string/trim content))) "")

--- a/src/main/electron/listener.cljs
+++ b/src/main/electron/listener.cljs
@@ -1,28 +1,29 @@
 (ns electron.listener
   "System-component-like ns that defines listeners by event name to receive ipc
   messages from electron's main process"
-  (:require [cljs-bean.core :as bean]
-            [clojure.string :as string]
-            [datascript.core :as d]
-            [dommy.core :as dom]
-            [electron.ipc :as ipc]
-            [frontend.config :as config]
-            [frontend.context.i18n :refer [t]]
-            [frontend.date :as date]
-            [frontend.db :as db]
-            [frontend.db.model :as db-model]
-            [frontend.fs.sync :as sync]
-            [frontend.fs.watcher-handler :as watcher-handler]
-            [frontend.handler.editor :as editor-handler]
-            [frontend.handler.file-sync :as file-sync-handler]
-            [frontend.handler.notification :as notification]
-            [frontend.handler.repo :as repo-handler]
-            [frontend.handler.route :as route-handler]
-            [frontend.handler.ui :as ui-handler]
-            [frontend.handler.user :as user]
-            [frontend.state :as state]
-            [frontend.ui :as ui]
-            [frontend.handler.page :as page-handler]))
+  (:require
+    [cljs-bean.core :as bean]
+    [clojure.string :as string]
+    [datascript.core :as d]
+    [dommy.core :as dom]
+    [electron.ipc :as ipc]
+    [frontend.config :as config]
+    [frontend.context.i18n :refer [t]]
+    [frontend.date :as date]
+    [frontend.db :as db]
+    [frontend.db.model :as db-model]
+    [frontend.fs.sync :as sync]
+    [frontend.fs.watcher-handler :as watcher-handler]
+    [frontend.handler.editor :as editor-handler]
+    [frontend.handler.file-sync :as file-sync-handler]
+    [frontend.handler.notification :as notification]
+    [frontend.handler.page :as page-handler]
+    [frontend.handler.repo :as repo-handler]
+    [frontend.handler.route :as route-handler]
+    [frontend.handler.ui :as ui-handler]
+    [frontend.handler.user :as user]
+    [frontend.state :as state]
+    [frontend.ui :as ui]))
 
 
 (defn persist-dbs!
@@ -30,8 +31,8 @@
   ;; only persist current db!
   ;; TODO rename the function and event to persist-db
   (repo-handler/persist-db! {:before     #(notification/show!
-                                           (ui/loading (t :graph/persist))
-                                           :warning)
+                                            (ui/loading (t :graph/persist))
+                                            :warning)
                              :on-success #(ipc/ipc "persistent-dbs-saved")
                              :on-error   #(ipc/ipc "persistent-dbs-error")}))
 
@@ -40,9 +41,9 @@
   []
   ;; TODO: move "file-watcher" to electron.ipc.channels
   (js/window.apis.on
-   "persistent-dbs"
-   (fn [_req]
-     (persist-dbs!))))
+    "persistent-dbs"
+    (fn [_req]
+      (persist-dbs!))))
 
 
 (defn ^:large-vars/cleanup-todo listen-to-electron!
@@ -128,14 +129,14 @@
                      (fn [data]
                        (let [repo (bean/->clj data)
                              before-f #(notification/show!
-                                        (ui/loading (t :graph/persist))
-                                        :warning)
+                                         (ui/loading (t :graph/persist))
+                                         :warning)
                              after-f #(ipc/ipc "broadcastPersistGraphDone")
                              error-f (fn []
                                        (after-f)
                                        (notification/show!
-                                        (t :graph/persist-error)
-                                        :error))
+                                         (t :graph/persist-error)
+                                         :error))
                              handlers {:before     before-f
                                        :on-success after-f
                                        :on-error   error-f}]
@@ -160,6 +161,9 @@
                              insert-today? (get-in (state/get-config)
                                                    [:quick-capture-options :insert-today]
                                                    false)
+                             redirect-page? (get-in (state/get-config)
+                                                    [:quick-capture-options :redirect-page]
+                                                    false)
                              today-page (when (state/enable-journals?)
                                           (string/lower-case (date/today)))
                              page (if (or (= page "TODAY")
@@ -168,7 +172,7 @@
                                     (or (not-empty page)
                                         (state/get-current-page)
                                         today-page))
-                             page (or page "quick capture") ;; default to quick capture page, if journals are not enabled
+                             page (or page "quick capture") ; default to quick capture page, if journals are not enabled
                              format (db/get-page-format page)
                              time (date/get-current-time)
                              text (or (and content (not-empty (string/trim content))) "")
@@ -195,7 +199,7 @@
 
                            (do
                              (when (not= page (state/get-current-page))
-                               (page-handler/create! page {:redirect? true}))
+                               (page-handler/create! page {:redirect? redirect-page?}))
                              (editor-handler/api-insert-new-block! content {:page page
                                                                             :edit-block? true
                                                                             :replace-empty-target? true}))))))


### PR DESCRIPTION
Ref: https://github.com/logseq/logseq/pull/7427

With the new changes from the above PR, user is redirected to the page where the quick capture item is inserted. This can be jarring. Hence offer the option to disable the redirect in `config.edn` using the following:

```
:quick-capture-options {
    :redirect-page false
}
```