### PR TITLE
feat: animate canvas camera movement

### DIFF
--- a/tldraw/apps/tldraw-logseq/src/components/ZoomMenu/ZoomMenu.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ZoomMenu/ZoomMenu.tsx
@@ -36,6 +36,7 @@ export const ZoomMenu = observer(function ZoomMenu(): JSX.Element {
           className="tl-menu-item"
           onSelect={preventEvent}
           onClick={app.api.zoomToSelection}
+          disabled={app.selectedShapesArray.length === 0}
         >
           Zoom to selection
           <div className="tl-menu-right-slot">

--- a/tldraw/apps/tldraw-logseq/src/hooks/useQuickAdd.ts
+++ b/tldraw/apps/tldraw-logseq/src/hooks/useQuickAdd.ts
@@ -4,6 +4,9 @@ import type { Shape } from '../lib'
 
 export function useQuickAdd() {
   return React.useCallback<TLReactCallbacks<Shape>['onCanvasDBClick']>(async app => {
-    app.selectTool('logseq-portal').selectedTool.transition('creating')
+    // Give a timeout so that the quick add input will not be blurred too soon
+    setTimeout(() => {
+      app.selectTool('logseq-portal').selectedTool.transition('creating')
+    }, 100)
   }, [])
 }

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
@@ -390,6 +390,12 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
       }
     }, [isEditing, this.props.collapsed])
 
+    React.useEffect(() => {
+      if (isCreating) {
+        app.viewport.zoomToBounds({ ...this.bounds, minY: this.bounds.maxY + 25 })
+      }
+    }, [app.viewport.currentView.height])
+
     const onPageNameChanged = React.useCallback((id: string) => {
       this.initialHeightCalculated = false
       const blockType = validUUID(id) ? 'B' : 'P'

--- a/tldraw/apps/tldraw-logseq/src/lib/tools/LogseqPortalTool/states/CreatingState.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/tools/LogseqPortalTool/states/CreatingState.tsx
@@ -32,9 +32,7 @@ export class CreatingState extends TLToolState<
       this.app.currentPage.addShapes(shape)
       this.app.setEditingShape(shape)
       this.app.setSelectedShapes([shape])
-      if (this.app.viewport.camera.zoom < 0.8 || this.app.viewport.camera.zoom > 1.2) {
-        this.app.api.resetZoomToCursor()
-      }
+      this.app.viewport.zoomToBounds({ ...shape.bounds, minY: shape.bounds.maxY + 200 })
     })
   }
 

--- a/tldraw/apps/tldraw-logseq/src/lib/tools/LogseqPortalTool/states/CreatingState.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/tools/LogseqPortalTool/states/CreatingState.tsx
@@ -32,7 +32,6 @@ export class CreatingState extends TLToolState<
       this.app.currentPage.addShapes(shape)
       this.app.setEditingShape(shape)
       this.app.setSelectedShapes([shape])
-      this.app.viewport.zoomToBounds({ ...shape.bounds, minY: shape.bounds.maxY + 200 })
     })
   }
 

--- a/tldraw/apps/tldraw-logseq/src/styles.css
+++ b/tldraw/apps/tldraw-logseq/src/styles.css
@@ -95,6 +95,10 @@ html[data-theme='light'] {
   .tl-menu-icon {
     @apply absolute left-4 text-base opacity-50;
   }
+
+  &[data-disabled] {
+    @apply opacity-50 pointer-events-none;
+  }
 }
 
 #tl-zoom {

