### PR TITLE
feat: export login-callback fn

### DIFF
--- a/src/main/frontend/handler/user.cljs
+++ b/src/main/frontend/handler/user.cljs
@@ -146,7 +146,7 @@
         ;; refresh remote graph list by pub login event
         (when (user-uuid) (state/pub-event! [:user/fetch-info-and-graphs]))))))
 
-(defn login-callback [code]
+(defn ^:export login-callback [code]
   (state/set-state! [:ui/loading? :login] true)
   (go
     (let [resp (<! (http/get (str "https://" config/API-DOMAIN "/auth_callback?code=" code)


### PR DESCRIPTION
if users can't redirect from the browser back to the app,
the workaround is calling
frontend.handler.user.login_callback(\<code\>) to finish login progress

<img width="1412" alt="image" src="https://user-images.githubusercontent.com/5608710/212058078-eab602b3-b22e-4834-9e54-ad935ea9b9da.png">
