### PR TITLE
Fix: Page blocks not displaying full property values in query tables

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/extract.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/extract.cljc
@@ -102,7 +102,7 @@
     (update result :block/properties #(apply dissoc % gp-property/editable-linkable-built-in-properties))))
 
 (defn- build-page-map
-  [properties invalid-properties file page page-name {:keys [date-formatter db from-page]}]
+  [properties invalid-properties properties-text-values file page page-name {:keys [date-formatter db from-page]}]
   (let [[*valid-properties *invalid-properties]
         ((juxt filter remove)
          (fn [[k _v]] (gp-property/valid-property-name? (str k))) properties)
@@ -120,7 +120,8 @@
       page-m
 
       (seq valid-properties)
-      (assoc :block/properties valid-properties)
+      (assoc :block/properties valid-properties
+             :block/properties-text-values (select-keys properties-text-values (keys valid-properties)))
 
       (seq invalid-properties)
       (assoc :block/invalid-properties invalid-properties))))
@@ -154,12 +155,14 @@
                                        :block/page [:block/name page-name]
                                        :block/refs block-ref-pages
                                        :block/path-refs block-path-ref-pages)))))
-                   blocks)
-          [properties invalid-properties] (if (:block/pre-block? (first blocks))
-                                            [(:block/properties (first blocks))
-                                             (:block/invalid-properties (first blocks))]
-                                            [properties []])
-          page-map (build-page-map properties invalid-properties file page page-name (assoc options' :from-page page))
+                      blocks)
+          [properties invalid-properties properties-text-values]
+          (if (:block/pre-block? (first blocks))
+            [(:block/properties (first blocks))
+             (:block/invalid-properties (first blocks))
+             (:block/properties-text-values (first blocks))]
+            [properties [] {}])
+          page-map (build-page-map properties invalid-properties properties-text-values file page page-name (assoc options' :from-page page))
           namespace-pages (let [page (:block/original-name page-map)]
                             (when (text/namespace-page? page)
                               (->> (gp-util/split-namespace-pages page)

--- a/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
@@ -142,7 +142,7 @@
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
     (is (= 211 (count files)) "Correct file count")
-    (is (= 42006 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 42110 (count (d/datoms db :eavt))) "Correct datoms count")
 
     (is (= 3600
            (ffirst

--- a/src/test/frontend/handler/repo_conversion_test.cljs
+++ b/src/test/frontend/handler/repo_conversion_test.cljs
@@ -98,7 +98,7 @@
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
     (is (= 211 (count files)) "Correct file count")
-    (is (= 42208 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 42312 (count (d/datoms db :eavt))) "Correct datoms count")
 
     (is (= 3600
            (ffirst


### PR DESCRIPTION
This PR fixes property values not showing their full text in query tables. This is the same issue as https://github.com/logseq/logseq/issues/8227 but for page results. See https://linear.app/logseq/issue/LOG-2374/fix-page-property-values-in-query-tables-not-displaying-full-text for more

Before:

<img width="739" alt="Screen Shot 2023-01-31 at 6 03 51 PM" src="https://user-images.githubusercontent.com/97210743/215903899-72c76e41-bd15-49b5-8679-57e3c45523b1.png">

After:
<img width="759" alt="Screen Shot 2023-01-31 at 6 02 50 PM" src="https://user-images.githubusercontent.com/97210743/215903698-ff727758-2690-4222-9792-f3f31a8bab5f.png">


To QA the fix:
- Create a page with content
```
desc:: mixing #foo and bar
```
- Then query it with `{{query (page-property :desc)}}` and switch to table view
