### PR TITLE
fix(e2e-test): should not wait for selector when there is no onboarding button

### DIFF
--- a/e2e-tests/utils.ts
+++ b/e2e-tests/utils.ts
@@ -190,7 +190,6 @@ export async function loadLocalGraph(page: Page, path: string): Promise<void> {
     await page.waitForSelector('#left-sidebar .dropdown-wrapper >> text="Add new graph"',
       { state: 'visible', timeout: 5000 })
     await page.click('text=Add new graph')
-    await page.waitForSelector('strong:has-text("Choose a folder")', { state: 'visible', timeout: 5000 })
 
     expect(page.locator('#repo-name')).toHaveText(pathlib.basename(path))
   }


### PR DESCRIPTION
This bug was found when I want to perform a **single** e2e test instead of all.

If we test just a single e2e test in debug mode(both debug and non-debug mode fails, debug mode is just used to 
 demonstrate how I found where the bug occurs), the test will be failed and we will be breaked at this line.

```typescript
await page.waitForSelector('strong:has-text("Choose a folder")', { state: 'visible', timeout: 5000 })
```

Here is screen recording.

https://user-images.githubusercontent.com/28241963/210493245-9b2d7087-d7cf-4362-a9dc-a36117834aa7.mp4

I have also found that the test dir is loaded by these codes so that simply clicking on `Add new graph` will automatically load the test graph.

https://github.com/logseq/logseq/blob/86b5c9dc770e5769eeb10bb98d2757e780ac6379/e2e-tests/utils.ts#L148-L161

https://github.com/logseq/logseq/blob/86b5c9dc770e5769eeb10bb98d2757e780ac6379/src/main/frontend/util.cljc#L119-L123

After fixing this bug.

https://user-images.githubusercontent.com/28241963/210493240-ef255ea2-dc7a-49f3-aae0-ddc4057b3727.mp4


