### PR TITLE
fix: some issues on pasting group shape

### DIFF
--- a/tldraw/packages/core/src/lib/TLApi/TLApi.ts
+++ b/tldraw/packages/core/src/lib/TLApi/TLApi.ts
@@ -219,14 +219,16 @@ export class TLApi<S extends TLShape = TLShape, K extends TLEventMap = TLEventMa
     bindings: Record<string, TLBinding>
   }) => {
     const commonBounds = BoundsUtils.getCommonBounds(
-      shapes.map(shape => ({
-        minX: shape.point?.[0] ?? point[0],
-        minY: shape.point?.[1] ?? point[1],
-        width: shape.size?.[0] ?? 4,
-        height: shape.size?.[1] ?? 4,
-        maxX: (shape.point?.[0] ?? point[0]) + (shape.size?.[0] ?? 4),
-        maxY: (shape.point?.[1] ?? point[1]) + (shape.size?.[1] ?? 4),
-      }))
+      shapes
+        .filter(s => s.type !== 'group')
+        .map(shape => ({
+          minX: shape.point?.[0] ?? point[0],
+          minY: shape.point?.[1] ?? point[1],
+          width: shape.size?.[0] ?? 4,
+          height: shape.size?.[1] ?? 4,
+          maxX: (shape.point?.[0] ?? point[0]) + (shape.size?.[0] ?? 4),
+          maxY: (shape.point?.[1] ?? point[1]) + (shape.size?.[1] ?? 4),
+        }))
     )
 
     const clonedShapes = shapes.map(shape => {
@@ -242,9 +244,9 @@ export class TLApi<S extends TLShape = TLShape, K extends TLEventMap = TLEventMa
 
     clonedShapes.forEach(s => {
       if (s.children && s.children?.length > 0) {
-        s.children = s.children.map(oldId => {
-          return clonedShapes[shapes.findIndex(s => s.id === oldId)].id
-        })
+        s.children = s.children
+          .map(oldId => clonedShapes[shapes.findIndex(s => s.id === oldId)]?.id)
+          .filter(isNonNullable)
       }
     })
 

--- a/tldraw/packages/core/src/lib/TLApp/TLApp.ts
+++ b/tldraw/packages/core/src/lib/TLApp/TLApp.ts
@@ -318,7 +318,7 @@ export class TLApp<
   /* --------------------- Shapes --------------------- */
 
   getShapeById = <T extends S>(id: string, pageId = this.currentPage.id): T | undefined => {
-    const shape = this.getPageById(pageId)?.shapes.find(shape => shape.id === id) as T
+    const shape = this.getPageById(pageId)?.shapesById[id] as T
     return shape
   }
 

--- a/tldraw/packages/core/src/lib/TLPage/TLPage.ts
+++ b/tldraw/packages/core/src/lib/TLPage/TLPage.ts
@@ -85,6 +85,10 @@ export class TLPage<S extends TLShape = TLShape, E extends TLEventMap = TLEventM
     }
   }
 
+  @computed get shapesById() {
+    return Object.fromEntries(this.shapes.map(shape => [shape.id, shape]))
+  }
+
   @observable nonce = 0
 
   @action bump = () => {


### PR DESCRIPTION
- fix pasting offset when the selected item contains a group shape
- fix an issue when pasting a group with an invalid shape id,
- fix performance issue of `getShapeById`