### PR TITLE
fix: pencil issue when drawing quickly

### DIFF
--- a/tldraw/packages/react/src/hooks/useCanvasEvents.ts
+++ b/tldraw/packages/react/src/hooks/useCanvasEvents.ts
@@ -19,7 +19,9 @@ export function useCanvasEvents() {
 
     const onPointerDown: TLReactCustomEvents['pointer'] = e => {
       const { order = 0 } = e
-      if (!order) e.currentTarget?.setPointerCapture(e.pointerId)
+      if (!order && e.pointerType !== 'pen') {
+        e.currentTarget?.setPointerCapture(e.pointerId)
+      }
 
       if (!e.isPrimary) {
         // ignore secondary pointers (in multi-touch scenarios)

--- a/tldraw/packages/react/src/hooks/useCanvasEvents.ts
+++ b/tldraw/packages/react/src/hooks/useCanvasEvents.ts
@@ -19,9 +19,7 @@ export function useCanvasEvents() {
 
     const onPointerDown: TLReactCustomEvents['pointer'] = e => {
       const { order = 0 } = e
-      if (!order) {
-        e.currentTarget?.setPointerCapture(e.pointerId)
-      }
+      if (!order) e.currentTarget?.setPointerCapture(e.pointerId)
 
       if (!e.isPrimary) {
         // ignore secondary pointers (in multi-touch scenarios)

--- a/tldraw/packages/react/src/hooks/useCanvasEvents.ts
+++ b/tldraw/packages/react/src/hooks/useCanvasEvents.ts
@@ -19,7 +19,7 @@ export function useCanvasEvents() {
 
     const onPointerDown: TLReactCustomEvents['pointer'] = e => {
       const { order = 0 } = e
-      if (!order && e.pointerType !== 'pen') {
+      if (!order) {
         e.currentTarget?.setPointerCapture(e.pointerId)
       }
 
@@ -77,6 +77,10 @@ export function useCanvasEvents() {
       onPointerLeave,
       onDrop,
       onDragOver,
+      // fix touch callout in iOS
+      onTouchEnd: (e: TouchEvent) => {
+        e.preventDefault()
+      }
     }
   }, [callbacks])
 


### PR DESCRIPTION
Looks like if we call event.preventDefault of the touchend event, the callout magnifier will not show any longer and makes sure user can draw quickly on the canvas.