### PR TITLE
Fix(Whiteboards): References error

### DIFF
--- a/src/main/frontend/components/reference.cljs
+++ b/src/main/frontend/components/reference.cljs
@@ -94,18 +94,20 @@
     (filter-dialog-inner filters-atom *references page-name)))
 
 (rum/defc block-linked-references < rum/reactive db-mixins/query
-  [block-id]
-  (let [ref-blocks (db/get-block-referenced-blocks block-id)
-        ref-hiccup (block/->hiccup ref-blocks
-                                   {:id (str block-id)
-                                    :ref? true
-                                    :breadcrumb-show? true
-                                    :group-by-page? true
-                                    :editor-box editor/box}
-                                   {})]
-    [:div.references-blocks
-     (content/content block-id
-                      {:hiccup ref-hiccup})]))
+  ([block-id]
+   (block-linked-references block-id {}))
+  ([block-id options]
+   (let [ref-blocks (db/get-block-referenced-blocks block-id options)
+         ref-hiccup (block/->hiccup ref-blocks
+                                    {:id (str block-id)
+                                     :ref? true
+                                     :breadcrumb-show? true
+                                     :group-by-page? true
+                                     :editor-box editor/box}
+                                    {})]
+     [:div.references-blocks
+      (content/content block-id
+                       {:hiccup ref-hiccup})])))
 
 (rum/defc references-inner
   [page-name filters filtered-ref-blocks]

--- a/src/main/frontend/components/whiteboard.cljs
+++ b/src/main/frontend/components/whiteboard.cljs
@@ -123,7 +123,7 @@
                                  :or {portal? true}}]
    (let [page-entity (model/get-page page-name-or-uuid)
          block-uuid (:block/uuid page-entity)
-         refs-count (model/get-block-references-count block-uuid)]
+         refs-count (model/get-block-references-count block-uuid {:use-cache? false})]
      (when (> refs-count 0)
        (dropdown-menu {:classname classname
                        :label (fn [open?]
@@ -132,7 +132,7 @@
                                  (when render-fn (render-fn open? refs-count))])
                        :hover? hover?
                        :portal? portal?
-                       :children (reference/block-linked-references block-uuid)})))))
+                       :children (reference/block-linked-references block-uuid {:use-cache? false})})))))
 
 (defn- get-page-display-name
   [page-name]

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -1324,7 +1324,7 @@ independent of format as format specific heading characters are stripped"
        (let [block (db-utils/entity [:block/uuid block-uuid])
              query-result (->> (react/q repo [:frontend.db.react/refs
                                               (:db/id block)]
-                                 {}
+                                 options
                                  '[:find [(pull ?ref-block ?block-attrs) ...]
                                    :in $ ?block-uuid ?block-attrs
                                    :where
@@ -1337,22 +1337,24 @@ independent of format as format specific heading characters are stripped"
          (db-utils/group-by-page query-result))))))
 
 (defn get-block-references-count
-  [block-uuid]
-  (when-let [repo (state/get-current-repo)]
-    (when (conn/get-db repo)
-      (let [block (db-utils/entity [:block/uuid block-uuid])
-            query-result (->> (react/q repo [:frontend.db.react/refs
-                                             (:db/id block)]
-                                       {}
-                                       '[:find [(pull ?ref-block ?block-attrs) ...]
-                                         :in $ ?block-uuid ?block-attrs
-                                         :where
-                                         [?block :block/uuid ?block-uuid]
-                                         [?ref-block :block/refs ?block]]
-                                       block-uuid
-                                       block-attrs)
-                              react)]
-        (count query-result)))))
+  ([block-uuid]
+   (get-block-references-count block-uuid {}))
+  ([block-uuid options]
+   (when-let [repo (state/get-current-repo)]
+     (when (conn/get-db repo)
+       (let [block (db-utils/entity [:block/uuid block-uuid])
+             query-result (->> (react/q repo [:frontend.db.react/refs
+                                              (:db/id block)]
+                                        options
+                                        '[:find [(pull ?ref-block ?block-attrs) ...]
+                                          :in $ ?block-uuid ?block-attrs
+                                          :where
+                                          [?block :block/uuid ?block-uuid]
+                                          [?ref-block :block/refs ?block]]
+                                        block-uuid
+                                        block-attrs)
+                               react)]
+         (count query-result))))))
 
 (defn journal-page?
   "sanitized page-name only"


### PR DESCRIPTION
Resolves #8339
Also see https://discord.com/channels/725182569297215569/1056543757065003048

Steps to reproduce this
1. Create a whiteboard and set its title
2. Shift+click on the title to open the whiteboard on the sidebar
3. Resize or toggle the sidebar to update the state of the app (the ref count will be 2)
4. Hover your mouse over the references count next to the title

It looks like disabling the query cache fixes both the ref count and the crash. I am not sure if there is a better way to handle this.
