### PR TITLE
Enhance/sync check working dir not changed

### DIFF
--- a/.clj-kondo/metosin/malli-types/config.edn
+++ b/.clj-kondo/metosin/malli-types/config.edn
@@ -2,27 +2,24 @@
  {:unresolved-symbol {:exclude [(malli.core/=>)]},
   :type-mismatch
   {:namespaces
-   {frontend.util
-    {safe-re-find {:arities {2 {:args [:any :string], :ret :any}}},
-     check-password-strength
+   {frontend.fs.sync
+    {sync-state
      {:arities
-      {1
-       {:args [:string],
+      {0
+       {:args [],
         :ret
         {:op :keys,
          :req
-         {:contains :sequential,
-          :length :int,
-          :id :int,
-          :value :string},
-         :nilable true}}}},
-     uuid-string? {:arities {1 {:args [:string], :ret :boolean}}},
-     safe-parse-int {:arities {1 {:args [:any], :ret :int}}},
-     safe-sanitize-file-name
-     {:arities {1 {:args [:string], :ret :string}}},
-     safe-parse-float {:arities {1 {:args [:any], :ret :double}}}},
-    frontend.fs.sync
-    {<update-graphs-txid-only-txid!
+         {:full-local->remote-files :set,
+          :history :sequential,
+          :queued-local->remote-files :set,
+          :state :keyword,
+          :current-remote->local-files :set,
+          :current-local->remote-files :set,
+          :full-remote->local-files :set,
+          :recent-remote->local-files :set,
+          :current-syncing-graph-uuid :nilable/string}}}}},
+     <update-graphs-txid-only-txid!
      {:arities {2 {:args [:int :string], :ret :any}}},
      read-graphs-txid
      {:arities
@@ -48,5 +45,24 @@
            :work-dir :string}}
          :string],
         :ret :any}}}},
+    frontend.util
+    {safe-re-find {:arities {2 {:args [:any :string], :ret :any}}},
+     check-password-strength
+     {:arities
+      {1
+       {:args [:string],
+        :ret
+        {:op :keys,
+         :req
+         {:contains :sequential,
+          :length :int,
+          :id :int,
+          :value :string},
+         :nilable true}}}},
+     uuid-string? {:arities {1 {:args [:string], :ret :boolean}}},
+     safe-parse-int {:arities {1 {:args [:any], :ret :int}}},
+     safe-sanitize-file-name
+     {:arities {1 {:args [:string], :ret :string}}},
+     safe-parse-float {:arities {1 {:args [:any], :ret :double}}}},
     frontend.state
     {pub-event! {:arities {1 {:args [:vector], :ret :any}}}}}}}}

--- a/.clj-kondo/metosin/malli-types/config.edn
+++ b/.clj-kondo/metosin/malli-types/config.edn
@@ -20,4 +20,23 @@
      safe-parse-int {:arities {1 {:args [:any], :ret :int}}},
      safe-sanitize-file-name
      {:arities {1 {:args [:string], :ret :string}}},
-     safe-parse-float {:arities {1 {:args [:any], :ret :double}}}}}}}}
+     safe-parse-float {:arities {1 {:args [:any], :ret :double}}}},
+    frontend.fs.sync
+    {<update-graphs-txid!
+     {:arities
+      {2
+       {:args
+        [{:op :keys,
+          :req {:user-uuid :string, :graph-uuid :string, :txid :int}}
+         :string],
+        :ret :any}}},
+     read-graphs-txid
+     {:arities
+      {0
+       {:args [],
+        :ret
+        {:op :keys,
+         :req {:user-uuid :string, :graph-uuid :string, :txid :int},
+         :nilable true}}}}},
+    frontend.state
+    {pub-event! {:arities {1 {:args [:vector], :ret :any}}}}}}}}

--- a/.clj-kondo/metosin/malli-types/config.edn
+++ b/.clj-kondo/metosin/malli-types/config.edn
@@ -22,21 +22,31 @@
      {:arities {1 {:args [:string], :ret :string}}},
      safe-parse-float {:arities {1 {:args [:any], :ret :double}}}},
     frontend.fs.sync
