### PR TITLE
Fix: Cannot upload assets with certain formats. 

### DIFF
--- a/src/main/frontend/config.cljs
+++ b/src/main/frontend/config.cljs
@@ -108,11 +108,15 @@
 (def html-render-formats
   #{:adoc :asciidoc})
 
+(def other-formats
+  #{:zip :msg :xltx :eml :odt})
+
 (defn extname-of-supported?
   ([input] (extname-of-supported?
             input
             [image-formats doc-formats audio-formats
-             video-formats markup-formats html-render-formats]))
+             video-formats markup-formats html-render-formats
+             (gp-config/text-formats) other-formats]))
   ([input formats]
    (when-let [input (some->
                      (cond-> input

--- a/src/main/frontend/config.cljs
+++ b/src/main/frontend/config.cljs
@@ -108,15 +108,12 @@
 (def html-render-formats
   #{:adoc :asciidoc})
 
-(def other-formats
-  #{:zip :msg :xltx :eml :odt})
-
 (defn extname-of-supported?
   ([input] (extname-of-supported?
             input
             [image-formats doc-formats audio-formats
              video-formats markup-formats html-render-formats
-             (gp-config/text-formats) other-formats]))
+             (gp-config/text-formats)]))
   ([input formats]
    (when-let [input (some->
                      (cond-> input

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -11,6 +11,7 @@
             ["remove-accents" :as removeAccents]
             ["sanitize-filename" :as sanitizeFilename]
             ["check-password-strength" :refer [passwordStrength]]
+            ["path-complete-extname" :as pathCompleteExtname]
             [frontend.loader :refer [load]]
             [cljs-bean.core :as bean]
             [cljs-time.coerce :as tc]
@@ -43,7 +44,7 @@
        (-write writer (str "\"" (.toString sym) "\"")))))
 
 #?(:cljs (defonce ^js node-path utils/nodePath))
-#?(:cljs (defonce ^js full-path-extname utils/fullPathExtname))
+#?(:cljs (defonce ^js full-path-extname pathCompleteExtname))
 #?(:cljs (defn app-scroll-container-node
            ([]
             (gdom/getElement "main-content-container"))


### PR DESCRIPTION
Closes #7435, #7416, #7295, #7271, #7264, #7211, #7077.

Till version 0.8.8 it was possible to upload files in any format. After this version, some changes were made (not sure if this was intended) that only accept a subset of file formats. 

This PR enables the following formats (replace `:` with `.`)

`:json :org :md :yml :dat :asciidoc :rst :txt :markdown :adoc :html :js :ts :edn :clj :ml :rb :ex :erl :java :php :c :css
    :excalidraw :tldr :sh :zip :msg :xltx :eml :odt`