### PR TITLE
fixes for PDF context menu

### DIFF
--- a/src/main/frontend/extensions/pdf/highlights.cljs
+++ b/src/main/frontend/extensions/pdf/highlights.cljs
@@ -600,9 +600,10 @@
                                                :properties {}})))]
 
            ;; show ctx menu
-           (set-tip-state! {:highlight hl-fn
-                            :selection selection
-                            :point     point}))))
+           (js/setTimeout (fn []
+                            (set-tip-state! {:highlight hl-fn
+                                             :selection selection
+                                             :point     point})))) 0))
 
      [(:range sel-state)])
 

--- a/src/main/frontend/extensions/pdf/highlights.cljs
+++ b/src/main/frontend/extensions/pdf/highlights.cljs
@@ -174,6 +174,7 @@
      {:ref      *el
       :style    {:top top :left left :visibility (if (and @*highlight-mode? new?) "hidden" "visible")}
       :on-click (fn [^js/MouseEvent e]
+                  (.stopPropagation e)
                   (when-let [action (.. e -target -dataset -action)]
                     (action-fn! action true)))}
 


### PR DESCRIPTION
1. Stop event propagation so that context menu will not be hidden when it is clicked. #7661 
2. Ensure that context menu is shown when text is selected. #7663 

close #7661 