### PR TITLE
Fix (Whiteboards): An attempt to fix most of the remaining issues

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2543,11 +2543,9 @@
                               level-limit 3}
                          :as opts}]
   (when block-id
-    (js/console.log block-id)
     (let [parents (db/get-block-parents repo block-id (inc level-limit))
           page (or (db/get-block-page repo block-id) ;; only return for block uuid
                    (model/query-block-by-uuid block-id)) ;; return page entity when received page uuid
-          _ (js/console.log (str page))
           page-name (:block/name page)
           page-original-name (:block/original-name page)
           show? (or (seq parents) show-page? page-name)

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2570,13 +2570,14 @@
                                                                    content)
                                        config (assoc config :block/uuid uuid)]
                                    [block
-                                    (if (seq title)
-                                      (->elem :span (map-inline config title))
-                                      (->elem :div (markup-elements-cp config body)))]))))
+                                    (when title
+                                      (if (seq title)
+                                        (->elem :span (map-inline config title))
+                                        (->elem :div (markup-elements-cp config body))))]))))
               breadcrumb (->> (into [] parents-props)
                               (concat [page-name-props] (when more? [:more]))
                               (filterv identity)
-                              (map (fn [x] (if (vector? x)
+                              (map (fn [x] (if (and (vector? x) (second x))
                                              (let [[block label] x]
                                                (rum/with-key (breadcrumb-fragment config block label opts) (:block/uuid block)))
                                              [:span.opacity-70 "⋯"])))

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2505,7 +2505,7 @@
 
 (rum/defc breadcrumb-fragment
   [config block label opts]
-  [:a {:on-mouse-down
+  [:a {:on-mouse-up
        (fn [e]
          (cond
            (gobj/get e "shiftKey")
@@ -2543,9 +2543,11 @@
                               level-limit 3}
                          :as opts}]
   (when block-id
+    (js/console.log block-id)
     (let [parents (db/get-block-parents repo block-id (inc level-limit))
           page (or (db/get-block-page repo block-id) ;; only return for block uuid
                    (model/query-block-by-uuid block-id)) ;; return page entity when received page uuid
+          _ (js/console.log (str page))
           page-name (:block/name page)
           page-original-name (:block/original-name page)
           show? (or (seq parents) show-page? page-name)

--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -29,7 +29,8 @@
 (defn shape->block [shape page-name]
   (let [properties {:ls-type :whiteboard-shape
                     :logseq.tldraw.shape shape}
-        block {:block/page {:block/name (util/page-name-sanity-lc page-name)}
+        block {:block/page {:block/name (util/page-name-sanity-lc page-name)
+                            :block/original-name page-name}
                :block/parent {:block/name page-name}
                :block/properties properties}
         additional-props (gp-whiteboard/with-whiteboard-block-props block page-name)]
@@ -285,7 +286,8 @@
             :block/uuid uuid
             :block/content (or content "")
             :block/format :markdown ;; fixme to support org?
-            :block/page {:block/name (util/page-name-sanity-lc page-name)}
+            :block/page {:block/name (util/page-name-sanity-lc page-name)
+                         :block/original-name page-name}
             :block/parent {:block/name page-name}}]
     (db-utils/transact! [tx])
     uuid))

--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -29,8 +29,7 @@
 (defn shape->block [shape page-name]
   (let [properties {:ls-type :whiteboard-shape
                     :logseq.tldraw.shape shape}
-        block {:block/page {:block/name (util/page-name-sanity-lc page-name)
-                            :block/original-name page-name}
+        block {:block/page {:block/name (util/page-name-sanity-lc page-name)}
                :block/parent {:block/name page-name}
                :block/properties properties}
         additional-props (gp-whiteboard/with-whiteboard-block-props block page-name)]

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -973,7 +973,6 @@ Similar to re-frame subscriptions"
 
 (defn clear-selection!
   []
-  (util/clear-selection!)
   (swap! state assoc
          :selection/mode false
          :selection/blocks nil

--- a/tldraw/apps/tldraw-logseq/src/lib/preview-manager.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/preview-manager.tsx
@@ -24,7 +24,7 @@ export class PreviewManager {
   }
 
   load(snapshot: TLDocumentModel) {
-    const page = snapshot.pages[0]
+    const page = snapshot?.pages?.[0]
     this.pageId = page?.id
     this.assets = snapshot.assets
     this.shapes = page?.shapes

--- a/tldraw/apps/tldraw-logseq/src/styles.css
+++ b/tldraw/apps/tldraw-logseq/src/styles.css
@@ -174,9 +174,6 @@ html[data-theme='light'] {
   align-items: stretch;
   box-shadow: var(--shadow-medium);
   z-index: 1000;
-  max-width: 90vw;
-  max-height: 90vh;
-  overflow: auto;
 }
 
 .tl-context-bar {
@@ -296,6 +293,8 @@ html[data-theme='light'] {
 }
 
 .tl-tools-floating-panel {
+  max-height: 90vh;
+  overflow-y: auto;
   flex-flow: column;
 }
 

--- a/tldraw/apps/tldraw-logseq/src/styles.css
+++ b/tldraw/apps/tldraw-logseq/src/styles.css
@@ -171,10 +171,12 @@ html[data-theme='light'] {
   border-radius: 8px;
   white-space: nowrap;
   gap: 8px;
-
   align-items: stretch;
   box-shadow: var(--shadow-medium);
   z-index: 1000;
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow: auto;
 }
 
 .tl-context-bar {
@@ -289,6 +291,7 @@ html[data-theme='light'] {
 
   .tl-button {
     font-size: 16px;
+    flex: 0 0 auto;
   }
 }
 


### PR DESCRIPTION
- Check if snapshot pages exist (resolves https://github.com/logseq/logseq/issues/8886)
- Fix breadcrumbs without label (resolves https://github.com/logseq/logseq/issues/7087 - not a whiteboards specific issue)
- Maintain original page name when we create a new page within a whiteboard (resolves https://github.com/logseq/logseq/issues/7811)
- Allow scrolling on tools (resolves https://github.com/logseq/logseq/issues/8364). This might not be the perfect solution, but it allows access to the tools that overflow the screen.
- This PR also reverts https://github.com/logseq/logseq/commit/cb2c1f1d6a466c821ae104ff445029e3dee0ef2e that seems to be causing focus issues on inputs. If you click to edit a page title and then click again somewhere in the middle of the input, the focus will be lost. Also, if you try to create a text element on whiteboards, you won't be able to type.