### PR TITLE
dev: add clj-holmes GH action

### DIFF
--- a/.github/workflows/clj-holmes.yml
+++ b/.github/workflows/clj-holmes.yml
@@ -1,0 +1,39 @@
+# https://github.com/clj-holmes/clj-holmes
+
+name: clj-holmes
+
+on:
+  push:
+    branches: [ "master", 2approvesbeforemerged ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: '0 14 * * MON-FRI'  # Runs at 13:00, Monday through Friday
+
+permissions:
+  contents: read
+
+jobs:
+  clj-holmes:
+    name: Run clj-holmes scanning
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # v3.3.0
+
+      - name: Scan code
+        uses: clj-holmes/clj-holmes-action@200d2d03900917d7eb3c24fc691ab83579a87fcb
+        with:
+          # rules-repository: 'git://org/private-rules-repo#main'
+          output-type: 'sarif'
+          output-file: 'clj-holmes-results.sarif'
+          fail-on-result: 'false'
+
+      - name: Upload analysis results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@9885f86fab4879632b7e44514f19148225dfbdcd  # v2.2.1
+        with:
+          sarif_file: ${{github.workspace}}/clj-holmes-results.sarif
+          wait-for-processing: true


### PR DESCRIPTION
Add a GH action for https://github.com/clj-holmes/clj-holmes with the default public rules (https://github.com/clj-holmes/clj-holmes-rules)

> A CLI SAST (Static application security testing) tool which was built with the intent of finding vulnerable Clojure code via rules that use a simple [pattern language](https://github.com/clj-holmes/shape-shifter). Although finding vulnerabilities is its main purpose, clj-holmes can also be used to find any kind of code pattern.


I have been using it locally for testing & I think it's a good idea to automate this scan for new PRs.

In the future, we can add our own custom rules based on the project needs.

Scan results: https://github.com/logseq/logseq/actions/runs/4040756450/jobs/6946697031

Once this PR is merged; you can see the results in the security tab under code-scanning (https://github.com/logseq/logseq/security/code-scanning)