### PR TITLE
enhance(pdf): UI lag for the case of large highlights data

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -28,7 +28,8 @@
   instaparse/instaparse                 {:mvn/version "1.4.10"}
   org.clojars.mmb90/cljs-cache          {:mvn/version "0.1.4"}
   logseq/graph-parser                   {:local/root "deps/graph-parser"}
-  metosin/malli                         {:mvn/version "0.10.0"}}
+  metosin/malli                         {:mvn/version "0.10.0"}
+  fipp/fipp                             {:mvn/version "0.6.26"}}
 
  :aliases {:cljs {:extra-paths ["src/dev-cljs/" "src/test/" "src/electron/"]
                   :extra-deps  {org.clojure/clojurescript        {:mvn/version "1.11.54"}

--- a/src/main/frontend/extensions/pdf/assets.cljs
+++ b/src/main/frontend/extensions/pdf/assets.cljs
@@ -1,7 +1,6 @@
 (ns frontend.extensions.pdf.assets
   (:require [cljs.reader :as reader]
             [clojure.string :as string]
-            [cljs.pprint :as pprint]
             [frontend.config :as config]
             [frontend.db.model :as db-model]
             [frontend.db.utils :as db-utils]
@@ -23,7 +22,8 @@
             [medley.core :as medley]
             [promesa.core :as p]
             [reitit.frontend.easy :as rfe]
-            [rum.core :as rum]))
+            [rum.core :as rum]
+            [fipp.edn :refer [pprint]]))
 
 (defn inflate-asset
   [original-path]
@@ -64,7 +64,7 @@
   (when hls-file
     (let [repo-cur (state/get-current-repo)
           repo-dir (config/get-repo-dir repo-cur)
-          data     (with-out-str (pprint/pprint {:highlights highlights :extra extra}))]
+          data     (with-out-str (pprint {:highlights highlights :extra extra}))]
       (fs/write-file! repo-cur repo-dir hls-file data {:skip-compare? true}))))
 
 (defn resolve-hls-data-by-key$

--- a/src/main/frontend/extensions/pdf/core.cljs
+++ b/src/main/frontend/extensions/pdf/core.cljs
@@ -844,8 +844,10 @@
        (when (= :completed (:status loader-state))
          (p/catch
           (when-not (:error hls-state)
-            (pdf-assets/persist-hls-data$
-             pdf-current (:latest-hls hls-state) (:extra hls-state)))
+            (p/do!
+              (p/delay 100)
+              (pdf-assets/persist-hls-data$
+                pdf-current (:latest-hls hls-state) (:extra hls-state))))
 
           ;; write hls file error
           (fn [e]


### PR DESCRIPTION
related https://github.com/logseq/logseq/issues/8735
For this issue, the main reason is that serializing large highlights data to the file system is so slow with clojure.core internal solution. so this PR is trying to do this work with a three-party library https://github.com/brandonbloom/fipp,  it's about 2 to 3 times faster than the built-in solution. This PR is a quick patch, not a final solution!