### PR TITLE
Fix: Provide consistent page links for web and publishing

### DIFF
--- a/src/main/frontend/handler/route.cljs
+++ b/src/main/frontend/handler/route.cljs
@@ -56,7 +56,9 @@
          :path-params {:name (get-in block [:block/page :block/name])
                        :block-route-name (model/heading-content->route-name (:block/content block))}}
         {:to :page
-         :path-params {:name (str page-name-or-block-uuid)}})))
+         :path-params {:name (if (string? page-name-or-block-uuid)
+                               (util/page-name-sanity-lc page-name-or-block-uuid)
+                               (str page-name-or-block-uuid))}})))
 
   (defn- default-page-route [page-name]
     {:to :page

--- a/src/test/frontend/handler/route_test.cljs
+++ b/src/test/frontend/handler/route_test.cljs
@@ -2,7 +2,7 @@
   (:require [frontend.handler.route :as route-handler]
             [frontend.test.helper :as test-helper :refer [load-test-files]]
             [frontend.db.utils :as db-utils]
-            [clojure.test :refer [deftest is use-fixtures]]))
+            [clojure.test :refer [deftest is use-fixtures testing]]))
 
 (use-fixtures :each {:before test-helper/start-test-db!
                      :after test-helper/destroy-test-db!})
@@ -14,15 +14,17 @@
 - ## B1
 - b2
 - ### Header 2
-foo:: bar"}])
+foo:: bar
+- ## Header 3 [[Dec 19th, 2022]]"}])
 
-  (let [block (ffirst
-               (db-utils/q '[:find (pull ?b [:block/uuid])
-                             :where [?b :block/content "## B1"]]))]
-    (is (= {:to :page-block
-            :path-params {:name "foo" :block-route-name "b1"}}
-           (#'route-handler/default-page-route (:block/uuid block)))
-        "Generates a page-block link if route-name is found"))
+  (testing ":page-block route"
+    (let [block (ffirst
+                 (db-utils/q '[:find (pull ?b [:block/uuid])
+                               :where [?b :block/content "## B1"]]))]
+      (is (= {:to :page-block
+              :path-params {:name "foo" :block-route-name "b1"}}
+             (#'route-handler/default-page-route (:block/uuid block)))
+          "Generates a page-block link if route-name is found")))
 
   (let [block (ffirst
                (db-utils/q '[:find (pull ?b [:block/uuid])
@@ -30,16 +32,29 @@ foo:: bar"}])
     (is (= {:to :page-block
             :path-params {:name "foo" :block-route-name "header 2"}}
            (#'route-handler/default-page-route (:block/uuid block)))
-        "Generates a page-block link if route-name with whitespace and properties is found"))
+        "Generates a page-block link for route-name with whitespace and properties is found")
 
-  (let [uuid (-> (db-utils/q '[:find (pull ?b [:block/uuid])
-                               :where [?b :block/content "b2"]])
-                 ffirst
-                 :block/uuid)]
-    (is (= {:to :page :path-params {:name (str uuid)}}
-           (#'route-handler/default-page-route uuid))
-        "Generates a page link if route-name is not found"))
+    (let [block (ffirst
+                 (db-utils/q '[:find (pull ?b [:block/uuid])
+                               :where [?b :block/content "## Header 3 [[Dec 19th, 2022]]"]]))]
+      (is (= {:to :page-block
+              :path-params {:name "foo" :block-route-name "header 3 [[dec 19th, 2022]]"}}
+             (#'route-handler/default-page-route (:block/uuid block)))
+          "Generates a page-block link for route name with page ref")))
 
-  (is (= {:to :page :path-params {:name "page-name"}}
-         (#'route-handler/default-page-route "page-name"))
-      "Generates a page link if name is not a uuid"))
+  (testing ":page route"
+    (let [uuid (-> (db-utils/q '[:find (pull ?b [:block/uuid])
+                                 :where [?b :block/content "b2"]])
+                   ffirst
+                   :block/uuid)]
+      (is (= {:to :page :path-params {:name (str uuid)}}
+             (#'route-handler/default-page-route uuid))
+          "Generates a page link if route-name is not found"))
+
+    (is (= {:to :page :path-params {:name "page-name"}}
+           (#'route-handler/default-page-route "page-name"))
+        "Generates a page link if name is not a uuid")
+
+    (is (= {:to :page :path-params {:name "page name"}}
+           (#'route-handler/default-page-route "Page name"))
+        "Generates a case insensitive page link")))


### PR DESCRIPTION
When coming from search, page links were capitalized but most everywhere else page links were lower case. This fix consistently enforces lower case and thus provides consistency to page identity in urls. With this consistency, web apps no longer encourage weird scenarios e.g. https://docs.logseq.com/#/page/Logseq%20Sync leading to https://docs.logseq.com/#/page/logseq%20sync/block/functionality when you click on a block