### PR TITLE
fix: hovered or selected shape should have higher zindex

### DIFF
--- a/tldraw/packages/react/src/components/Canvas/Canvas.tsx
+++ b/tldraw/packages/react/src/components/Canvas/Canvas.tsx
@@ -110,7 +110,7 @@ export const Canvas = observer(function Renderer<S extends TLReactShape>({
   const selectedShapesSet = React.useMemo(() => new Set(selectedShapes || []), [selectedShapes])
   const erasingShapesSet = React.useMemo(() => new Set(erasingShapes || []), [erasingShapes])
   const singleSelectedShape = selectedShapes?.length === 1 ? selectedShapes[0] : undefined
-  const selectedOrHooveredShape = hoveredShape || singleSelectedShape
+  const selectedOrHoveredShape = hoveredShape || singleSelectedShape
 
   return (
     <div ref={rContainer} className={`tl-container ${className ?? ''}`}>
@@ -139,7 +139,7 @@ export const Canvas = observer(function Renderer<S extends TLReactShape>({
                 isSelected={selectedShapesSet.has(shape)}
                 isErasing={erasingShapesSet.has(shape)}
                 meta={meta}
-                zIndex={selectedOrHooveredShape === shape ? 10000 : 1000 + i}
+                zIndex={selectedOrHoveredShape === shape ? 10000 : 1000 + i}
                 onEditingEnd={onEditingEnd}
               />
             ))}

--- a/tldraw/packages/react/src/components/Canvas/Canvas.tsx
+++ b/tldraw/packages/react/src/components/Canvas/Canvas.tsx
@@ -138,7 +138,7 @@ export const Canvas = observer(function Renderer<S extends TLReactShape>({
                 isSelected={selectedShapesSet.has(shape)}
                 isErasing={erasingShapesSet.has(shape)}
                 meta={meta}
-                zIndex={1000 + i}
+                zIndex={selectedOrHooveredShape === shape ? 10000 : 1000 + i}
                 onEditingEnd={onEditingEnd}
               />
             ))}

--- a/tldraw/packages/react/src/components/Canvas/Canvas.tsx
+++ b/tldraw/packages/react/src/components/Canvas/Canvas.tsx
@@ -110,6 +110,7 @@ export const Canvas = observer(function Renderer<S extends TLReactShape>({
   const selectedShapesSet = React.useMemo(() => new Set(selectedShapes || []), [selectedShapes])
   const erasingShapesSet = React.useMemo(() => new Set(erasingShapes || []), [erasingShapes])
   const singleSelectedShape = selectedShapes?.length === 1 ? selectedShapes[0] : undefined
+  const selectedOrHooveredShape = hoveredShape || singleSelectedShape
 
   return (
     <div ref={rContainer} className={`tl-container ${className ?? ''}`}>


### PR DESCRIPTION
The original bug is to fix an issue that if blocks are too close to each other, the links underneath are hard to be clicked.
The fix makes sure that the hovered or selected shape will have higher order so that the hovering state will not be transferred

https://user-images.githubusercontent.com/584378/204176772-13ae8382-f0a8-47cd-a3a3-215bf2620b73.mp4

