### PR TITLE
fix: duplicate block ids in same file

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/block.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljc
@@ -12,7 +12,9 @@
             [logseq.graph-parser.utf8 :as utf8]
             [logseq.graph-parser.util :as gp-util]
             [logseq.graph-parser.util.block-ref :as block-ref]
-            [logseq.graph-parser.util.page-ref :as page-ref]))
+            [logseq.graph-parser.util.page-ref :as page-ref]
+            #?(:org.babashka/nbb [logseq.graph-parser.log :as log]
+               :default [lambdaisland.glogi :as log])))
 
 (defn heading-block?
   [block]
@@ -594,6 +596,8 @@
 
 (defn fix-duplicate-id
   [block]
+  (log/info :duplicated-block block)
+  (log/info :notice "Logseq will assign a new id for this block.")
   (-> block
       (assoc :uuid (d/squuid))
       (update :properties dissoc :id)
@@ -604,8 +608,8 @@
                                             (str
                                              "\n*\\s*"
                                              (if (= :markdown (:format block))
-                                               (str "id:: " (:uuid block))
-                                               (str ":id: " (:uuid block)))))]
+                                               (str "id" gp-property/colons " " (:uuid block))
+                                               (str (gp-property/colons-org "id") " " (:uuid block)))))]
                            (string/replace-first c replace-str ""))))))
 
 (defn extract-blocks

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -12,9 +12,7 @@
             [logseq.graph-parser.utf8 :as utf8]
             [logseq.graph-parser.util :as gp-util]
             [logseq.graph-parser.util.block-ref :as block-ref]
-            [logseq.graph-parser.util.page-ref :as page-ref]
-            #?(:org.babashka/nbb [logseq.graph-parser.log :as log]
-               :default [lambdaisland.glogi :as log])))
+            [logseq.graph-parser.util.page-ref :as page-ref]))
 
 (defn heading-block?
   [block]
@@ -596,8 +594,7 @@
 
 (defn fix-duplicate-id
   [block]
-  (log/info :duplicated-block block)
-  (log/info :notice "Logseq will assign a new id for this block.")
+  (println "Logseq will assign a new id for this block: " block)
   (-> block
       (assoc :uuid (d/squuid))
       (update :properties dissoc :id)

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -616,50 +616,47 @@
                :extract-macros, :date-formatter and :db"
   [blocks content with-id? format {:keys [user-config] :as options}]
   {:pre [(seq blocks) (string? content) (boolean? with-id?) (contains? #{:markdown :org} format)]}
-  (try
-    (let [encoded-content (utf8/encode content)
-         [blocks body pre-block-properties]
-         (loop [headings []
-                block-ids #{}
-                blocks (reverse blocks)
-                timestamps {}
-                properties {}
-                body []]
-           (if (seq blocks)
-             (let [[block pos-meta] (first blocks)
-                   ;; fix start_pos
-                   pos-meta (assoc pos-meta :end_pos
-                                   (if (seq headings)
-                                     (get-in (last headings) [:meta :start_pos])
-                                     nil))]
-               (cond
-                 (paragraph-timestamp-block? block)
-                 (let [timestamps (extract-timestamps block)
-                       timestamps' (merge timestamps timestamps)]
-                   (recur headings block-ids (rest blocks) timestamps' properties body))
+  (let [encoded-content (utf8/encode content)
+        [blocks body pre-block-properties]
+        (loop [headings []
+               block-ids #{}
+               blocks (reverse blocks)
+               timestamps {}
+               properties {}
+               body []]
+          (if (seq blocks)
+            (let [[block pos-meta] (first blocks)
+                  ;; fix start_pos
+                  pos-meta (assoc pos-meta :end_pos
+                                  (if (seq headings)
+                                    (get-in (last headings) [:meta :start_pos])
+                                    nil))]
+              (cond
+                (paragraph-timestamp-block? block)
+                (let [timestamps (extract-timestamps block)
+                      timestamps' (merge timestamps timestamps)]
+                  (recur headings block-ids (rest blocks) timestamps' properties body))
 
-                 (gp-property/properties-ast? block)
-                 (let [properties (extract-properties (second block) (assoc user-config :format format))]
-                   (recur headings block-ids (rest blocks) timestamps properties body))
+                (gp-property/properties-ast? block)
+                (let [properties (extract-properties (second block) (assoc user-config :format format))]
+                  (recur headings block-ids (rest blocks) timestamps properties body))
 
-                 (heading-block? block)
-                 (let [block' (construct-block block properties timestamps body encoded-content format pos-meta with-id? options)
-                       block'' (assoc block' :macros (extract-macros-from-ast (cons block body)))
-                       [block-ids block] (if (block-ids (:uuid block''))
-                                           [block-ids (fix-duplicate-id-in-same-file block'')]
-                                           [(conj block-ids (:uuid block'')) block''])]
-                   (recur (conj headings block) block-ids (rest blocks) {} {} []))
+                (heading-block? block)
+                (let [block' (construct-block block properties timestamps body encoded-content format pos-meta with-id? options)
+                      block'' (assoc block' :macros (extract-macros-from-ast (cons block body)))
+                      [block-ids block] (if (block-ids (:uuid block''))
+                                          [block-ids (fix-duplicate-id-in-same-file block'')]
+                                          [(conj block-ids (:uuid block'')) block''])]
+                  (recur (conj headings block) block-ids (rest blocks) {} {} []))
 
-                 :else
-                 (recur headings block-ids (rest blocks) timestamps properties (conj body block))))
-             [(-> (reverse headings)
-                  sanity-blocks-data)
-              body
-              properties]))
-         result (with-pre-block-if-exists blocks body pre-block-properties encoded-content options)]
-      (map #(dissoc % :block/meta) result))
-    (catch js/Error e
-      (js/console.error e))))
+                :else
+                (recur headings block-ids (rest blocks) timestamps properties (conj body block))))
+            [(-> (reverse headings)
+                 sanity-blocks-data)
+             body
+             properties]))
+        result (with-pre-block-if-exists blocks body pre-block-properties encoded-content options)]
+    (map #(dissoc % :block/meta) result)))
 
 (defn with-parent-and-left
   [page-id blocks]

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -592,7 +592,7 @@
                 (assoc :block/updated-at updated-at))]
     (dissoc block :title :body :anchor)))
 
-(defn fix-duplicate-id-in-same-file
+(defn fix-duplicate-id
   [block]
   (-> block
       (assoc :uuid (d/squuid))
@@ -645,7 +645,7 @@
                 (let [block' (construct-block block properties timestamps body encoded-content format pos-meta with-id? options)
                       block'' (assoc block' :macros (extract-macros-from-ast (cons block body)))
                       [block-ids block] (if (block-ids (:uuid block''))
-                                          [block-ids (fix-duplicate-id-in-same-file block'')]
+                                          [block-ids (fix-duplicate-id block'')]
                                           [(conj block-ids (:uuid block'')) block''])]
                   (recur (conj headings block) block-ids (rest blocks) {} {} []))
 

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -606,7 +606,7 @@
                                              (if (= :markdown (:format block))
                                                (str "id:: " (:uuid block))
                                                (str ":id: " (:uuid block)))))]
-                           (string/replace c replace-str ""))))))
+                           (string/replace-first c replace-str ""))))))
 
 (defn extract-blocks
   "Extract headings from mldoc ast.

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -592,6 +592,19 @@
                 (assoc :block/updated-at updated-at))]
     (dissoc block :title :body :anchor)))
 
+(defn fix-duplicate-id-in-same-file
+  [block]
+  (-> block
+      (assoc :uuid (d/squuid))
+      (update :properties dissoc :id)
+      (update :properties-text-values dissoc :id)
+      (update :properties-order #(vec (remove #{:id} %)))
+      (update :content (fn [c]
+                         (let [replace-str (if (= :markdown (:format block))
+                                             (str "\nid:: " (:uuid block))
+                                             (str "\n:id: " (:uuid block)))]
+                           (string/replace c replace-str ""))))))
+
 (defn extract-blocks
   "Extract headings from mldoc ast.
   Args:
@@ -603,43 +616,50 @@
                :extract-macros, :date-formatter and :db"
   [blocks content with-id? format {:keys [user-config] :as options}]
   {:pre [(seq blocks) (string? content) (boolean? with-id?) (contains? #{:markdown :org} format)]}
-  (let [encoded-content (utf8/encode content)
-        [blocks body pre-block-properties]
-        (loop [headings []
-               blocks (reverse blocks)
-               timestamps {}
-               properties {}
-               body []]
-          (if (seq blocks)
-            (let [[block pos-meta] (first blocks)
-                  ;; fix start_pos
-                  pos-meta (assoc pos-meta :end_pos
-                                  (if (seq headings)
-                                    (get-in (last headings) [:meta :start_pos])
-                                    nil))]
-              (cond
-                (paragraph-timestamp-block? block)
-                (let [timestamps (extract-timestamps block)
-                      timestamps' (merge timestamps timestamps)]
-                  (recur headings (rest blocks) timestamps' properties body))
+  (try
+    (let [encoded-content (utf8/encode content)
+         [blocks body pre-block-properties]
+         (loop [headings []
+                block-ids #{}
+                blocks (reverse blocks)
+                timestamps {}
+                properties {}
+                body []]
+           (if (seq blocks)
+             (let [[block pos-meta] (first blocks)
+                   ;; fix start_pos
+                   pos-meta (assoc pos-meta :end_pos
+                                   (if (seq headings)
+                                     (get-in (last headings) [:meta :start_pos])
+                                     nil))]
+               (cond
+                 (paragraph-timestamp-block? block)
+                 (let [timestamps (extract-timestamps block)
+                       timestamps' (merge timestamps timestamps)]
+                   (recur headings block-ids (rest blocks) timestamps' properties body))
 
-                (gp-property/properties-ast? block)
-                (let [properties (extract-properties (second block) (assoc user-config :format format))]
-                  (recur headings (rest blocks) timestamps properties body))
+                 (gp-property/properties-ast? block)
+                 (let [properties (extract-properties (second block) (assoc user-config :format format))]
+                   (recur headings block-ids (rest blocks) timestamps properties body))
 
-                (heading-block? block)
-                (let [block' (construct-block block properties timestamps body encoded-content format pos-meta with-id? options)
-                      block'' (assoc block' :macros (extract-macros-from-ast (cons block body)))]
-                  (recur (conj headings block'') (rest blocks) {} {} []))
+                 (heading-block? block)
+                 (let [block' (construct-block block properties timestamps body encoded-content format pos-meta with-id? options)
+                       block'' (assoc block' :macros (extract-macros-from-ast (cons block body)))
+                       [block-ids block] (if (block-ids (:uuid block''))
+                                           [block-ids (fix-duplicate-id-in-same-file block'')]
+                                           [(conj block-ids (:uuid block'')) block''])]
+                   (recur (conj headings block) block-ids (rest blocks) {} {} []))
 
-                :else
-                (recur headings (rest blocks) timestamps properties (conj body block))))
-            [(-> (reverse headings)
-                 sanity-blocks-data)
-             body
-             properties]))
-        result (with-pre-block-if-exists blocks body pre-block-properties encoded-content options)]
-    (map #(dissoc % :block/meta) result)))
+                 :else
+                 (recur headings block-ids (rest blocks) timestamps properties (conj body block))))
+             [(-> (reverse headings)
+                  sanity-blocks-data)
+              body
+              properties]))
+         result (with-pre-block-if-exists blocks body pre-block-properties encoded-content options)]
+      (map #(dissoc % :block/meta) result))
+    (catch js/Error e
+      (js/console.error e))))
 
 (defn with-parent-and-left
   [page-id blocks]

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -600,9 +600,12 @@
       (update :properties-text-values dissoc :id)
       (update :properties-order #(vec (remove #{:id} %)))
       (update :content (fn [c]
-                         (let [replace-str (if (= :markdown (:format block))
-                                             (str "\nid:: " (:uuid block))
-                                             (str "\n:id: " (:uuid block)))]
+                         (let [replace-str (re-pattern
+                                            (str
+                                             "\n*\\s*"
+                                             (if (= :markdown (:format block))
+                                               (str "id:: " (:uuid block))
+                                               (str ":id: " (:uuid block)))))]
                            (string/replace c replace-str ""))))))
 
 (defn extract-blocks

--- a/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
@@ -30,6 +30,12 @@
     {:properties {},
      :content "bar",
      :properties-text-values {},
+     :properties-order []}
+
+    {:properties {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :tags [], :format :markdown, :meta {:start_pos 51, :end_pos 101}, :macros [], :unordered true, :content "bar\n  \n  id:: 63f199bc-c737-459f-983d-84acfcda14fe\nblock body", :properties-text-values {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :level 1, :uuid #uuid "63f199bc-c737-459f-983d-84acfcda14fe", :properties-order [:id]}
+    {:properties {},
+     :content "bar\nblock body",
+     :properties-text-values {},
      :properties-order []}))
 
 (deftest test-extract-properties

--- a/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
@@ -13,6 +13,23 @@
     properties)
    user-config))
 
+(deftest test-fix-duplicate-id-in-same-file
+  (are [x y] (and
+              (:uuid y)
+              (not= (:uuid x) (:uuid y))
+              (= (select-keys (gp-block/fix-duplicate-id-in-same-file x)
+                              [{:properties :content :properties-text-values :properties-order}]) y))
+    [{:properties {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :tags [], :format :markdown, :meta {:start_pos 51, :end_pos 101}, :macros [], :unordered true, :content "bar\nid:: 63f199bc-c737-459f-983d-84acfcda14fe", :properties-text-values {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :level 1, :uuid #uuid "63f199bc-c737-459f-983d-84acfcda14fe", :properties-order [:id]}
+     {:properties {},
+      :content "bar",
+      :properties-text-values {},
+      :properties-order []}]
+    [{:properties {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :tags [], :format :org, :meta {:start_pos 51, :end_pos 101}, :macros [], :unordered true, :content "bar\n:id: 63f199bc-c737-459f-983d-84acfcda14fe", :properties-text-values {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :level 1, :uuid #uuid "63f199bc-c737-459f-983d-84acfcda14fe", :properties-order [:id]}
+     {:properties {},
+      :content "bar",
+      :properties-text-values {},
+      :properties-order []}]))
+
 (deftest test-extract-properties
   (are [x y] (= (:properties (extract-properties x {})) y)
        ;; Built-in properties

--- a/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
@@ -13,12 +13,12 @@
     properties)
    user-config))
 
-(deftest test-fix-duplicate-id-in-same-file
+(deftest test-fix-duplicate-id
   (are [x y]
-      (let [result (gp-block/fix-duplicate-id-in-same-file x)]
+      (let [result (gp-block/fix-duplicate-id x)]
         (and (:uuid result)
              (not= (:uuid x) (:uuid result))
-             (= (select-keys (gp-block/fix-duplicate-id-in-same-file x)
+             (= (select-keys result
                              [:properties :content :properties-text-values :properties-order]) y)))
     {:properties {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :tags [], :format :markdown, :meta {:start_pos 51, :end_pos 101}, :macros [], :unordered true, :content "bar\nid:: 63f199bc-c737-459f-983d-84acfcda14fe", :properties-text-values {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :level 1, :uuid #uuid "63f199bc-c737-459f-983d-84acfcda14fe", :properties-order [:id]}
     {:properties {},

--- a/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
@@ -14,21 +14,23 @@
    user-config))
 
 (deftest test-fix-duplicate-id-in-same-file
-  (are [x y] (and
-              (:uuid y)
-              (not= (:uuid x) (:uuid y))
-              (= (select-keys (gp-block/fix-duplicate-id-in-same-file x)
-                              [{:properties :content :properties-text-values :properties-order}]) y))
-    [{:properties {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :tags [], :format :markdown, :meta {:start_pos 51, :end_pos 101}, :macros [], :unordered true, :content "bar\nid:: 63f199bc-c737-459f-983d-84acfcda14fe", :properties-text-values {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :level 1, :uuid #uuid "63f199bc-c737-459f-983d-84acfcda14fe", :properties-order [:id]}
-     {:properties {},
-      :content "bar",
-      :properties-text-values {},
-      :properties-order []}]
-    [{:properties {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :tags [], :format :org, :meta {:start_pos 51, :end_pos 101}, :macros [], :unordered true, :content "bar\n:id: 63f199bc-c737-459f-983d-84acfcda14fe", :properties-text-values {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :level 1, :uuid #uuid "63f199bc-c737-459f-983d-84acfcda14fe", :properties-order [:id]}
-     {:properties {},
-      :content "bar",
-      :properties-text-values {},
-      :properties-order []}]))
+  (are [x y]
+      (let [result (gp-block/fix-duplicate-id-in-same-file x)]
+        (and (:uuid result)
+             (not= (:uuid x) (:uuid result))
+             (= (select-keys (gp-block/fix-duplicate-id-in-same-file x)
+                             [:properties :content :properties-text-values :properties-order]) y)))
+    {:properties {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :tags [], :format :markdown, :meta {:start_pos 51, :end_pos 101}, :macros [], :unordered true, :content "bar\nid:: 63f199bc-c737-459f-983d-84acfcda14fe", :properties-text-values {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :level 1, :uuid #uuid "63f199bc-c737-459f-983d-84acfcda14fe", :properties-order [:id]}
+    {:properties {},
+     :content "bar",
+     :properties-text-values {},
+     :properties-order []}
+
+    {:properties {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :tags [], :format :org, :meta {:start_pos 51, :end_pos 101}, :macros [], :unordered true, :content "bar\n:id: 63f199bc-c737-459f-983d-84acfcda14fe", :properties-text-values {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :level 1, :uuid #uuid "63f199bc-c737-459f-983d-84acfcda14fe", :properties-order [:id]}
+    {:properties {},
+     :content "bar",
+     :properties-text-values {},
+     :properties-order []}))
 
 (deftest test-extract-properties
   (are [x y] (= (:properties (extract-properties x {})) y)


### PR DESCRIPTION
To reproduce:
1. Create a new file `test.md` in a graph with the content as below:
    ```
    - foo
      id:: 63f199bc-c737-459f-983d-84acfcda14fe
    - bar
      id:: 63f199bc-c737-459f-983d-84acfcda14fe
    ```
2. Notice that Logseq can't load the blocks in the `test` page
3. Write some content on the page `test`, the file content will be overwritten without any warning

Caveat: this PR will keep the bottom block's id and generate new ids for the above block, it's easier to implement but may not be the user's intention.

The same block ids across different files could happen too, I will address it in another PR.