### PR TITLE
fix(logbook):  `with-second-support?` doesn't work

### DIFF
--- a/src/main/frontend/util/clock.cljs
+++ b/src/main/frontend/util/clock.cljs
@@ -43,7 +43,7 @@
                  (if (zero? seconds) "" (str seconds "s")))))
 
 (def support-seconds?
-  (get (state/get-config)
+  (get-in (state/get-config)
        [:logbook/settings :with-second-support?] true))
 
 (defn- now []


### PR DESCRIPTION
Fix #8794