### PR TITLE
Fix: Allow keywords for macros in config.edn

### DIFF
--- a/src/main/frontend/schema/handler/common_config.cljc
+++ b/src/main/frontend/schema/handler/common_config.cljc
@@ -53,7 +53,7 @@
                          [:or :string [:vector :some]]]]]
     [:outliner/block-title-collapse-enabled? :boolean]
     [:macros [:map-of
-              :string
+              [:or :string :keyword]
               :string]]
     [:ref/default-open-blocks-level :int]
     [:ref/linked-references-collapsed-threshold :int]


### PR DESCRIPTION
Fix #8410 