### PR TITLE
[WIP] fix: localecompare on null issue of Safari

### DIFF
--- a/src/main/frontend/components/query_table.cljs
+++ b/src/main/frontend/components/query_table.cljs
@@ -128,6 +128,7 @@
           ;; Sort state needs to be in sync between final result and sortable title
           ;; as user needs to know if there result is sorted
           sort-state (get-sort-state current-block)
+          result (remove nil? result)
           result' (sort-result result sort-state)]
       [:div.overflow-x-auto {:on-mouse-down (fn [e] (.stopPropagation e))
                              :style {:width "100%"}


### PR DESCRIPTION
**Before fix:**
<img width="297" alt="image" src="https://user-images.githubusercontent.com/9862022/221422868-e2c0dd69-857f-4d73-9705-71b9f5cbcf72.png">


- [ ] Find a way to test public site generation on Safari
Failure attempts: generate public site in release & overwrite the `main.js`. The public site of the graph is accessible on both Chrome & Firefox, but doesn't work on Safari (always shown as 'demo graph' instead of the published graph)
- [ ] Test on Android device (Edge browser)