-    {<update-graphs-txid!
-     {:arities
-      {2
-       {:args
-        [{:op :keys,
-          :req {:user-uuid :string, :graph-uuid :string, :txid :int}}
-         :string],
-        :ret :any}}},
+    {<update-graphs-txid-only-txid!
+     {:arities {2 {:args [:int :string], :ret :any}}},
      read-graphs-txid
      {:arities
       {0
        {:args [],
         :ret
         {:op :keys,
-         :req {:user-uuid :string, :graph-uuid :string, :txid :int},
-         :nilable true}}}}},
+         :req
+         {:user-uuid :string,
+          :graph-uuid :string,
+          :txid :int,
+          :work-dir :string},
+         :nilable true}}}},
+     <update-graphs-txid-all-fields!
+     {:arities
+      {2
+       {:args
+        [{:op :keys,
+          :req
+          {:user-uuid :string,
+           :graph-uuid :string,
+           :txid :int,
+           :work-dir :string}}
+         :string],
+        :ret :any}}}},
     frontend.state
     {pub-event! {:arities {1 {:args [:vector], :ret :any}}}}}}}}

--- a/src/dev-cljs/gen_malli_kondo_config/core.cljs
+++ b/src/dev-cljs/gen_malli_kondo_config/core.cljs
@@ -3,6 +3,7 @@
   (:require-macros [gen-malli-kondo-config.collect :refer [collect-schema]])
   (:require [frontend.util]
             [frontend.util.list]
+            [frontend.fs.sync]
             [malli.clj-kondo :as mc]
             [malli.instrument]))
 

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -11,7 +11,6 @@
             ["os" :as os]
             ["path" :as path]
             [cljs-bean.core :as bean]
-            [cljs.reader :as reader]
             [clojure.core.async :as async]
             [clojure.string :as string]
             [electron.backup-file :as backup-file]
