### PR TITLE
fix(ui): incorrect position of absolute modal on some mobile platforms

### DIFF
--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -392,11 +392,9 @@
                 :z-index    11}
                (when set-default-width?
                  {:width max-width})
-               (when-let [^js/HTMLElement editor
-                          (js/document.querySelector ".editor-wrapper")]
-                 (if (<= (.-clientWidth editor) (+ left (if set-default-width? max-width 500)))
-                   {:right 0}
-                   {:left (if (or (nil? y-diff) (and y-diff (= y-diff 0))) left 0)})))]
+               (if (<= vw-max-width (+ left (if set-default-width? max-width 500)))
+                 {:right 0}
+                 {:left (if (or (nil? y-diff) (and y-diff (= y-diff 0))) left 0)}))]
     [:div.absolute.rounded-md.shadow-lg.absolute-modal
      {:ref *el
       :data-modal-name modal-name

--- a/src/main/frontend/components/editor.css
+++ b/src/main/frontend/components/editor.css
@@ -42,8 +42,10 @@
   }
 
   &[data-modal-name="commands"] {
-    width: 380px !important;
-    max-width: 90vw !important;
+    @screen sm {
+      width: 380px !important;
+      max-width: 90vw !important;
+    }
   }
 }
 


### PR DESCRIPTION
# Before
<img width="559" alt="CleanShot 2023-03-15 at 11 29 13@2x" src="https://user-images.githubusercontent.com/1779837/225203011-80f7424c-3a79-40bd-865a-8fc38515d099.png">

# After
<img width="554" alt="CleanShot 2023-03-15 at 12 02 05@2x" src="https://user-images.githubusercontent.com/1779837/225203241-fd371245-e8e2-4ac3-9fae-f04eb4e3c7ee.png">
