### PR TITLE
Enhance: Add page column for query tables with block results

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -3263,7 +3263,10 @@
                 [:div.flex.flex-row.items-center.fade-in
                  (when (> (count result) 0)
                    [:span.results-count
-                    (str (count result) (if (> (count result) 1) " results" " result"))])
+                    (let [result-count (if (and (not table?) (map? result))
+                                         (apply + (map (comp count val) result))
+                                         (count result))]
+                      (str result-count (if (> result-count 1) " results" " result")))])
 
                  (when (and current-block (not view-f) (nil? table-view?) (not page-list?))
                    (if table?


### PR DESCRIPTION
This PR adds a :page column for block results as asked for at https://discuss.logseq.com/t/add-pagename-field-to-the-list-of-table-fields-in-simple-query/15176/2 and https://discuss.logseq.com/t/query-table-view-display-the-page-title-when-block-result-is-a-page-property-block/4716. To QA try the test example. This PR also fixes a query result count in the list view per steps in #8586