### PR TITLE
fix: breadcrumb image size

### DIFF
--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -658,3 +658,51 @@ html.is-mac {
     }
   }
 }
+
+/**
+ * Fix broken styles of breadcrumb caused by mixed contents
+ * TODO: implement the logic in code instead of CSS selector
+*/
+
+/*Fix images*/
+.breadcrumb .image-resize {
+  width: auto;
+  height: 17px;
+  display: inline-block;
+  vertical-align: middle;
+  top: -1px;
+}
+
+.breadcrumb .image-resize img {
+  height: 17px;
+  width: auto;
+}
+
+.breadcrumb .image-resize :is(.asset-action-bar, .erd_scroll_detection_container) {
+  display: none;
+}
+
+/*Fix iframe(e.g YouTube)*/
+.breadcrumb :is(.embed-block>div, iframe) {
+  display: none;
+}
+
+/*Fix embed-block, properties*/
+.breadcrumb>a>div:not([style="display: inline;"]),
+.breadcrumb .embed-block {
+  display: inline-block;
+}
+
+/*Use ... to replace the invalid items*/
+.breadcrumb .embed-block {
+  background: initial;
+}
+
+:is(.breadcrumb .embed-block, .breadcrumb>a>div:not([style="display: inline;"]))::after {
+  content: "...";
+}
+
+/*Fix blockquote*/
+.breadcrumb :is(cp__fenced-code-block, blockquote) {
+  display: none;
+}

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -698,11 +698,20 @@ html.is-mac {
   background: initial;
 }
 
+/*Fix blockquote*/
+.breadcrumb :is(cp__fenced-code-block, blockquote) {
+  display: none;
+}
+
 :is(.breadcrumb .embed-block, .breadcrumb>a>div:not([style="display: inline;"]))::after {
   content: "...";
 }
 
-/*Fix blockquote*/
-.breadcrumb :is(cp__fenced-code-block, blockquote) {
-  display: none;
+/*cards-review*/
+.breadcrumb .cards-review>div {
+  display:none;
+}
+
+.breadcrumb .cards-review:before {
+  content:"..."
 }

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -699,7 +699,7 @@ html.is-mac {
 }
 
 /*Fix blockquote*/
-.breadcrumb :is(cp__fenced-code-block, blockquote) {
+.breadcrumb :is(.cp__fenced-code-block, blockquote) {
   display: none;
 }
 


### PR DESCRIPTION
Close #7638 

Before (Image is too big):
<img width="587" alt="image" src="https://user-images.githubusercontent.com/9862022/206664502-15714de7-0ac0-4d4a-beab-9537463be891.png">

After:
<img width="336" alt="image" src="https://user-images.githubusercontent.com/9862022/206664681-31a0020c-e430-4255-963a-294584dba8a6.png">

Based on the CSS file provided by @hillsmao @mzwlevi

TODO in future:
Add class for breadcrumb item to minimize the selectors
Handle tweets
