### PR TITLE
fix(electron): global config dir name under windows

### DIFF
--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -35,12 +35,19 @@
   ([url options]
    (_fetch url (bean/->js (merge options {:agent @*fetchAgent})))))
 
+(defn fix-win-path!
+  [path]
+  (when path
+    (if win32?
+      (string/replace path "\\" "/")
+      path)))
+
 (defn get-ls-dotdir-root
   []
   (let [lg-dir (path/join (.getPath app "home") ".logseq")]
-    (if-not (fs/existsSync lg-dir)
-      (do (fs/mkdirSync lg-dir) lg-dir)
-      lg-dir)))
+    (when-not (fs/existsSync lg-dir)
+      (fs/mkdirSync lg-dir))
+    (fix-win-path! lg-dir)))
 
 (defn get-ls-default-plugins
   []
@@ -213,13 +220,6 @@
   [path]
   (let [ext (string/lower-case (path/extname path))]
     (contains? #{".md" ".markdown" ".org" ".js" ".edn" ".css"} ext)))
-
-(defn fix-win-path!
-  [path]
-  (when path
-    (if win32?
-      (string/replace path "\\" "/")
-      path)))
 
 (defn read-file
   [path]


### PR DESCRIPTION
Fix #8740 