### PR TITLE
chore: replace hard-coded text with existing i18n key

### DIFF
--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -118,7 +118,7 @@
         :icon (ui/icon "brand-discord")}
        
        {:title [:div.flex-row.flex.justify-between.items-center
-                [:span "Bug report"]]
+                [:span (t :help/bug)]]
         :options {:href bug-report-url
                   :title "Fire a bug report on Github"
                   :target "_blank"}

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -453,7 +453,7 @@
    [:div.mt-1.sm:mt-0.sm:col-span-2
     [:div
      (ui/button
-       "Settings"
+       (t :settings)
        :class "text-sm p-1"
        :style {:margin-top "0px"}
        :on-click


### PR DESCRIPTION
There are some translated keys in i18n file, but logseq does not replace the origin hard-coded text in the code with the i18n key. After replacing them, everything looks good to me.

Note: Screenshots are taken under language Chinese(Simpified)

<img width="743" alt="image" src="https://user-images.githubusercontent.com/28241963/206443773-e5e9d2bf-f23d-40d3-aec4-3e31c1eb6a2e.png">

<img width="327" alt="image" src="https://user-images.githubusercontent.com/28241963/206443906-f86ead31-b710-4617-8e4d-1969cab55c58.png">

By the way, I also found that there are some hard-coded text in settings, I would like to translate them.

<img width="1034" alt="image" src="https://user-images.githubusercontent.com/28241963/206444524-4caea0d1-bb7b-43a4-bed3-aeef2bd7aa1e.png">