@@ -198,7 +197,7 @@
     (if path
       (try
         (p/resolved (bean/->js (get-files path)))
-        (catch js/Error e 
+        (catch js/Error e
           (do
             (utils/send-to-renderer window "notification" {:type "error"
                                                            :payload (str "Opening the specified directory failed.\n"
@@ -255,30 +254,6 @@
 
 (defmethod handle :getGraphs [_window [_]]
   (get-graphs))
-
-(defn- read-txid-info!
-  [root]
-  (try
-    (let [txid-path (.join path root "logseq/graphs-txid.edn")]
-      (when (fs/existsSync txid-path)
-        (when-let [sync-meta (and (not (string/blank? root))
-                                  (.toString (.readFileSync fs txid-path)))]
-          (reader/read-string sync-meta))))
-    (catch :default e
-      (js/console.debug "[read txid meta] #" root (.-message e)))))
-
-(defmethod handle :inflateGraphsInfo [_win [_ graphs]]
-  (if (seq graphs)
-    (for [{:keys [root] :as graph} graphs]
-      (if-let [sync-meta (read-txid-info! root)]
-        (assoc graph
-               :sync-meta sync-meta
-               :GraphUUID (second sync-meta))
-        graph))
-    []))
-
-(defmethod handle :readGraphTxIdInfo [_win [_ root]]
-  (read-txid-info! root))
 
 (defn- get-graph-path
   [graph-name]

--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -209,7 +209,7 @@
      (some #(string/includes? path (str "/" % "/"))
            ["." ".recycle" "node_modules" "logseq/bak" "version-files"])
      (some #(string/ends-with? path %)
-           [".DS_Store" "logseq/graphs-txid.edn"])
+           [".DS_Store" "logseq/graphs-txid.edn" "logseq/.graphs-txid.edn"])
      ;; hidden directory or file
      (let [relpath (path/relative dir path)]
        (or (re-find #"/\.[^.]+" relpath)

--- a/src/main/frontend/components/conversion.cljs
+++ b/src/main/frontend/components/conversion.cljs
@@ -36,7 +36,7 @@
     (let [renamed-paths (keep (fn [{:keys [file file-name target]}]
                                 (when (not= file-name target)
                                   (sync/relative-path (:file/path file)))) rename-items)
-          graph-txid (second @sync/graphs-txid)]
+          graph-txid (:graph-uuid (sync/read-graphs-txid))]
       (when (and (seq renamed-paths) sync? graph-txid)
         (async/<!
          (sync/<delete-remote-files-control

--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -1,7 +1,6 @@
 (ns frontend.components.file-sync
   (:require [cljs.core.async :as async]
             [cljs.core.async.interop :refer [p->c]]
-            [frontend.util.persist-var :as persist-var]
             [clojure.string :as string]
             [electron.ipc :as ipc]
             [frontend.components.lazy-editor :as lazy-editor]

--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -546,11 +546,10 @@
                           (-> (if empty-dir?
                                 (p/resolved nil)
                                 (fs-sync/read-graphs-txid (config/get-local-repo root)))
-                              (p/then (fn [^js info]
+                              (p/then (fn [{select-graph-uuid :graph-uuid}]
                                         (when (and (not empty-dir?)
-                                                   (or (nil? info)
-                                                       (nil? (:graph-uuid info))
-                                                       (not= (:graph-uuid info) (:GraphUUID graph))))
+                                                   (or (nil? select-graph-uuid)
+                                                       (not= select-graph-uuid (:GraphUUID graph))))
                                           (if (js/confirm "This directory is not empty, are you sure to sync the remote graph to it? Make sure to back up the directory first.")
                                             (p/resolved nil)
                                             (throw (js/Error. nil)))))))

--- a/src/main/frontend/dicts.cljc
+++ b/src/main/frontend/dicts.cljc
@@ -344,6 +344,7 @@
 
         :file-sync/other-user-graph "Current local graph is bound to other user's remote graph. So can't start syncing."
         :file-sync/graph-deleted "The current remote graph has been deleted"
+        :file-sync/work-dir-changed "This graph's sync work dir has changed(may caused by moving graph dir). Need to delete the file 'logseq/graphs-txid.edn', then create a new remote graph to start syncing."
 
         :notification/clear-all "Clear all"}
 
@@ -1621,6 +1622,7 @@
 
            :file-sync/other-user-graph "当前本地图谱绑定在其他用户的远程图谱上。因此无法启动同步。"
            :file-sync/graph-deleted "当前远程图谱已经删除"
+           :file-sync/work-dir-changed "当前图谱的同步工作目录已经被改变(可能是由于移动图谱目录造成)。需要删除文件'logseq/graphs-txid.edn'，然后创建一个新的远程图谱来开始同步。"
 
            :notification/clear-all "清除全部通知"}
 
@@ -1724,7 +1726,8 @@
              :pdf/linked-ref "轉到註解"
 
              :file-sync/other-user-graph "當前本地 graph 綁定到其他用戶的遠程 graph 上。因此無法啟動同步。"
-             :file-sync/graph-deleted "當前遠程 graph 已被刪除"}
+             :file-sync/graph-deleted "當前遠程 graph 已被刪除"
+             :file-sync/work-dir-changed "當前圖譜的同步工作目錄已經被改變(可能是由於移動圖譜目錄造成)。需要刪除文件'logseq/graphs-txid.edn'，然後創建一個新的遠程圖譜來開始同步。"}
 
    :af {:on-boarding/demo-graph "This is a demo graph, changes will not be saved until you open a local folder."
         :on-boarding/add-graph "Add a graph"

--- a/src/main/frontend/dicts.cljc
+++ b/src/main/frontend/dicts.cljc
@@ -344,7 +344,7 @@
 
         :file-sync/other-user-graph "Current local graph is bound to other user's remote graph. So can't start syncing."
         :file-sync/graph-deleted "The current remote graph has been deleted"
-        :file-sync/work-dir-changed "This graph's sync work dir has changed(may caused by moving graph dir). Need to delete the file 'logseq/graphs-txid.edn', then create a new remote graph to start syncing."
+        :file-sync/work-dir-changed "This graph's sync work dir has changed(may caused by moving graph dir). Need to *delete* the file 'logseq/.graphs-txid.edn', then *create* a new remote graph to start syncing."
 
         :notification/clear-all "Clear all"}
 
@@ -1622,7 +1622,7 @@
 
            :file-sync/other-user-graph "当前本地图谱绑定在其他用户的远程图谱上。因此无法启动同步。"
            :file-sync/graph-deleted "当前远程图谱已经删除"
-           :file-sync/work-dir-changed "当前图谱的同步工作目录已经被改变(可能是由于移动图谱目录造成)。需要删除文件'logseq/graphs-txid.edn'，然后创建一个新的远程图谱来开始同步。"
+           :file-sync/work-dir-changed "当前图谱的同步工作目录已经被改变(可能是由于移动图谱目录造成)。需要 *删除* 文件'logseq/.graphs-txid.edn'，然后 *创建* 一个新的远程图谱来开始同步。"
 
            :notification/clear-all "清除全部通知"}
 
@@ -1727,7 +1727,7 @@
 
              :file-sync/other-user-graph "當前本地 graph 綁定到其他用戶的遠程 graph 上。因此無法啟動同步。"
              :file-sync/graph-deleted "當前遠程 graph 已被刪除"
-             :file-sync/work-dir-changed "當前圖譜的同步工作目錄已經被改變(可能是由於移動圖譜目錄造成)。需要刪除文件'logseq/graphs-txid.edn'，然後創建一個新的遠程圖譜來開始同步。"}
+             :file-sync/work-dir-changed "當前圖譜的同步工作目錄已經被改變(可能是由於移動圖譜目錄造成)。需要 *刪除* 文件'logseq/graphs-txid.edn'，然後 *創建* 一個新的遠程圖譜來開始同步。"}
 
    :af {:on-boarding/demo-graph "This is a demo graph, changes will not be saved until you open a local folder."
         :on-boarding/add-graph "Add a graph"

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -196,11 +196,11 @@
        (vector? r)
        (let [[user-uuid graph-uuid txid] r]
          {:user-uuid user-uuid :graph-uuid graph-uuid :txid txid
-          :work-dir (config/get-repo-dir (state/get-current-repo))})
+          :work-dir (config/get-repo-dir repo-url)})
 
        (map? r)
        (if (nil? (:work-dir r))
-         (assoc r :work-dir (config/get-repo-dir (state/get-current-repo)))
+         (assoc r :work-dir (config/get-repo-dir repo-url))
          r)))))
 
 

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -175,7 +175,8 @@
        (reset! graphs-txid
                {:user-uuid user-uuid :graph-uuid graph-uuid :txid txid
                 :work-dir (config/get-repo-dir (state/get-current-repo))})
-       (remove-graphs-txid-legacy))
+       (remove-graphs-txid-legacy)
+       (persist-var/-save graphs-txid))
 
      ;; just remove the legacy graphs-txid.edn if (some? @graphs-txid)
      (and (some? @graphs-txid-legacy)

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -116,11 +116,11 @@
   ([desc]
    [:string {:desc desc :min 36 :max 36}]))
 
-;; (def ^:private graphs-txid-schema-legacy
-;;   [:tuple
-;;    (uuid-string-schema "user-uuid")
-;;    (uuid-string-schema "graph-uuid")
-;;    [:int {:desc "txid"}]])
+(def ^:private graphs-txid-schema-legacy
+  [:tuple
+   (uuid-string-schema "user-uuid")
+   (uuid-string-schema "graph-uuid")
+   [:int {:desc "txid"}]])
 
 (def ^:private graphs-txid-schema
   [:map {:closed true}
@@ -148,7 +148,7 @@
    (cond
      ;; empty .graphs-txid.edn & some graphs-txid-legacy
      ;; do migration
-     (and (some? @graphs-txid-legacy)
+     (and (m/validate graphs-txid-schema-legacy @graphs-txid-legacy)
           (empty? @graphs-txid))
      (let [[user-uuid graph-uuid txid] @graphs-txid-legacy]
        (reset! graphs-txid

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -147,14 +147,17 @@
    (let [graphs-txid-map        (into {} graphs-txid)
          graphs-txid-legacy-map (into {} graphs-txid-legacy)
          merged                 (merge graphs-txid-legacy-map graphs-txid-map)
-         unified                (map (fn [[repo-url v]]
-                                       (if (vector? v)
-                                         (let [[user-uuid graph-uuid txid] v
-                                               work-dir (config/get-repo-dir repo-url)]
-                                           {:user-uuid user-uuid :graph-uuid graph-uuid :txid txid
-                                            :work-dir work-dir})
-                                         v))
-                                     merged)]
+         unified                (into
+                                 {}
+                                 (map (fn [[repo-url v]]
+                                        (if (vector? v)
+                                          (let [[user-uuid graph-uuid txid] v
+                                                work-dir (config/get-repo-dir repo-url)]
+                                            [repo-url
+                                             {:user-uuid user-uuid :graph-uuid graph-uuid :txid txid
+                                              :work-dir work-dir}])
+                                          [repo-url v]))
+                                      merged))]
      unified)))
 
 (defn <load-graph-txid

--- a/src/main/frontend/fs/sync_schema.cljs
+++ b/src/main/frontend/fs/sync_schema.cljs
@@ -1,0 +1,97 @@
+(ns frontend.fs.sync-schema
+  "malli schema for frontend.fs.sync"
+  (:require [cljs-time.core :as t]))
+
+
+(def graph-uuid-schema
+  [:string {:min 36 :max 36}])
+
+(def state-schema
+  [:enum
+   :frontend.fs.sync/starting
+   :frontend.fs.sync/need-password
+   :frontend.fs.sync/idle
+   :frontend.fs.sync/local->remote
+   :frontend.fs.sync/remote->local
+   :frontend.fs.sync/local->remote-full-sync
+   :frontend.fs.sync/remote->local-full-sync
+   :frontend.fs.sync/pause
+   :frontend.fs.sync/stop])
+
+(def recent-remote->local-file-item-schema
+  [:map {:closed true}
+   [:remote->local-type [:enum :delete :update]]
+   [:checksum :string]
+   [:path :string]])
+
+(def history-item-schema
+  [:and
+   [:map {:closed true}
+    [:path :string]
+    [:time :any]]
+   [:fn #(t/date? (:time %))]])
+
+(def ^:private file-change-event-schema
+  [:fn #(= "frontend.fs.sync/FileChangeEvent" (type->str (type %)))])
+
+(def ^:private file-metadata-schema
+  [:fn #(= "frontend.fs.sync/FileMetadata" (type->str (type %)))])
+
+(def sync-state-schema
+  [:map {:closed true}
+   [:current-syncing-graph-uuid [:maybe graph-uuid-schema]]
+   [:state state-schema]
+   [:full-local->remote-files [:set file-change-event-schema]]
+   [:full-remote->local-files [:set file-metadata-schema]]
+   [:current-local->remote-files [:set :string]]
+   [:current-remote->local-files [:set :string]]
+   [:queued-local->remote-files [:set file-change-event-schema]]
+   ;; Downloading files from remote will trigger filewatcher events,
+   ;; causes unreasonable information in the content of :queued-local->remote-files,
+   ;; use :recent-remote->local-files to filter such events
+   [:recent-remote->local-files [:set recent-remote->local-file-item-schema]]
+   [:history [:sequential history-item-schema]]])
+
+(def diff-schema
+  [:map {:closed true}
+   [:TXId [:int {:min 1}]]
+   [:TXType [:enum "update_files" "delete_files" "rename_file"]]
+   [:TXContent [:sequential
+                [:catn
+                 [:to-path :string]
+                 [:from-path [:maybe :string]]
+                 [:checksum [:maybe :string]]]]]])
+
+
+
+(def sync-local->remote!-result-schema
+  [:or
+   [:enum {:desc "add first map to avoid {:succ true} be treated as the property map "}
+    {:succ true}
+    {:stop true}
+    {:pause true}
+    {:need-sync-remote true}
+    {:graph-has-been-deleted true}]
+   [:map {:closed true}
+    [:unknown :some]]])
+
+
+(def sync-remote->local!-result-schema
+  [:or
+   [:enum {:desc "add first map to avoid {:succ true} be treated as the property map "}
+    {:succ true}
+    {:stop true}
+    {:pause true}
+    {:need-remote->local-full-sync true}]
+   [:map {:closed true}
+    [:unknown :some]]])
+
+(def sync-local->remote-all-files!-result-schema
+  [:or
+   [:enum {:desc "add first map to avoid {:succ true} be treated as the property map "}
+    {:succ true}
+    {:stop true}
+    {:need-sync-remote true}
+    {:graph-has-been-deleted true}]
+   [:map {:closed true}
+    [:unknown :some]]])

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -111,9 +111,9 @@
               (p/let [repos (repo-handler/refresh-repos!)]
                 (when-let [repo (state/get-current-repo)]
                   (when (some #(and (= (:url %) repo)
-                                    (vector? (:sync-meta %))
-                                    (util/uuid-string? (first (:sync-meta %)))
-                                    (util/uuid-string? (second (:sync-meta %)))) repos)
+                                    (map? (:sync-meta %))
+                                    (util/uuid-string? (:user-uuid (:sync-meta %)))
+                                    (util/uuid-string? (:graph-uuid (:sync-meta %)))) repos)
                     (sync/<sync-start)))))
             (ui-handler/re-render-root!)
             (file-sync/maybe-onboarding-show status)

--- a/src/main/frontend/handler/web/nfs.cljs
+++ b/src/main/frontend/handler/web/nfs.cljs
@@ -24,7 +24,8 @@
             [logseq.graph-parser.config :as gp-config]
             [logseq.graph-parser.util :as gp-util]
             [promesa.core :as p]
-            [frontend.fs.capacitor-fs :as capacitor-fs]))
+            [frontend.fs.capacitor-fs :as capacitor-fs]
+            [frontend.fs.sync :as sync]))
 
 (defn remove-ignore-files
   [files dir-name nfs?]
@@ -195,7 +196,7 @@
                                 (assoc file :file/content content))) markup-files))
                 (p/then (fn [result]
                           (p/let [files (map #(dissoc % :file/file) result)
-                                  graphs-txid-meta (util-fs/read-graphs-txid-info dir-name)
+                                  graphs-txid-meta (sync/read-graphs-txid (config/get-local-repo dir-name))
                                   graph-uuid (and (vector? graphs-txid-meta) (second graphs-txid-meta))]
                             (if-let [exists-graph (state/get-sync-graph-by-id graph-uuid)]
                               (state/pub-event!

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -3,13 +3,13 @@
   cursors"
   (:require [cljs-bean.core :as bean]
             [cljs.core.async :as async :refer [<!]]
-            [cljs.spec.alpha :as s]
             [clojure.string :as string]
             [dommy.core :as dom]
             [electron.ipc :as ipc]
+            [frontend.fs.sync-schema :as sync-schema]
             [frontend.mobile.util :as mobile-util]
-            [frontend.storage :as storage]
             [frontend.spec.storage :as storage-spec]
+            [frontend.storage :as storage]
             [frontend.util :as util]
             [frontend.util.cursor :as cursor]
             [goog.dom :as gdom]
@@ -1992,8 +1992,9 @@ Similar to re-frame subscriptions"
                :file-sync/progress]
               nil))
 
-(defn set-file-sync-state [graph-uuid v]
-  (when v (s/assert :frontend.fs.sync/sync-state v))
+(defn set-file-sync-state
+  [graph-uuid v]
+  {:pre [(util/validate [:maybe sync-schema/sync-state-schema] v)]}
   (set-state! [:file-sync/graph-state graph-uuid :file-sync/sync-state] v))
 
 (defn get-current-file-sync-graph-uuid

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -2,34 +2,35 @@
   "Main ns for utility fns. This ns should be split up into more focused namespaces"
   #?(:clj (:refer-clojure :exclude [format]))
   #?(:cljs (:require-macros [frontend.util]))
-  #?(:cljs (:require
-            ["/frontend/selection" :as selection]
-            ["/frontend/utils" :as utils]
-            ["@capacitor/status-bar" :refer [^js StatusBar Style]]
-            ["@hugotomazi/capacitor-navigation-bar" :refer [^js NavigationBar]]
-            ["grapheme-splitter" :as GraphemeSplitter]
-            ["remove-accents" :as removeAccents]
-            ["sanitize-filename" :as sanitizeFilename]
-            ["check-password-strength" :refer [passwordStrength]]
-            ["path-complete-extname" :as pathCompleteExtname]
-            [frontend.loader :refer [load]]
-            [cljs-bean.core :as bean]
-            [cljs-time.coerce :as tc]
-            [cljs-time.core :as t]
-            [clojure.pprint]
-            [dommy.core :as d]
-            [frontend.mobile.util :as mobile-util]
-            [logseq.graph-parser.util :as gp-util]
-            [goog.dom :as gdom]
-            [goog.object :as gobj]
-            [goog.string :as gstring]
-            [goog.userAgent]
-            [promesa.core :as p]
-            [rum.core :as rum]
-            [clojure.core.async :as async]
-            [cljs.core.async.impl.channels :refer [ManyToManyChannel]]
-            [medley.core :as medley]
-            [frontend.pubsub :as pubsub]))
+  #?(:cljs (:require ["/frontend/selection" :as selection]
+                     ["/frontend/utils" :as utils]
+                     ["@capacitor/status-bar" :refer [^js StatusBar Style]]
+                     ["@hugotomazi/capacitor-navigation-bar" :refer [^js NavigationBar]]
+                     ["check-password-strength" :refer [passwordStrength]]
+                     ["grapheme-splitter" :as GraphemeSplitter]
+                     ["path-complete-extname" :as pathCompleteExtname]
+                     ["remove-accents" :as removeAccents]
+                     ["sanitize-filename" :as sanitizeFilename]
+                     [cljs-bean.core :as bean]
+                     [cljs-time.coerce :as tc]
+                     [cljs-time.core :as t]
+                     [cljs.core.async.impl.channels :refer [ManyToManyChannel]]
+                     [clojure.core.async :as async]
+                     [clojure.pprint]
+                     [dommy.core :as d]
+                     [frontend.loader :refer [load]]
+                     [frontend.mobile.util :as mobile-util]
+                     [frontend.pubsub :as pubsub]
+                     [goog.dom :as gdom]
+                     [goog.object :as gobj]
+                     [goog.string :as gstring]
+                     [goog.userAgent]
+                     [logseq.graph-parser.util :as gp-util]
+                     [malli.core :as m]
+                     [malli.util :as mu]
+                     [medley.core :as medley]
+                     [promesa.core :as p]
+                     [rum.core :as rum]))
   #?(:cljs (:import [goog.async Debouncer]))
   (:require
    [clojure.pprint]
@@ -1521,3 +1522,14 @@ Arg *stop: atom, reset to true to stop the loop"
   "Vector version of remove. non-lazy"
   [pred coll]
   `(vec (remove ~pred ~coll)))
+
+
+#?(:cljs
+   (defn validate
+     "call malli.core/validate, if failed, then explain it,
+  return the boolean value"
+     [malli-schema value]
+     (let [v (m/validate malli-schema value)]
+       (when-not v
+         (js/console.error :validate-err (mu/explain-data malli-schema value)))
+       v)))

--- a/src/main/frontend/util/fs.cljs
+++ b/src/main/frontend/util/fs.cljs
@@ -8,9 +8,7 @@
             [clojure.string :as string]
             [frontend.state :as state]
             [frontend.fs :as fs]
-            [frontend.config :as config]
-            [promesa.core :as p]
-            [cljs.reader :as reader]))
+            [frontend.config :as config]))
 
 ;; NOTE: This is not the same ignored-path? as src/electron/electron/utils.cljs.
 ;;       The assets directory is ignored.
@@ -43,30 +41,6 @@
           (not
            (some #(string/ends-with? path %)
                  [".md" ".markdown" ".org" ".js" ".edn" ".css"]))))))))
-
-(defn read-graphs-txid-info
-  [root]
-  (when (string? root)
-    (p/let [exists? (fs/file-exists? root "logseq/graphs-txid.edn")]
-      (when exists?
-        (-> (p/let [txid-str (fs/read-file root "logseq/graphs-txid.edn")
-                    txid-meta (and txid-str (reader/read-string txid-str))]
-              txid-meta)
-            (p/catch
-                (fn [^js e]
-                  (js/console.error "[fs read txid data error]" e))))))))
-
-(defn inflate-graphs-info
-  [graphs]
-  (if (seq graphs)
-    (p/all (for [{:keys [root] :as graph} graphs]
-             (p/let [sync-meta (read-graphs-txid-info root)]
-               (if sync-meta
-                 (assoc graph
-                        :sync-meta sync-meta
-                        :GraphUUID (second sync-meta))
-                 graph))))
-    []))
 
 (defn read-repo-file
   [repo-url file]

--- a/src/main/frontend/util/persist_var.cljs
+++ b/src/main/frontend/util/persist_var.cljs
@@ -41,7 +41,11 @@
     (p/let [dir (config/get-repo-dir repo-url)
             path (load-path location repo-url)
             file-exists? (fs/file-exists? dir path)]
-      (when file-exists?
+      (if-not file-exists?
+        (swap! *value (fn [o]
+                        (-> o
+                            (assoc-in [repo-url :load?] false)
+                            (assoc-in [repo-url :value] nil))))
         (-> (p/chain (fs/stat dir path)
                      (fn [stat]
                        (when stat

--- a/src/main/frontend/util/persist_var.cljs
+++ b/src/main/frontend/util/persist_var.cljs
@@ -9,11 +9,15 @@
             [promesa.core :as p]))
 
 
-(defn- load-path [location]
-  (config/get-file-path (state/get-current-repo) (str config/app-name "/" location ".edn")))
+(defn- load-path
+  ([location]
+   (load-path location (state/get-current-repo)))
+  ([location repo-url]
+   (config/get-file-path repo-url (str config/app-name "/" location ".edn"))))
 
 (defprotocol ILoad
   (-load [this])
+  (-load-by-repo-url [this repo-url])
   (-loaded? [this]))
 
 (defprotocol ISave
@@ -28,33 +32,36 @@
     (reset! *value (assoc-in @*value [graph :value] new)))
 
   ILoad
-  (-load [_]
+  (-load [this]
     (if (config/demo-graph?)
       (p/resolved nil)
-      (let [repo (state/get-current-repo)
-            dir (config/get-repo-dir repo)
-            path (load-path location)]
-        (p/let [file-exists? (fs/file-exists? dir path)]
-          (when file-exists?
-            (-> (p/chain (fs/stat dir path)
-                         (fn [stat]
-                           (when stat
-                             (fs/read-file dir path)))
-                         (fn [content]
-                           (when (not-empty content)
-                             (try (reader/read-string content)
-                                  (catch :default e
-                                    (println (util/format "read persist-var failed: %s" (load-path location)))
-                                    (js/console.dir e)))))
-                         (fn [value]
-                           (when (some? value)
-                             (swap! *value (fn [o]
-                                             (-> o
-                                                 (assoc-in [repo :loaded?] true)
-                                                 (assoc-in [repo :value] value))))
-                             (get *value repo))))
-                (p/catch (fn [e]
-                           (println (util/format "load persist-var failed: %s: %s" (load-path location) e))))))))))
+      (-load-by-repo-url this (state/get-current-repo))))
+
+  (-load-by-repo-url [_ repo-url]
+    (p/let [dir (config/get-repo-dir repo-url)
+            path (load-path location repo-url)
+            file-exists? (fs/file-exists? dir path)]
+      (when file-exists?
+        (-> (p/chain (fs/stat dir path)
+                     (fn [stat]
+                       (when stat
+                         (fs/read-file dir path)))
+                     (fn [content]
+                       (when (not-empty content)
+                         (try (reader/read-string content)
+                              (catch :default e
+                                (println (util/format "read persist-var failed: %s" (load-path location)))
+                                (js/console.dir e)))))
+                     (fn [value]
+                       (when (some? value)
+                         (swap! *value (fn [o]
+                                         (-> o
+                                             (assoc-in [repo-url :loaded?] true)
+                                             (assoc-in [repo-url :value] value))))
+                         (get *value repo-url))))
+            (p/catch (fn [e]
+                       (println (util/format "load persist-var failed: %s: %s" (load-path location) e))))))))
+
   (-loaded? [_]
     (get-in @*value [(state/get-current-repo) :loaded?]))
 
@@ -80,13 +87,30 @@
 
   IPrintWithWriter
   (-pr-writer [_ w _opts]
-    (write-all w (str "#PersistVar[" @*value ", loc: " location "]"))))
+    (write-all w (str "#PersistVar[" @*value ", loc: " location "]")))
+
+  ISeqable
+  (-seq [_]
+    (seq (update-vals @*value :value)))
+
+  ILookup
+  (-lookup [_ repo-url] (get-in @*value [repo-url :value]))
+  (-lookup [_ repo-url not-found] (get-in @*value [repo-url :value] not-found)))
 
 
 (def *all-persist-vars (atom []))
 
-(defn load-vars []
+(defn load-vars
+  "load current graph's all persist-vars"
+  []
   (p/all (mapv -load @*all-persist-vars)))
+
+(defn load-by-repo-urls
+  "load all `repo-url-coll` on one persist-var"
+  [persist-var repo-url-coll]
+  (p/all
+   (for [repo-url repo-url-coll]
+     (-load-by-repo-url persist-var repo-url))))
 
 (defn persist-var
   "This var is stored at logseq/LOCATION.edn"

--- a/src/main/frontend/util/persist_var.cljs
+++ b/src/main/frontend/util/persist_var.cljs
@@ -51,7 +51,8 @@
                              (swap! *value (fn [o]
                                              (-> o
                                                  (assoc-in [repo :loaded?] true)
-                                                 (assoc-in [repo :value] value)))))))
+                                                 (assoc-in [repo :value] value))))
+                             (get *value repo))))
                 (p/catch (fn [e]
                            (println (util/format "load persist-var failed: %s: %s" (load-path location) e))))))))))
   (-loaded? [_]

--- a/src/test/frontend/fs/sync_test.cljs
+++ b/src/test/frontend/fs/sync_test.cljs
@@ -9,6 +9,7 @@
     ".DS_store" true
     "foo/.DS_store" true
     "logseq/graphs-txid.edn" true
+    "logseq/.graphs-txid.edn" true
     "logseq/version-files/1.md" true
     "logseq/bak/1.md" true
     "node_modules/test" true


### PR DESCRIPTION
- `logseq/graphs-txid.edn` is deprecated, move to `logseq/.graphs-txid.edn`, schema: `frontend.fs.sync/graphs-txid-schema` 
- add :work-dir to graphs-txid.edn, ensure that :work-dir equals to current repo dir when `sync/<sync-start`
- replace clojure.spec with malli schema for `frontend.fs.sync`, and split it into ns `frontend.fs.sync-schema`
