### PR TITLE
Enhancement: Add dev ast inspector menu items, dev commands and clear all notifications command

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -58,6 +58,7 @@
              frontend.handler.common common-handler
              frontend.handler.common.file file-common-handler
              frontend.handler.common.plugin plugin-common-handler
+             frontend.handler.common.developer dev-common-handler
              frontend.handler.config config-handler
              frontend.handler.events events
              frontend.handler.global-config global-config-handler

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -20,6 +20,7 @@
             [frontend.util :as util]
             [logseq.graph-parser.util :as gp-util]
             [logseq.graph-parser.util.block-ref :as block-ref]
+            [logseq.graph-parser.mldoc :as gp-mldoc]
             [frontend.util.url :as url-util]
             [goog.dom :as gdom]
             [goog.object :as gobj]
@@ -168,8 +169,8 @@
             :icon "h-auto"
             :icon-props {:extension? true}
             :class "to-heading-button"
-            :title (if (= format :markdown) 
-                     (str (t :auto-heading) " - " (t :not-available-in-mode format)) 
+            :title (if (= format :markdown)
+                     (str (t :auto-heading) " - " (t :not-available-in-mode format))
                      (t :auto-heading))
             :disabled (= format :markdown)
             :on-click (fn [_e]
@@ -212,7 +213,7 @@
           (t :content/copy-block-emebed)
           nil)
 
-          ;; TODO Logseq protocol mobile support
+         ;; TODO Logseq protocol mobile support
          (when (util/electron?)
            (ui/menu-link
             {:key      "Copy block URL"
@@ -305,6 +306,27 @@
                             :success
                             false)))}
             "(Dev) Show block data"
+            nil))
+  
+         (when (state/sub [:ui/developer-mode?])
+           (ui/menu-link
+            {:key      "(Dev) Show block AST"
+             :on-click (fn []
+                         (let [block (db/pull [:block/uuid block-id])
+                               block-data (-> (gp-mldoc/->edn (:block/content block)
+                                                              (gp-mldoc/default-config (:block/format block)))
+                                              pprint/pprint
+                                              with-out-str)]
+                           (println block-data)
+                           (notification/show!
+                            [:div
+                             [:pre.code block-data]
+                             [:br]
+                             (ui/button "Copy to clipboard"
+                                        :on-click #(.writeText js/navigator.clipboard block-data))]
+                            :success
+                            false)))}
+            "(Dev) Show block AST"
             nil))])))
 
 (rum/defc block-ref-custom-context-menu-content

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -1,6 +1,5 @@
 (ns frontend.components.content
-  (:require [cljs.pprint :as pprint]
-            [clojure.string :as string]
+  (:require [clojure.string :as string]
             [dommy.core :as d]
             [frontend.commands :as commands]
             [frontend.components.editor :as editor]
@@ -20,7 +19,6 @@
             [frontend.util :as util]
             [logseq.graph-parser.util :as gp-util]
             [logseq.graph-parser.util.block-ref :as block-ref]
-            [logseq.graph-parser.mldoc :as gp-mldoc]
             [frontend.util.url :as url-util]
             [goog.dom :as gdom]
             [goog.object :as gobj]
@@ -295,37 +293,16 @@
            (ui/menu-link
             {:key      "(Dev) Show block data"
              :on-click (fn []
-                         (let [block-data (with-out-str (pprint/pprint (db/pull [:block/uuid block-id])))]
-                           (println block-data)
-                           (notification/show!
-                            [:div
-                             [:pre.code block-data]
-                             [:br]
-                             (ui/button "Copy to clipboard"
-                                        :on-click #(.writeText js/navigator.clipboard block-data))]
-                            :success
-                            false)))}
+                         (state/pub-event! [:dev/show-entity-data [:block/uuid block-id]]))}
             "(Dev) Show block data"
             nil))
-  
+
          (when (state/sub [:ui/developer-mode?])
            (ui/menu-link
             {:key      "(Dev) Show block AST"
              :on-click (fn []
-                         (let [block (db/pull [:block/uuid block-id])
-                               block-data (-> (gp-mldoc/->edn (:block/content block)
-                                                              (gp-mldoc/default-config (:block/format block)))
-                                              pprint/pprint
-                                              with-out-str)]
-                           (println block-data)
-                           (notification/show!
-                            [:div
-                             [:pre.code block-data]
-                             [:br]
-                             (ui/button "Copy to clipboard"
-                                        :on-click #(.writeText js/navigator.clipboard block-data))]
-                            :success
-                            false)))}
+                         (let [block (db/pull [:block/uuid block-id])]
+                           (state/pub-event! [:dev/show-content-ast (:block/content block) (:block/format block)])))}
             "(Dev) Show block AST"
             nil))])))
 

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -13,6 +13,7 @@
             [frontend.handler.image :as image-handler]
             [frontend.handler.notification :as notification]
             [frontend.handler.page :as page-handler]
