### PR TITLE
Fix: ios path handing

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -515,7 +515,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 0.9.1;
+				MARKETING_VERSION = 0.9.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.logseq.logseq;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -542,7 +542,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 0.9.1;
+				MARKETING_VERSION = 0.9.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.logseq.logseq;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
@@ -567,7 +567,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 0.9.1;
+				MARKETING_VERSION = 0.9.2;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.logseq.logseq.ShareViewController;
@@ -594,7 +594,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 0.9.1;
+				MARKETING_VERSION = 0.9.2;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.logseq.logseq.ShareViewController;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -46,7 +46,7 @@
   (let [graph-dir      (config/get-repo-dir repo)
         [selected-path set-selected-path] (rum/use-state "")
         selected-path? (and (not (string/blank? selected-path))
-                            (not (mobile-util/iCloud-container-path? selected-path)))
+                            (not (mobile-util/in-iCloud-container-path? selected-path)))
         on-confirm     (fn []
                          (when-let [dest-dir (and selected-path?
                                                   ;; avoid using `util/node-path.join` to join mobile path since it replaces `file:///abc` to `file:/abc`
@@ -84,7 +84,7 @@
 
       (when (not (string/blank? selected-path))
         [:h5.text-xs.pt-1.-mb-1.flex.items-center.leading-none
-         (if (mobile-util/iCloud-container-path? selected-path)
+         (if (mobile-util/in-iCloud-container-path? selected-path)
            [:span.inline-block.pr-1.text-error.scale-75 (ui/icon "alert-circle")]
            [:span.inline-block.pr-1.text-success.scale-75 (ui/icon "circle-check")])
          selected-path])
@@ -128,7 +128,7 @@
         (fn []
           (async/go
             (close-fn)
-            (if (mobile-util/iCloud-container-path? repo)
+            (if (mobile-util/in-iCloud-container-path? repo)
               (open-icloud-graph-clone-picker repo)
               (do
                 (state/set-state! [:ui/loading? :graph/create-remote?] true)
@@ -810,7 +810,7 @@
 (defn open-icloud-graph-clone-picker
   ([] (open-icloud-graph-clone-picker (state/get-current-repo)))
   ([repo]
-   (when (and repo (mobile-util/iCloud-container-path? repo))
+   (when (and repo (mobile-util/in-iCloud-container-path? repo))
      (state/set-modal!
       (fn [close-fn]
         (clone-local-icloud-graph-panel repo (util/node-path.basename repo) close-fn))

--- a/src/main/frontend/config.cljs
+++ b/src/main/frontend/config.cljs
@@ -408,7 +408,7 @@
 (defn get-string-repo-dir
   [repo-dir]
   (if (mobile-util/native-ios?)
-    (str (if (mobile-util/iCloud-container-path? repo-dir)
+    (str (if (mobile-util/in-iCloud-container-path? repo-dir)
            "iCloud"
            (cond (mobile-util/native-iphone?)
                  "On My iPhone"

--- a/src/main/frontend/fs/capacitor_fs.cljs
+++ b/src/main/frontend/fs/capacitor_fs.cljs
@@ -299,11 +299,16 @@
                                                            nil))) ;; NOTE: If pick folder fails, let it crash
           _ (when (and (mobile-util/native-ios?)
                        (not (or (local-container-path? path localDocumentsPath)
-                                (mobile-util/iCloud-container-path? path))))
+                                (mobile-util/in-iCloud-container-path? path))))
               (state/pub-event! [:modal/show-instruction]))
+          exists? (<dir-exists? path)
+          _ (when-not exists?
+             (p/rejected (str "Cannot access selected directory: " path)))
+          _ (when (mobile-util/is-iCloud-container-path? path)
+              (p/rejected (str "Please avoid accessing the top-level iCloud container path: " path)))
           path (if (mobile-util/native-ios?)
-                  (ios-force-include-private path)
-                  path)
+                 (ios-force-include-private path)
+                 path)
           _ (js/console.log "Opening or Creating graph at directory: " path)
           files (get-files path)]
     {:path path

--- a/src/main/frontend/handler.cljs
+++ b/src/main/frontend/handler.cljs
@@ -41,7 +41,8 @@
             [frontend.util.persist-var :as persist-var]
             [goog.object :as gobj]
             [lambdaisland.glogi :as log]
-            [promesa.core :as p]))
+            [promesa.core :as p]
+            [frontend.mobile.core :as mobile]))
 
 (defn set-global-error-notification!
   []
@@ -216,6 +217,8 @@
   (events/run!)
 
   (p/do!
+   (when (mobile-util/native-platform?)
+     (mobile/mobile-preinit))
    (-> (p/let [repos (get-repos)
                _ (state/set-repos! repos)
                _ (restore-and-setup! repos)]

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -540,7 +540,7 @@
 (defmethod handle :validate-appId [[_ graph-switch-f graph]]
   (when-let [deprecated-repo (or graph (state/get-current-repo))]
     ;; Installation is not changed for iCloud
-    (if (mobile-util/iCloud-container-path? deprecated-repo)
+    (if (mobile-util/in-iCloud-container-path? deprecated-repo)
       (when graph-switch-f
         (graph-switch-f graph true)
         (state/pub-event! [:graph/ready (state/get-current-repo)]))

--- a/src/main/frontend/mobile/core.cljs
+++ b/src/main/frontend/mobile/core.cljs
@@ -21,6 +21,13 @@
 (def *last-shared-url (atom nil))
 (def *last-shared-seconds (atom 0))
 
+(defn mobile-preinit
+  "preinit logic of mobile platforms: setup document folder permission"
+  []
+  (when (mobile-util/native-ios?)
+    ;; Caution: This must be called before any file accessing
+    (capacitor-fs/ios-ensure-documents!)))
+
 (defn- ios-init
   "Initialize iOS-specified event listeners"
   []

--- a/src/main/frontend/mobile/util.cljs
+++ b/src/main/frontend/mobile/util.cljs
@@ -89,10 +89,15 @@
       (let [^js cl (.-classList js/document.documentElement)]
         (.add cl "is-zoomed-native-ios")))))
 
-(defn iCloud-container-path?
+(defn in-iCloud-container-path?
   "Check whether `path' is logseq's iCloud container path on iOS"
   [path]
-  (string/includes? path "iCloud~com~logseq~logseq"))
+  (string/includes? path "/iCloud~com~logseq~logseq/"))
+
+(defn is-iCloud-container-path?
+  "Check whether `path' is iCloud container path on iOS"
+  [path]
+  (re-matches #"/iCloud~com~logseq~logseq/Documents/?$" path))
 
 (defn app-active?
   "Whether the app is active. This function returns a promise."


### PR DESCRIPTION
Releated #9002

BUG: `ios-ensure-documents!` is called after `persist_var` loading

Other fixes:

- Graph names with special chars
- Await iOS folder creation, (1s wait)
- Handle exceptional cases for folder selection: top iCloud directory, no permission

Chore:

- iOS version is bumped, allowing for the TestFlight release.