### PR TITLE
fix: internal blocks paste

### DIFF
--- a/e2e-tests/editor.spec.ts
+++ b/e2e-tests/editor.spec.ts
@@ -190,6 +190,7 @@ test('copy & paste block ref and replace its content', async ({ page, block }) =
 
   // Trigger replace-block-reference-with-content-at-point
   await page.keyboard.press(modKey + '+Shift+r')
+  await page.waitForTimeout(100)
 
   await expect(page.locator('textarea >> nth=0')).toHaveValue('Some random text')
   await block.escapeEditing()

--- a/e2e-tests/editor.spec.ts
+++ b/e2e-tests/editor.spec.ts
@@ -173,8 +173,9 @@ test('copy & paste block ref and replace its content', async ({ page, block }) =
 
   await page.press('textarea >> nth=0', 'Enter')
   await block.waitForBlocks(2)
-
+  await page.waitForTimeout(100)
   await page.keyboard.press(modKey + '+v')
+  await page.waitForTimeout(100)
   await page.keyboard.press('Enter')
 
   // Check if the newly created block-ref has the same referenced content

--- a/e2e-tests/editor.spec.ts
+++ b/e2e-tests/editor.spec.ts
@@ -188,11 +188,16 @@ test('copy & paste block ref and replace its content', async ({ page, block }) =
 
   await expect(page.locator('textarea >> nth=0')).not.toHaveValue('Some random text')
 
+  // FIXME: Sometimes the cursor is in the end of the editor
+  for (let i = 0; i < 4; i++) {
+    await page.press('textarea >> nth=0', 'ArrowLeft')
+  }
+
   // Trigger replace-block-reference-with-content-at-point
   await page.keyboard.press(modKey + '+Shift+r')
-  await page.waitForTimeout(100)
 
   await expect(page.locator('textarea >> nth=0')).toHaveValue('Some random text')
+
   await block.escapeEditing()
 
   await expect(page.locator('.block-ref >> text="Some random text"')).toHaveCount(0);

--- a/e2e-tests/editor.spec.ts
+++ b/e2e-tests/editor.spec.ts
@@ -168,8 +168,6 @@ test('copy & paste block ref and replace its content', async ({ page, block }) =
   await createRandomPage(page)
 
   await block.mustType('Some random text')
-  // FIXME: https://github.com/logseq/logseq/issues/7541
-  await page.waitForTimeout(1000)
 
   await page.keyboard.press(modKey + '+c')
 

--- a/e2e-tests/logseq-url.spec.ts
+++ b/e2e-tests/logseq-url.spec.ts
@@ -15,6 +15,9 @@ test("Logseq URLs (same graph)", async ({ page, block }) => {
   await createRandomPage(page)
   await block.mustFill("") // to enter editing mode
   await page.keyboard.press(paste_key)
+  // paste returns a promise which is async, so we need give it a little bit
+  // more time
+  await page.waitForTimeout(100)
   let cursor_locator = page.locator('textarea >> nth=0')
   expect(await cursor_locator.inputValue()).toContain("page=" + page_title)
   await cursor_locator.press("Enter")
@@ -32,6 +35,7 @@ test("Logseq URLs (same graph)", async ({ page, block }) => {
   await createRandomPage(page)
   await block.mustFill("") // to enter editing mode
   await page.keyboard.press(paste_key)
+  await page.waitForTimeout(100)
   cursor_locator = page.locator('textarea >> nth=0')
   expect(await cursor_locator.inputValue()).toContain("block-id=")
   await cursor_locator.press("Enter")

--- a/src/main/frontend/components/export.cljs
+++ b/src/main/frontend/components/export.cljs
@@ -207,5 +207,6 @@
      [:div.mt-4
       (ui/button (if @*copied? "Copied to clipboard!" "Copy to clipboard")
                  :on-click (fn []
-                             (util/copy-to-clipboard! @*content (when (= tp :html) @*content))
+                             (util/copy-to-clipboard! @*content
+                                                      :html (when (= tp :html) @*content))
                              (reset! *copied? true)))]]))

--- a/src/main/frontend/extensions/pdf/assets.cljs
+++ b/src/main/frontend/extensions/pdf/assets.cljs
@@ -213,8 +213,8 @@
   [highlight ^js viewer]
   (when-let [ref-block (ensure-ref-block! (state/get-current-pdf) highlight)]
     (util/copy-to-clipboard!
-     (block-ref/->block-ref (:block/uuid ref-block)) nil
-     (pdf-windows/resolve-own-window viewer))))
+     (block-ref/->block-ref (:block/uuid ref-block))
+     :owner-window (pdf-windows/resolve-own-window viewer))))
 
 (defn open-block-ref!
   [block]

--- a/src/main/frontend/extensions/pdf/core.cljs
+++ b/src/main/frontend/extensions/pdf/core.cljs
@@ -141,8 +141,8 @@
                             "copy"
                             (do
                               (util/copy-to-clipboard!
-                               (or (:text content) (pdf-utils/fix-selection-text-breakline (.toString selection))) nil
-                               (pdf-windows/resolve-own-window viewer))
+                               (or (:text content) (pdf-utils/fix-selection-text-breakline (.toString selection)))
+                               :owner-window (pdf-windows/resolve-own-window viewer))
                               (pdf-utils/clear-all-selection))
 
                             "link"

--- a/src/main/frontend/extensions/tldraw.cljs
+++ b/src/main/frontend/extensions/tldraw.cljs
@@ -94,7 +94,7 @@
    :isMobile util/mobile?
    :saveAsset save-asset-handler
    :makeAssetUrl editor-handler/make-asset-url
-   :copyToClipboard (fn [text, html] (util/copy-to-clipboard! text html))
+   :copyToClipboard (fn [text, html] (util/copy-to-clipboard! text :html html))
    :getRedirectPageName (fn [page-name-or-uuid] (model/get-redirect-page-name page-name-or-uuid))
    :insertFirstPageBlock (fn [page-name] (editor-handler/insert-first-page-block-if-not-exists! page-name {:redirect? false}))
    :addNewWhiteboard (fn [page-name]

--- a/src/main/frontend/handler/common.cljs
+++ b/src/main/frontend/handler/common.cljs
@@ -11,8 +11,10 @@
             ["ignore" :as Ignore]))
 
 (defn copy-to-clipboard-without-id-property!
-  [format raw-text html]
-  (util/copy-to-clipboard! (property/remove-id-property format raw-text) html))
+  [format raw-text html blocks]
+  (util/copy-to-clipboard! (property/remove-id-property format raw-text)
+                           :html html
+                           :blocks blocks))
 
 (defn config-with-document-mode
   [config]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1013,7 +1013,6 @@
         (let [html (export-html/export-blocks-as-html repo top-level-block-uuids nil)
               copied-blocks (get-all-blocks-by-ids repo top-level-block-uuids)]
           (common-handler/copy-to-clipboard-without-id-property! (:block/format block) content (when html? html) copied-blocks))
-        ;; (state/set-copied-blocks! content (get-all-blocks-by-ids repo top-level-block-uuids))
         (notification/show! "Copied!" :success)))))
 
 (defn copy-block-refs
@@ -1229,7 +1228,6 @@
           [_top-level-block-uuids md-content] (compose-copied-blocks-contents repo [block-id])
           html (export-html/export-blocks-as-html repo [block-id] nil)
           sorted-blocks (tree/get-sorted-block-and-children repo (:db/id block))]
