### PR TITLE
Fix (Whiteboards): History issues

### DIFF
--- a/e2e-tests/whiteboards.spec.ts
+++ b/e2e-tests/whiteboards.spec.ts
@@ -88,6 +88,41 @@ test('draw a rectangle', async ({ page }) => {
   ).not.toHaveCount(0)
 })
 
+test('undo the action', async ({ page }) => {
+  await page.keyboard.press(modKey + '+z')
+
+  await expect(page.locator('.logseq-tldraw .tl-positioned-svg rect')).toHaveCount(0)
+})
+
+test('redo the action', async ({ page }) => {
+  await page.keyboard.press(modKey + '+Shift+z')
+
+  await expect(
+    page.locator('.logseq-tldraw .tl-positioned-svg rect')
+  ).not.toHaveCount(0)
+})
+
+test('undo the action again', async ({ page }) => {
+  await page.keyboard.press(modKey + '+z')
+
+  await expect(page.locator('.logseq-tldraw .tl-positioned-svg rect')).toHaveCount(0)
+})
+
+test('create a block', async ({ page }) => {
+  const canvas = await page.waitForSelector('.logseq-tldraw')
+  const bounds = (await canvas.boundingBox())!
+
+  await page.keyboard.press('s')
+  await page.mouse.dblclick(bounds.x + 5, bounds.y + 5)
+  await page.waitForTimeout(100)
+
+  await page.keyboard.type('a')
+  await page.keyboard.press('Enter')
+
+
+  await expect(page.locator('.logseq-tldraw .tl-logseq-portal-container')).toHaveCount(1)
+})
+
 test('copy/paste url to create an iFrame shape', async ({ page }) => {
   const canvas = await page.waitForSelector('.logseq-tldraw')
   const bounds = (await canvas.boundingBox())!

--- a/e2e-tests/whiteboards.spec.ts
+++ b/e2e-tests/whiteboards.spec.ts
@@ -108,21 +108,6 @@ test('undo the action again', async ({ page }) => {
   await expect(page.locator('.logseq-tldraw .tl-positioned-svg rect')).toHaveCount(0)
 })
 
-test('create a block', async ({ page }) => {
-  const canvas = await page.waitForSelector('.logseq-tldraw')
-  const bounds = (await canvas.boundingBox())!
-
-  await page.keyboard.press('s')
-  await page.mouse.dblclick(bounds.x + 5, bounds.y + 5)
-  await page.waitForTimeout(100)
-
-  await page.keyboard.type('a')
-  await page.keyboard.press('Enter')
-
-
-  await expect(page.locator('.logseq-tldraw .tl-logseq-portal-container')).toHaveCount(1)
-})
-
 test('copy/paste url to create an iFrame shape', async ({ page }) => {
   const canvas = await page.waitForSelector('.logseq-tldraw')
   const bounds = (await canvas.boundingBox())!

--- a/e2e-tests/whiteboards.spec.ts
+++ b/e2e-tests/whiteboards.spec.ts
@@ -88,24 +88,45 @@ test('draw a rectangle', async ({ page }) => {
   ).not.toHaveCount(0)
 })
 
-test('undo the action', async ({ page }) => {
+test('undo the rectangle action', async ({ page }) => {
   await page.keyboard.press(modKey + '+z')
 
   await expect(page.locator('.logseq-tldraw .tl-positioned-svg rect')).toHaveCount(0)
 })
 
-test('redo the action', async ({ page }) => {
-  await page.keyboard.press(modKey + '+Shift+z')
+test('create a block', async ({ page }) => {
+  const canvas = await page.waitForSelector('.logseq-tldraw')
+  const bounds = (await canvas.boundingBox())!
 
-  await expect(
-    page.locator('.logseq-tldraw .tl-positioned-svg rect')
-  ).not.toHaveCount(0)
+  await page.keyboard.press('s')
+  await page.mouse.dblclick(bounds.x + 5, bounds.y + 5)
+  await page.waitForTimeout(100)
+
+  await page.keyboard.type('a')
+  await page.keyboard.press('Enter')
+
+
+  await expect(page.locator('.logseq-tldraw .tl-logseq-portal-container')).toHaveCount(1)
 })
 
-test('undo the action again', async ({ page }) => {
+test('expand the block', async ({ page }) => {
+  await page.keyboard.press('Escape')
+  await page.click('.logseq-tldraw .tl-context-bar .tie-object-expanded ')
+  await page.waitForTimeout(100)
+
+  await expect(page.locator('.logseq-tldraw .tl-logseq-portal-container .tl-logseq-portal-header')).toHaveCount(1)
+})
+
+test('undo the expand action', async ({ page }) => {
   await page.keyboard.press(modKey + '+z')
 
-  await expect(page.locator('.logseq-tldraw .tl-positioned-svg rect')).toHaveCount(0)
+  await expect(page.locator('.logseq-tldraw .tl-logseq-portal-container .tl-logseq-portal-header')).toHaveCount(0)
+})
+
+test('undo the block action', async ({ page }) => {
+  await page.keyboard.press(modKey + '+z')
+
+  await expect(page.locator('.logseq-tldraw .tl-logseq-portal-container')).toHaveCount(0)
 })
 
 test('copy/paste url to create an iFrame shape', async ({ page }) => {
@@ -174,14 +195,16 @@ test('cleanup the shapes', async ({ page }) => {
 test('zoom in', async ({ page }) => {
   await page.keyboard.press('Shift+0') // reset zoom
   await page.waitForTimeout(1500) // wait for the zoom animation to finish
-  await page.click('#tl-zoom-in')
+  await page.keyboard.press(`${modKey}++`)
+  await page.waitForTimeout(1500) // wait for the zoom animation to finish
   await expect(page.locator('#tl-zoom')).toContainText('125%')
 })
 
 test('zoom out', async ({ page }) => {
   await page.keyboard.press('Shift+0')
-  await page.waitForTimeout(1500)
-  await page.click('#tl-zoom-out')
+  await page.waitForTimeout(1500) // wait for the zoom animation to finish
+  await page.keyboard.press(`${modKey}+-`)
+  await page.waitForTimeout(1500) // wait for the zoom animation to finish
   await expect(page.locator('#tl-zoom')).toContainText('80%')
 })
 

--- a/src/main/frontend/extensions/tldraw.cljs
+++ b/src/main/frontend/extensions/tldraw.cljs
@@ -152,8 +152,8 @@
        (tldraw {:renderers tldraw-renderers
                 :handlers (get-tldraw-handlers page-name)
                 :onMount on-mount
-                :onPersist (fn [app _info]
+                :onPersist (fn [app info]
                              (state/set-state! [:whiteboard/last-persisted-at (state/get-current-repo)] (util/time-ms))
                              (util/profile "tldraw persist"
-                                           (whiteboard-handler/transact-tldr-delta! page-name app)))
+                                           (whiteboard-handler/transact-tldr-delta! page-name app (.-replace info))))
                 :model data})])))

--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -119,7 +119,7 @@
                            (map #(shape->block % page-name))
                            (map with-timestamps))
      :delete-blocks deleted-shapes-tx
-     :metadata {:whiteboard/transact? true
+     :metadata {:whiteboard/transact? (not replace?)
                 :replace? replace?
                 :data {:page-name page-name
                        :deleted-shapes deleted-shapes

--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -83,7 +83,7 @@
                            (util/time-ms))}))
 
 (defn- compute-tx
-  [^js app ^js tl-page new-id-nonces db-id-nonces page-name transact?]
+  [^js app ^js tl-page new-id-nonces db-id-nonces page-name replace?]
   (let [assets (js->clj-keywordize (.getCleanUpAssets app))
         new-shapes (.-shapes tl-page)
         shapes-index (map #(gobj/get % "id") new-shapes)
@@ -119,7 +119,8 @@
                            (map #(shape->block % page-name))
                            (map with-timestamps))
      :delete-blocks deleted-shapes-tx
-     :metadata {:whiteboard/transact? transact?
+     :metadata {:whiteboard/transact? true
+                :replace? replace?
                 :data {:page-name page-name
                        :deleted-shapes deleted-shapes
                        :new-shapes created-shapes
@@ -139,7 +140,7 @@
                       (set (->> (model/get-whiteboard-id-nonces repo page-name)
                                 (map #(update % :id str)))))
         {:keys [page-block upserted-blocks delete-blocks metadata]}
-        (compute-tx app tl-page new-id-nonces db-id-nonces page-name (not replace?))
+        (compute-tx app tl-page new-id-nonces db-id-nonces page-name replace?)
         tx-data (concat delete-blocks [page-block] upserted-blocks)
         new-shapes (get-in metadata [:data :new-shapes])
         metadata' (cond

--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -83,7 +83,7 @@
                            (util/time-ms))}))
 
 (defn- compute-tx
-  [^js app ^js tl-page new-id-nonces db-id-nonces page-name]
+  [^js app ^js tl-page new-id-nonces db-id-nonces page-name transact?]
   (let [assets (js->clj-keywordize (.getCleanUpAssets app))
         new-shapes (.-shapes tl-page)
         shapes-index (map #(gobj/get % "id") new-shapes)
@@ -119,7 +119,7 @@
                            (map #(shape->block % page-name))
                            (map with-timestamps))
      :delete-blocks deleted-shapes-tx
-     :metadata {:whiteboard/transact? true
+     :metadata {:whiteboard/transact? transact?
                 :data {:page-name page-name
                        :deleted-shapes deleted-shapes
                        :new-shapes created-shapes
@@ -127,7 +127,7 @@
                        :prev-changed-blocks prev-changed-blocks}}}))
 
 (defonce *last-shapes-nonce (atom {}))
-(defn transact-tldr-delta! [page-name ^js app]
+(defn transact-tldr-delta! [page-name ^js app replace?]
   (let [tl-page ^js (second (first (.-pages app)))
         shapes (.-shapes ^js tl-page)
         new-id-nonces (set (map (fn [shape]
@@ -139,7 +139,7 @@
                       (set (->> (model/get-whiteboard-id-nonces repo page-name)
                                 (map #(update % :id str)))))
         {:keys [page-block upserted-blocks delete-blocks metadata]}
-        (compute-tx app tl-page new-id-nonces db-id-nonces page-name)
+        (compute-tx app tl-page new-id-nonces db-id-nonces page-name (not replace?))
         tx-data (concat delete-blocks [page-block] upserted-blocks)
         new-shapes (get-in metadata [:data :new-shapes])
         metadata' (cond

--- a/src/main/frontend/modules/editor/undo_redo.cljs
+++ b/src/main/frontend/modules/editor/undo_redo.cljs
@@ -147,7 +147,7 @@
                    (set (map :a tx-data))
                    #{:block/created-at :block/updated-at})))
     (reset-redo)
-    (if (:compute-new-refs? tx-meta)
+    (if (:replace? tx-meta)
       (let [[removed-e _prev-e] (pop-undo)
             entity (update removed-e :txs concat tx-data)]
         (push-undo entity))

--- a/src/main/frontend/modules/outliner/pipeline.cljs
+++ b/src/main/frontend/modules/outliner/pipeline.cljs
@@ -63,7 +63,7 @@
   (let [tx-meta (:tx-meta tx-report)]
     (when (and (not (:from-disk? tx-meta))
                (not (:new-graph? tx-meta))
-               (not (:compute-new-refs? tx-meta)))
+               (not (:replace? tx-meta)))
       (let [{:keys [pages blocks]} (ds-report/get-blocks-and-pages tx-report)
             repo (state/get-current-repo)
             refs-tx (util/profile
@@ -73,7 +73,7 @@
             tx (util/concat-without-nil truncate-refs-tx refs-tx)
             tx-report' (if (seq tx)
                          (let [refs-tx-data' (:tx-data (db/transact! repo tx {:outliner/transact? true
-                                                                              :compute-new-refs? true}))]
+                                                                              :replace? true}))]
                            ;; merge
                            (assoc tx-report :tx-data (concat (:tx-data tx-report) refs-tx-data')))
                          tx-report)

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
@@ -293,6 +293,15 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
     const [loaded, setLoaded] = React.useState(false)
 
     React.useEffect(() => {
+      if (!this.initialHeightCalculated) {
+        setTimeout(() => {
+          this.onResetBounds()
+          app.persist(true)
+        })
+      }
+    }, [this.initialHeightCalculated])
+
+    React.useEffect(() => {
       setTimeout(function () {
         setLoaded(true)
       })

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
@@ -146,20 +146,11 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
       this.update({ compact: collapsed })
       this.canResize[1] = !collapsed
       if (!collapsed) {
-        // this will also persist the state, so we can skip persist call
-        await delay()
         this.onResetBounds()
       }
-      this.persist?.()
     } else {
       const originalHeight = this.props.size[1]
       this.canResize[1] = !collapsed
-      console.log(
-        collapsed,
-        collapsed ? this.getHeaderHeight() : this.props.collapsedHeight,
-        this.getHeaderHeight(),
-        this.props.collapsedHeight
-      )
       this.update({
         isAutoResizing: !collapsed,
         collapsed: collapsed,
@@ -167,6 +158,7 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
         collapsedHeight: collapsed ? originalHeight : this.props.collapsedHeight,
       })
     }
+    this.persist?.()
   }
 
   @computed get scaleLevel() {

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
@@ -276,6 +276,7 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
       return null // not being correctly configured
     }
     const { Page, Block } = renderers
+    const [loaded, setLoaded] = React.useState(false)
 
     React.useEffect(() => {
       if (this.props.isAutoResizing) {
@@ -285,12 +286,11 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
           this.update({
             size: [this.props.size[0], newHeight],
           })
-          app.persist(true)
+
+          if (loaded) app.persist(true)
         }
       }
     }, [innerHeight, this.props.isAutoResizing])
-
-    const [loaded, setLoaded] = React.useState(false)
 
     React.useEffect(() => {
       if (!this.initialHeightCalculated) {

--- a/tldraw/packages/core/src/lib/TLHistory.ts
+++ b/tldraw/packages/core/src/lib/TLHistory.ts
@@ -33,7 +33,7 @@ export class TLHistory<S extends TLShape = TLShape, K extends TLEventMap = TLEve
   @action persist = (replace = false) => {
     if (this.isPaused || this.creating) return
     this.app.pages.forEach(page => page.bump()) // Is it ok here?
-    this.app.notify('persist', null)
+    this.app.notify('persist', {replace})
   }
 
   @action undo = () => {

--- a/tldraw/packages/core/src/types/types.ts
+++ b/tldraw/packages/core/src/types/types.ts
@@ -155,7 +155,7 @@ export type TLSubscriptionEvent =
     }
   | {
       event: 'persist'
-      info: null
+      info: { replace: boolean }
     }
   | {
       event: 'save'


### PR DESCRIPTION
Is some cases we had to persist a new state by replacing the last history entry, instead of pushing a new one.
The related block was removed here https://github.com/logseq/logseq/pull/7786/files#diff-f8d520c32e2ccdf12b14a130b819d3ecbc21284ceabab9ac1ed48d2cab65f272L68-L70

As a result, calling `app.persist(true)`, disregards the boolean and always pushes a new entry. For example, if you drag and drop a block into the canvas and then undo the action, you will notice that there are intermediate history entries that shouldn't exist. There is a similar problem with tweet shapes and iframes.

I think we can achieve a similar result by setting `:whiteboard/transact?` to false and by using the existing `:compute-new-refs?` that seems to swap the data of the last undo entry.

Fixed another bug (https://github.com/logseq/logseq/pull/8788/commits/d3cd17ec5fe6559816e66f613c3d5282328a4e96) that didn't allow us to undo a block/page creation by using the portal tool or by double clicking. The issue was accidentally fixed by #7786, because replace stopped working. The problem was that the first persist was called with replace true (so not undoable). The next one was called with replace false, but the portal element was already part of the state.

Also fixed persisting the collapsed state of portals and added tests for the mentioned cases.

Some notes about history
- I think we need to eliminate both replace and pause/resume on whiteboards. Since we have to explicitly call persist, we should be able to avoid those quirks by persisting only when needed.
- Having a shared history stack for all pages under the same repo, can lead to perceived data loss. This can be  overstated on Whiteboards, because the canvas feels like a completely different context. You might add something to a whiteboard, navigate to a different page, make some changes, spam the undo and loose the changes on the whiteboard without noticing. Ideally, we should have a dedicated history per page. Clearing the stack when we navigate could help, but it could also end up being annoying.
- Persisting to edn on undo/redo seems to behave inconsistently.