### PR TITLE
fix(typo): wrong case of macOS

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -46,7 +46,7 @@ body:
         Would you mind to tell us the system information about your desktop or mobile platform?
       placeholder: |
         OS version, Browser or App, Logseq App version
-        example: MacOS 12.2, Desktop App v0.5.9
+        example: macOS 12.2, Desktop App v0.5.9
         example: iPhone 12, iOS8.1, v0.5.9
         example: Pixel XL, Android 12, v0.5.9
     validations:


### PR DESCRIPTION
When I created a new issue for logseq, I noticed that there is a typo **MacOS** in the hint of `Desktop or Mobile Platform Information`. The name with correct case should be **macOS**.

<img width="565" alt="image" src="https://user-images.githubusercontent.com/28241963/205932325-7804c578-a663-4d58-9b2d-6711b7519ac4.png">