-      ;; (state/set-copied-blocks! md-content sorted-blocks)
       (common-handler/copy-to-clipboard-without-id-property! (:block/format block) md-content html sorted-blocks)
       (delete-block-aux! block true))))
 

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -88,11 +88,11 @@
   (util/stop e)
   (p/let [clipboard-items (when (and js/window (gobj/get js/window "navigator") js/navigator.clipboard)
                             (js/navigator.clipboard.read))
-          blocks-blob ^js (try
-                            (.getType ^js (first clipboard-items)
-                                      "web application/logseq")
-                            (catch :default _e
-                                nil))
+          blocks-blob ^js (when clipboard-items
+                            (let [types (.-types ^js (first clipboard-items))]
+                              (when (contains? (set types) "web application/logseq")
+                                (.getType ^js (first clipboard-items)
+                                         "web application/logseq"))))
           blocks-str (when blocks-blob (.text blocks-blob))
           copied-blocks (when blocks-str
                           (gp-util/safe-read-string blocks-str))]

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -18,7 +18,8 @@
             [cljs.core.match :refer [match]]
             [frontend.util.text :as text-util]
             [frontend.format.mldoc :as mldoc]
-            [lambdaisland.glogi :as log]))
+            [lambdaisland.glogi :as log]
+            [promesa.core :as p]))
 
 (defn- paste-text-parseable
   [format text]
@@ -85,79 +86,78 @@
   ;; todo: logseq/whiteboard-shapes is now text/html
   [text e html]
   (util/stop e)
-  (let [copied-blocks (state/get-copied-blocks)
-        input (state/get-input)
-        input-id (state/get-edit-input-id)
-        text (string/replace text "\r\n" "\n") ;; Fix for Windows platform
-        replace-text-f (fn [text]
-                         (commands/delete-selection! input-id)
-                         (commands/simple-insert! input-id text nil))
-        internal-paste? (and
-                         (seq (:copy/blocks copied-blocks))
-                         ;; not copied from the external clipboard
-                         (= (string/trimr text)
-                            (string/trimr (:copy/content copied-blocks))))]
-    (if internal-paste?
-      (let [blocks (:copy/blocks copied-blocks)]
-        (when (seq blocks)
-          (editor-handler/paste-blocks blocks {})))
-      (let [shape-refs-text (when (and (not (string/blank? html))
-                                       (get-whiteboard-tldr-from-text html))
-                              ;; text should always be prepared block-ref generated in tldr
-                              text)
-            {:keys [value selection] :as selection-and-format} (editor-handler/get-selection-and-format)
-            text-url? (gp-util/url? text)
-            selection-url? (gp-util/url? selection)]
-        (cond
-          (not (string/blank? shape-refs-text))
-          (commands/simple-insert! input-id shape-refs-text nil)
+  (p/let [clipboard-items (js/navigator.clipboard.read)
+          blocks-blob ^js (.getType ^js (first clipboard-items)
+                                    "web application/logseq")
+          blocks-str (when blocks-blob (.text blocks-blob))
+          copied-blocks (when blocks-str
+                          (gp-util/safe-read-string blocks-str))]
+    (let [input (state/get-input)
+          input-id (state/get-edit-input-id)
+          text (string/replace text "\r\n" "\n") ;; Fix for Windows platform
+          replace-text-f (fn [text]
+                           (commands/delete-selection! input-id)
+                           (commands/simple-insert! input-id text nil))
+          internal-paste? (seq copied-blocks)]
+      (if internal-paste?
+        (editor-handler/paste-blocks copied-blocks {})
+        (let [shape-refs-text (when (and (not (string/blank? html))
+                                         (get-whiteboard-tldr-from-text html))
+                                ;; text should always be prepared block-ref generated in tldr
+                                text)
+              {:keys [value selection] :as selection-and-format} (editor-handler/get-selection-and-format)
+              text-url? (gp-util/url? text)
+              selection-url? (gp-util/url? selection)]
+          (cond
+            (not (string/blank? shape-refs-text))
+            (commands/simple-insert! input-id shape-refs-text nil)
 
-          (or (and (or text-url? selection-url?)
-                   (selection-within-link? selection-and-format))
-              (and text-url? selection-url?))
-          (replace-text-f text)
+            (or (and (or text-url? selection-url?)
+                     (selection-within-link? selection-and-format))
+                (and text-url? selection-url?))
+            (replace-text-f text)
 
-          (and (or text-url?
-                   (and value (gp-util/url? (string/trim value))))
-               (not (string/blank? (util/get-selected-text))))
-          (editor-handler/html-link-format! text)
+            (and (or text-url?
+                     (and value (gp-util/url? (string/trim value))))
+                 (not (string/blank? (util/get-selected-text))))
+            (editor-handler/html-link-format! text)
 
-          (and (block-ref/block-ref? text)
-               (editor-handler/wrapped-by? input block-ref/left-parens block-ref/right-parens))
-          (commands/simple-insert! input-id (block-ref/get-block-ref-id text) nil)
+            (and (block-ref/block-ref? text)
+                 (editor-handler/wrapped-by? input block-ref/left-parens block-ref/right-parens))
+            (commands/simple-insert! input-id (block-ref/get-block-ref-id text) nil)
 
-          :else
-          ;; from external
-          (let [format (or (db/get-page-format (state/get-current-page)) :markdown)
-                html-text (let [result (when-not (string/blank? html)
-                                         (try
-                                           (html-parser/convert format html)
-                                           (catch :default e
-                                             (log/error :exception e)
-                                             nil)))]
-                            (if (string/blank? result) nil result))
-                text (or html-text text)]
-            (match [format
-                    (nil? (util/safe-re-find #"(?m)^\s*(?:[-+*]|#+)\s+" text))
-                    (nil? (util/safe-re-find #"(?m)^\s*\*+\s+" text))
-                    (nil? (util/safe-re-find #"(?:\r?\n){2,}" text))]
-              [:markdown false _ _]
-              (paste-text-parseable format text)
+            :else
+            ;; from external
+            (let [format (or (db/get-page-format (state/get-current-page)) :markdown)
+                  html-text (let [result (when-not (string/blank? html)
+                                           (try
+                                             (html-parser/convert format html)
+                                             (catch :default e
+                                               (log/error :exception e)
+                                               nil)))]
+                              (if (string/blank? result) nil result))
+                  text (or html-text text)]
+              (match [format
+                      (nil? (util/safe-re-find #"(?m)^\s*(?:[-+*]|#+)\s+" text))
+                      (nil? (util/safe-re-find #"(?m)^\s*\*+\s+" text))
+                      (nil? (util/safe-re-find #"(?:\r?\n){2,}" text))]
+                [:markdown false _ _]
+                (paste-text-parseable format text)
 
-              [:org _ false _]
-              (paste-text-parseable format text)
+                [:org _ false _]
+                (paste-text-parseable format text)
 
-              [:markdown true _ false]
-              (paste-segmented-text format text)
+                [:markdown true _ false]
+                (paste-segmented-text format text)
 
-              [:markdown true _ true]
-              (replace-text-f text)
+                [:markdown true _ true]
+                (replace-text-f text)
 
-              [:org _ true false]
-              (paste-segmented-text format text)
+                [:org _ true false]
+                (paste-segmented-text format text)
 
-              [:org _ true true]
-              (replace-text-f text))))))))
+                [:org _ true true]
+                (replace-text-f text)))))))))
 
 (defn paste-text-in-one-block-at-point
   []

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -86,9 +86,13 @@
   ;; todo: logseq/whiteboard-shapes is now text/html
   [text e html]
   (util/stop e)
-  (p/let [clipboard-items (js/navigator.clipboard.read)
-          blocks-blob ^js (.getType ^js (first clipboard-items)
-                                    "web application/logseq")
+  (p/let [clipboard-items (when (and js/window (gobj/get js/window "navigator") js/navigator.clipboard)
+                            (js/navigator.clipboard.read))
+          blocks-blob ^js (try
+                            (.getType ^js (first clipboard-items)
+                                      "web application/logseq")
+                            (catch :default _e
+                                nil))
           blocks-str (when blocks-blob (.text blocks-blob))
           copied-blocks (when blocks-str
                           (gp-util/safe-read-string blocks-str))]

--- a/src/main/frontend/modules/outliner/core.cljs
+++ b/src/main/frontend/modules/outliner/core.cljs
@@ -13,8 +13,7 @@
             [frontend.state :as state]
             [frontend.util :as util]
             [logseq.graph-parser.util :as gp-util]
-            [cljs.spec.alpha :as s]
-            [frontend.config :as config]))
+            [cljs.spec.alpha :as s]))
 
 (s/def ::block-map (s/keys :req [:db/id]
                            :opt [:block/page :block/left :block/parent]))
@@ -558,7 +557,7 @@
                         [{:block/uuid (tree/-get-id next)
                           :block/left (:db/id left)}]))
             full-tx (util/concat-without-nil uuids-tx tx next-tx)]
-        (when (and replace-empty-target? (not config/test?) (state/editing?))
+        (when (and replace-empty-target? (state/editing?))
           (state/set-edit-content! (state/get-edit-input-id) (:block/content (first blocks))))
         {:tx-data full-tx
          :blocks tx}))))

--- a/src/main/frontend/modules/outliner/core.cljs
+++ b/src/main/frontend/modules/outliner/core.cljs
@@ -13,7 +13,8 @@
             [frontend.state :as state]
             [frontend.util :as util]
             [logseq.graph-parser.util :as gp-util]
-            [cljs.spec.alpha :as s]))
+            [cljs.spec.alpha :as s]
+            [frontend.config :as config]))
 
 (s/def ::block-map (s/keys :req [:db/id]
                            :opt [:block/page :block/left :block/parent]))
@@ -557,7 +558,7 @@
                         [{:block/uuid (tree/-get-id next)
                           :block/left (:db/id left)}]))
             full-tx (util/concat-without-nil uuids-tx tx next-tx)]
