### PR TITLE
Deprecate: use g c to git commit instead of `c`

### DIFF
--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -420,7 +420,7 @@
    :ui/toggle-cards                 {:binding "t c"
                                      :fn      ui-handler/toggle-cards!}
 
-   :git/commit                      {:binding "c"
+   :git/commit                      {:binding "g c"
                                      :fn      commit/show-commit-modal!}})
 
 (let [keyboard-shortcuts


### PR DESCRIPTION
In general, we should avoid using single char as shortcut, the only exception is for whiteboard actions.