### PR TITLE
Chore: Add deprecation for :editor/command-trigger config

### DIFF
--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -95,9 +95,9 @@ html[data-theme='dark'] {
   --ls-highlight-color-blue: var(--color-blue-900);
   --ls-highlight-color-purple: var(--color-purple-900);
   --ls-highlight-color-pink: var(--color-pink-900);
-  --ls-error-text-color: var(--color-red-100);
+  --ls-error-text-color: var(--color-red-400);
   --ls-error-background-color: var(--color-red-900);
-  --ls-warning-text-color: var(--color-yellow-100);
+  --ls-warning-text-color: var(--color-yellow-400);
   --ls-warning-background-color: var(--color-yellow-900);
   --ls-success-text-color: var(--color-green-100);
   --ls-success-background-color: var(--color-green-900);
@@ -173,9 +173,9 @@ html[data-theme='light'] {
   --ls-highlight-color-blue: var(--color-blue-100);
   --ls-highlight-color-purple: var(--color-purple-100);
   --ls-highlight-color-pink: var(--color-pink-100);
-  --ls-error-text-color: var(--color-red-800);
+  --ls-error-text-color: var(--color-red-600);
   --ls-error-background-color: var(--color-red-100);
-  --ls-warning-text-color: var(--color-yellow-800);
+  --ls-warning-text-color: var(--color-yellow-700);
   --ls-warning-background-color: var(--color-yellow-100);
   --ls-success-text-color: var(--color-green-800);
   --ls-success-background-color: var(--color-green-100);

--- a/src/main/frontend/handler/common/config_edn.cljs
+++ b/src/main/frontend/handler/common/config_edn.cljs
@@ -6,6 +6,7 @@
             [goog.string :as gstring]
             [malli.core :as m]
             [malli.error :as me]
+            [reitit.frontend.easy :as rfe]
             [lambdaisland.glogi :as log]))
 
 (defn- humanize-more
@@ -79,7 +80,7 @@ in {}. Also make sure that the characters '( { [' have their corresponding closi
   (let [body (try (edn/read-string content)
                (catch :default _ ::failed-to-detect))
         warnings {:editor/command-trigger
-                  "will no longer be supported soon. Please use '/' and report bugs on it."}]
+                  "Will no longer be supported soon. Please use '/' and report bugs on it."}]
     (cond
       (= body ::failed-to-detect)
       (log/info :msg "Skip deprecation check since config is not valid edn")
@@ -89,11 +90,11 @@ in {}. Also make sure that the characters '( { [' have their corresponding closi
 
       :else
       (when-let [deprecations (seq (keep #(when (body (key %)) %) warnings))]
-        (notification/show! (gstring/format "The file '%s' has the following deprecations:\n%s"
-                                            path
-                                            (->> deprecations
-                                                 (map (fn [[k v]]
-                                                        (str "- " k " " v)))
-                                                 (string/join "\n")))
+        (notification/show! [:div.mb-4
+                             [:.text-lg  "The file " [:a {:href (rfe/href :file {:path path})} path] " has the following deprecations:"]
+                             (map (fn [[k v]]
+                                    [:dl.mt-4.mb-0
+                                     [:dt [:strong (str k)]]
+                                     [:dd v]]) deprecations)]
                             :warning
                             false)))))

--- a/src/main/frontend/handler/file.cljs
+++ b/src/main/frontend/handler/file.cljs
@@ -89,6 +89,14 @@
     :else
     nil))
 
+(defn- detect-deprecations
+  [repo path content]
+  (when (or (= path (config/get-repo-config-path repo))
+            (and
+             (config/global-config-enabled?)
+             (= (path/dirname path) (global-config-handler/global-config-dir))))
+    (config-edn-common-handler/detect-deprecations path content)))
+
 (defn- validate-file
   "Returns true if valid and if false validator displays error message. Files
   that are not validated just return true"
@@ -129,6 +137,7 @@
                            skip-compare? false}}]
   (let [path (gp-util/path-normalize path)
         config-file? (string/ends-with? path config/config-file)
+        _ (when config-file? (detect-deprecations repo path content))
         config-valid? (and config-file? (validate-file repo path content))]
     (when-not (and config-file? (not config-valid?)) ; non-config file or valid config
       (let [opts {:new-graph? new-graph?

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -218,15 +218,15 @@
     (let [svg
           (case status
             :success
-            (icon "circle-check" {:class "text-green-500" :size "22"})
+            (icon "circle-check" {:class "text-success" :size "32"})
 
             :warning
-            (icon "alert-circle" {:class "text-yellow-500" :size "22"})
+            (icon "alert-circle" {:class "text-warning" :size "32"})
 
             :error
-            (icon "circle-x" {:class "text-red-500" :size "22"})
+            (icon "circle-x" {:class "text-error" :size "32"})
 
-            (icon "info-circle" {:class "text-indigo-500" :size "22"}))]
+            (icon "info-circle" {:class "text-indigo-500" :size "32"}))]
       [:div.ui__notifications-content
        {:style
         (when (or (= state "exiting")

--- a/src/test/frontend/handler/common/config_edn_test.cljs
+++ b/src/test/frontend/handler/common/config_edn_test.cljs
@@ -14,6 +14,13 @@
              (config-edn-common-handler/validate-config-edn "config.edn" config-body schema)))
       (str @error-message))))
 
+(defn- deprecation-warnings-for
+  [config-body]
+  (let [error-message (atom nil)]
+    (with-redefs [notification/show! (fn [msg _] (reset! error-message msg))]
+      (config-edn-common-handler/detect-deprecations "config.edn" config-body)
+      (str @error-message))))
+
 (deftest validate-config-edn
   (testing "Valid cases"
     (is (= true
@@ -47,3 +54,12 @@
       (is (string/includes?
            (validation-config-error-for "{:start-of-week 7\n:start-of-week 8}" schema)
            "The key ':start-of-week' is assigned multiple times")))))
+
+(deftest detect-deprecations
+  (is (string/includes?
+       (deprecation-warnings-for "{:preferred-workflow :todo :editor/command-trigger \",\"}")
+       ":editor/command-trigger will")
+      "Warning when there is a deprecation")
+
+  (is (= "" (deprecation-warnings-for "{:preferred-workflow :todo}"))
+      "No warning when there is no deprecation"))


### PR DESCRIPTION
Per https://linear.app/logseq/issue/LOG-2402/deprecation-warning-for-editorcommand-trigger-config, display a deprecation warning for the :editor/command-trigger config option when it is detected. Deprecation setup is reusable for any config keys in the future should we need to migrate or deprecate future keys

To QA:
- With an unparseable config file - detection is skipped
- With a config file containing :editor/command-trigger - warning displayed
- Any other config file - nothing different happens