### PR TITLE
enhance(sync): reduce ws ping messages

### DIFF
--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -216,7 +216,9 @@
           (do (<! (timeout 1000))
               (recur))
           (do (.send ws "PING")
-              (<! (timeout 30000))
+              ;; aws apigateway websocket
+              ;; Idle Connection Timeout: 10min
+              (<! (timeout (* 5 60 1000)))
               (recur)))))))
 
 (defn- ws-stop! [*ws]


### PR DESCRIPTION
aws apigateway websocket idle timeout is 10min.

https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html#apigateway-execution-service-websocket-limits-table