### PR TITLE
perf(whiteboards): enhance whiteboards performance & responsiveness 🚀

### DIFF
--- a/src/main/frontend/components/whiteboard.cljs
+++ b/src/main/frontend/components/whiteboard.cljs
@@ -178,8 +178,9 @@
      [:div (get-page-human-update-time page-name)]
      [:div.flex-1]
      (references-count page-name nil {:hover? true})]]
-   [:div.p-4.h-64.flex.justify-center
-    (tldraw-preview page-name)]])
+   (ui/lazy-visible
+    (fn [] [:div.p-4.h-64.flex.justify-center
+            (tldraw-preview page-name)]))])
 
 (rum/defc dashboard-create-card
   []

--- a/tldraw/apps/tldraw-logseq/src/components/ContextBar/ContextBar.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextBar/ContextBar.tsx
@@ -30,7 +30,7 @@ const _ContextBar: TLContextBarComponent<Shape> = ({ shapes, offsets, hidden }) 
     if (!elm) return
     const size = rSize.current ?? [0, 0]
     const [x, y] = getContextBarTranslation(size, offsets)
-    elm.style.setProperty('transform', `translateX(${x}px) translateY(${y}px)`)
+    elm.style.transform = `translateX(${x}px) translateY(${y}px)`
   }, [offsets])
 
   if (!app) return null

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
@@ -140,7 +140,8 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
     return this.props.blockType === 'B' ? this.props.compact : this.props.collapsed
   }
 
-  @action setCollapsed = async (collapsed: boolean) => {
+  @action toggleCollapsed = async () => {
+    const collapsed = !this.collapsed
     if (this.props.blockType === 'B') {
       this.update({ compact: collapsed })
       this.canResize[1] = !collapsed
@@ -311,6 +312,7 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
         <div
           className="absolute inset-0 tl-logseq-cp-container-bg"
           style={{
+            textRendering: app.viewport.camera.zoom < 0.5 ? 'optimizeSpeed' : 'auto',
             background:
               fill && fill !== 'var(--ls-secondary-background-color)'
                 ? `var(--ls-highlight-color-${fill})`
@@ -509,7 +511,7 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
                 active={!!this.collapsed}
                 style={{ opacity: isSelected ? 1 : 0 }}
                 icon={this.props.blockType === 'B' ? 'block' : 'page'}
-                onClick={() => this.setCollapsed(!this.collapsed)}
+                onClick={this.toggleCollapsed}
                 otherIcon={'whiteboard-element'}
               />
             </>

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
@@ -324,11 +324,13 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
           className="relative tl-logseq-cp-container"
           style={{ overflow: this.props.isAutoResizing ? 'visible' : 'auto' }}
         >
-          {loaded && (this.props.blockType === 'B' && this.props.compact ? (
-            <Block blockId={pageId} />
-          ) : (
-            <Page pageName={pageId} />
-          ))}
+          {(loaded || !this.initialHeightCalculated) &&
+            (this.props.blockType === 'B' && this.props.compact ? (
+              <Block blockId={pageId} />
+            ) : (
+              <Page pageName={pageId} />
+            ))
+          }
         </div>
       </>
     )

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
@@ -298,14 +298,13 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
       }
     }, [innerHeight, this.props.isAutoResizing])
 
+    const [loaded, setLoaded] = React.useState(false)
+
     React.useEffect(() => {
-      if (!this.initialHeightCalculated) {
-        setTimeout(() => {
-          this.onResetBounds()
-          app.persist(true)
-        })
-      }
-    }, [this.initialHeightCalculated])
+      setTimeout(function () {
+        setLoaded(true)
+      })
+    }, [])
 
     return (
       <>
@@ -325,11 +324,11 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
           className="relative tl-logseq-cp-container"
           style={{ overflow: this.props.isAutoResizing ? 'visible' : 'auto' }}
         >
-          {this.props.blockType === 'B' && this.props.compact ? (
+          {loaded && (this.props.blockType === 'B' && this.props.compact ? (
             <Block blockId={pageId} />
           ) : (
             <Page pageName={pageId} />
-          )}
+          ))}
         </div>
       </>
     )

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
@@ -329,8 +329,7 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
               <Block blockId={pageId} />
             ) : (
               <Page pageName={pageId} />
-            ))
-          }
+            ))}
         </div>
       </>
     )

