### PR TITLE
fix: improve query performance

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/property.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/property.cljs
@@ -47,6 +47,7 @@
   "Properties used by logseq that user can edit"
   []
   (into #{:title :icon :template :template-including-parent :public :filters :exclude-from-graph-view
+          :logseq.query/nlp-date
           ;; org-mode only
           :macro :filetags}
         editable-linkable-built-in-properties))
@@ -70,6 +71,7 @@
   {:template-including-parent :boolean
    :public :boolean
    :exclude-from-graph-view :boolean
+   :logseq.query/nlp-date :boolean
    :heading :boolean
    :collapsed :boolean
    :created-at :integer

--- a/docs/dev-practices.md
+++ b/docs/dev-practices.md
@@ -149,6 +149,17 @@ To write a test that uses a datascript db:
 * The easiest way to set up test data is to use `test-helper/load-test-files`.
 * For the repo argument that most fns take, pass it `test-helper/test-db`
 
+#### Performance tests
+To write a performance test:
+
+* Use `frontend.util/with-time-number` to get the time in ms. 
+ 
+* Example:
+  ```clojure
+  (are [x timeout] (>= timeout (:time (util/with-time-number (block/normalize-block x true))))
+      ... )
+  ```
+
 For examples of these tests, see `frontend.db.query-dsl-test` and `frontend.db.model-test`.
 
 ### Async Unit Testing

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2024,6 +2024,13 @@
 (assert (set/subset? hidden-editable-page-properties (gp-property/editable-built-in-properties))
         "Hidden editable page properties must be valid editable properties")
 
+(def hidden-editable-block-properties
+  "Properties that are hidden in a block (block property)"
+  #{:logseq.query/nlp-date})
+
+(assert (set/subset? hidden-editable-block-properties (gp-property/editable-built-in-properties))
+        "Hidden editable page properties must be valid editable properties")
+
 (defn- add-aliases-to-properties
   [properties block]
   (let [repo (state/get-current-repo)
@@ -2044,6 +2051,8 @@
                            (dissoc-keys (property/hidden-properties))
                            pre-block?
                            (dissoc-keys hidden-editable-page-properties)
+                           (not pre-block?)
+                           (dissoc-keys hidden-editable-block-properties)
                            pre-block?
                            (add-aliases-to-properties block))]
     (cond

--- a/src/main/frontend/components/query_table.cljs
+++ b/src/main/frontend/components/query_table.cljs
@@ -46,11 +46,11 @@
     (.localeCompare x y (state/sub :preferred-language))
     (< x y)))
 
-(defn- sort-result [result {:keys [sort-by-column sort-desc?]}]
+(defn- sort-result [result {:keys [sort-by-column sort-desc? sort-nlp-date?]}]
   (if (some? sort-by-column)
     (let [comp-fn (if sort-desc? #(locale-compare %2 %1) locale-compare)]
       (sort-by (fn [item]
-                 (block/normalize-block (sort-by-fn sort-by-column item)))
+                 (block/normalize-block (sort-by-fn sort-by-column item) sort-nlp-date?))
                comp-fn
                result))
     result))
@@ -63,12 +63,14 @@
   (let [p-desc? (get-in current-block [:block/properties :query-sort-desc])
         desc? (if (some? p-desc?) p-desc? true)
         p-sort-by (keyword (get-in current-block [:block/properties :query-sort-by]))
+        nlp-date? (get-in current-block [:block/properties :query-nlp-date])
         sort-by-column (or (some-> p-sort-by keyword)
                          (if (query-dsl/query-contains-filter? (:block/content current-block) "sort-by")
                            nil
                            :updated-at))]
     {:sort-desc? desc?
-     :sort-by-column sort-by-column}))
+     :sort-by-column sort-by-column
+     :sort-nlp-date? nlp-date?}))
 
 ;; Components
 ;; ==========

