### PR TITLE
improve(ux): add delete option for blocks context menu

### DIFF
--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -36,6 +36,12 @@
     "Cut"
     nil)
    (ui/menu-link
+    {:key      "delete"
+     :on-click #(do (editor-handler/delete-selection %)
+                    (state/hide-custom-context-menu!))}
+    "Delete"
+    nil)
+   (ui/menu-link
     {:key "copy"
      :on-click editor-handler/copy-selection-blocks}
     "Copy"
@@ -230,6 +236,12 @@
            :on-click (fn [_e]
                        (editor-handler/cut-block! block-id))}
           "Cut"
+          nil)
+
+         (ui/menu-link
+          {:key      "delete"
+           :on-click #(editor-handler/delete-block-aux! block true)}
+          "Delete"
           nil)
 
          [:hr.menu-separator]


### PR DESCRIPTION
Mentioned: https://discuss.logseq.com/t/fundamental-need-keyboard-and-menu-shortcut-to-delete-block/13832/1

https://user-images.githubusercontent.com/1779837/210298219-697d06ca-8884-471e-8d0d-b830b65824a8.mp4

