### PR TITLE
Fix/arrow indicator

### DIFF
--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LineShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LineShape.tsx
@@ -123,7 +123,6 @@ export class LineShape extends TLLineShape<LineShapeProps> {
     }, [bounds, scale, midPoint])
     return (
       <g>
-        <LabelMask id={id} bounds={bounds} labelSize={labelSize} offset={offset} scale={scale} />
         <path
           mask={label ? `url(#${id}_clip)` : ``}
           d={getArrowPath(

--- a/tldraw/apps/tldraw-logseq/src/styles.css
+++ b/tldraw/apps/tldraw-logseq/src/styles.css
@@ -471,6 +471,8 @@ button.tl-select-input-trigger {
   &:focus {
     outline: none;
     border: none;
+    box-shadow: none;
+    background-color: hsla(0, 0%, 50%, 0.15) !important;
   }
 }
 

--- a/tldraw/packages/core/src/lib/tools/TLSelectTool/states/IdleState.ts
+++ b/tldraw/packages/core/src/lib/tools/TLSelectTool/states/IdleState.ts
@@ -127,8 +127,6 @@ export class IdleState<
     const selectedShape = this.app.selectedShapesArray[0]
     if (!selectedShape.canEdit) return
 
-    if (!PointUtils.pointInBounds(this.app.inputs.currentPoint, selectedShape.bounds)) return
-
     switch (info.type) {
       case TLTargetType.Shape: {
         this.tool.transition('editingShape', info)


### PR DESCRIPTION
- [x] Change the style of focused textarea on editable labels
- [x] Remove label mask from arrow indicato, to avoid the strikethrough text effect on horizontal arrows
- [x] Remove bounds check on double click to allow switching to edit mode when you double click on the arrow label

@peng The last bullet point is not a great solution, but `hideSelection` id already set to `false` on arrows, so we don't care about the visual part. Also , the first click will always modify the current selection, so I am not sure if there is an actual case that this condition prevents.