### PR TITLE
Enhance: Validate global config

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -66,8 +66,8 @@
   dev:validate-plugins-edn
   logseq.tasks.malli/validate-plugins-edn
 
-  dev:validate-global-config-edn
-  logseq.tasks.malli/validate-global-config-edn
+  dev:validate-config-edn
+  logseq.tasks.malli/validate-config-edn
 
   dev:lint
   logseq.tasks.dev/lint

--- a/bb.edn
+++ b/bb.edn
@@ -66,6 +66,9 @@
   dev:validate-plugins-edn
   logseq.tasks.malli/validate-plugins-edn
 
+  dev:validate-global-config-edn
+  logseq.tasks.malli/validate-global-config-edn
+
   dev:lint
   logseq.tasks.dev/lint
 

--- a/scripts/src/logseq/tasks/malli.clj
+++ b/scripts/src/logseq/tasks/malli.clj
@@ -3,6 +3,7 @@
   (:require [malli.core :as m]
             [malli.error :as me]
             [frontend.schema.handler.plugin-config :as plugin-config-schema]
+            [frontend.schema.handler.global-config :as global-config-schema]
             [clojure.pprint :as pprint]
             [clojure.edn :as edn]))
 
@@ -13,6 +14,19 @@
                        slurp
                        edn/read-string
                        (m/explain plugin-config-schema/Plugins-edn)
+                       me/humanize)]
+    (do
+      (println "Found errors:")
+      (pprint/pprint errors))
+    (println "Valid!")))
+
+(defn validate-global-config-edn
+  "Validate a global config.edn file"
+  [file]
+  (if-let [errors (->> file
+                       slurp
+                       edn/read-string
+                       (m/explain global-config-schema/Config-edn)
                        me/humanize)]
     (do
       (println "Found errors:")

--- a/scripts/src/logseq/tasks/malli.clj
+++ b/scripts/src/logseq/tasks/malli.clj
@@ -20,8 +20,9 @@
       (pprint/pprint errors))
     (println "Valid!")))
 
