### PR TITLE
enhancement: no native FS API support display for web version

### DIFF
--- a/src/main/frontend/components/onboarding/setups.cljs
+++ b/src/main/frontend/components/onboarding/setups.cljs
@@ -4,6 +4,7 @@
             [frontend.ui :as ui]
             [frontend.context.i18n :refer [t]]
             [frontend.components.svg :as svg]
+            [frontend.components.widgets :as widgets]
             [frontend.handler.page :as page-handler]
             [frontend.handler.route :as route-handler]
             [frontend.handler.ui :as ui-handler]
@@ -96,11 +97,7 @@
                  [:small "Open existing directory or Create a new one"]])]]]
            [:div.px-5
             (ui/admonition :warning
-                           [:p "It seems that your browser doesn't support the "
-                            [:a {:href   "https://web.dev/file-system-access/"
-                                 :target "_blank"}
-                             "new native filesystem API"]
-                            [:span ", please use any Chromium 86+ based browser like Chrome, Vivaldi, Edge, etc. Notice that the API doesn't support mobile browsers at the moment."]])]))]
+                           (widgets/native-fs-api-alert))]))]
       [:section.b.flex.items-center.flex-col
        [:p.flex
         [:i.as-flex-center (ui/icon "zoom-question" {:style {:fontSize "22px"}})]

--- a/src/main/frontend/components/repo.cljs
+++ b/src/main/frontend/components/repo.cljs
@@ -184,7 +184,9 @@
     (->>
      (concat repo-links
              [(when (seq repo-links) {:hr true})
-              {:title (t :new-graph) :options {:on-click #(state/pub-event! [:graph/setup-a-repo])}}
+              (if (or (nfs-handler/supported?) (mobile-util/native-platform?)) 
+                {:title (t :new-graph) :options {:on-click #(state/pub-event! [:graph/setup-a-repo])}}
+                {:title (t :new-graph) :options {:href (rfe/href :repos)}}) ;; Brings to the repos page for showing fallback message
               {:title (t :all-graphs) :options {:href (rfe/href :repos)}}
               refresh-link
               reindex-link

--- a/src/main/frontend/components/widgets.cljs
+++ b/src/main/frontend/components/widgets.cljs
@@ -9,6 +9,15 @@
             [frontend.mobile.util :as mobile-util]
             [frontend.state :as state]))
 
+
+(rum/defc native-fs-api-alert
+  []
+  [:p "It seems that your browser doesn't support the "
+   [:a {:href   "https://web.dev/file-system-access/"
+        :target "_blank"}
+    "new native filesystem API"]
+   [:span ", please use any Chromium 86+ based browser like Chrome, Vivaldi, Edge, etc. Notice that the API doesn't support mobile browsers at the moment."]])
+
 (rum/defc add-local-directory
   []
   [:div.flex.flex-col
@@ -38,12 +47,7 @@
            [:li (t :on-boarding/new-graph-desc-4)]
            [:li (t :on-boarding/new-graph-desc-5)]]
           (when-not nfs-supported?
-            (ui/admonition :warning
-                           [:p "It seems that your browser doesn't support the "
-                            [:a {:href   "https://web.dev/file-system-access/"
-                                 :target "_blank"}
-                             "new native filesystem API"]
-                            [:span ", please use any Chromium 86+ based browser like Chrome, Vivaldi, Edge, etc. Notice that the API doesn't support mobile browsers at the moment."]]))]]]))])
+            (ui/admonition :warning (native-fs-api-alert)))]]]))])
 
 (rum/defc android-permission-alert
   []


### PR DESCRIPTION
The current behavior of clicking `Add new graph` on browsers with no native FS API support is a silent dead.
<img width="268" alt="image" src="https://user-images.githubusercontent.com/9862022/215675164-0c78d71e-4e5c-4954-9615-e4908aab3817.png">

After this PR the button will bring user to the page with fallback message:
<img width="1502" alt="image" src="https://user-images.githubusercontent.com/9862022/215674868-47d97042-6d38-41c8-9f49-5384ed999363.png">

