### PR TITLE
feat: WIP native cli command support

### DIFF
--- a/resources/package.json
+++ b/resources/package.json
@@ -40,7 +40,8 @@
     "posthog-js": "1.10.2",
     "@logseq/rsapi": "0.0.50",
     "electron-deeplink": "1.0.10",
-    "abort-controller": "3.0.0"
+    "abort-controller": "3.0.0",
+    "command-exists": "1.2.9"
   },
   "devDependencies": {
     "@electron-forge/cli": "^6.0.0-beta.57",

--- a/src/main/frontend/components/shell.cljs
+++ b/src/main/frontend/components/shell.cljs
@@ -32,7 +32,7 @@
        [:div
         [:h1.title
          "Input command"]
-        [:div.mt-4.mb-4.relative.rounded-md.shadow-sm.max-w-xs
+        [:div.mt-4.mb-4.relative.rounded-md.shadow-sm
          [:input#run-command.form-input.font-mono.block.w-full.sm:text-sm.sm:leading-5
           {:autoFocus true
            :on-key-down util/stop-propagation

--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -131,9 +131,11 @@
             [frontend.extensions.calc :as calc]
             [frontend.handler.editor :as editor-handler]
             [frontend.handler.file :as file-handler]
+            [frontend.handler.shell :as shell-handler]
             [frontend.state :as state]
             [logseq.graph-parser.utf8 :as utf8]
             [frontend.util :as util]
+            [frontend.ui :as ui]
             [frontend.config :as config]
             [goog.dom :as gdom]
             [goog.object :as gobj]
@@ -302,8 +304,20 @@
   [:div.extensions__code
    (when-let [mode (:data-lang attr)]
      (when-not (= mode "calc")
-       [:div.extensions__code-lang
-        (string/lower-case mode)]))
+       [:div
+        [:div.extensions__code-lang
+         (if (contains? (shell-handler/get-commands) (string/lower-case mode))
+           [:a {:title (str "Run command " mode)
+                :on-click (fn [_e]
+                            (let [editor-atom (:editor-atom state)]
+                              (when-let [editor @editor-atom]
+                                (state/pub-event! [:run/cli-command
+                                                   (string/lower-case mode)
+                                                   (.getValue editor)]))))}
+            (if (= mode "alda")
+              (ui/icon "player-play" {:style {:font-size 20}})
+              "Run")]
+           (string/lower-case mode))]]))
    [:div.code-editor.flex.flex-1.flex-row.w-full
     [:textarea (merge {:id id
                        ;; Expose the textarea associated with the CodeMirror instance via

--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -315,7 +315,7 @@
                                                    (string/lower-case mode)
                                                    (.getValue editor)]))))}
             (if (= mode "alda")
-              (ui/icon "player-play" {:style {:font-size 20}})
+              (ui/icon "player-play" {:size 20})
               "Run")]
            (string/lower-case mode))]]))
    [:div.code-editor.flex.flex-1.flex-row.w-full

--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -306,7 +306,7 @@
      (when-not (= mode "calc")
        [:div
         [:div.extensions__code-lang
-         (if (contains? (shell-handler/get-commands) (string/lower-case mode))
+         (if (contains? (shell-handler/get-code-block-commands) (string/lower-case mode))
            [:a {:title (str "Run command " mode)
                 :on-click (fn [_e]
                             (let [editor-atom (:editor-atom state)]

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -39,6 +39,7 @@
             [frontend.handler.search :as search-handler]
             [frontend.handler.ui :as ui-handler]
             [frontend.handler.user :as user-handler]
+            [frontend.handler.shell :as shell-handler]
             [frontend.handler.web.nfs :as nfs-handler]
             [frontend.mobile.core :as mobile]
             [frontend.mobile.util :as mobile-util]
@@ -867,6 +868,10 @@
                                 [:p (.-message error)]]))))]
                        [:p "Don't forget to re-index your graph when all the conflicts are resolved."]]
                       :status :error}]))
+
+(defmethod handle :run/cli-command [[_ command content]]
+  (when (and command (not (string/blank? content)))
+    (shell-handler/run-cli-command-wrapper! command content)))
 
 (defn run!
   []

--- a/src/main/frontend/handler/shell.cljs
+++ b/src/main/frontend/handler/shell.cljs
@@ -55,7 +55,9 @@
           (= "git" command)
           (wrap-notification! command (fn [_ args] (run-git-command! args)) args)
 
-          (contains? commands-whitelist command)
+          (contains? (merge (map (comp #(remove string/blank? %) string/lower-case str)
+                              (:commands-whitelist (state/get-config)))
+                            commands-whitelist) command)
           (run-cli-command! command args)
 
           :else

--- a/src/main/frontend/handler/shell.cljs
+++ b/src/main/frontend/handler/shell.cljs
@@ -42,11 +42,20 @@
 (def dangerous-commands
   #{"rm" "mv" "rename" "dd" ">" "command" "sudo"})
 
+(def code-block-commands-whitelist
+  #{"alda"})
+
 (defn get-commands
   []
   (set/union (map (comp #(remove string/blank? %) string/lower-case str)
                (:commands-whitelist (state/get-config)))
              commands-whitelist))
+
+(defn get-code-block-commands
+  []
+  (set/union (map (comp #(remove string/blank? %) string/lower-case str)
+               (:code-block/command-whitelist (state/get-config)))
+             code-block-commands-whitelist))
 
 (defn run-command!
   [command]

--- a/src/main/frontend/handler/shell.cljs
+++ b/src/main/frontend/handler/shell.cljs
@@ -38,7 +38,7 @@
   #{"git" "pandoc" "ag" "grep" "alda"})
 
 (def dangerous-commands
-  #{"rm" "move" "rename" "dd" ">" "command" "sudo"})
+  #{"rm" "mv" "rename" "dd" ">" "command" "sudo"})
 
 (defn run-command!
   [command]

--- a/templates/config.edn
+++ b/templates/config.edn
@@ -284,7 +284,7 @@
  ;; Decide the way to escape the special characters in the page title.
  ;; Warning:
  ;;   This is a dangerous operation. If you want to change the setting,
- ;;   should access the setting `Filename format` and follow the instructions. 
+ ;;   should access the setting `Filename format` and follow the instructions.
  ;;   Or you have to rename all the affected files manually then re-index on all
  ;;   clients after the files are synced. Wrong handling may cause page titles
  ;;   containing special characters to be messy.
@@ -296,4 +296,7 @@
  ;;     ;use Percent-encoding for slash and other invalid characters
  ;;     ;parse `.` in file name as slash `/` in page title
  :file/name-format :triple-lowbar
+
+ ;; Commands that are allowed to be invoked from Logseq.
+ :shell/command-whitelist #{}
  }

--- a/templates/config.edn
+++ b/templates/config.edn
@@ -299,4 +299,7 @@
 
  ;; Commands that are allowed to be invoked from Logseq.
  :shell/command-whitelist #{}
+
+ ;; Commands that could be executed in code blocks, e.g. alda, dot
+ :code-block/command-whitelist #{}
  }


### PR DESCRIPTION
This enables cli access to both logseq and plugins.

Some useful cases:
1. play alda notes from Logseq:
Demo: https://user-images.githubusercontent.com/479169/203942326-d961344d-f6f0-4e82-9a11-5c998c0777fb.mov
