### PR TITLE
fix: remove spaces around CJK characters when auto-complete pages

### DIFF
--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -335,11 +335,15 @@
                            (+ current-pos i)))
                        current-pos)
           orig-prefix (subs edit-content 0 current-pos)
+          postfix (subs edit-content current-pos)
+          postfix (if postfix-fn (postfix-fn postfix) postfix)
           space? (let [space? (when (and last-pattern orig-prefix)
                                 (let [s (when-let [last-index (string/last-index-of orig-prefix last-pattern)]
                                           (gp-util/safe-subs orig-prefix 0 last-index))]
                                   (not
                                    (or
+                                    (util/cjk-string? (str (last orig-prefix)))
+                                    (util/cjk-string? (str (first postfix)))
                                     (and s
                                          (string/ends-with? s "(")
                                          (or (string/starts-with? last-pattern block-ref/left-parens)
@@ -365,8 +369,6 @@
 
                    :else
                    (util/replace-last last-pattern orig-prefix value space?))
-          postfix (subs edit-content current-pos)
-          postfix (if postfix-fn (postfix-fn postfix) postfix)
           new-value (cond
                       (string/blank? postfix)
                       prefix
@@ -380,11 +382,7 @@
                      (or backward-pos 0))]
       (when-not (string/blank? new-value)
         (state/set-block-content-and-last-pos! id new-value new-pos)
-        (cursor/move-cursor-to input
-                               (if (and (or backward-pos forward-pos)
-                                        (not= end-pattern page-ref/right-brackets))
-                                 new-pos
-                                 (inc new-pos)))))))
+        (cursor/move-cursor-to input new-pos)))))
 
 (defn simple-insert!
   [id value

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -322,7 +322,7 @@
 
 (defn insert!
   [id value
-   {:keys [last-pattern postfix-fn backward-pos forward-pos end-pattern backward-truncate-number command]
+   {:keys [last-pattern postfix-fn backward-pos end-pattern backward-truncate-number command]
     :as _option}]
   (when-let [input (gdom/getElement id)]
     (let [last-pattern (when-not backward-truncate-number
@@ -342,7 +342,8 @@
                                           (gp-util/safe-subs orig-prefix 0 last-index))]
                                   (not
                                    (or
-                                    (and (not= command :block-ref)
+                                    (and (= :page-ref command)
+                                         (util/cjk-string? value)
                                          (or (util/cjk-string? (str (last orig-prefix)))
                                              (util/cjk-string? (str (first postfix)))))
                                     (and s

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -322,7 +322,7 @@
 
 (defn insert!
   [id value
-   {:keys [last-pattern postfix-fn backward-pos forward-pos end-pattern backward-truncate-number]
+   {:keys [last-pattern postfix-fn backward-pos forward-pos end-pattern backward-truncate-number command]
     :as _option}]
   (when-let [input (gdom/getElement id)]
     (let [last-pattern (when-not backward-truncate-number
@@ -342,8 +342,9 @@
                                           (gp-util/safe-subs orig-prefix 0 last-index))]
                                   (not
                                    (or
-                                    (util/cjk-string? (str (last orig-prefix)))
-                                    (util/cjk-string? (str (first postfix)))
+                                    (and (not= command :block-ref)
+                                         (or (util/cjk-string? (str (last orig-prefix)))
+                                             (util/cjk-string? (str (first postfix)))))
                                     (and s
                                          (string/ends-with? s "(")
                                          (or (string/starts-with? last-pattern block-ref/left-parens)

--- a/src/main/frontend/components/datetime.cljs
+++ b/src/main/frontend/components/datetime.cljs
@@ -163,7 +163,7 @@
                (editor-handler/insert-command! id
                                                (page-ref/->page-ref journal)
                                                format
-                                               nil)
+                                               {:command :page-ref})
                (state/clear-editor-action!)
                (reset! commands/*current-command nil))))})
        (when deadline-or-schedule?

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -76,7 +76,8 @@
                                    (not (contains? #{"Date picker" "Template" "Deadline" "Scheduled" "Upload an image"} command))))]
               (editor-handler/insert-command! id command-steps
                                               format
-                                              {:restore? restore-slash?}))))
+                                              {:restore? restore-slash?
+                                               :command command}))))
         :class
         "black"}))))
 
@@ -89,7 +90,8 @@
        {:on-chosen (fn [chosen]
                      (editor-handler/insert-command! id (get (into {} matched) chosen)
                                                      format
-                                                     {:last-pattern commands/angle-bracket}))
+                                                     {:last-pattern commands/angle-bracket
+                                                      :command :block-commands}))
         :class     "black"}))))
 
 (defn- in-sidebar? [el]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1478,7 +1478,8 @@
                                        image?)
                   format
                   {:last-pattern (if drop-or-paste? "" (state/get-editor-command-trigger))
-                   :restore?     true})))))
+                   :restore?     true
+                   :command      :insert-asset})))))
           (p/finally
             (fn []
               (reset! uploading? false)
@@ -1732,7 +1733,8 @@
                id
                (get-link format link label)
                format
-               {:last-pattern (str (state/get-editor-command-trigger) "link")})))
+               {:last-pattern (str (state/get-editor-command-trigger) "link")
+                :command :link})))
 
     :image-link (let [{:keys [link label]} m]
                   (when (not (string/blank? link))
@@ -1740,7 +1742,8 @@
                      id
                      (get-image-link format link label)
                      format
-                     {:last-pattern (str (state/get-editor-command-trigger) "link")})))
+                     {:last-pattern (str (state/get-editor-command-trigger) "link")
+                      :command :image-link})))
 
     nil)
 
@@ -1858,7 +1861,8 @@
                        {:last-pattern (str block-ref/left-parens (if @*selected-text "" q))
                         :end-pattern block-ref/right-parens
                         :postfix-fn   (fn [s] (util/replace-first block-ref/right-parens s ""))
-                        :forward-pos 3})
+                        :forward-pos 3
+                        :command :block-ref})
 
       ;; Save it so it'll be parsed correctly in the future
       (set-block-property! (:block/uuid chosen)
@@ -1890,7 +1894,7 @@
            {:block/page {:db/id (:db/id page)}
             :block/format format
             :block/properties (apply dissoc (:block/properties block)
-                                (concat 
+                                (concat
                                   (when (not keep-uuid?) [:id])
                                   [:custom_id :custom-id]
                                   exclude-properties))
@@ -2837,7 +2841,8 @@
                   (insert-command! input-id
                                    (last (first matched-block-commands))
                                    format
-                                   {:last-pattern commands/angle-bracket}))
+                                   {:last-pattern commands/angle-bracket
+                                    :command :block-commands}))
 
                 :else
                 (reset! commands/*matched-block-commands matched-block-commands))

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -771,19 +771,18 @@
                        (page-ref/->page-ref chosen)
                        chosen)
               q (if @editor-handler/*selected-text "" q)
-              [last-pattern forward-pos] (if wrapped?
-                                           [q 3]
-                                           (if (= \# (first q))
-                                             [(subs q 1) 1]
-                                             [q 2]))
+              last-pattern (if wrapped?
+                             q
+                             (if (= \# (first q))
+                               (subs q 1)
+                               q))
               last-pattern (str "#" (when wrapped? page-ref/left-brackets) last-pattern)]
           (editor-handler/insert-command! id
                                           (str "#" (when wrapped? page-ref/left-brackets) chosen)
                                           format
                                           {:last-pattern last-pattern
                                            :end-pattern (when wrapped? page-ref/right-brackets)
-                                           :forward-pos forward-pos
-                                           :command :tag-page-ref})))
+                                           :command :page-ref})))
       (fn [chosen _click?]
         (state/clear-editor-action!)
         (let [prefix (str (t :new-page) ": ")
@@ -797,7 +796,6 @@
                                           {:last-pattern (str page-ref/left-brackets (if @editor-handler/*selected-text "" q))
                                            :end-pattern page-ref/right-brackets
                                            :postfix-fn   (fn [s] (util/replace-first page-ref/right-brackets s ""))
-                                           :forward-pos 3
                                            :command :page-ref}))))))
 
 (defn create-today-journal!

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -782,7 +782,8 @@
                                           format
                                           {:last-pattern last-pattern
                                            :end-pattern (when wrapped? page-ref/right-brackets)
-                                           :forward-pos forward-pos})))
+                                           :forward-pos forward-pos
+                                           :command :tag-page-ref})))
       (fn [chosen _click?]
         (state/clear-editor-action!)
         (let [prefix (str (t :new-page) ": ")
@@ -796,7 +797,8 @@
                                           {:last-pattern (str page-ref/left-brackets (if @editor-handler/*selected-text "" q))
                                            :end-pattern page-ref/right-brackets
                                            :postfix-fn   (fn [s] (util/replace-first page-ref/right-brackets s ""))
-                                           :forward-pos 3}))))))
+                                           :forward-pos 3
+                                           :command :page-ref}))))))
 
 (defn create-today-journal!
   []

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -537,6 +537,10 @@
            (when-not not-space? " ")
            (triml-without-newlines right)))))
 
+(defn cjk-string?
+  [s]
+  (re-find #"[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uff66-\uff9f]" s))
+
 ;; Add documentation
 (defn replace-first [pattern s new-value]
   (if-let [first-index (string/index-of s pattern)]
@@ -1437,7 +1441,7 @@
 (defn memoize-last
   "Different from core.memoize, it only cache the last result.
    Returns a memoized version of a referentially transparent function. The
-  memoized version of the function cache the the last result, and replay when calls 
+  memoized version of the function cache the the last result, and replay when calls
    with the same arguments, or update cache when with different arguments."
   [f]
   (let [last-mem (atom nil)


### PR DESCRIPTION
close #5929