### PR TITLE
fix: build-docker GH Action yarn timeout

### DIFF
--- a/.github/workflows/build-desktop-release.yml
+++ b/.github/workflows/build-desktop-release.yml
@@ -128,7 +128,7 @@ jobs:
           echo "ENABLE_FILE_SYNC_PRODUCTION=${{ github.event_name == 'schedule' || github.event.inputs.enable-file-sync-production == 'true' }}" >> $GITHUB_ENV
 
       - name: Compile CLJS
-        run: yarn install && gulp build && yarn cljs:release-electron
+        run: yarn install --network-timeout 100000 && gulp build && yarn cljs:release-electron
         env:
           LOGSEQ_SENTRY_DSN: ${{ secrets.LOGSEQ_SENTRY_DSN }}
           LOGSEQ_POSTHOG_TOKEN: ${{ secrets.LOGSEQ_POSTHOG_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,12 @@ RUN apt-get update && apt-get install ca-certificates && \
 
 WORKDIR /data
 
+RUN git clone -b fix/docker-bulid-timeout https://github.com/logseq/logseq.git .
+
+RUN yarn install --network-timeout 100000
+
 # Build static resources
-RUN git clone -b fix/docker-bulid-timeout https://github.com/logseq/logseq.git . \
-    yarn install --network-timeout 100000 && gulp build && yarn cljs:release
+RUN gulp build && yarn cljs:release
 
 # Web App Runner image
 FROM nginx:stable-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN git clone -b fix/docker-bulid-timeout https://github.com/logseq/logseq.git .
 RUN yarn install --network-timeout 100000
 
 # Build static resources
-RUN gulp build && yarn cljs:release
+RUN  yarn release 
 
 # Web App Runner image
 FROM nginx:stable-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /data
 
 # Build for static resources
 RUN git clone -b master https://github.com/logseq/logseq.git . \
-    yarn install  && gulp build && yarn cljs:release
+    yarn install --network-timeout 100000 && gulp build && yarn cljs:release
 
 # Web App Runner image
 FROM nginx:stable-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install ca-certificates && \
 
 WORKDIR /data
 
-RUN git clone -b fix/docker-bulid-timeout https://github.com/logseq/logseq.git .
+RUN git clone -b master https://github.com/logseq/logseq.git .
 
 RUN yarn install --network-timeout 100000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,16 +11,16 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
 RUN apt-get update && apt-get install ca-certificates && \
     wget --no-check-certificate -qO - https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    apt-get update && \
-    apt-get install -y yarn
+    apt-get update && apt-get install -y yarn
 
-WORKDIR /data/
+WORKDIR /data
 
 # Build for static resources
-RUN git clone https://github.com/logseq/logseq.git &&  cd /data/logseq && yarn && yarn release && mv ./static ./public
+RUN git clone -b master https://github.com/logseq/logseq.git . \
+    yarn install  && gulp build && yarn cljs:release
 
 # Web App Runner image
 FROM nginx:stable-alpine
 
-COPY --from=builder /data/logseq/public /usr/share/nginx/html
+COPY --from=builder /data/static /usr/share/nginx/html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 # NOTE: please keep it in sync with .github pipelines
+# NOTE: during testing make sure to change the branch below
+# NOTE: before runing the build-docker GH action edit
+#       build-docker.yml and change the release channel to testing
 
 # Builder image
 FROM clojure:openjdk-11-tools-deps-1.10.1.727 as builder
@@ -15,8 +18,8 @@ RUN apt-get update && apt-get install ca-certificates && \
 
 WORKDIR /data
 
-# Build for static resources
-RUN git clone -b master https://github.com/logseq/logseq.git . \
+# Build static resources
+RUN git clone -b fix/docker-bulid-timeout https://github.com/logseq/logseq.git . \
     yarn install --network-timeout 100000 && gulp build && yarn cljs:release
 
 # Web App Runner image

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "cljs:lint": "clojure -M:clj-kondo --parallel --lint src --cache false",
         "ios:dev": "cross-env PLATFORM=ios gulp cap",
         "android:dev": "cross-env PLATFORM=android gulp cap",
-        "tldraw:build": "cd tldraw && yarn",
+        "tldraw:build": "cd tldraw && yarn install --network-timeout 100000",
         "postinstall": "yarn tldraw:build"
     },
     "dependencies": {


### PR DESCRIPTION
changelog

- [x] enhance: keep Dockerfile in sync with .github pipelines
- [x] fix: increase yarn install network timeout limit
- [x] separated the build command into multiple layers to the Dockerfile to improve testing and debugging
- [ ] passing build (https://github.com/logseq/logseq/actions/runs/3945969166/jobs/6753322423)
	- [x]  from previous branch (https://github.com/logseq/logseq/actions/runs/3945333908/jobs/6752134470) 	