### PR TITLE
fix: hide empty settings description

### DIFF
--- a/src/main/frontend/components/plugins.css
+++ b/src/main/frontend/components/plugins.css
@@ -496,8 +496,12 @@
         margin: 12px 12px 6px;
         border-bottom: 1px solid var(--ls-border-color, #738694);
 
-        > h2 {
+        h2 {
           font-weight: bold;
+        }
+
+        small:empty {
+          display: none;
         }
       }
 

--- a/src/main/frontend/components/plugins_settings.cljs
+++ b/src/main/frontend/components/plugins_settings.cljs
@@ -85,7 +85,7 @@
   [:div.heading-item
    {:data-key key}
    [:h2 title]
-   [:small.pl-1.flex-1 description]])
+   [:small description]])
 
 (rum/defc settings-container
   [schema ^js pl]


### PR DESCRIPTION
If there is no `descrition` value in config, header looks not good. I've missed this case 😕
As there is no (in whole file) checks for empty values, will add just CSS solution

update for https://github.com/logseq/logseq/pull/8643