### PR TITLE
WIP: fix(test): removal of select-all shortcut

### DIFF
--- a/e2e-tests/page-rename.spec.ts
+++ b/e2e-tests/page-rename.spec.ts
@@ -7,15 +7,9 @@ import { IsMac, createPage, randomLowerString, newBlock, newInnerBlock, randomSt
  ***/
 
 async function rename_page(page: Page, new_name: string) {
-  let selectAll = 'Control+a'
-  if (IsMac) {
-    selectAll = 'Meta+a'
-  }
-
   await page.click('.ls-page-title .page-title')
   await page.waitForSelector('input[type="text"]')
-  await page.keyboard.press(selectAll)
-  await page.keyboard.press('Backspace')
+  await page.fill('input[type="text"]', '')
   await page.type('.title input', new_name)
   await page.keyboard.press('Enter')
   await page.click('.ui__confirm-modal button')

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3426,7 +3426,8 @@
 
 (defn select-parent [e]
   (let [edit-input (some-> (state/get-edit-input-id) gdom/getElement)
-        edit-block (state/get-edit-block)]
+        edit-block (state/get-edit-block)
+        target-element (.-nodeName (.-target e))]
     (cond
       ;; editing block fully selected
       (and edit-block edit-input
@@ -3437,6 +3438,10 @@
          [(gdom/getElementByClass (str (:block/uuid edit-block)))]))
 
       edit-block
+      nil
+
+      ;; Focusing other input element, e.g. when editing page title.
+      (contains? #{"INPUT" "TEXTAREA"} target-element)
       nil
 
       :else

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -953,7 +953,7 @@ Similar to re-frame subscriptions"
    (set-selection-blocks! blocks :down))
   ([blocks direction]
    (when (seq blocks)
-     (let [blocks (util/sort-by-height blocks)]
+     (let [blocks (util/sort-by-height (remove nil? blocks))]
        (swap! state assoc
              :selection/mode true
              :selection/blocks blocks


### PR DESCRIPTION
`mod+a` is now registered as a global shortcut.

Releated #7803

Bug1:
- when editing page title, `mod+a` will ignore current editing status and select page blocks

Bug2:
- when viewing "Unlinked References", `mod+a` will cause error:
<img width="677" alt="image" src="https://user-images.githubusercontent.com/72891/210035250-cc277dfa-a53c-4a46-9a56-d1aea3200f2d.png">



