### PR TITLE
Fix: Highlight text color on light themes

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1925,7 +1925,8 @@
       (when bg-color
         {:style {:background-color (if (some #{bg-color} ui/block-background-colors)
                                      (str "var(--ls-highlight-color-" bg-color ")")
-                                     bg-color)}
+                                     bg-color)
+                 :color (when-not (some #{bg-color} ui/block-background-colors) "white")}
          :class "px-1 with-bg-color"}))
      (remove-nils
       (concat


### PR DESCRIPTION
The highlight colors introduced here https://github.com/logseq/logseq/pull/6821, change depending on the theme mode (dark/light). Highlight color values produced prior to this PR are used as is, so the text is not readable on light themes anymore. This PR fixes the issue by adding an inline color rule for this case.