### PR TITLE
Fix incorrect version control description in settings

### DIFF
--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -644,8 +644,8 @@
   [:div.panel-wrap
    [:div.text-sm.my-4
     [:span.text-sm.opacity-50.my-4
-     "You can view a page's edit history by clicking the three vertical dots "
-     "in the top-right corner and selecting \"Check page's history\". "
+     "You can view a page's edit history by clicking the three horizontal dots "
+     "in the top-right corner and selecting \"View page history\". "
      "Logseq uses "]
     [:a {:href "https://git-scm.com/" :target "_blank"}
      "Git"]


### PR DESCRIPTION
This pull request fixes the incorrect version control description in the settings (please see issue: #8665). The original description stated that users can view a page's edit history by clicking on three vertical dots in the top-right corner and selecting "Check page's history". However, the three dots were actually horizontally aligned and the menu item said "View page history" instead of "Check page's history".

Please let me know if there are any concerns or questions about this pull request. Thank you.