### PR TITLE
dev: update cider-nrepl to 0.29.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -33,7 +33,7 @@
  :aliases {:cljs {:extra-paths ["src/dev-cljs/" "src/test/" "src/electron/"]
                   :extra-deps  {org.clojure/clojurescript        {:mvn/version "1.11.54"}
                                 org.clojure/tools.namespace      {:mvn/version "0.2.11"}
-                                cider/cider-nrepl                {:mvn/version "0.28.4"}
+                                cider/cider-nrepl                {:mvn/version "0.29.0"}
                                 org.clojars.knubie/cljs-run-test {:mvn/version "1.0.1"}}
                   :main-opts   ["-m" "shadow.cljs.devtools.cli"]}
 


### PR DESCRIPTION
I updated emacs cider to 1.6.0, and it suggests me to upgrade cider-nrepl 