### PR TITLE
feat: Add close-stale-issues-action

### DIFF
--- a/.github/stale-issues.yml
+++ b/.github/stale-issues.yml
@@ -46,7 +46,7 @@ jobs:
               - **Blog**: https://blog.logseq.com
               - **Docs**: https://docs.logseq.com
 
-            Thanks for your contributions to Logseq! If you have any other **issues** or **feature** requests, please don't hesitate to let us know. We always welcome pull requests too!
+            Thanks for your contributions to Logseq! If you have any other [**issues**](https://github.com/logseq/logseq/issues/new/choose) or [**feature requests**](https://discuss.logseq.com/c/feature-requests/), please don't hesitate to [let us know](https://github.com/logseq/logseq/issues/new/choose). We always welcome pull requests too!
 
       - name: 'Print outputs'
         run: |
@@ -81,7 +81,7 @@ jobs:
               - **Blog**: https://blog.logseq.com
               - **Docs**: https://docs.logseq.com
 
-            Thanks for your contributions to Logseq! If you have any other **issues** or **feature** requests, please don't hesitate to let us know. We always welcome pull requests too!
+            Thanks for your contributions to Logseq! If you have any other [**issues**](https://github.com/logseq/logseq/issues/new/choose) or [**feature requests**](https://discuss.logseq.com/c/feature-requests/), please don't hesitate to [let us know](https://github.com/logseq/logseq/issues/new/choose). We always welcome pull requests too!
 
       - name: 'Print outputs'
         run: |

--- a/.github/stale-issues.yml
+++ b/.github/stale-issues.yml
@@ -30,7 +30,7 @@ jobs:
         operations-per-run: 100 # The maximum number of operations per run, used to control rate limiting
         stale-issue-label: ':status/automatic-stale'
         close-issue-label: ':status/automatic-closing'
-        exempt-issue-labels: ':status/hold, :status/WIP, :type/enhancement'
+        exempt-issue-labels: ':status/hold, :status/WIP, :type/enhancement, type/can-be-reproduced, priority-A'
         remove-stale-when-updated: true
         stale-issue-message: |
             👋 Hello,

--- a/.github/stale-issues.yml
+++ b/.github/stale-issues.yml
@@ -5,7 +5,7 @@
 #   https://github.com/actions/stale/blob/master/action.yml
 #   https://github.com/actions/stale
 ---
-name: '180 Days Stale Issues Policy'
+name: 'Stale Issues Policy'
 on:
   schedule:
     - cron: "0 0 * * *" # Run at 00:00 UTC every day
@@ -13,11 +13,10 @@ on:
 
 permissions:
   contents: read
+  issues: write  # for actions/stale to close stale issues
 
 jobs:
-  stale:
-    permissions:
-      issues: write  # for actions/stale to close stale issues
+  stale: 
     runs-on: ubuntu-latest
     steps:
     - name: '🧹 Mark & close stale issues'
@@ -31,6 +30,42 @@ jobs:
         stale-issue-label: ':status/automatic-stale'
         close-issue-label: ':status/automatic-closing'
         exempt-issue-labels: ':status/hold, :status/WIP, :type/enhancement, type/can-be-reproduced, priority-A'
+        remove-stale-when-updated: true
+        stale-issue-message: |
+            👋 Hello,
+            There hasn't been any recent activity on this issue :sleeping:
+            To keep our backlog manageable & to help us focus on the active issues, we have to clean old issues,
+            as many of them have already been resolved with the latest updates.
+
+            Please make sure to update to the latest [Logseq](https://logseq.com) version and
+            Let us know if that solves the issue by adding a comment 💬
+
+            This issue has been automatically marked as stale & will be closed in 20 days
+            if no further activity occurs.
+
+            Access additional [Logseq](https://logseq.com) 🚀 resources:
+              - **Forum**: https://discuss.logseq.com
+              - **Blog**: https://blog.logseq.com
+              - **Docs**: https://docs.logseq.com
+
+            Feel free to inform us of any other **issues** you discover or **feature requests** that come to mind in the future. Pull Requests (PRs) are also always welcomed!
+
+            Thank you for your contributions to Logseq! :heart:
+
+    - name: 'Print outputs'
+      run: printf '%s\n' ${{ join(steps.stale.outputs.*, ',') }}
+
+    - name: '🧹 Close stale awaiting response issues'
+      id: awaiting_issues
+      uses: actions/stale@6f05e4244c9a0b2ed3401882b05d701dd0a7289b # v7
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-issue-stale: 40
+        days-before-close: 20
+        operations-per-run: 30 # The maximum number of operations per run, used to control rate limiting
+        stale-issue-label: ':status/automatic-stale'
+        close-issue-label: ':status/automatic-closing'
+        only-labels: 'awaiting response'
         remove-stale-when-updated: true
         stale-issue-message: |
             👋 Hello,

--- a/.github/stale-issues.yml
+++ b/.github/stale-issues.yml
@@ -38,7 +38,7 @@ jobs:
 
           If the issue has been resolved or is no longer relevant, that's great news! We'll go ahead and close this issue to keep our backlog organized. Please note that this issue will be closed automatically in 20 days if there is no further activity. If you need more time to resolve the issue or provide more information, please just let us know by adding a comment.
 
-          If you're still having trouble, you might find it helpful to update to the latest version of Logseq. You can download the latest version from [our website](https://logseq.com). If updating to the latest version doesn't help, please don't hesitate to reach out for assistance.
+          If you're still having trouble, you might find it helpful to update to the latest version of Logseq. The latest version includes bug fixes and new features that may help to resolve this issue, and you can download it from [our website](https://logseq.com). If updating to the latest version doesn't help, please don't hesitate to reach out for assistance.
 
           Access additional [Logseq](https://logseq.com) 🚀 resources:
             - **Forum**: https://discuss.logseq.com
@@ -69,7 +69,7 @@ jobs:
 
           If the issue has been resolved or is no longer relevant, that's great news! We'll go ahead and close this issue to keep our backlog organized. Please note that this issue will be closed automatically in 20 days if there is no further activity. If you need more time to resolve the issue or provide more information, please just let us know by adding a comment.
 
-          If you're still having trouble, you might find it helpful to update to the latest version of Logseq. You can download the latest version from [our website](https://logseq.com). If updating to the latest version doesn't help, please don't hesitate to reach out for assistance.
+          If you're still having trouble, you might find it helpful to update to the latest version of Logseq. The latest version includes bug fixes and new features that may help to resolve this issue, and you can download it from [our website](https://logseq.com). If updating to the latest version doesn't help, please don't hesitate to reach out for assistance.
 
           Access additional [Logseq](https://logseq.com) 🚀 resources:
             - **Forum**: https://discuss.logseq.com

--- a/.github/stale-issues.yml
+++ b/.github/stale-issues.yml
@@ -37,7 +37,8 @@ jobs:
 
             We haven't seen any activity on this issue in a while :sleeping:, and we just wanted to make sure that it's still relevant. If you're still experiencing this issue, you might find it helpful to update to the latest version of Logseq. The latest version includes bug fixes and new features that may help to resolve this issue, and you can download it from [our website](https://logseq.com). If updating to the latest version doesn't help, please let us know by adding a comment 💬. We're here to help!
 
-            If the issue has been resolved or is no longer relevant, that's great news! We'll go ahead and close this issue to keep our backlog organized. Please note that this issue will be closed automatically in 20 days if there is no further activity. If you need more time to resolve the issue or provide more information, please just let us know by adding a comment.
+            If the issue has been resolved or is no longer relevant, that's great news! 🎉
+            We'll go ahead and close this issue to keep our backlog organized. Please note that this issue will be closed automatically in 20 days if there is no further activity. If you need more time to resolve the issue or provide more information, please just let us know by adding a comment.
 
 
             Access additional [Logseq](https://logseq.com) 🚀 resources:
@@ -69,11 +70,10 @@ jobs:
           stale-issue-message: |
             Hi There! 👋
 
-            # trunk-ignore(yamllint/line-length)
             We haven't seen any activity on this issue in a while :sleeping:, and we just wanted to make sure that it's still relevant. If you're still experiencing this issue, you might find it helpful to update to the latest version of Logseq. The latest version includes bug fixes and new features that may help to resolve this issue, and you can download it from [our website](https://logseq.com). If updating to the latest version doesn't help, please let us know by adding a comment 💬. We're here to help!
 
-            # trunk-ignore(yamllint/line-length)
-            If the issue has been resolved or is no longer relevant, that's great news! We'll go ahead and close this issue to keep our backlog organized. Please note that this issue will be closed automatically in 20 days if there is no further activity. If you need more time to resolve the issue or provide more information, please just let us know by adding a comment.
+            If the issue has been resolved or is no longer relevant, that's great news! 🎉
+            We'll go ahead and close this issue to keep our backlog organized. Please note that this issue will be closed automatically in 20 days if there is no further activity. If you need more time to resolve the issue or provide more information, please just let us know by adding a comment.
 
 
             Access additional [Logseq](https://logseq.com) 🚀 resources:

--- a/.github/stale-issues.yml
+++ b/.github/stale-issues.yml
@@ -1,0 +1,58 @@
+# This workflow warns and then closes issues that have had no activity for a 
+# specified amount of time. You can adjust the behavior by modifying this file.
+# For more information, see:
+#   https://github.com/marketplace/actions/close-stale-issues
+#   https://github.com/actions/stale/blob/master/action.yml
+#   https://github.com/actions/stale
+---
+name: '180 Days Stale Issues Policy'
+on:
+  schedule:
+    - cron: "0 0 * * *" # Run at 00:00 UTC every day
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+    runs-on: ubuntu-latest
+    steps:
+    - name: '🧹 Mark & close stale issues'
+      id: stale_issues
+      uses: actions/stale@6f05e4244c9a0b2ed3401882b05d701dd0a7289b # v7
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-issue-stale: 180
+        days-before-close: 20
+        operations-per-run: 100 # The maximum number of operations per run, used to control rate limiting
+        stale-issue-label: ':status/automatic-stale'
+        close-issue-label: ':status/automatic-closing'
+        exempt-issue-labels: ':status/hold, :status/WIP, :type/enhancement'
+        remove-stale-when-updated: true
+        stale-issue-message: |
+            👋 Hello,
+            There hasn't been any recent activity on this issue :sleeping:
+            To keep our backlog manageable & to help us focus on the active issues we have to clean old issues,
+            as many of them have already been resolved with the latest updates.
+            
+            Please make sure to update to the latest [Logseq](https://logseq.com) version and
+            Let us know us know if that solves the issue by adding a comment 💬
+            
+            This issue has been automatically marked as stale & will be closed in 20 days
+            if no further activity occurs.
+            
+            Access additional 🌐 [Logseq](https://logseq.com) resources:
+              - **Forum**: https://discuss.logseq.com
+              - **Blog**: https://blog.logseq.com
+              - **Docs**: https://docs.logseq.com
+            
+            Feel free to inform us of any other **issues** you discover or **feature requests** that come to mind in the
+            future. Pull Requests (PRs) are also always welcomed!
+            
+            Thank you for your contributions to Logseq :heart:! 
+
+    - name: 'Print outputs'
+      run: printf '%s\n' ${{ join(steps.stale.outputs.*, ',') }}

--- a/.github/stale-issues.yml
+++ b/.github/stale-issues.yml
@@ -1,4 +1,4 @@
-# This workflow warns and then closes issues that have had no activity for a 
+# This workflow warns and then closes issues that have had no activity for a
 # specified amount of time. You can adjust the behavior by modifying this file.
 # For more information, see:
 #   https://github.com/marketplace/actions/close-stale-issues
@@ -6,9 +6,9 @@
 #   https://github.com/actions/stale
 ---
 name: 'Stale Issues Policy'
-on:
+on:  # yamllint disable-line rule:truthy
   schedule:
-    - cron: "0 0 * * *" # Run at 00:00 UTC every day
+    - cron: '0 0 * * *'  # Run at 00:00 UTC every day
   workflow_dispatch:
 
 permissions:
@@ -16,65 +16,76 @@ permissions:
   issues: write  # for actions/stale to close stale issues
 
 jobs:
-  stale: 
+  stale:
     runs-on: ubuntu-latest
     steps:
-    - name: '🧹 Mark & close stale issues'
-      id: stale_issues
-      uses: actions/stale@6f05e4244c9a0b2ed3401882b05d701dd0a7289b # v7
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-issue-stale: 180
-        days-before-close: 20
-        operations-per-run: 100 # The maximum number of operations per run, used to control rate limiting
-        stale-issue-label: ':status/automatic-stale'
-        close-issue-label: ':status/automatic-closing'
-        exempt-issue-labels: ':status/hold, :status/WIP, :type/enhancement, type/can-be-reproduced, priority-A'
-        remove-stale-when-updated: true
-        stale-issue-message: |
-          Hi There! 👋
+      - name: '🧹 Mark & close stale issues'
+        id: stale_issues
+        uses: actions/stale@6f05e4244c9a0b2ed3401882b05d701dd0a7289b  # v7
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 180
+          days-before-close: 20
+          operations-per-run: 100  # max num of ops per run
+          stale-issue-label: ':status/automatic-stale'
+          close-issue-label: ':status/automatic-closing'
+          # trunk-ignore(yamllint/line-length)
+          exempt-issue-labels: ':status/hold, :status/WIP, :type/enhancement, type/can-be-reproduced, priority-A'
+          remove-stale-when-updated: true
+          stale-issue-message: |
+            Hi There! 👋
 
-          We haven't seen any activity on this issue in a while :sleeping:, and we just wanted to make sure that it's still relevant. If you're still experiencing this issue, you might find it helpful to update to the latest version of Logseq. The latest version includes bug fixes and new features that may help to resolve this issue, and you can download it from [our website](https://logseq.com). If updating to the latest version doesn't help, please let us know by adding a comment 💬. We're here to help!
+            We haven't seen any activity on this issue in a while :sleeping:, and we just wanted to make sure that it's still relevant. If you're still experiencing this issue, you might find it helpful to update to the latest version of Logseq. The latest version includes bug fixes and new features that may help to resolve this issue, and you can download it from [our website](https://logseq.com). If updating to the latest version doesn't help, please let us know by adding a comment 💬. We're here to help!
 
-          If the issue has been resolved or is no longer relevant, that's great news! We'll go ahead and close this issue to keep our backlog organized. Please note that this issue will be closed automatically in 20 days if there is no further activity. If you need more time to resolve the issue or provide more information, please just let us know by adding a comment.
-
-
-          Access additional [Logseq](https://logseq.com) 🚀 resources:
-            - **Forum**: https://discuss.logseq.com
-            - **Blog**: https://blog.logseq.com
-            - **Docs**: https://docs.logseq.com
-
-          Thanks for your contributions to Logseq! If you have any other **issues** or **feature** requests, please don't hesitate to let us know. We always welcome pull requests too!
-
-    - name: 'Print outputs'
-      run: printf '%s\n' ${{ join(steps.stale.outputs.*, ',') }}
-
-    - name: '🧹 Close stale awaiting response issues'
-      id: awaiting_issues
-      uses: actions/stale@6f05e4244c9a0b2ed3401882b05d701dd0a7289b # v7
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-issue-stale: 40
-        days-before-close: 20
-        operations-per-run: 30 # The maximum number of operations per run, used to control rate limiting
-        stale-issue-label: ':status/automatic-stale'
-        close-issue-label: ':status/automatic-closing'
-        only-labels: 'awaiting response'
-        remove-stale-when-updated: true
-        stale-issue-message: |
-          Hi There! 👋
-
-          We haven't seen any activity on this issue in a while :sleeping:, and we just wanted to make sure that it's still relevant. If you're still experiencing this issue, you might find it helpful to update to the latest version of Logseq. The latest version includes bug fixes and new features that may help to resolve this issue, and you can download it from [our website](https://logseq.com). If updating to the latest version doesn't help, please let us know by adding a comment 💬. We're here to help!
-
-          If the issue has been resolved or is no longer relevant, that's great news! We'll go ahead and close this issue to keep our backlog organized. Please note that this issue will be closed automatically in 20 days if there is no further activity. If you need more time to resolve the issue or provide more information, please just let us know by adding a comment.
+            If the issue has been resolved or is no longer relevant, that's great news! We'll go ahead and close this issue to keep our backlog organized. Please note that this issue will be closed automatically in 20 days if there is no further activity. If you need more time to resolve the issue or provide more information, please just let us know by adding a comment.
 
 
-          Access additional [Logseq](https://logseq.com) 🚀 resources:
-            - **Forum**: https://discuss.logseq.com
-            - **Blog**: https://blog.logseq.com
-            - **Docs**: https://docs.logseq.com
+            Access additional [Logseq](https://logseq.com) 🚀 resources:
+              - **Forum**: https://discuss.logseq.com
+              - **Blog**: https://blog.logseq.com
+              - **Docs**: https://docs.logseq.com
 
-          Thanks for your contributions to Logseq! If you have any other **issues** or **feature** requests, please don't hesitate to let us know. We always welcome pull requests too!
+            Thanks for your contributions to Logseq! If you have any other **issues** or **feature** requests, please don't hesitate to let us know. We always welcome pull requests too!
 
-    - name: 'Print outputs'
-      run: printf '%s\n' ${{ join(steps.stale.outputs.*, ',') }}
+      - name: 'Print outputs'
+        run: |
+          for key in steps.stale_issues.outputs
+            do
+              printf '%s: %s\n' "${key}" "${steps.stale_issues.outputs[key]}"
+            done
+
+      - name: '🧹 Close stale awaiting response issues'
+        id: awaiting_issues
+        uses: actions/stale@6f05e4244c9a0b2ed3401882b05d701dd0a7289b  # v7
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 40
+          days-before-close: 20
+          operations-per-run: 30  # max num of ops per run
+          stale-issue-label: ':status/automatic-stale'
+          close-issue-label: ':status/automatic-closing'
+          only-labels: 'awaiting response'
+          remove-stale-when-updated: true
+          stale-issue-message: |
+            Hi There! 👋
+
+            # trunk-ignore(yamllint/line-length)
+            We haven't seen any activity on this issue in a while :sleeping:, and we just wanted to make sure that it's still relevant. If you're still experiencing this issue, you might find it helpful to update to the latest version of Logseq. The latest version includes bug fixes and new features that may help to resolve this issue, and you can download it from [our website](https://logseq.com). If updating to the latest version doesn't help, please let us know by adding a comment 💬. We're here to help!
+
+            # trunk-ignore(yamllint/line-length)
+            If the issue has been resolved or is no longer relevant, that's great news! We'll go ahead and close this issue to keep our backlog organized. Please note that this issue will be closed automatically in 20 days if there is no further activity. If you need more time to resolve the issue or provide more information, please just let us know by adding a comment.
+
+
+            Access additional [Logseq](https://logseq.com) 🚀 resources:
+              - **Forum**: https://discuss.logseq.com
+              - **Blog**: https://blog.logseq.com
+              - **Docs**: https://docs.logseq.com
+
+            Thanks for your contributions to Logseq! If you have any other **issues** or **feature** requests, please don't hesitate to let us know. We always welcome pull requests too!
+
+      - name: 'Print outputs'
+        run: |
+          for key in steps.awaiting_issues.outputs
+            do
+              printf '%s: %s\n' "${key}" "${steps.awaiting_issues.outputs[key]}"
+            done

--- a/.github/stale-issues.yml
+++ b/.github/stale-issues.yml
@@ -32,24 +32,20 @@ jobs:
         exempt-issue-labels: ':status/hold, :status/WIP, :type/enhancement, type/can-be-reproduced, priority-A'
         remove-stale-when-updated: true
         stale-issue-message: |
-          👋 Hello,
-          There hasn't been any recent activity on this issue :sleeping:
-          To keep our backlog manageable & to help us focus on active issues, we have to clean old issues, as many of them have already been resolved with the latest updates.
+          Hi There! 👋
 
-          Please make sure to update to the latest [Logseq](https://logseq.com) version and
-          Let us know if that solves the issue by adding a comment 💬
+          We haven't seen any activity on this issue in a while :sleeping:, and we just wanted to make sure that it's still relevant. If you're still experiencing this issue, please let us know by adding a comment 💬. We're here to help!
 
-          This issue has been automatically marked as stale & will be closed in 20 days
-          if no further activity occurs.
+          If the issue has been resolved or is no longer relevant, that's great news! We'll go ahead and close this issue to keep our backlog organized. Please note that this issue will be closed automatically in 20 days if there is no further activity. If you need more time to resolve the issue or provide more information, please just let us know by adding a comment.
+
+          If you're still having trouble, you might find it helpful to update to the latest version of Logseq. You can download the latest version from [our website](https://logseq.com). If updating to the latest version doesn't help, please don't hesitate to reach out for assistance.
 
           Access additional [Logseq](https://logseq.com) 🚀 resources:
             - **Forum**: https://discuss.logseq.com
             - **Blog**: https://blog.logseq.com
             - **Docs**: https://docs.logseq.com
 
-          Feel free to inform us of any other **issues** you discover or **feature requests** that come to mind in the future. Pull Requests (PRs) are also always welcomed!
-
-          Thank you for your contributions to Logseq! :heart:
+          Thanks for your contributions to Logseq! If you have any other **issues** or **feature** requests, please don't hesitate to let us know. We always welcome pull requests too!
 
     - name: 'Print outputs'
       run: printf '%s\n' ${{ join(steps.stale.outputs.*, ',') }}
@@ -67,24 +63,20 @@ jobs:
         only-labels: 'awaiting response'
         remove-stale-when-updated: true
         stale-issue-message: |
-          👋 Hello,
-          There hasn't been any recent activity on this issue :sleeping:
-          To keep our backlog manageable & to help us focus on active issues, we have to clean old issues, as many of them have already been resolved with the latest updates.
+          Hi There! 👋
 
-          Please make sure to update to the latest [Logseq](https://logseq.com) version and
-          Let us know if that solves the issue by adding a comment 💬
+          We haven't seen any activity on this issue in a while :sleeping:, and we just wanted to make sure that it's still relevant. If you're still experiencing this issue, please let us know by adding a comment 💬. We're here to help!
 
-          This issue has been automatically marked as stale & will be closed in 20 days
-          if no further activity occurs.
+          If the issue has been resolved or is no longer relevant, that's great news! We'll go ahead and close this issue to keep our backlog organized. Please note that this issue will be closed automatically in 20 days if there is no further activity. If you need more time to resolve the issue or provide more information, please just let us know by adding a comment.
+
+          If you're still having trouble, you might find it helpful to update to the latest version of Logseq. You can download the latest version from [our website](https://logseq.com). If updating to the latest version doesn't help, please don't hesitate to reach out for assistance.
 
           Access additional [Logseq](https://logseq.com) 🚀 resources:
             - **Forum**: https://discuss.logseq.com
             - **Blog**: https://blog.logseq.com
             - **Docs**: https://docs.logseq.com
 
-          Feel free to inform us of any other **issues** you discover or **feature requests** that come to mind in the future. Pull Requests (PRs) are also always welcomed!
-
-          Thank you for your contributions to Logseq! :heart:
+          Thanks for your contributions to Logseq! If you have any other **issues** or **feature** requests, please don't hesitate to let us know. We always welcome pull requests too!
 
     - name: 'Print outputs'
       run: printf '%s\n' ${{ join(steps.stale.outputs.*, ',') }}

--- a/.github/stale-issues.yml
+++ b/.github/stale-issues.yml
@@ -38,7 +38,6 @@ jobs:
 
           If the issue has been resolved or is no longer relevant, that's great news! We'll go ahead and close this issue to keep our backlog organized. Please note that this issue will be closed automatically in 20 days if there is no further activity. If you need more time to resolve the issue or provide more information, please just let us know by adding a comment.
 
-          If you're still having trouble, 
 
           Access additional [Logseq](https://logseq.com) 🚀 resources:
             - **Forum**: https://discuss.logseq.com
@@ -69,7 +68,6 @@ jobs:
 
           If the issue has been resolved or is no longer relevant, that's great news! We'll go ahead and close this issue to keep our backlog organized. Please note that this issue will be closed automatically in 20 days if there is no further activity. If you need more time to resolve the issue or provide more information, please just let us know by adding a comment.
 
-          If you're still having trouble, 
 
           Access additional [Logseq](https://logseq.com) 🚀 resources:
             - **Forum**: https://discuss.logseq.com

--- a/.github/stale-issues.yml
+++ b/.github/stale-issues.yml
@@ -32,25 +32,24 @@ jobs:
         exempt-issue-labels: ':status/hold, :status/WIP, :type/enhancement, type/can-be-reproduced, priority-A'
         remove-stale-when-updated: true
         stale-issue-message: |
-            👋 Hello,
-            There hasn't been any recent activity on this issue :sleeping:
-            To keep our backlog manageable & to help us focus on the active issues, we have to clean old issues,
-            as many of them have already been resolved with the latest updates.
+          👋 Hello,
+          There hasn't been any recent activity on this issue :sleeping:
+          To keep our backlog manageable & to help us focus on active issues, we have to clean old issues, as many of them have already been resolved with the latest updates.
 
-            Please make sure to update to the latest [Logseq](https://logseq.com) version and
-            Let us know if that solves the issue by adding a comment 💬
+          Please make sure to update to the latest [Logseq](https://logseq.com) version and
+          Let us know if that solves the issue by adding a comment 💬
 
-            This issue has been automatically marked as stale & will be closed in 20 days
-            if no further activity occurs.
+          This issue has been automatically marked as stale & will be closed in 20 days
+          if no further activity occurs.
 
-            Access additional [Logseq](https://logseq.com) 🚀 resources:
-              - **Forum**: https://discuss.logseq.com
-              - **Blog**: https://blog.logseq.com
-              - **Docs**: https://docs.logseq.com
+          Access additional [Logseq](https://logseq.com) 🚀 resources:
+            - **Forum**: https://discuss.logseq.com
+            - **Blog**: https://blog.logseq.com
+            - **Docs**: https://docs.logseq.com
 
-            Feel free to inform us of any other **issues** you discover or **feature requests** that come to mind in the future. Pull Requests (PRs) are also always welcomed!
+          Feel free to inform us of any other **issues** you discover or **feature requests** that come to mind in the future. Pull Requests (PRs) are also always welcomed!
 
-            Thank you for your contributions to Logseq! :heart:
+          Thank you for your contributions to Logseq! :heart:
 
     - name: 'Print outputs'
       run: printf '%s\n' ${{ join(steps.stale.outputs.*, ',') }}
@@ -68,25 +67,24 @@ jobs:
         only-labels: 'awaiting response'
         remove-stale-when-updated: true
         stale-issue-message: |
-            👋 Hello,
-            There hasn't been any recent activity on this issue :sleeping:
-            To keep our backlog manageable & to help us focus on the active issues, we have to clean old issues,
-            as many of them have already been resolved with the latest updates.
+          👋 Hello,
+          There hasn't been any recent activity on this issue :sleeping:
+          To keep our backlog manageable & to help us focus on active issues, we have to clean old issues, as many of them have already been resolved with the latest updates.
 
-            Please make sure to update to the latest [Logseq](https://logseq.com) version and
-            Let us know if that solves the issue by adding a comment 💬
+          Please make sure to update to the latest [Logseq](https://logseq.com) version and
+          Let us know if that solves the issue by adding a comment 💬
 
-            This issue has been automatically marked as stale & will be closed in 20 days
-            if no further activity occurs.
+          This issue has been automatically marked as stale & will be closed in 20 days
+          if no further activity occurs.
 
-            Access additional [Logseq](https://logseq.com) 🚀 resources:
-              - **Forum**: https://discuss.logseq.com
-              - **Blog**: https://blog.logseq.com
-              - **Docs**: https://docs.logseq.com
+          Access additional [Logseq](https://logseq.com) 🚀 resources:
+            - **Forum**: https://discuss.logseq.com
+            - **Blog**: https://blog.logseq.com
+            - **Docs**: https://docs.logseq.com
 
-            Feel free to inform us of any other **issues** you discover or **feature requests** that come to mind in the future. Pull Requests (PRs) are also always welcomed!
+          Feel free to inform us of any other **issues** you discover or **feature requests** that come to mind in the future. Pull Requests (PRs) are also always welcomed!
 
-            Thank you for your contributions to Logseq! :heart:
+          Thank you for your contributions to Logseq! :heart:
 
     - name: 'Print outputs'
       run: printf '%s\n' ${{ join(steps.stale.outputs.*, ',') }}

--- a/.github/stale-issues.yml
+++ b/.github/stale-issues.yml
@@ -35,24 +35,23 @@ jobs:
         stale-issue-message: |
             👋 Hello,
             There hasn't been any recent activity on this issue :sleeping:
-            To keep our backlog manageable & to help us focus on the active issues we have to clean old issues,
+            To keep our backlog manageable & to help us focus on the active issues, we have to clean old issues,
             as many of them have already been resolved with the latest updates.
-            
+
             Please make sure to update to the latest [Logseq](https://logseq.com) version and
-            Let us know us know if that solves the issue by adding a comment 💬
-            
+            Let us know if that solves the issue by adding a comment 💬
+
             This issue has been automatically marked as stale & will be closed in 20 days
             if no further activity occurs.
-            
-            Access additional 🌐 [Logseq](https://logseq.com) resources:
+
+            Access additional [Logseq](https://logseq.com) 🚀 resources:
               - **Forum**: https://discuss.logseq.com
               - **Blog**: https://blog.logseq.com
               - **Docs**: https://docs.logseq.com
-            
-            Feel free to inform us of any other **issues** you discover or **feature requests** that come to mind in the
-            future. Pull Requests (PRs) are also always welcomed!
-            
-            Thank you for your contributions to Logseq :heart:! 
+
+            Feel free to inform us of any other **issues** you discover or **feature requests** that come to mind in the future. Pull Requests (PRs) are also always welcomed!
+
+            Thank you for your contributions to Logseq! :heart:
 
     - name: 'Print outputs'
       run: printf '%s\n' ${{ join(steps.stale.outputs.*, ',') }}

--- a/.github/stale-issues.yml
+++ b/.github/stale-issues.yml
@@ -34,11 +34,11 @@ jobs:
         stale-issue-message: |
           Hi There! 👋
 
-          We haven't seen any activity on this issue in a while :sleeping:, and we just wanted to make sure that it's still relevant. If you're still experiencing this issue, please let us know by adding a comment 💬. We're here to help!
+          We haven't seen any activity on this issue in a while :sleeping:, and we just wanted to make sure that it's still relevant. If you're still experiencing this issue, you might find it helpful to update to the latest version of Logseq. The latest version includes bug fixes and new features that may help to resolve this issue, and you can download it from [our website](https://logseq.com). If updating to the latest version doesn't help, please let us know by adding a comment 💬. We're here to help!
 
           If the issue has been resolved or is no longer relevant, that's great news! We'll go ahead and close this issue to keep our backlog organized. Please note that this issue will be closed automatically in 20 days if there is no further activity. If you need more time to resolve the issue or provide more information, please just let us know by adding a comment.
 
-          If you're still having trouble, you might find it helpful to update to the latest version of Logseq. The latest version includes bug fixes and new features that may help to resolve this issue, and you can download it from [our website](https://logseq.com). If updating to the latest version doesn't help, please don't hesitate to reach out for assistance.
+          If you're still having trouble, 
 
           Access additional [Logseq](https://logseq.com) 🚀 resources:
             - **Forum**: https://discuss.logseq.com
@@ -65,11 +65,11 @@ jobs:
         stale-issue-message: |
           Hi There! 👋
 
-          We haven't seen any activity on this issue in a while :sleeping:, and we just wanted to make sure that it's still relevant. If you're still experiencing this issue, please let us know by adding a comment 💬. We're here to help!
+          We haven't seen any activity on this issue in a while :sleeping:, and we just wanted to make sure that it's still relevant. If you're still experiencing this issue, you might find it helpful to update to the latest version of Logseq. The latest version includes bug fixes and new features that may help to resolve this issue, and you can download it from [our website](https://logseq.com). If updating to the latest version doesn't help, please let us know by adding a comment 💬. We're here to help!
 
           If the issue has been resolved or is no longer relevant, that's great news! We'll go ahead and close this issue to keep our backlog organized. Please note that this issue will be closed automatically in 20 days if there is no further activity. If you need more time to resolve the issue or provide more information, please just let us know by adding a comment.
 
-          If you're still having trouble, you might find it helpful to update to the latest version of Logseq. The latest version includes bug fixes and new features that may help to resolve this issue, and you can download it from [our website](https://logseq.com). If updating to the latest version doesn't help, please don't hesitate to reach out for assistance.
+          If you're still having trouble, 
 
           Access additional [Logseq](https://logseq.com) 🚀 resources:
             - **Forum**: https://discuss.logseq.com


### PR DESCRIPTION
This GitHub Action is designed to close stale issues in a repository. An issue is considered stale if it hasn't received any new activity (e.g. comments, reactions, etc.) for a specified number of days. The Action will first apply a label to the issue to mark it as stale and then, after a specified number of days, it will close the issue if there has been no new activity. The Action can also be configured to exempt certain issues from being closed, for example if they have certain labels or if they are marked as a work in progress. The Action can be run on a schedule (e.g. daily), or it can be manually triggered using the workflow_dispatch event.

Here's a breakdown of the main configuration options for the Action:
  - days-before-issue-stale: The number of days of inactivity that must pass before an issue is marked as stale.
  - days-before-close: The number of days of inactivity that must pass after an issue is marked as stale, before it is closed.
  - operations-per-run: The maximum number of operations (e.g. marking an issue as stale or closing an issue) that the Action will perform in a single run. This is used to control rate limiting.
  - stale-issue-label: The label that will be applied to issues that are marked as stale.
  - close-issue-label: The label that will be applied to issues that are scheduled to be closed.
  - exempt-issue-labels: A list of labels that will exempt an issue from being closed.
  - remove-stale-when-updated: If set to true, the stale label will be removed from an issue if it receives any new activity.
  - stale-issue-message: The message that will be added as a comment on an issue when it is marked as stale.

The Action also has a number of additional configuration options that allow you to further customize its behavior. 

For more information, see:
 - https://github.com/marketplace/actions/close-stale-issues
 - https://github.com/actions/stale/blob/master/action.yml
 - https://github.com/actions/stale

<br></br>
### Current configuration:
- run every day at 00:00 UTC
- limit number of operations per run to: 100
- days before marking the issue stale: 180
- days before closing the issue after marking it: 20
- label added to stale issues: `:status/automatic-stale`
- label added to closed stale issues: `:status/automatic-closing`
- exempt issue labels: `:status/hold`, `:status/WIP`, `:type/enhancement`

<br></br>
### Awaiting response issues configuration:
there is a separate task to handle tasks marked with awaiting response. 
- limit number of operations per run to: 30 (default) 
- days before marking the issue stale: 40
- days before closing the issue after marking it: 20
- this only affects issues labeled `awaiting response`

<br></br>

### The stale issue message posted by the action:
---
Hi There! 👋

We haven't seen any activity on this issue in a while :sleeping:, and we just wanted to make sure that it's still relevant. If you're still experiencing this issue, you might find it helpful to update to the latest version of Logseq. The latest version includes bug fixes and new features that may help to resolve this issue, and you can download it from [our website](https://logseq.com). If updating to the latest version doesn't help, please let us know by adding a comment 💬. We're here to help!

If the issue has been resolved or is no longer relevant, that's great news! 🎉
We'll go ahead and close this issue to keep our backlog organized. Please note that this issue will be closed automatically in 20 days if there is no further activity. If you need more time to resolve the issue or provide more information, please just let us know by adding a comment.


Access additional [Logseq](https://logseq.com) 🚀 resources:
  - **Forum**: https://discuss.logseq.com
  - **Blog**: https://blog.logseq.com
  - **Docs**: https://docs.logseq.com

Thanks for your contributions to Logseq! If you have any other [**issues**](https://github.com/logseq/logseq/issues/new/choose) or [**feature requests**](https://discuss.logseq.com/c/feature-requests/), please don't hesitate to [let us know](https://github.com/logseq/logseq/issues/new/choose). We always welcome pull requests too!


---


Please provide your feedback and suggestions regarding the configuration and message used.

I have opted to not add a message when closing the issue after the grace period of 20 days, as I deemed it unnecessary and repetitive. 
