### PR TITLE
fix: remove orphaned files/blocks from db when comparing db && disk

### DIFF
--- a/src/main/frontend/fs/watcher_handler.cljs
+++ b/src/main/frontend/fs/watcher_handler.cljs
@@ -129,7 +129,7 @@
         (let [deleted-files (set/difference (set db-files) (set files))]
           (when (seq deleted-files)
             (let [delete-tx-data (->> (db/delete-files deleted-files)
-                                      (concat (db/delete-blocks graph files nil))
+                                      (concat (db/delete-blocks graph deleted-files nil))
                                       (remove nil?))]
               (db/transact! graph delete-tx-data)))
           (doseq [file files]


### PR DESCRIPTION
To reproduce:
1. Create a page `odroid-c2` with the content:
    ```
    alias:: Board/ODROID-C2
    title:: odroid-c2
    ```
2. Rename `odroid-c2` to `ODROID-C2`
3. Cmd+R to refresh the app

An error similar to `Page already exists` will be notified.