### PR TITLE
fix: electron menu handler(Redo, Undo, Copy)

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -244,14 +244,14 @@
                                                (.send web-contents "invokeEditorHandler" "redo")))
                                     :accelerator "Shift+CommandOrControl+Z"}
                                    {:type "separator"}
-                                   {:role "cut"}
-                                   {:role "copy"}
+                                   {:role "cut"}  ;; FIXME not work as expected
+                                   {:role "copy"} ;; FIXME not work as expected
                                    {:role "paste"}]
 
                                   (if mac?
                                     [{:role "pasteAndMatchStyle"}
                                      {:role "delete"}
-                                     {:role "selectAll"}
+                                     {:role "selectAll"} ;; FIXME not work as expected
                                      {:type "separator"}
                                      {:label "Speech"
                                       :submenu [{:role "startSpeaking"},

--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -244,11 +244,7 @@
                                                (.send web-contents "invokeEditorHandler" "redo")))
                                     :accelerator "Shift+CommandOrControl+Z"}
                                    {:type "separator"}
-                                   {:label "Cut"
-                                    :click (fn []
-                                             (let [browser-window ^js/BrowserWindow @*win
-                                                   web-contents (.-webContents browser-window)]
-                                               (.send web-contents "invokeEditorHandler" "cut")))}
+                                   {:role "cut"}
                                    {:label "Copy"
                                     :click (fn []
                                              (let [browser-window ^js/BrowserWindow @*win

--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -228,7 +228,36 @@
                                   (if mac?
                                     {:role "close"}
                                     {:role "quit"})]}
-                       {:role "editMenu"}
+                       {:role "editMenu"
+                        :submenu [{:label "Undo"
+                                   :click (fn []
+                                            (let [browser-window ^js/BrowserWindow @*win
+                                                  web-contents (.-webContents browser-window)]
+                                              (.send web-contents "invokeEditorHandler" "undo")))
+                                   :accelerator "CommandOrControl+Z"}
+                                  {:label "Redo"
+                                   :click (fn []
+                                            (let [browser-window ^js/BrowserWindow @*win
+                                                  web-contents (.-webContents browser-window)]
+                                              (.send web-contents "invokeEditorHandler" "redo")))
+                                   :accelerator "Shift+CommandOrControl+Z"}
+                                  {:type "separator"}
+                                  {:role "cut"} ;; FIXME not working as expected
+                                  {:role "copy"} ;; FIXME not working as expected
+                                  {:role "paste"}
+                                  {:role "pasteAndMatchStyle"}
+                                  {:role "delete"}
+                                  {:role "selectAll"} ;; FIXME not working as expected
+                                  {:type "separator"}
+                                  {:label "Substitutions"
+                                   :submenu [{:role "showSubstitutions"}
+                                             {:type "separator"}
+                                             {:role "toggleSmartQuotes"}
+                                             {:role "toggleSmartDashes"}
+                                             {:role "toggleTextReplacement"}]}
+                                  {:label "Speech"
+                                   :submenu [{:role "startSpeaking"}
+                                             {:role "stopSpeaking"}]}]}
                        {:role "viewMenu"}
                        {:role "windowMenu"})
         ;; Windows has no about role

--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -244,8 +244,16 @@
                                                (.send web-contents "invokeEditorHandler" "redo")))
                                     :accelerator "Shift+CommandOrControl+Z"}
                                    {:type "separator"}
