### PR TITLE
fix: allows empty config.edn

### DIFF
--- a/src/main/frontend/handler/global_config.cljs
+++ b/src/main/frontend/handler/global_config.cljs
@@ -99,6 +99,9 @@ nested keys or positional errors e.g. tuples"
                       (edn/read-string file-body)
                       (catch :default _ ::failed-to-read))]
     (cond
+      (nil? parsed-body)
+      true
+
       (= ::failed-to-read parsed-body)
       (do
         (notification/show! (gstring/format "Failed to read file '%s'. Make sure your config is wrapped


### PR DESCRIPTION
The default global config.edn will trigger this notification because the `parsed-body` is nil.
![CleanShot 2022-12-09 at 15 53 39](https://user-images.githubusercontent.com/479169/206652614-6d74fb95-0b85-42a3-89e0-5ad08ad81859.png)
