### PR TITLE
fix(pdf): missing min max value of page number

### DIFF
--- a/src/main/frontend/extensions/pdf/toolbar.cljs
+++ b/src/main/frontend/extensions/pdf/toolbar.cljs
@@ -519,6 +519,8 @@
         [:span.nu.flex.items-center.opacity-70
          [:input {:ref            *page-ref
                   :type           "number"
+                  :min            1
+                  :max            total-page-num
                   :class          (util/classnames [{:is-long (> (util/safe-parse-int current-page-num) 999)}])
                   :default-value  current-page-num
                   :on-mouse-enter #(.select ^js (.-target %))


### PR DESCRIPTION
When scrolling the page number input box:
<img width="189" alt="image" src="https://user-images.githubusercontent.com/72891/203937990-dd3a23b9-4a1b-4501-ace6-013873baf1df.png">
