### PR TITLE
Chore: Consistent "path" aliases

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -52,7 +52,7 @@
              frontend.format.mldoc mldoc
              frontend.format.block block
              frontend.fs fs
-             frontend.fs.bfs bfs
+             frontend.fs.memory-fs memory-fs
              frontend.fs.capacitor-fs capacitor-fs
              frontend.fs.nfs nfs
              frontend.handler.extract extract
@@ -92,6 +92,7 @@
              frontend.util.url url-util
              frontend.util.thingatpt thingatpt
              lambdaisland.glogi log
+             logseq.common.path path
              logseq.graph-parser graph-parser
              logseq.graph-parser.text text
              logseq.graph-parser.block gp-block

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -105,6 +105,7 @@
              logseq.graph-parser.util.db db-util
              logseq.graph-parser.date-time-util date-time-util
              medley.core medley
+             "path" node-path
              promesa.core p}}
 
   :namespace-name-mismatch {:level :warning}

--- a/src/electron/electron/backup_file.cljs
+++ b/src/electron/electron/backup_file.cljs
@@ -1,6 +1,6 @@
 (ns electron.backup-file
   (:require [clojure.string :as string]
-            ["path" :as path]
+            ["path" :as node-path]
             ["fs" :as fs]
             ["fs-extra" :as fs-extra]))
 
@@ -10,11 +10,11 @@
 (defn- get-backup-dir*
   [repo relative-path bak-dir]
   (let [relative-path* (string/replace relative-path repo "")
-        bak-dir (path/join repo bak-dir)
-        path (path/join bak-dir relative-path*)
-        parsed-path (path/parse path)]
-    (path/join (.-dir parsed-path)
-               (.-name parsed-path))))
+        bak-dir (node-path/join repo bak-dir)
+        path (node-path/join bak-dir relative-path*)
+        parsed-path (node-path/parse path)]
+    (node-path/join (.-dir parsed-path)
+                    (.-name parsed-path))))
 
 (defn get-backup-dir
   [repo relative-path]
@@ -31,7 +31,7 @@
         files (mapv #(.-name %) files)
         old-versioned-files (drop 6 (reverse (sort files)))]
     (doseq [file old-versioned-files]
-      (fs-extra/removeSync (path/join dir file)))))
+      (fs-extra/removeSync (node-path/join dir file)))))
 
 (defn backup-file
   "backup CONTENT under DIR :backup-dir or :version-file-dir
@@ -42,9 +42,9 @@
   (let [dir* (case dir
                :backup-dir (get-backup-dir repo relative-path)
                :version-file-dir (get-version-file-dir repo relative-path))
-        new-path (path/join dir*
-                            (str (string/replace (.toISOString (js/Date.)) ":" "_")
-                                 ".Desktop" ext))]
+        new-path (node-path/join dir*
+                                 (str (string/replace (.toISOString (js/Date.)) ":" "_")
+                                      ".Desktop" ext))]
     (fs-extra/ensureDirSync dir*)
     (fs/writeFileSync new-path content)
     (fs/statSync new-path)

--- a/src/electron/electron/configs.cljs
+++ b/src/electron/electron/configs.cljs
@@ -1,14 +1,14 @@
 (ns electron.configs
   (:require
     ["fs-extra" :as ^js fs]
-    ["path" :as ^js path]
+    ["path" :as ^js node-path]
     ["electron" :refer [^js app] :as electron]
     [cljs.reader :as reader]))
 
 ;; FIXME: move configs.edn to where it should be
-(defonce dot-root (.join path (.getPath app "home") ".logseq"))
+(defonce dot-root (.join node-path (.getPath app "home") ".logseq"))
 (defonce cfg-root (.getPath app "userData"))
-(defonce cfg-path (.join path cfg-root "configs.edn"))
+(defonce cfg-path (.join node-path cfg-root "configs.edn"))
 
 (defn- ensure-cfg
   []

--- a/src/electron/electron/git.cljs
+++ b/src/electron/electron/git.cljs
@@ -7,7 +7,7 @@
             [promesa.core :as p]
             [clojure.string :as string]
             ["fs-extra" :as fs]
-            ["path" :as path]
+            ["path" :as node-path]
             ["os" :as os]))
 
 (def log-error (partial logger/error "[Git]"))
