### PR TITLE
fix: searching in page defers while entering Chinese character using a Pinyin IME

### DIFF
--- a/src/main/frontend/handler/search.cljs
+++ b/src/main/frontend/handler/search.cljs
@@ -10,8 +10,7 @@
             [promesa.core :as p]
             [logseq.graph-parser.text :as text]
             [electron.ipc :as ipc]
-            [dommy.core :as dom])
-  (:import [goog.async Debouncer]))
+            [dommy.core :as dom]))
 
 (defn add-search-to-recent!
   [repo q]
@@ -87,23 +86,8 @@
                           (str " " (subs q 1)))))
         (ipc/ipc "find-in-page" q option)))))
 
-;; TODO move to ns frontend.util
-(defn cancelable-debounce
-  "Create a stateful debounce function with specified interval
-   
-   Returns [fire-fn, cancel-fn]
-   
-   Use `fire-fn` to call the function(debounced)
-   
-   Use `cancel-fn` to cancel pending callback if there is"
-  [f interval]
-  (let [debouncer (Debouncer. f interval)]
-    (js/console.log debouncer)
-    [(fn [& args] (.apply (.-fire debouncer) debouncer (to-array args)))
-     (fn [] (.stop debouncer))]))
-
 ;; TODO more graceful way to destruct from array and defonce them?
-(defonce cancelable-debounce-search (cancelable-debounce electron-find-in-page! 500))
+(defonce cancelable-debounce-search (util/cancelable-debounce electron-find-in-page! 500))
 (defonce debounced-search (get cancelable-debounce-search 0))
 (defonce stop-debounced-search! (get cancelable-debounce-search 1))
 

--- a/src/main/frontend/handler/search.cljs
+++ b/src/main/frontend/handler/search.cljs
@@ -88,17 +88,24 @@
         (ipc/ipc "find-in-page" q option)))))
 
 ;; TODO move to ns frontend.util
-(defn debounce [f interval]
+(defn cancelable-debounce
+  "Create a stateful debounce function with specified interval
+   
+   Returns [fire-fn, cancel-fn]
+   
+   Use `fire-fn` to call the function(debounced)
+   
+   Use `cancel-fn` to cancel pending callback if there is"
+  [f interval]
   (let [debouncer (Debouncer. f interval)]
     (js/console.log debouncer)
-    [(fn [& args] (.apply (.-fire debouncer) debouncer (to-array args))) ;; fire
-     (fn [] (.stop debouncer)) ;; cancel pending callback
-     ]))
+    [(fn [& args] (.apply (.-fire debouncer) debouncer (to-array args)))
+     (fn [] (.stop debouncer))]))
 
 ;; TODO more graceful way to destruct from array and defonce them?
-(defonce debouncer-search (debounce electron-find-in-page! 500))
-(defonce debounced-search (get debouncer-search 0))
-(defonce stop-debounced-search! (get debouncer-search 1))
+(defonce cancelable-debounce-search (cancelable-debounce electron-find-in-page! 500))
+(defonce debounced-search (get cancelable-debounce-search 0))
+(defonce stop-debounced-search! (get cancelable-debounce-search 1))
 
 (defn loop-find-in-page!
   [backward?]

--- a/src/main/frontend/handler/search.cljs
+++ b/src/main/frontend/handler/search.cljs
@@ -86,10 +86,9 @@
                           (str " " (subs q 1)))))
         (ipc/ipc "find-in-page" q option)))))
 
-;; TODO more graceful way to destruct from array and defonce them?
-(defonce cancelable-debounce-search (util/cancelable-debounce electron-find-in-page! 500))
-(defonce debounced-search (get cancelable-debounce-search 0))
-(defonce stop-debounced-search! (get cancelable-debounce-search 1))
+(let [cancelable-debounce-search (util/cancelable-debounce electron-find-in-page! 500)]
+  (defonce debounced-search (first cancelable-debounce-search))
+  (defonce stop-debounced-search! (second cancelable-debounce-search)))
 
 (defn loop-find-in-page!
   [backward?]

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -30,6 +30,7 @@
             [cljs.core.async.impl.channels :refer [ManyToManyChannel]]
             [medley.core :as medley]
             [frontend.pubsub :as pubsub]))
+  #?(:cljs (:import [goog.async Debouncer]))
   (:require
    [clojure.pprint]
    [clojure.string :as string]
@@ -296,6 +297,20 @@
                                       (reset! t nil)
                                       (apply f args))
                                    threshold)))))))
+#?(:cljs 
+   (defn cancelable-debounce
+     "Create a stateful debounce function with specified interval
+   
+      Returns [fire-fn, cancel-fn]
+   
+      Use `fire-fn` to call the function(debounced)
+   
+      Use `cancel-fn` to cancel pending callback if there is"
+     [f interval]
+     (let [debouncer (Debouncer. f interval)]
+       (js/console.log debouncer)
+       [(fn [& args] (.apply (.-fire debouncer) debouncer (to-array args)))
+        (fn [] (.stop debouncer))])))
 
 (defn nth-safe [c i]
   (if (or (< i 0) (>= i (count c)))


### PR DESCRIPTION
close https://github.com/logseq/logseq/issues/7761
close #7212

The experience isn't great when searching the contents of pages, especially when using a Pinyin IME, but I've finally figured out how to fix it.

A react ref  `*composing?` is created to represent the current IME composing state. The state will be mutated in `on-change-fn`. `on-change-fn` is also registered to `:on-composition-start` and `:on-composition-end` to listen to composition events. For more information about `:on-composition-start` and `:on-composition-end`, check: https://reactjs.org/docs/events.html#composition-events.

If `composition-start`, cancel the pending debounced function callback. This can be prevented from being interrupted by `electron-find-in-page!` when you type some letters and then quickly switch to Pinyin IME to type Chinese.

Here is the screen recording.


https://user-images.githubusercontent.com/28241963/213616005-7e057f83-a0de-4d3e-8640-a1bec901e36c.mp4


