### PR TITLE
[WIP] fix: move primary directory to ~/.config/Logseq

### DIFF
--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -37,10 +37,11 @@
 
 (defn get-ls-dotdir-root
   []
-  (let [lg-dir (path/join (.getPath app "home") ".logseq")]
-    (if-not (fs/existsSync lg-dir)
-      (do (fs/mkdirSync lg-dir) lg-dir)
-      lg-dir)))
+  (let [legacy-dir (path/join (.getPath app "home") ".logseq")
+        new-dir (path/join (.getPath app "userData") "Logseq")
+        exists? #(when (fs/existsSync %1) %1)]
+    (or (exists? legacy-dir) (exists? new-dir) 
+        (do (fs/mkdirSync new-dir) new-dir))))
 
 (defn get-ls-default-plugins
   []


### PR DESCRIPTION
PR for #3462 

Took quite long since I had to scrap my original implementation after finding "appData" for gethPath, which should return the correct path (see https://www.electronjs.org/docs/latest/api/app#appgetpathname )

Status: replaced the main method for getting the root dir

TODO:

- [ ] Reuse the existing method in ~5 other places that access the path. ![grafik](https://user-images.githubusercontent.com/68823230/213141939-ac4a5a20-5b98-4536-ad47-dc2ec0837287.png)
 
- [ ] Ensure there won't be any conflicts with the existing electron files
- [ ] Test on different platforms (only have access to MacOS and Linux atm)
