### PR TITLE
e2e: reenable whiteboard e2e

### DIFF
--- a/e2e-tests/whiteboards.spec.ts
+++ b/e2e-tests/whiteboards.spec.ts
@@ -2,147 +2,177 @@ import { expect } from '@playwright/test'
 import { test } from './fixtures'
 import { IsMac } from './utils'
 
-test.skip('enable whiteboards', async ({ page }) => {
-    await page.evaluate(() => {
-        window.localStorage.removeItem('ls-onboarding-whiteboard?')
-    })
+test('enable whiteboards', async ({ page }) => {
+  await page.evaluate(() => {
+    window.localStorage.removeItem('ls-onboarding-whiteboard?')
+  })
 
-    await expect(page.locator('.nav-header .whiteboard')).toBeHidden()
-    await page.click('#head .toolbar-dots-btn')
-    await page.click('#head .dropdown-wrapper >> text=Settings')
-    await page.click('.settings-modal a[data-id=features]')
-    await page.click('text=Whiteboards >> .. >> .ui__toggle')
-    await page.keyboard.press('Escape')
-    await expect(page.locator('.nav-header .whiteboard')).toBeVisible()
+  await expect(page.locator('.nav-header .whiteboard')).toBeHidden()
+  await page.click('#head .toolbar-dots-btn')
+  await page.click('#head .dropdown-wrapper >> text=Settings')
+  await page.click('.settings-modal a[data-id=features]')
+  await page.click('text=Whiteboards >> .. >> .ui__toggle')
+  await page.keyboard.press('Escape')
+  await expect(page.locator('.nav-header .whiteboard')).toBeVisible()
 })
 
-test.skip('create new whiteboard', async ({ page }) => {
-    await page.click('.nav-header .whiteboard')
-    await page.click('#tl-create-whiteboard')
-    await expect(page.locator('.logseq-tldraw')).toBeVisible()
+test('create new whiteboard', async ({ page }) => {
+  await page.click('.nav-header .whiteboard')
+  await page.click('#tl-create-whiteboard')
+  await expect(page.locator('.logseq-tldraw')).toBeVisible()
 })
 
-test.skip('check if the page contains the onboarding whiteboard', async ({ page }) => {
-    await expect(page.locator('.tl-text-shape-wrapper >> text=Welcome to')).toHaveCount(1)
+test('check if the page contains the onboarding whiteboard', async ({
+  page,
+}) => {
+  await expect(
+    page.locator('.tl-text-shape-wrapper >> text=Welcome to')
+  ).toHaveCount(1)
 })
 
-test.skip('cleanup the shapes', async ({ page }) => {
-    if (IsMac) {
-        await page.keyboard.press('Meta+a')
-    } else {
-        await page.keyboard.press('Control+a')
-    }
-    await page.keyboard.press('Delete')
-    await expect(page.locator('[data-type=Shape]')).toHaveCount(0)
+test('cleanup the shapes', async ({ page }) => {
+  if (IsMac) {
+    await page.keyboard.press('Meta+a')
+  } else {
+    await page.keyboard.press('Control+a')
+  }
+  await page.keyboard.press('Delete')
+  await expect(page.locator('[data-type=Shape]')).toHaveCount(0)
 })
 
-test.skip('can right click title to show context menu', async ({ page }) => {
-    await page.click('.whiteboard-page-title', {
-        button: 'right',
-    })
+test('can right click title to show context menu', async ({ page }) => {
+  await page.click('.whiteboard-page-title', {
+    button: 'right',
+  })
 
-    await expect(page.locator('#custom-context-menu')).toBeVisible()
+  await expect(page.locator('#custom-context-menu')).toBeVisible()
 
-    await page.keyboard.press('Escape')
+  await page.keyboard.press('Escape')
 
-    await expect(page.locator('#custom-context-menu')).toHaveCount(0)
+  await expect(page.locator('#custom-context-menu')).toHaveCount(0)
 })
 
-test.skip('set whiteboard title', async ({ page }) => {
-    const title = "my-whiteboard"
-    // Newly created whiteboard should have a default title
-    await expect(page.locator('.whiteboard-page-title .title')).toContainText("Untitled");
+test('set whiteboard title', async ({ page }) => {
+  const title = 'my-whiteboard'
+  // Newly created whiteboard should have a default title
+  await expect(page.locator('.whiteboard-page-title .title')).toContainText(
+    'Untitled'
+  )
 
-    await page.click('.whiteboard-page-title')
-    await page.fill('.whiteboard-page-title input', title)
-    await page.keyboard.press('Enter')
-    await expect(page.locator('.whiteboard-page-title .title')).toContainText(title);
+  await page.click('.whiteboard-page-title')
+  await page.fill('.whiteboard-page-title input', title)
+  await page.keyboard.press('Enter')
+  await expect(page.locator('.whiteboard-page-title .title')).toContainText(
+    title
+  )
 
-    await page.click('.whiteboard-page-title')
-    await page.fill('.whiteboard-page-title input', title + "-2")
-    await page.keyboard.press('Enter')
+  await page.click('.whiteboard-page-title')
+  await page.fill('.whiteboard-page-title input', title + '-2')
+  await page.keyboard.press('Enter')
 
-    // Updating non-default title should pop up a confirmation dialog
-    await expect(page.locator('.ui__confirm-modal >> .headline')).toContainText(`Do you really want to change the page name to “${title}-2”?`);
-    await page.click('.ui__confirm-modal button')
-    await expect(page.locator('.whiteboard-page-title .title')).toContainText(title + "-2");
+  // Updating non-default title should pop up a confirmation dialog
+  await expect(page.locator('.ui__confirm-modal >> .headline')).toContainText(
+    `Do you really want to change the page name to “${title}-2”?`
+  )
+  await page.click('.ui__confirm-modal button')
+  await expect(page.locator('.whiteboard-page-title .title')).toContainText(
+    title + '-2'
+  )
 })
 
-test.skip('select rectangle tool', async ({ page }) => {
-    await page.keyboard.press('7')
-    await expect(page.locator('.tl-geometry-tools-pane-anchor [title*="Rectangle"]')).toHaveAttribute('data-selected', 'true')
+test('select rectangle tool', async ({ page }) => {
+  await page.keyboard.press('7')
+  await expect(
+    page.locator('.tl-geometry-tools-pane-anchor [title*="Rectangle"]')
+  ).toHaveAttribute('data-selected', 'true')
 })
 
-test.skip('draw a rectangle', async ({ page }) => {
-    const canvas = await page.waitForSelector('.logseq-tldraw');
-    const bounds = (await canvas.boundingBox())!;
+test('draw a rectangle', async ({ page }) => {
+  const canvas = await page.waitForSelector('.logseq-tldraw')
+  const bounds = (await canvas.boundingBox())!
 
-    await page.keyboard.press('7')
+  await page.keyboard.press('7')
 
-    await page.mouse.move(bounds.x + 5, bounds.y + 5);
-    await page.mouse.down();
+  await page.mouse.move(bounds.x + 5, bounds.y + 5)
+  await page.mouse.down()
 
-    await page.mouse.move(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2);
-    await page.mouse.up();
+  await page.mouse.move(
+    bounds.x + bounds.width / 2,
+    bounds.y + bounds.height / 2
+  )
+  await page.mouse.up()
 
-    await expect(page.locator('.logseq-tldraw .tl-positioned-svg rect')).not.toHaveCount(0);
+  await expect(
+    page.locator('.logseq-tldraw .tl-positioned-svg rect')
+  ).not.toHaveCount(0)
 })
 
-test.skip('zoom in', async ({ page }) => {
-    await page.click('#tl-zoom-in')
-    await expect(page.locator('#tl-zoom')).toContainText('125%');
+test('zoom in', async ({ page }) => {
+  await page.click('#tl-zoom-in')
+  await expect(page.locator('#tl-zoom')).toContainText('125%')
 })
 
-test.skip('zoom out', async ({ page }) => {
-    await page.click('#tl-zoom-out')
-    await expect(page.locator('#tl-zoom')).toContainText('100%');
+test('zoom out', async ({ page }) => {
+  await page.click('#tl-zoom-out')
+  await expect(page.locator('#tl-zoom')).toContainText('100%')
 })
 
-test.skip('open context menu', async ({ page }) => {
-    await page.locator('.logseq-tldraw').click({ button: "right" })
-    await expect(page.locator('.tl-context-menu')).toBeVisible()
+test('open context menu', async ({ page }) => {
+  await page.locator('.logseq-tldraw').click({ button: 'right' })
+  await expect(page.locator('.tl-context-menu')).toBeVisible()
 })
 
-test.skip('close context menu on esc', async ({ page }) => {
-    await page.keyboard.press('Escape')
-    await expect(page.locator('.tl-context-menu')).toBeHidden()
+test('close context menu on esc', async ({ page }) => {
+  await page.keyboard.press('Escape')
+  await expect(page.locator('.tl-context-menu')).toBeHidden()
 })
 
-test.skip('quick add another whiteboard', async ({ page }) => {
-    // create a new board first
-    await page.click('.nav-header .whiteboard')
-    await page.click('#tl-create-whiteboard')
+test('quick add another whiteboard', async ({ page }) => {
+  // create a new board first
+  await page.click('.nav-header .whiteboard')
+  await page.click('#tl-create-whiteboard')
 
-    await page.click('.whiteboard-page-title')
-    await page.fill('.whiteboard-page-title input', "my-whiteboard-3")
-    await page.keyboard.press('Enter')
+  await page.click('.whiteboard-page-title')
+  await page.fill('.whiteboard-page-title input', 'my-whiteboard-3')
+  await page.keyboard.press('Enter')
 
-    const canvas = await page.waitForSelector('.logseq-tldraw');
-    await canvas.dblclick({
-        position: {
-            x: 100,
-            y: 100
-        }
-    })
+  const canvas = await page.waitForSelector('.logseq-tldraw')
+  await canvas.dblclick({
+    position: {
+      x: 100,
+      y: 100,
+    },
+  })
 
-    const quickAdd$ = page.locator('.tl-quick-search')
-    await expect(quickAdd$).toBeVisible()
+  const quickAdd$ = page.locator('.tl-quick-search')
+  await expect(quickAdd$).toBeVisible()
 
-    await page.fill('.tl-quick-search input', 'my-whiteboard')
-    await quickAdd$.locator('.tl-quick-search-option >> text=my-whiteboard-2').first().click()
+  await page.fill('.tl-quick-search input', 'my-whiteboard')
+  await quickAdd$
+    .locator('.tl-quick-search-option >> text=my-whiteboard-2')
+    .first()
+    .click()
 
-    await expect(quickAdd$).toBeHidden()
-    await expect(page.locator('.tl-logseq-portal-container >> text=my-whiteboard-2')).toBeVisible()
+  await expect(quickAdd$).toBeHidden()
+  await expect(
+    page.locator('.tl-logseq-portal-container >> text=my-whiteboard-2')
+  ).toBeVisible()
 })
 
-test.skip('go to another board and check reference', async ({ page }) => {
-    await page.locator('.tl-logseq-portal-container >> text=my-whiteboard-2').click()
-    await expect(page.locator('.whiteboard-page-title .title')).toContainText("my-whiteboard-2");
+test('go to another board and check reference', async ({ page }) => {
+  await page
+    .locator('.tl-logseq-portal-container >> text=my-whiteboard-2')
+    .click()
+  await expect(page.locator('.whiteboard-page-title .title')).toContainText(
+    'my-whiteboard-2'
+  )
 
-    const pageRefCount$ = page.locator('.whiteboard-page-refs-count')
-    await expect(pageRefCount$.locator('.open-page-ref-link')).toContainText('1')
+  const pageRefCount$ = page.locator('.whiteboard-page-refs-count')
+  await expect(pageRefCount$.locator('.open-page-ref-link')).toContainText('1')
 
-    await pageRefCount$.click()
-    await expect(page.locator('.references-blocks')).toBeVisible()
-    await expect(page.locator('.references-blocks >> .page-ref >> text=my-whiteboard-3')).toBeVisible()
+  await pageRefCount$.click()
+  await expect(page.locator('.references-blocks')).toBeVisible()
+  await expect(
+    page.locator('.references-blocks >> .page-ref >> text=my-whiteboard-3')
+  ).toBeVisible()
 })


### PR DESCRIPTION
Since e2e tracing is re-enabled now. We can enable the whiteboard tests again and see what is the error cause if any of them failed.
I manually retriggered the whiteboard test runs, but none of them failed 😅