--- a/src/main/frontend/components/query_table.cljs
+++ b/src/main/frontend/components/query_table.cljs
@@ -63,7 +63,8 @@
   (let [p-desc? (get-in current-block [:block/properties :query-sort-desc])
         desc? (if (some? p-desc?) p-desc? true)
         p-sort-by (keyword (get-in current-block [:block/properties :query-sort-by]))
-        nlp-date? (get-in current-block [:block/properties :query-nlp-date])
+        ;; Starting with #6105, we started putting properties under namespaces.
+        nlp-date? (get-in current-block [:block/properties :logseq.query/nlp-date])
         sort-by-column (or (some-> p-sort-by keyword)
                          (if (query-dsl/query-contains-filter? (:block/content current-block) "sort-by")
                            nil

--- a/src/main/frontend/date.cljs
+++ b/src/main/frontend/date.cljs
@@ -172,7 +172,8 @@
                  :hourCycle "h23"}))))
 
 (defn normalize-date
-  "Given raw date string, return a normalized date string at best effort."
+  "Given raw date string, return a normalized date string at best effort.
+   Warning: this is a function with heavy cost (likely 50ms). Use with caution"
   [s]
   (some
    (fn [formatter]

--- a/src/main/frontend/db/react.cljs
+++ b/src/main/frontend/db/react.cljs
@@ -111,7 +111,7 @@
 
 (defn add-q!
   [k query time inputs result-atom transform-fn query-fn inputs-fn]
-  (let [time' (int (util/safe-parse-float time))]
+  (let [time' (int (util/safe-parse-float time))] ;; for robustness. `time` should already be float
     (swap! query-state assoc k {:query query
                                :query-time time'
                                :inputs inputs

--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -56,9 +56,13 @@ and handles unexpected failure."
             (tf/unparse date/custom-formatter))))
 
 (defn normalize-block
-  "Normalizes supported formats such as dates and percentages."
-  ([block]
-   (->> [normalize-as-percentage normalize-as-date identity]
+  "Normalizes supported formats such as dates and percentages.
+   Be careful, this function may harm query sort performance!
+   - nlp-date? - Enable NLP parsing on date items.
+       Requires heavy computation (see `normalize-as-date` for details)"
+  ([block nlp-date?]
+   (->> [normalize-as-percentage (when nlp-date? normalize-as-date) identity]
+        (remove nil?)
         (map #(% (if (set? block) (first block) block)))
         (remove nil?)
         (first))))

--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -41,31 +41,31 @@ and handles unexpected failure."
    (gp-block/page-name->map original-page-name with-id? (db/get-db (state/get-current-repo)) with-timestamp? (state/get-date-formatter))))
 
 (defn- normalize-as-percentage
-  ([block]
-   (some->> block
-            str
-            (re-matches #"(-?\d+\.?\d*)%")
-            second
-            (#(/ % 100)))))
+  [block]
+  (some->> block
+           str
+           (re-matches #"(-?\d+\.?\d*)%")
+           second
+           (#(/ % 100))))
 
 (defn- normalize-as-date
-  ([block]
-   (some->> block
-            str
-            date/normalize-date
-            (tf/unparse date/custom-formatter))))
+  [block]
+  (some->> block
+           str
+           date/normalize-date
+           (tf/unparse date/custom-formatter)))
 
 (defn normalize-block
   "Normalizes supported formats such as dates and percentages.
    Be careful, this function may harm query sort performance!
    - nlp-date? - Enable NLP parsing on date items.
        Requires heavy computation (see `normalize-as-date` for details)"
-  ([block nlp-date?]
-   (->> [normalize-as-percentage (when nlp-date? normalize-as-date) identity]
-        (remove nil?)
-        (map #(% (if (set? block) (first block) block)))
-        (remove nil?)
-        (first))))
+  [block nlp-date?]
+  (->> [normalize-as-percentage (when nlp-date? normalize-as-date) identity]
+       (remove nil?)
+       (map #(% (if (set? block) (first block) block)))
+       (remove nil?)
+       (first)))
 
 (defn parse-block
   ([block]

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1041,17 +1041,7 @@
 #?(:clj
    (defmacro with-time
      "Evaluates expr and prints the time it took. 
-      Returns the value of expr and the spent time of string in msecs."
-     [expr]
-     `(let [start# (cljs.core/system-time)
-            ret# ~expr]
-        {:result ret#
-         :time (.toFixed (- (cljs.core/system-time) start#) 6)})))
-
-#?(:clj
-   (defmacro with-time-number
-     "Evaluates expr and prints the time it took. 
-      Returns the value of expr and the spent time of number in msecs."
+      Returns the value of expr and the spent time of float number in msecs."
      [expr]
      `(let [start# (cljs.core/system-time)
             ret# ~expr]

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1040,12 +1040,23 @@
 
 #?(:clj
    (defmacro with-time
-     "Evaluates expr and prints the time it took. Returns the value of expr and the spent time."
+     "Evaluates expr and prints the time it took. 
+      Returns the value of expr and the spent time of string in msecs."
      [expr]
      `(let [start# (cljs.core/system-time)
             ret# ~expr]
         {:result ret#
          :time (.toFixed (- (cljs.core/system-time) start#) 6)})))
+
+#?(:clj
+   (defmacro with-time-number
+     "Evaluates expr and prints the time it took. 
+      Returns the value of expr and the spent time of number in msecs."
+     [expr]
+     `(let [start# (cljs.core/system-time)
+            ret# ~expr]
+        {:result ret#
+         :time (- (cljs.core/system-time) start#)})))
 
 ;; TODO: profile and profileEnd
 

--- a/src/test/frontend/components/query_table_test.cljs
+++ b/src/test/frontend/components/query_table_test.cljs
@@ -76,10 +76,10 @@
       {:sort-desc? true :sort-by-column :rating}
       [{:rating 8} {:rating 7}]
       [{:rating 8} {:rating 7}]
-      0.5 ;; actual: ~0.05
+      2.0 ;; actual: ~0.05
 
       {:sort-desc? false :sort-by-column :rating}
       [{:rating 8} {:rating 7}]
       [{:rating 7} {:rating 8}]
-      0.5 ;; actual: ~0.05
+      2.0 ;; actual: ~0.05
       )))

--- a/src/test/frontend/components/query_table_test.cljs
+++ b/src/test/frontend/components/query_table_test.cljs
@@ -72,7 +72,7 @@
 
   (testing "monitor time of sort by integer block property"
     (are [sort-state result _sorted-result timeout]
-         (>= timeout (:time (util/with-time-number (#'query-table/sort-result (mapv #(hash-map :block/properties %) result) sort-state))))
+         (>= timeout (:time (util/with-time (#'query-table/sort-result (mapv #(hash-map :block/properties %) result) sort-state))))
       {:sort-desc? true :sort-by-column :rating}
       [{:rating 8} {:rating 7}]
       [{:rating 8} {:rating 7}]

--- a/src/test/frontend/components/query_table_test.cljs
+++ b/src/test/frontend/components/query_table_test.cljs
@@ -70,16 +70,16 @@
          [{:title "意志"} {:title "圆圈"}])
     (state/set-preferred-language! "en"))
 
-  (testing "monitor sort time"
+  (testing "monitor time of sort by integer block property"
     (are [sort-state result _sorted-result timeout]
          (>= timeout (:time (util/with-time-number (#'query-table/sort-result (mapv #(hash-map :block/properties %) result) sort-state))))
       {:sort-desc? true :sort-by-column :rating}
       [{:rating 8} {:rating 7}]
       [{:rating 8} {:rating 7}]
-      0.1 ;; actual: ~0.05
+      0.5 ;; actual: ~0.05
 
       {:sort-desc? false :sort-by-column :rating}
       [{:rating 8} {:rating 7}]
       [{:rating 7} {:rating 8}]
-      0.2 ;; actual: ~0.05
+      0.5 ;; actual: ~0.05
       )))

--- a/src/test/frontend/components/query_table_test.cljs
+++ b/src/test/frontend/components/query_table_test.cljs
@@ -1,7 +1,8 @@
 (ns frontend.components.query-table-test
   (:require [clojure.test :refer [deftest testing are]]
             [frontend.state :as state]
-            [frontend.components.query-table :as query-table]))
+            [frontend.components.query-table :as query-table]
+            [frontend.util :as util]))
 
 (deftest sort-result
   ;; Define since it's not defined
@@ -67,4 +68,18 @@
          {:sort-desc? false :sort-by-column :title}
          [{:title "圆圈"} {:title "意志"}]
          [{:title "意志"} {:title "圆圈"}])
-    (state/set-preferred-language! "en")))
+    (state/set-preferred-language! "en"))
+
+  (testing "monitor sort time"
+    (are [sort-state result _sorted-result timeout]
+         (>= timeout (:time (util/with-time-number (#'query-table/sort-result (mapv #(hash-map :block/properties %) result) sort-state))))
+      {:sort-desc? true :sort-by-column :rating}
+      [{:rating 8} {:rating 7}]
+      [{:rating 8} {:rating 7}]
+      0.1 ;; actual: ~0.05
+
+      {:sort-desc? false :sort-by-column :rating}
+      [{:rating 8} {:rating 7}]
+      [{:rating 7} {:rating 8}]
+      0.2 ;; actual: ~0.05
+      )))

--- a/src/test/frontend/format/block_test.cljs
+++ b/src/test/frontend/format/block_test.cljs
@@ -24,19 +24,19 @@
     (are [x _y timeout] (>= timeout (:time (util/with-time-number (block/normalize-block x true))))
       "Aug 12th, 2022"
       "2022-08-12T00:00:00Z"
-      5.0 ;; actual 2.2
+      50.0 ;; actual 2.2
 
       "2022-08-12T00:00:00Z"
       "2022-08-12T00:00:00Z"
-      500 ;; actual 125
+      1000.0 ;; actual 125
 
       #{"Aug 12th, 2022"}
       "2022-08-12T00:00:00Z"
-      5.0 ;; actual 1.7
+      50.0 ;; actual 1.7
 
       #{"2022-08-12T00:00:00Z"}
       "2022-08-12T00:00:00Z"
-      50  ;; actual 17.0
+      250.0  ;; actual 17.0
       )))
 
 (deftest test-normalize-percentage
@@ -77,23 +77,23 @@
     (are [x _y timeout] (>= timeout (:time (util/with-time-number (block/normalize-block x false))))
       "anreanre"
       "anreanre"
-      0.5 ;; actual 0.07
+      2.0 ;; actual 0.07
 
       ""
       ""
-      0.5 ;; actual 0.07
+      2.0 ;; actual 0.07
 
       "a.0%"
       "a.0%"
-      0.1 ;; actual 0.02
+      0.5 ;; actual 0.02
 
       "%"
       "%"
-      0.2 ;; actual 0.03
+      1.0 ;; actual 0.03
 
       "-%"
       "-%"
-      0.1 ;; actual 0.02
+      0.5 ;; actual 0.02
       )))
 
 (deftest test-normalize-journal-title

--- a/src/test/frontend/format/block_test.cljs
+++ b/src/test/frontend/format/block_test.cljs
@@ -5,7 +5,7 @@
 
 (deftest test-normalize-date
   (testing "normalize date values"
-    (are [x y] (= (block/normalize-block x) y)
+    (are [x y] (= (block/normalize-block x true) y)
          "Aug 12th, 2022"
          "2022-08-12T00:00:00Z"
 
@@ -20,7 +20,7 @@
 
 (deftest test-normalize-percentage
   (testing "normalize percentages"
-    (are [x y] (= (block/normalize-block x) y)
+    (are [x y] (= (block/normalize-block x false) y)
          "50%"
          0.5
 
@@ -35,7 +35,7 @@
 
 (deftest test-random-values
   (testing "random values should not be processed"
-    (are [x y] (= (block/normalize-block x) y)
+    (are [x y] (= (block/normalize-block x false) y)
          "anreanre"
          "anreanre"
 

--- a/src/test/frontend/format/block_test.cljs
+++ b/src/test/frontend/format/block_test.cljs
@@ -21,7 +21,7 @@
 
 (deftest monitor-normalize-date-time
   (testing "monitor time consumption of normalize date values"
-    (are [x _y timeout] (>= timeout (:time (util/with-time-number (block/normalize-block x true))))
+    (are [x _y timeout] (>= timeout (:time (util/with-time (block/normalize-block x true))))
       "Aug 12th, 2022"
       "2022-08-12T00:00:00Z"
       50.0 ;; actual 2.2
@@ -74,7 +74,7 @@
 
 (deftest monitor-normalize-randome-values-time
   (testing "monitor time consumption of random values should not be processed"
-    (are [x _y timeout] (>= timeout (:time (util/with-time-number (block/normalize-block x false))))
+    (are [x _y timeout] (>= timeout (:time (util/with-time (block/normalize-block x false))))
       "anreanre"
       "anreanre"
       2.0 ;; actual 0.07


### PR DESCRIPTION
The query performance was degraded by date normalization

![image](https://user-images.githubusercontent.com/9862022/207350223-2d85f1fa-ff2f-4502-a572-d951d7e2aa45.png)

- [x] Breaking change: introduce query property `:logseq.query/nlp-date`. Query without `logseq.query/nlp-date:: true` would disable date normalization by default.
- [x] monitor performance in unit test

TODO after merge: update document
TODO in future: use LRU cache to speed up sort with nlp-date parsing