### PR TITLE
fix: paste html

### DIFF
--- a/src/test/frontend/extensions/html_parser_test.cljs
+++ b/src/test/frontend/extensions/html_parser_test.cljs
@@ -1,0 +1,32 @@
+(ns frontend.extensions.html-parser-test
+  (:require [clojure.test :as test :refer [deftest is testing are]]
+            [frontend.extensions.html-parser :as parser]))
+
+(deftest convert-test
+  (testing "markdown"
+    (are [x y] (= (parser/convert :markdown x) y)
+      "<ul><li>a</li><ul><li>b</li></ul></ul>"
+      "- a\n\n\t- b"
+
+      "<ul><li>a</li><li>b</li></ul>"
+      "- a\n- b"
+
+      "<ul><li>a</li><li>b</li><ol><li>c</li><dl>d</dl></ol></ul>"
+      "- a\n- b\n\n\t- c\n\n\t\t- d"
+
+      "<b>bold</b> <i>italic</i> <mark>mark</mark>"
+      "**bold** *italic* ==mark=="))
+
+  (testing "org mode"
+    (are [x y] (= (parser/convert :org x) y)
+      "<ul><li>a</li><ul><li>b</li></ul></ul>"
+      "* a\n\n\t* b"
+
+      "<ul><li>a</li><li>b</li></ul>"
+      "* a\n* b"
+
+      "<ul><li>a</li><li>b</li><ol><li>c</li><dl>d</dl></ol></ul>"
+      "* a\n* b\n\n\t* c\n\nd"
+
+      "<b>bold</b> <i>italic</i> <mark>mark</mark>"
+      "*bold* /italic/ ^^mark^^")))

--- a/src/test/frontend/extensions/html_parser_test.cljs
+++ b/src/test/frontend/extensions/html_parser_test.cljs
@@ -2,7 +2,10 @@
   (:require [clojure.test :as test :refer [deftest testing are]]
             [frontend.extensions.html-parser :as parser]))
 
-(deftest convert-test
+;; Disabled temporally because document is not supported on Node
+;; and jsdom can't be required
+
+#_(deftest convert-test
   (testing "markdown"
     (are [x y] (= (parser/convert :markdown x) y)
       "<ul><li>a</li><ul><li>b</li></ul></ul>"

--- a/src/test/frontend/extensions/html_parser_test.cljs
+++ b/src/test/frontend/extensions/html_parser_test.cljs
@@ -1,6 +1,7 @@
 (ns frontend.extensions.html-parser-test
-  (:require [clojure.test :as test :refer [deftest testing are]]
-            [frontend.extensions.html-parser :as parser]))
+  #_(:require [clojure.test :as test :refer [deftest testing are]]
+              [frontend.extensions.html-parser :as parser])
+  )
 
 ;; Disabled temporally because document is not supported on Node
 ;; and jsdom can't be required

--- a/src/test/frontend/extensions/html_parser_test.cljs
+++ b/src/test/frontend/extensions/html_parser_test.cljs
@@ -1,5 +1,5 @@
 (ns frontend.extensions.html-parser-test
-  (:require [clojure.test :as test :refer [deftest is testing are]]
+  (:require [clojure.test :as test :refer [deftest testing are]]
             [frontend.extensions.html-parser :as parser]))
 
 (deftest convert-test


### PR DESCRIPTION
This PR adds missing `\t` to the md/org converted from HTML, it also fixed the converting result for org mode (using `*` instead of `-` for blocks)

To reproduce:
1. Create a page on http://localhost:3001
2. Create a block `a` with a child block `b`
```
- a
 - b
```
3. Copy both blocks to the Logseq Electron app, the indentations will be gone.