### PR TITLE
Fix: rendering of inline symbols #7054

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1562,7 +1562,7 @@
 
          ["Entity" e]
          [:span {:dangerouslySetInnerHTML
-                 {:__html (:html (security/sanitize-html e))}}]
+                 {:__html (security/sanitize-html (:html e))}}]
 
          ["Latex_Fragment" [display s]] ;display can be "Displayed" or "Inline"
          (if html-export?


### PR DESCRIPTION
closes https://github.com/logseq/logseq/issues/7054

--
The call to `security/sanitize-html` was previously being called on a Clojurescript map (`{:html &gamma; ...}`), but in reality the `:html` should be called first to extract the `&gamma;` from the map, then it can be sanitized!

Super small diff to fix a super annoying and long-standing bug!