### PR TITLE
fix(editor): autocomplete and highlight selection conflict

### DIFF
--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -577,7 +577,8 @@
                   ::id (str (random-uuid))))
    :did-mount (fn [state]
                 (state/set-editor-args! (:rum/args state))
-                state)}
+                state)
+   :will-unmount (fn [state] (reset! editor-handler/*selected-text nil) state)}
   (mixins/event-mixin setup-key-listener!)
   (shortcut/mixin :shortcut.handler/block-editing-only)
   lifecycle/lifecycle


### PR DESCRIPTION
When using the auto pair function to add prefix/suffix to a selection, the status is not cleared, resulting in a wrong initial state of autocomplete.

Known Issue: Not fixed if the cursor is still in the same block.

https://user-images.githubusercontent.com/72891/207306933-2f543ff8-993e-4e41-9f6f-74d41be77715.mov

<img width="620" alt="image" src="https://user-images.githubusercontent.com/72891/207305089-953c8aa4-492b-45b8-9049-945244665acd.png">

