### PR TITLE
feat: always show hamburger button for mobile

### DIFF
--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -215,12 +215,12 @@
                               (state/pub-event! [:go/search]))}
               (ui/icon "search" {:size ui/icon-size})]))])
       (when (mobile-util/native-platform?)
-        (if (or (state/home?) custom-home-page?)
-          left-menu
-          (ui/with-shortcut :go/backward "bottom"
-            [:button.it.navigation.nav-left.button.icon.opacity-70
-             {:title "Go back" :on-click #(js/window.history.back)}
-             (ui/icon "chevron-left" {:size 26})])))]
+        [left-menu
+         (when-not (or (state/home?) custom-home-page? (state/whiteboard-dashboard?))
+           (ui/with-shortcut :go/backward "bottom"
+             [:button.it.navigation.nav-left.button.icon.opacity-70
+              {:title "Go back" :on-click #(js/window.history.back)}
+              (ui/icon "chevron-left" {:size 26})]))])]
 
      [:div.r.flex.drag-region
       (when (and current-repo

--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -203,9 +203,16 @@
                              (util/scroll-to-top true))))
       :style           {:fontSize 50}}
      [:div.l.flex.drag-region
-      (when-not (mobile-util/native-platform?)
-        [left-menu
-         (when current-repo ;; this is for the Search button
+      [left-menu
+       (if (mobile-util/native-platform?)
+         ;; back button for mobile
+         (when-not (or (state/home?) custom-home-page? (state/whiteboard-dashboard?))
+           (ui/with-shortcut :go/backward "bottom"
+             [:button.it.navigation.nav-left.button.icon.opacity-70
+              {:title "Go back" :on-click #(js/window.history.back)}
+              (ui/icon "chevron-left" {:size 26})]))
+         ;; search button for non-mobile
+         (when current-repo
            (ui/with-shortcut :go/search "right"
              [:button.button.icon#search-button
               {:title "Search"
@@ -213,14 +220,7 @@
                                         (mobile-util/native-iphone?))
                                 (state/set-left-sidebar-open! false))
                               (state/pub-event! [:go/search]))}
-              (ui/icon "search" {:size ui/icon-size})]))])
-      (when (mobile-util/native-platform?)
-        [left-menu
-         (when-not (or (state/home?) custom-home-page? (state/whiteboard-dashboard?))
-           (ui/with-shortcut :go/backward "bottom"
-             [:button.it.navigation.nav-left.button.icon.opacity-70
-              {:title "Go back" :on-click #(js/window.history.back)}
-              (ui/icon "chevron-left" {:size 26})]))])]
+              (ui/icon "search" {:size ui/icon-size})])))]]
 
      [:div.r.flex.drag-region
       (when (and current-repo

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -710,6 +710,10 @@ Similar to re-frame subscriptions"
   []
   (= :home (get-current-route)))
 
+(defn whiteboard-dashboard?
+  []
+  (= :whiteboards (get-current-route)))
+
 (defn setups-picker?
   []
   (= :repo-add (get-current-route)))


### PR DESCRIPTION
There are cases that right-swiping from the left edge will not work well on mobile (eg. on iPad with stage manager on). The proposed fix is to always show the hamburger button.