### PR TITLE
dev: add clj-watson GH action

### DIFF
--- a/.github/workflows/clj-watson.yml
+++ b/.github/workflows/clj-watson.yml
@@ -1,0 +1,49 @@
+# clj-watson scans dependencies in a clojure deps.edn
+# seeking for vulnerable direct/transitive dependencies and
+# build a report with all the information needed to help you
+# understand how the vulnerability manifest in your software.
+# More details at https://github.com/clj-holmes/clj-watson
+
+name: clj-watson
+
+on:
+  push:
+    branches: [ "master", 2approvesbeforemerged ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "master" ]
+  schedule:
+    - cron: '43 16 * * 4'
+
+permissions:
+  contents: read
+
+jobs:
+  clj-holmes:
+    name: Run clj-watson scanning
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # v3.3.0
+
+      - name: Dependency scan
+        uses: clj-holmes/clj-watson-action@39b8ed306f2c125860cf6e69b6939363689f998c
+        with:
+          clj-watson-sha: "65d928c"
+          clj-watson-tag: "v4.0.1"
+          database-strategy: github-advisory
+          aliases: clojure-lsp,test
+          deps-edn-path: deps.edn
+          suggest-fix: true
+          output-type: sarif
+          output-file: clj-watson-results.sarif
+          fail-on-result: false
+
+      - name: Upload analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@9885f86fab4879632b7e44514f19148225dfbdcd  # v2.2.1
+        with:
+          sarif_file: ${{github.workspace}}/clj-watson-results.sarif
+          wait-for-processing: true


### PR DESCRIPTION
Follow-up PR to #8465

> clj-watson scans dependencies in a clojure deps.edn
> seeking for vulnerable direct/transitive dependencies and
> build a report with all the information needed to help you 
> understand how the vulnerability manifest in your software. 
> More details at https://github.com/clj-holmes/clj-watson

Run: https://github.com/logseq/logseq/actions/runs/4040814609