### PR TITLE
Fix search tippy component failing

### DIFF
--- a/src/main/frontend/components/search.cljs
+++ b/src/main/frontend/components/search.cljs
@@ -413,7 +413,7 @@
                    :theme       "monospace"}
                   [:a.flex.fade-link.items-center
                    {:style {:margin-left 12}
-                    :on-click #(state/pub-event! :modal/command-palette)}
+                    :on-click #(state/pub-event! [:modal/command-palette])}
                    (ui/icon "command" {:style {:font-size 20}})])])]]
    (let [recent-search (mapv (fn [q] {:type :search :data q}) (db/get-key-value :recent/search))
          pages (->> (db/get-key-value :recent/pages)

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1729,6 +1729,7 @@ Similar to re-frame subscriptions"
   (:system/events @state))
 
 (defn pub-event!
+  {:malli/schema [:=> [:cat vector?] :any]}
   [payload]
   (let [chan (get-events-chan)]
     (async/put! chan payload)))


### PR DESCRIPTION
Fix small bug that was introduced in #7805 -
https://sentry.io/organizations/logseq/issues/3857043471/?project=5311485&query=is%3Aunresolved&referrer=issue-stream. Also added a malli schema for the offending fn so future stacktraces lead to the buggy UI component. To QA this, Cmd-k and then click on the command palette icon (furthest right)