### PR TITLE
fix: notify users if page name already exists when parsing files

### DIFF
--- a/src/main/frontend/handler/common/file.cljs
+++ b/src/main/frontend/handler/common/file.cljs
@@ -27,7 +27,7 @@
                        (distinct))]
     (when-let [current-file (page-exists-in-another-file repo-url first-page file)]
       (when (not= file current-file)
-        (let [error (str "Page already exists with another file: " current-file ", current file: " file)]
+        (let [error (str "Page already exists with another file: " current-file ", current file: " file ". Please keep only one of them and re-index your graph.")]
           (state/pub-event! [:notification/show
                              {:content error
                               :status :error


### PR DESCRIPTION
![CleanShot 2022-11-23 at 19 50 53](https://user-images.githubusercontent.com/479169/203539923-2729411d-b1c6-436e-a59f-3d277be7d98d.png)
