### PR TITLE
fix: disable macos sign temporarily

### DIFF
--- a/.github/workflows/build-desktop-release.yml
+++ b/.github/workflows/build-desktop-release.yml
@@ -492,6 +492,8 @@ jobs:
           body: |
             This is a nightly release of the Logseq desktop app.
             It's unstable compared to the official releases, **use it with caution**!
+
+            Known Issue: macOS build is not signed, so you need to allow it to run in System Preferences -> Security & Privacy -> General.
           files: |
             ./SHA256SUMS.txt
             ./*.zip

--- a/resources/forge.config.js
+++ b/resources/forge.config.js
@@ -11,6 +11,7 @@ module.exports = {
         "schemes":"logseq"
       }
     ],
+    /*
     osxSign: {
       identity: 'Developer ID Application: Tiansheng Qin',
       'hardened-runtime': true,
@@ -23,6 +24,7 @@ module.exports = {
       appleIdPassword: process.env['APPLE_ID_PASSWORD'],
       ascProvider: process.env['APPLE_ASC_PROVIDER']
     },
+    */
   },
   makers: [
     {


### PR DESCRIPTION

Apple said they need some workdays to migrate developer certificates from individual to organization.
