### PR TITLE
fix: sync icon disappear with unstable network

### DIFF
--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -86,7 +86,7 @@
         nil
         (map? result)
         (do
-          (state/set-state! :user/info result)
+          (state/set-user-info! result)
           (let [status (if (user-handler/alpha-or-beta-user?) :welcome :unavailable)]
             (when (and (= status :welcome) (user-handler/logged-in?))
               (when-not (false? (state/enable-sync?)) ; user turns it off

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -263,7 +263,7 @@
      :file-sync/graph-state                 {:current-graph-uuid nil
                                              ;; graph-uuid -> ...
                                              }
-
+     :user/info                             {:UserGroups (storage/get :user-groups)}
      :encryption/graph-parsing?             false
 
      :ui/loading?                           {}
@@ -2064,3 +2064,11 @@ Similar to re-frame subscriptions"
      (when (and shape-id (parse-uuid shape-id))
        (. api selectShapes shape-id)
        (. api zoomToSelection)))))
+
+(defn set-user-info!
+  [info]
+  (when info
+    (set-state! :user/info info)
+    (let [groups (:UserGroups info)]
+      (when (seq groups)
+        (storage/set :user-groups groups)))))


### PR DESCRIPTION
User's groups will be stored in local storage.

How to test?
1. Login if you haven't 
2. Disable Wifi
3. Restart logseq 

The sync icon should still be there.