### PR TITLE
config: update default templete to correct format

### DIFF
--- a/templates/config.edn
+++ b/templates/config.edn
@@ -270,7 +270,7 @@
  ;; :property/separated-by-commas #{}
 
  ;; Properties that are ignored when parsing property values for references
- ;; :ignored-page-references-keywords #{"author" "startup"}
+ ;; :ignored-page-references-keywords #{:author :startup}
 
  ;; logbook setup
  ;; :logbook/settings


### PR DESCRIPTION
`:ignored-page-references-keywords` should use `#{:author :startup}`.