### PR TITLE
enhancement: add several internationalizations to the right-click menu

### DIFF
--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -187,7 +187,7 @@
           {:key      "Open in sidebar"
            :on-click (fn [_e]
                        (editor-handler/open-block-in-sidebar! block-id))}
-          "Open in sidebar"
+          (t :content/open-in-sidebar)
           ["⇧" "click"])
 
          [:hr.menu-separator]
@@ -196,14 +196,14 @@
           {:key      "Copy block ref"
            :on-click (fn [_e]
                        (editor-handler/copy-block-ref! block-id block-ref/->block-ref))}
-          "Copy block ref"
+          (t :content/copy-block-ref)
           nil)
 
          (ui/menu-link
           {:key      "Copy block embed"
            :on-click (fn [_e]
                        (editor-handler/copy-block-ref! block-id #(util/format "{{embed ((%s))}}" %)))}
-          "Copy block embed"
+          (t :content/copy-block-emebed)
           nil)
 
           ;; TODO Logseq protocol mobile support


### PR DESCRIPTION
The right-click menu on bullets is not yet internationalized.

'open-in-sidebar', 'copy-block-ref' and 'copy-block-emebed' have already been translated in dicts.cljc and applied to the keyboard shortcuts in the help.

Therefore, I have also applied this translation to the right-click menu.