### PR TITLE
fix: display page's original name when possible

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -575,6 +575,9 @@
                        (not= (util/safe-page-name-sanity-lc original-name) page-name-in-block)
                        page-name-in-block ;; page-name-in-block might be overridden (legacy))
 
+                       original-name
+                       (util/trim-safe original-name)
+
                        :else
                        (util/trim-safe page-name))
                _ (when-not page-entity (js/console.warn "page-inner's page-entity is nil, given page-name: " page-name


### PR DESCRIPTION
How to reproduce:
1. Create a page `Test` with the content
```
- [[foo]] test
```
2. Click the `[[foo]]` reference
3. In the linked references, a lower-case page `test` is displayed instead of its original name `Test`.