@@ -17,7 +17,7 @@
   (when-let [graph-path (some-> (state/get-graph-path)
                                 (string/replace "/" "_")
                                 (string/replace ":" "comma"))]
-    (let [dir (.join path (.homedir os) ".logseq" "git" graph-path ".git")]
+    (let [dir (.join node-path (.homedir os) ".logseq" "git" graph-path ".git")]
       (. fs ensureDirSync dir)
       dir)))
 
@@ -44,7 +44,7 @@
 (defn git-dir-exists?
   []
   (try
-    (let [p (.join path (state/get-graph-path) ".git")]
+    (let [p (.join node-path (state/get-graph-path) ".git")]
       (.isDirectory (fs/statSync p)))
     (catch :default _e
       nil)))
@@ -56,7 +56,7 @@
           _ (when (string/blank? graph-path)
               (utils/send-to-renderer "getCurrentGraph" {})
               (throw (js/Error. "Empty graph path")))
-          p (.join path graph-path ".git")]
+          p (.join node-path graph-path ".git")]
       (when (and (fs/existsSync p)
                  (.isFile (fs/statSync p)))
         (let [content (string/trim (.toString (fs/readFileSync p)))

--- a/src/electron/electron/search.cljs
+++ b/src/electron/electron/search.cljs
@@ -1,6 +1,6 @@
 (ns electron.search
   "Provides both page level and block level index"
-  (:require ["path" :as path]
+  (:require ["path" :as node-path]
             ["fs-extra" :as fs]
             ["better-sqlite3" :as sqlite3]
             [clojure.string :as string]
@@ -113,7 +113,7 @@
 (defn get-search-dir
   []
   (let [path (.getPath ^object app "userData")]
-    (path/join path "search")))
+    (node-path/join path "search")))
 
 (defn ensure-search-dir!
   []
@@ -123,14 +123,14 @@
   [db-name]
   (let [db-name (sanitize-db-name db-name)
         search-dir (get-search-dir)]
-    [db-name (path/join search-dir db-name)]))
+    [db-name (node-path/join search-dir db-name)]))
 
 (defn get-db-path
   "Search cache paths"
   [db-name]
   (let [db-name (sanitize-db-name db-name)
         search-dir (get-search-dir)]
-    [db-name (path/join search-dir db-name)]))
+    [db-name (node-path/join search-dir db-name)]))
 
 (defn open-db!
   [db-name]

--- a/src/electron/electron/server.cljs
+++ b/src/electron/electron/server.cljs
@@ -3,7 +3,7 @@
             ["@fastify/cors" :as FastifyCORS]
             ["electron" :refer [ipcMain]]
             ["fs-extra" :as fs-extra]
-            ["path" :as path]
+            ["path" :as node-path]
             [clojure.string :as string]
             [promesa.core :as p]
             [cljs-bean.core :as bean]
@@ -141,7 +141,7 @@
                       (.addHook "preHandler" api-pre-handler!)
                       (.post "/api" api-handler!)
                       (.get "/" (fn [_ ^js rep]
-                                  (let [html (fs-extra/readFileSync (.join path js/__dirname "./docs/api_server.html"))
+                                  (let [html (fs-extra/readFileSync (.join node-path js/__dirname "./docs/api_server.html"))
                                         HOST (get-host)
                                         PORT (get-port)
                                         html (-> (str html)

--- a/src/electron/electron/updater.cljs
+++ b/src/electron/electron/updater.cljs
@@ -9,7 +9,7 @@
             ["semver" :as semver]
             ["os" :as os]
             ["fs" :as fs]
-            ["path" :as path]
+            ["path" :as node-path]
             ["electron" :refer [ipcMain app autoUpdater]]))
 
 (def *update-ready-to-install (atom nil))
@@ -61,7 +61,7 @@
              artifact (when-let [remote-version (and artifact (re-find #"\d+\.\d+\.\d+" (:url artifact)))]
                         (when (and (. semver valid remote-version)
                                    (. semver lt electron-version remote-version)) artifact))
-             
+
              url (if-not artifact (do (emit "update-not-available" nil) (throw nil)) (:url artifact))
              _ (if url (emit "update-available" (bean/->js artifact)) (throw (js/Error. "download url not exists")))
                ;; start download FIXME: user's preference about auto download
@@ -75,8 +75,8 @@
                                 body (.-body dl-res)
                                 start-at (.now js/Date)
                                 *downloaded (atom 0)
-                                dest-basename (path/basename url)
-                                tmp-dest-file (path/join (os/tmpdir) (str dest-basename ".pending"))
+                                dest-basename (node-path/basename url)
+                                tmp-dest-file (node-path/join (os/tmpdir) (str dest-basename ".pending"))
                                 dest-file (.createWriteStream fs tmp-dest-file)]
                             (doto body
                               (.on "data" (fn [chunk]

--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -2,7 +2,7 @@
   (:require ["@logseq/rsapi" :as rsapi]
             ["electron" :refer [app BrowserWindow]]
             ["fs-extra" :as fs]
-            ["path" :as path]
+            ["path" :as node-path]
             [clojure.string :as string]
             [electron.configs :as cfgs]
             [electron.logger :as logger]
@@ -44,21 +44,21 @@
 
 (defn get-ls-dotdir-root
   []
-  (let [lg-dir (path/join (.getPath app "home") ".logseq")]
+  (let [lg-dir (node-path/join (.getPath app "home") ".logseq")]
     (when-not (fs/existsSync lg-dir)
       (fs/mkdirSync lg-dir))
     (fix-win-path! lg-dir)))
 
 (defn get-ls-default-plugins
   []
-  (let [plugins-root (path/join (get-ls-dotdir-root) "plugins")
+  (let [plugins-root (node-path/join (get-ls-dotdir-root) "plugins")
         _ (when-not (fs/existsSync plugins-root)
             (fs/mkdirSync plugins-root))
         dirs (js->clj (fs/readdirSync plugins-root #js{"withFileTypes" true}))
         dirs (->> dirs
                   (filter #(.isDirectory %))
                   (filter (fn [f] (not (some #(string/starts-with? (.-name f) %) ["_" "."]))))
-                  (map #(path/join plugins-root (.-name %))))]
+                  (map #(node-path/join plugins-root (.-name %))))]
     dirs))
 
 (defn- set-fetch-agent-proxy
@@ -211,14 +211,14 @@
      (some #(string/ends-with? path %)
            [".DS_Store" "logseq/graphs-txid.edn"])
      ;; hidden directory or file
-     (let [relpath (path/relative dir path)]
+     (let [relpath (node-path/relative dir path)]
        (or (re-find #"/\.[^.]+" relpath)
            (re-find #"^\.[^.]+" relpath))))))
 
 (defn should-read-content?
   "Skip reading content of file while using file-watcher"
   [path]
-  (let [ext (string/lower-case (path/extname path))]
+  (let [ext (string/lower-case (node-path/extname path))]
     (contains? #{".md" ".markdown" ".org" ".js" ".edn" ".css"} ext)))
 
 (defn read-file

--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -5,7 +5,7 @@
             [electron.context-menu :as context-menu]
             [electron.logger :as logger]
             ["electron" :refer [BrowserWindow app session shell] :as electron]
-            ["path" :as path]
+            ["path" :as node-path]
             ["url" :as URL]
             [electron.state :as state]
             [cljs-bean.core :as bean]
@@ -16,8 +16,8 @@
 
 (def MAIN_WINDOW_ENTRY (if dev?
                          ;;"http://localhost:3001"
-                         (str "file://" (path/join js/__dirname "index.html"))
-                         (str "file://" (path/join js/__dirname "electron.html"))))
+                         (str "file://" (node-path/join js/__dirname "index.html"))
+                         (str "file://" (node-path/join js/__dirname "electron.html"))))
 
 (defn create-main-window!
   ([]
@@ -45,13 +45,13 @@
                        ;; Remove OverlayScrollbars and transition `.scrollbar-spacing`
                        ;; to use `scollbar-gutter` after the feature is implemented in browsers.
                        :enableBlinkFeatures     'OverlayScrollbars'
-                       :preload                 (path/join js/__dirname "js/preload.js")}}
+                       :preload                 (node-path/join js/__dirname "js/preload.js")}}
 
                      (seq opts)
                      (merge opts)
 
                      linux?
-                     (assoc :icon (path/join js/__dirname "icons/logseq.png")))
+                     (assoc :icon (node-path/join js/__dirname "icons/logseq.png")))
          win       (BrowserWindow. (clj->js win-opts))]
      (.manage win-state win)
      (.onBeforeSendHeaders (.. session -defaultSession -webRequest)
@@ -136,8 +136,8 @@
                   url (if-not win32? (string/replace url "file://" "") url)]
               (logger/info "new-window" url)
               (if (some #(string/includes?
-                          (.normalize path url)
-                          (.join path (. app getAppPath) %))
+                          (.normalize node-path url)
+                          (.join node-path (. app getAppPath) %))
                         ["index.html" "electron.html"])
                 (logger/info "pass-window" url)
                 (open-default-app! url open))))
@@ -173,7 +173,7 @@
                              {:plugins          true
                               :nodeIntegration  false
                               :webSecurity      (not dev?)
-                              :preload          (path/join js/__dirname "js/preload.js")
+                              :preload          (node-path/join js/__dirname "js/preload.js")
                               :nativeWindowOpen true}}}
                            features)
                     (do (open-external! url) {:action "deny"}))

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -35,7 +35,7 @@
             [lambdaisland.glogi :as log]
             [frontend.fs.capacitor-fs :as capacitor-fs]
             ["@capawesome/capacitor-background-task" :refer [BackgroundTask]]
-            ["path" :as path]))
+            ["path" :as node-path]))
 
 ;;; ### Commentary
 ;; file-sync related local files/dirs:
@@ -662,7 +662,7 @@
   (let [favorite-pages* (set favorite-pages)]
     (fn [^FileMetadata item]
       (let [path (relative-path item)
-            journal-dir (path/join (config/get-journals-directory) path/sep)
+            journal-dir (node-path/join (config/get-journals-directory) node-path/sep)
             journal? (string/starts-with? path journal-dir)
             journal-day
             (when journal?
@@ -1429,8 +1429,8 @@
 (defn- is-journals-or-pages?
   [filetxn]
   (let [rel-path (relative-path filetxn)]
-    (or (string/starts-with? rel-path (path/join (config/get-journals-directory) path/sep))
-        (string/starts-with? rel-path (path/join (config/get-pages-directory) path/sep)))))
+    (or (string/starts-with? rel-path (node-path/join (config/get-journals-directory) node-path/sep))
+        (string/starts-with? rel-path (node-path/join (config/get-pages-directory) node-path/sep)))))
 
 (defn- need-add-version-file?
   "when we need to create a new version file:

--- a/src/main/frontend/mobile/intent.cljs
+++ b/src/main/frontend/mobile/intent.cljs
@@ -1,6 +1,6 @@
 (ns frontend.mobile.intent
   (:require ["@capacitor/filesystem" :refer [Filesystem]]
-            ["path" :as path]
+            ["path" :as node-path]
             ["send-intent" :refer [^js SendIntent]]
             [clojure.pprint :as pprint]
             [clojure.set :as set]
@@ -62,7 +62,7 @@
 
 
 (defn- embed-asset-file [url format]
-  (p/let [basename (path/basename url)
+  (p/let [basename (node-path/basename url)
           label (-> basename util/node-path.name)
           time (date/get-current-time)
           path (editor-handler/get-asset-path basename)
@@ -82,14 +82,14 @@
   "Store external content with url into Logseq repo"
   [url title]
   (p/let [time (date/get-current-time)
-          title (some-> (or title (path/basename url))
+          title (some-> (or title (node-path/basename url))
                         gp-util/safe-decode-uri-component
                         util/node-path.name
                         ;; make the title more user friendly
                         gp-util/page-name-sanity)
-          path (path/join (config/get-repo-dir (state/get-current-repo))
+          path (node-path/join (config/get-repo-dir (state/get-current-repo))
                           (config/get-pages-directory)
-                          (str (js/encodeURI (fs-util/file-name-sanity title)) (path/extname url)))
+                          (str (js/encodeURI (fs-util/file-name-sanity title)) (node-path/extname url)))
           _ (p/catch
              (.copy Filesystem (clj->js {:from url :to path}))
              (fn [error]

--- a/src/main/frontend/util/fs.cljs
+++ b/src/main/frontend/util/fs.cljs
@@ -2,7 +2,7 @@
 
 (ns frontend.util.fs
   "Misc util fns built on top of frontend.fs"
-  (:require ["path" :as path]
+  (:require ["path" :as node-path]
             [frontend.util :as util]
             [logseq.graph-parser.util :as gp-util]
             [clojure.string :as string]
@@ -34,12 +34,12 @@
        (some #(string/ends-with? path %)
              [".DS_Store" "logseq/graphs-txid.edn"])
       ;; hidden directory or file
-       (let [relpath (path/relative dir path)]
+       (let [relpath (node-path/relative dir path)]
          (or (re-find #"/\.[^.]+" relpath)
              (re-find #"^\.[^.]+" relpath)))
        (let [path (string/lower-case path)]
          (and
-          (not (string/blank? (path/extname path)))
+          (not (string/blank? (node-path/extname path)))
           (not
            (some #(string/ends-with? path %)
                  [".md" ".markdown" ".org" ".js" ".edn" ".css"]))))))))

--- a/src/test/frontend/fs_test.cljs
+++ b/src/test/frontend/fs_test.cljs
@@ -5,14 +5,14 @@
             [frontend.fs :as fs]
             [promesa.core :as p]
             ["fs" :as fs-node]
-            ["path" :as path]))
+            ["path" :as node-path]))
 
 (use-fixtures :once fixtures/redef-get-fs)
 
 (deftest-async create-if-not-exists-creates-correctly
   ;; dir needs to be an absolute path for fn to work correctly
-  (let [dir (path/resolve (test-helper/create-tmp-dir))
-        some-file (path/join dir "something.txt")]
+  (let [dir (node-path/resolve (test-helper/create-tmp-dir))
+        some-file (node-path/join dir "something.txt")]
 
     (->
      (p/do!
@@ -29,8 +29,8 @@
         (fs-node/rmdirSync dir))))))
 
 (deftest-async create-if-not-exists-does-not-create-correctly
-  (let [dir (path/resolve (test-helper/create-tmp-dir))
-        some-file (path/join dir "something.txt")]
+  (let [dir (node-path/resolve (test-helper/create-tmp-dir))
+        some-file (node-path/join dir "something.txt")]
     (fs-node/writeFileSync some-file "OLD")
 
     (->

--- a/src/test/frontend/handler/plugin_config_test.cljs
+++ b/src/test/frontend/handler/plugin_config_test.cljs
@@ -6,7 +6,7 @@
             [frontend.handler.global-config :as global-config-handler]
             [frontend.schema.handler.plugin-config :as plugin-config-schema]
             ["fs" :as fs-node]
-            ["path" :as path]
+            ["path" :as node-path]
             [clojure.edn :as edn]
             [malli.generator :as mg]
             [promesa.core :as p]
@@ -18,17 +18,17 @@
 (defn- create-global-config-dir
   []
   (let [dir (test-helper/create-tmp-dir "config")
-        root-dir (path/dirname dir)]
+        root-dir (node-path/dirname dir)]
     (reset! global-config-handler/root-dir root-dir)
     dir))
 
 (defn- delete-global-config-dir
   [config-dir]
   (doseq [relative-file (fs-node/readdirSync config-dir)]
-    (fs-node/unlinkSync (path/join config-dir relative-file)))
+    (fs-node/unlinkSync (node-path/join config-dir relative-file)))
   (reset! global-config-handler/root-dir nil)
   (fs-node/rmdirSync config-dir)
-  (fs-node/rmdirSync (path/dirname config-dir)))
+  (fs-node/rmdirSync (node-path/dirname config-dir)))
 
 (deftest-async add-or-update-plugin
   (let [dir (create-global-config-dir)

--- a/src/test/frontend/test/helper.cljs
+++ b/src/test/frontend/test/helper.cljs
@@ -2,7 +2,7 @@
   "Common helper fns for tests"
   (:require [frontend.handler.repo :as repo-handler]
             [frontend.db.conn :as conn]
-            ["path" :as path]
+            ["path" :as node-path]
             ["fs" :as fs-node]))
 
 (defonce test-db "test-db")
@@ -31,9 +31,9 @@ This can be called in synchronous contexts as no async fns should be invoked"
   ([] (create-tmp-dir nil))
   ([subdir]
    (when-not (fs-node/existsSync "tmp") (fs-node/mkdirSync "tmp"))
-   (let [dir (fs-node/mkdtempSync (path/join "tmp" "unit-test-"))]
+   (let [dir (fs-node/mkdtempSync (node-path/join "tmp" "unit-test-"))]
      (if subdir
        (do
-         (fs-node/mkdirSync (path/join dir subdir))
-         (path/join dir subdir))
+         (fs-node/mkdirSync (node-path/join dir subdir))
+         (node-path/join dir subdir))
        dir))))


### PR DESCRIPTION
This is a follow up to https://github.com/logseq/logseq/pull/8792#discussion_r1145228387 so that the path alias doesn't have conflicting namespaces