### PR TITLE
fix(mobile): missing urlencode when sharing asset url

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -385,8 +385,12 @@
             share-fn (fn [event]
                        (util/stop event)
                        (when (mobile-util/native-platform?)
-                         (.share Share #js {:url path
-                                            :title "Open file with your favorite app"})))]
+                         ;; File URL must be legal, so filename muse be URI-encoded
+                         (let [[rel-dir basename] (util/get-dir-and-basename href)
+                               basename (js/encodeURIComponent basename)
+                               asset-url (str repo-dir rel-dir "/" basename)]
+                           (.share Share (clj->js {:url asset-url
+                                                   :title "Open file with your favorite app"})))))]
 
         (cond
           (contains? config/audio-formats ext)
@@ -401,7 +405,7 @@
           [:a.asset-ref.is-plaintext {:href (rfe/href :file {:path path})
                                       :on-click (fn [_event]
                                                   (p/let [result (fs/read-file repo-dir path)]
-                                                    (db/set-file-content! repo path result )))}
+                                                    (db/set-file-content! repo path result)))}
            title]
 
           (= ext :pdf)


### PR DESCRIPTION
Fix: cannot open assets(PDF) with non-ASCII filenames on iOS.

Or else conversion to URL fails.

https://github.com/ionic-team/capacitor-plugins/blob/473dbe5159258c4e8ea5c9bbbd9542f864da55c0/share/ios/Plugin/SharePlugin.swift#L20-L37

![image](https://user-images.githubusercontent.com/72891/203930101-262853b3-1035-40ba-bad8-facbf9074493.png)

