### PR TITLE
Fix: shortcuts can be disabled with `false`

### DIFF
--- a/src/main/frontend/schema/handler/common_config.cljc
+++ b/src/main/frontend/schema/handler/common_config.cljc
@@ -38,7 +38,7 @@
     [:org-mode/insert-file-link? :boolean]
     [:shortcuts [:map-of
                  :keyword
-                 [:or :string [:vector :string]]]]
+                 [:or :string false? [:vector :string]]]]
     [:shortcut/doc-mode-enter-for-new-block? :boolean]
     [:block/content-max-length :int]
     [:ui/show-command-doc? :boolean]

--- a/templates/config.edn
+++ b/templates/config.edn
@@ -127,7 +127,7 @@
  ;; 2. ` ` empty space between keys represents key chords. eg: `t s` means press `t` followed by `s`
  ;; 3. `mod` means `Ctrl` for Windows/Linux  and `Command` for Mac
  ;; 4. use `false` to disable particular shortcut
- ;; 4. you can define multiple bindings for one action, eg `["ctrl+j" "down"]`
+ ;; 5. you can define multiple bindings for one action, eg `["ctrl+j" "down"]`
  ;; full list of configurable shortcuts are available below:
  ;; https://github.com/logseq/logseq/blob/master/src/main/frontend/modules/shortcut/config.cljs
  ;; Example:
@@ -135,7 +135,7 @@
  ;; {:editor/new-block       "enter"
  ;;  :editor/new-line        "shift+enter"
  ;;  :editor/insert-link     "mod+shift+k"
- ;;  :editor/hightlight       false
+ ;;  :editor/highlight       false
  ;;  :ui/toggle-settings     "t s"
  ;;  :editor/up              ["ctrl+k" "up"]
  ;;  :editor/down            ["ctrl+j" "down"]


### PR DESCRIPTION
This PR fixes #8580. To QA:
- Toggle a favorite on a page with `"mod+shift+f"`
- Add `:command/toggle-favorite false` to :shortcuts in config.edn
- Confirm toggling favorite no longer works