### PR TITLE
Fix (Whiteboards): Shape index and arrow binding issue

### DIFF
--- a/e2e-tests/whiteboards.spec.ts
+++ b/e2e-tests/whiteboards.spec.ts
@@ -16,8 +16,9 @@ test('enable whiteboards', async ({ page }) => {
 })
 
 test('should display onboarding tour', async ({ page }) => {
+  // ensure onboarding tour is going to be triggered locally
+  await page.evaluate(`window.localStorage.removeItem('whiteboard-onboarding-tour?')`)
   await page.click('.nav-header .whiteboard')
-  await page.waitForTimeout(1000)
 
   await expect(page.locator('.cp__whiteboard-welcome')).toBeVisible()
   await page.click('.cp__whiteboard-welcome button.bg-gray-600')
@@ -138,8 +139,44 @@ test('connect rectangles with an arrow', async ({ page }) => {
   await page.mouse.up()
   await page.keyboard.press('Escape')
 
-
   await expect(page.locator('.logseq-tldraw .tl-line-container')).toHaveCount(1)
+})
+
+test('delete the first rectangle', async ({ page }) => {
+  await page.click('.logseq-tldraw .tl-box-container:first-of-type')
+  await page.keyboard.press('Delete')
+
+  await expect(page.locator('.logseq-tldraw .tl-box-container')).toHaveCount(1)
+  await expect(page.locator('.logseq-tldraw .tl-line-container')).toHaveCount(0)
+})
+
+test('undo the delete action', async ({ page }) => {
+  await page.keyboard.press(modKey + '+z')
+
+  await expect(page.locator('.logseq-tldraw .tl-box-container')).toHaveCount(2)
+  await expect(page.locator('.logseq-tldraw .tl-line-container')).toHaveCount(1)
+})
+
+test('move arrow to back', async ({ page }) => {
+  await page.click('.logseq-tldraw .tl-line-container')
+  await page.keyboard.press('Shift+[')
+
+  await expect(page.locator('.logseq-tldraw .tl-canvas .tl-layer > div:first-of-type > div:first-of-type')).toHaveClass('tl-line-container')
+})
+
+test('move arrow to front', async ({ page }) => {
+  await page.click('.logseq-tldraw .tl-canvas')
+  await page.waitForTimeout(1000)
+  await page.click('.logseq-tldraw .tl-line-container')
+  await page.keyboard.press('Shift+]')
+
+  await expect(page.locator('.logseq-tldraw .tl-canvas .tl-layer > div:first-of-type > div:first-of-type')).not.toHaveClass('tl-line-container')
+})
+
+test('undo the move action', async ({ page }) => {
+  await page.keyboard.press(modKey + '+z')
+
+  await expect(page.locator('.logseq-tldraw .tl-canvas .tl-layer > div:first-of-type > div:first-of-type')).toHaveClass('tl-line-container')
 })
 
 test('cleanup the shapes', async ({ page }) => {

--- a/e2e-tests/whiteboards.spec.ts
+++ b/e2e-tests/whiteboards.spec.ts
@@ -143,6 +143,8 @@ test('connect rectangles with an arrow', async ({ page }) => {
 })
 
 test('delete the first rectangle', async ({ page }) => {
+  await page.click('.logseq-tldraw .tl-canvas')
+  await page.waitForTimeout(1000)
   await page.click('.logseq-tldraw .tl-box-container:first-of-type')
   await page.keyboard.press('Delete')
 
@@ -158,6 +160,8 @@ test('undo the delete action', async ({ page }) => {
 })
 
 test('move arrow to back', async ({ page }) => {
+  await page.click('.logseq-tldraw .tl-canvas')
+  await page.waitForTimeout(1000)
   await page.click('.logseq-tldraw .tl-line-container')
   await page.keyboard.press('Shift+[')
 

--- a/e2e-tests/whiteboards.spec.ts
+++ b/e2e-tests/whiteboards.spec.ts
@@ -143,7 +143,7 @@ test('connect rectangles with an arrow', async ({ page }) => {
 })
 
 test('delete the first rectangle', async ({ page }) => {
-  await page.click('.logseq-tldraw .tl-canvas')
+  await page.keyboard.press('Escape')
   await page.waitForTimeout(1000)
   await page.click('.logseq-tldraw .tl-box-container:first-of-type')
   await page.keyboard.press('Delete')
@@ -160,7 +160,7 @@ test('undo the delete action', async ({ page }) => {
 })
 
 test('move arrow to back', async ({ page }) => {
-  await page.click('.logseq-tldraw .tl-canvas')
+  await page.keyboard.press('Escape')
   await page.waitForTimeout(1000)
   await page.click('.logseq-tldraw .tl-line-container')
   await page.keyboard.press('Shift+[')
@@ -169,7 +169,7 @@ test('move arrow to back', async ({ page }) => {
 })
 
 test('move arrow to front', async ({ page }) => {
-  await page.click('.logseq-tldraw .tl-canvas')
+  await page.keyboard.press('Escape')
   await page.waitForTimeout(1000)
   await page.click('.logseq-tldraw .tl-line-container')
   await page.keyboard.press('Shift+]')

--- a/src/main/frontend/components/whiteboard.css
+++ b/src/main/frontend/components/whiteboard.css
@@ -165,7 +165,7 @@ input.tl-text-input {
     width: calc(100% - 20px);
 
     > .title {
-      @apply whitespace-nowrap min-w-[80px];
+      @apply whitespace-nowrap min-w-[100px];
     }
   }
 

--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -134,13 +134,13 @@
 (defn transact-tldr-delta! [page-name ^js app replace?]
   (let [tl-page ^js (second (first (.-pages app)))
         shapes (.-shapes ^js tl-page)
-        page (db/entity [:block/name page-name])
-        db-page-nonoce (get-in page [:block/properties :logseq.tldraw.page :nonce])
+        shapes-index (map #(gobj/get % "id") shapes)
         new-id-nonces (set (map (fn [shape]
-                                  {:id (.-id shape)
-                                   :nonce (if (= (gobj/get tl-page "nonce") db-page-nonoce) 
-                                            (.-nonce shape)
-                                            (.getTime (js/Date.)))}) shapes))
+                                  (let [id (.-id shape)]
+                                   {:id id
+                                    :nonce (if (= shape.id (.indexOf shapes-index id))
+                                             (.-nonce shape)
+                                             (.getTime (js/Date.)))})) shapes))
         repo (state/get-current-repo)
         db-id-nonces (or
                       (get-in @*last-shapes-nonce [repo page-name])
@@ -161,7 +161,7 @@
 
                     ;; arrow
                     (some #(and (= "line" (:type %))
-                                (= "arrow "(:end (:decorations %)))) new-shapes)
+                                (= "arrow " (:end (:decorations %)))) new-shapes)
 
                     (assoc metadata :whiteboard/op :new-arrow)
                     :else

--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -92,7 +92,8 @@
         upsert-shapes (->> (set/difference new-id-nonces db-id-nonces)
                            (map (fn [{:keys [id]}]
                                   (-> (.-serialized ^js (.getShapeById tl-page id))
-                                      js->clj-keywordize)))
+                                      js->clj-keywordize
+                                      (assoc :index (.indexOf shapes-index id)))))
                            (set))
         old-ids (set (map :id db-id-nonces))
         new-ids (set (map :id new-id-nonces))
@@ -133,9 +134,13 @@
 (defn transact-tldr-delta! [page-name ^js app replace?]
   (let [tl-page ^js (second (first (.-pages app)))
         shapes (.-shapes ^js tl-page)
+        page (db/entity [:block/name page-name])
+        db-page-nonoce (get-in page [:block/properties :logseq.tldraw.page :nonce])
         new-id-nonces (set (map (fn [shape]
                                   {:id (.-id shape)
-                                   :nonce (.-nonce shape)}) shapes))
+                                   :nonce (if (= (gobj/get tl-page "nonce") db-page-nonoce) 
+                                            (.-nonce shape)
+                                            (.getTime (js/Date.)))}) shapes))
         repo (state/get-current-repo)
         db-id-nonces (or
                       (get-in @*last-shapes-nonce [repo page-name])
@@ -358,15 +363,25 @@
       (when (seq bindings)
         (.updateBindings tl-page (bean/->js bindings))))))
 
+(defn update-shapes-index!
+  [^js tl-page page-name]
+  (when-let [page (db/entity [:block/name page-name])]
+    (let [shapes-index (get-in page [:block/properties :logseq.tldraw.page :shapes-index!])]
+      (when (seq shapes-index)
+        (.updateShapesIndex tl-page (bean/->js shapes-index))))))
+
 (defn undo!
   [{:keys [tx-meta]}]
   (history/pause-listener!)
   (try
     (when-let [app (state/active-tldraw-app)]
-      (let [{:keys [deleted-shapes new-shapes changed-shapes prev-changed-blocks]} (:data tx-meta)
+      (let [{:keys [page-name deleted-shapes new-shapes changed-shapes prev-changed-blocks]} (:data tx-meta)
             whiteboard-op (:whiteboard/op tx-meta)
-            ^js api (.-api app)]
+            ^js api (.-api app)
+            tl-page ^js (second (first (.-pages app)))]
         (when api
+          (update-bindings! tl-page page-name)
+          (update-shapes-index! tl-page page-name)
           (case whiteboard-op
             :group
             (do
@@ -383,7 +398,7 @@
                 (delete-shapes! api new-shapes))
               (when (seq changed-shapes)
                 (let [prev-shapes (map (fn [b] (get-in b [:block/properties :logseq.tldraw.shape]))
-                                    prev-changed-blocks)]
+                                       prev-changed-blocks)]
                   (update-shapes! api prev-shapes))))))))
     (catch :default e
       (js/console.error e)))
@@ -400,6 +415,7 @@
             tl-page ^js (second (first (.-pages app)))]
         (when api
           (update-bindings! tl-page page-name)
+          (update-shapes-index! tl-page page-name)
           (case whiteboard-op
             :group
             (do

--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -366,7 +366,7 @@
 (defn update-shapes-index!
   [^js tl-page page-name]
   (when-let [page (db/entity [:block/name page-name])]
-    (let [shapes-index (get-in page [:block/properties :logseq.tldraw.page :shapes-index!])]
+    (let [shapes-index (get-in page [:block/properties :logseq.tldraw.page :shapes-index])]
       (when (seq shapes-index)
         (.updateShapesIndex tl-page (bean/->js shapes-index))))))
 

--- a/tldraw/packages/core/src/lib/TLHistory.ts
+++ b/tldraw/packages/core/src/lib/TLHistory.ts
@@ -32,7 +32,6 @@ export class TLHistory<S extends TLShape = TLShape, K extends TLEventMap = TLEve
 
   @action persist = (replace = false) => {
     if (this.isPaused || this.creating) return
-    this.app.pages.forEach(page => page.bump()) // Is it ok here?
     this.app.notify('persist', {replace})
   }
 

--- a/tldraw/packages/core/src/lib/TLPage/TLPage.ts
+++ b/tldraw/packages/core/src/lib/TLPage/TLPage.ts
@@ -176,7 +176,6 @@ export class TLPage<S extends TLShape = TLShape, E extends TLEventMap = TLEventM
   @action sendToBack = (shapes: S[] | string[]): this => {
     const shapesToMove = this.parseShapesArg(shapes)
     this.shapes = shapesToMove.concat(this.shapes.filter(shape => !shapesToMove.includes(shape)))
-
     this.app.persist()
     return this
   }

--- a/tldraw/packages/core/src/lib/TLPage/TLPage.ts
+++ b/tldraw/packages/core/src/lib/TLPage/TLPage.ts
@@ -106,7 +106,7 @@ export class TLPage<S extends TLShape = TLShape, E extends TLEventMap = TLEventM
   }
 
   @action updateShapesIndex(shapesIndex: string[]) {
-    this.shapes.sort((a,b) => shapesIndex.indexOf(b.id) - shapesIndex.indexOf(a.id))
+    this.shapes.sort((a,b) => shapesIndex.indexOf(a.id) - shapesIndex.indexOf(b.id))
     return this
   }
 

--- a/tldraw/packages/core/src/lib/TLPage/TLPage.ts
+++ b/tldraw/packages/core/src/lib/TLPage/TLPage.ts
@@ -92,7 +92,7 @@ export class TLPage<S extends TLShape = TLShape, E extends TLEventMap = TLEventM
   @observable nonce = 0
 
   @action bump = () => {
-    // this.nonce++
+    this.nonce++
   }
 
   @action update(props: Partial<TLPageProps<S>>) {
@@ -102,6 +102,11 @@ export class TLPage<S extends TLShape = TLShape, E extends TLEventMap = TLEventM
 
   @action updateBindings(bindings: Record<string, TLBinding>) {
     Object.assign(this.bindings, bindings)
+    return this
+  }
+
+  @action updateShapesIndex(shapesIndex: string[]) {
+    this.shapes.sort((a,b) => shapesIndex.indexOf(b.id) - shapesIndex.indexOf(a.id))
     return this
   }
 
@@ -115,7 +120,6 @@ export class TLPage<S extends TLShape = TLShape, E extends TLEventMap = TLEventM
             return new ShapeClass(shape)
           })
     this.shapes.push(...shapeInstances)
-    this.bump()
     return shapeInstances
   }
 
@@ -145,6 +149,7 @@ export class TLPage<S extends TLShape = TLShape, E extends TLEventMap = TLEventM
         this.shapes[index] = this.shapes[index + 1]
         this.shapes[index + 1] = t
       })
+    this.bump()
     this.app.persist()
     return this
   }
@@ -162,6 +167,7 @@ export class TLPage<S extends TLShape = TLShape, E extends TLEventMap = TLEventM
         this.shapes[index] = this.shapes[index - 1]
         this.shapes[index - 1] = t
       })
+    this.bump()
     this.app.persist()
     return this
   }
