### PR TITLE
fix: query with breadcrumbs show blocks on wrong hierarchy

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2550,7 +2550,7 @@
 
 (defn breadcrumb
   "block-id - uuid of the target block of breadcrumb. page uuid is also acceptable"
-  [config repo block-id {:keys [show-page? indent? end-separator? level-limit navigating-block]
+  [config repo block-id {:keys [show-page? indent? end-separator? level-limit _navigating-block]
                          :or {show-page? true
                               level-limit 3}
                          :as opts}]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -3699,10 +3699,17 @@
                  [:div
                   (page-cp config page)
                   (when alias? [:span.text-sm.font-medium.opacity-50 " Alias"])]
-                 (for [[parent blocks] parent-blocks]
-                   (rum/with-key
-                     (breadcrumb-with-container blocks config)
-                     (:db/id parent)))
+                 (let [{top-level-blocks true others false} (group-by
+                                                             (fn [b] (= (:db/id page) (:db/id (first b))))
+                                                             parent-blocks)
+                       sorted-parent-blocks (concat top-level-blocks others)]
+                   (for [[parent blocks] sorted-parent-blocks]
+                     [:div {:class (if (= (:db/id parent) (:db/id page))
+                                     "top-level-matched-blocks"
+                                     "nested-matched-blocks")}
+                      (rum/with-key
+                        (breadcrumb-with-container blocks config)
+                        (:db/id parent))]))
                  {:debug-id page
                   :trigger-once? false})])))))]
 

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2594,7 +2594,7 @@
                                                (rum/with-key (breadcrumb-fragment config block label opts) (:block/uuid block)))
                                              [:span.opacity-70 "⋯"])))
                               (interpose (breadcrumb-separator)))]
-          [:div.breadcrumb.block-parents.flex.flex-row.flex-1.items-center
+          [:div.breadcrumb.block-parents.flex.flex-row.flex-1.flex-wrap.items-center
            {:class (when (seq breadcrumb)
                      (str (when-not (:search? config)
                             " my-2")

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -632,6 +632,10 @@ a.cloze-revealed {
   opacity: 1;
 }
 
+.nested-matched-blocks {
+  margin-left: 27px;
+}
+
 .cp__fenced-code-block {
   .not-edit {
     cursor: default;

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -633,7 +633,7 @@ a.cloze-revealed {
 }
 
 .nested-matched-blocks {
-  margin-left: 27px;
+  margin-left: 26px;
 }
 
 .cp__fenced-code-block {

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -632,10 +632,6 @@ a.cloze-revealed {
   opacity: 1;
 }
 
-.nested-matched-blocks {
-  margin-left: 26px;
-}
-
 .cp__fenced-code-block {
   .not-edit {
     cursor: default;

--- a/tldraw/apps/tldraw-logseq/src/styles.css
+++ b/tldraw/apps/tldraw-logseq/src/styles.css
@@ -1173,9 +1173,6 @@ button.tl-shape-links-panel-item-remove-button {
 
 .block-link-reference-row {
   @apply block;
-  > * {
-    @apply inline;
-  }
 }
 
 .tl-tooltip-content {


### PR DESCRIPTION
close #5859

Master:
<img width="860" alt="CleanShot 2023-03-29 at 04 44 18@2x" src="https://user-images.githubusercontent.com/479169/228362406-9d9b4c68-98d7-456d-9546-442ca320e014.png">

This PR:
<img width="855" alt="CleanShot 2023-03-29 at 05 14 47@2x" src="https://user-images.githubusercontent.com/479169/228368563-3f73bc4c-3daf-4e61-b9a9-dd250bafc08a.png">
