### PR TITLE
fix: undo cycle todos

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -737,10 +737,11 @@
     (let [ids (->> (distinct (map #(when-let [id (dom/attr % "blockid")]
                                      (uuid id)) blocks))
                    (remove nil?))]
-      (doseq [id ids]
-        (let [block (db/pull [:block/uuid id])]
-          (when (not-empty (:block/content block))
-            (set-marker block)))))))
+      (outliner-tx/transact! {:outliner-op :cycle-todos}
+        (doseq [id ids]
+          (let [block (db/pull [:block/uuid id])]
+            (when (not-empty (:block/content block))
+              (set-marker block))))))))
 
 (defn cycle-todo!
   []


### PR DESCRIPTION
Previously, undo cycle todos needed multiple steps.

Before:
https://www.loom.com/share/5513dde568d74d3f9bb5c4d0138dfd71

After:
https://www.loom.com/share/c51a82b549294084a3e72529995e03c8