### PR TITLE
Fix: Display error when unexpected invalid repo config.edn occurs

### DIFF
--- a/src/main/frontend/handler/repo_config.cljs
+++ b/src/main/frontend/handler/repo_config.cljs
@@ -7,6 +7,7 @@
             [frontend.config :as config]
             [frontend.state :as state]
             [frontend.handler.common.file :as file-common-handler]
+            [frontend.handler.notification :as notification]
             [frontend.fs :as fs]
             [promesa.core :as p]
             [clojure.edn :as edn]
@@ -19,7 +20,12 @@
 (defn read-repo-config
   "Converts file content to edn"
   [content]
-  (edn/read-string content))
+  (try
+    (edn/read-string content)
+    (catch :default e
+      (notification/show! "The file 'logseq/config.edn' is invalid. Please reload the app to in order to see the error and fix it." :error)
+      ;; Rethrow so we know how long this is an issue and to prevent downstream errors
+      (throw e))))
 
 (defn set-repo-config-state!
   "Sets repo config state using given file content"


### PR DESCRIPTION
This PR improves the error experience when a config.edn is invalid while they are trying to use it from the Settings UI. Currently there is silent (js console only) failure so we should let them know something is wrong. This error shouldn't happen much once [config validation](https://github.com/logseq/logseq/pull/8382) has been used by most. Some examples of these errors are https://logseq.sentry.io/issues/3930076858/?project=5311485&referrer=slack and https://logseq.sentry.io/issues/3928852010/?project=5311485&referrer=slack. 