-(defn validate-global-config-edn
-  "Validate a global config.edn file"
+;; This fn should be split if the global and repo definitions diverge
+(defn validate-config-edn
+  "Validate a global or repo config.edn file"
   [file]
   (if-let [errors (->> file
                        slurp

--- a/src/main/frontend/handler/file.cljs
+++ b/src/main/frontend/handler/file.cljs
@@ -85,6 +85,36 @@
     :else
     nil))
 
+(defn- validate-file
+  "Returns true if valid and if false validator displays error message. Files
+  that are not validated just return true"
+  [path content]
+  (if (and
+       (config/global-config-enabled?)
+       (= (path/dirname path) (global-config-handler/global-config-dir)))
+    (global-config-handler/validate-config-edn path content)
+    true))
+
+(defn- validate-and-write-file
+  "Validates and if valid writes file. Returns boolean indicating if file content was valid"
+  [repo path content write-file-options]
+  (let [original-content (db/get-file repo path)
+        path-dir (if (and
+                      (config/global-config-enabled?)
+                      ;; Hack until we better understand failure in error handler
+                      (global-config-handler/global-config-dir-exists?)
+                      (= (path/dirname path) (global-config-handler/global-config-dir)))
+                   (global-config-handler/global-config-dir)
+                   (config/get-repo-dir repo))
+        write-file-options' (merge write-file-options
+                                   (when original-content {:old-content original-content}))]
+    (p/do!
+     (if (validate-file path content)
+       (do
+         (fs/write-file! repo path-dir path content write-file-options')
+         true)
+       false))))
+
 ;; TODO: Remove this function in favor of `alter-files`
 (defn alter-file
   [repo path content {:keys [reset? re-render-root? from-disk? skip-compare? new-graph? verbose
@@ -94,19 +124,9 @@
                            from-disk? false
                            skip-compare? false}}]
   (let [path (gp-util/path-normalize path)
-        original-content (db/get-file repo path)
         write-file! (if from-disk?
-                      #(p/resolved nil)
-                      #(let [path-dir (if (and
-                                           (config/global-config-enabled?)
-                                           ;; Hack until we better understand failure in error handler
-                                           (global-config-handler/global-config-dir-exists?)
-                                           (= (path/dirname path) (global-config-handler/global-config-dir)))
-                                        (global-config-handler/global-config-dir)
-                                        (config/get-repo-dir repo))]
-                         (fs/write-file! repo path-dir path content
-                                        (assoc (when original-content {:old-content original-content})
-                                               :skip-compare? skip-compare?))))
+                      #(p/promise (validate-file path content))
+                      #(validate-and-write-file repo path content {:skip-compare? skip-compare?}))
         opts {:new-graph? new-graph?
               :from-disk? from-disk?
               :skip-db-transact? skip-db-transact?}
@@ -115,14 +135,14 @@
                    (when-not skip-db-transact?
                      (when-let [page-id (db/get-file-page-id path)]
                        (db/transact! repo
-                         [[:db/retract page-id :block/alias]
-                          [:db/retract page-id :block/tags]]
-                         opts)))
+                                     [[:db/retract page-id :block/alias]
+                                      [:db/retract page-id :block/tags]]
+                                     opts)))
                    (file-common-handler/reset-file! repo path content (merge opts
                                                                              (when (some? verbose) {:verbose verbose}))))
                  (db/set-file-content! repo path content opts))]
     (util/p-handle (write-file!)
-                   (fn [_]
+                   (fn [valid-result?]
                      (when re-render-root? (ui-handler/re-render-root!))
 
                      (cond
@@ -131,11 +151,13 @@
 
                        (= path (config/get-repo-config-path repo))
                        (p/let [_ (repo-config-handler/restore-repo-config! repo content)]
-                         (state/pub-event! [:shortcut/refresh]))
+                              (state/pub-event! [:shortcut/refresh]))
 
-                       (and (config/global-config-enabled?) (= path (global-config-handler/global-config-path)))
+                       (and (config/global-config-enabled?)
+                            (= path (global-config-handler/global-config-path))
+                            valid-result?)
                        (p/let [_ (global-config-handler/restore-global-config!)]
-                         (state/pub-event! [:shortcut/refresh]))))
+                              (state/pub-event! [:shortcut/refresh]))))
                    (fn [error]
                      (when (and (config/global-config-enabled?)
                                 ;; Global-config not started correctly but don't

--- a/src/main/frontend/handler/global_config.cljs
+++ b/src/main/frontend/handler/global_config.cljs
@@ -4,10 +4,17 @@
   component depends on a repo."
   (:require [frontend.fs :as fs]
             [frontend.handler.common.file :as file-common-handler]
+            [frontend.handler.notification :as notification]
+            [frontend.schema.handler.global-config :as global-config-schema]
             [frontend.state :as state]
             [cljs.reader :as reader]
             [promesa.core :as p]
             [shadow.resource :as rc]
+            [malli.error :as me]
+            [malli.core :as m]
+            [goog.string :as gstring]
+            [clojure.edn :as edn]
+            [clojure.string :as string]
             [electron.ipc :as ipc]
             ["path" :as path]))
 
@@ -55,6 +62,63 @@
         config-path (global-config-path)]
     (p/let [config-content (fs/read-file config-dir config-path)]
            (set-global-config-state! config-content))))
