### PR TITLE
fix(fs): whiteboards drop file on win32

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1513,7 +1513,9 @@
    Requires editing state"
   [file-path]
   (if-let [current-file-rpath (or (db-model/get-block-file-path (state/get-edit-block))
-                            ;; fix dummy file path of page
+                                  ;; fix dummy file path of page
+                                  (when (config/get-pages-directory)
+                                    (path/path-join (config/get-pages-directory) "_.md"))
                                   "pages/contents.md")]
     (let [repo-dir (config/get-repo-dir (state/get-current-repo))
           current-file-fpath (path/path-join repo-dir current-file-rpath)]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1438,7 +1438,7 @@
                  (fn [dest]
                    [file-rpath
                     (if (string? dest) (js/File. #js[] dest) file)
-                    (.join util/node-path dir file-rpath)
+                    (path/path-join dir file-rpath)
                     matched-alias]))
                 (p/catch #(js/console.error "Debug: Copy Asset Error#" %))))
 
@@ -1514,14 +1514,10 @@
   [file-path]
   (if-let [current-file-rpath (or (db-model/get-block-file-path (state/get-edit-block))
                             ;; fix dummy file path of page
-                                  (and (util/electron?)
-                                       (util/node-path.join
-                                        (config/get-repo-dir (state/get-current-repo))
-                                        (config/get-pages-directory) "_.md"))
                                   "pages/contents.md")]
     (let [repo-dir (config/get-repo-dir (state/get-current-repo))
           current-file-fpath (path/path-join repo-dir current-file-rpath)]
-      (util/get-relative-path current-file-fpath file-path))
+      (path/get-relative-path current-file-fpath file-path))
     file-path))
 
 (defn upload-asset


### PR DESCRIPTION
> BUG: I pick an image from the desktop and drop it into the whiteboard that's possible but nothing happens, just a ring spinning forever (in Win 10). is it a feature not so well implemented yet or a problem of my pc or win 10?


