### PR TITLE
dev(lint): add :path-invalid-construct/string-join linter

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -10,7 +10,7 @@
                          {:exclude [frontend.db.conn frontend.db.react logseq.db.default]}}}}
 
  :linters
- {:path-invalid-construct/string-join {:level :warning}
+ {:path-invalid-construct/string-join {:level :info}
   :aliased-namespace-symbol {:level :warning}
   ;; Disable until it doesn't trigger false positives on rum/defcontext
   :earmuffed-var-not-dynamic {:level :off}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -10,7 +10,8 @@
                          {:exclude [frontend.db.conn frontend.db.react logseq.db.default]}}}}
 
  :linters
- {:aliased-namespace-symbol {:level :warning}
+ {:path-invalid-construct/string-join {:level :warning}
+  :aliased-namespace-symbol {:level :warning}
   ;; Disable until it doesn't trigger false positives on rum/defcontext
   :earmuffed-var-not-dynamic {:level :off}
   :unresolved-symbol {:exclude [goog.DEBUG
@@ -108,7 +109,8 @@
   :used-underscored-binding {:level :warning}}
 
  :hooks {:analyze-call {rum.core/defc hooks.rum/defc
-                         rum.core/defcs hooks.rum/defcs}}
+                        rum.core/defcs hooks.rum/defcs
+                        clojure.string/join hooks.path-invalid-construct/string-join}}
  :lint-as {promesa.core/let clojure.core/let
            promesa.core/loop clojure.core/loop
            promesa.core/recur clojure.core/recur

--- a/.clj-kondo/hooks/path_invalid_construct.clj
+++ b/.clj-kondo/hooks/path_invalid_construct.clj
@@ -1,0 +1,15 @@
+(ns hooks.path-invalid-construct
+  "This hook try to find out those error-prone path construction expressions:
+  - (string/join \"/\" [...])"
+  (:require [clj-kondo.hooks-api :as api]))
+
+
+(defn string-join
+  [{:keys [node]}]
+  (let [[_ sep-v & _args] (:children node)]
+    ;; (prn :string-join)
+    (when (and (api/string-node? sep-v)
+               (= ["/"] (:lines sep-v)))
+      (api/reg-finding! (assoc (meta node)
+                               :message "don't use clojure.string/join to build a path, (use #_{:clj-kondo/ignore [:path-invalid-construct/string-join]} to ignore)"
+                               :type :path-invalid-construct/string-join)))))

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -162,7 +162,7 @@
     (when current-file
       (let [parts (string/split current-file #"/")
             parts-2 (string/split path #"/")
-            current-dir (string/join "/" (drop-last 1 parts))]
+            current-dir (util/string-join-path (drop-last 1 parts))]
         (cond
           (if util/win32? (utils/win32 path) (util/starts-with? path "/"))
           path
@@ -187,7 +187,7 @@
                                    parts
                                    (rest col)))))
                 parts (remove #(string/blank? %) parts)]
-            (string/join "/" (reverse parts))))))))
+            (util/string-join-path (reverse parts))))))))
 
 (rum/defcs asset-loader
   < rum/reactive

--- a/src/main/frontend/components/hierarchy.cljs
+++ b/src/main/frontend/components/hierarchy.cljs
@@ -55,7 +55,7 @@
              (for [[idx page] (medley/indexed namespace)]
                (when (and (string? page) page)
                  (let [full-page (->> (take (inc idx) namespace)
-                                      (string/join "/"))]
+                                      util/string-join-path)]
                    (block/page-reference false
                                          full-page
                                          {}

--- a/src/main/frontend/db/conn.cljs
+++ b/src/main/frontend/db/conn.cljs
@@ -16,7 +16,7 @@
   (when url
     (if (util/starts-with? url "http")
       (->> (take-last 2 (string/split url #"/"))
-           (string/join "/"))
+           util/string-join-path)
       url)))
 
 (defn get-repo-name

--- a/src/main/frontend/fs/nfs.cljs
+++ b/src/main/frontend/fs/nfs.cljs
@@ -65,7 +65,7 @@
     (let [parts (->> (string/split dir "/")
                      (remove string/blank?))
           root (->> (butlast parts)
-                    (string/join "/"))
+                    util/string-join-path)
           new-dir (last parts)
           root-handle (str "handle/" root)]
       (->
@@ -132,7 +132,7 @@
           basename (last parts)
           sub-dir (->> (butlast parts)
                        (remove string/blank?)
-                       (string/join "/"))
+                       util/string-join-path)
           sub-dir-handle-path (str "handle/"
                                    (subs dir 1)
                                    (when sub-dir
@@ -208,7 +208,7 @@
                        (remove string/blank?))
             dir (str "/" (first parts))
             new-path (->> (rest parts)
-                          (string/join "/"))
+                          util/string-join-path)
             handle (idb/get-item (str "handle" old-path))
             file (.getFile handle)
             content (.text file)

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -322,7 +322,7 @@
     (if (and (< 2 (count parts))
              (= 36 (count (parts 0)))
              (= 36 (count (parts 1))))
-      (string/join "/" (drop 2 parts))
+      (util/string-join-path (drop 2 parts))
       path)))
 
 (defprotocol IRelativePath
@@ -531,7 +531,7 @@
   {:post [(s/valid? ::diff %)]}
   {:TXId (inc index)
    :TXType "update_files"
-   :TXContent [[(string/join "/" [user-uuid graph-uuid relative-path]) nil checksum]]})
+   :TXContent [[(util/string-join-path [user-uuid graph-uuid relative-path]) nil checksum]]})
 
 (defn filepath+checksum-coll->partitioned-filetxns
   "transducer.

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -194,7 +194,7 @@
         ext (last (string/split (last result) "."))
         new-file (str new-file-name-body "." ext)
         parts (concat (butlast result) [new-file])]
-    (string/join "/" parts)))
+    (util/string-join-path parts)))
 
 (defn rename-file!
   "emit file-rename events to :file/rename-event-chan

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -58,6 +58,13 @@
                (gdom/getElementByClass "sidebar-item-list")
                (app-scroll-container-node))))))
 
+(defn string-join-path
+  "Replace all `strings/join` used to construct paths with this function to reduce lint output.
+  https://github.com/logseq/logseq/pull/8679"
+  [parts]
+  (string/join "/" parts))
+
+
 #?(:cljs
    (defn safe-re-find
      {:malli/schema [:=> [:cat :any :string] [:or :nil :string [:vector [:maybe :string]]]]}
@@ -1034,7 +1041,7 @@
   (let [parts (string/split path "/")
         basename (last parts)
         dir (->> (butlast parts)
-                 (string/join "/"))]
+                 string-join-path)]
     [dir basename]))
 
 (defn get-relative-path
@@ -1050,7 +1057,7 @@
             ["."])
           parts-2
           [another-file-name])
-         (string/join "/"))))
+         string-join-path)))
 
 ;; Copied from https://github.com/tonsky/datascript-todo
 #?(:clj

--- a/src/main/frontend/util/text.cljs
+++ b/src/main/frontend/util/text.cljs
@@ -145,6 +145,6 @@
     (let [parts (->> (string/split path #"/")
                      (take-last 2))]
       (-> (if (not= (first parts) "0")
-            (string/join "/" parts)
+            (util/string-join-path parts)
             (last parts))
           js/decodeURI))))


### PR DESCRIPTION
Lint those exprs that use `string/join` to construct the path:
`(string/join "/" [...])`

@andelf is working on a unified way(for different platforms) to do path-related operations.