### PR TITLE
Update code edit for the codeblocks that are opened in main area and sidebar, as embeds.

### DIFF
--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -260,8 +260,13 @@
                 state)
    :did-update (fn [state]
                  (reset! (:code-options state) (last (:rum/args state)))
-                 (.setValue @(:editor-atom state)
-                            (string/join "" (butlast (:lines (last (:rum/args state))))))
+                 (->> state
+                      :rum/args
+                      last
+                      :lines
+                      butlast
+                      (string/join "")
+                      (.setValue @(:editor-atom state)))
                  state)}
   [state _config id attr code _theme _options]
   [:div.extensions__code

--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -260,6 +260,8 @@
                 state)
    :did-update (fn [state]
                  (reset! (:code-options state) (last (:rum/args state)))
+                 (.setValue @(:editor-atom state)
+                            (string/join "" (butlast (:lines (last (:rum/args state))))))
                  state)}
   [state _config id attr code _theme _options]
   [:div.extensions__code


### PR DESCRIPTION
Fixes #7460 

The bug: 
![Screenshot from 2022-12-08 16-21-44](https://user-images.githubusercontent.com/22994594/206429200-c9b6a100-3651-414b-8de4-9365d42ea4f5.png)

After fix:
![Screenshot from 2022-12-08 16-21-07](https://user-images.githubusercontent.com/22994594/206429211-ee07154d-ad35-4d60-9543-8cd67729ca37.png)


From my understanding, the issue is that  `block/content` of every codeblock updates (the main and referenced/embed block included) but the codemirror view updates only for the block that is being edited. 

This solution might be the best solution and I could be missing something trivial, if that's the case please let me know. 

cc @andelf 