### PR TITLE
fix: CodeMirror indenting shortcuts cause page routing

### DIFF
--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -226,6 +226,18 @@
                                                 {:editor editor
                                                  :config config
                                                  :state state})))
+
+        (.addEventListener element "keydown" (fn [e]
+                                               (let [key-code (.-code e)
+                                                     meta-or-ctrl-pressed? (or (.-ctrlKey e) (.-metaKey e))]
+                                                 (when meta-or-ctrl-pressed?
+                                                   ;; prevent default behavior of browser
+                                                   ;; Cmd + [ => Go back in browser, outdent in CodeMirror
+                                                   ;; Cmd + ] => Go forward in browser, indent in CodeMirror
+                                                   (case key-code
+                                                     "BracketLeft" (util/stop e)
+                                                     "BracketRight" (util/stop e)
+                                                     nil)))))
         (.addEventListener element "mousedown"
                            (fn [e]
                              (util/stop e)


### PR DESCRIPTION
stop propagation and preventDefault of event on wrapper element of CodeMirror editor

## How to reproduce the bug?

1. Create a code block.
2. Click on or select some codes on the block.
3. Press `Cmd+[` to indent the code or `Cmd+]` to outdent the code.
4. If the web browser can go back or forward to other pages, it will do that.

https://user-images.githubusercontent.com/28241963/213966830-01c1f73b-ae85-4182-ad5c-61e91cb8c1c0.mp4

## After fix

https://user-images.githubusercontent.com/28241963/213966891-3c53bb51-de6f-46cf-9852-00bbd7e244a7.mp4


