### PR TITLE
fix: remove extra braces for some incorrect macro usages

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -853,8 +853,8 @@
   [name arguments]
   (if (and (seq arguments)
            (not= arguments ["null"]))
-    (util/format "{{{%s %s}}}" name (string/join ", " arguments))
-    (util/format "{{{%s}}}" name)))
+    (util/format "{{%s %s}}" name (string/join ", " arguments))
+    (util/format "{{%s}}" name)))
 
 (declare block-content)
 (declare block-container)

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1361,9 +1361,9 @@
                 :width width
                 :height height}]))))
       [:span.warning.mr-1 {:title "Invalid URL"}
-       (str "{{video " url "}}")])
+       (macro->text "video" arguments)])
     [:span.warning.mr-1 {:title "Empty URL"}
-     (str "{{video}}")]))
+     (macro->text "video" arguments)]))
 
 (defn- macro-else-cp
   [name config arguments]


### PR DESCRIPTION
- refactor: use macro->text instead of str concat

Related to https://github.com/logseq/logseq/pull/8164/commits/344103e56ed4b571b1c4f34cb5c346bf907ff52f in PR https://github.com/logseq/logseq/pull/8164

- fix(macro->text): remove redundant brackets

<img width="394" alt="image" src="https://user-images.githubusercontent.com/28241963/212922774-b622a010-e268-445f-9ad4-8f688ac86ec4.png">

The macro name and argument are enclosed by {{}} rather than {{{}}} 