--- a/tldraw/packages/core/src/lib/TLApi/TLApi.ts
+++ b/tldraw/packages/core/src/lib/TLApi/TLApi.ts
@@ -153,7 +153,7 @@ export class TLApi<S extends TLShape = TLShape, K extends TLEventMap = TLEventMa
 
   resetZoomToCursor = (): this => {
     const viewport = this.app.viewport
-    viewport.update({
+    viewport.animate({
       zoom: 1,
       point: Vec.sub(this.app.inputs.originScreenPoint, this.app.inputs.originPoint),
     })

--- a/tldraw/packages/core/src/lib/TLApi/TLApi.ts
+++ b/tldraw/packages/core/src/lib/TLApi/TLApi.ts
@@ -153,7 +153,7 @@ export class TLApi<S extends TLShape = TLShape, K extends TLEventMap = TLEventMa
 
   resetZoomToCursor = (): this => {
     const viewport = this.app.viewport
-    viewport.animate({
+    viewport.animateCamera({
       zoom: 1,
       point: Vec.sub(this.app.inputs.originScreenPoint, this.app.inputs.originPoint),
     })

--- a/tldraw/packages/core/src/lib/TLViewport.ts
+++ b/tldraw/packages/core/src/lib/TLViewport.ts
@@ -3,6 +3,14 @@ import { action, computed, makeObservable, observable } from 'mobx'
 import { FIT_TO_SCREEN_PADDING, ZOOM_UPDATE_FACTOR } from '../constants'
 import type { TLBounds } from '../types'
 
+const ease = (x: number) => {
+  return x * x
+}
+
+const elapsedProgress = (t: number) => {
+  return ease(Vec.clamp(t / 200, 0, 1)) // 200ms
+}
+
 export class TLViewport {
   constructor() {
     makeObservable(this)
@@ -73,8 +81,8 @@ export class TLViewport {
     return Vec.mul(Vec.add(point, camera.point), camera.zoom)
   }
 
-  onZoom = (point: number[], zoom: number): this => {
-    return this.pinchZoom(point, [0, 0], zoom)
+  onZoom = (point: number[], zoom: number, animate = false): this => {
+    return this.pinchZoom(point, [0, 0], zoom, animate)
   }
 
   /**
@@ -84,43 +92,62 @@ export class TLViewport {
    * @param delta The movement delta.
    * @param zoom The new zoom level
    */
-  pinchZoom = (point: number[], delta: number[], zoom: number): this => {
+  pinchZoom = (point: number[], delta: number[], zoom: number, animate = false): this => {
     const { camera } = this
-    const nextPoint = Vec.sub(camera.point, Vec.div(delta, camera.zoom))
-    zoom = Vec.clamp(zoom, TLViewport.minZoom, TLViewport.maxZoom)
-    const p0 = Vec.sub(Vec.div(point, camera.zoom), nextPoint)
-    const p1 = Vec.sub(Vec.div(point, zoom), nextPoint)
-    return this.update({ point: Vec.toFixed(Vec.add(nextPoint, Vec.sub(p1, p0))), zoom })
+
+    const runZoom = (currentZoom: number) => {
+      const nextPoint = Vec.sub(camera.point, Vec.div(delta, camera.zoom))
+      currentZoom = Vec.clamp(currentZoom, TLViewport.minZoom, TLViewport.maxZoom)
+      const p0 = Vec.sub(Vec.div(point, camera.zoom), nextPoint)
+      const p1 = Vec.sub(Vec.div(point, currentZoom), nextPoint)
+      this.update({ point: Vec.toFixed(Vec.add(nextPoint, Vec.sub(p1, p0))), zoom: currentZoom })
+    }
+
+    if (animate) {
+      const diff = zoom - camera.zoom
+      const initialZoom = camera.zoom
+      const startTime = performance.now()
+      const step = () => {
+        const elapsed = performance.now() - startTime
+        const progress = elapsedProgress(elapsed) // 0 ~ 1, 100ms
+        const currentZoom = initialZoom + diff * progress
+        console.log(progress)
+        runZoom(currentZoom)
+        if (progress < 1) {
+          requestAnimationFrame(step)
+        } else {
+          runZoom(zoom)
+        }
+      }
+      step()
+    } else {
+      runZoom(zoom)
+    }
+    return this
   }
 
-  setZoom = (zoom: number) => {
+  setZoom = (zoom: number, animate = false) => {
     const { bounds } = this
     const center = [bounds.width / 2, bounds.height / 2]
-    this.onZoom(center, zoom)
+    this.onZoom(center, zoom, animate)
   }
 
   zoomIn = () => {
     const { camera } = this
-    this.setZoom(camera.zoom / ZOOM_UPDATE_FACTOR)
+    this.setZoom(camera.zoom / ZOOM_UPDATE_FACTOR, true)
   }
 
   zoomOut = () => {
     const { camera, bounds } = this
-    this.setZoom(camera.zoom * ZOOM_UPDATE_FACTOR)
+    this.setZoom(camera.zoom * ZOOM_UPDATE_FACTOR, true)
   }
 
   resetZoom = (): this => {
-    const {
-      bounds,
-      camera: { zoom, point },
-    } = this
-    const center = [bounds.width / 2, bounds.height / 2]
-    const p0 = Vec.sub(Vec.div(center, zoom), point)
-    const p1 = Vec.sub(Vec.div(center, 1), point)
-    return this.update({ point: Vec.toFixed(Vec.add(point, Vec.sub(p1, p0))), zoom: 1 })
+    this.setZoom(1, true)
+    return this
   }
 
-  zoomToBounds = ({ width, height, minX, minY }: TLBounds): this => {
+  zoomToBounds = ({ width, height, minX, minY }: TLBounds) => {
     const { bounds, camera } = this
     let zoom = Math.min(
       (bounds.width - FIT_TO_SCREEN_PADDING) / width,
@@ -137,6 +164,29 @@ export class TLViewport {
       (bounds.width - width * zoom) / 2 / zoom,
       (bounds.height - height * zoom) / 2 / zoom,
     ]
-    return this.update({ point: Vec.add([-minX, -minY], delta), zoom })
+
+    const point = Vec.add([-minX, -minY], delta)
+
+    const originalPoint = camera.point
+    const originalZoom = camera.zoom
+    const zoomDiff = zoom - camera.zoom
+    const positionDiff = Vec.sub(point, camera.point)
+
+    // Animate by default
+    const startTime = performance.now()
+    const step = () => {
+      const elapsed = performance.now() - startTime
+      const progress = elapsedProgress(elapsed) // 0 ~ 1, 100ms
+      const currentZoom = originalZoom + zoomDiff * progress
+      // fixme: the point should be calculated by the CURRENT zoom, not the final zoom
+      const currentPoint = Vec.add(originalPoint, Vec.mul(positionDiff, progress))
+      this.update({ point: currentPoint, zoom: currentZoom })
+      if (progress < 1) {
+        requestAnimationFrame(step)
+      } else {
+        this.update({ point, zoom })
+      }
+    }
+    step()
   }
 }


### PR DESCRIPTION
Apply a transition animation for canvas camera-related actions. The implementation refers to the new beta.tldraw.com.
Also moves the canvas to zoom in to the quick search after creating a portal shape. 

Note the FPS on the simulator is not that smooth because of rendering performance. We still need to improve this.


https://user-images.githubusercontent.com/584378/205478765-c352dec4-f276-45c0-98c1-23750934ba28.mp4

https://user-images.githubusercontent.com/584378/205478585-aecd4a8f-f4f2-4009-8e45-52d967717cd2.mp4

