### PR TITLE
Fix(ui): overflow image from the breadcrumb items

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -359,23 +359,23 @@
                         (state/set-modal! confirm-fn))))}
                  (ui/icon "trash")])
 
-           [:button.asset-action-btn
-            {:title         (t :asset/copy)
-             :tabIndex      "-1"
-             :on-mouse-down util/stop
-             :on-click      (fn [e]
-                              (util/stop e)
-                              (-> (util/copy-image-to-clipboard image-src)
-                                  (p/then #(notification/show! "Copied!" :success))))}
-            (ui/icon "copy")]
+              [:button.asset-action-btn
+               {:title         (t :asset/copy)
+                :tabIndex      "-1"
+                :on-mouse-down util/stop
+                :on-click      (fn [e]
+                                 (util/stop e)
+                                 (-> (util/copy-image-to-clipboard image-src)
+                                     (p/then #(notification/show! "Copied!" :success))))}
+               (ui/icon "copy")]
 
-           [:button.asset-action-btn
-            {:title (t :asset/maximize)
-             :tabIndex "-1"
-             :on-mouse-down util/stop
-             :on-click open-lightbox}
+              [:button.asset-action-btn
+               {:title         (t :asset/maximize)
+                :tabIndex      "-1"
+                :on-mouse-down util/stop
+                :on-click      open-lightbox}
 
-            (ui/icon "maximize")]]])]))))
+               (ui/icon "maximize")]]])])]))))
 
 (rum/defc audio-cp [src]
   ;; Change protocol to allow media fragment uris to play

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -99,6 +99,13 @@
   }
 }
 
+.breadcrumb {
+  .asset-container img {
+    height: 18px;
+  }
+}
+
+
 .open-block-ref-link {
   background-color: var(--ls-page-properties-background-color);
   padding: 1px 4px;


### PR DESCRIPTION
## Before
<img width="486" alt="CleanShot 2023-04-04 at 16 49 34@2x" src="https://user-images.githubusercontent.com/1779837/229739902-328000f5-8022-4113-9ad1-3f0e804413de.png">


## After
<img width="474" alt="CleanShot 2023-04-04 at 16 48 27@2x" src="https://user-images.githubusercontent.com/1779837/229739966-372cc5cf-393b-4c36-a5bb-609fd51bb183.png">
