### PR TITLE
Revert "fix: hovered or selected shape should have higher zindex" 

### DIFF
--- a/tldraw/packages/react/src/components/Canvas/Canvas.tsx
+++ b/tldraw/packages/react/src/components/Canvas/Canvas.tsx
@@ -110,7 +110,7 @@ export const Canvas = observer(function Renderer<S extends TLReactShape>({
   const selectedShapesSet = React.useMemo(() => new Set(selectedShapes || []), [selectedShapes])
   const erasingShapesSet = React.useMemo(() => new Set(erasingShapes || []), [erasingShapes])
   const singleSelectedShape = selectedShapes?.length === 1 ? selectedShapes[0] : undefined
-  const selectedOrHoveredShape = hoveredShape || singleSelectedShape
+  const selectedOrHooveredShape = hoveredShape || singleSelectedShape
 
   return (
     <div ref={rContainer} className={`tl-container ${className ?? ''}`}>
@@ -139,7 +139,7 @@ export const Canvas = observer(function Renderer<S extends TLReactShape>({
                 isSelected={selectedShapesSet.has(shape)}
                 isErasing={erasingShapesSet.has(shape)}
                 meta={meta}
-                zIndex={selectedOrHoveredShape === shape ? 10000 : 1000 + i}
+                zIndex={selectedOrHooveredShape === shape ? 10000 : 1000 + i}
                 onEditingEnd={onEditingEnd}
               />
             ))}

--- a/tldraw/packages/react/src/components/Canvas/Canvas.tsx
+++ b/tldraw/packages/react/src/components/Canvas/Canvas.tsx
@@ -138,7 +138,7 @@ export const Canvas = observer(function Renderer<S extends TLReactShape>({
                 isSelected={selectedShapesSet.has(shape)}
                 isErasing={erasingShapesSet.has(shape)}
                 meta={meta}
-                zIndex={selectedOrHooveredShape === shape ? 10000 : 1000 + i}
+                zIndex={1000 + i}
                 onEditingEnd={onEditingEnd}
               />
             ))}

--- a/tldraw/packages/react/src/components/Canvas/Canvas.tsx
+++ b/tldraw/packages/react/src/components/Canvas/Canvas.tsx
@@ -110,7 +110,6 @@ export const Canvas = observer(function Renderer<S extends TLReactShape>({
   const selectedShapesSet = React.useMemo(() => new Set(selectedShapes || []), [selectedShapes])
   const erasingShapesSet = React.useMemo(() => new Set(erasingShapes || []), [erasingShapes])
   const singleSelectedShape = selectedShapes?.length === 1 ? selectedShapes[0] : undefined
-  const selectedOrHooveredShape = hoveredShape || singleSelectedShape
 
   return (
     <div ref={rContainer} className={`tl-container ${className ?? ''}`}>


### PR DESCRIPTION
Reverts logseq/logseq#7491
The introduces another regression described in https://github.com/logseq/logseq/pull/7491#issuecomment-1329438197, which is even harder to fix for now.