### PR TITLE
Page content search fine-tuning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/e2e-dump
 /target
 /classes
 /checkouts

--- a/e2e-tests/page-search.spec.ts
+++ b/e2e-tests/page-search.spec.ts
@@ -8,14 +8,14 @@ import { IsMac, createRandomPage, newBlock, newInnerBlock, randomString, lastBlo
  * Consider diacritics
  ***/
 
-test('Search page and blocks (diacritics)', async ({ page, block }) => {
-  let hotkeyOpenLink = 'Control+o'
-  let hotkeyBack = 'Control+['
-  if (IsMac) {
-    hotkeyOpenLink = 'Meta+o'
-    hotkeyBack = 'Meta+['
-  }
+ let hotkeyOpenLink = 'Control+o'
+ let hotkeyBack = 'Control+['
+ if (IsMac) {
+   hotkeyOpenLink = 'Meta+o'
+   hotkeyBack = 'Meta+['
+ }
 
+test('Search page and blocks (diacritics)', async ({ page, block }) => {
   const rand = randomString(20)
 
   // diacritic opening test
@@ -52,14 +52,36 @@ test('Search page and blocks (diacritics)', async ({ page, block }) => {
   await page.keyboard.press("Escape") // escape modal
 })
 
-async function alias_test(page: Page, page_name: string, search_kws: string[]) {
-  let hotkeyOpenLink = 'Control+o'
-  let hotkeyBack = 'Control+['
-  if (IsMac) {
-    hotkeyOpenLink = 'Meta+o'
-    hotkeyBack = 'Meta+['
-  }
+test('Search CJK', async ({ page, block }) => {
+  const rand = randomString(20)
 
+  // diacritic opening test
+  await createRandomPage(page)
+
+  await block.mustType('[[今日daytime进度条' + rand + ']] diacritic-block-1', { delay: 10 })
+  await page.keyboard.press(hotkeyOpenLink)
+
+  const pageTitle = page.locator('.page-title').first()
+  expect(await pageTitle.innerText()).toEqual('Einführung in die Allgemeine Sprachwissenschaft' + rand)
+
+  await page.waitForTimeout(500)
+
+  // check if diacritics are indexed
+  await page.click('#search-button')
+  await page.waitForSelector('[placeholder="Search or create page"]')
+  await page.type('[placeholder="Search or create page"]', '进度' + rand, { delay: 10 })
+
+  await page.waitForTimeout(2000) // wait longer for search contents to render
+  // 2 blocks + 1 page + 1 page content
+  const searchResults = page.locator('#ui__ac-inner>div')
+  await expect(searchResults).toHaveCount(3)
+
+  await page.keyboard.press("Escape") // escape search box typing
+  await page.waitForTimeout(500)
+  await page.keyboard.press("Escape") // escape modal
+})
+
+async function alias_test(page: Page, page_name: string, search_kws: string[]) {
   const rand = randomString(10)
   let target_name = page_name + ' target ' + rand
   let alias_name = page_name + ' alias ' + rand

--- a/e2e-tests/utils.ts
+++ b/e2e-tests/utils.ts
@@ -115,6 +115,7 @@ export async function newInnerBlock(page: Page): Promise<Locator> {
   return page.locator('textarea >> nth=0')
 }
 
+// Deprecated by block.enterNext
 export async function newBlock(page: Page): Promise<Locator> {
   let blockNumber = await page.locator('.page-blocks-inner .ls-block').count()
   await lastBlock(page)

--- a/src/electron/electron/search.cljs
+++ b/src/electron/electron/search.cljs
@@ -307,6 +307,7 @@
   (when-let [database (get-db repo)]
     (when-not (string/blank? q)
       (let [match-inputs (get-match-inputs q)
+            non-match-input (str "%" (string/replace q #"\s+" "%") "%")
             limit  (or limit 20)
             ;; https://www.sqlite.org/fts5.html#the_highlight_function
             ;; the 2nd column in pages_fts (content)
@@ -316,6 +317,8 @@
             select (str "select rowid, uuid, content, " snippet-aux " from pages_fts where ")
             match-sql (str select
                            " content match ? order by rank limit ?")
+            non-match-sql (str select
+                               " content like ? limit ?")
             matched-result (->>
                             (map
                               (fn [match-input]

--- a/src/electron/electron/search.cljs
+++ b/src/electron/electron/search.cljs
@@ -273,9 +273,13 @@
         (->>
          (concat matched-result
                  (search-blocks-aux database non-match-sql non-match-input page limit))
-         (distinct-by :id)
+         (distinct-by :rowid)
          (take limit)
          (vec))))))
+
+(defn- snippet-by
+  [content length]
+  (str (subs content 0 length) "..."))
 
 (defn- search-pages-res-unpack
   [arr]
@@ -283,7 +287,9 @@
     {:id      rowid
      :uuid    uuid
      :content content
-     :snippet snippet}))
+     :snippet (if (string/includes? snippet "$pfts_2lqh>$ ")
+                snippet
+                (snippet-by snippet 250))}))
 
 (defn- search-pages-aux
   [database sql input limit]
@@ -317,7 +323,8 @@
                               match-inputs)
                             (apply concat))]
         (->>
-         matched-result
+         (concat matched-result
+                 (search-pages-aux database non-match-sql non-match-input limit))
          (distinct-by :id)
          (take limit)
          (vec))))))

--- a/src/electron/electron/search.cljs
+++ b/src/electron/electron/search.cljs
@@ -279,7 +279,7 @@
 
 (defn- snippet-by
   [content length]
-  (str (subs content 0 length) "..."))
+  (str (subs content 0 length) (when (> (count content) 250) "...")))
 
 (defn- search-pages-res-unpack
   [arr]
@@ -287,9 +287,19 @@
     {:id      rowid
      :uuid    uuid
      :content content
-     :snippet (if (string/includes? snippet "$pfts_2lqh>$ ")
-                snippet
-                (snippet-by snippet 250))}))
+     ;; post processing
+     :snippet (let [;; Remove title from snippet
+                    flag-title " $<pfts_f6ld$ "
+                    flag-title-pos (string/index-of snippet flag-title)
+                    snippet (if flag-title-pos
+                              (subs snippet (+ flag-title-pos (count flag-title)))
+                              snippet)
+                    ;; Cut snippet to 250 chars for non-matched results
+                    flag-highlight "$pfts_2lqh>$ "
+                    snippet (if (string/includes? snippet flag-highlight)
+                              snippet
+                              (snippet-by snippet 250))]
+                snippet)}))
 
 (defn- search-pages-aux
   [database sql input limit]

--- a/src/main/frontend/search/db.cljs
+++ b/src/main/frontend/search/db.cljs
@@ -30,13 +30,14 @@
 (defn page->index
   "Convert a page name to the index for searching (page content level)
    Generate index based on the DB content AT THE POINT OF TIME"
-  [{:block/keys [uuid _original-name] :as page}]
+  [{:block/keys [uuid original-name] :as page}]
   (when-let [content (some-> (:block/file page)
                              (:file/content))]
     (when-not (> (count content) (* (max-len) 10))
       {:id   (:db/id page)
        :uuid (str uuid)
-       :content (sanitize content)})))
+       ;; Add page name to the index
+       :content (sanitize (str "$pfts_f6ld>$ " original-name " $<pfts_f6ld$ " content))})))
 
 (defn build-blocks-indice
   ;; TODO: Remove repo effects fns further up the call stack. db fns need standardization on taking connection


### PR DESCRIPTION
- Fix: Wrong handled `distinct-by` at block search
- Feat: Page content search index now contains title (addressing #7510)
- E2E tests:
  - CJK search test
  - ~Recover alias test~