### PR TITLE
enhance: re-index performance

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -248,7 +248,7 @@
                               (assoc :repeated? true))))))]
     (apply merge m)))
 
-(defn convert-page-if-journal
+(defn- convert-page-if-journal-impl
   "Convert journal file name to user' custom date format"
   [original-page-name date-formatter]
   (when original-page-name
@@ -258,6 +258,8 @@
        (let [original-page-name (date-time-util/int->journal-title day date-formatter)]
          [original-page-name (gp-util/page-name-sanity-lc original-page-name) day])
        [original-page-name page-name day]))))
+
+(def convert-page-if-journal (memoize convert-page-if-journal-impl))
 
 ;; TODO: refactor
 (defn page-name->map


### PR DESCRIPTION
The `convert-page-if-journal` is repeatly called in building reference.

This PR improve re-index performance by 20%~25% 
* From 25% -> 5%

Remaining time-costing stages in re-index:
* Datomic transact - 30% (bottle-neck)
* Mldoc parsing - 30% (can be off-load to worker?)
* Search index building - 5%