@@ -169,6 +175,7 @@ export class TLPage<S extends TLShape = TLShape, E extends TLEventMap = TLEventM
   @action bringToFront = (shapes: S[] | string[]): this => {
     const shapesToMove = this.parseShapesArg(shapes)
     this.shapes = this.shapes.filter(shape => !shapesToMove.includes(shape)).concat(shapesToMove)
+    this.bump()
     this.app.persist()
     return this
   }
@@ -176,6 +183,7 @@ export class TLPage<S extends TLShape = TLShape, E extends TLEventMap = TLEventM
   @action sendToBack = (shapes: S[] | string[]): this => {
     const shapesToMove = this.parseShapesArg(shapes)
     this.shapes = shapesToMove.concat(this.shapes.filter(shape => !shapesToMove.includes(shape)))
+    this.bump()
     this.app.persist()
     return this
   }

--- a/tldraw/packages/core/src/lib/TLPage/TLPage.ts
+++ b/tldraw/packages/core/src/lib/TLPage/TLPage.ts
@@ -91,10 +91,6 @@ export class TLPage<S extends TLShape = TLShape, E extends TLEventMap = TLEventM
 
   @observable nonce = 0
 
-  @action bump = () => {
-    this.nonce++
-  }
-
   @action update(props: Partial<TLPageProps<S>>) {
     Object.assign(this, props)
     return this
@@ -149,7 +145,6 @@ export class TLPage<S extends TLShape = TLShape, E extends TLEventMap = TLEventM
         this.shapes[index] = this.shapes[index + 1]
         this.shapes[index + 1] = t
       })
