### PR TITLE
enhance(dev): add `cljs:dev-release-electron`

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "cljs:test": "clojure -M:test compile test",
         "cljs:run-test": "node static/tests.js",
         "cljs:dev-release-app": "clojure -M:cljs release app --config-merge \"{:closure-defines {frontend.config/DEV-RELEASE true}}\"",
+        "cljs:dev-release-electron": "clojure -M:cljs release app electron --debug --config-merge \"{:closure-defines {frontend.config/DEV-RELEASE true}}\" && clojure -M:cljs release publishing",
         "cljs:debug": "clojure -M:cljs release app --debug",
         "cljs:report": "clojure -M:cljs run shadow.cljs.build-report app report.html",
         "cljs:build-electron": "clojure -A:cljs compile app electron",


### PR DESCRIPTION
I like to have a dev version of logseq on my system alongside a regular build. I have been building it so far using the full command:
```sh
$ clojure -M:cljs release app electron --config-merge "{:closure-defines {frontend.config/DEV-RELEASE true}}"
```
Since `cljs:dev-release-app` already exist; It would be nice to add `cljs:dev-release-electron` as well
```sh
$ yarn cljs:dev-release-electron
```