### PR TITLE
Adds support for :query-page as an input

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/util/db.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/util/db.cljs
@@ -74,7 +74,7 @@ it will return 1622433600000, which is equivalent to Mon May 31 2021 00 :00:00."
 
 (defn keyword-input-dispatch [input]
   (cond 
-    (#{:current-page :current-block :parent-block :today :yesterday :tomorrow :right-now-ms} input) input
+    (#{:current-page :query-page :current-block :parent-block :today :yesterday :tomorrow :right-now-ms} input) input
 
     (re-find #"^[+-]\d+[dwmy]?$" (name input)) :relative-date
     (re-find #"^[+-]\d+[dwmy]-(ms|start|end|\d{2}|\d{4}|\d{6}|\d{9})?$" (name input)) :relative-date-time
@@ -90,6 +90,10 @@ it will return 1622433600000, which is equivalent to Mon May 31 2021 00 :00:00."
 (defmethod resolve-keyword-input :current-page [_ _ {:keys [current-page-fn]}]
   (when current-page-fn
     (some-> (current-page-fn) string/lower-case)))
+
+(defmethod resolve-keyword-input :query-page [db _ {:keys [current-block-uuid]}]
+  (when-let [current-block (and current-block-uuid (d/entity db [:block/uuid current-block-uuid]))]
+    (get-in current-block [:block/page :block/name])))
 
 (defmethod resolve-keyword-input :current-block [db _ {:keys [current-block-uuid]}]
   (when current-block-uuid

--- a/src/main/frontend/date.cljs
+++ b/src/main/frontend/date.cljs
@@ -213,8 +213,8 @@
   (def default-formatter (tf/formatter "MMM do, yyyy"))
   (def zh-formatter (tf/formatter "YYYY年MM月dd日"))
 
-  (tf/show-formatters)
+  (tf/show-formatters))
 
   ;; :date 2020-05-31
   ;; :rfc822 Sun, 31 May 2020 03:00:57 Z
-)
+

--- a/src/test/frontend/db/query_react_test.cljs
+++ b/src/test/frontend/db/query_react_test.cljs
@@ -41,17 +41,6 @@ adds rules that users often use"
                                               :in $ ?start ?end
                                               :where (between ?b ?start ?end)]})))
 
-         ; (let [block-uuid (-> (db-utils/q '[:find (pull ?b [:block/uuid])
-         ;                                    :where [?b :block/content "parent"]])
-         ;                      ffirst
-         ;                      :block/uuid)]
-         ;   (map :block/content
-         ;        (custom-query {:inputs [:current-block]
-         ;                       :query '[:find (pull ?b [*])
-         ;                                :in $ ?current-block
-         ;                                :where [?b :block/parent ?current-block]]}
-         ;                      {:current-block-uuid block-uuid})))))
-
 (defn- block-with-content [block-content]
   (-> (db-utils/q '[:find (pull ?b [:block/uuid])
                     :in $ ?content
@@ -60,12 +49,10 @@ adds rules that users often use"
       ffirst))
 
 (defn- blocks-on-journal-page-from-block-with-content [page-input block-content]
-  (prn :blocks-on-journal-page-from-block-with-content page-input)
-  (prn :blocks-on-journal-page-from-block-with-content block-content)
-  (map :block/content (custom-query {:inputs [page-input] 
+  (map :block/content (custom-query {:inputs [page-input]
                                      :query '[:find (pull ?b [*])
                                               :in $ ?page
-                                              :where [?b :block/page ?e] 
+                                              :where [?b :block/page ?e]
                                                      [?e :block/name ?page]]}
                                     {:current-block-uuid (get (block-with-content block-content) :block/uuid)})))
 
@@ -217,7 +204,7 @@ created-at:: %s"
   (is (= ["today" "tonight"] (blocks-created-between-inputs :start-of-today-ms :end-of-today-ms))
       ":start-of-today-ms and :end-of-today-ms resolve to correct datetime range")
 
-  (is (= ["+1d" "-1d" "today" "tonight"] (blocks-created-between-inputs :1d-before-ms :5d-after-ms)) 
+  (is (= ["+1d" "-1d" "today" "tonight"] (blocks-created-between-inputs :1d-before-ms :5d-after-ms))
       ":Xd-before-ms and :Xd-after-ms resolve to correct datetime range")
 
   (is (= ["today" "tonight"] (blocks-created-between-inputs :today-start :today-end))
@@ -251,10 +238,10 @@ created-at:: %s"
       ":-XT-HHMM and :+XT-HHMM resolve to correct datetime range")
 
   (is (= [] (blocks-created-between-inputs :-0d-abcd :+1d-23.45))
-      ":-XT-HHMM and :+XT-HHMM will not reoslve with invalid time formats but will fail gracefully")) 
-        
+      ":-XT-HHMM and :+XT-HHMM will not reoslve with invalid time formats but will fail gracefully"))
 
-(deftest resolve-input-for-relative-date-queries 
+
+(deftest resolve-input-for-relative-date-queries
   (load-test-files [{:file/content "- -1y" :file/path "journals/2022_01_01.md"}
                     {:file/content "- -1m" :file/path "journals/2022_12_01.md"}
                     {:file/content "- -1w" :file/path "journals/2022_12_25.md"}
@@ -268,10 +255,10 @@ created-at:: %s"
   (with-redefs [t/today (constantly (t/date-time 2023 1 1))]
     (is (= ["now" "-1d" "-1w" "-1m" "-1y"] (blocks-journaled-between-inputs :-365d :today))
         ":-365d and today resolve to correct journal range")
-    
+
     (is (= ["now" "-1d" "-1w" "-1m" "-1y"] (blocks-journaled-between-inputs :-1y :today))
         ":-1y and today resolve to correct journal range")
-    
+
     (is (= ["now" "-1d" "-1w" "-1m"] (blocks-journaled-between-inputs :-1m :today))
         ":-1m and today resolve to correct journal range")
 
@@ -283,10 +270,10 @@ created-at:: %s"
 
     (is (= ["+1y" "+1m" "+1w" "+1d" "now"] (blocks-journaled-between-inputs :today :+365d))
         ":+365d and today resolve to correct journal range")
-    
+
     (is (= ["+1y" "+1m" "+1w" "+1d" "now"] (blocks-journaled-between-inputs :today :+1y))
         ":+1y and today resolve to correct journal range")
-    
+
     (is (= ["+1m" "+1w" "+1d" "now"] (blocks-journaled-between-inputs :today :+1m))
         ":+1m and today resolve to correct journal range")
 
@@ -299,7 +286,7 @@ created-at:: %s"
     (is (= ["+1d" "now"] (blocks-journaled-between-inputs :today :today/+1d))
         ":today/+1d and today resolve to correct journal range")))
 
-(deftest resolve-input-for-query-page 
+(deftest resolve-input-for-query-page
   (load-test-files [{:file/content "- -1d" :file/path "journals/2022_12_31.md"}
                     {:file/content "- now" :file/path "journals/2023_01_01.md"}
                     {:file/content "- +1d" :file/path "journals/2023_01_02.md"}])
@@ -316,4 +303,3 @@ created-at:: %s"
 
     (is (= ["+1d"] (blocks-on-journal-page-from-block-with-content :query-page "+1d"))
         ":query-page resolves to the parent page when called from another page")))
-


### PR DESCRIPTION
This adds support for `:query-page` as an input for advanced queries. This resolves issues such as #6528 (I'll look up more issues in a moment).

Logseq at the moment provides a `:current-page` and `<% current page %>` input type that resolves to the page open in the current window. Embedding blocks that contain any queries using these inputs causes the results to change depending on where the block is shown. This adds an alternate input `:query-page`, that will resolve to the page of the block of that query originally comes from.

Currently this does not add `<% query page %>` to simple queries, as we are not currently providing the current block id to simple queries which makes it a little tricker, and this is namely to support the journal day queries in advanced queries. That functionality should maybe be added eventually.

Here is a screenshot showing the test cases in action, with four queries from `#task-a`, and the same four queries embedded from a page on `#task-b`.

<img width="507" alt="Screenshot 2023-01-27 at 19 12 10" src="https://user-images.githubusercontent.com/3488879/215162758-58df45aa-4550-400c-9207-922ea66f206b.png">

The four queries are:

```
{{query (and (task TODO) <% current page %>)}}

#+BEGIN_QUERY
{:title "Todos with current page"
 :query [:find (pull ?b [*])
              :in $ ?current-page 
              :where [?p :block/name ?current-page] 
                           [?b :block/marker "TODO"] 
                           [?b :block/ref-pages ?p] 
 :inputs [:current-page]}
#+END_QUERY

{{query (and (task TODO) <% query page %>)}}

#+BEGIN_QUERY
{:title "Todos with query page"
 :query [:find (pull ?b [*])
              :in $ ?query-page 
              :where [?p :block/name ?query-page] 
                           [?b :block/marker "TODO"] 
                           [?b :block/ref-pages ?p]]
 :inputs [:query-page]}
#+END_QUERY

```