### PR TITLE
Fix: Plugins menu item not opening from plugins dashboard

### DIFF
--- a/src/main/frontend/components/plugins.cljs
+++ b/src/main/frontend/components/plugins.cljs
@@ -1177,7 +1177,7 @@
 
 (defn open-plugins-modal!
   []
-  (state/set-sub-modal!
+  (state/set-modal!
    (fn [_close!]
      (plugins-page))
    {:label "plugins-dashboard"}))

--- a/src/main/frontend/components/plugins.cljs
+++ b/src/main/frontend/components/plugins.cljs
@@ -1177,7 +1177,7 @@
 
 (defn open-plugins-modal!
   []
-  (state/set-modal!
+  (state/set-sub-modal!
    (fn [_close!]
      (plugins-page))
    {:label "plugins-dashboard"}))

--- a/src/main/frontend/handler/plugin_config.cljs
+++ b/src/main/frontend/handler/plugin_config.cljs
@@ -76,7 +76,6 @@ returns map of plugins to install and uninstall"
 
 (defn open-replace-plugins-modal
   []
-  (state/pub-event! [:go/plugins])
   (p/catch
    (p/let [edn-plugins* (fs/read-file "" (plugin-config-path))
            edn-plugins (edn/read-string edn-plugins*)]


### PR DESCRIPTION
Fixes #8726. Not sure what changed but looks like this should be opening as a sub-modal since it's under the plugin modal. To QA, just follow the referenced bug's instructions