### PR TITLE
Enhance: Add support for block refs in properties to backlink to blocks

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -526,21 +526,24 @@
                                                       (when (coll? refs)
                                                         refs))))
                                             (map :block/original-name))
-                         block {:uuid id
-                                :content content
-                                :level 1
-                                :properties properties
-                                :properties-order (vec properties-order)
-                                :properties-text-values properties-text-values
-                                :invalid-properties invalid-properties
-                                :refs property-refs
-                                :pre-block? true
-                                :unordered true
-                                :macros (extract-macros-from-ast body)
-                                :body body}
-                         block (with-page-block-refs block false supported-formats db date-formatter)
-                         block' (update block :refs concat (:block-refs pre-block-properties))]
-                     (block-keywordize block'))
+                         block {:block/uuid id
+                                :block/content content
+                                :block/level 1
+                                :block/properties properties
+                                :block/properties-order (vec properties-order)
+                                :block/properties-text-values properties-text-values
+                                :block/invalid-properties invalid-properties
+                                :block/pre-block? true
+                                :block/unordered true
+                                :block/macros (extract-macros-from-ast body)
+                                :block/body body}
+                         {:keys [tags refs]}
+                         (with-page-block-refs {:body body :refs property-refs} false supported-formats db date-formatter)]
+                     (cond-> block
+                             tags
+                             (assoc :block/tags tags)
+                             true
+                             (assoc :block/refs (concat refs (:block-refs pre-block-properties)))))
                    (select-keys first-block [:block/format :block/page]))
                   blocks)
                  blocks)]

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -181,6 +181,20 @@
          (remove string/blank?)
          distinct)))
 
+(defn- extract-block-refs
+  [nodes]
+  (let [ref-blocks (atom nil)]
+    (walk/postwalk
+     (fn [form]
+       (when-let [block (get-block-reference form)]
+         (swap! ref-blocks conj block))
+       form)
+     nodes)
+    (keep (fn [block]
+            (when-let [id (parse-uuid block)]
+              [:block/uuid id]))
+          @ref-blocks)))
+
 (defn extract-properties
   [properties user-config]
   (when (seq properties)
@@ -202,9 +216,10 @@
                                            v' (text/parse-property k v mldoc-ast user-config)]
                                        [k' v' mldoc-ast v])
                                      (do (swap! *invalid-properties conj k)
-                                         nil)))))
+                                       nil)))))
                           (remove #(nil? (second %))))
           page-refs (get-page-ref-names-from-properties properties user-config)
+          block-refs (extract-block-refs properties)
           properties-text-values (->> (map (fn [[k _v _refs original-text]] [k original-text]) properties)
                                       (into {}))
           properties (map (fn [[k v _]] [k v]) properties)
@@ -213,7 +228,8 @@
        :properties-order (map first properties)
        :properties-text-values properties-text-values
        :invalid-properties @*invalid-properties
-       :page-refs page-refs})))
+       :page-refs page-refs
+       :block-refs block-refs})))
 
 (defn- paragraph-timestamp-block?
   [block]
@@ -351,19 +367,9 @@
 
 (defn- with-block-refs
   [{:keys [title body] :as block}]
-  (let [ref-blocks (atom nil)]
-    (walk/postwalk
-     (fn [form]
-       (when-let [block (get-block-reference form)]
-         (swap! ref-blocks conj block))
-       form)
-     (concat title body))
-    (let [ref-blocks (keep (fn [block]
-                             (when-let [id (parse-uuid block)]
-                               [:block/uuid id]))
-                           @ref-blocks)
-          refs (distinct (concat (:refs block) ref-blocks))]
-      (assoc block :refs refs))))
+  (let [ref-blocks (extract-block-refs (concat title body))
+        refs (distinct (concat (:refs block) ref-blocks))]
+    (assoc block :refs refs)))
 
 (defn- block-keywordize
   [block]
@@ -532,8 +538,9 @@
                                 :unordered true
                                 :macros (extract-macros-from-ast body)
                                 :body body}
-                         block (with-page-block-refs block false supported-formats db date-formatter)]
-                     (block-keywordize block))
+                         block (with-page-block-refs block false supported-formats db date-formatter)
+                         block' (update block :refs concat (:block-refs pre-block-properties))]
+                     (block-keywordize block'))
                    (select-keys first-block [:block/format :block/page]))
                   blocks)
                  blocks)]
@@ -584,6 +591,7 @@
                 block)
         block (assoc block :body body)
         block (with-page-block-refs block with-id? supported-formats db date-formatter)
+        block (update block :refs concat (:block-refs properties))
         {:keys [created-at updated-at]} (:properties properties)
         block (cond-> block
                 (and created-at (integer? created-at))


### PR DESCRIPTION
This PR adds support for block refs in properties to show up as block backlinks. This should bring blocks to parity with pages as far as ability to be referenced

<img width="822" alt="Screen Shot 2023-02-22 at 5 10 36 PM" src="https://user-images.githubusercontent.com/97210743/220771275-af145850-d474-4526-a715-49aee7377b90.png">

This fixes https://github.com/logseq/logseq/issues/5286, https://github.com/logseq/logseq/issues/8594 and https://github.com/logseq/logseq/issues/5796. Also adds some tests for timestamp blocks as there was nothing to test its functionality

To QA:

create one page with:
```
- A block
  id:: 63f528da-284a-45d1-ac9c-5d6a7435f6b4
- Link to  ((63f528da-284a-45d1-ac9c-5d6a7435f6b4))
- B block
  author:: ((63f528da-284a-45d1-ac9c-5d6a7435f6b4))
```

Create another page with:
```
ref:: ((63f528da-284a-45d1-ac9c-5d6a7435f6b4))
```

Observe there are 3 references to the first block

