### PR TITLE
Feat: Use tooltips instead of titles on whiteboard buttons

### DIFF
--- a/e2e-tests/whiteboards.spec.ts
+++ b/e2e-tests/whiteboards.spec.ts
@@ -81,7 +81,7 @@ test('set whiteboard title', async ({ page }) => {
 })
 
 test('select rectangle tool', async ({ page }) => {
-  await page.keyboard.press('7')
+  await page.keyboard.press('r')
   await expect(
     page.locator('.tl-geometry-tools-pane-anchor [title*="Rectangle"]')
   ).toHaveAttribute('data-selected', 'true')
@@ -91,7 +91,7 @@ test('draw a rectangle', async ({ page }) => {
   const canvas = await page.waitForSelector('.logseq-tldraw')
   const bounds = (await canvas.boundingBox())!
 
-  await page.keyboard.press('7')
+  await page.keyboard.press('r')
 
   await page.mouse.move(bounds.x + 5, bounds.y + 5)
   await page.mouse.down()

--- a/e2e-tests/whiteboards.spec.ts
+++ b/e2e-tests/whiteboards.spec.ts
@@ -80,13 +80,6 @@ test('set whiteboard title', async ({ page }) => {
   )
 })
 
-test('select rectangle tool', async ({ page }) => {
-  await page.keyboard.press('r')
-  await expect(
-    page.locator('.tl-geometry-tools-pane-anchor [title*="Rectangle"]')
-  ).toHaveAttribute('data-selected', 'true')
-})
-
 test('draw a rectangle', async ({ page }) => {
   const canvas = await page.waitForSelector('.logseq-tldraw')
   const bounds = (await canvas.boundingBox())!

--- a/tldraw/apps/tldraw-logseq/package.json
+++ b/tldraw/apps/tldraw-logseq/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-switch": "^1.0.1",
     "@radix-ui/react-toggle": "^1.0.1",
     "@radix-ui/react-toggle-group": "^1.0.1",
+    "@radix-ui/react-tooltip": "^1.0.2",
     "@tldraw/core": "2.0.0-alpha.1",
     "@tldraw/react": "2.0.0-alpha.1",
     "@tldraw/vec": "2.0.0-alpha.1",

--- a/tldraw/apps/tldraw-logseq/src/components/ActionBar/ActionBar.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ActionBar/ActionBar.tsx
@@ -31,19 +31,19 @@ export const ActionBar = observer(function ActionBar(): JSX.Element {
   return (
     <div className="tl-action-bar">
       <div className="tl-toolbar tl-history-bar">
-        <Button title="Undo" onClick={undo}>
+        <Button tooltip="Undo" onClick={undo}>
           <TablerIcon name="arrow-back-up" />
         </Button>
-        <Button title="Redo" onClick={redo}>
+        <Button tooltip="Redo" onClick={redo}>
           <TablerIcon name="arrow-forward-up" />
         </Button>
       </div>
 
       <div className="tl-toolbar tl-zoom-bar">
-        <Button title="Zoom in" onClick={zoomIn} id="tl-zoom-in">
+        <Button tooltip="Zoom in" onClick={zoomIn} id="tl-zoom-in">
           <TablerIcon name="plus" />
         </Button>
-        <Button title="Zoom out" onClick={zoomOut} id="tl-zoom-out">
+        <Button tooltip="Zoom out" onClick={zoomOut} id="tl-zoom-out">
           <TablerIcon name="minus" />
         </Button>
         <Separator.Root className="tl-toolbar-separator" orientation="vertical" />

--- a/tldraw/apps/tldraw-logseq/src/components/ActionBar/ActionBar.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ActionBar/ActionBar.tsx
@@ -31,13 +31,6 @@ export const ActionBar = observer(function ActionBar(): JSX.Element {
   return (
     <div className="tl-action-bar">
       <div className="tl-toolbar tl-history-bar">
-        <ToolButton title="Select" id="select" icon="select-cursor" />
-        <ToolButton
-          title="Move"
-          id="move"
-          icon={app.isIn('move.panning') ? 'hand-grab' : 'hand-stop'}
-        />
-        <Separator.Root className="tl-toolbar-separator" orientation="vertical" />
         <Button title="Undo" onClick={undo}>
           <TablerIcon name="arrow-back-up" />
         </Button>

--- a/tldraw/apps/tldraw-logseq/src/components/Button/Button.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/Button/Button.tsx
@@ -1,7 +1,24 @@
+import * as Tooltip from '@radix-ui/react-tooltip';
+import type { Side } from '@radix-ui/react-popper'
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode
+  tooltipSide?: Side
 }
 
-export function Button({ className, ...rest }: ButtonProps) {
-  return <button className={'tl-button ' + (className ?? '')} {...rest} />
+export function Button({ className, title, tooltipSide, ...rest }: ButtonProps) {
+  return (
+    <Tooltip.Provider>
+      <Tooltip.Root>
+        <Tooltip.Trigger asChild>
+          <button className={'tl-button ' + (className ?? '')} {...rest} />
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content className="tl-tooltip-content" sideOffset={5} side={tooltipSide}>
+            {title}
+            <Tooltip.Arrow className="tl-tooltip-arrow" />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  )
 }

--- a/tldraw/apps/tldraw-logseq/src/components/Button/Button.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/Button/Button.tsx
@@ -2,12 +2,13 @@ import { Tooltip } from '../Tooltip'
 import type { Side } from '@radix-ui/react-popper'
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode
+  tooltip?: React.ReactNode
   tooltipSide?: Side
 }
 
-export function Button({ className, title, tooltipSide, ...rest }: ButtonProps) {
+export function Button({ className, tooltip, tooltipSide, ...rest }: ButtonProps) {
   return (
-    <Tooltip title={title} side={tooltipSide}>
+    <Tooltip content={tooltip} side={tooltipSide}>
       <button className={'tl-button ' + (className ?? '')} {...rest} />
     </Tooltip>
   )

--- a/tldraw/apps/tldraw-logseq/src/components/Button/Button.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import * as Tooltip from '@radix-ui/react-tooltip';
+import { Tooltip } from '../Tooltip'
 import type { Side } from '@radix-ui/react-popper'
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode
@@ -7,18 +7,8 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 
 export function Button({ className, title, tooltipSide, ...rest }: ButtonProps) {
   return (
-    <Tooltip.Provider>
-      <Tooltip.Root>
-        <Tooltip.Trigger asChild>
-          <button className={'tl-button ' + (className ?? '')} {...rest} />
-        </Tooltip.Trigger>
-        <Tooltip.Portal>
-          <Tooltip.Content className="tl-tooltip-content" sideOffset={5} side={tooltipSide}>
-            {title}
-            <Tooltip.Arrow className="tl-tooltip-arrow" />
-          </Tooltip.Content>
-        </Tooltip.Portal>
-      </Tooltip.Root>
-    </Tooltip.Provider>
+    <Tooltip title={title} side={tooltipSide}>
+      <button className={'tl-button ' + (className ?? '')} {...rest} />
+    </Tooltip>
   )
 }

--- a/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
@@ -160,10 +160,12 @@ const LogseqPortalViewModeAction = observer(() => {
     {
       value: '1',
       icon: 'object-compact',
+      tooltip: 'Collapse',
     },
     {
       value: '0',
       icon: 'object-expanded',
+      tooltip: 'Expand',
     },
   ]
   return (
@@ -352,10 +354,12 @@ const StrokeTypeAction = observer(() => {
     {
       value: 'line',
       icon: 'circle',
+      tooltip: 'Solid',
     },
     {
       value: 'dashed',
       icon: 'circle-dashed',
+      tooltip: 'Dashed',
     },
   ]
 

--- a/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
@@ -96,7 +96,7 @@ const EditAction = observer(() => {
   return (
     <Button
       type="button"
-      title="Edit"
+      tooltip="Edit"
       onClick={() => {
         app.api.editShape(shape)
         if (shape.props.type === 'logseq-portal') {
@@ -242,7 +242,7 @@ const IFrameSourceAction = observer(() => {
 
   return (
     <span className="flex gap-3">
-      <Button title="Reload" type="button" onClick={handleReload}>
+      <Button tooltip="Reload" type="button" onClick={handleReload}>
         <TablerIcon name="refresh" />
       </Button>
       <TextInput
@@ -251,7 +251,7 @@ const IFrameSourceAction = observer(() => {
         value={`${shape.props.url}`}
         onChange={handleChange}
       />
-      <Button title="Open website url" type="button" onClick={() => window.open(shape.props.url)}>
+      <Button tooltip="Open website url" type="button" onClick={() => window.open(shape.props.url)}>
         <TablerIcon name="external-link" />
       </Button>
     </span>
@@ -275,7 +275,7 @@ const YoutubeLinkAction = observer(() => {
         onChange={handleChange}
       />
       <Button
-        title="Open YouTube Link"
+        tooltip="Open YouTube Link"
         type="button"
         onClick={() => window.logseq?.api?.open_external_link?.(shape.props.url)}
       >
@@ -300,7 +300,7 @@ const NoFillAction = observer(() => {
 
   return (
     <ToggleInput
-      title="Fill Toggle"
+      title="Fill"
       className="tl-button"
       pressed={noFill}
       onPressedChange={handleChange}

--- a/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
@@ -300,12 +300,7 @@ const NoFillAction = observer(() => {
   const noFill = shapes.every(s => s.props.noFill)
 
   return (
-    <ToggleInput
-      title="Fill"
-      className="tl-button"
-      pressed={noFill}
-      onPressedChange={handleChange}
-    >
+    <ToggleInput title="Fill" className="tl-button" pressed={noFill} onPressedChange={handleChange}>
       <TablerIcon name={noFill ? 'droplet-off' : 'droplet'} />
     </ToggleInput>
   )

--- a/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
@@ -334,7 +334,6 @@ const SwatchAction = observer(() => {
   const color = shapes[0].props.noFill ? shapes[0].props.stroke : shapes[0].props.fill
   return (
     <ColorInput
-      title="Color Picker"
       popoverSide="top"
       color={color}
       opacity={shapes[0].props.opacity}

--- a/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
@@ -15,7 +15,6 @@ import type {
   TextShape,
   YouTubeShape,
 } from '../../lib'
-import { LogseqContext } from '../../lib/logseq-context'
 import { Button } from '../Button'
 import { TablerIcon } from '../icons'
 import { ColorInput } from '../inputs/ColorInput'

--- a/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
@@ -214,7 +214,7 @@ const ScaleLevelAction = observer(() => {
   ]
   return (
     <SelectInput
-      title="Scale Level"
+      tooltip="Scale Level"
       options={sizeOptions}
       value={scaleLevel}
       onValueChange={v => {

--- a/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
@@ -58,26 +58,26 @@ export const ContextMenu = observer(function ContextMenu({
               <ReactContextMenu.Item>
                 <div className="tl-menu-button-row pb-0">
                   <Button
-                    title="Align left"
+                    tooltip="Align left"
                     onClick={() => runAndTransition(() => app.align(AlignType.Left))}
                   >
                     <TablerIcon name="layout-align-left" />
                   </Button>
                   <Button
-                    title="Align center horizontally"
+                    tooltip="Align center horizontally"
                     onClick={() => runAndTransition(() => app.align(AlignType.CenterHorizontal))}
                   >
                     <TablerIcon name="layout-align-center" />
                   </Button>
                   <Button
-                    title="Align right"
+                    tooltip="Align right"
                     onClick={() => runAndTransition(() => app.align(AlignType.Right))}
                   >
                     <TablerIcon name="layout-align-right" />
                   </Button>
                   <Separator.Root className="tl-toolbar-separator" orientation="vertical" />
                   <Button
-                    title="Distribute horizontally"
+                    tooltip="Distribute horizontally"
                     onClick={() =>
                       runAndTransition(() => app.distribute(DistributeType.Horizontal))
                     }
@@ -87,26 +87,26 @@ export const ContextMenu = observer(function ContextMenu({
                 </div>
                 <div className="tl-menu-button-row pt-0">
                   <Button
-                    title="Align top"
+                    tooltip="Align top"
                     onClick={() => runAndTransition(() => app.align(AlignType.Top))}
                   >
                     <TablerIcon name="layout-align-top" />
                   </Button>
                   <Button
-                    title="Align center vertically"
+                    tooltip="Align center vertically"
                     onClick={() => runAndTransition(() => app.align(AlignType.CenterVertical))}
                   >
                     <TablerIcon name="layout-align-middle" />
                   </Button>
                   <Button
-                    title="Align bottom"
+                    tooltip="Align bottom"
                     onClick={() => runAndTransition(() => app.align(AlignType.Bottom))}
                   >
                     <TablerIcon name="layout-align-bottom" />
                   </Button>
                   <Separator.Root className="tl-toolbar-separator" orientation="vertical" />
                   <Button
-                    title="Distribute vertically"
+                    tooltip="Distribute vertically"
                     onClick={() => runAndTransition(() => app.distribute(DistributeType.Vertical))}
                   >
                     <TablerIcon name="layout-distribute-horizontal" />

--- a/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
@@ -165,17 +165,17 @@ export const ContextMenu = observer(function ContextMenu({
             </div>
           </ReactContextMenu.Item>
           {app.selectedShapes?.size === 1 && (
-          <ReactContextMenu.Item
-            className="tl-menu-item"
-            onClick={() => runAndTransition(() => app.paste(undefined, true))}
-          >
-            Paste as link
-            <div className="tl-menu-right-slot">
-              <span className="keyboard-shortcut">
-                <code>{MOD_KEY}</code> <code>⇧</code> <code>V</code>
-              </span>
-            </div>
-          </ReactContextMenu.Item>
+            <ReactContextMenu.Item
+              className="tl-menu-item"
+              onClick={() => runAndTransition(() => app.paste(undefined, true))}
+            >
+              Paste as link
+              <div className="tl-menu-right-slot">
+                <span className="keyboard-shortcut">
+                  <code>{MOD_KEY}</code> <code>⇧</code> <code>V</code>
+                </span>
+              </div>
+            </ReactContextMenu.Item>
           )}
           <ReactContextMenu.Separator className="menu-separator" />
           <ReactContextMenu.Item

--- a/tldraw/apps/tldraw-logseq/src/components/GeometryTools/GeometryTools.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/GeometryTools/GeometryTools.tsx
@@ -10,17 +10,17 @@ export const GeometryTools = observer(function GeometryTools() {
     {
       id: 'box',
       icon: 'square',
-      title: 'Rectangle',
+      tooltip: 'Rectangle',
     },
     {
       id: 'ellipse',
       icon: 'circle',
-      title: 'Circle',
+      tooltip: 'Circle',
     },
     {
       id: 'polygon',
       icon: 'triangle',
-      title: 'Triangle',
+      tooltip: 'Triangle',
     },
   ]
 

--- a/tldraw/apps/tldraw-logseq/src/components/GeometryTools/GeometryTools.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/GeometryTools/GeometryTools.tsx
@@ -37,13 +37,15 @@ export const GeometryTools = observer(function GeometryTools() {
 
   return (
     <Popover.Root>
-      <Popover.Trigger className="tl-geometry-tools-pane-anchor">
-        <ToolButton {...geometries.find(geo => geo.id === activeGeomId)!} />
-        <TablerIcon
-          data-selected={geometries.some(geo => geo.id === app.selectedTool.id)}
-          className="tl-popover-indicator"
-          name="chevron-down-left"
-        />
+      <Popover.Trigger asChild>
+        <div className="tl-geometry-tools-pane-anchor">
+          <ToolButton {...geometries.find(geo => geo.id === activeGeomId)!} />
+          <TablerIcon
+            data-selected={geometries.some(geo => geo.id === app.selectedTool.id)}
+            className="tl-popover-indicator"
+            name="chevron-down-left"
+          />
+        </div>
       </Popover.Trigger>
 
       <Popover.Content className="tl-popover-content" side="left" sideOffset={15}>

--- a/tldraw/apps/tldraw-logseq/src/components/PrimaryTools/PrimaryTools.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/PrimaryTools/PrimaryTools.tsx
@@ -36,7 +36,6 @@ export const PrimaryTools = observer(function PrimaryTools() {
           style={{ margin: '0 -4px' }}
         />
         <ColorInput
-          title="Color Picker"
           popoverSide="left"
           color={app.settings.color}
           setColor={handleSetColor}

--- a/tldraw/apps/tldraw-logseq/src/components/PrimaryTools/PrimaryTools.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/PrimaryTools/PrimaryTools.tsx
@@ -16,19 +16,19 @@ export const PrimaryTools = observer(function PrimaryTools() {
   return (
     <div className="tl-primary-tools">
       <div className="tl-toolbar tl-tools-floating-panel">
-        <ToolButton title="Select" id="select" icon="select-cursor" />
+        <ToolButton tooltip="Select" id="select" icon="select-cursor" />
         <ToolButton
-          title="Move"
+          tooltip="Move"
           id="move"
           icon={app.isIn('move.panning') ? 'hand-grab' : 'hand-stop'}
         />
         <Separator.Root className="tl-toolbar-separator" orientation="horizontal" />
-        <ToolButton title="Add block or page" id="logseq-portal" icon="circle-plus" />
-        <ToolButton title="Draw" id="pencil" icon="ballpen" />
-        <ToolButton title="Highlight" id="highlighter" icon="highlight" />
-        <ToolButton title="Eraser" id="erase" icon="eraser" />
-        <ToolButton title="Connector" id="line" icon="connector" />
-        <ToolButton title="Text" id="text" icon="text" />
+        <ToolButton tooltip="Add block or page" id="logseq-portal" icon="circle-plus" />
+        <ToolButton tooltip="Draw" id="pencil" icon="ballpen" />
+        <ToolButton tooltip="Highlight" id="highlighter" icon="highlight" />
+        <ToolButton tooltip="Eraser" id="erase" icon="eraser" />
+        <ToolButton tooltip="Connector" id="line" icon="connector" />
+        <ToolButton tooltip="Text" id="text" icon="text" />
         <GeometryTools />
         <Separator.Root
           className="tl-toolbar-separator"

--- a/tldraw/apps/tldraw-logseq/src/components/PrimaryTools/PrimaryTools.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/PrimaryTools/PrimaryTools.tsx
@@ -35,11 +35,7 @@ export const PrimaryTools = observer(function PrimaryTools() {
           orientation="horizontal"
           style={{ margin: '0 -4px' }}
         />
-        <ColorInput
-          popoverSide="left"
-          color={app.settings.color}
-          setColor={handleSetColor}
-        />
+        <ColorInput popoverSide="left" color={app.settings.color} setColor={handleSetColor} />
       </div>
     </div>
   )

--- a/tldraw/apps/tldraw-logseq/src/components/PrimaryTools/PrimaryTools.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/PrimaryTools/PrimaryTools.tsx
@@ -16,8 +16,14 @@ export const PrimaryTools = observer(function PrimaryTools() {
   return (
     <div className="tl-primary-tools">
       <div className="tl-toolbar tl-tools-floating-panel">
-        <ToolButton title="Add block or page" id="logseq-portal" icon="circle-plus" />
+        <ToolButton title="Select" id="select" icon="select-cursor" />
+        <ToolButton
+          title="Move"
+          id="move"
+          icon={app.isIn('move.panning') ? 'hand-grab' : 'hand-stop'}
+        />
         <Separator.Root className="tl-toolbar-separator" orientation="horizontal" />
+        <ToolButton title="Add block or page" id="logseq-portal" icon="circle-plus" />
         <ToolButton title="Draw" id="pencil" icon="ballpen" />
         <ToolButton title="Highlight" id="highlighter" icon="highlight" />
         <ToolButton title="Eraser" id="erase" icon="eraser" />

--- a/tldraw/apps/tldraw-logseq/src/components/ToolButton/ToolButton.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ToolButton/ToolButton.tsx
@@ -25,16 +25,20 @@ export const ToolButton = observer(({ id, icon, tooltip, ...props }: ToolButtonP
   // Tool must exist
   const Tool = [...app.Tools, TLSelectTool, TLMoveTool]?.find(T => T.id === id)
 
-  const shortcuts = ((Tool as any)['shortcut'])
+  const shortcuts = (Tool as any)['shortcut']
 
-  const tooltipContent = shortcuts ?
+  const tooltipContent = shortcuts ? (
     <>
       {tooltip}
       <span className="ml-2 keyboard-shortcut">
-        {shortcuts.map((shortcut: string) => (<code>{shortcut.toUpperCase()}</code>)).reduce((prev: React.ReactNode, curr: React.ReactNode) => [prev, ' | ', curr])}
+        {shortcuts
+          .map((shortcut: string) => <code>{shortcut.toUpperCase()}</code>)
+          .reduce((prev: React.ReactNode, curr: React.ReactNode) => [prev, ' | ', curr])}
       </span>
-    </> :
-      {tooltip}
+    </>
+  ) : (
+    { tooltip }
+  )
 
   return (
     <Button

--- a/tldraw/apps/tldraw-logseq/src/components/ToolButton/ToolButton.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ToolButton/ToolButton.tsx
@@ -30,6 +30,7 @@ export const ToolButton = observer(({ id, icon, title, ...props }: ToolButtonPro
   return (
     <Button
       {...props}
+      tooltipSide="left"
       title={titleWithShortcut}
       data-tool={id}
       data-selected={id === app.selectedTool.id}

--- a/tldraw/apps/tldraw-logseq/src/components/ToolButton/ToolButton.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ToolButton/ToolButton.tsx
@@ -8,9 +8,10 @@ import { TablerIcon } from '../icons'
 export interface ToolButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   id: string
   icon: string | React.ReactNode
+  tooltip: string
 }
 
-export const ToolButton = observer(({ id, icon, title, ...props }: ToolButtonProps) => {
+export const ToolButton = observer(({ id, icon, tooltip, ...props }: ToolButtonProps) => {
   const app = useApp()
 
   const handleToolClick = React.useCallback(
@@ -24,14 +25,22 @@ export const ToolButton = observer(({ id, icon, title, ...props }: ToolButtonPro
   // Tool must exist
   const Tool = [...app.Tools, TLSelectTool, TLMoveTool]?.find(T => T.id === id)
 
-  const shortcut = ((Tool as any)['shortcut'] as string[])?.join(', ').toUpperCase()
+  const shortcuts = ((Tool as any)['shortcut'])
 
-  const titleWithShortcut = shortcut ? `${title} - ${shortcut}` : title
+  const tooltipContent = shortcuts ?
+    <>
+      {tooltip}
+      <span className="ml-2 keyboard-shortcut">
+        {shortcuts.map((shortcut: string) => (<code>{shortcut.toUpperCase()}</code>)).reduce((prev: React.ReactNode, curr: React.ReactNode) => [prev, ' | ', curr])}
+      </span>
+    </> :
+      {tooltip}
+
   return (
     <Button
       {...props}
       tooltipSide="left"
-      title={titleWithShortcut}
+      tooltip={tooltipContent}
       data-tool={id}
       data-selected={id === app.selectedTool.id}
       onClick={handleToolClick}

--- a/tldraw/apps/tldraw-logseq/src/components/ToolButton/ToolButton.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ToolButton/ToolButton.tsx
@@ -32,7 +32,7 @@ export const ToolButton = observer(({ id, icon, tooltip, ...props }: ToolButtonP
       {tooltip}
       <span className="ml-2 keyboard-shortcut">
         {shortcuts
-          .map((shortcut: string) => <code>{shortcut.toUpperCase()}</code>)
+          .map((shortcut: string, idx: number) => <code key={idx}>{shortcut.toUpperCase()}</code>)
           .reduce((prev: React.ReactNode, curr: React.ReactNode) => [prev, ' | ', curr])}
       </span>
     </>

--- a/tldraw/apps/tldraw-logseq/src/components/Tooltip/Tooltip.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import * as ReactTooltip from '@radix-ui/react-tooltip';
+import * as ReactTooltip from '@radix-ui/react-tooltip'
 import type { Side } from '@radix-ui/react-popper'
 export interface TooltipProps extends ReactTooltip.TooltipContentProps {
   children: React.ReactNode
@@ -9,23 +9,24 @@ export interface TooltipProps extends ReactTooltip.TooltipContentProps {
 }
 
 export function Tooltip({ side, content, asChild = true, sideOffset = 10, ...rest }: TooltipProps) {
-  return (content ?
+  return content ? (
     <ReactTooltip.Provider delayDuration={300}>
       <ReactTooltip.Root>
-        <ReactTooltip.Trigger asChild={asChild}>
-          {rest.children}
-        </ReactTooltip.Trigger>
+        <ReactTooltip.Trigger asChild={asChild}>{rest.children}</ReactTooltip.Trigger>
         <ReactTooltip.Portal>
-          <ReactTooltip.Content className="tl-tooltip-content" sideOffset={sideOffset} side={side} {...rest}>
+          <ReactTooltip.Content
+            className="tl-tooltip-content"
+            sideOffset={sideOffset}
+            side={side}
+            {...rest}
+          >
             {content}
             <ReactTooltip.Arrow className="tl-tooltip-arrow" />
           </ReactTooltip.Content>
         </ReactTooltip.Portal>
       </ReactTooltip.Root>
     </ReactTooltip.Provider>
-    :
-    <>
-      {rest.children}
-    </>
-    )
+  ) : (
+    <>{rest.children}</>
+  )
 }

--- a/tldraw/apps/tldraw-logseq/src/components/Tooltip/Tooltip.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,24 @@
+import * as ReactTooltip from '@radix-ui/react-tooltip';
+import type { Side } from '@radix-ui/react-popper'
+export interface TooltipProps extends ReactTooltip.TooltipContentProps {
+  children: React.ReactNode
+  side?: Side
+}
+
+export function Tooltip({ title, side, ...rest }: TooltipProps) {
+  return (
+    <ReactTooltip.Provider>
+      <ReactTooltip.Root>
+        <ReactTooltip.Trigger asChild>
+          {rest.children}
+        </ReactTooltip.Trigger>
+        <ReactTooltip.Portal>
+          <ReactTooltip.Content className="tl-tooltip-content" sideOffset={10} side={side} {...rest}>
+            {title}
+            <ReactTooltip.Arrow className="tl-tooltip-arrow" />
+          </ReactTooltip.Content>
+        </ReactTooltip.Portal>
+      </ReactTooltip.Root>
+    </ReactTooltip.Provider>
+  )
+}

--- a/tldraw/apps/tldraw-logseq/src/components/Tooltip/Tooltip.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/Tooltip/Tooltip.tsx
@@ -8,7 +8,7 @@ export interface TooltipProps extends ReactTooltip.TooltipContentProps {
 
 export function Tooltip({ title, side, sideOffset = 10, ...rest }: TooltipProps) {
   return (
-    <ReactTooltip.Provider>
+    <ReactTooltip.Provider delayDuration={300}>
       <ReactTooltip.Root>
         <ReactTooltip.Trigger asChild>
           {rest.children}

--- a/tldraw/apps/tldraw-logseq/src/components/Tooltip/Tooltip.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/Tooltip/Tooltip.tsx
@@ -4,9 +4,10 @@ export interface TooltipProps extends ReactTooltip.TooltipContentProps {
   children: React.ReactNode
   side?: Side
   sideOffset?: number
+  content?: React.ReactNode
 }
 
-export function Tooltip({ title, side, sideOffset = 10, ...rest }: TooltipProps) {
+export function Tooltip({ side, content, sideOffset = 10, ...rest }: TooltipProps) {
   return (
     <ReactTooltip.Provider delayDuration={300}>
       <ReactTooltip.Root>
@@ -15,7 +16,7 @@ export function Tooltip({ title, side, sideOffset = 10, ...rest }: TooltipProps)
         </ReactTooltip.Trigger>
         <ReactTooltip.Portal>
           <ReactTooltip.Content className="tl-tooltip-content" sideOffset={sideOffset} side={side} {...rest}>
-            {title}
+            {content}
             <ReactTooltip.Arrow className="tl-tooltip-arrow" />
           </ReactTooltip.Content>
         </ReactTooltip.Portal>

--- a/tldraw/apps/tldraw-logseq/src/components/Tooltip/Tooltip.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/Tooltip/Tooltip.tsx
@@ -5,13 +5,14 @@ export interface TooltipProps extends ReactTooltip.TooltipContentProps {
   side?: Side
   sideOffset?: number
   content?: React.ReactNode
+  asChild?: boolean
 }
 
-export function Tooltip({ side, content, sideOffset = 10, ...rest }: TooltipProps) {
-  return (
+export function Tooltip({ side, content, asChild = true, sideOffset = 10, ...rest }: TooltipProps) {
+  return (content ?
     <ReactTooltip.Provider delayDuration={300}>
       <ReactTooltip.Root>
-        <ReactTooltip.Trigger asChild>
+        <ReactTooltip.Trigger asChild={asChild}>
           {rest.children}
         </ReactTooltip.Trigger>
         <ReactTooltip.Portal>
@@ -22,5 +23,9 @@ export function Tooltip({ side, content, sideOffset = 10, ...rest }: TooltipProp
         </ReactTooltip.Portal>
       </ReactTooltip.Root>
     </ReactTooltip.Provider>
-  )
+    :
+    <>
+      {rest.children}
+    </>
+    )
 }

--- a/tldraw/apps/tldraw-logseq/src/components/Tooltip/Tooltip.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/Tooltip/Tooltip.tsx
@@ -3,9 +3,10 @@ import type { Side } from '@radix-ui/react-popper'
 export interface TooltipProps extends ReactTooltip.TooltipContentProps {
   children: React.ReactNode
   side?: Side
+  sideOffset?: number
 }
 
-export function Tooltip({ title, side, ...rest }: TooltipProps) {
+export function Tooltip({ title, side, sideOffset = 10, ...rest }: TooltipProps) {
   return (
     <ReactTooltip.Provider>
       <ReactTooltip.Root>
@@ -13,7 +14,7 @@ export function Tooltip({ title, side, ...rest }: TooltipProps) {
           {rest.children}
         </ReactTooltip.Trigger>
         <ReactTooltip.Portal>
-          <ReactTooltip.Content className="tl-tooltip-content" sideOffset={10} side={side} {...rest}>
+          <ReactTooltip.Content className="tl-tooltip-content" sideOffset={sideOffset} side={side} {...rest}>
             {title}
             <ReactTooltip.Arrow className="tl-tooltip-arrow" />
           </ReactTooltip.Content>

--- a/tldraw/apps/tldraw-logseq/src/components/Tooltip/Tooltip.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/Tooltip/Tooltip.tsx
@@ -5,14 +5,13 @@ export interface TooltipProps extends ReactTooltip.TooltipContentProps {
   side?: Side
   sideOffset?: number
   content?: React.ReactNode
-  asChild?: boolean
 }
 
-export function Tooltip({ side, content, asChild = true, sideOffset = 10, ...rest }: TooltipProps) {
+export function Tooltip({ side, content, sideOffset = 10, ...rest }: TooltipProps) {
   return content ? (
     <ReactTooltip.Provider delayDuration={300}>
       <ReactTooltip.Root>
-        <ReactTooltip.Trigger asChild={asChild}>{rest.children}</ReactTooltip.Trigger>
+        <ReactTooltip.Trigger asChild>{rest.children}</ReactTooltip.Trigger>
         <ReactTooltip.Portal>
           <ReactTooltip.Content
             className="tl-tooltip-content"

--- a/tldraw/apps/tldraw-logseq/src/components/Tooltip/index.ts
+++ b/tldraw/apps/tldraw-logseq/src/components/Tooltip/index.ts
@@ -1,0 +1,1 @@
+export * from './Tooltip'

--- a/tldraw/apps/tldraw-logseq/src/components/inputs/ColorInput.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/inputs/ColorInput.tsx
@@ -3,6 +3,7 @@ import * as Slider from '@radix-ui/react-slider'
 import { Color } from '@tldraw/core'
 import { TablerIcon } from '../icons'
 import { PopoverButton } from '../PopoverButton'
+import { Tooltip } from '../Tooltip'
 
 interface ColorInputProps extends React.HTMLAttributes<HTMLButtonElement> {
   color?: string
@@ -18,7 +19,7 @@ export function ColorInput({
   popoverSide,
   setColor,
   setOpacity,
-  title,
+  title = "Color",
   ...rest
 }: ColorInputProps) {
   function renderColor(color?: string) {
@@ -34,7 +35,7 @@ export function ColorInput({
   }
 
   return (
-    <PopoverButton {...rest} border arrow side={popoverSide} label={renderColor(color)}>
+    <PopoverButton {...rest} border arrow side={popoverSide} label={<Tooltip title={title} side={popoverSide} sideOffset={14}>{renderColor(color)}</Tooltip>}>
       <div className="p-1">
         <div className={'tl-color-palette'}>
           {Object.values(Color).map(value => (

--- a/tldraw/apps/tldraw-logseq/src/components/inputs/ColorInput.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/inputs/ColorInput.tsx
@@ -19,7 +19,6 @@ export function ColorInput({
   popoverSide,
   setColor,
   setOpacity,
-  title = "Color",
   ...rest
 }: ColorInputProps) {
   function renderColor(color?: string) {
@@ -35,7 +34,7 @@ export function ColorInput({
   }
 
   return (
-    <PopoverButton {...rest} border arrow side={popoverSide} label={<Tooltip title={title} side={popoverSide} sideOffset={14}>{renderColor(color)}</Tooltip>}>
+    <PopoverButton {...rest} border arrow side={popoverSide} label={<Tooltip content={"Color"} side={popoverSide} sideOffset={14}>{renderColor(color)}</Tooltip>}>
       <div className="p-1">
         <div className={'tl-color-palette'}>
           {Object.values(Color).map(value => (

--- a/tldraw/apps/tldraw-logseq/src/components/inputs/ColorInput.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/inputs/ColorInput.tsx
@@ -34,7 +34,17 @@ export function ColorInput({
   }
 
   return (
-    <PopoverButton {...rest} border arrow side={popoverSide} label={<Tooltip content={"Color"} side={popoverSide} sideOffset={14}>{renderColor(color)}</Tooltip>}>
+    <PopoverButton
+      {...rest}
+      border
+      arrow
+      side={popoverSide}
+      label={
+        <Tooltip content={'Color'} side={popoverSide} sideOffset={14}>
+          {renderColor(color)}
+        </Tooltip>
+      }
+    >
       <div className="p-1">
         <div className={'tl-color-palette'}>
           {Object.values(Color).map(value => (

--- a/tldraw/apps/tldraw-logseq/src/components/inputs/ColorInput.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/inputs/ColorInput.tsx
@@ -18,6 +18,7 @@ export function ColorInput({
   popoverSide,
   setColor,
   setOpacity,
+  title,
   ...rest
 }: ColorInputProps) {
   function renderColor(color?: string) {

--- a/tldraw/apps/tldraw-logseq/src/components/inputs/SelectInput.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/inputs/SelectInput.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import * as Select from '@radix-ui/react-select'
 import { TablerIcon } from '../icons'
+import { Tooltip } from '../Tooltip'
 
 export interface SelectOption {
   value: string
@@ -10,10 +11,11 @@ export interface SelectOption {
 interface SelectInputProps extends React.HTMLAttributes<HTMLElement> {
   options: SelectOption[]
   value: string
+  tooltip?: React.ReactNode
   onValueChange: (value: string) => void
 }
 
-export function SelectInput({ options, value, onValueChange, ...rest }: SelectInputProps) {
+export function SelectInput({ options, tooltip, value, onValueChange, ...rest }: SelectInputProps) {
   const [isOpen, setIsOpen] = React.useState(false)
   return (
     <div {...rest} className="tl-select-input">
@@ -23,14 +25,16 @@ export function SelectInput({ options, value, onValueChange, ...rest }: SelectIn
         value={value}
         onValueChange={onValueChange}
       >
-        <Select.Trigger className="tl-select-input-trigger">
-          <div className="tl-select-input-trigger-value">
-            <Select.Value />
-          </div>
-          <Select.Icon style={{ lineHeight: 1 }}>
-            <TablerIcon name={isOpen ? 'chevron-up' : 'chevron-down'} />
-          </Select.Icon>
-        </Select.Trigger>
+        <Tooltip content={tooltip}>
+          <Select.Trigger className="tl-select-input-trigger">
+            <div className="tl-select-input-trigger-value">
+              <Select.Value />
+            </div>
+            <Select.Icon style={{ lineHeight: 1 }}>
+              <TablerIcon name={isOpen ? 'chevron-up' : 'chevron-down'} />
+            </Select.Icon>
+          </Select.Trigger>
+        </Tooltip>
 
         <Select.Portal className="tl-select-input-portal">
           <Select.Content className="tl-select-input-content">

--- a/tldraw/apps/tldraw-logseq/src/components/inputs/ShapeLinksInput.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/inputs/ShapeLinksInput.tsx
@@ -90,13 +90,12 @@ export const ShapeLinksInput = observer(function ShapeLinksInput({
       align="start"
       alignOffset={-6}
       label={
-        <Tooltip content={"Link"} sideOffset={14}>
+        <Tooltip content={'Link'} sideOffset={14}>
           <div className="flex gap-1 relative items-center justify-center px-1">
             <TablerIcon name={noOfLinks > 0 ? 'link' : 'add-link'} />
             {noOfLinks > 0 && <div className="tl-shape-links-count">{noOfLinks}</div>}
           </div>
         </Tooltip>
-
       }
     >
       <div className="color-level rounded-lg" data-show-reference-panel={showReferencePanel}>

--- a/tldraw/apps/tldraw-logseq/src/components/inputs/ShapeLinksInput.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/inputs/ShapeLinksInput.tsx
@@ -6,6 +6,7 @@ import { observer } from 'mobx-react-lite'
 import { LogseqContext } from '../../lib/logseq-context'
 import { BlockLink } from '../BlockLink'
 import { Button } from '../Button'
+import { Tooltip } from '../Tooltip'
 import { TablerIcon } from '../icons'
 import { PopoverButton } from '../PopoverButton'
 import { LogseqQuickSearch } from '../QuickSearch'
@@ -38,11 +39,11 @@ function ShapeLinkItem({
         <BlockLink id={id} showReferenceContent={showContent} />
       </div>
       <div className="flex-1" />
-      <Button title="Open Page" type="button" onClick={() => handlers?.redirectToPage(id)}>
+      <Button tooltip="Open Page" type="button" onClick={() => handlers?.redirectToPage(id)}>
         <TablerIcon name="open-as-page" />
       </Button>
       <Button
-        title="Open Page in Right Sidebar"
+        tooltip="Open Page in Right Sidebar"
         type="button"
         onClick={() => handlers?.sidebarAddBlock(id, type === 'B' ? 'block' : 'page')}
       >
@@ -51,7 +52,7 @@ function ShapeLinkItem({
       {onRemove && (
         <Button
           className="tl-shape-links-panel-item-remove-button"
-          title="Remove link"
+          tooltip="Remove link"
           type="button"
           onClick={onRemove}
         >
@@ -89,10 +90,13 @@ export const ShapeLinksInput = observer(function ShapeLinksInput({
       align="start"
       alignOffset={-6}
       label={
-        <div className="flex gap-1 relative items-center justify-center px-1">
-          <TablerIcon name={noOfLinks > 0 ? 'link' : 'add-link'} />
-          {noOfLinks > 0 && <div className="tl-shape-links-count">{noOfLinks}</div>}
-        </div>
+        <Tooltip content={"Link"} sideOffset={14}>
+          <div className="flex gap-1 relative items-center justify-center px-1">
+            <TablerIcon name={noOfLinks > 0 ? 'link' : 'add-link'} />
+            {noOfLinks > 0 && <div className="tl-shape-links-count">{noOfLinks}</div>}
+          </div>
+        </Tooltip>
+
       }
     >
       <div className="color-level rounded-lg" data-show-reference-panel={showReferencePanel}>

--- a/tldraw/apps/tldraw-logseq/src/components/inputs/ToggleGroupInput.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/inputs/ToggleGroupInput.tsx
@@ -1,9 +1,11 @@
 import * as ToggleGroup from '@radix-ui/react-toggle-group'
 import { TablerIcon } from '../icons'
+import { Tooltip } from '../Tooltip'
 
 export interface ToggleGroupInputOption {
   value: string
   icon: string
+  tooltip?: string
 }
 
 interface ToggleGroupInputProps extends React.HTMLAttributes<HTMLElement> {
@@ -28,14 +30,16 @@ export function ToggleGroupInput({ options, value, onValueChange }: ToggleGroupI
     >
       {options.map(option => {
         return (
-          <ToggleGroup.Item
-            className="tl-toggle-group-input-button"
-            key={option.value}
-            value={option.value}
-            disabled={option.value === value}
-          >
-            <TablerIcon name={option.icon} />
-          </ToggleGroup.Item>
+          <Tooltip content={option.tooltip} asChild={false}>
+            <ToggleGroup.Item
+              className="tl-toggle-group-input-button"
+              key={option.value}
+              value={option.value}
+              disabled={option.value === value}
+            >
+              <TablerIcon name={option.icon} />
+            </ToggleGroup.Item>
+          </Tooltip>
         )
       })}
     </ToggleGroup.Root>

--- a/tldraw/apps/tldraw-logseq/src/components/inputs/ToggleGroupInput.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/inputs/ToggleGroupInput.tsx
@@ -30,15 +30,16 @@ export function ToggleGroupInput({ options, value, onValueChange }: ToggleGroupI
     >
       {options.map(option => {
         return (
-          <Tooltip content={option.tooltip} asChild={false}>
-            <ToggleGroup.Item
-              className="tl-toggle-group-input-button"
-              key={option.value}
-              value={option.value}
-              disabled={option.value === value}
-            >
-              <TablerIcon name={option.icon} />
-            </ToggleGroup.Item>
+          <Tooltip content={option.tooltip} key={option.value}>
+            <div className='inline-block'>
+              <ToggleGroup.Item
+                className="tl-toggle-group-input-button"
+                value={option.value}
+                disabled={option.value === value}
+              >
+                <TablerIcon name={option.icon} />
+              </ToggleGroup.Item>
+            </div>
           </Tooltip>
         )
       })}

--- a/tldraw/apps/tldraw-logseq/src/components/inputs/ToggleInput.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/inputs/ToggleInput.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '../Tooltip'
 import * as Toggle from '@radix-ui/react-toggle'
 
 interface ToggleInputProps extends React.HTMLAttributes<HTMLElement> {
@@ -11,15 +12,18 @@ export function ToggleInput({
   pressed,
   onPressedChange,
   className,
+  title,
   ...rest
 }: ToggleInputProps) {
   return (
-    <Toggle.Root
-      {...rest}
-      data-toggle={toggle}
-      className={'tl-toggle-input' + (className ? ' ' + className : '')}
-      pressed={pressed}
-      onPressedChange={onPressedChange}
-    ></Toggle.Root>
+    <Tooltip title={title}>
+      <Toggle.Root
+        {...rest}
+        data-toggle={toggle}
+        className={'tl-toggle-input' + (className ? ' ' + className : '')}
+        pressed={pressed}
+        onPressedChange={onPressedChange}
+      ></Toggle.Root>
+    </Tooltip>
   )
 }

--- a/tldraw/apps/tldraw-logseq/src/components/inputs/ToggleInput.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/inputs/ToggleInput.tsx
@@ -16,7 +16,7 @@ export function ToggleInput({
   ...rest
 }: ToggleInputProps) {
   return (
-    <Tooltip title={title}>
+    <Tooltip content={title}>
       <Toggle.Root
         {...rest}
         data-toggle={toggle}

--- a/tldraw/apps/tldraw-logseq/src/lib/tools/BoxTool.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/tools/BoxTool.tsx
@@ -4,6 +4,6 @@ import { BoxShape, type Shape } from '../shapes'
 
 export class BoxTool extends TLBoxTool<BoxShape, Shape, TLReactEventMap> {
   static id = 'box'
-  static shortcut = ['7', 'r']
+  static shortcut = ['9', 'r']
   Shape = BoxShape
 }

--- a/tldraw/apps/tldraw-logseq/src/lib/tools/EraseTool.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/tools/EraseTool.tsx
@@ -4,5 +4,5 @@ import type { Shape } from '../shapes'
 
 export class NuEraseTool extends TLEraseTool<Shape, TLReactEventMap> {
   static id = 'erase'
-  static shortcut = ['4', 'e']
+  static shortcut = ['6', 'e']
 }

--- a/tldraw/apps/tldraw-logseq/src/lib/tools/HighlighterTool.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/tools/HighlighterTool.tsx
@@ -4,7 +4,7 @@ import { HighlighterShape, type Shape } from '../shapes'
 
 export class HighlighterTool extends TLDrawTool<HighlighterShape, Shape, TLReactEventMap> {
   static id = 'highlighter'
-  static shortcut = ['3', 'h']
+  static shortcut = ['5', 'h']
   Shape = HighlighterShape
   simplify = true
   simplifyTolerance = 0.618

--- a/tldraw/apps/tldraw-logseq/src/lib/tools/LineTool.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/tools/LineTool.tsx
@@ -5,6 +5,6 @@ import { LineShape, type Shape } from '../shapes'
 // @ts-expect-error maybe later
 export class LineTool extends TLLineTool<LineShape, Shape, TLReactEventMap> {
   static id = 'line'
-  static shortcut = ['5', 'c']
+  static shortcut = ['7', 'c']
   Shape = LineShape
 }

--- a/tldraw/apps/tldraw-logseq/src/lib/tools/LogseqPortalTool/LogseqPortalTool.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/tools/LogseqPortalTool/LogseqPortalTool.tsx
@@ -9,7 +9,7 @@ export class LogseqPortalTool extends TLTool<
   TLApp<Shape, TLReactEventMap>
 > {
   static id = 'logseq-portal'
-  static shortcut = ['1']
+  static shortcut = ['3']
   static states = [IdleState, CreatingState]
   static initial = 'idle'
 

--- a/tldraw/apps/tldraw-logseq/src/lib/tools/PencilTool.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/tools/PencilTool.tsx
@@ -4,7 +4,7 @@ import { PencilShape, type Shape } from '../shapes'
 
 export class PencilTool extends TLDrawTool<PencilShape, Shape, TLReactEventMap> {
   static id = 'pencil'
-  static shortcut = ['2', 'd']
+  static shortcut = ['4', 'd']
   Shape = PencilShape
   simplify = false
 }

--- a/tldraw/apps/tldraw-logseq/src/lib/tools/TextTool.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/tools/TextTool.tsx
@@ -4,6 +4,6 @@ import { TextShape, type Shape } from '../shapes'
 
 export class TextTool extends TLTextTool<TextShape, Shape, TLReactEventMap> {
   static id = 'text'
-  static shortcut = ['6', 't']
+  static shortcut = ['8', 't']
   Shape = TextShape
 }

--- a/tldraw/apps/tldraw-logseq/src/styles.css
+++ b/tldraw/apps/tldraw-logseq/src/styles.css
@@ -808,13 +808,6 @@ button.tl-select-input-trigger {
   @apply p-0 rounded-none;
 }
 
-.logseq-img-icon {
-  width: 20px;
-  height: 20px;
-  border-radius: 4px;
-  box-shadow: 0 8px 12px 0 #85c8c81a, 0 4px 32px 0 #85c8c880;
-}
-
 .tl-target-not-found {
   @apply flex h-full w-full items-center justify-center;
 }

--- a/tldraw/apps/tldraw-logseq/src/styles.css
+++ b/tldraw/apps/tldraw-logseq/src/styles.css
@@ -1175,7 +1175,7 @@ button.tl-shape-links-panel-item-remove-button {
 }
 
 .tl-tooltip-arrow {
-  fill: var(--ls-secondary-background-color);;
+  fill: var(--ls-secondary-background-color);
 }
 
 @keyframes fadeIn {

--- a/tldraw/apps/tldraw-logseq/src/styles.css
+++ b/tldraw/apps/tldraw-logseq/src/styles.css
@@ -1156,7 +1156,6 @@ button.tl-shape-links-panel-item-remove-button {
   }
 }
 
-
 .tl-tooltip-content {
   border-radius: 4px;
   padding: 10px 15px;
@@ -1164,7 +1163,7 @@ button.tl-shape-links-panel-item-remove-button {
   line-height: 1;
   color: var(--ls-secondary-text-color);
   background-color: var(--ls-secondary-background-color);
-  box-shadow: var(--shadow-medium);
+  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   user-select: none;
   animation-duration: 700ms;
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);

--- a/tldraw/apps/tldraw-logseq/src/styles.css
+++ b/tldraw/apps/tldraw-logseq/src/styles.css
@@ -1162,3 +1162,35 @@ button.tl-shape-links-panel-item-remove-button {
     @apply inline;
   }
 }
+
+
+.tl-tooltip-content {
+  border-radius: 4px;
+  padding: 10px 15px;
+  font-size: 15px;
+  line-height: 1;
+  color: var(--ls-secondary-text-color);
+  background-color: var(--ls-secondary-background-color);
+  box-shadow: var(--shadow-medium);
+  user-select: none;
+  animation-duration: 300ms;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform, opacity;
+
+  &[data-state='delayed-open'] {
+    animation-name: fadeIn;
+  }
+}
+
+.tl-tooltip-arrow {
+  fill: var(--ls-secondary-background-color);;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/tldraw/apps/tldraw-logseq/src/styles.css
+++ b/tldraw/apps/tldraw-logseq/src/styles.css
@@ -1173,7 +1173,7 @@ button.tl-shape-links-panel-item-remove-button {
   background-color: var(--ls-secondary-background-color);
   box-shadow: var(--shadow-medium);
   user-select: none;
-  animation-duration: 300ms;
+  animation-duration: 700ms;
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   will-change: transform, opacity;
 

--- a/tldraw/demo/src/App.jsx
+++ b/tldraw/demo/src/App.jsx
@@ -213,7 +213,7 @@ export default function App() {
   }, [])
 
   return (
-    <div className={`h-screen w-screen`} id="main-content-container">
+    <div className={`h-screen w-screen z-0 relative`}>
       <ThemeSwitcher />
       <PreviewButton model={model} />
       <TldrawApp

--- a/tldraw/packages/core/src/lib/tools/TLMoveTool/TLMoveTool.ts
+++ b/tldraw/packages/core/src/lib/tools/TLMoveTool/TLMoveTool.ts
@@ -10,7 +10,7 @@ export class TLMoveTool<
   R extends TLApp<S, K> = TLApp<S, K>
 > extends TLTool<S, K, R> {
   static id = 'move'
-  static shortcut = ['m', '2']
+  static shortcut = ['2', 'm']
 
   static states = [IdleState, IdleHoldState, PanningState, PinchingState]
 

--- a/tldraw/packages/core/src/lib/tools/TLMoveTool/TLMoveTool.ts
+++ b/tldraw/packages/core/src/lib/tools/TLMoveTool/TLMoveTool.ts
@@ -10,7 +10,7 @@ export class TLMoveTool<
   R extends TLApp<S, K> = TLApp<S, K>
 > extends TLTool<S, K, R> {
   static id = 'move'
-  static shortcut = ['m', '9']
+  static shortcut = ['m', '2']
 
   static states = [IdleState, IdleHoldState, PanningState, PinchingState]
 

--- a/tldraw/packages/core/src/lib/tools/TLSelectTool/TLSelectTool.tsx
+++ b/tldraw/packages/core/src/lib/tools/TLSelectTool/TLSelectTool.tsx
@@ -33,7 +33,7 @@ export class TLSelectTool<
 
   static initial = 'idle'
 
-  static shortcut = ['s', '8']
+  static shortcut = ['s', '1']
 
   static states = [
     IdleState,

--- a/tldraw/packages/core/src/lib/tools/TLSelectTool/TLSelectTool.tsx
+++ b/tldraw/packages/core/src/lib/tools/TLSelectTool/TLSelectTool.tsx
@@ -33,7 +33,7 @@ export class TLSelectTool<
 
   static initial = 'idle'
 
-  static shortcut = ['s', '1']
+  static shortcut = ['1', 's']
 
   static states = [
     IdleState,

--- a/tldraw/yarn.lock
+++ b/tldraw/yarn.lock
@@ -872,6 +872,25 @@
     "@radix-ui/react-primitive" "1.0.1"
     "@radix-ui/react-use-controllable-state" "1.0.0"
 
+"@radix-ui/react-tooltip@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-1.0.2.tgz#8e10b075767f785bf013146fdc954ac6885efda3"
+  integrity sha512-11gUlok2rv5mu+KBtxniOKKNKjqC/uTbgFHWoQdbF46vMV+zjDaBvCtVDK9+MTddlpmlisGPGvvojX7Qm0yr+g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-dismissable-layer" "1.0.2"
+    "@radix-ui/react-id" "1.0.0"
+    "@radix-ui/react-popper" "1.0.1"
+    "@radix-ui/react-portal" "1.0.1"
+    "@radix-ui/react-presence" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.1"
+    "@radix-ui/react-slot" "1.0.1"
+    "@radix-ui/react-use-controllable-state" "1.0.0"
+    "@radix-ui/react-visually-hidden" "1.0.1"
+
 "@radix-ui/react-use-callback-ref@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz#9e7b8b6b4946fe3cbe8f748c82a2cce54e7b6a90"


### PR DESCRIPTION
Merged with https://github.com/logseq/logseq/pull/7641, because it is going to affect the implementation of this enhancement.

- [x] Move select and pan to main toolbar
- [x] Create tooltip component
- [x] Add tooltip support to button, toggle, toggle groups, select and color input
- [x] Style shortcuts on primary tools

[Screencast from 2022-12-09 12-44-06.webm](https://user-images.githubusercontent.com/10744960/206685043-ecba2157-3785-4af8-a78d-91c96e8c9a8d.webm)