### PR TITLE
enhance(docs): Add note about auto-formatting in `dev-practices.md`

### DIFF
--- a/docs/dev-practices.md
+++ b/docs/dev-practices.md
@@ -3,7 +3,8 @@
 This page describes development practices for this codebase.
 
 ## Auto-formatting
-`cljfmt` is a common formatter used for Clojure, analogous to Prettier for other languages. While we do not format/indent consistently with `cljfmt` across the whole codebase, we recommend that you do so for code that you change/add. You can do so easily with the [Calva](https://marketplace.visualstudio.com/items?itemName=betterthantomorrow.calva) extension in VSCode: It will (mostly) indent your code correctly as you type, and you can move your cursor to the start of the line(s) you've written and press `Tab` to auto-indent all clojure forms nested under the one starting on the current line.
+
+[cljfmt](https://cljdoc.org/d/cljfmt/cljfmt/0.9.0/doc/readme) is a common formatter used for Clojure, analogous to Prettier for other languages. While we do not format/indent consistently with cljfmt across the whole codebase, we recommend that you do so for code that you change/add. You can do so easily with the [Calva](https://marketplace.visualstudio.com/items?itemName=betterthantomorrow.calva) extension in [VSCode](https://code.visualstudio.com/): It will (mostly) indent your code correctly as you type, and you can move your cursor to the start of the line(s) you've written and press `Tab` to auto-indent all Clojure forms nested under the one starting on the current line.
 
 ## Linting
 

--- a/docs/dev-practices.md
+++ b/docs/dev-practices.md
@@ -2,6 +2,9 @@
 
 This page describes development practices for this codebase.
 
+## Auto-formatting
+`cljfmt` is a common formatter used for Clojure, analogous to Prettier for other languages. While we do not format/indent consistently with `cljfmt` across the whole codebase, we recommend that you do so for code that you change/add. You can do so easily with the [Calva](https://marketplace.visualstudio.com/items?itemName=betterthantomorrow.calva) extension in VSCode: It will (mostly) indent your code correctly as you type, and you can move your cursor to the start of the line(s) you've written and press `Tab` to auto-indent all clojure forms nested under the one starting on the current line.
+
 ## Linting
 
 Most of our linters require babashka. Before running them, please install


### PR DESCRIPTION
This adds a short note to dev-practices.md, that I believe accurately reflects the current situation about auto-formatting code (and will hopefully help others like me avoid spending a bunch of time looking into this).