### PR TITLE
fix: filename format revert manual title check

### DIFF
--- a/src/test/frontend/db/name_sanity_test.cljs
+++ b/src/test/frontend/db/name_sanity_test.cljs
@@ -74,7 +74,7 @@
     "aaa__bbb__cccon" "aaa/bbb/cccon"  true
     "aaa.bbb.ccc"     "adbcde/aks/sdf" true
     "a__.bbb.ccc"     "adbcde/aks/sdf" true
-    ))
+    "aaa__bbb__ccc" nil false))
 
 (deftest rename-previous-tests
   (are [x y] (= y (#'conversion-handler/calc-previous-name :legacy :triple-lowbar x))


### PR DESCRIPTION
New rule:
Don't rename file with custom `title::`property, unless it contains reserved characters

![捕获](https://user-images.githubusercontent.com/9862022/203723024-b1a21d7c-0ce0-4707-9c95-0f6d47d76ffe.PNG)