-        (when (and replace-empty-target? (state/editing?))
+        (when (and replace-empty-target? (not config/test?) (state/editing?))
           (state/set-edit-content! (state/get-edit-input-id) (:block/content (first blocks))))
         {:tx-data full-tx
          :blocks tx}))))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -217,11 +217,6 @@
      ;; graph -> state
      :graph/parsing-state                   {}
 
-     ;; copied blocks
-     :copy/blocks                           {:copy/content nil
-                                             :copy/graph nil
-                                             :copy/blocks nil}
-
      :copy/export-block-text-indent-style   (or (storage/get :copy/export-block-text-indent-style)
                                                 "dashes")
      :copy/export-block-text-remove-options (or (storage/get :copy/export-block-text-remove-options)
@@ -753,7 +748,7 @@ Similar to re-frame subscriptions"
   "Returns the current repo URL, or else open demo graph"
   []
   (or (:git/current-repo @state)
-      "local")) 
+      "local"))
 
 (defn get-remote-graphs
   []
@@ -1710,16 +1705,6 @@ Similar to re-frame subscriptions"
   [payload]
   (let [chan (get-events-chan)]
     (async/put! chan payload)))
-
-(defn get-copied-blocks
-  []
-  (:copy/blocks @state))
-
-(defn set-copied-blocks!
-  [content blocks]
-  (set-state! :copy/blocks {:copy/graph (get-current-repo)
-                            :copy/content (or content (get-in @state [:copy/blocks :copy/content]))
-                            :copy/blocks blocks}))
 
 (defn get-export-block-text-indent-style []
   (:copy/export-block-text-indent-style @state))

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -770,16 +770,14 @@
 
 #?(:cljs
    (defn copy-to-clipboard!
-     ([s]
-      (utils/writeClipboard (clj->js {:text s})))
-     ([s html]
-      (utils/writeClipboard (clj->js {:text s :html html})))
-     ([s html owner-window]
-      (-> (cond-> {:text s}
-            (not (string/blank? html))
-            (assoc :html html))
-          (bean/->js)
-          (utils/writeClipboard owner-window)))))
+     [text & {:keys [html blocks owner-window]}]
+     (let [data (clj->js
+                 {:text text
+                  :html html
+                  :blocks (when blocks (pr-str blocks))})]
+       (if owner-window
+         (utils/writeClipboard data owner-window)
+         (utils/writeClipboard data)))))
 
 (defn drop-nth [n coll]
   (keep-indexed #(when (not= %1 n) %2) coll))

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -772,9 +772,10 @@
    (defn copy-to-clipboard!
      [text & {:keys [html blocks owner-window]}]
      (let [data (clj->js
-                 {:text text
-                  :html html
-                  :blocks (when blocks (pr-str blocks))})]
+                 (gp-util/remove-nils-non-nested
+                  {:text text
+                   :html html
+                   :blocks (when (seq blocks) (pr-str blocks))}))]
        (if owner-window
          (utils/writeClipboard data owner-window)
          (utils/writeClipboard data)))))