+            [frontend.handler.common.developer :as dev-common-handler]
             [frontend.mixins :as mixins]
             [frontend.state :as state]
             [frontend.ui :as ui]
@@ -293,7 +294,7 @@
            (ui/menu-link
             {:key      "(Dev) Show block data"
              :on-click (fn []
-                         (state/pub-event! [:dev/show-entity-data [:block/uuid block-id]]))}
+                         (dev-common-handler/show-entity-data [:block/uuid block-id]))}
             "(Dev) Show block data"
             nil))
 
@@ -302,7 +303,7 @@
             {:key      "(Dev) Show block AST"
              :on-click (fn []
                          (let [block (db/pull [:block/uuid block-id])]
-                           (state/pub-event! [:dev/show-content-ast (:block/content block) (:block/format block)])))}
+                           (dev-common-handler/show-content-ast (:block/content block) (:block/format block))))}
             "(Dev) Show block AST"
             nil))])))
 

--- a/src/main/frontend/components/page_menu.cljs
+++ b/src/main/frontend/components/page_menu.cljs
@@ -6,6 +6,7 @@
             [frontend.handler.notification :as notification]
             [frontend.handler.page :as page-handler]
             [frontend.handler.route :as route-handler]
+            [frontend.handler.common.developer :as dev-common-handler]
             [frontend.state :as state]
             [frontend.ui :as ui]
             [frontend.util :as util]
@@ -162,13 +163,14 @@
           (when developer-mode?
             {:title   "(Dev) Show page data"
              :options {:on-click (fn []
-                                   (state/pub-event! [:dev/show-entity-data (:db/id page)]))}})
+                                   (dev-common-handler/show-entity-data (:db/id page)))}})
 
           (when developer-mode?
             {:title   "(Dev) Show page AST"
              :options {:on-click (fn []
                                    (let [page (db/pull '[:block/format {:block/file [:file/content]}] (:db/id page))]
-                                     (state/pub-event! [:dev/show-content-ast (get-in page [:block/file :file/content])
-                                                        (:block/format page)])))}})]
+                                     (dev-common-handler/show-content-ast
+                                      (get-in page [:block/file :file/content])
+                                      (:block/format page))))}})]
          (flatten)
          (remove nil?))))))