-    this.bump()
     this.app.persist()
     return this
   }
@@ -167,7 +162,6 @@ export class TLPage<S extends TLShape = TLShape, E extends TLEventMap = TLEventM
         this.shapes[index] = this.shapes[index - 1]
         this.shapes[index - 1] = t
       })
-    this.bump()
     this.app.persist()
     return this
   }
@@ -175,7 +169,6 @@ export class TLPage<S extends TLShape = TLShape, E extends TLEventMap = TLEventM
   @action bringToFront = (shapes: S[] | string[]): this => {
     const shapesToMove = this.parseShapesArg(shapes)
     this.shapes = this.shapes.filter(shape => !shapesToMove.includes(shape)).concat(shapesToMove)
-    this.bump()
     this.app.persist()
     return this
   }
@@ -183,7 +176,7 @@ export class TLPage<S extends TLShape = TLShape, E extends TLEventMap = TLEventM
   @action sendToBack = (shapes: S[] | string[]): this => {
     const shapesToMove = this.parseShapesArg(shapes)
     this.shapes = shapesToMove.concat(this.shapes.filter(shape => !shapesToMove.includes(shape)))
-    this.bump()
+
     this.app.persist()
     return this
   }


### PR DESCRIPTION
- Fixed persisting and undoing shape index changes. To reproduce the issue, place shapes on top of each other and click `[` or `]` to change their order. After changing their original order, navigate to a different page or undo the action. You will see that the index changes are not persisted, and cannot be undone. Reintroduced the index property of shapes to fix persist. If the current index is different from the shape index, we update its nonce. Also added `update-shapes-index` to update the order on undo/redo. I removed `bump` from page, since it doesn't do anything anymore.
- Fixed an issue with arrow bindings and undo/redo, To reproduce this, create two shapes, connect them with an arrow, delete one of them, undo the delete action and move the previously deleted shape. The arrow should follow the shape.
- Fixed a minor overflow issue on references modal (see https://discord.com/channels/725182569297215569/1056543757065003048/1088117614070480928)