-                                   {:role "cut"}  ;; FIXME not work as expected
-                                   {:role "copy"} ;; FIXME not work as expected
+                                   {:label "Cut"
+                                    :click (fn []
+                                             (let [browser-window ^js/BrowserWindow @*win
+                                                   web-contents (.-webContents browser-window)]
+                                               (.send web-contents "invokeEditorHandler" "cut")))}
+                                   {:label "Copy"
+                                    :click (fn []
+                                             (let [browser-window ^js/BrowserWindow @*win
+                                                   web-contents (.-webContents browser-window)]
+                                               (.send web-contents "invokeEditorHandler" "copy")))}
                                    {:role "paste"}]
 
                                   (if mac?

--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -249,7 +249,8 @@
                                     :click (fn []
                                              (let [browser-window ^js/BrowserWindow @*win
                                                    web-contents (.-webContents browser-window)]
-                                               (.send web-contents "invokeEditorHandler" "copy")))}
+                                               (.send web-contents "invokeEditorHandler" "copy")))
+                                    :accelerator "CommandOrControl+C"}
                                    {:role "paste"}]
 
                                   (if mac?

--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -229,35 +229,36 @@
                                     {:role "close"}
                                     {:role "quit"})]}
                        {:role "editMenu"
-                        :submenu [{:label "Undo"
-                                   :click (fn []
-                                            (let [browser-window ^js/BrowserWindow @*win
-                                                  web-contents (.-webContents browser-window)]
-                                              (.send web-contents "invokeEditorHandler" "undo")))
-                                   :accelerator "CommandOrControl+Z"}
-                                  {:label "Redo"
-                                   :click (fn []
-                                            (let [browser-window ^js/BrowserWindow @*win
-                                                  web-contents (.-webContents browser-window)]
-                                              (.send web-contents "invokeEditorHandler" "redo")))
-                                   :accelerator "Shift+CommandOrControl+Z"}
-                                  {:type "separator"}
-                                  {:role "cut"} ;; FIXME not working as expected
-                                  {:role "copy"} ;; FIXME not working as expected
-                                  {:role "paste"}
-                                  {:role "pasteAndMatchStyle"}
-                                  {:role "delete"}
-                                  {:role "selectAll"} ;; FIXME not working as expected
-                                  {:type "separator"}
-                                  {:label "Substitutions"
-                                   :submenu [{:role "showSubstitutions"}
-                                             {:type "separator"}
-                                             {:role "toggleSmartQuotes"}
-                                             {:role "toggleSmartDashes"}
-                                             {:role "toggleTextReplacement"}]}
-                                  {:label "Speech"
-                                   :submenu [{:role "startSpeaking"}
-                                             {:role "stopSpeaking"}]}]}
+                        ;; https://github.com/electron/electron/blob/85f41d59aceabbdeee1fdec75770249c6335e73a/lib/browser/api/menu-item-roles.ts#L239-L276
+                        :submenu (concat
+                                  [{:label "Undo"
+                                    :click (fn []
+                                             (let [browser-window ^js/BrowserWindow @*win
+                                                   web-contents (.-webContents browser-window)]
+                                               (.send web-contents "invokeEditorHandler" "undo")))
+                                    :accelerator "CommandOrControl+Z"}
+                                   {:label "Redo"
+                                    :click (fn []
+                                             (let [browser-window ^js/BrowserWindow @*win
+                                                   web-contents (.-webContents browser-window)]
+                                               (.send web-contents "invokeEditorHandler" "redo")))
+                                    :accelerator "Shift+CommandOrControl+Z"}
+                                   {:type "separator"}
+                                   {:role "cut"}
+                                   {:role "copy"}
+                                   {:role "paste"}]
+
+                                  (if mac?
+                                    [{:role "pasteAndMatchStyle"}
+                                     {:role "delete"}
+                                     {:role "selectAll"}
+                                     {:type "separator"}
+                                     {:label "Speech"
+                                      :submenu [{:role "startSpeaking"},
+                                                {:role "stopSpeaking"}]}]
+                                    [{:role "delete"}
+                                     {:type "separator"}
+                                     {:role "selectAll"}]))}
                        {:role "viewMenu"}
                        {:role "windowMenu"})
         ;; Windows has no about role

--- a/src/main/electron/listener.cljs
+++ b/src/main/electron/listener.cljs
@@ -12,6 +12,7 @@
             [frontend.fs.watcher-handler :as watcher-handler]
             [frontend.handler.editor :as editor-handler]
             [frontend.handler.file-sync :as file-sync-handler]
+            [frontend.handler.history :as history]
             [frontend.handler.notification :as notification]
             [frontend.handler.repo :as repo-handler]
             [frontend.handler.route :as route-handler]
@@ -181,7 +182,14 @@
 
   (js/window.apis.on "syncAPIServerState"
                      (fn [^js data]
-                       (state/set-state! :electron/server (bean/->clj data)))))
+                       (state/set-state! :electron/server (bean/->clj data))))
+
+  (js/window.apis.on "invokeEditorHandler"
+                     (fn [action]
+                       (println "invokeEditorHandler with action:" action)
+                       (case action
+                         "undo" (history/undo!)
+                         "redo" (history/redo!)))))
 
 (defn listen!
   []

--- a/src/main/electron/listener.cljs
+++ b/src/main/electron/listener.cljs
@@ -191,7 +191,8 @@
                          "undo" (history/undo! nil)
                          "redo" (history/redo! nil)
                          "copy" (editor-handler/shortcut-copy nil)
-                         "cut" (editor-handler/shortcut-cut nil)))))
+                         "cut" (editor-handler/shortcut-cut nil) ;; FIXME this handler relies on arg Event
+                         ))))
 
 (defn listen!
   []

--- a/src/main/electron/listener.cljs
+++ b/src/main/electron/listener.cljs
@@ -188,8 +188,10 @@
                      (fn [action]
                        (println "invokeEditorHandler with action:" action)
                        (case action
-                         "undo" (history/undo!)
-                         "redo" (history/redo!)))))
+                         "undo" (history/undo! nil)
+                         "redo" (history/redo! nil)
+                         "copy" (editor-handler/shortcut-copy nil)
+                         "cut" (editor-handler/shortcut-cut nil)))))
 
 (defn listen!
   []


### PR DESCRIPTION
close https://github.com/logseq/logseq/issues/3549

Some menu items are not fixed because they rely on `Event` object.