--- a/tldraw/packages/react/src/components/HTMLLayer/HTMLLayer.tsx
+++ b/tldraw/packages/react/src/components/HTMLLayer/HTMLLayer.tsx
@@ -2,6 +2,7 @@ import { autorun } from 'mobx'
 import { observer } from 'mobx-react-lite'
 import * as React from 'react'
 import { useRendererContext } from '../../hooks'
+import { useApp } from '@tldraw/react'
 
 interface HTMLLayerProps {
   children: React.ReactNode
@@ -9,26 +10,32 @@ interface HTMLLayerProps {
 
 export const HTMLLayer = observer(function HTMLLayer({ children }: HTMLLayerProps) {
   const rLayer = React.useRef<HTMLDivElement>(null)
+  const app = useApp()
 
   const { viewport } = useRendererContext()
+  const layer = rLayer.current
+
+  const { zoom, point } = viewport.camera
 
   React.useEffect(
-    () =>
-      autorun(() => {
-        const layer = rLayer.current
+    () => {
         if (!layer) return
 
-        const { zoom, point } = viewport.camera
-        layer.style.setProperty(
-          'transform',
-          `scale(${zoom}) translate3d(${point[0]}px, ${point[1]}px, 0)`
-        )
-      }),
-    []
+        let transform = 'scale('
+        transform += zoom
+        transform += ') translateX('
+        transform += point[0]
+        transform += 'px) translateY('
+        transform += point[1]
+        transform += 'px)'
+
+        layer.style.transform = transform
+      },
+    [zoom, point, layer]
   )
 
   return (
-    <div ref={rLayer} className="tl-absolute tl-layer">
+    <div ref={rLayer} className="tl-absolute tl-layer" style={{willChange: 'transform',  textRendering: viewport.camera.zoom < 0.5 ? 'optimizeSpeed' : 'auto'}}>
       {children}
     </div>
   )

--- a/tldraw/packages/react/src/components/HTMLLayer/HTMLLayer.tsx
+++ b/tldraw/packages/react/src/components/HTMLLayer/HTMLLayer.tsx
@@ -35,7 +35,7 @@ export const HTMLLayer = observer(function HTMLLayer({ children }: HTMLLayerProp
   )
 
   return (
-    <div ref={rLayer} className="tl-absolute tl-layer" style={{willChange: 'transform',  textRendering: viewport.camera.zoom < 0.5 ? 'optimizeSpeed' : 'auto'}}>
+    <div ref={rLayer} className="tl-absolute tl-layer">
       {children}
     </div>
   )

--- a/tldraw/packages/react/src/components/HTMLLayer/HTMLLayer.tsx
+++ b/tldraw/packages/react/src/components/HTMLLayer/HTMLLayer.tsx
@@ -21,15 +21,7 @@ export const HTMLLayer = observer(function HTMLLayer({ children }: HTMLLayerProp
     () => {
         if (!layer) return
 
-        let transform = 'scale('
-        transform += zoom
-        transform += ') translateX('
-        transform += point[0]
-        transform += 'px) translateY('
-        transform += point[1]
-        transform += 'px)'
-
-        layer.style.transform = transform
+        layer.style.transform = `scale(${zoom}) translate3d(${point[0]}px, ${point[1]}px, 0)`
       },
     [zoom, point, layer]
   )

--- a/tldraw/packages/react/src/components/HTMLLayer/HTMLLayer.tsx
+++ b/tldraw/packages/react/src/components/HTMLLayer/HTMLLayer.tsx
@@ -1,8 +1,6 @@
-import { autorun } from 'mobx'
 import { observer } from 'mobx-react-lite'
 import * as React from 'react'
 import { useRendererContext } from '../../hooks'
-import { useApp } from '@tldraw/react'
 
 interface HTMLLayerProps {
   children: React.ReactNode
@@ -10,21 +8,17 @@ interface HTMLLayerProps {
 
 export const HTMLLayer = observer(function HTMLLayer({ children }: HTMLLayerProps) {
   const rLayer = React.useRef<HTMLDivElement>(null)
-  const app = useApp()
 
   const { viewport } = useRendererContext()
   const layer = rLayer.current
 
   const { zoom, point } = viewport.camera
 
-  React.useEffect(
-    () => {
-        if (!layer) return
+  React.useEffect(() => {
+    if (!layer) return
 
-        layer.style.transform = `scale(${zoom}) translate3d(${point[0]}px, ${point[1]}px, 0)`
-      },
-    [zoom, point, layer]
-  )
+    layer.style.transform = `scale(${zoom}) translate3d(${point[0]}px, ${point[1]}px, 0)`
+  }, [zoom, point, layer])
 
   return (
     <div ref={rLayer} className="tl-absolute tl-layer">

--- a/tldraw/packages/react/src/components/SVGLayer/SVGLayer.tsx
+++ b/tldraw/packages/react/src/components/SVGLayer/SVGLayer.tsx
@@ -19,16 +19,21 @@ export const SVGLayer = observer(function SVGLayer({ children }: SVGLayerProps) 
         if (!group) return
 
         const { zoom, point } = viewport.camera
-        group.style.setProperty(
-          'transform',
-          `scale(${zoom}) translateX(${point[0]}px) translateY(${point[1]}px)`
-        )
+        let transform = 'scale('
+        transform += zoom
+        transform += ') translateX('
+        transform += point[0]
+        transform += 'px) translateY('
+        transform += point[1]
+        transform += 'px)'
+
+        group.style.transform = transform
       }),
     []
   )
 
   return (
-    <svg className="tl-absolute tl-overlay" pointerEvents="none">
+    <svg className="tl-absolute tl-overlay" pointerEvents="none" style={{shapeRendering: 'optimizeSpeed', textRendering: viewport.camera.zoom < 0.5 ? 'optimizeSpeed' : 'auto'}}>
       <g ref={rGroup} pointerEvents="none">
         {children}
       </g>

--- a/tldraw/packages/react/src/components/SVGLayer/SVGLayer.tsx
+++ b/tldraw/packages/react/src/components/SVGLayer/SVGLayer.tsx
@@ -33,7 +33,7 @@ export const SVGLayer = observer(function SVGLayer({ children }: SVGLayerProps) 
   )
 
   return (
-    <svg className="tl-absolute tl-overlay" pointerEvents="none" style={{shapeRendering: 'optimizeSpeed', textRendering: viewport.camera.zoom < 0.5 ? 'optimizeSpeed' : 'auto'}}>
+    <svg className="tl-absolute tl-overlay" pointerEvents="none">
       <g ref={rGroup} pointerEvents="none">
         {children}
       </g>

--- a/tldraw/packages/react/src/components/SVGLayer/SVGLayer.tsx
+++ b/tldraw/packages/react/src/components/SVGLayer/SVGLayer.tsx
@@ -19,15 +19,8 @@ export const SVGLayer = observer(function SVGLayer({ children }: SVGLayerProps) 
         if (!group) return
 
         const { zoom, point } = viewport.camera
-        let transform = 'scale('
-        transform += zoom
-        transform += ') translateX('
-        transform += point[0]
-        transform += 'px) translateY('
-        transform += point[1]
-        transform += 'px)'
 
-        group.style.transform = transform
+        group.style.transform = `scale(${zoom}) translateX(${point[0]}px) translateY(${point[1]}px)`
       }),
     []
   )

--- a/tldraw/packages/react/src/components/ui/DirectionIndicator/DirectionIndicator.tsx
+++ b/tldraw/packages/react/src/components/ui/DirectionIndicator/DirectionIndicator.tsx
@@ -28,10 +28,7 @@ export const DirectionIndicator = observer(function DirectionIndicator<
       const int = intersectRayLineSegment(center, direction, A, B)
       if (!int.didIntersect) continue
       const point = int.points[0]
-      elm.style.setProperty(
-        'transform',
-        `translate(${point[0] - 6}px,${point[1] - 6}px) rotate(${Vec.toAngle(direction)}rad)`
-      )
+      elm.style.transform = `translate(${point[0] - 6}px,${point[1] - 6}px) rotate(${Vec.toAngle(direction)}rad)`
     }
   }, [direction, bounds])
   return (

--- a/tldraw/packages/react/src/components/ui/DirectionIndicator/DirectionIndicator.tsx
+++ b/tldraw/packages/react/src/components/ui/DirectionIndicator/DirectionIndicator.tsx
@@ -28,7 +28,9 @@ export const DirectionIndicator = observer(function DirectionIndicator<
       const int = intersectRayLineSegment(center, direction, A, B)
       if (!int.didIntersect) continue
       const point = int.points[0]
-      elm.style.transform = `translate(${point[0] - 6}px,${point[1] - 6}px) rotate(${Vec.toAngle(direction)}rad)`
+      elm.style.transform = `translate(${point[0] - 6}px,${point[1] - 6}px) rotate(${Vec.toAngle(
+        direction
+      )}rad)`
     }
   }, [direction, bounds])
   return (

--- a/tldraw/packages/react/src/hooks/useCursor.ts
+++ b/tldraw/packages/react/src/hooks/useCursor.ts
@@ -1,5 +1,7 @@
 import { GeomUtils, TLCursor } from '@tldraw/core'
+import { useApp } from './useApp'
 import * as React from 'react'
+
 
 function getCursorCss(svg: string, r: number, f = false) {
   return (
@@ -43,9 +45,11 @@ const CURSORS: Record<TLCursor, (r: number, f?: boolean) => string> = {
 }
 
 export function useCursor(ref: React.RefObject<HTMLDivElement>, cursor: TLCursor, rotation = 0) {
+  const app = useApp()
+
   React.useEffect(() => {
     const elm = ref.current
-    if (!elm) return
+    if (!elm || app.currentState.id === 'move') return
     elm.style.setProperty('--tl-cursor', CURSORS[cursor](GeomUtils.radiansToDegrees(rotation)))
   }, [cursor, rotation])
 }

--- a/tldraw/packages/react/src/hooks/useCursor.ts
+++ b/tldraw/packages/react/src/hooks/useCursor.ts
@@ -1,7 +1,6 @@
 import { GeomUtils, TLCursor } from '@tldraw/core'
 import * as React from 'react'
 
-
 function getCursorCss(svg: string, r: number, f = false) {
   return (
     `url("data:image/svg+xml,<svg height='32' width='32' viewBox='0 0 35 35' xmlns='http://www.w3.org/2000/svg'><g fill='none' style='transform-origin:center center' transform='rotate(${r})${

--- a/tldraw/packages/react/src/hooks/useCursor.ts
+++ b/tldraw/packages/react/src/hooks/useCursor.ts
@@ -1,5 +1,4 @@
 import { GeomUtils, TLCursor } from '@tldraw/core'
-import { useApp } from './useApp'
 import * as React from 'react'
 
 
@@ -45,11 +44,9 @@ const CURSORS: Record<TLCursor, (r: number, f?: boolean) => string> = {
 }
 
 export function useCursor(ref: React.RefObject<HTMLDivElement>, cursor: TLCursor, rotation = 0) {
-  const app = useApp()
-
   React.useEffect(() => {
     const elm = ref.current
-    if (!elm || app.currentState.id === 'move') return
-    elm.style.setProperty('--tl-cursor', CURSORS[cursor](GeomUtils.radiansToDegrees(rotation)))
+    if (!elm) return
+    elm.style.cursor = CURSORS[cursor](GeomUtils.radiansToDegrees(rotation))
   }, [cursor, rotation])
 }

--- a/tldraw/packages/react/src/hooks/useStylesheet.ts
+++ b/tldraw/packages/react/src/hooks/useStylesheet.ts
@@ -79,7 +79,6 @@ const defaultTheme: TLTheme = {
 
 const tlcss = css`
   .tl-container {
-    --tl-cursor: inherit;
     --tl-zoom: 1;
     --tl-scale: calc(1 / var(--tl-zoom));
     --tl-padding: 64px;
@@ -116,7 +115,7 @@ const tlcss = css`
     touch-action: none;
     overscroll-behavior: none;
     background-color: var(--tl-background);
-    cursor: var(--tl-cursor) !important;
+    cursor: inherit;
     box-sizing: border-box;
     color: var(--tl-foreground);
     -webkit-user-select: none;


### PR DESCRIPTION
This PR improves the performance and the perceived responsiveness of whiteboards by
- Lazy loading the previews on WB dashboard. Navigating to dashboard should now feel smoother.
- Loading the content of portals after rendering the wrapper. Rendering an empty portal with the correct dimensions once, allows fast loading heavy on portals canvases. The content of portals will be lazily loaded when we are already viewing the whiteboard.
- Improving the performance of panning. It could previously take more than a second to start panning on a complicated canvas, due to calling setProperty to change the cursor.