### PR TITLE
Fix: Command completion triggering too often

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1825,9 +1825,7 @@
     ;; (not= (gobj/get native-e "inputType") "insertFromPaste")
     (cond
       (and (= last-input-char (state/get-editor-command-trigger))
-           ;; By default, "/" is also used as namespace separator in Logseq.
-           (not (contains? #{:page-search-hashtag} (state/sub :editor/action)))
-           (or (= 1 pos) (start-of-new-word? input pos)))
+           (or (re-find #"(?m)^/" (str (.-value input))) (start-of-new-word? input pos)))
       (do
         (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)})
         (commands/reinit-matched-commands!)
@@ -1860,8 +1858,8 @@
 
       ;; Open "Search page or New page" auto-complete
       (and (= last-input-char commands/hashtag)
-           ;; Only trigger at beginning of line or before whitespace
-           (or (= 1 pos) (start-of-new-word? input pos)))
+           ;; Only trigger at beginning of a line or before whitespace
+           (or (re-find #"(?m)^#" (str (.-value input))) (start-of-new-word? input pos)))
       (do
         (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)})
         (state/set-editor-last-pos! pos)
@@ -2910,7 +2908,6 @@
           (if (= (state/get-editor-command-trigger) (second (re-find #"(\S+)\s+$" value)))
             (state/clear-editor-action!)
             (let [matched-commands (get-matched-commands input)]
-              (prn :KEYUP {:k k :input input :value (gobj/get input "value")})
               (if (seq matched-commands)
                 (reset! commands/*matched-commands matched-commands)
                 (state/clear-editor-action!))))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2812,7 +2812,68 @@
         :else
         nil))))
 
-(defn ^:large-vars/cleanup-todo keyup-handler
+(defn- default-case-for-keyup-handler
+  [input current-pos k code is-processed? c]
+  (let [last-key-code (state/get-last-key-code)
+        blank-selected? (string/blank? (util/get-selected-text))
+        non-enter-processed? (and is-processed? ;; #3251
+                                  (not= code keycode/enter-code))  ;; #3459
+        editor-action (state/get-editor-action)]
+    (when (and (not editor-action) (not non-enter-processed?))
+      (cond
+        ;; When you type text inside square brackets
+        (and (not (contains? #{"ArrowDown" "ArrowLeft" "ArrowRight" "ArrowUp" "Escape"} k))
+             (wrapped-by? input page-ref/left-brackets page-ref/right-brackets))
+        (let [orig-pos (cursor/get-caret-pos input)
+              value (gobj/get input "value")
+              square-pos (string/last-index-of (subs value 0 (:pos orig-pos)) page-ref/left-brackets)
+              pos (+ square-pos 2)
+              _ (state/set-editor-last-pos! pos)
+              pos (assoc orig-pos :pos pos)
+              command-step (if (= \# (util/nth-safe value (dec square-pos)))
+                             :editor/search-page-hashtag
+                             :editor/search-page)]
+          (commands/handle-step [command-step])
+          (state/set-editor-action-data! {:pos pos}))
+
+        ;; Handle non-ascii square brackets
+        (and blank-selected?
+             (contains? keycode/left-square-brackets-keys k)
+             (= (:key last-key-code) k)
+             (> current-pos 0)
+             (not (wrapped-by? input page-ref/left-brackets page-ref/right-brackets)))
+        (do
+          (commands/handle-step [:editor/input page-ref/left-and-right-brackets {:backward-truncate-number 2
+                                                                                 :backward-pos 2}])
+          (commands/handle-step [:editor/search-page])
+          (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)}))
+
+        ;; Handle non-ascii parentheses
+        (and blank-selected?
+             (contains? keycode/left-paren-keys k)
+             (= (:key last-key-code) k)
+             (> current-pos 0)
+             (not (wrapped-by? input block-ref/left-parens block-ref/right-parens)))
+        (do
+          (commands/handle-step [:editor/input block-ref/left-and-right-parens {:backward-truncate-number 2
+                                                                                :backward-pos 2}])
+          (commands/handle-step [:editor/search-block :reference])
+          (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)}))
+
+        ;; Handle non-ascii angle brackets
+        (and (= "〈" c)
+             (= "《" (util/nth-safe (gobj/get input "value") (dec (dec current-pos))))
+             (> current-pos 0))
+        (do
+          (commands/handle-step [:editor/input commands/angle-bracket {:last-pattern "《〈"
+                                                                       :backward-pos 0}])
+          (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)})
+          (state/set-editor-show-block-commands!))
+
+        :else
+        nil))))
+
+(defn keyup-handler
   [_state input input-id]
   (fn [e key-code]
     (when-not (util/event-is-composing? e)
@@ -2841,12 +2902,8 @@
                (if (mobile-util/native-android?)
                  (gobj/get e "key")
                  (gobj/getValueByKeys e "event_" "code"))
-               (util/event-is-composing? e true)]) ;; #3440
-            last-key-code (state/get-last-key-code)
-            blank-selected? (string/blank? (util/get-selected-text))
-            non-enter-processed? (and is-processed? ;; #3251
-                                      (not= code keycode/enter-code))  ;; #3459
-            editor-action (state/get-editor-action)]
+                ;; #3440
+               (util/event-is-composing? e true)])]
         (cond
           ;; When you type something after /
           (and (= :commands (state/get-editor-action)) (not= k (state/get-editor-command-trigger)))
@@ -2859,7 +2916,7 @@
                 (state/clear-editor-action!))))
 
           ;; When you type search text after < (and when you release shift after typing <)
-          (and (= :block-commands editor-action) (not= key-code 188)) ; not <
+          (and (= :block-commands (state/get-editor-action)) (not= key-code 188)) ; not <
           (let [matched-block-commands (get-matched-block-commands input)
                 format (:format (get-state))]
             (if (seq matched-block-commands)
@@ -2888,59 +2945,7 @@
           (state/clear-editor-action!)
 
           :else
-          (when (and (not editor-action) (not non-enter-processed?))
-            (cond
-              ;; When you type text inside square brackets
-              (and (not (contains? #{"ArrowDown" "ArrowLeft" "ArrowRight" "ArrowUp" "Escape"} k))
-                   (wrapped-by? input page-ref/left-brackets page-ref/right-brackets))
-              (let [orig-pos (cursor/get-caret-pos input)
-                    value (gobj/get input "value")
-                    square-pos (string/last-index-of (subs value 0 (:pos orig-pos)) page-ref/left-brackets)
-                    pos (+ square-pos 2)
-                    _ (state/set-editor-last-pos! pos)
-                    pos (assoc orig-pos :pos pos)
-                    command-step (if (= \# (util/nth-safe value (dec square-pos)))
-                                   :editor/search-page-hashtag
-                                   :editor/search-page)]
-                (commands/handle-step [command-step])
-                (state/set-editor-action-data! {:pos pos}))
-
-              ;; Handle non-ascii square brackets
-              (and blank-selected?
-                   (contains? keycode/left-square-brackets-keys k)
-                   (= (:key last-key-code) k)
-                   (> current-pos 0)
-                   (not (wrapped-by? input page-ref/left-brackets page-ref/right-brackets)))
-              (do
-                (commands/handle-step [:editor/input page-ref/left-and-right-brackets {:backward-truncate-number 2
-                                                             :backward-pos 2}])
-                (commands/handle-step [:editor/search-page])
-                (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)}))
-
-              ;; Handle non-ascii parentheses
-              (and blank-selected?
-                   (contains? keycode/left-paren-keys k)
-                   (= (:key last-key-code) k)
-                   (> current-pos 0)
-                   (not (wrapped-by? input block-ref/left-parens block-ref/right-parens)))
-              (do
-                (commands/handle-step [:editor/input block-ref/left-and-right-parens {:backward-truncate-number 2
-                                                             :backward-pos 2}])
-                (commands/handle-step [:editor/search-block :reference])
-                (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)}))
-
-              ;; Handle non-ascii angle brackets
-              (and (= "〈" c)
-                   (= "《" (util/nth-safe value (dec (dec current-pos))))
-                   (> current-pos 0))
-              (do
-                (commands/handle-step [:editor/input commands/angle-bracket {:last-pattern "《〈"
-                                                                             :backward-pos 0}])
-                (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)})
-                (state/set-editor-show-block-commands!))
-
-              :else
-              nil)))
+          (default-case-for-keyup-handler input current-pos k code is-processed? c))
 
         (close-autocomplete-if-outside input)
 

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -83,7 +83,7 @@
        #js {:key (subs value (dec (count value)))}
        nil))))
 
-(deftest ^:focus keyup-handler-test
+(deftest keyup-handler-test
   (testing "Command completion"
     (keyup-handler {:value "/b"
                     :action :commands
@@ -148,14 +148,17 @@
     (is (= :commands (state/get-editor-action))
         "Command search on start of new word")
 
+    (handle-last-input-handler {:value "a line\n/"})
+    (is (= :commands (state/get-editor-action))
+        "Command search on start of a new line")
+
     (handle-last-input-handler {:value "https://"})
     (is (= nil (state/get-editor-action))
         "No command search in middle of a word")
 
     (handle-last-input-handler {:value "#blah/"})
     (is (= nil (state/get-editor-action))
-        "No command search after a tag search to allow for namespace completion")
-    )
+        "No command search after a tag search to allow for namespace completion"))
 
   (testing "Tag autocompletion"
     (handle-last-input-handler {:value "#"

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -98,6 +98,24 @@
     (is (= nil (state/get-editor-action))
         "Don't autocomplete properties if typing in a block where properties already exist"))
 
+  (testing "Command autocompletion"
+    (handle-last-input-handler {:value "/"})
+    (is (= :commands (state/get-editor-action))
+        "Command search if only / has been typed")
+
+    (handle-last-input-handler {:value "some words /"})
+    (is (= :commands (state/get-editor-action))
+        "Command search on start of new word")
+
+    (handle-last-input-handler {:value "https://"})
+    (is (= nil (state/get-editor-action))
+        "No command search in middle of a word")
+
+    (handle-last-input-handler {:value "#blah/"})
+    (is (= nil (state/get-editor-action))
+        "No command search after a tag search to allow for namespace completion")
+    )
+
   (testing "Tag autocompletion"
     (handle-last-input-handler {:value "#"
                                 :cursor-pos 1})

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -2,7 +2,6 @@
   (:require [frontend.handler.editor :as editor]
             [clojure.test :refer [deftest is testing are]]
             [frontend.state :as state]
-            [frontend.util :as util]
             [frontend.util.cursor :as cursor]))
 
 (deftest extract-nearest-link-from-text-test
@@ -79,7 +78,6 @@
   (let [pos (or cursor-pos (count value))
         input #js {:value value}]
     (with-redefs [editor/get-matched-commands (constantly commands)
-                  util/get-selected-text (constantly nil)
                   cursor/pos (constantly pos)]
       ((editor/keyup-handler nil input nil)
        #js {:key (subs value (dec (count value)))}


### PR DESCRIPTION
This PR fixes command completion triggering too often, especially in the middle of words e.g. typing out a url. It has been annoying enough that [users wanted to remap '/'](https://discuss.logseq.com/t/custom-command-trigger/3081) to get around this. This PR also fixes #5510 to make typing a single '/' easier. By improving command completion, the experience should be great and we can deprecate `:editor/command-trigger`. To QA this PR, try any of the test cases