### PR TITLE
fix(ui): null while query .editor-wrapper

### DIFF
--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -381,8 +381,8 @@
                 :z-index    11}
                (when set-default-width?
                  {:width max-width})
-               (let [^js/HTMLElement editor
-                     (js/document.querySelector ".editor-wrapper")]
+               (when-let [^js/HTMLElement editor
+                          (js/document.querySelector ".editor-wrapper")]
                  (if (<= (.-clientWidth editor) (+ left (if set-default-width? max-width 500)))
                    {:right 0}
                    {:left (if (or (nil? y-diff) (and y-diff (= y-diff 0))) left 0)})))]


### PR DESCRIPTION
When switching pages with modals open, `.editor-wrapper` might be a `null`.