### PR TITLE
security: upgrade codemirror from 5.58.1 to 5.58.2

### DIFF
--- a/.clj-kondo/babashka/fs/config.edn
+++ b/.clj-kondo/babashka/fs/config.edn
@@ -1,0 +1,1 @@
+{:lint-as {babashka.fs/with-temp-dir clojure.core/let}}

--- a/.clj-kondo/metosin/malli/config.edn
+++ b/.clj-kondo/metosin/malli/config.edn
@@ -1,0 +1,2 @@
+{:lint-as {malli.experimental/defn schema.core/defn}
+ :linters {:unresolved-symbol {:exclude [(malli.core/=>)]}}}

--- a/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
+++ b/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
@@ -1,0 +1,5 @@
+{:lint-as
+ {rewrite-clj.zip/subedit-> clojure.core/->
+  rewrite-clj.zip/subedit->> clojure.core/->>
+  rewrite-clj.zip/edit-> clojure.core/->
+  rewrite-clj.zip/edit->> clojure.core/->>}}

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
         "check-password-strength": "2.0.7",
         "chokidar": "3.5.1",
         "chrono-node": "2.2.4",
-        "codemirror": "5.58.1",
+        "codemirror": "5.58.2",
         "d3-force": "3.0.0",
         "diff": "5.0.0",
         "dompurify": "2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1838,10 +1838,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==
 
-codemirror@5.58.1:
-  version "5.58.1"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.58.1.tgz#ec6bf38ad2a17f74c61bd00cc6dc5a69bd167854"
-  integrity sha512-UGb/ueu20U4xqWk8hZB3xIfV2/SFqnSLYONiM3wTMDqko0bsYrsAkGGhqUzbRkYm89aBKPyHtuNEbVWF9FTFzw==
+codemirror@5.58.2:
+  version "5.58.2"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.58.2.tgz#ed54a1796de1498688bea1cdd4e9eeb187565d1b"
+  integrity sha512-K/hOh24cCwRutd1Mk3uLtjWzNISOkm4fvXiMO7LucCrqbh6aJDdtqUziim3MZUI6wOY0rvY1SlL1Ork01uMy6w==
 
 collection-map@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Included in this PR are changes to the following files to upgrade the vulnerable dependency to a fixed version:
    - package.json
    - yarn.lock


#### Vulnerabilities that will be fixed
##### With an upgrade:
Severity                   | Priority Score (*)                   | Issue                   | Breaking Change                   | Exploit Maturity
:-------------------------:|-------------------------|:-------------------------|:-------------------------|:-------------------------
![medium severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/m.png "medium severity")  |  **586/1000**  <br/> **Why?** Proof of Concept exploit, Has a fix available, CVSS 5.3  | Regular Expression Denial of Service (ReDoS) <br/>[SNYK-JS-CODEMIRROR-1016937](https://snyk.io/vuln/SNYK-JS-CODEMIRROR-1016937) |  No  | Proof of Concept 

(*) Note that the real score may have changed since the PR was raised.
