### PR TITLE
Switch to use `browser-fs-access` npm module directly

### DIFF
--- a/externs.js
+++ b/externs.js
@@ -148,6 +148,5 @@ dummy.TEXT = function() {};
 var openDirectoryOptions;
 /**
  * @param {(undefined | openDirectoryOptions)} options
- * @param {function} cb
  */
-var openDirectory = function(options, cb) {};
+var openDirectory = function(options) {};

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "@tailwindcss/typography": "0.5.7",
         "@types/gulp": "^4.0.7",
         "autoprefixer": "^10.4.13",
+        "browser-fs-access": "^0.32.1",
         "cross-env": "^7.0.3",
         "cssnano": "^5.1.13",
         "del": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1428,6 +1428,11 @@ brorand@^1.0.1, brorand@^1.1.0:
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==
 
+browser-fs-access@^0.32.1:
+  version "0.32.1"
+  resolved "https://registry.yarnpkg.com/browser-fs-access/-/browser-fs-access-0.32.1.tgz#bd9ab6933082e8486bf0dbf2d4c307d7ee2ad406"
+  integrity sha512-NGzbF/ZpAjmgJIS17rlBpv5kkoBzIAyALzT4GrJpj4OIZYQq3Gqrx8pube6mtfqksARw8YK40GpTZR2fKtFA4w==
+
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"


### PR DESCRIPTION
This PR switches logseq to use the `browser-fs-access` npm module directly. It was using code from the project already, and the mentioned babel transform issues have (hopefully) been fixed. 