### PR TITLE
chore(ios): config keys of non-exmpect encryption

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -107,5 +107,7 @@
 	<true/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
Ref: https://developer.apple.com/documentation/bundleresources/information_property_list/itsappusesnonexemptencryption
Ref: https://stackoverflow.com/questions/35841117/missing-compliance-status-in-testflight
