### PR TITLE
Fix: Access to features

### DIFF
--- a/src/main/frontend/handler/user.cljs
+++ b/src/main/frontend/handler/user.cljs
@@ -186,6 +186,7 @@
 
 (defn logout []
   (clear-tokens)
+  (state/clear-user-info!)
   (state/pub-event! [:user/logout]))
 
 (defn <ensure-id&access-token

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -2113,3 +2113,7 @@ Similar to re-frame subscriptions"
     (let [groups (:UserGroups info)]
       (when (seq groups)
         (storage/set :user-groups groups)))))
+
+(defn clear-user-info!
+  []
+  (storage/remove :user-groups))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -596,7 +596,7 @@ Similar to re-frame subscriptions"
    (enable-whiteboards? (get-current-repo)))
   ([repo]
    (and
-    ((resolve 'frontend.handler.user/alpha-or-beta-user?)) ;; using resolve to avoid circular dependency
+    ((resolve 'frontend.handler.user/feature-available?) :whiteboard) ;; using resolve to avoid circular dependency
     (:feature/enable-whiteboards? (sub-config repo)))))
 
 (defn export-heading-to-list?


### PR DESCRIPTION
See https://discord.com/channels/725182569297215569/1070813646143369268

Logged out users should't be able to visit whiteboards, even if the have previously enabled the feature. The feature should also be off and disabled under Settings->Features.

`frontend.handler.user/feature-available?`  explicitly  checks for the logged-in state and also the feature-matrix, so it should be a better option regardless. The problem is that the previous implementation should also work. The underlying issue seems to be that `user-groups` are not cleared from the local storage upon logout, so I changed that too although it's not required in this case. My only concern that this could affect sync's behavior. A signed out user shouldn't be marked as `beta` or `alpha`, but I might be missing something (see `frontend.handler.user\alpha-user?` and `frontend.handler.user\beta-user?`).