### PR TITLE
fix: select only the current block when open its context-menu

### DIFF
--- a/e2e-tests/hotkey.spec.ts
+++ b/e2e-tests/hotkey.spec.ts
@@ -1,8 +1,9 @@
 import { expect } from '@playwright/test'
 import { test } from './fixtures'
-import { createRandomPage, newBlock, lastBlock, modKey, IsLinux } from './utils'
+import { createRandomPage, enterNextBlock, lastBlock, modKey, IsLinux } from './utils'
 
 test('open search dialog', async ({ page }) => {
+  await page.waitForTimeout(200)
   await page.keyboard.press(modKey + '+k')
 
   await page.waitForSelector('[placeholder="Search or create page"]')
@@ -25,7 +26,7 @@ test('insert link #3278', async ({ page }) => {
   await page.fill('textarea >> nth=0', '[Logseq Website](https://logseq.com)')
 
   // Case 2: link with label
-  await newBlock(page)
+  await enterNextBlock(page)
   await page.type('textarea >> nth=0', 'Logseq')
   await page.press('textarea >> nth=0', selectAll)
   await page.press('textarea >> nth=0', hotKey)
@@ -34,7 +35,7 @@ test('insert link #3278', async ({ page }) => {
   expect(await page.inputValue('textarea >> nth=0')).toBe('[Logseq](https://logseq.com/)')
 
   // Case 3: link with URL
-  await newBlock(page)
+  await enterNextBlock(page)
   await page.type('textarea >> nth=0', 'https://logseq.com/')
   await page.press('textarea >> nth=0', selectAll)
   await page.press('textarea >> nth=0', hotKey)

--- a/e2e-tests/page-rename.spec.ts
+++ b/e2e-tests/page-rename.spec.ts
@@ -1,6 +1,6 @@
 import { expect, Page } from '@playwright/test'
 import { test } from './fixtures'
-import { IsMac, createPage, randomLowerString, newBlock, newInnerBlock, randomString, lastBlock } from './utils'
+import { IsMac, createPage, randomLowerString, newInnerBlock, randomString, lastBlock } from './utils'
 
 /***
  * Test rename feature

--- a/e2e-tests/page-search.spec.ts
+++ b/e2e-tests/page-search.spec.ts
@@ -1,7 +1,7 @@
 import { expect, Page } from '@playwright/test'
 import { test } from './fixtures'
 import { Block } from './types'
-import { modKey, createRandomPage, newBlock, newInnerBlock, randomString, lastBlock, enterNextBlock } from './utils'
+import { modKey, createRandomPage, newInnerBlock, randomString, lastBlock, enterNextBlock } from './utils'
 import { searchPage, closeSearchBox } from './util/search-modal'
 
 /***

--- a/e2e-tests/utils.ts
+++ b/e2e-tests/utils.ts
@@ -1,6 +1,7 @@
 import { Page, Locator } from 'playwright'
 import { expect, ConsoleMessage } from '@playwright/test'
 import * as pathlib from 'path'
+import { modKey } from './util/basic'
 
 // TODO: The file should be a facade of utils in the /util folder
 // No more additional functions should be added to this file
@@ -34,6 +35,9 @@ export async function lastBlock(page: Page): Promise<Locator> {
  * @param page The Playwright Page object.
  */
 export async function enterNextBlock(page: Page): Promise<Locator> {
+  // Move cursor to the end of the editor
+  await page.press('textarea >> nth=0', modKey + '+a') // select all
+  await page.press('textarea >> nth=0', 'ArrowRight')
   let blockCount = await page.locator('.page-blocks-inner .ls-block').count()
   await page.press('textarea >> nth=0', 'Enter')
   await page.waitForTimeout(10)
@@ -50,15 +54,6 @@ export async function newInnerBlock(page: Page): Promise<Locator> {
   await lastBlock(page)
   await page.press('textarea >> nth=0', 'Enter')
 
-  return page.locator('textarea >> nth=0')
-}
-
-// Deprecated by block.enterNext
-export async function newBlock(page: Page): Promise<Locator> {
-  let blockNumber = await page.locator('.page-blocks-inner .ls-block').count()
-  await lastBlock(page)
-  await page.press('textarea >> nth=0', 'Enter')
-  await page.waitForSelector(`.page-blocks-inner .ls-block >> nth=${blockNumber} >> textarea`, { state: 'visible' })
   return page.locator('textarea >> nth=0')
 }
 
@@ -173,8 +168,8 @@ export async function editFirstBlock(page: Page) {
 /**
  * Wait for a console message with a given prefix to appear, and return the full text of the message
  * Or reject after a timeout
- * 
- * @param page 
+ *
+ * @param page
  * @param prefix - the prefix to look for
  * @param timeout - the timeout in ms
  * @returns the full text of the console message

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -18,6 +18,7 @@
             [frontend.state :as state]
             [frontend.ui :as ui]
             [frontend.util :as util]
+            [frontend.modules.shortcut.core :as shortcut]
             [logseq.graph-parser.util :as gp-util]
             [logseq.graph-parser.util.block-ref :as block-ref]
             [frontend.util.url :as url-util]
@@ -83,6 +84,7 @@
               #(swap! *template-including-parent? not))])
 
 (rum/defcs block-template < rum/reactive
+  (shortcut/disable-all-shortcuts)
   (rum/local false ::edit?)
   (rum/local "" ::input)
   {:will-unmount (fn [state]
@@ -389,7 +391,8 @@
                           (and block-id (parse-uuid block-id))
                           (let [block (.closest target ".ls-block")]
                             (when block
-                              (util/select-highlight! [block]))
+                              (state/clear-selection!)
+                              (state/conj-selection-block! block :down))
                             (common-handler/show-custom-context-menu!
                              e
                              (block-context-menu-content target (uuid block-id))))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -205,8 +205,7 @@
 
 (defn clear-selection!
   []
-  (state/clear-selection!)
-  (util/select-unhighlight! (dom/by-class "selected")))
+  (state/clear-selection!))
 
 (defn- text-range-by-lst-fst-line [content [direction pos]]
   (case direction

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -973,6 +973,7 @@ Similar to re-frame subscriptions"
 
 (defn clear-selection!
   []
+  (util/clear-selection!)
   (swap! state assoc
          :selection/mode false
          :selection/blocks nil

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1116,18 +1116,6 @@
 (defn keyname [key] (str (namespace key) "/" (name key)))
 
 #?(:cljs
-   (defn select-highlight!
-     [blocks]
-     (doseq [block blocks]
-       (d/add-class! block "selected noselect"))))
-
-#?(:cljs
-   (defn select-unhighlight!
-     [blocks]
-     (doseq [block blocks]
-       (d/remove-class! block "selected" "noselect"))))
-
-#?(:cljs
    (defn drain-chan
      "drop all stuffs in CH, and return all of them"
      [ch]


### PR DESCRIPTION
This PR will select the current block only when the context menu for this specific block has been opened.
It also disables the global shortcuts to prevent any further operations on selected blocks.

Before:
https://www.loom.com/share/2fa708a32c284ae5948083efd99ae7b1

After:
https://www.loom.com/share/0b4dd4be985a46ae91f3760b3ea28445