### PR TITLE
docs: Fix arch/sudo command in instructions

### DIFF
--- a/docs/develop-logseq-on-mobile.md
+++ b/docs/develop-logseq-on-mobile.md
@@ -9,7 +9,7 @@
   Note: use the following commands from *ios/App* directory to fix **ffi_c.bundle** related issue for M1 MacBook [^1].  
   (Working directory: `ios/App`)
   ```shell
-  sudo arch -x86_64 gem install ffi
+  arch -x86_64 sudo gem install ffi
   arch -x86_64 pod install
   ```
  


### PR DESCRIPTION
This command runs properly on my M1; the one listed before gives the error `arch: posix_spawnp: gem: Bad CPU type in executable`