### PR TITLE
Enhancement: File and page commands work in more contexts and warn when they don't work

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -83,6 +83,7 @@
              frontend.ui ui
              frontend.util util
              frontend.util.clock clock
+             frontend.util.page page-util
              frontend.util.property property
              frontend.util.persist-var persist-var
              frontend.util.text text-util

--- a/src/main/frontend/components/page_menu.cljs
+++ b/src/main/frontend/components/page_menu.cljs
@@ -11,6 +11,7 @@
             [frontend.ui :as ui]
             [frontend.util :as util]
             [frontend.util.url :as url-util]
+            [frontend.util.page :as page-util]
             [frontend.handler.shell :as shell]
             [frontend.mobile.util :as mobile-util]
             [electron.ipc :as ipc]
@@ -72,7 +73,7 @@
           favorited? (contains? (set (map util/page-name-sanity-lc favorites))
                                 page-name)
           developer-mode? (state/sub [:ui/developer-mode?])
-          file-path (when (util/electron?) (page-handler/get-page-file-path))
+          file-path (when (util/electron?) (page-util/get-page-file-path page-name))
           _ (state/sub :auth/id-token)
           file-sync-graph-uuid (and (user-handler/logged-in?)
                                     (file-sync-handler/enable-sync?)

--- a/src/main/frontend/handler/common/developer.cljs
+++ b/src/main/frontend/handler/common/developer.cljs
@@ -5,6 +5,7 @@
             [frontend.state :as state]
             [frontend.handler.notification :as notification]
             [frontend.ui :as ui]
+            [frontend.util.page :as page-util]
             [logseq.graph-parser.mldoc :as gp-mldoc]))
 
 ;; Fns used between menus and commands
@@ -42,25 +43,21 @@
   ;; Use editor state to locate most recent block
   (if-let [block-uuid (:block-id (first (state/get-editor-args)))]
     (show-entity-data [:block/uuid block-uuid])
-    (notification/show! "No block found" :error)))
+    (notification/show! "No block found" :warning)))
 
 (defn ^:export show-block-ast []
   (if-let [{:block/keys [content format]} (:block (first (state/get-editor-args)))]
     (show-content-ast content format)
-    (notification/show! "No block found" :error)))
+    (notification/show! "No block found" :warning)))
 
 (defn ^:export show-page-data []
-  ;; Use editor state to locate most recent page.
-  ;; Consider replacing with navigation history if it's more useful
-  (if-let [page-id (get-in (first (state/get-editor-args))
-                           [:block :block/page :db/id])]
+  (if-let [page-id (page-util/get-current-page-id)]
     (show-entity-data page-id)
-    (notification/show! "No page found" :error)))
+    (notification/show! "No page found" :warning)))
 
 (defn ^:export show-page-ast []
   (let [page-data (db/pull '[:block/format {:block/file [:file/content]}]
-                           (get-in (first (state/get-editor-args))
-                                   [:block :block/page :db/id]))]
+                           (page-util/get-current-page-id))]
     (if (get-in page-data [:block/file :file/content])
       (show-content-ast (get-in page-data [:block/file :file/content]) (:block/format page-data))
-      (notification/show! "No page found" :error))))
+      (notification/show! "No page found" :warning))))

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -31,6 +31,7 @@
             [frontend.util.property :as property]
             [frontend.util.fs :as fs-util]
             [frontend.util.page-property :as page-property]
+            [frontend.util.page :as page-util]
             [goog.object :as gobj]
             [lambdaisland.glogi :as log]
             [promesa.core :as p]
@@ -59,15 +60,6 @@
                  (gp-util/page-name-sanity (string/lower-case title)))]
     ;; Win10 file path has a length limit of 260 chars
     (gp-util/safe-subs s 0 200)))
-
-(defn get-page-file-path
-  ([] (get-page-file-path (or (state/get-current-page)
-                              (state/get-current-whiteboard))))
-  ([page-name]
-   (when page-name
-     (let [page-name (util/page-name-sanity-lc page-name)]
-       (when-let [page (db/entity [:block/name page-name])]
-         (:file/path (:block/file page)))))))
 
 (defn- build-title [page]
   ;; Don't wrap `\"` anymore, as tiitle property is not effected by `,` now
@@ -870,13 +862,16 @@
      :page)))
 
 (defn open-file-in-default-app []
-  (when-let [file-path (and (util/electron?) (get-page-file-path))]
-    (js/window.apis.openPath file-path)))
+  (if-let [file-path (and (util/electron?) (page-util/get-page-file-path))]
+    (js/window.apis.openPath file-path)
+    (notification/show! "No file found" :warning)))
 
 (defn copy-current-file []
-  (when-let [file-path (and (util/electron?) (get-page-file-path))]
-    (util/copy-to-clipboard! file-path)))
+  (if-let [file-path (and (util/electron?) (page-util/get-page-file-path))]
+    (util/copy-to-clipboard! file-path)
+    (notification/show! "No file found" :warning)))
 
 (defn open-file-in-directory []
-  (when-let [file-path (and (util/electron?) (get-page-file-path))]
-    (js/window.apis.showItemInFolder file-path)))
+  (if-let [file-path (and (util/electron?) (page-util/get-page-file-path))]
+    (js/window.apis.showItemInFolder file-path)
+    (notification/show! "No file found" :warning)))

--- a/src/main/frontend/util/page.cljs
+++ b/src/main/frontend/util/page.cljs
@@ -1,0 +1,24 @@
+(ns frontend.util.page
+  "Provides util fns for page blocks"
+  (:require [frontend.state :as state]
+            [frontend.util :as util]
+            [frontend.db :as db]))
+
+(defn get-current-page-id
+  "Fetches the current page id. Looks up page based on latest route and if
+  nothing is found, gets page of last edited block"
+  []
+  (let [page-name (some-> (or (state/get-current-page) (state/get-current-whiteboard))
+                          util/page-name-sanity-lc)]
+    (or (and page-name (:db/id (db/entity [:block/name page-name])))
+        (get-in (first (state/get-editor-args)) [:block :block/page :db/id]))))
+
+(defn get-page-file-path
+  "Gets the file path of a page. If no page is given, detects the current page.
+Returns nil if no file path is found or no page is detected or given"
+  ([]
+   (when-let [page-id (get-current-page-id)]
+     (get-in (db/entity page-id) [:block/file :file/path])))
+  ([page-name]
+   (when-let [page-name' (some-> page-name util/page-name-sanity-lc)]
+     (get-in (db/entity [:block/name page-name']) [:block/file :file/path]))))


### PR DESCRIPTION
This PR enhances some of the behavior for file related commands, fixes #8117 and ports those improvements to dev commands in #8450. The file related commands are "Copy current file", "Open file in default app", and "Open file in parent directory". One enhancement is that these file commands will work in journal pages that have been edited after going home (a common workflow in my experience). Previously nothing happened.  Another enhancement is that when a file isn't found, the user is given a warning notification.

To QA:
- file commands display a "No file found" warning: type 'gh', invoke a file command
- file commands work in edited journal contexts: type 'gh', edit a journal page, invoke a file command
- dev page commands work in navigation contexts: type 'gh', navigate to a page by mouse or search, invoke 'show page data'