### PR TITLE
enhance(issue-template): add description to `ask-pr`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -77,7 +77,10 @@ body:
   - type: checkboxes
     id: ask-pr
     attributes:
-      label: Are you willing to submit a PR?
-      description: Your contributions are greatly appreciated and play a vital role in helping to improve the project!
+      label: Are you willing to submit a PR? If you know how to fix the bug.
+      description: |
+        If you are not familiar with programming, you can skip this step.
+        If you are a developer and know how to fix the bug, you can submit a PR to fix it. You can find the [contributing guide](https://github.com/logseq/logseq#how-to-contribute-with-a-pr) here.
+        Your contributions are greatly appreciated and play a vital role in helping to improve the project!
       options:
         - label: I'm willing to submit a PR (Thank you!)


### PR DESCRIPTION
The short and simple description at `ask-pr` may confuse people, especially the user. They may check this box without any understanding of what a PR is or what actually happens if the box is checked. For example, see https://github.com/logseq/logseq/issues/8438 and https://github.com/logseq/logseq/issues/8371.