### PR TITLE
enhance: consider references when inserting links

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/util.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/util.cljs
@@ -88,6 +88,12 @@
          (catch :default _e
            false))))
 
+(defn link?
+  "Check whether s is a link (including page/block refs)."
+  [s]
+  (or (url? s)
+      (re-matches #"^(\[\[|\(\().*(\]\]|\)\))$" (string/trim s))))
+
 (defn json->clj
   [json-string]
   (-> json-string

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -131,7 +131,7 @@
      (let [{:keys [selection-start selection-end format selection value edit-id input]} m
            cur-pos (cursor/pos input)
            empty-selection? (= selection-start selection-end)
-           selection-link? (and selection (gp-util/url? selection))
+           selection-link? (and selection (gp-util/link? selection))
            [content forward-pos] (cond
                                    empty-selection?
                                    (config/get-empty-link-and-forward-pos format)


### PR DESCRIPTION
Fix #8261 

This makes mod+l recognize references as links. For example, select "[[page]]" and press mod+l,

- before: `[[[page]]](_)`
- after: `[_]([[page]])`

The same applies to block references. Nothing else is changed.