### PR TITLE
feat: open right side bar helping page shortcut settings on right side

### DIFF
--- a/src/main/frontend/components/onboarding.cljs
+++ b/src/main/frontend/components/onboarding.cljs
@@ -1,8 +1,8 @@
 (ns frontend.components.onboarding
   (:require [frontend.context.i18n :refer [t]]
-            [frontend.handler.route :as route-handler]
             [rum.core :as rum]
             [frontend.ui :as ui]
+            [frontend.state :as state]
             [frontend.components.onboarding.setups :as setups]))
 
 (rum/defc intro
@@ -18,7 +18,7 @@
          list
          [{:title "Usage"
            :children [[[:a
-                        {:on-click (fn [] (route-handler/redirect! {:to :shortcut-setting}))}
+                        {:on-click (fn [] (state/sidebar-add-block! (state/get-current-repo) "shortcut-settings" :shortcut-settings))}
                         [:div.flex-row.inline-flex.items-center
                          [:span.mr-1 (t :help/shortcuts)]
                          (ui/icon "command" {:style {:font-size 20}})]]]

--- a/src/main/frontend/components/right_sidebar.cljs
+++ b/src/main/frontend/components/right_sidebar.cljs
@@ -5,6 +5,7 @@
             [frontend.components.onboarding :as onboarding]
             [frontend.components.page :as page]
             [frontend.components.svg :as svg]
+            [frontend.components.shortcut :as shortcut]
             [frontend.context.i18n :refer [t]]
             [frontend.date :as date]
             [frontend.db :as db]
@@ -48,6 +49,11 @@
   [:div.contents.flex-col.flex.ml-3
    (when-let [contents (db/entity [:block/name "contents"])]
      (page/contents-page contents))])
+
+(rum/defc shortcut-settings
+  []
+  [:div.contents.flex-col.flex.ml-3
+   (shortcut/shortcut {:show-title? false})])
 
 (defn- block-with-breadcrumb
   [repo block idx sidebar-key ref?]
@@ -106,6 +112,9 @@
         (db-model/get-page-original-name page-name)]
        [:div.ml-2.slide.mt-2
         (slide/slide page-name)]])
+    
+    :shortcut-settings
+    [(t :help/shortcuts) (shortcut-settings)]
 
     ["" [:span]]))
 

--- a/src/main/frontend/components/shortcut.cljs
+++ b/src/main/frontend/components/shortcut.cljs
@@ -168,9 +168,10 @@
         list)]]))
 
 (rum/defc shortcut
-  []
+  [{:keys [show-title?]
+    :or {show-title? true}}]
   [:div
-   [:h1.title (t :help/shortcut-page-title)]
+   (when show-title? [:h1.title (t :help/shortcut-page-title)])
    (trigger-table)
    (markdown-and-orgmode-syntax)
    (shortcut-table :shortcut.category/basics true)

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1432,3 +1432,21 @@
                       (.then (fn [blob]
                                (js/navigator.clipboard.write (clj->js [(js/ClipboardItem. (clj->js {(.-type blob) blob}))]))))
                       (.catch js/console.error)))))))
+
+
+(defn memoize-last
+  "Different from core.memoize, it only cache the last result.
+   Returns a memoized version of a referentially transparent function. The
+  memoized version of the function cache the the last result, and replay when calls 
+   with the same arguments, or update cache when with different arguments."
+  [f]
+  (let [last-mem (atom nil)
+        last-args (atom nil)]
+    (fn [& args]
+      (if (or (nil? @last-mem)
+              (not= @last-args args))
+        (let [ret (apply f args)]
+          (reset! last-args args)
+          (reset! last-mem ret)
+          ret)
+        @last-mem))))

--- a/src/test/frontend/util_test.cljs
+++ b/src/test/frontend/util_test.cljs
@@ -1,6 +1,7 @@
 (ns frontend.util-test
   (:require [cljs.test :refer [deftest is testing]]
-            [frontend.util :as util]))
+            [frontend.util :as util]
+            [frontend.modules.shortcut.data-helper :as shortcut-data-helper]))
 
 (deftest test-find-first
   (testing "find-first"
@@ -31,3 +32,78 @@
     (is (= (util/node-path.join "content://a/b" "../d.md") "content://a/d.md"))
     (is (= (util/node-path.join "https://logseq.com/a/b" "c/d.md") "https://logseq.com/a/b/c/d.md"))))
 
