### PR TITLE
chore(webapp): migrate 🐋 builder image from openjdk to temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,21 @@ FROM clojure:openjdk-11-tools-deps-1.10.1.727 as builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y curl ca-certificates
+# Install reqs
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    gpg
 
+# install NodeJS
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
     apt-get install -y nodejs
 
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+# install yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | \
+    tee /etc/apt/trusted.gpg.d/yarn.gpg && \
+    echo "deb [signed-by=/etc/apt/trusted.gpg.d/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" | \
+    tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && apt-get install -y yarn
 
 WORKDIR /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,18 +12,18 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
+    apt-transport-https \
     gpg
 
 # install NodeJS
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
-    apt-get install -y nodejs
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 
 # install yarn
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | \
     tee /etc/apt/trusted.gpg.d/yarn.gpg && \
-    echo "deb [signed-by=/etc/apt/trusted.gpg.d/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" | \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | \
     tee /etc/apt/sources.list.d/yarn.list && \
-    apt-get update && apt-get install -y yarn
+    apt-get update && apt-get install -y nodejs yarn
 
 WORKDIR /data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #       build-docker.yml and change the release channel from :latest to :testing
 
 # Builder image
-FROM clojure:openjdk-11-tools-deps-1.10.1.727 as builder
+FROM clojure:temurin-11-tools-deps-1.11.1.1208-bullseye-slim as builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,12 @@ FROM clojure:openjdk-11-tools-deps-1.10.1.727 as builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+RUN apt-get update && apt-get install -y curl ca-certificates
+
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
     apt-get install -y nodejs
 
-RUN apt-get update && apt-get install ca-certificates && \
-    wget --no-check-certificate -qO - https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && apt-get install -y yarn
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \
     gpg
 
-# install NodeJS
+# install NodeJS & yarn
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 
-# install yarn
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | \
     tee /etc/apt/trusted.gpg.d/yarn.gpg && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | \
@@ -27,11 +26,11 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | \
 
 WORKDIR /data
 
+# build Logseq static resources
 RUN git clone -b master https://github.com/logseq/logseq.git .
 
 RUN yarn config set network-timeout 240000 -g && yarn install
 
-# Build static resources
 RUN  yarn release 
 
 # Web App Runner image


### PR DESCRIPTION
Addresses Clojure Docker images breaking change: [groups.google.com/g/clojure](https://groups.google.com/g/clojure/c/eNLvJMEchM8)

> Wes Morgan July 25th 2022:
> Upstream has recently announced that even the old
> openjdk:8 and openjdk:11 images are being deprecated and
> will no longer receive updates (security and otherwise).
> 
- [x] closes #8396
- [x] update deps to fit the new base image
- [x] Passing build: https://github.com/logseq/logseq/actions/runs/3963322124