### PR TITLE
fix: Link can't be pasted on selected text in block content

### DIFF
--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -19,7 +19,8 @@
             [frontend.handler.notification :as notification]
             [frontend.util.text :as text-util]
             [frontend.format.mldoc :as mldoc]
-            [lambdaisland.glogi :as log]))
+            [lambdaisland.glogi :as log]
+            [frontend.handler.editor :as editor]))
 
 (defn- paste-text-parseable
   [format text]
@@ -155,10 +156,11 @@
   (utils/getClipText
    (fn [clipboard-data]
      (when-let [_ (state/get-input)]
-       (let [data (or (when (gp-util/url? clipboard-data)
-                        (wrap-macro-url clipboard-data))
-                      clipboard-data)]
-         (editor-handler/insert data true))))
+       (if (gp-util/url? clipboard-data)
+         (if (string/blank? (util/get-selected-text))
+           (editor-handler/insert (or (wrap-macro-url clipboard-data) clipboard-data) true)
+           (editor-handler/html-link-format! clipboard-data))
+         (editor-handler/insert clipboard-data true))))
    (fn [error]
      (js/console.error error))))
 

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -19,8 +19,7 @@
             [frontend.handler.notification :as notification]
             [frontend.util.text :as text-util]
             [frontend.format.mldoc :as mldoc]
-            [lambdaisland.glogi :as log]
-            [frontend.handler.editor :as editor]))
+            [lambdaisland.glogi :as log]))
 
 (defn- paste-text-parseable
   [format text]


### PR DESCRIPTION
fixes #7268

Fixed by testing whether text is selected while pasting and formatting accordingly

The code is kinda ugly, but I don't know of a nicer way