### PR TITLE
fix(ui): stop click event propagation for pdf links

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1051,9 +1051,10 @@
       (cond
         (util/electron?)
         [:a.asset-ref.is-pdf
-         {:on-mouse-down (fn [_event]
+         {:on-mouse-down (fn [event]
                            (when-let [current (pdf-assets/inflate-asset s)]
-                             (state/set-current-pdf! current)))}
+                             (state/set-current-pdf! current)
+                             (util/stop event)))}
          (or label-text
              (->elem :span (map-inline config label)))]
 


### PR DESCRIPTION
To reproduce:

- Create a block with a pdf asset
- Create a new block ref to the above block
- Click the PDF link in the new block
- BUG: PDF view opens, **with page navigated to zoom-view of the block**