### PR TITLE
Revert "fix: electron menu handler(Redo, Undo, Copy)"

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -228,42 +228,7 @@
                                   (if mac?
                                     {:role "close"}
                                     {:role "quit"})]}
-                       {:role "editMenu"
-                        ;; https://github.com/electron/electron/blob/85f41d59aceabbdeee1fdec75770249c6335e73a/lib/browser/api/menu-item-roles.ts#L239-L276
-                        :submenu (concat
-                                  [{:label "Undo"
-                                    :click (fn []
-                                             (let [browser-window ^js/BrowserWindow @*win
-                                                   web-contents (.-webContents browser-window)]
-                                               (.send web-contents "invokeEditorHandler" "undo")))
-                                    :accelerator "CommandOrControl+Z"}
-                                   {:label "Redo"
-                                    :click (fn []
-                                             (let [browser-window ^js/BrowserWindow @*win
-                                                   web-contents (.-webContents browser-window)]
-                                               (.send web-contents "invokeEditorHandler" "redo")))
-                                    :accelerator "Shift+CommandOrControl+Z"}
-                                   {:type "separator"}
-                                   {:role "cut"}
-                                   {:label "Copy"
-                                    :click (fn []
-                                             (let [browser-window ^js/BrowserWindow @*win
-                                                   web-contents (.-webContents browser-window)]
-                                               (.send web-contents "invokeEditorHandler" "copy")))
-                                    :accelerator "CommandOrControl+C"}
-                                   {:role "paste"}]
-
-                                  (if mac?
-                                    [{:role "pasteAndMatchStyle"}
-                                     {:role "delete"}
-                                     {:role "selectAll"} ;; FIXME not work as expected
-                                     {:type "separator"}
-                                     {:label "Speech"
-                                      :submenu [{:role "startSpeaking"},
-                                                {:role "stopSpeaking"}]}]
-                                    [{:role "delete"}
-                                     {:type "separator"}
-                                     {:role "selectAll"}]))}
+                       {:role "editMenu"}
                        {:role "viewMenu"}
                        {:role "windowMenu"})
         ;; Windows has no about role

--- a/src/main/electron/listener.cljs
+++ b/src/main/electron/listener.cljs
@@ -12,7 +12,6 @@
             [frontend.fs.watcher-handler :as watcher-handler]
             [frontend.handler.editor :as editor-handler]
             [frontend.handler.file-sync :as file-sync-handler]
-            [frontend.handler.history :as history]
             [frontend.handler.notification :as notification]
             [frontend.handler.repo :as repo-handler]
             [frontend.handler.route :as route-handler]
@@ -182,17 +181,7 @@
 
   (js/window.apis.on "syncAPIServerState"
                      (fn [^js data]
-                       (state/set-state! :electron/server (bean/->clj data))))
-
-  (js/window.apis.on "invokeEditorHandler"
-                     (fn [action]
-                       (println "invokeEditorHandler with action:" action)
-                       (case action
-                         "undo" (history/undo! nil)
-                         "redo" (history/redo! nil)
-                         "copy" (editor-handler/shortcut-copy nil)
-                         "cut" (editor-handler/shortcut-cut nil) ;; FIXME this handler relies on arg Event
-                         ))))
+                       (state/set-state! :electron/server (bean/->clj data)))))
 
 (defn listen!
   []


### PR DESCRIPTION
Reverts logseq/logseq#8466

The original PR breaks Copy&Pasting in the Developer console.