### PR TITLE
enhance(sync): no ttl for update-type recent-remote->local-files-item [WIP]

### DIFF
--- a/src/test/frontend/fs/sync_test.cljs
+++ b/src/test/frontend/fs/sync_test.cljs
@@ -1,6 +1,6 @@
 (ns frontend.fs.sync-test
   (:require [frontend.fs.sync :as sync]
-            [clojure.test :refer [deftest are]]))
+            [clojure.test :refer [deftest are is]]))
 
 (deftest ignored?
   (are [x y] (= y (sync/ignored? x))
@@ -41,3 +41,40 @@
 
     )
   )
+
+(deftest sync-state--recent-remote->local-files
+  (let [item1       {:remote->local-type :update
+                     :checksum           "checksum1"
+                     :path               "path1"}
+        item2       {:remote->local-type :update
+                     :checksum           "checksum2"
+                     :path               "path2"}
+        item-map    (fn [items] (into {} (map (juxt :path identity)) items))
+        sync-state  (sync/sync-state)
+        sync-state1 (sync/sync-state--add-recent-remote->local-files sync-state [item1 item2])]
+
+    (is (= (assoc sync-state
+                  :recent-remote->local-files-map
+                  (item-map [item1 item2])
+                  :recent-remote->local-files
+                  (set [item1 item2]))
+           sync-state1))
+
+    (let [item3 (assoc item1 :checksum "checksum3")
+          sync-state2 (sync/sync-state--add-recent-remote->local-files sync-state1 [item3])]
+      (is (= (-> sync-state1
+                 (assoc-in [:recent-remote->local-files-map (:path item1) :checksum] (:checksum item3))
+                 (assoc :recent-remote->local-files (set [item2 item3])))
+             sync-state2))
+
+      (let [sync-state3 (sync/sync-state--remove-recent-remote->local-files sync-state2 [item2])]
+        (is (= (-> sync-state2
+                   (update :recent-remote->local-files-map dissoc (:path item2))
+                   (update :recent-remote->local-files disj (:path item2)))
+               sync-state3))
+
+        (let [sync-state4 (sync/sync-state--remove-recent-remote->local-files sync-state3 [item3])]
+          (is (= (-> sync-state3
+                     (update :recent-remote->local-files-map dissoc (:path item3))
+                     (update :recent-remote->local-files disj (:path item3)))
+                 sync-state4)))))))


### PR DESCRIPTION
there's a [checksum](https://github.com/logseq/logseq/pull/7773/files#diff-7bf347ecbc0122ebba0b92f35056be526988b452b0713796616e991d883a2f28R91) property attr in [update-items](https://github.com/logseq/logseq/pull/7773/files#diff-7bf347ecbc0122ebba0b92f35056be526988b452b0713796616e991d883a2f28R1602),
so it won't conflict with another same file update event. 
they will stay in `:recent-remote->local-files` to prevent the late file-watch event from triggering a new extra upload event