+(deftest test-memoize-last
+  (testing "memoize-last add test"
+    (let [actual-ops (atom 0)
+          m+         (util/memoize-last (fn [x1 x2]
+                                           (swap! actual-ops inc) ;; side effect for counting
+                                           (+ x1 x2)))]
+      (is (= (m+ 1 1) 2))
+      (is (= @actual-ops 1))
+      (is (= (m+ 1 1) 2))
+      (is (= (m+ 1 1) 2))
+      (is (= @actual-ops 1))
+      (is (= (m+ 1 2) 3))
+      (is (= @actual-ops 2))
+      (is (= (m+ 2 3) 5))
+      (is (= @actual-ops 3))
+      (is (= (m+ 3 5) 8))
+      (is (= @actual-ops 4))
+      (is (= (m+ 3 5) 8))
+      (is (= @actual-ops 4))))
+
+  (testing "memoize-last nested mapping test"
+    (let [actual-ops (atom 0)
+          flatten-f  (util/memoize-last (fn [& args]
+                                           (swap! actual-ops inc) ;; side effect for counting
+                                           (apply #'shortcut-data-helper/flatten-key-bindings args)))
+          target     (atom {:part1 {:date-picker/complete         {:binding "enter"
+                                                                   :fn      "ui-handler/shortcut-complete"}
+                                    :date-picker/prev-day         {:binding "left"
+                                                                   :fn      "ui-handler/shortcut-prev-day"}}
+                            :part2 {:date-picker/next-day         {:binding "right"
+                                                                   :fn      "ui-handler/shortcut-next-day"}
+                                    :date-picker/prev-week        {:binding ["up" "ctrl+p"]
+                                                                   :fn      "ui-handler/shortcut-prev-week"}}})]
+      (is (= (flatten-f (vals @target)) {:date-picker/complete         "enter"
+                                         :date-picker/prev-day         "left"
+                                         :date-picker/next-day         "right"
+                                         :date-picker/prev-week        ["up" "ctrl+p"]}))
+      (is (= @actual-ops 1))
+      (is (= (flatten-f (vals @target)) {:date-picker/complete         "enter"
+                                         :date-picker/prev-day         "left"
+                                         :date-picker/next-day         "right"
+                                         :date-picker/prev-week        ["up" "ctrl+p"]}))
+      (is (= @actual-ops 1))
+      ;; edit value
+      (swap! target assoc-in [:part1 :date-picker/complete :binding] "tab")
+      (is (= (flatten-f (vals @target)) {:date-picker/complete         "tab"
+                                         :date-picker/prev-day         "left"
+                                         :date-picker/next-day         "right"
+                                         :date-picker/prev-week        ["up" "ctrl+p"]}))
+      (is (= @actual-ops 2))
+      (is (= (flatten-f (vals @target)) {:date-picker/complete         "tab"
+                                         :date-picker/prev-day         "left"
+                                         :date-picker/next-day         "right"
+                                         :date-picker/prev-week        ["up" "ctrl+p"]}))
+      (is (= @actual-ops 2))
+      (is (= (flatten-f (vals @target)) {:date-picker/complete         "tab"
+                                         :date-picker/prev-day         "left"
+                                         :date-picker/next-day         "right"
+                                         :date-picker/prev-week        ["up" "ctrl+p"]}))
+      (is (= @actual-ops 2))
+      ;; edit key
+      (swap! target assoc :part3 {:date-picker/next-week {:binding "down"
+                                                          :fn      "ui-handler/shortcut-next-week"}})
+      (is (= (flatten-f (vals @target)) {:date-picker/complete         "tab"
+                                         :date-picker/prev-day         "left"
+                                         :date-picker/next-day         "right"
+                                         :date-picker/prev-week        ["up" "ctrl+p"]
+                                         :date-picker/next-week        "down"}))
+      (is (= @actual-ops 3))
+      (is (= (flatten-f (vals @target)) {:date-picker/complete         "tab"
+                                         :date-picker/prev-day         "left"
+                                         :date-picker/next-day         "right"
+                                         :date-picker/prev-week        ["up" "ctrl+p"]
+                                         :date-picker/next-week        "down"}))
+      (is (= @actual-ops 3)))))


### PR DESCRIPTION
1. As proposed in [here](https://discuss.logseq.com/t/new-user-frustrated-with-learning-shortcuts/12909?u=ramses), the `keyboard shortcut` button in the right sidebar will open the shortcut panel in place:

* <img width="1065" alt="image" src="https://user-images.githubusercontent.com/9862022/205127371-04800095-de1b-4220-a8c2-7be1224e26e9.png">

2. Reduce lagging of opening shortcut view
* Before, likely blocked by 1 sec 
  * <img width="1375" alt="image" src="https://user-images.githubusercontent.com/9862022/205127820-f6e3d8ad-e67b-4664-8102-f2f53808aaca.png">

* After, by caching, cut time consumption by 80% to ~200ms
  * <img width="1260" alt="image" src="https://user-images.githubusercontent.com/9862022/205270192-62d0717e-5ae0-4e9d-8fdf-d8c62648e3a6.png">


* Add function `util/memorize-last` to cache the last result, if arguments unchanged (check via `=`)