--- a/src/main/frontend/utils.js
+++ b/src/main/frontend/utils.js
@@ -250,8 +250,6 @@ export const getClipText = (cb, errorHandler) => {
 }
 
 export const writeClipboard = ({text, html, blocks}, ownerWindow) => {
-  console.log("block")
-  console.log(blocks)
     if (Capacitor.isNativePlatform()) {
         CapacitorClipboard.write({ string: text });
         return

--- a/src/main/frontend/utils.js
+++ b/src/main/frontend/utils.js
@@ -249,7 +249,9 @@ export const getClipText = (cb, errorHandler) => {
   })
 }
 
-export const writeClipboard = ({text, html}, ownerWindow) => {
+export const writeClipboard = ({text, html, blocks}, ownerWindow) => {
+  console.log("block")
+  console.log(blocks)
     if (Capacitor.isNativePlatform()) {
         CapacitorClipboard.write({ string: text });
         return
@@ -281,6 +283,19 @@ export const writeClipboard = ({text, html}, ownerWindow) => {
                     ["text/html"]: richBlob
                 })];
             }
+          if (blocks) {
+            let blocksBlob = new Blob([blocks], {
+              type: ["web application/logseq"]
+            })
+            let richBlob = new Blob([html], {
+              type: ["text/html"]
+            })
+            data = [new ClipboardItem({
+              ["text/plain"]: blob,
+              ["text/html"]: richBlob,
+              ["web application/logseq"]: blocksBlob
+            })];
+          }
             promise_written = navigator.clipboard.write(data)
         } else {
             console.debug("Degraded copy without `ClipboardItem` support:", text)

--- a/src/test/frontend/handler/paste_test.cljs
+++ b/src/test/frontend/handler/paste_test.cljs
@@ -122,6 +122,24 @@
                (is (= expected-paste result))
                (reset))))))
 
