### PR TITLE
fix: zoom menu trigger should not gain focus on close LOG-1962

### DIFF
--- a/tldraw/apps/tldraw-logseq/src/components/ZoomMenu/ZoomMenu.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ZoomMenu/ZoomMenu.tsx
@@ -14,7 +14,12 @@ export const ZoomMenu = observer(function ZoomMenu(): JSX.Element {
       <DropdownMenuPrimitive.Trigger className="tl-button text-sm px-2 important" id="tl-zoom">
         {(app.viewport.camera.zoom * 100).toFixed(0) + '%'}
       </DropdownMenuPrimitive.Trigger>
-      <DropdownMenuPrimitive.Content className="tl-menu" id="zoomPopup" sideOffset={12}>
+      <DropdownMenuPrimitive.Content
+        onCloseAutoFocus={e => e.preventDefault()}
+        className="tl-menu"
+        id="zoomPopup"
+        sideOffset={12}
+      >
         <DropdownMenuPrimitive.Item
           className="tl-menu-item"
           onSelect={preventEvent}

--- a/tldraw/packages/react/src/components/Canvas/Canvas.tsx
+++ b/tldraw/packages/react/src/components/Canvas/Canvas.tsx
@@ -111,8 +111,6 @@ export const Canvas = observer(function Renderer<S extends TLReactShape>({
   const erasingShapesSet = React.useMemo(() => new Set(erasingShapes || []), [erasingShapes])
   const singleSelectedShape = selectedShapes?.length === 1 ? selectedShapes[0] : undefined
 
-  const selectedOrHooveredShape = hoveredShape || singleSelectedShape
-
   return (
     <div ref={rContainer} className={`tl-container ${className ?? ''}`}>
       <div tabIndex={-1} className="tl-absolute tl-canvas" {...events}>


### PR DESCRIPTION
fixes LOG-1962

Steps to reproduce:
Zoom buttons keep focus, Steps to reproduce: click Reset Zoom, click on whiteboard once, press Space. Zoom changes.
https://discord.com/channels/725182569297215569/1006913306822459484/1045340931655745557

Issue caused by the following line:
https://github.com/radix-ui/primitives/blob/main/packages/react/dropdown-menu/src/DropdownMenu.tsx#L186-L191