### PR TITLE
fix (Whiteboards): Toggle collapsed button action

### DIFF
--- a/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
@@ -195,7 +195,7 @@ const LogseqPortalViewModeAction = observer(() => {
       value={collapsed ? '1' : '0'}
       onValueChange={v => {
         shapes.forEach(shape => {
-          shape.setCollapsed(v === '1' ? true : false)
+          shape.toggleCollapsed()
         })
         app.persist()
       }}


### PR DESCRIPTION
Introduced here https://github.com/logseq/logseq/pull/8448/files

Use the collapse toggle on a portal element to test this
![Screenshot from 2023-02-13 12-04-13](https://user-images.githubusercontent.com/10744960/218428751-3187fb19-a3fe-4d42-841d-c78bab123875.png)