+(deftest-async editor-on-paste-with-copied-blocks
+  (let [actual-blocks (atom nil)
+        ;; Simplified version of block attributes that are copied
+        expected-blocks [{:block/content "Test node"}
+                         {:block/content "Notes\nid:: 6422ec75-85c7-4e09-9a4d-2a1639a69b2f"}]
+        clipboard "- Test node\n\t- Notes\nid:: 6422ec75-85c7-4e09-9a4d-2a1639a69b2f"]
+    (test-helper/with-reset
+      reset
+      [state/get-input (constantly #js {:value "block"})
+       ;; paste-copied-blocks-or-text mocks below
+       util/stop (constantly nil)
+       paste-handler/get-copied-blocks (constantly (p/resolved expected-blocks))
+       editor-handler/paste-blocks (fn [blocks _] (reset! actual-blocks blocks))]
+      (p/let [_ ((paste-handler/editor-on-paste! nil)
+                      #js {:clipboardData #js {:getData (constantly clipboard)}})]
+             (is (= expected-blocks @actual-blocks))
+             (reset)))))
+
 (deftest-async editor-on-paste-with-selection-in-property
   (let [clipboard "after"
         expected-paste "after"


### PR DESCRIPTION
fix #8924

This PR adds a custom `web application/logseq` type for the internal paste item in clipboard, check this [link](https://developer.chrome.com/blog/web-custom-formats-for-the-async-clipboard-api/) for more details on clipboard's web custom formats. 

Test:
- [x] Electron
- [x] Chrome
- [x] iOS
- [x] Android