### PR TITLE
fix tables not widening in wide mode (#2398)

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2975,8 +2975,7 @@
                         :tbody
                         (mapv #(tr :td %) group)))
                      groups)]
-    [:div.table-wrapper {:style {:max-width (min 700
-                                                 (gobj/get js/window "innerWidth"))}}
+    [:div.table-wrapper
      (->elem
       :table
       {:class "table-auto"


### PR DESCRIPTION
Fixes the issue described in #2398 by allowing tables to widen when the user switches to wide mode.