### PR TITLE
Fix: Tooltip without shortcuts

### DIFF
--- a/tldraw/apps/tldraw-logseq/src/components/ToolButton/ToolButton.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ToolButton/ToolButton.tsx
@@ -37,7 +37,7 @@ export const ToolButton = observer(({ id, icon, tooltip, ...props }: ToolButtonP
       </span>
     </>
   ) : (
-    { tooltip }
+    tooltip
   )
 
   return (


### PR DESCRIPTION
When there are no shortcuts for a tool button, we need to render just the tooltip which is a string.