### PR TITLE
fix(android): share with no url

### DIFF
--- a/src/main/frontend/mobile/intent.cljs
+++ b/src/main/frontend/mobile/intent.cljs
@@ -21,7 +21,7 @@
             [promesa.core :as p]))
 
 (defn- handle-received-text [args]
-  ;; {:title :type :url}
+  ;; :title :type :url
   (state/pub-event! [:editor/quick-capture args]))
 
 (defn- embed-asset-file [url format]

--- a/src/main/frontend/util/text.cljs
+++ b/src/main/frontend/util/text.cljs
@@ -14,10 +14,11 @@
 
 (defn get-matched-video
   [url]
-  (or (re-find youtube-regex url)
-      (re-find loom-regex url)
-      (re-find vimeo-regex url)
-      (re-find bilibili-regex url)))
+  (when (not-empty url)
+    (or (re-find youtube-regex url)
+        (re-find loom-regex url)
+        (re-find vimeo-regex url)
+        (re-find bilibili-regex url))))
 
 (defn build-data-value
   [col]


### PR DESCRIPTION
- add `[:quick-capture-options :default-page]` config, for default page of quick-capture (other than current-page and today-page)
