### PR TITLE
fix(ui): marker layout of area highlight ref block content

### DIFF
--- a/src/main/frontend/extensions/pdf/pdf.css
+++ b/src/main/frontend/extensions/pdf/pdf.css
@@ -822,12 +822,9 @@ input::-webkit-inner-spin-button {
     }
 
     [data-hl-type=area] {
-      display: flex;
-      margin-bottom: 10px;
-      flex-direction: column;
-
       .prefix-link {
-        display: inline;
+        padding-top: 5px;
+        display: block;
       }
 
       .hl-page {


### PR DESCRIPTION
## Before

![CleanShot 2023-02-16 at 15 58 31@2x](https://user-images.githubusercontent.com/1779837/219315853-c8d979f3-8a0f-4afe-947c-372ff6ceeb63.png)

## After

<img width="511" alt="CleanShot 2023-02-16 at 16 54 45@2x" src="https://user-images.githubusercontent.com/1779837/219316080-23e3af3d-9281-4eee-bbb9-461b3cf4baf6.png">