--- a/src/main/frontend/handler/common/developer.cljs
+++ b/src/main/frontend/handler/common/developer.cljs
@@ -1,0 +1,66 @@
+(ns frontend.handler.common.developer
+  "Common fns for developer related functionality"
+  (:require [frontend.db :as db]
+            [cljs.pprint :as pprint]
+            [frontend.state :as state]
+            [frontend.handler.notification :as notification]
+            [frontend.ui :as ui]
+            [logseq.graph-parser.mldoc :as gp-mldoc]))
+
+;; Fns used between menus and commands
+(defn show-entity-data
+  [& pull-args]
+  (let [pull-data (with-out-str (pprint/pprint (apply db/pull pull-args)))]
+    (println pull-data)
+    (notification/show!
+     [:div
+      [:pre.code pull-data]
+      [:br]
+      (ui/button "Copy to clipboard"
+                 :on-click #(.writeText js/navigator.clipboard pull-data))]
+     :success
+     false)))
+
+(defn show-content-ast
+  [content format]
+  (let [ast-data (-> (gp-mldoc/->edn content (gp-mldoc/default-config format))
+                     pprint/pprint
+                     with-out-str)]
+    (println ast-data)
+    (notification/show!
+     [:div
+      ;; Show clipboard at top since content is really long for pages
+      (ui/button "Copy to clipboard"
+                 :on-click #(.writeText js/navigator.clipboard ast-data))
+      [:br]
+      [:pre.code ast-data]]
+     :success
+     false)))
+
+;; Public Commands
+(defn ^:export show-block-data []
+  ;; Use editor state to locate most recent block
+  (if-let [block-uuid (:block-id (first (state/get-editor-args)))]
+    (show-entity-data [:block/uuid block-uuid])
+    (notification/show! "No block found" :error)))
+
+(defn ^:export show-block-ast []
+  (if-let [{:block/keys [content format]} (:block (first (state/get-editor-args)))]
+    (show-content-ast content format)
+    (notification/show! "No block found" :error)))
+
+(defn ^:export show-page-data []
+  ;; Use editor state to locate most recent page.
+  ;; Consider replacing with navigation history if it's more useful
+  (if-let [page-id (get-in (first (state/get-editor-args))
+                           [:block :block/page :db/id])]
+    (show-entity-data page-id)
+    (notification/show! "No page found" :error)))
+
+(defn ^:export show-page-ast []
+  (let [page-data (db/pull '[:block/format {:block/file [:file/content]}]
+                           (get-in (first (state/get-editor-args))
+                                   [:block :block/page :db/id]))]
+    (if (get-in page-data [:block/file :file/content])
+      (show-content-ast (get-in page-data [:block/file :file/content]) (:block/format page-data))
+      (notification/show! "No page found" :error))))

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -8,7 +8,6 @@
             [clojure.core.async.interop :refer [p->c]]
             [clojure.set :as set]
             [clojure.string :as string]
-            [cljs.pprint :as pprint]
             [datascript.core :as d]
             [frontend.commands :as commands]
             [frontend.components.diff :as diff]
@@ -66,7 +65,6 @@
             [promesa.core :as p]
             [rum.core :as rum]
             [logseq.graph-parser.config :as gp-config]
-            [logseq.graph-parser.mldoc :as gp-mldoc]
             [cljs-bean.core :as bean]
             ["@sentry/react" :as Sentry]
             [frontend.modules.instrumentation.sentry :as sentry-event]))
@@ -920,33 +918,6 @@
 (defmethod handle :run/cli-command [[_ command content]]
   (when (and command (not (string/blank? content)))
     (shell-handler/run-cli-command-wrapper! command content)))
-
-(defmethod handle :dev/show-entity-data [[_ & pull-args]]
-  (let [pull-data (with-out-str (pprint/pprint (apply db/pull pull-args)))]
-    (println pull-data)
-    (notification/show!
-     [:div
-      [:pre.code pull-data]
-      [:br]
-      (ui/button "Copy to clipboard"
-                 :on-click #(.writeText js/navigator.clipboard pull-data))]
-     :success
-     false)))
-
-(defmethod handle :dev/show-content-ast [[_ content format]]
-  (let [ast-data (-> (gp-mldoc/->edn content (gp-mldoc/default-config format))
-                       pprint/pprint
-                       with-out-str)]
-    (println ast-data)
-    (notification/show!
-     [:div
-      ;; Show clipboard at top since content is really long for pages
-      (ui/button "Copy to clipboard"
-                 :on-click #(.writeText js/navigator.clipboard ast-data))
-      [:br]
-      [:pre.code ast-data]]
-     :success
-     false)))
 
 (defn run!
   []

--- a/src/main/frontend/modules/shortcut/dicts.cljc
+++ b/src/main/frontend/modules/shortcut/dicts.cljc
@@ -128,7 +128,12 @@
    :ui/install-plugins-from-file    "Install plugins from plugins.edn"
    :editor/toggle-open-blocks       "Toggle open blocks (collapse or expand all blocks)"
    :ui/toggle-cards                 "Toggle cards"
-   :git/commit                      "Create git commit with message"})
+   :ui/clear-all-notifications      "Clear all notifications"
+   :git/commit                      "Create git commit with message"
+   :dev/show-block-data             "(Dev) Show block data"
+   :dev/show-block-ast              "(Dev) Show block AST"
+   :dev/show-page-data              "(Dev) Show page data"
+   :dev/show-page-ast               "(Dev) Show page AST"})
 
 (def category
   {:shortcut.category/basics "Basics"
@@ -1154,7 +1159,7 @@
              :command.go/electron-jump-to-the-next    "Ir para a próxima correspondência da sua pesquisa"
              :command.go/electron-jump-to-the-previous "Voltar para a correspondência anterior da sua pesquisa"
              :command.graph/re-index                  "Reindexar o grafo atual"
-             
+
              :command.editor/new-whiteboard           "Novo quadro branco"
              :command.editor/select-parent            "Selecione o bloco pai"
              :command.go/whiteboards                  "Ir para os quadros brancos"


### PR DESCRIPTION
This PR adds a couple nice things for developers and a clear all notifications command. The developer improvements:
* Block AST inspector

<img width="825" alt="Screen Shot 2023-01-28 at 1 02 02 AM" src="https://user-images.githubusercontent.com/97210743/215250094-4ea46d84-e46a-4de0-b84e-8faf01097bea.png">

* Page AST inspector
<img width="837" alt="Screen Shot 2023-01-28 at 1 01 36 AM" src="https://user-images.githubusercontent.com/97210743/215250139-3fbd53f6-49a2-4309-8e4f-03089d1cb89c.png">

* Make all dev menu items available as commands

To QA commands, invoke any of the 4 dev commands and it will use the last editing state to invoke the page or block functionality. The new ast menu items can be found off any block or page level menu