### PR TITLE
docs: add repl setup to development document

### DIFF
--- a/docs/develop-logseq.md
+++ b/docs/develop-logseq.md
@@ -27,9 +27,17 @@ Then open the browser <http://localhost:3001>.
 ### REPL setup
 
 #### VSCode + Calva
+With ```yarn watch``` running, it should prints ``shadow-cljs - nREPL server started on port 8701``
+
+You may connect to the nREPL server with:
 
 ``cmd + shift + p`` -> ``Calva: Connect to a running nREPL server`` -> ``logseq`` -> ``shadow-cljs``->``:app`` ->``localhost:8701``
 
+(change ``:app`` to ``:electron`` if you want to connect to the main thread of the Electron app)
+
+Open a dev environment (Browser dev app on ``localhost:3000`` or Desktop dev app), then you can play REPL on the current editing file:
+
+``cmd + shift + p`` -> ``Calva: Load/Evaluate Current File and its Requires/Dependencies``
 
 ### Production Build
 

--- a/docs/develop-logseq.md
+++ b/docs/develop-logseq.md
@@ -24,6 +24,13 @@ yarn watch
 
 Then open the browser <http://localhost:3001>.
 
+### REPL setup
+
+#### VSCode + Calva
+
+``cmd + shift + p`` -> ``Calva: Connect to a running nREPL server`` -> ``logseq`` -> ``shadow-cljs``->``:app`` ->``localhost:8701``
+
+
 ### Production Build
 
 ```bash


### PR DESCRIPTION
Hi there,

This is LA, I love to use Clojure/Script and reading PDF within Logseq. But when I try to contribute to Logseq I found that it doesn't have a document about how to connect REPL in the docs. Development experience is crucial in Clojure world, missing REPL setup feels like unforgivable. I'm not sure my config is universal correct, but at least it works for me. It would be better core dev team can share their REPL setup to other contributors.




