### PR TITLE
fix: decrease Object Action Bar distance when below portal

### DIFF
--- a/tldraw/apps/tldraw-logseq/src/components/ContextBar/ContextBar.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextBar/ContextBar.tsx
@@ -29,7 +29,7 @@ const _ContextBar: TLContextBarComponent<Shape> = ({ shapes, offsets, hidden }) 
     const elm = rContextBar.current
     if (!elm) return
     const size = rSize.current ?? [0, 0]
-    const [x, y] = getContextBarTranslation(size, { ...offsets, bottom: offsets.bottom - 32 })
+    const [x, y] = getContextBarTranslation(size, offsets)
     elm.style.setProperty('transform', `translateX(${x}px) translateY(${y}px)`)
   }, [offsets])
 

--- a/tldraw/packages/react/src/index.ts
+++ b/tldraw/packages/react/src/index.ts
@@ -14,7 +14,7 @@ export function getContextBarTranslation(barSize: number[], offset: TLOffset) {
   let y = 0
   if (offset.top < 116) {
     // Show on bottom
-    y = offset.height / 2 + 72
+    y = offset.height / 2 + 40
     // Too far down, move up
     if (offset.bottom < 140) {
       y += offset.bottom - 140


### PR DESCRIPTION
fixes https://linear.app/logseq/issue/LOG-1961/decrease-object-action-bar-distance-when-below-portal