### PR TITLE
Fix: Button display

### DIFF
--- a/src/main/frontend/ui.css
+++ b/src/main/frontend/ui.css
@@ -259,7 +259,7 @@ html.is-mobile {
 }
 
 .ui__button {
-  @apply flex items-center px-3 py-2 border border-transparent
+  @apply inline-flex items-center px-3 py-2 border border-transparent
   text-sm leading-4 font-medium rounded-md text-white
   focus:outline-none transition ease-in-out duration-150;
 


### PR DESCRIPTION
The default display property of buttons is inline. Since we need to use flexbox in order to align nested elements, using inline-flex might be the best option, in order to maintain the default behavior. For instance, that would fix the alignment of the shortcut buttons.

![Screenshot from 2022-12-20 15-21-45](https://user-images.githubusercontent.com/10744960/208678053-4f6196a2-dbef-4f2f-b30f-f1e3ce61f885.png)

![Screenshot from 2022-12-20 15-22-10](https://user-images.githubusercontent.com/10744960/208678067-f9a512ea-b021-4720-b3a7-4afc4343296a.png)

