### PR TITLE
fix(fs): wrong graph name from graph-parser; readdir should not return directories

### DIFF
--- a/deps/graph-parser/.carve/ignore
+++ b/deps/graph-parser/.carve/ignore
@@ -38,3 +38,5 @@ logseq.graph-parser/get-blocks-to-delete
 logseq.graph-parser.property/colons-org
 ;; API
 logseq.graph-parser.util.db/resolve-input
+;; API
+logseq.graph-parser.text/get-file-basename

--- a/deps/graph-parser/src/logseq/graph_parser/text.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/text.cljs
@@ -10,9 +10,15 @@
             [logseq.graph-parser.util.page-ref :as page-ref]))
 
 (defn get-file-basename
+  "Returns the basename of a file path. e.g. /a/b/c.md -> c.md"
   [path]
   (when-not (string/blank? path)
-    ;; Same as util/node-path.name
+    (.-base (path/parse (string/replace path "+" "/")))))
+
+(defn get-file-rootname
+  "Returns the rootname of a file path. e.g. /a/b/c.md -> c"
+  [path]
+  (when-not (string/blank? path)
     (.-name (path/parse (string/replace path "+" "/")))))
 
 (def page-ref-re-0 #"\[\[(.*)\]\]")
@@ -28,7 +34,7 @@
        (or (when-let [[_ label _path] (re-matches markdown-page-ref-re s)]
              (string/trim label))
            (when-let [[_ path _label] (re-matches org-page-ref-re s)]
-             (some-> (get-file-basename path)
+             (some-> (get-file-rootname path)
                      (string/replace "." "/")))
            (-> (re-matches page-ref-re-0 s)
                second))))

--- a/src/main/frontend/handler/file_sync.cljs
+++ b/src/main/frontend/handler/file_sync.cljs
@@ -145,23 +145,22 @@
                                      (apply path/join base-path))
             version-file-paths (<! (p->c (fs/readdir version-files-dir :path-only? true)))]
         (when-not (instance? ExceptionInfo version-file-paths)
-          (let [version-file-paths (remove #{version-files-dir} version-file-paths)]
-            (when (seq version-file-paths)
-              (->>
-               (mapv
-                (fn [path]
-                  (try
-                    (let [create-time
-                          (-> (path/parse path)
-                              (js->clj :keywordize-keys true)
-                              :name
-                              (#(tf/parse (tf/formatter "yyyy-MM-dd'T'HH_mm_ss.SSSZZ") %)))]
-                      {:create-time create-time :path path :relative-path (string/replace-first path base-path "")})
-                    (catch :default e
-                      (log/error :page-history/parse-format-error e)
-                      nil)))
-                version-file-paths)
-               (remove nil?)))))))))
+          (when (seq version-file-paths)
+            (->>
+             (mapv
+              (fn [path]
+                (try
+                  (let [create-time
+                        (-> (path/parse path)
+                            (js->clj :keywordize-keys true)
+                            :name
+                            (#(tf/parse (tf/formatter "yyyy-MM-dd'T'HH_mm_ss.SSSZZ") %)))]
+                    {:create-time create-time :path path :relative-path (string/replace-first path base-path "")})
+                  (catch :default e
+                    (log/error :page-history/parse-format-error e)
+                    nil)))
+              version-file-paths)
+             (remove nil?))))))))
 
 (defn fetch-page-file-versions [graph-uuid page]
   []


### PR DESCRIPTION
- Fix #8292
- Now Electron's `readdir` only returns files, the same as capacitor


Solved: ~~After fixing this, some fs access warnings come out at Electron main part. It seems there're still other fs bugs.~~
