### PR TITLE
fix: overflow of installed plugin settings dialog

### DIFF
--- a/src/main/frontend/components/plugins.cljs
+++ b/src/main/frontend/components/plugins.cljs
@@ -806,7 +806,7 @@
       false develop-mode? nil
       agent-opts)
 
-     [:div.cp__plugins-item-lists
+     [:div.cp__plugins-item-lists.pb-6
       {:ref "list-ref"}
       [:div.cp__plugins-item-lists-inner
        (for [item sorted-plugins]


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/68823230/207075443-cb553a0c-c206-4d79-b96e-a920ab93a650.png)

fixes #7401  

Added padding at the bottom. As a side effect there is now more whitespace at the bottom. IMO this matches with the title whitespace and looks balanced.