### PR TITLE
fix(paste): do not convert url to macro while raw pasting

### DIFF
--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -197,9 +197,8 @@
        (if raw-paste?
          (utils/getClipText
           (fn [clipboard-data]
-            (when-let [_ (state/get-input)]
-              (let [text clipboard-data]
-                (paste-text-or-blocks-aux input e text nil))))
+            (when (state/get-input)
+              (paste-text-or-blocks-aux input e clipboard-data nil)))
           (fn [error]
             (js/console.error error)))
          (let [clipboard-data (gobj/get e "clipboardData")

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -198,9 +198,7 @@
          (utils/getClipText
           (fn [clipboard-data]
             (when-let [_ (state/get-input)]
-              (let [text (or (when (gp-util/url? clipboard-data)
-                               (wrap-macro-url clipboard-data))
-                             clipboard-data)]
+              (let [text clipboard-data]
                 (paste-text-or-blocks-aux input e text nil))))
           (fn [error]
             (js/console.error error)))

--- a/src/test/frontend/handler/paste_test.cljs
+++ b/src/test/frontend/handler/paste_test.cljs
@@ -87,4 +87,5 @@
          commands/simple-insert! (fn [_input text] (p/resolved text))
          util/get-selected-text (constantly nil)]
         (p/let [result ((paste-handler/editor-on-paste! nil true))]
-               (is (= expected-paste result)))))))
+               (is (= expected-paste result))
+               (reset))))))

--- a/src/test/frontend/handler/plugin_config_test.cljs
+++ b/src/test/frontend/handler/plugin_config_test.cljs
@@ -73,7 +73,9 @@
         (plugin-config-handler/open-replace-plugins-modal)
         (is (string/starts-with? @error-message "Malformed plugins.edn")
             "User sees correct notification"))
-       (p/finally #(delete-global-config-dir dir))))))
+       (p/finally #(do
+                     (reset)
+                     (delete-global-config-dir dir)))))))
 
 (deftest-async open-replace-plugins-modal-invalid-edn
   (let [dir (create-global-config-dir)
@@ -89,7 +91,9 @@
         (plugin-config-handler/open-replace-plugins-modal)
         (is (string/starts-with? @error-message "Invalid plugins.edn")
             "User sees correct notification"))
-       (p/finally #(delete-global-config-dir dir))))))
+       (p/finally #(do
+                     (reset)
+                     (delete-global-config-dir dir)))))))
 
 (defn- installed-plugins->edn-plugins
   "Converts installed plugins state to edn.plugins format"


### PR DESCRIPTION
fix #8810, #8809

We should not change the data or text in clipboard but keep it unchanged while `raw-pasting?` is true.
