### PR TITLE
Fix (Whiteboards): Autocomplete on portals

### DIFF
--- a/tldraw/apps/tldraw-logseq/src/styles.css
+++ b/tldraw/apps/tldraw-logseq/src/styles.css
@@ -718,7 +718,6 @@ button.tl-select-input-trigger {
   left: 0;
   overscroll-behavior: none;
   opacity: 1;
-  overflow: hidden;
   user-select: text;
   transform-origin: top left;
 
@@ -758,6 +757,10 @@ button.tl-select-input-trigger {
   .block-content {
     white-space: nowrap;
   }
+}
+
+.tl-logseq-cp-container-bg {
+  border-radius: 8px;
 }
 
 .tl-type-tag {

--- a/tldraw/packages/react/src/components/ui/SelectionForeground/SelectionForeground.tsx
+++ b/tldraw/packages/react/src/components/ui/SelectionForeground/SelectionForeground.tsx
@@ -27,14 +27,14 @@ export const SelectionForeground = observer(function SelectionForeground<S exten
 
   return (
     <SVGContainer>
-      <rect
+      {!app.editingShape && (<rect
         className="tl-bounds-fg"
         width={Math.max(width, 1)}
         height={Math.max(height, 1)}
         rx={borderRadius}
         ry={borderRadius}
         pointerEvents="none"
-      />
+      />)}
       <EdgeHandle
         x={targetSize * 2}
         y={0}


### PR DESCRIPTION
Allow overflow on portal elements to display autocomplete components. The border radius fixes the background component that is used for coloring.

See https://discord.com/channels/725182569297215569/1080832699255758961/1080832699255758961
and https://github.com/logseq/logseq/pull/8652#issuecomment-1439505679

![Screenshot from 2023-03-02 16-26-01](https://user-images.githubusercontent.com/10744960/222457900-1f1e1057-3b5d-4aef-bbbe-94c9fd5f1057.png)
