### PR TITLE
fix: disable plugins e2e tests temporally

### DIFF
--- a/e2e-tests/plugins.spec.ts
+++ b/e2e-tests/plugins.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test'
 import { test } from './fixtures'
 
-test('enabled plugin system default', async ({ page }) => {
+test.skip('enabled plugin system default', async ({ page }) => {
   const callAPI = callPageAPI.bind(null, page)
 
   const pluginEnabled = await callAPI('get_state_from_store', 'plugin/enabled')
@@ -14,7 +14,7 @@ test('enabled plugin system default', async ({ page }) => {
   expect(Object.keys(currentGraph)).toEqual(['url', 'name', 'path'])
 })
 
-test('play a plugin<logseq-journals-calendar> from the Marketplace', async ({ page }) => {
+test.skip('play a plugin<logseq-journals-calendar> from the Marketplace', async ({ page }) => {
   await page.keyboard.press('t+p')
   const searchInput = page.locator('.search-ctls .form-input')
   await searchInput.type('journals')


### PR DESCRIPTION
Will enable it once it's stable.