### PR TITLE
enhance: paste from clipboard

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -127,7 +127,7 @@
 (defn html-link-format!
   ([]
    (html-link-format! nil))
-  ([link]
+  ([text]
    (when-let [m (get-selection-and-format)]
      (let [{:keys [selection-start selection-end format selection value edit-id input]} m
            cur-pos (cursor/pos input)
@@ -137,8 +137,11 @@
                                    empty-selection?
                                    (config/get-empty-link-and-forward-pos format)
 
-                                   link
-                                   (config/with-label-link format selection link)
+                                   (and text selection-link?)
+                                   (config/with-label-link format text selection)
+
+                                   text
+                                   (config/with-label-link format selection text)
 
                                    selection-link?
                                    (config/with-default-link format selection)

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -107,18 +107,20 @@
       (let [blocks (:copy/blocks copied-blocks)]
         (when (seq blocks)
           (editor-handler/paste-blocks blocks {})))
-      (let [{:keys [value selection] :as selection-and-format} (editor-handler/get-selection-and-format)
-            shape-refs-text (when (and (not (string/blank? html))
+      (let [shape-refs-text (when (and (not (string/blank? html))
                                        (get-whiteboard-tldr-from-text html))
                               ;; text should alway be prepared block-ref generated in tldr
                               text)
-            text-url? (gp-util/url? text)]
+            {:keys [value selection] :as selection-and-format} (editor-handler/get-selection-and-format)
+            text-url? (gp-util/url? text)
+            selection-url? (gp-util/url? selection)]
         (cond
           (not (string/blank? shape-refs-text))
           (commands/simple-insert! input-id shape-refs-text nil)
 
-          (and (or text-url? (gp-util/url? selection))
-               (selection-within-link? selection-and-format))
+          (or (and (or text-url? selection-url?)
+                   (selection-within-link? selection-and-format))
+              (and text-url? selection-url?))
           (replace-text-f text)
 
           (and (or text-url?

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -107,19 +107,21 @@
       (let [blocks (:copy/blocks copied-blocks)]
         (when (seq blocks)
           (editor-handler/paste-blocks blocks {})))
-      (let [{:keys [value] :as selection-and-format} (editor-handler/get-selection-and-format)
+      (let [{:keys [value selection] :as selection-and-format} (editor-handler/get-selection-and-format)
             shape-refs-text (when (and (not (string/blank? html))
                                        (get-whiteboard-tldr-from-text html))
                               ;; text should alway be prepared block-ref generated in tldr
-                              text)]
+                              text)
+            text-url? (gp-util/url? text)]
         (cond
           (not (string/blank? shape-refs-text))
           (commands/simple-insert! input-id shape-refs-text nil)
 
-          (selection-within-link? selection-and-format)
+          (and (or text-url? (gp-util/url? selection))
+               (selection-within-link? selection-and-format))
           (replace-text-f text)
 
-          (and (or (gp-util/url? text)
+          (and (or text-url?
                    (and value (gp-util/url? (string/trim value))))
                (not (string/blank? (util/get-selected-text))))
           (editor-handler/html-link-format! text)

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -76,16 +76,16 @@
 
 (defn- selection-within-link?
   [selection-and-format]
-  (let [{:keys [format selection-start selection-end selection value]} selection-and-format
-        matched-links (case format
-                        :markdown (util/re-pos #"\[.*?\]\(.*?\)" value)
-                        :org (util/re-pos #"\[\[.*?\]\[.*?\]\]" value))]
-    (when (not= selection-start selection-end)
-      (->> matched-links
-           (some (fn [[start-index matched-text]]
-                   (and (<= start-index selection-start)
-                        (>= (+ start-index (count matched-text)) selection-end)
-                        (clojure.string/includes? matched-text selection))))))))
+  (let [{:keys [format selection-start selection-end selection value]} selection-and-format]
+    (and (not= selection-start selection-end)
+         (->> (case format
+                :markdown (util/re-pos #"\[.*?\]\(.*?\)" value)
+                :org (util/re-pos #"\[\[.*?\]\[.*?\]\]" value))
+              (some (fn [[start-index matched-text]]
+                      (and (<= start-index selection-start)
+                           (>= (+ start-index (count matched-text)) selection-end)
+                           (clojure.string/includes? matched-text selection))))
+              some?))))
 
 (defn- paste-copied-blocks-or-text
   ;; todo: logseq/whiteboard-shapes is now text/html

--- a/src/test/frontend/handler/paste_test.cljs
+++ b/src/test/frontend/handler/paste_test.cljs
@@ -30,3 +30,41 @@
     "[{\"number\": 1234}]" nil nil
     ;; invalid JSON
     "{number: 1234}" nil nil))
+  
+(deftest selection-within-link-test
+  (are [x y] (= (#'paste-handler/selection-within-link? x) y)
+    {:format :markdown
+     :value "[logseq](https://logseq.com)"
+     :selection-start 0
+     :selection-end 28
+     :selection "[logseq](https://logseq.com)"} true
+    {:format :markdown
+     :value "[logseq](https://logseq.com)"
+     :selection-start 1
+     :selection-end 27
+     :selection "logseq](https://logseq.com"} true
+    {:format :markdown
+     :value "[logseq](https://logseq.com)"
+     :selection-start 1
+     :selection-end 7
+     :selection "logseq"} true
+    {:format :markdown
+     :value "[logseq](https://logseq.com)"
+     :selection-start 9
+     :selection-end 27
+     :selection "https://logseq.com"} true
+    {:format :markdown
+     :value "[logseq](https://logseq.com) is awesome"
+     :selection-start 32
+     :selection-end 39
+     :selection "awesome"} false
+    {:format :markdown
+     :value "[logseq](https://logseq.com) is awesome"
+     :selection-start 9
+     :selection-end 39
+     :selection "https://logseq.com) is awesome"} false
+    {:format :markdown
+     :value "[logseq](https://logseq.com) is developed with [Clojure](https://clojure.org)"
+     :selection-start 9
+     :selection-end 76
+     :selection "https://logseq.com) is developed with [Clojure](https://clojure.org"} false)) 


### PR DESCRIPTION
fix [#8640](https://github.com/logseq/logseq/issues/8640)

Now the logic of pasting from the clipboard after selecting some contents as below:

- If the selected content is part of a link, replace it from the clipboard instead of formatting it to a link
- If the selected content is not part of a link
  - If the selected content is a URL, format it to a link and make content from the clipboard as the label of the link
  - If the selected content is not a URL, format it to a link and make it the label of the link and content from the clipboard as the URL of the link
  - If the selected content and content from the clipboard are both URL, replace it