### PR TITLE
Fix: Tag and property value autocompletion cases

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1772,7 +1772,9 @@
              (contains? #{:page-search :page-search-hashtag :block-search} (state/get-editor-action))
              (not (wrapped-by? input page-ref/left-brackets page-ref/right-brackets))
              (not (wrapped-by? input block-ref/left-parens block-ref/right-parens))
-             (not (wrapped-by? input "#" "")))
+             ;; wrapped-by? doesn't detect multiple beginnings when ending with "" so
+             ;; use subs to correctly detect current hashtag
+             (not (text-util/wrapped-by? (subs (.-value input) 0 (cursor/pos input)) (cursor/pos input) commands/hashtag "")))
     (state/clear-editor-action!)))
 
 (defn resize-image!


### PR DESCRIPTION
This PR builds off #8546. This fixes https://github.com/logseq/logseq/issues/6805 and https://github.com/logseq/logseq/issues/8175 by keeping the tag menu open instead of abruptly closing for multiple tags in a block. This also fixes property values that are references not autocompleting their reference characters. For example, property values like `[[Class]]` complete as `Class` and lose valuable refs. I noticed this with the docs graph. To QA, try the scenarios in tests.