### PR TITLE
fix(mobile): refactor mobile camera toolbar command

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1,6 +1,5 @@
 (ns ^:no-doc frontend.handler.editor
-  (:require ["path" :as path]
-            [clojure.set :as set]
+  (:require [clojure.set :as set]
             [clojure.string :as string]
             [clojure.walk :as w]
             [dommy.core :as dom]
@@ -1329,20 +1328,18 @@
              (util/format "[[%s][%s]]" url file-name))
       nil)))
 
-(defn ensure-assets-dir!
+(defn- ensure-assets-dir!
   [repo]
-  (let [repo-dir (config/get-repo-dir repo)
-        assets-dir "assets"]
-    (p/then
-     (fs/mkdir-if-not-exists (str repo-dir "/" assets-dir))
-     (fn [] [repo-dir assets-dir]))))
+  (p/let [repo-dir (config/get-repo-dir repo)
+          assets-dir "assets"
+          _ (fs/mkdir-if-not-exists (str repo-dir "/" assets-dir))]
+    [repo-dir assets-dir]))
 
-(defn get-asset-path [filename]
-  (p/let [[repo-dir assets-dir] (ensure-assets-dir! (state/get-current-repo))
-          path (path/join repo-dir assets-dir filename)]
-    (if (mobile-util/native-android?)
-      path
-      (js/encodeURI (js/decodeURI path)))))
+(defn get-asset-path
+  "Get asset path from filename, ensure assets dir exists"
+  [filename]
+  (p/let [[repo-dir assets-dir] (ensure-assets-dir! (state/get-current-repo))]
+    (util/safe-path-join repo-dir assets-dir filename)))
 
 (defn save-assets!
   ([_ repo files]

--- a/src/main/frontend/mobile/camera.cljs
+++ b/src/main/frontend/mobile/camera.cljs
@@ -6,32 +6,35 @@
             [frontend.handler.editor :as editor-handler]
             [frontend.state :as state]
             [frontend.date :as date]
-            [frontend.util :as util]
             [frontend.commands :as commands]
             [goog.object :as gobj]
             [frontend.util.cursor :as cursor]))
 
-(defn- save-photo []
-  (p/let [photo (p/catch
-                    (.getPhoto Camera (clj->js
-                                       {:allowEditing (get-in
-                                                       (state/get-config)
-                                                       [:mobile/photo :allow-editing?])
-                                        :saveToGallery true
-                                        :resultType (.-Base64 CameraResultType)}))
-                    (fn [error]
-                      (log/error :photo/get-failed {:error error})))
-          filename (str (date/get-date-time-string-2) ".jpeg")
-          path (editor-handler/get-asset-path filename)
-          _file (when photo
-                  (p/catch
-                     (.writeFile Filesystem (clj->js {:data (.-base64String photo)
-                                                      :path path
-                                                      :recursive true}))
-                     (fn [error]
-                       (log/error :file/write-failed {:path path
-                                                      :error error}))))]
-    (p/resolved filename)))
+(defn- take-or-choose-photo []
+  (-> (.getPhoto Camera (clj->js
+                         {:allowEditing (get-in
+                                         (state/get-config)
+                                         [:mobile/photo :allow-editing?])
+                          :quality (get-in (state/get-config)
+                                           [:mobile/photo :quality] 80)
+                          :saveToGallery true
+                          :resultType (.-Base64 CameraResultType)}))
+      (p/catch (fn [error]
+                 (log/error :photo/get-failed {:error error})))
+      (p/then (fn [photo]
+                (prn ::debug-photo photo)
+                (if (nil? photo)
+                  (p/resolved nil)
+                  ;; NOTE: For iOS and Android, only jpeg format will be returned as base64 string.
+                  ;; See-also: https://capacitorjs.com/docs/apis/camera#galleryphoto
+                  (p/let [filename (str (date/get-date-time-string-2) ".jpeg")
+                          image-path (editor-handler/get-asset-path filename)
+                          _ret (.writeFile Filesystem (clj->js {:data (.-base64String photo)
+                                                                :path image-path
+                                                                :recursive true}))]
+                    filename))))
+      (p/catch (fn [error]
+                 (log/error :file/write-failed {:error error})))))
 
 (defn embed-photo [id]
   (let [block (state/get-edit-block)
@@ -48,11 +51,11 @@
 
                        :else " ")
         format (:block/format block)]
-    (p/let [filename (save-photo)
-            url (util/format "../assets/%s" filename)]
-      (commands/simple-insert!
-       id
-       (str left-padding
-            (editor-handler/get-asset-file-link format url filename true)
-        " ")
-       {}))))
+    (p/let [filename (take-or-choose-photo)]
+      (when (not-empty filename)
+        (commands/simple-insert!
+         id
+         (str left-padding
+              (editor-handler/get-asset-file-link format (str "../assets/" filename) filename true)
+              " ")
+         {})))))


### PR DESCRIPTION
- fix: When clicking then not picking any image, an empty image link still gets created
- fix: use safe path join for image asset path