### PR TITLE
fix(editor): avoid nav to block with empty uuid

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1676,7 +1676,7 @@
         (util/stop e))
 
     :else
-    (route-handler/redirect-to-page! uuid)))
+    (when uuid (route-handler/redirect-to-page! uuid))))
 
 (rum/defc block-children < rum/reactive
   [config block children collapsed?]


### PR DESCRIPTION
This is a temporary fix. To avoid showing empty block content, a fix in parser is required.

To reproduce:

1.  edit
<img width="199" alt="image" src="https://user-images.githubusercontent.com/72891/226846123-67af538d-214b-4981-be60-135b21194692.png">

2. render
<img width="379" alt="image" src="https://user-images.githubusercontent.com/72891/226846165-a4dcd1ec-828e-4c98-8015-1dc9ad8bb8f5.png">

3. Click a bullet with empty content, the router will nav to a blank page