### PR TITLE
Enhance: add git revision to sentry report

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -33,10 +33,12 @@
                                                 "externs.js"]
                            :warnings           {:fn-deprecated false
                                                 :redef false}}
+        :build-hooks      [(shadow.hooks/git-revision-hook "--long --always --dirty")]
         :closure-defines  {goog.debug.LOGGING_ENABLED       true
-                           frontend.config/ENABLE-PLUGINS   #shadow/env ["ENABLE_PLUGINS"   :as :bool :default true]
+                           frontend.config/ENABLE-PLUGINS #shadow/env ["ENABLE_PLUGINS"   :as :bool :default true]
                            frontend.config/ENABLE-FILE-SYNC-PRODUCTION #shadow/env ["ENABLE_FILE_SYNC_PRODUCTION" :as :bool :default true]
-                           frontend.config/TEST #shadow/env ["LOGSEQ_CI" :as :bool :default false]}
+                           frontend.config/TEST #shadow/env ["LOGSEQ_CI" :as :bool :default false]
+                           frontend.config/REVISION #shadow/env ["LOGSEQ_REVISION" :default "dev"]} ;; set by git-revision-hook
 
         ;; NOTE: electron, browser/mobile-app use different asset-paths.
         ;;   For browser/mobile-app devs, assets are located in /static/js(via HTTP root).

--- a/src/dev-cljs/shadow/hooks.clj
+++ b/src/dev-cljs/shadow/hooks.clj
@@ -1,15 +1,15 @@
 (ns shadow.hooks
   (:require [clojure.java.shell :refer [sh]]
-            [clojure.string :as str]))
+            [clojure.string :as string]))
 
 ;; copied from https://gist.github.com/mhuebert/ba885b5e4f07923e21d1dc4642e2f182
 (defn exec [& cmd]
-  (let [cmd (str/split (str/join " " (flatten cmd)) #"\s+")
-        _ (println (str/join " " cmd))
+  (let [cmd (string/split (string/join " " (flatten cmd)) #"\s+")
+        _ (println (string/join " " cmd))
         {:keys [exit out err]} (apply sh cmd)]
     (if (zero? exit)
-      (when-not (str/blank? out)
-        (println out))
+      (when-not (string/blank? out)
+        (string/trim out))
       (println err))))
 
 (defn purge-css
@@ -27,5 +27,18 @@
     :dev
     (do
       (exec "mkdir -p" public-dir)
-      (exec "cp" css-source (str public-dir "/" (last (str/split css-source #"/"))))))
+      (exec "cp" css-source (str public-dir "/" (last (string/split css-source #"/"))))))
   state)
+
+(defn git-revision-hook
+  {:shadow.build/stage :configure}
+  [build-state & args]
+  (let [defines-in-config (get-in build-state [:shadow.build/config :closure-defines])
+        defines-in-options (get-in build-state [:compiler-options :closure-defines])
+        revision (exec "git" "describe" args)]
+    (prn ::git-revision-hook revision)
+    (-> build-state
+        (assoc-in [:shadow.build/config :closure-defines]
+                  (assoc defines-in-config 'frontend.config/REVISION revision))
+        (assoc-in [:compiler-options :closure-defines]
+                  (assoc defines-in-options 'frontend.config/REVISION revision)))))

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -77,7 +77,9 @@
                :else
                nil)]
 
-       [:div.text-sm version]
+       [:div.text-sm
+        {:title (str "Revision: " config/revison)}
+        version]
 
        [:a.text-sm.fade-link.underline.inline
         {:target "_blank"

--- a/src/main/frontend/config.cljs
+++ b/src/main/frontend/config.cljs
@@ -16,6 +16,9 @@
 (goog-define PUBLISHING false)
 (defonce publishing? PUBLISHING)
 
+(goog-define REVISION "unknown")
+(defonce revison REVISION)
+
 (reset! state/publishing? publishing?)
 
 (goog-define TEST false)

--- a/src/main/frontend/modules/instrumentation/sentry.cljs
+++ b/src/main/frontend/modules/instrumentation/sentry.cljs
@@ -14,11 +14,14 @@
                          version)
    :environment (if config/dev? "development" "production")
    :initialScope {:tags
-                  {:platform (cond
-                               (util/electron?) "electron"
-                               (mobile-util/native-platform?) "mobile"
-                               :else "web")
-                   :publishing config/publishing?}}
+                  (merge
+                   (when (not-empty config/revison)
+                     {:revision config/revison})
+                   {:platform (cond
+                                (util/electron?) "electron"
+                                (mobile-util/native-platform?) "mobile"
+                                :else "web")
+                    :publishing config/publishing?})}
    ;; :integrations [(new posthog/SentryIntegration posthog "logseq" 5311485)
    ;;                (new BrowserTracing)]
    :debug config/dev?


### PR DESCRIPTION
- implemented using shadow-cljs build hooks
- hover on VERSION text to acquire the revision string
- report to sentry.io

<img width="417" alt="image" src="https://user-images.githubusercontent.com/72891/204817453-a3c05b50-0e75-4fec-96f8-27d7d86a482e.png">
