### PR TITLE
enhance(api): no need to pass `isPageBlock` for api/insert_block

### DIFF
--- a/src/main/logseq/api.cljs
+++ b/src/main/logseq/api.cljs
@@ -833,7 +833,7 @@
       (let [block'   (if page? (second-child-of-block block) (first-child-of-block block))
             sibling? (and page? (not (nil? block')))
             opts     (bean/->clj opts)
-            opts     (merge opts {:isPageBlock (and page? (not sibling?)) :sibling sibling? :before sibling?})
+            opts     (merge opts {:sibling sibling? :before sibling?})
             src      (if sibling? (str (:block/uuid block')) uuid-or-page-name)]
         (insert_block src content (bean/->js opts))))))
 
@@ -849,7 +849,7 @@
       (let [block'   (last-child-of-block block)
             sibling? (not (nil? block'))
             opts     (bean/->clj opts)
-            opts     (merge opts {:isPageBlock (and page? (not sibling?)) :sibling sibling?}
+            opts     (merge opts {:sibling sibling?}
                             (when sibling? {:before false}))
             src      (if sibling? (str (:block/uuid block')) uuid-or-page-name)]
         (insert_block src content (bean/->js opts))))))

--- a/src/main/logseq/api.cljs
+++ b/src/main/logseq/api.cljs
@@ -40,7 +40,8 @@
             [frontend.version :as fv]
             [frontend.handler.shell :as shell]
             [frontend.modules.layout.core]
-            [frontend.handler.code :as code-handler]))
+            [frontend.handler.code :as code-handler]
+            [frontend.handler.search :as search-handler]))
 
 ;; helpers
 (defn- normalize-keyword-for-json
@@ -1010,6 +1011,11 @@
 (defn ^:export http_request_abort
   [req-id]
   (ipc/ipc :httpRequestAbort req-id))
+
+;; search
+(defn search
+  [q]
+  (search-handler/search q))
 
 ;; helpers
 (defn ^:export query_element_by_id

--- a/src/main/logseq/api.cljs
+++ b/src/main/logseq/api.cljs
@@ -1013,7 +1013,7 @@
   (ipc/ipc :httpRequestAbort req-id))
 
 ;; search
-(defn search
+(defn ^:export search
   [q]
   (search-handler/search q))
 


### PR DESCRIPTION
Some enhancements for api/insert_block :
1. remove `isPageBlock` 
There's no need for it because block's id is UUID and page name is not.
2. create a new page if it doesn't exist, otherwise, users have to create a page first and invoke this method then to add content, which is tedious.