### PR TITLE
add description to settings headers

### DIFF
--- a/src/main/frontend/components/plugins.css
+++ b/src/main/frontend/components/plugins.css
@@ -494,8 +494,11 @@
 
       .heading-item {
         margin: 12px 12px 6px;
-        font-weight: bold;
         border-bottom: 1px solid var(--ls-border-color, #738694);
+
+        > h2 {
+          font-weight: bold;
+        }
       }
 
       .desc-item {

--- a/src/main/frontend/components/plugins_settings.cljs
+++ b/src/main/frontend/components/plugins_settings.cljs
@@ -80,11 +80,12 @@
     [:div.pl-1 (edit-settings-file pid nil)]]])
 
 (rum/defc render-item-heading
-  [{:keys [key title]}]
+  [{:keys [key title description]}]
 
   [:div.heading-item
    {:data-key key}
-   [:h2 title]])
+   [:h2 title]
+   [:small.pl-1.flex-1 description]])
 
 (rum/defc settings-container
   [schema ^js pl]


### PR DESCRIPTION
Some complicated settings sections need more info for users...

![image](https://user-images.githubusercontent.com/137919/219680556-a0f7a429-1584-4ac5-86b0-f599e1405e45.png)
