### PR TITLE
Chore: Document components related to hide page-preview itself when hovered hierarchy ref in the preview

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -754,6 +754,11 @@
       (draw-component {:file file :block-uuid block-uuid}))))
 
 (rum/defc page-reference < rum/reactive
+  "Component for page reference, if there is existing page reference, will render the reference.
+   
+   Arguments:
+   
+   `config`: will be passed as first argument to `page-cp`"
   [html-export? s {:keys [nested-link? id] :as config} label]
   (let [show-brackets? (state/show-brackets?)
         block-uuid (:block/uuid config)

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -679,7 +679,13 @@
       children)))
 
 (rum/defc page-cp
-  "Accepts {:block/name sanitized / unsanitized page-name}"
+  "The page components
+
+   Accepts {:block/name sanitized / unsanitized page-name}
+
+   Configurable keys: 
+   
+   - `:preview?`: Is this component under preview mode? (If true, page-preview-trigger won't be registered to this page-cp)"
   [{:keys [html-export? redirect-page-name label children contents-page? preview?] :as config} page]
   (when-let [page-name-in-block (:block/name page)]
     (let [page-name-in-block (gp-util/remove-boundary-slashes page-name-in-block)

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -648,7 +648,7 @@
                                          (->>
                                           (for [page (string/split page-original-name #"/")]
                                             (when (and (string? page) page)
-                                              (page-reference false page {} nil)))
+                                              (page-reference false page {:preview? true} nil)))
                                           (interpose [:span.mx-2.opacity-30 "/"]))]
                                         [:h2.font-bold.text-lg (if (= page-name redirect-page-name)
                                                                  page-original-name

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -685,7 +685,7 @@
 
    Configurable keys: 
    
-   - `:preview?`: Is this component under preview mode? (If true, page-preview-trigger won't be registered to this page-cp)"
+   - `:preview?`: Is this component under preview mode? (If true, `page-preview-trigger` won't be registered to this `page-cp`)"
   [{:keys [html-export? redirect-page-name label children contents-page? preview?] :as config} page]
   (when-let [page-name-in-block (:block/name page)]
     (let [page-name-in-block (gp-util/remove-boundary-slashes page-name-in-block)


### PR DESCRIPTION
Tried to fix it and finally worked it out , seems it works well.

## Why fix it in this way

I figure out that hovering on page ref in page-preview does not show another page-preview if `{:preview? true}` was passed to `page-blocks-cp` like the following code.

https://github.com/logseq/logseq/blob/f5e37091dd0e1d23fa52acf7b368899b85a33f24/src/main/frontend/components/block.cljs#L664

## Before

https://user-images.githubusercontent.com/28241963/210232438-57b04ac3-65e0-49ce-a4bb-190ecef14235.mp4

## After

https://user-images.githubusercontent.com/28241963/210232444-d607d7c6-d48f-467f-9101-0486be05e417.mp4



