### PR TITLE
Fix: git commit command not opening

### DIFF
--- a/src/main/frontend/components/commit.cljs
+++ b/src/main/frontend/components/commit.cljs
@@ -89,15 +89,5 @@
            "Commit"]]]])]))
 
 (defn show-commit-modal! [e]
-  (when (and
-         (util/electron?)
-         (not (util/input? (gobj/get e "target")))
-         (not (gobj/get e "shiftKey"))
-         (not (gobj/get e "ctrlKey"))
-         (not (gobj/get e "altKey"))
-         (not (gobj/get e "metaKey")))
-    #_:clj-kondo/ignore
-    (when-let [repo-url (state/get-current-repo)]
-      (when-not (state/get-edit-input-id)
-        (util/stop e)
-        (state/set-modal! add-commit-message)))))
+  (state/set-modal! add-commit-message)
+  (when e (util/stop e)))

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -437,6 +437,7 @@
                                      :fn      ui-handler/toggle-cards!}
 
    :git/commit                      {:binding "mod+g c"
+                                     :inactive (not (util/electron?))
                                      :fn      commit/show-commit-modal!}
 
    :dev/show-block-data            {:binding false


### PR DESCRIPTION
Went to QA the git commit command from https://github.com/logseq/logseq/pull/7808 and noticed that the command only works with the keybinding and not when selected from the command palette:
<img width="953" alt="Screen Shot 2023-02-16 at 2 25 21 PM" src="https://user-images.githubusercontent.com/97210743/219498608-1a48c8e2-989b-489c-95b4-71b13d15c58c.png">

Removed most of the event handler logic as it was outdated from when it was keydown based - https://github.com/logseq/logseq/commit/5d0ecd68b2d5394db058bf7cdc3d0b359420effa