### PR TITLE
clj-kondo: check regex error prone double escaping

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -11,6 +11,7 @@
 
  :linters
  {:path-invalid-construct/string-join {:level :info}
+  :regex-checks/double-escaped-regex {:level :warning}
   :aliased-namespace-symbol {:level :warning}
   ;; Disable until it doesn't trigger false positives on rum/defcontext
   :earmuffed-var-not-dynamic {:level :off}
@@ -113,7 +114,8 @@
 
  :hooks {:analyze-call {rum.core/defc hooks.rum/defc
                         rum.core/defcs hooks.rum/defcs
-                        clojure.string/join hooks.path-invalid-construct/string-join}}
+                        clojure.string/join hooks.path-invalid-construct/string-join
+                        clojure.string/replace hooks.regex-checks/double-escaped-regex}}
  :lint-as {promesa.core/let clojure.core/let
            promesa.core/loop clojure.core/loop
            promesa.core/recur clojure.core/recur

--- a/.clj-kondo/hooks/path_invalid_construct.clj
+++ b/.clj-kondo/hooks/path_invalid_construct.clj
@@ -7,7 +7,6 @@
 (defn string-join
   [{:keys [node]}]
   (let [[_ sep-v & _args] (:children node)]
-    ;; (prn :string-join)
     (when (and (api/string-node? sep-v)
                (= ["/"] (:lines sep-v)))
       (api/reg-finding! (assoc (meta node)

--- a/.clj-kondo/hooks/regex_checks.clj
+++ b/.clj-kondo/hooks/regex_checks.clj
@@ -11,5 +11,5 @@
     (when (and (= (api/tag regex) :regex)
                (re-matches double-escaped-checker regex-string))
      (api/reg-finding! (assoc (meta regex)
-                             :message (str "double slash (\\\\) found in this regular expression followed by a regex special character (, + , * , ? , ^ , $ , | , \\ ), are you mistakenly double escaped a special character? Only escape one-time is required. No escape is required in character class []. (use #_{:clj-kondo/ignore [:regex-checks/double-escaped-regex]} to ignore)")
+                             :message (str "double slash (\\\\) found in this regular expression followed by a regex special character (, + , * , ? , ^ , $ , | , \\ ), have you mistakenly double escaped a special character? Only escaping one-time is required. No escape is required in character class []. (use #_{:clj-kondo/ignore [:regex-checks/double-escaped-regex]} to ignore)")
                              :type :regex-checks/double-escaped-regex)))))

--- a/.clj-kondo/hooks/regex_checks.clj
+++ b/.clj-kondo/hooks/regex_checks.clj
@@ -1,0 +1,15 @@
+(ns hooks.regex-checks
+  "This hook try to find out those error-prone double escaping regex expressions"
+  (:require [clj-kondo.hooks-api :as api]))
+
+(def double-escaped-checker #"\(re-pattern .*\\\\\\\\[\?\#\|\.\^\$\\\+].*\)")
+
+(defn double-escaped-regex
+  [{:keys [node]}]
+  (let [[_ _content regex & _args] (:children node)
+        regex-string (str (api/sexpr regex))]
+    (when (and (= (api/tag regex) :regex)
+               (re-matches double-escaped-checker regex-string))
+     (api/reg-finding! (assoc (meta regex)
+                             :message (str "double slash (\\\\) found in this regular expression followed by a regex special character (, + , * , ? , ^ , $ , | , \\ ), are you mistakenly double escaped a special character? Only escape one-time is required. No escape is required in character class []. (use #_{:clj-kondo/ignore [:regex-checks/double-escaped-regex]} to ignore)")
+                             :type :regex-checks/double-escaped-regex)))))

--- a/src/main/frontend/util/fs.cljs
+++ b/src/main/frontend/util/fs.cljs
@@ -143,6 +143,9 @@
 (defn legacy-dot-file-name-sanity
   [page-name]
   (when (string? page-name)
+    ;; Bug in original code, but doesn't affect the result
+    ;; https://github.com/logseq/logseq/blob/1519e35e0c8308d8db90b2525bfe7a716c4cdf04/src/main/frontend/util.cljc#L892
+    #_{:clj-kondo/ignore [:regex-checks/double-escaped-regex]}
     (let [normalize (fn [s] (.normalize s "NFC"))
           remove-boundary-slashes (fn [s] (when (string? s)
                                             (let [s (if (= \/ (first s))
@@ -165,9 +168,12 @@
 (defn legacy-url-file-name-sanity
   [page-name]
   (let [url-encode #(some-> % str (js/encodeURIComponent) (.replace "+" "%20"))]
+    ;; Bug in original code, but doesn't affect the result
+    ;; https://github.com/logseq/logseq/blob/1519e35e0c8308d8db90b2525bfe7a716c4cdf04/src/main/frontend/util.cljc#L892
+    #_{:clj-kondo/ignore [:regex-checks/double-escaped-regex]}
     (some-> page-name
             gp-util/page-name-sanity
-             ;; for android filesystem compatibility
+            ;; for android filesystem compatibility
             (string/replace #"[\\#|%]+" url-encode)
              ;; Windows reserved path characters
             (string/replace #"[:\\*\\?\"<>|]+" url-encode)


### PR DESCRIPTION
Following up the fix https://github.com/logseq/logseq/pull/8927

This PR is just introducing a check to the `string/replace`, no actual logic modified.
This PR is to avoid mistakenly escaping special characters with double slashing `\\` and create unexpected results (see https://github.com/logseq/logseq/pull/8927/files)
![image_1680025406917_0](https://user-images.githubusercontent.com/9862022/228326072-1dfce36b-a838-4d26-b5a4-f67e7e24db99.png)

It's easy to make the mistake. Similar mistake happens in the legacy code (but it doesn't affect the actual result for this line) https://github.com/logseq/logseq/blob/1519e35e0c8308d8db90b2525bfe7a716c4cdf04/src/main/frontend/util.cljc#L892

TODO: introduce the check to other functions accepting regex?
Seems clj-kondo doesn't have a hook to analyze all Regex nodes