### PR TITLE
Fix: 2 query table bugs

### DIFF
--- a/src/main/frontend/components/query_table.cljs
+++ b/src/main/frontend/components/query_table.cljs
@@ -170,7 +170,7 @@
                               [:string (when-let [updated-at (:block/updated-at item)]
                                          (date/int->local-time-2 updated-at))]
 
-                              [:string (get-in item [:block/properties column])])]
+                              [:string (get-in item [:block/properties-text-values column])])]
                   [:td.whitespace-nowrap {:on-mouse-down (fn [] (reset! select? false))
                                           :on-mouse-move (fn [] (reset! select? true))
                                           :on-mouse-up (fn []

--- a/src/main/frontend/publishing.cljs
+++ b/src/main/frontend/publishing.cljs
@@ -9,6 +9,7 @@
             [frontend.page :as page]
             [frontend.util :as util]
             [frontend.routes :as routes]
+            [frontend.context.i18n :as i18n]
             [reitit.frontend :as rf]
             [reitit.frontend.easy :as rfe]
             [cljs.reader :as reader]
@@ -79,6 +80,8 @@
   ;; this is called in the index.html and must be exported
   ;; so it is available even in :advanced release builds
   (register-components-fns!)
+  ;; Set :preferred-lang as some components depend on it
+  (i18n/start)
   (restore-from-transit-str!)
   (restore-state!)
   (shortcut/refresh!)


### PR DESCRIPTION
This PR fixes https://github.com/logseq/logseq/issues/8227 which is a bug when we implemented https://github.com/logseq/logseq/pull/6529. Screenshot of fix:
<img width="789" alt="Screen Shot 2023-01-10 at 2 42 48 PM" src="https://user-images.githubusercontent.com/97210743/211664338-81d0a8c1-6aa4-4ab7-97da-20ece7117294.png">

This PR also fixes #7332 and #8211 so query tables can work again on publishing