### PR TITLE
Fix (Whiteboards): paste type order

### DIFF
--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/TweetShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/TweetShape.tsx
@@ -177,7 +177,7 @@ export class TweetShape extends TLBoxShape<TweetShapeProps> {
 
   validateProps = (props: Partial<TweetShapeProps>) => {
     if (props.size !== undefined) {
-      props.size[0] = Math.min(Math.max(props.size[0], 1), 550)
+      props.size[0] = Math.min(Math.max(props.size[0], 300), 550)
       props.size[1] = Math.max(props.size[1], 1)
     }
     return withClampedStyles(this, props)


### PR DESCRIPTION
- We now try to create a shape on DataTransfer (dnd) or ClipboardItem (paste) based on `text/plain` first. If that fails, we use `text/html` to create a shape. As a last resort, we use `text/plain` again to create a new block with plain text. The reason behind this choice is that when both `text/plain` and `text/html` are available, it probably makes sense to attempt  creating an embed based on a raw url first, The preferred order is debatable, but I think this is a better default. Resolves #8407
- Added a min width to tweet shape.