+
+(defn- humanize-more
+  "Make error maps from me/humanize more readable for users. Doesn't try to handle
+nested keys or positional errors e.g. tuples"
+  [errors]
+  (map
+   (fn [[k v]]
+     (if (map? v)
+       [k (str "Has errors in the following keys - " (string/join ", " (keys v)))]
+       ;; Only show first error since we don't have a use case yet for multiple yet
+       [k (->> v flatten (remove nil?) first)]))
+   errors))
+
+(defn- validate-config-map
+  [m path]
+  (if-let [errors (->> m
+                       (m/explain global-config-schema/Config-edn)
+                       me/humanize
+                       seq)]
+    (do
+      (notification/show! (gstring/format "The file '%s' has the following errors:\n%s"
+                                          path
+                                          (->> errors
+                                               humanize-more
+                                               (map (fn [[k v]]
+                                                      (str k " - " v)))
+                                               (string/join "\n")))
+                          :error)
+      false)
+    true))
+
+(defn validate-config-edn
+  "Validates a global config.edn file for correctness and pops up an error
+  notification if invalid. Returns a boolean indicating if file is invalid.
+  Error messages are written with consideration that this validation is called
+  regardless of whether a file is written outside or inside Logseq."
+  [path file-body]
+  (let [parsed-body (try
+                      (edn/read-string file-body)
+                      (catch :default _ ::failed-to-read))]
+    (cond
+      (= ::failed-to-read parsed-body)
+      (do
+        (notification/show! (gstring/format "Failed to read file '%s'. Make sure your config is wrapped
+in {}. Also make sure that the characters '( { [' have their corresponding closing character ') } ]'."
+                                            path)
+                            :error)
+        false)
+      ;; Custom error message is better than malli's "invalid type" error
+      (not (map? parsed-body))
+      (do
+        (notification/show! (gstring/format "The file '%s' is not valid. Make sure the config is wrapped in {}."
+                                            path)
+                            :error)
+        false)
+      :else
+      (validate-config-map parsed-body path))))
 
 (defn start
   "This component has four responsibilities on start:

--- a/src/main/frontend/handler/global_config.cljs
+++ b/src/main/frontend/handler/global_config.cljs
@@ -7,7 +7,6 @@
             [frontend.handler.notification :as notification]
             [frontend.schema.handler.global-config :as global-config-schema]
             [frontend.state :as state]
-            [cljs.reader :as reader]
             [promesa.core :as p]
             [shadow.resource :as rc]
             [malli.error :as me]
@@ -39,7 +38,7 @@
 
 (defn- set-global-config-state!
   [content]
-  (let [config (reader/read-string content)]
+  (let [config (edn/read-string content)]
     (state/set-global-config! config)
     config))
 
@@ -77,10 +76,7 @@ nested keys or positional errors e.g. tuples"
 
 (defn- validate-config-map
   [m path]
-  (if-let [errors (->> m
-                       (m/explain global-config-schema/Config-edn)
-                       me/humanize
-                       seq)]
+  (if-let [errors (->> m (m/explain global-config-schema/Config-edn) me/humanize)]
     (do
       (notification/show! (gstring/format "The file '%s' has the following errors:\n%s"
                                           path

--- a/src/main/frontend/schema/handler/common_config.cljc
+++ b/src/main/frontend/schema/handler/common_config.cljc
@@ -1,0 +1,78 @@
+(ns frontend.schema.handler.common-config
+  "Schema that is common for global-config and repo-config"
+  (:require [malli.util :as mu]))
+
+(def Config-edn
+  (mu/optional-keys
+   [:map
+    [:meta/version :int]
+    ;; Loose since it looks like capitalization and string are possible
+    [:preferred-format [:or :keyword :string]]
+    [:preferred-workflow [:enum :now :todo]]
+    [:hidden [:vector :string]]
+    [:default-templates [:map-of
+                         [:enum :journals]
+                         :string]]
+    [:ui/enable-tooltip? :boolean]
+    [:feature/enable-block-timestamps? :boolean]
+    [:feature/enable-search-remove-accents? :boolean]
+    [:feature/disable-scheduled-and-deadline-query? :boolean]
+    [:start-of-week [:enum 0 1 2 3 4 5 6]]
+    [:custom-css-url :string]
+    [:export/bullet-indentation
+     [:enum :eight-spaces :four-spaces :two-spaces :tab]]
+    [:publishing/all-pages-public? :boolean]
+    [:default-home [:map
+                    [:page {:optional true} :string]
+                    [:sidebar {:optional true} [:or :string [:vector :string]]]]]
+    [:pages-directory :string]
+    [:journal-directory :string]
+    [:org-mode/insert-file-link? :boolean]
+    [:shortcuts [:map-of
+                 :keyword
+                 [:or :string [:vector :string]]]]
+    [:shortcut/doc-mode-enter-for-new-block? :boolean]
+    [:block/content-max-length :int]
+    [:ui/show-command-doc? :boolean]
+    [:ui/show-empty-bullets? :boolean]
+    [:query/views [:map-of
+                   :keyword
+                   [:sequential any?]]]
+    [:query/result-transforms [:map-of
+                               :keyword
+                               [:sequential any?]]]
+    [:default-queries [:map
+                       ;; Maybe validate these query maps later
+                       [:journals [:vector :map]]]]
+    [:commands [:vector [:tuple :string :string]]]
+    [:outliner/block-title-collapse-enabled? :boolean]
+    [:macros [:map-of
+              :string
+              :string]]
+    [:ref/default-open-blocks-level :int]
+    [:ref/linked-references-collapsed-threshold :int]
+    [:favorites [:vector :string]]
+    ;; There isn't a :float yet
+    [:srs/learning-fraction float?]
+    [:srs/initial-interval :int]
+    [:block-hidden-properties [:set :keyword]]
+    [:property-pages/enabled? :boolean]
+    [:property-pages/excludelist [:set :keyword]]
+    [:property/separated-by-commas [:set :keyword]]
+    [:logbook/settings :map]
+    [:mobile/photo [:map
+                    [:allow-editing? {:optional true} :boolean]
+                    [:quality {:optional true} :int]]]
+    [:mobile [:map
+              [:gestures/disabled-in-block-with-tags {:optional true} [:vector :string]]]]
+    [:editor/extra-codemirror-options :map]
+    [:ignored-page-references-keywords [:set :keyword]]
+    [:quick-capture-templates [:map
+                               [:text {:optional true} :string]
+                               [:media {:optional true} :string]]]
+    [:quick-capture-options [:map
+                             [:insert-today? {:optional true} :boolean]
+                             [:redirect-page? {:optional true} :boolean]]]
+    [:file-sync/ignore-files [:vector :string]]
+    [:dwim/settings [:map-of :keyword :boolean]]
+    [:file/name-format [:enum :legacy :triple-lowbar]]]))

--- a/src/main/frontend/schema/handler/common_config.cljc
+++ b/src/main/frontend/schema/handler/common_config.cljc
@@ -14,8 +14,11 @@
                          [:enum :journals]
                          :string]]
     [:ui/enable-tooltip? :boolean]
+    [:ui/show-brackets? :boolean]
     [:feature/enable-block-timestamps? :boolean]
     [:feature/enable-search-remove-accents? :boolean]
+    [:feature/enable-journals? :boolean]
+    [:feature/enable-flashcards? :boolean]
     [:feature/disable-scheduled-and-deadline-query? :boolean]
     [:start-of-week [:enum 0 1 2 3 4 5 6]]
     [:custom-css-url :string]
@@ -59,6 +62,7 @@
     [:property-pages/enabled? :boolean]
     [:property-pages/excludelist [:set :keyword]]
     [:property/separated-by-commas [:set :keyword]]
+    [:ignored-page-references-keywords [:set :keyword]]
     [:logbook/settings :map]
     [:mobile/photo [:map
                     [:allow-editing? {:optional true} :boolean]
@@ -66,7 +70,8 @@
     [:mobile [:map
               [:gestures/disabled-in-block-with-tags {:optional true} [:vector :string]]]]
     [:editor/extra-codemirror-options :map]
-    [:ignored-page-references-keywords [:set :keyword]]
+    [:editor/logical-outdenting? :boolean]
+    [:editor/preferred-pasting-file? :boolean]
     [:quick-capture-templates [:map
                                [:text {:optional true} :string]
                                [:media {:optional true} :string]]]

--- a/src/main/frontend/schema/handler/global_config.cljc
+++ b/src/main/frontend/schema/handler/global_config.cljc
@@ -1,0 +1,9 @@
+(ns frontend.schema.handler.global-config
+  "Malli schemas for global-config"
+  (:require [frontend.schema.handler.common-config :as common-config]))
+
+;; For now this just references a common schema but repo-config and
+;; global-config could diverge
+(def Config-edn
+  "Schema for global config.edn"
+  common-config/Config-edn)

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -17,8 +17,7 @@
             [logseq.graph-parser.config :as gp-config]
             [medley.core :as medley]
             [promesa.core :as p]
-            [rum.core :as rum]
-            [logseq.graph-parser.log :as log]))
+            [rum.core :as rum]))
 
 ;; Stores main application state
 (defonce ^:large-vars/data-var state
@@ -335,19 +334,10 @@ should be done through this fn in order to get global config and config defaults
   ([]
    (get-config (get-current-repo)))
   ([repo-url]
-   (try
-     (merge-configs
-      default-config
-      (get-in @state [:config ::global-config])
-      (get-in @state [:config repo-url]))
-     (catch :default e
-       (do
-         (log/error "Cannot parse global config file" e)
-         (log/error "Restore repo config")
-         ;; NOTE: Since repo config is guarded by a try-catch, we can safely failback to it
-         (merge-configs
-          default-config
-          (get-in @state [:config repo-url])))))))
+   (merge-configs
+    default-config
+    (get-in @state [:config ::global-config])
+    (get-in @state [:config repo-url]))))
 
 (defonce publishing? (atom nil))
 
@@ -560,15 +550,9 @@ Similar to re-frame subscriptions"
   ([] (sub-config (get-current-repo)))
   ([repo]
    (let [config (sub :config)]
-     (try
-       (merge-configs default-config
-                      (get config ::global-config)
-                      (get config repo))
-       (catch :default e
-         (do
-           (log/error "Cannot parse config files" e)
-           (log/error "Restore default config")
-           default-config))))))
+     (merge-configs default-config
+                    (get config ::global-config)
+                    (get config repo)))))
 
 (defn enable-grammarly?
   []

--- a/src/test/frontend/handler/global_config_test.cljs
+++ b/src/test/frontend/handler/global_config_test.cljs
@@ -1,0 +1,32 @@
+(ns frontend.handler.global-config-test
+  (:require [clojure.test :refer [is testing deftest]]
+            [frontend.handler.global-config :as global-config-handler]
+            [clojure.string :as string]
+            [frontend.handler.notification :as notification]))
+
+(defn- validation-config-error-for
+  [config-body]
+  (let [error-message (atom nil)]
+      (with-redefs [notification/show! (fn [msg _] (reset! error-message msg))]
+        (is (= false
+               (global-config-handler/validate-config-edn "config.edn" config-body)))
+        (str @error-message))))
+
+(deftest validate-config-edn
+  (testing "Valid cases"
+    (is (= true
+           (global-config-handler/validate-config-edn
+            "config.edn" "{:preferred-workflow :todo}"))))
+
+  (testing "Invalid cases"
+    (is (string/includes?
+         (validation-config-error-for ":export/bullet-indentation :two-spaces")
+         "wrapped in {}"))
+
+    (is (string/includes?
+         (validation-config-error-for "{:preferred-workflow :todo")
+         "Failed to read"))
+
+    (is (string/includes?
+         (validation-config-error-for "{:start-of-week 7}")
+         "has the following errors"))))


### PR DESCRIPTION
This adds validation to global config to improve the user experience when editing global config and to prevent invalid config data that can cause unexpected failures like https://github.com/logseq/logseq/issues/7392.  Validation works whether the global config is edited inside or outside of Logseq. If this validation works fairly well for global config, it would be pretty easy to also add it to the repo config.edn