### PR TITLE
feat (Whiteboards): Auto pan canvas to pointer when out of view

### DIFF
--- a/tldraw/packages/core/src/lib/TLViewport.ts
+++ b/tldraw/packages/core/src/lib/TLViewport.ts
@@ -18,6 +18,7 @@ export class TLViewport {
 
   static readonly minZoom = 0.1
   static readonly maxZoom = 4
+  static readonly panMultiplier = 0.05
 
   /* ------------------- Properties ------------------- */
 
@@ -47,6 +48,17 @@ export class TLViewport {
       point: Vec.sub(this.camera.point, Vec.div(delta, this.camera.zoom)),
     })
   }
+
+  panToPointWhenOutOfBounds = (point: number[]) => {
+    const deltaMax = Vec.sub([this.currentView.maxX, this.currentView.maxY], point)
+    const deltaMin = Vec.sub([this.currentView.minX, this.currentView.minY], point)
+
+    const deltaX = deltaMax[0] < 0 ? deltaMax[0] : deltaMin[0] > 0 ? deltaMin[0] : 0
+    const deltaY = deltaMax[1] < 0 ? deltaMax[1] : deltaMin[1] > 0 ? deltaMin[1] : 0
+
+    this.panCamera(Vec.mul([deltaX, deltaY], -TLViewport.panMultiplier))
+}
+
 
   @action update = ({ point, zoom }: Partial<{ point: number[]; zoom: number }>): this => {
     if (point !== undefined && !isNaN(point[0]) && !isNaN(point[1])) this.camera.point = point

--- a/tldraw/packages/core/src/lib/tools/TLSelectTool/states/BrushingState.ts
+++ b/tldraw/packages/core/src/lib/tools/TLSelectTool/states/BrushingState.ts
@@ -68,6 +68,7 @@ export class BrushingState<
       // Select hit shapes
       this.app.setSelectedShapes(hits)
     }
+    this.app.viewport.panToPointWhenOutOfBounds(currentPoint)
   }
 
   onPointerUp: TLEvents<S>['pointer'] = () => {

--- a/tldraw/packages/core/src/lib/tools/TLSelectTool/states/ResizingState.ts
+++ b/tldraw/packages/core/src/lib/tools/TLSelectTool/states/ResizingState.ts
@@ -227,6 +227,7 @@ export class ResizingState<
       })
     })
     this.updateCursor(scaleX, scaleY)
+    this.app.viewport.panToPointWhenOutOfBounds(currentPoint)
   }
 
   onPointerUp: TLEvents<S>['pointer'] = () => {

--- a/tldraw/packages/core/src/lib/tools/TLSelectTool/states/TranslatingState.ts
+++ b/tldraw/packages/core/src/lib/tools/TLSelectTool/states/TranslatingState.ts
@@ -137,7 +137,12 @@ export class TranslatingState<
   }
 
   onPointerMove: TLEvents<S>['pointer'] = () => {
+    const {
+      inputs: { currentPoint },
+    } = this.app
+
     this.moveSelectedShapesToPointer()
+    this.app.viewport.panToPointWhenOutOfBounds(currentPoint)
   }
 
   onPointerDown: TLEvents<S>['pointer'] = () => {


### PR DESCRIPTION
A common feature on 2D applications is auto panning to pointer position. When we move our mouse out of the visible canvas while dragging, selecting or resizing elements, the viewport should be adjusted so we don't have to stop the action to pan (see demo video).

I don't think we need to document this. It's considered standard behavior on similar applications.

Also see https://discord.com/channels/725182569297215569/1054782990435229806/1054782990435229806

[Screencast from 2023-02-13 21-38-43.webm](https://user-images.githubusercontent.com/10744960/218557729-b403ef19-2449-48db-9f95-9207637daf10.webm)
