### PR TITLE
style(search): center content in search items

### DIFF
--- a/src/main/frontend/components/command_palette.cljs
+++ b/src/main/frontend/components/command_palette.cljs
@@ -23,10 +23,10 @@
   [{:keys [id shortcut] :as cmd} chosen?]
   (let [first-shortcut (first (string/split shortcut #" \| "))
         desc (translate t cmd)]
-    [:div.inline-grid.grid-cols-4.gap-x-4.w-full
+    [:div.inline-grid.grid-cols-4.items-center.w-full
      {:class (when chosen? "chosen")}
      [:span.col-span-3 desc]
-     [:div.col-span-1.justify-end.tip.flex
+     [:div.col-span-1.flex.justify-end.tip
       (when (and (keyword? id) (namespace id))
         [:code.opacity-40.bg-transparent (namespace id)])
       (when-not (string/blank? first-shortcut)
@@ -40,7 +40,7 @@
   (let [input (::input state)]
     [:div.cp__palette.cp__palette-main
      [:div.input-wrap
-      [:input.cp__palette-input.w-full
+      [:input.cp__palette-input.w-full.h-full
        {:type        "text"
         :placeholder (t :command-palette/prompt)
         :auto-focus  true

--- a/src/main/frontend/components/search.cljs
+++ b/src/main/frontend/components/search.cljs
@@ -497,7 +497,7 @@
     [:div.cp__palette.cp__palette-main
      [:div.ls-search.p-2.md:p-0
       [:div.input-wrap
-      [:input.cp__palette-input.w-full
+      [:input.cp__palette-input.w-full.h-full
        {:type          "text"
         :auto-focus    true
         :placeholder   (case search-mode


### PR DESCRIPTION
As the title.

Before:

<img width="523" alt="image" src="https://user-images.githubusercontent.com/15034155/210150342-a30a1d8c-7440-4ca8-a3bd-f5e11a5ae0a5.png">

After:

<img width="427" alt="image" src="https://user-images.githubusercontent.com/15034155/210150350-6cb73dd6-674a-42ea-bd0c-b020e29b55b1.png">

Edit:
- [x] Fixes https://github.com/logseq/logseq/issues/8181