### PR TITLE
fix: disable backspace from the start and delete at the end for query

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2693,7 +2693,10 @@
         (delete-and-update input selected-start selected-end)
 
         (and end? current-block)
-        (delete-concat current-block)
+        (let [editor-state (get-state)
+              custom-query? (get-in editor-state [:config :custom-query?])]
+          (when-not custom-query?
+            (delete-concat current-block)))
 
         :else
         (delete-and-update input current-pos (inc current-pos))))))
@@ -2723,11 +2726,13 @@
         (delete-and-update input selected-start selected-end))
 
       (zero? current-pos)
-      (do
+      (let [editor-state (get-state)
+            custom-query? (get-in editor-state [:config :custom-query?])]
         (util/stop e)
         (when (and (if top-block? (string/blank? value) true)
                    (not root-block?)
-                   (not single-block?))
+                   (not single-block?)
+                   (not custom-query?))
           (delete-block! repo false)))
 
       (and (> current-pos 1)


### PR DESCRIPTION
To reproduce:
1. add `- NOW test` in the current journal page
2. put the cursor in the beginning of the first block in the default NOW query
3. press `backspace`

The block will be deleted. 

In most situations, it doesn't make sense to concat two blocks in the query result, so Delete at the end of any block in the query result is disabled too.