### PR TITLE
feat(srs): support cloze cues

### DIFF
--- a/src/main/frontend/extensions/srs.cljs
+++ b/src/main/frontend/extensions/srs.cljs
@@ -539,13 +539,14 @@
 (defn cloze-parse
   "Parse the cloze content, and return [answer cue]."
   [content]
-  (let [parts (string/split content cloze-cue-separator)]
-    (if (> (count parts) 1)
-      ;; If there are more than one separator, only the last component is considered the cue.
-      [(string/trimr (string/join cloze-cue-separator (drop-last parts)))
-       (string/trim (last parts))]
-      ;; No separator found.
-      [(string/join cloze-cue-separator parts) nil])))
+  (let [parts (string/split content cloze-cue-separator -1)]
+    (if (<= (count parts) 1)
+      [content nil]
+      (let [cue (string/trim (last parts))]
+        ;; If there are more than one separator, only the last component is considered the cue.
+        (if (string/blank? cue)
+          [(string/trimr (string/join cloze-cue-separator (drop-last parts))) nil]
+          [(string/trimr (string/join cloze-cue-separator (drop-last parts))) cue])))))
 
 (rum/defcs cloze-macro-show < rum/reactive
   {:init (fn [state]

--- a/src/main/frontend/extensions/srs.cljs
+++ b/src/main/frontend/extensions/srs.cljs
@@ -544,9 +544,7 @@
       [content nil]
       (let [cue (string/trim (last parts))]
         ;; If there are more than one separator, only the last component is considered the cue.
-        (if (string/blank? cue)
-          [(string/trimr (string/join cloze-cue-separator (drop-last parts))) nil]
-          [(string/trimr (string/join cloze-cue-separator (drop-last parts))) cue])))))
+        [(string/trimr (string/join cloze-cue-separator (drop-last parts))) cue]))))
 
 (rum/defcs cloze-macro-show < rum/reactive
   {:init (fn [state]
@@ -563,9 +561,9 @@
       [:a.cloze-revealed {:on-click toggle!}
        (util/format "[%s]" answer)]
       [:a.cloze {:on-click toggle!}
-       (if cue
-         (str "(" cue ")")
-         "[...]")])))
+       (if (string/blank? cue)
+         "[...]"
+         (str "(" cue ")"))])))
 
 (component-macro/register cloze-macro-name cloze-macro-show)
 

--- a/src/main/frontend/extensions/srs.cljs
+++ b/src/main/frontend/extensions/srs.cljs
@@ -534,9 +534,9 @@
 
 ;;; register cloze macro
 
-(def cloze-cue-separator "\\\\")
+(def ^:private cloze-cue-separator "\\\\")
 
-(defn cloze-parse
+(defn- cloze-parse
   "Parse the cloze content, and return [answer cue]."
   [content]
   (let [parts (string/split content cloze-cue-separator -1)]
@@ -552,7 +552,6 @@
                  shown? (atom (:show-cloze? config))]
              (assoc state :shown? shown?)))}
   [state config options]
-  (print (:arguments options))
   (let [shown?* (:shown? state)
         shown? (rum/react shown?*)
         toggle! #(swap! shown?* not)


### PR DESCRIPTION
This is more-or-less also a feature request.  It works, but the design may not be the best.  I'm glad to improve it if you decide this is a worthwhile addition to Logseq.

## Motivation

SRS users usually need some "cues" to restrict possible answers of a cloze.  For example, 

```
#card Apples are {{cloze red}} (color).
```

AFAIC, this approach has two issues:

1. It takes a bit longer time to input.
2. The display in the flashcard interface looks bad.  The cue is not part of the cloze, so it stays there after the cloze is revealed.

Especially consider this example:

<img width="394" alt="image" src="https://user-images.githubusercontent.com/23358293/219949765-8a30695a-63b5-40e1-b9dd-4e997654ca4b.png">

Therefore, it's desired that the cue could be directly combined with the cloze itself.

## Proposal

This PR proposes a syntax addition to the `cloze` macro.

- Before: `{{cloze <answer>}}`
- After:  `{{cloze <answer> [\\ <cue>]}}`  ([...] = optional)

I chose `\\` because `,` `|` `/` are short and are likely to be already widely used in answers.  OTOH, `\\` is relatively rare.  This avoids potential breakages.

And it is rendered like this:

- When the cloze is not revealed
  <img width="433" alt="image" src="https://user-images.githubusercontent.com/23358293/219949940-0cc11e03-9a35-4ae2-bb86-0f3509afd69f.png">

- When the cloze is revealed
  <img width="429" alt="image" src="https://user-images.githubusercontent.com/23358293/219949949-cad2053b-ae53-49fd-9372-e57806a00dea.png">

Cues are placed in `(  )` instead of `[  ]` to avoid potential confusion with a revealed cloze.

This proposal resolves the aforementioned two issues,

1. `\\` is easier to type on a qwerty keyboard, and there's no need to move outside `}}`.
2. `(cue)` is more clear than `[...](cue)`, and the cue goes away when the answer is revealed.

## Downsides

1. `(cue)` and `[...]` look different.
2. Users who wish to write `\\` in a cloze answer will need to write something like `{{cloze bla\\bla \\}}` to explicitly say that the cue is empty.
3. `\\` is weird. Maybe `//` (comment syntax in many PLs) is better?

## Appendix

A user may use this advanced query to find queries that need migrating.

```
#+BEGIN_QUERY 
{ :title "Find clozes with \\\\ in this graph"
  :collapsed? true
   :query [:find (pull ?b [*])
           :in $ ?matcher
           :where
           [?b :block/content ?c]
           [(re-pattern ?matcher) ?regex]
           [(re-find ?regex ?c)]
           ]
   :inputs ["{{cloze.*\\\\.*}}"]
   }
#+END_QUERY
```