### PR TITLE
enhance: validate outliner data when get-block-children-ids

### DIFF
--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -890,18 +890,24 @@ independent of format as format specific heading characters are stripped"
                               '[:db/id :block/name :block/original-name]
                               ids))))))
 
-
 (defn get-block-children-ids
   [repo block-uuid]
   (when-let [db (conn/get-db repo)]
     (when-let [eid (:db/id (db-utils/entity repo [:block/uuid block-uuid]))]
-      (let [get-children-ids (fn get-children-ids [eid]
-                               (mapcat
-                                (fn [datom]
-                                  (let [id (first datom)]
-                                    (cons (:block/uuid (db-utils/entity db id)) (get-children-ids id))))
-                                (d/datoms db :avet :block/parent eid)))]
-        (get-children-ids eid)))))
+      (let [seen   (volatile! [])]
+        (loop [steps          100               ;check result every 100 steps
+               eids-to-expand [eid]]
+          (when (seq eids-to-expand)
+            (let [eids-to-expand*
+                  (mapcat (fn [eid] (map first (d/datoms db :avet :block/parent eid))) eids-to-expand)
+                  uuids-to-add (remove nil? (map #(:block/uuid (db-utils/entity db %)) eids-to-expand*))]
+              (when (and (zero? steps)
+                         (seq (set/intersection (set @seen) (set uuids-to-add))))
+                (throw (ex-info "bad outliner data, need to re-index to fix"
+                                {:seen @seen :eids-to-expand eids-to-expand})))
+              (vswap! seen (partial apply conj) uuids-to-add)
+              (recur (if (zero? steps) 100 (dec steps)) eids-to-expand*))))
+        @seen))))
 
 (defn get-block-immediate-children
   "Doesn't include nested children."

--- a/src/test/fixtures/broken-outliner-data-with-cycle.edn
+++ b/src/test/fixtures/broken-outliner-data-with-cycle.edn
@@ -1,0 +1,14 @@
+;;; datoms
+;;; - 1 <----+
+;;;   - 2    |
+;;;     - 3 -+
+[{:db/id 1
+  :block/uuid #uuid"e538d319-48d4-4a6d-ae70-c03bb55b6fe4"
+  :block/parent 3}
+ {:db/id 2
+  :block/uuid #uuid"c46664c0-ea45-4998-adf0-4c36486bb2e5"
+  :block/parent 1}
+ {:db/id 3
+  :block/uuid #uuid"2b736ac4-fd49-4e04-b00f-48997d2c61a2"
+  :block/parent 2}
+ ]

--- a/src/test/frontend/db/model_test.cljs
+++ b/src/test/frontend/db/model_test.cljs
@@ -3,7 +3,7 @@
             [frontend.db.model :as model]
             [frontend.db :as db]
             [frontend.db.conn :as conn]
-            [logseq.db.schema :as schema]
+            [logseq.db.schema :as db-schema]
             [frontend.test.helper :as test-helper :refer [load-test-files]]
             [datascript.core :as d]
             [shadow.resource :as rc]
@@ -154,7 +154,7 @@ foo:: bar"}])
                                          edn/read-string))
 
 (deftest get-block-children-ids-on-bad-outliner-data
-  (let [db (d/db-with (d/empty-db logseq.db.schema/schema)
+  (let [db (d/db-with (d/empty-db db-schema/schema)
                       broken-outliner-data-with-cycle)]
 
     (is (= "bad outliner data, need to re-index to fix"

--- a/src/test/frontend/db/model_test.cljs
+++ b/src/test/frontend/db/model_test.cljs
@@ -3,7 +3,11 @@
             [frontend.db.model :as model]
             [frontend.db :as db]
             [frontend.db.conn :as conn]
-            [frontend.test.helper :as test-helper :refer [load-test-files]]))
+            [logseq.db.schema :as schema]
+            [frontend.test.helper :as test-helper :refer [load-test-files]]
+            [datascript.core :as d]
+            [shadow.resource :as rc]
+            [clojure.edn :as edn]))
 
 (use-fixtures :each {:before test-helper/start-test-db!
                      :after test-helper/destroy-test-db!})
@@ -129,7 +133,7 @@
 (deftest entity-query-should-support-both-graph-string-and-db
   (is (= 1 (:db/id (db/entity test-helper/test-db 1))))
   (is (= 1 (:db/id (db/entity (conn/get-db test-helper/test-db) 1)))))
-  
+
 (deftest get-block-by-page-name-and-block-route-name
   (load-test-files [{:file/path "foo.md"
                      :file/content "foo:: bar
@@ -144,3 +148,16 @@ foo:: bar"}])
   (is (nil?
        (model/get-block-by-page-name-and-block-route-name test-helper/test-db "foo" "b2"))
       "Non header block's content returns nil"))
+
+
+(def broken-outliner-data-with-cycle (-> (rc/inline "fixtures/broken-outliner-data-with-cycle.edn")
+                                         edn/read-string))
+
+(deftest get-block-children-ids-on-bad-outliner-data
+  (let [db (d/db-with (d/empty-db logseq.db.schema/schema)
+                      broken-outliner-data-with-cycle)]
+
+    (is (= "bad outliner data, need to re-index to fix"
+           (try (model/get-block-children-ids-in-db db #uuid"e538d319-48d4-4a6d-ae70-c03bb55b6fe4")
+                (catch :default e
+                  (ex-message e)))))))


### PR DESCRIPTION
`get-block-children-ids` may forever loop when some outliner data construct a cycle: parent-block's parent is its child-block
- [x] add testcase for this fn