### PR TITLE
[WIP] enhance(sync): reduce <get-local-files-meta calls

### DIFF
--- a/resources/package.json
+++ b/resources/package.json
@@ -37,7 +37,7 @@
     "https-proxy-agent": "5.0.0",
     "@sentry/electron": "2.5.1",
     "posthog-js": "1.10.2",
-    "@logseq/rsapi": "0.0.54",
+    "@logseq/rsapi": "0.0.56",
     "electron-deeplink": "1.0.10",
     "abort-controller": "3.0.0"
   },

--- a/src/main/frontend/modules/outliner/file.cljs
+++ b/src/main/frontend/modules/outliner/file.cljs
@@ -96,10 +96,11 @@
   []
   (util/<ratelimit (state/get-file-write-chan) batch-write-interval
                  :filter-fn
-                 (fn [[repo _ time]]
-                   (swap! *writes-finished? assoc repo {:time time
-                                                        :value false})
-                   true)
+                 (fn [elems]
+                   (doseq [[repo _ time] elems]
+                     (swap! *writes-finished? assoc repo
+                            {:time time :value false}))
+                   elems)
                  :flush-fn
                  (fn [col]
                    (let [start-time (tc/to-long (t/now))

--- a/src/test/frontend/fs/sync_test.cljs
+++ b/src/test/frontend/fs/sync_test.cljs
@@ -24,20 +24,20 @@
 (deftest diff-file-metadata-sets
   (are [x y z] (= x (sync/diff-file-metadata-sets y z))
     #{}
-    #{(sync/->FileMetadata 1 2 "3" 4 5 nil nil nil)}
-    #{(sync/->FileMetadata 1 2 "3" 4 5 nil nil nil)}
+    #{(sync/->FileMetadata 1 2 "3" 4 5 nil nil nil nil)}
+    #{(sync/->FileMetadata 1 2 "3" 4 5 nil nil nil nil)}
 
     #{}
-    #{(sync/->FileMetadata 1 2 "3" 4 5 nil nil nil)}
-    #{(sync/->FileMetadata 1 22 "3" 4 6 nil nil nil)}
+    #{(sync/->FileMetadata 1 2 "3" 4 5 nil nil nil nil)}
+    #{(sync/->FileMetadata 1 22 "3" 4 6 nil nil nil nil)}
 
-    #{(sync/->FileMetadata 1 2 "3" 4 5 nil nil nil)}
-    #{(sync/->FileMetadata 1 2 "3" 4 5 nil nil nil)}
-    #{(sync/->FileMetadata 1 22 "3" 4 4 nil nil nil) (sync/->FileMetadata 1 22 "3" 44 5 nil nil nil)}
+    #{(sync/->FileMetadata 1 2 "3" 4 5 nil nil nil nil)}
+    #{(sync/->FileMetadata 1 2 "3" 4 5 nil nil nil nil)}
+    #{(sync/->FileMetadata 1 22 "3" 4 4 nil nil nil nil) (sync/->FileMetadata 1 22 "3" 44 5 nil nil nil nil)}
 
     #{}
-    #{(sync/->FileMetadata 1 2 "3" 4 5 nil nil nil)}
-    #{(sync/->FileMetadata 1 2 "3" 4 4 nil nil nil) (sync/->FileMetadata 1 2 "3" 4 6 nil nil nil)}
+    #{(sync/->FileMetadata 1 2 "3" 4 5 nil nil nil nil)}
+    #{(sync/->FileMetadata 1 2 "3" 4 4 nil nil nil nil) (sync/->FileMetadata 1 2 "3" 4 6 nil nil nil nil)}
 
     )
   )

--- a/static/yarn.lock
+++ b/static/yarn.lock
@@ -351,41 +351,41 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@logseq/rsapi-darwin-arm64@0.0.54":
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi-darwin-arm64/-/rsapi-darwin-arm64-0.0.54.tgz#a6f671c22fa13b86897c987e237626ea5e35b067"
-  integrity sha512-sNPWTeUO/wgogQuS3Dbs0eJMCzkahCvkOtYfj/gOwZ5tOrpg8/ZHr7yVX4tbYBLcWKvIXLZYDG2thCZ7nnwP0w==
+"@logseq/rsapi-darwin-arm64@0.0.56":
+  version "0.0.56"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi-darwin-arm64/-/rsapi-darwin-arm64-0.0.56.tgz#16d0c8e5760b90ffdc11380b6be1ce469e5eb445"
+  integrity sha512-0JbnQRJyapQABKF7nKrBmAXXuCDygCYZkFKM6bb2/WlkVxjJV2EZle5otmXye6DTPBUm2Ve2PcBXNL8JqMnsgg==
 
-"@logseq/rsapi-darwin-x64@0.0.54":
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi-darwin-x64/-/rsapi-darwin-x64-0.0.54.tgz#04867139ff2711c9ce8efa943be6fe7fbb811920"
-  integrity sha512-hd7//syo4SybzWggCXQ26IaExRDFZtE6NCjP4V9WSNVW0NdFHn9XcwK/yPvolaxe2NosNvmMkKnnK0u7LXGgrw==
+"@logseq/rsapi-darwin-x64@0.0.56":
+  version "0.0.56"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi-darwin-x64/-/rsapi-darwin-x64-0.0.56.tgz#16224e6beb5905fe3d2a5e993fc02fe7add596eb"
+  integrity sha512-xGItNcUsNtCa6XU2YEdvhnIXJCwn8+HTY5f3RsYxjhrh1Sk7E6XOAVIif/H/awosD/EScy48ehkV8wkZwSihkA==
 
-"@logseq/rsapi-linux-arm64-gnu@0.0.54":
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi-linux-arm64-gnu/-/rsapi-linux-arm64-gnu-0.0.54.tgz#d3158381510cec95307fef0459bdbecd29ab4f64"
-  integrity sha512-9Y+a23aWcPyZp+FZqv3yUdYzYMQd6mlCdPHBSmVRBBDSM6rTLNMs4xQEiJjxm2BNgjDQMoqZGzXjhvR0ZlPgbQ==
+"@logseq/rsapi-linux-arm64-gnu@0.0.56":
+  version "0.0.56"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi-linux-arm64-gnu/-/rsapi-linux-arm64-gnu-0.0.56.tgz#fb0f051ff3f0359efb703c93847d9d1fd2d0f277"
+  integrity sha512-0yeVK6H7aAKfA2Fz+a0nAKoMLHrt3AjThzocFPPLW4Wmskdyb3hpTkhWKHjnlHiaXkgs7ivdqlsqJsaLpnEh8w==
 
-"@logseq/rsapi-linux-x64-gnu@0.0.54":
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi-linux-x64-gnu/-/rsapi-linux-x64-gnu-0.0.54.tgz#a569a69886d7a4c1416c99cbe6df234ca459fdfb"
-  integrity sha512-wwipWPt/F+MLlBw82nOVusB0bD7Ha5Q+h2fnggHknpCMBuhCnJj9xY2jnwa92AiW8KQIPUYpCG5VmUK4dNH8eg==
+"@logseq/rsapi-linux-x64-gnu@0.0.56":
+  version "0.0.56"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi-linux-x64-gnu/-/rsapi-linux-x64-gnu-0.0.56.tgz#5752074d8d51d98d658bd1500e3fbfc2fca4c946"
+  integrity sha512-e7qf93L3BuXyOW/8dxmcHtZxSWCCn7LDxtMaudGrIU+xlpmLYK+WxRei3iHOC2luz/szJpXQsbH0arpSOtrygw==
 
-"@logseq/rsapi-win32-x64-msvc@0.0.54":
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi-win32-x64-msvc/-/rsapi-win32-x64-msvc-0.0.54.tgz#a6fb15d8d1cdb177a3ae30a37c04335bdcff36e0"
-  integrity sha512-sUKCObHWXrwdJK5Lda0rhYVLQUaE64FBJoC2oPPfRoBRDzJiYdH3dX18SpAj8j1VEoyoJry7OklwQzptbpj0LA==
+"@logseq/rsapi-win32-x64-msvc@0.0.56":
+  version "0.0.56"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi-win32-x64-msvc/-/rsapi-win32-x64-msvc-0.0.56.tgz#c0327a68090d83066e1207be25ffa41218299292"
+  integrity sha512-hHTwN7EzHYoDR0t1de6br8DyyHTNNpGvUUkBXq7py5OQmGeiZT5JxD6pQRi1oYpBE1WraN215mYfPKNr5ETJ6w==
 
-"@logseq/rsapi@0.0.54":
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi/-/rsapi-0.0.54.tgz#35eab4b5e07b034f604debac292f9070aa33f2c3"
-  integrity sha512-5m7Nuus9bx/SWM8EN0c4Kc6v+rhiY1bjiymCe6PoYfq/IX1J0NObUSXmUv5r1KpJLKBdO2wyx1300k45Hgu3QA==
+"@logseq/rsapi@0.0.56":
+  version "0.0.56"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi/-/rsapi-0.0.56.tgz#1f2306dcac194ecba6a196853ebbedccb19928f9"
+  integrity sha512-F97Mdn9xi0kAhpmTKNhTrh+PyToGrxYBDP0fJ38S93CWvowN2nkVK+SwUfAcm4M3GwX9dEtMJQquc+WTkSwGRw==
   optionalDependencies:
-    "@logseq/rsapi-darwin-arm64" "0.0.54"
-    "@logseq/rsapi-darwin-x64" "0.0.54"
-    "@logseq/rsapi-linux-arm64-gnu" "0.0.54"
-    "@logseq/rsapi-linux-x64-gnu" "0.0.54"
-    "@logseq/rsapi-win32-x64-msvc" "0.0.54"
+    "@logseq/rsapi-darwin-arm64" "0.0.56"
+    "@logseq/rsapi-darwin-x64" "0.0.56"
+    "@logseq/rsapi-linux-arm64-gnu" "0.0.56"
+    "@logseq/rsapi-linux-x64-gnu" "0.0.56"
+    "@logseq/rsapi-win32-x64-msvc" "0.0.56"
 
 "@malept/cross-spawn-promise@^1.0.0", "@malept/cross-spawn-promise@^1.1.0":
   version "1.1.1"


### PR DESCRIPTION
- add `:filter-fn-duration-window` option to `util/<ratelimit` to enable batch handle file-change-events in `:filter-fn`
- there're still a few places calling`<get-local-files-meta` by one filepath arg, which need to be optimized together with another `reduce <get-remote-files-meta calls` pr
 
WIP: waiting for mobile file-sync API support