### PR TITLE
fix (witeboards): disable onboarding tour on demo graph

### DIFF
--- a/src/main/frontend/components/whiteboard.cljs
+++ b/src/main/frontend/components/whiteboard.cljs
@@ -17,6 +17,7 @@
                                   use-click-outside]]
             [frontend.state :as state]
             [frontend.storage :as storage]
+            [frontend.config :as config]
             [frontend.ui :as ui]
             [frontend.util :as util]
             [promesa.core :as p]
@@ -300,6 +301,7 @@
   []
   (when (and (user-handler/feature-available? :whiteboard)
              (not (or (state/sub :whiteboard/onboarding-tour?)
+                      (config/demo-graph?)
                       (util/mobile?))))
     (state/pub-event! [:whiteboard/onboarding])
     (state/set-state! [:whiteboard/onboarding-tour?] true)


### PR DESCRIPTION
Do not show whiteboards tour on demo graph.
See https://discord.com/channels/725182569297215569/1065425525683785818/1065425525683785818