### PR TITLE
feature: Display full search result in the web app

### DIFF
--- a/src/main/frontend/components/search.cljs
+++ b/src/main/frontend/components/search.cljs
@@ -378,7 +378,7 @@
        :on-shift-chosen #(search-on-shift-chosen repo search-q %)
        :item-render #(search-item-render search-q %)
        :on-chosen-open-link #(search-on-chosen-open-link repo search-q %)})
-     (when (and has-more? (util/electron?) (not all?))
+     (when (and has-more? (not all?))
        [:div.px-2.py-4.search-more
         [:a.text-sm.font-medium {:href (rfe/href :search {:q search-q})
                                  :on-click (fn []


### PR DESCRIPTION
I found that the `More` button in searching results only exists in electron app but the function works also well in web app.

<img width="1244" alt="image" src="https://user-images.githubusercontent.com/28241963/209830832-d6efea17-48ff-407d-bb03-2082a43c5722.png">

<img width="1244" alt="image" src="https://user-images.githubusercontent.com/28241963/209830842-e237d0e2-b707-4f38-9ce8-fe0ffd46728c.png">
