### PR TITLE
replace all explicit text with i18n text in the context menu

### DIFF
--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -43,18 +43,18 @@
    (ui/menu-link
     {:key "cut"
      :on-click #(editor-handler/cut-selection-blocks true)}
-    (t :content/cut)
+    (t :command.editor/cut)
     (ui/keyboard-shortcut-from-config :editor/cut))
    (ui/menu-link
     {:key "delete"
      :on-click #(do (editor-handler/delete-selection %)
                     (state/hide-custom-context-menu!))}
-    "Delete"
+    (t :command.editor/delete-selection)
     (ui/keyboard-shortcut-from-config :editor/delete))
    (ui/menu-link
     {:key "copy"
      :on-click editor-handler/copy-selection-blocks}
-    (t :content/copy)
+    (t :command.editor/copy)
     (ui/keyboard-shortcut-from-config :editor/copy))
    (ui/menu-link
     {:key "copy as"
@@ -67,12 +67,12 @@
    (ui/menu-link
     {:key "copy block refs"
      :on-click editor-handler/copy-block-refs}
-    "Copy block refs"
+    (t :content/copy-block-ref)
     nil)
    (ui/menu-link
     {:key "copy block embeds"
      :on-click editor-handler/copy-block-embeds}
-    "Copy block embeds"
+    (t :content/copy-block-emebed)
     nil)
 
    [:hr.menu-separator]
@@ -87,7 +87,7 @@
    (ui/menu-link
     {:key "cycle todos"
      :on-click editor-handler/cycle-todos!}
-    "Cycle todos"
+    (t :command.editor/cycle-todo)
     (ui/keyboard-shortcut-from-config :editor/cycle-todo))
 
    [:hr.menu-separator]
@@ -95,13 +95,13 @@
    (ui/menu-link
     {:key "Expand all"
      :on-click editor-handler/expand-all-selection!}
-    "Expand all"
+    (t :command.editor/expand-block-children)
     (ui/keyboard-shortcut-from-config :editor/expand-block-children))
 
    (ui/menu-link
     {:key "Collapse all"
      :on-click editor-handler/collapse-all-selection!}
-    "Collapse all"
+    (t :command.editor/collapse-block-children)
     (ui/keyboard-shortcut-from-config :editor/collapse-block-children))])
 
 (defonce *template-including-parent? (atom nil))
@@ -142,7 +142,7 @@
                          (reset! input (util/evalue e)))}]
           (when has-children?
             (template-checkbox template-including-parent?))
-          (ui/button "Submit"
+          (ui/button (t :submit)
                      :on-click (fn []
                                  (let [title (string/trim @input)]
                                    (when (not (string/blank? title))
@@ -226,13 +226,13 @@
           {:key      "Cut"
            :on-click (fn [_e]
                        (editor-handler/cut-block! block-id))}
-          (t :content/cut)
+          (t :command.editor/cut)
           (ui/keyboard-shortcut-from-config :editor/cut))
 
          (ui/menu-link
           {:key      "delete"
            :on-click #(editor-handler/delete-block-aux! block true)}
-          "Delete"
+          (t :command.editor/delete-selection)
           (ui/keyboard-shortcut-from-config :editor/delete))
 
          [:hr.menu-separator]
@@ -261,14 +261,14 @@
           {:key      "Expand all"
            :on-click (fn [_e]
                        (editor-handler/expand-all! block-id))}
-          "Expand all"
+          (t :command.editor/expand-block-children)
           (ui/keyboard-shortcut-from-config :editor/expand-block-children))
 
          (ui/menu-link
           {:key      "Collapse all"
            :on-click (fn [_e]
                        (editor-handler/collapse-all! block-id {}))}
-          "Collapse all"
+          (t :command.editor/collapse-block-children)
           (ui/keyboard-shortcut-from-config :editor/collapse-block-children))
 
          (when (state/sub [:plugin/simple-commands])
@@ -286,7 +286,7 @@
             {:key      "(Dev) Show block data"
              :on-click (fn []
                          (dev-common-handler/show-entity-data [:block/uuid block-id]))}
-            "(Dev) Show block data"
+            (t :command.dev/show-block-data)
             nil))
 
          (when (state/sub [:ui/developer-mode?])
@@ -295,7 +295,7 @@
              :on-click (fn []
                          (let [block (db/pull [:block/uuid block-id])]
                            (dev-common-handler/show-content-ast (:block/content block) (:block/format block))))}
-            "(Dev) Show block AST"
+            (t :command.dev/show-block-ast)
             nil))])))
 
 (rum/defc block-ref-custom-context-menu-content
@@ -309,7 +309,7 @@
                     (state/get-current-repo)
                     block-ref-id
                     :block-ref))}
-      "Open in sidebar"
+      (t :content/open-in-sidebar)
       ["⇧" "click"])
      (ui/menu-link
       {:key "copy"

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -62,7 +62,7 @@
                  (let [block-uuids (editor-handler/get-selected-toplevel-block-uuids)]
                    (state/set-modal!
                     #(export/export-blocks block-uuids))))}
-    "Copy as..."
+    (t :content/copy-as)
     nil)
    (ui/menu-link
     {:key "copy block refs"
@@ -81,7 +81,7 @@
      (ui/menu-link
       {:key "Make a Card"
        :on-click #(srs/batch-make-cards!)}
-      "Make a Flashcard"
+      (t :context-menu/make-a-flashcard)
       nil))
 
    (ui/menu-link
@@ -109,7 +109,7 @@
 (rum/defc template-checkbox
   [template-including-parent?]
   [:div.flex.flex-row.w-auto.items-center
-   [:p.text-medium.mr-2 "Including the parent block in the template?"]
+   [:p.text-medium.mr-2 (t :context-menu/template-include-parent-block)]
    (ui/toggle template-including-parent?
               #(swap! *template-including-parent? not))])
 
@@ -135,7 +135,7 @@
         (state/clear-edit!)
         [:<>
          [:div.px-4.py-2.text-sm {:on-click (fn [e] (util/stop e))}
-          [:p "What's the template's name?"]
+          [:p (t :context-menu/input-template-name)]
           [:input#new-template.form-input.block.w-full.sm:text-sm.sm:leading-5.my-2
            {:auto-focus true
             :on-change (fn [e]
@@ -148,7 +148,7 @@
                                    (when (not (string/blank? title))
                                      (if (page-handler/template-exists? title)
                                        (notification/show!
-                                        [:p "Template already exists!"]
+                                        [:p (t :context-menu/template-exists-warning)]
                                         :error)
                                        (do
                                          (editor-handler/set-block-property! block-id :template title)
@@ -161,7 +161,7 @@
         :on-click (fn [e]
                     (util/stop e)
                     (reset! edit? true))}
-       "Make a Template"
+       (t :context-menu/make-a-template)
        nil))))
 
 (rum/defc ^:large-vars/cleanup-todo block-context-menu-content <
@@ -212,14 +212,14 @@
                                tap-f (fn [block-id]
                                        (url-util/get-logseq-graph-uuid-url nil current-repo block-id))]
                            (editor-handler/copy-block-ref! block-id tap-f)))}
-            "Copy block URL"
+            (t :content/copy-block-url)
             nil))
 
          (ui/menu-link
           {:key      "Copy as"
            :on-click (fn [_]
                        (state/set-modal! #(export/export-blocks [block-id])))}
-          "Copy as..."
+          (t :content/copy-as)
           nil)
 
          (ui/menu-link
@@ -244,13 +244,13 @@
            (ui/menu-link
             {:key      "Preview Card"
              :on-click #(srs/preview (:db/id block))}
-            "Preview Card"
+            (t :context-menu/preview-flashcard)
             nil)
            (state/enable-flashcards?)
            (ui/menu-link
             {:key      "Make a Card"
              :on-click #(srs/make-block-a-card! block-id)}
-            "Make a Flashcard"
+            (t :context-menu/make-a-flashcard)
             nil)
            :else
            nil)
@@ -314,22 +314,22 @@
      (ui/menu-link
       {:key "copy"
        :on-click (fn [] (editor-handler/copy-current-ref block-ref-id))}
-      "Copy this reference"
+      (t :content/copy-ref)
       nil)
      (ui/menu-link
       {:key "delete"
        :on-click (fn [] (editor-handler/delete-current-ref! block block-ref-id))}
-      "Delete this reference"
+      (t :content/delete-ref)
       nil)
      (ui/menu-link
       {:key "replace-with-text"
        :on-click (fn [] (editor-handler/replace-ref-with-text! block block-ref-id))}
-      "Replace with text"
+      (t :content/replace-with-text)
       nil)
      (ui/menu-link
       {:key "replace-with-embed"
        :on-click (fn [] (editor-handler/replace-ref-with-embed! block block-ref-id))}
-      "Replace with embed"
+      (t :content/replace-with-embed)
       nil)]))
 
 (rum/defc page-title-custom-context-menu-content

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -44,18 +44,18 @@
     {:key "cut"
      :on-click #(editor-handler/cut-selection-blocks true)}
     (t :content/cut)
-    nil)
+    (ui/keyboard-shortcut-from-config :editor/cut))
    (ui/menu-link
     {:key "delete"
      :on-click #(do (editor-handler/delete-selection %)
                     (state/hide-custom-context-menu!))}
     "Delete"
-    nil)
+    (ui/keyboard-shortcut-from-config :editor/delete))
    (ui/menu-link
     {:key "copy"
      :on-click editor-handler/copy-selection-blocks}
     (t :content/copy)
-    nil)
+    (ui/keyboard-shortcut-from-config :editor/copy))
    (ui/menu-link
     {:key "copy as"
      :on-click (fn [_]
@@ -88,7 +88,7 @@
     {:key "cycle todos"
      :on-click editor-handler/cycle-todos!}
     "Cycle todos"
-    nil)
+    (ui/keyboard-shortcut-from-config :editor/cycle-todo))
 
    [:hr.menu-separator]
 
@@ -96,13 +96,13 @@
     {:key "Expand all"
      :on-click editor-handler/expand-all-selection!}
     "Expand all"
-    nil)
+    (ui/keyboard-shortcut-from-config :editor/expand-block-children))
 
    (ui/menu-link
     {:key "Collapse all"
      :on-click editor-handler/collapse-all-selection!}
     "Collapse all"
-    nil)])
+    (ui/keyboard-shortcut-from-config :editor/collapse-block-children))])
 
 (defonce *template-including-parent? (atom nil))
 
@@ -227,13 +227,13 @@
            :on-click (fn [_e]
                        (editor-handler/cut-block! block-id))}
           (t :content/cut)
-          nil)
+          (ui/keyboard-shortcut-from-config :editor/cut))
 
          (ui/menu-link
           {:key      "delete"
            :on-click #(editor-handler/delete-block-aux! block true)}
           "Delete"
-          nil)
+          (ui/keyboard-shortcut-from-config :editor/delete))
 
          [:hr.menu-separator]
 
@@ -262,14 +262,14 @@
            :on-click (fn [_e]
                        (editor-handler/expand-all! block-id))}
           "Expand all"
-          nil)
+          (ui/keyboard-shortcut-from-config :editor/expand-block-children))
 
          (ui/menu-link
           {:key      "Collapse all"
            :on-click (fn [_e]
                        (editor-handler/collapse-all! block-id {}))}
           "Collapse all"
-          nil)
+          (ui/keyboard-shortcut-from-config :editor/collapse-block-children))
 
          (when (state/sub [:plugin/simple-commands])
            (when-let [cmds (state/get-plugins-commands-with-type :block-context-menu-item)]

--- a/src/main/frontend/components/page_menu.cljs
+++ b/src/main/frontend/components/page_menu.cljs
@@ -163,12 +163,12 @@
                                      pid (assoc cmd :page page-name) action)}}))
 
           (when developer-mode?
-            {:title   "(Dev) Show page data"
+            {:title   (t :command.dev/show-page-data)
              :options {:on-click (fn []
                                    (dev-common-handler/show-entity-data (:db/id page)))}})
 
           (when developer-mode?
-            {:title   "(Dev) Show page AST"
+            {:title   (t :command.dev/show-page-ast)
              :options {:on-click (fn []
                                    (let [page (db/pull '[:block/format {:block/file [:file/content]}] (:db/id page))]
                                      (dev-common-handler/show-content-ast

--- a/src/main/frontend/dicts.cljc
+++ b/src/main/frontend/dicts.cljc
@@ -151,10 +151,22 @@
         :color/pink "Pink"
         :content/copy "Copy"
         :content/cut "Cut"
+        :content/copy-as "Copy as..."
+        :content/copy-block-url "Copy block URL"
         :content/copy-block-ref "Copy block ref"
         :content/copy-block-emebed "Copy block embed"
+        :content/copy-ref "Copy this reference"
+        :content/delete-ref "Delete this reference"
+        :content/replace-with-text "Replace with text"
+        :content/replace-with-embed "Replace with embed"
         :content/open-in-sidebar "Open in sidebar"
         :content/click-to-edit "Click to edit"
+        :context-menu/make-a-flashcard "Make a Flashcard"
+        :context-menu/preview-flashcard "Preview Flashcard"
+        :context-menu/make-a-template "Make a Template"
+        :context-menu/input-template-name "What's the template's name?"
+        :context-menu/template-include-parent-block "Including the parent block in the template?"
+        :context-menu/template-exists-warning "Template already exists!"
         :settings-page/git-confirm "You need to restart the app after updating the Git settings."
         :settings-page/git-switcher-label "Enable Git auto commit"
         :settings-page/git-commit-delay "Git auto commit seconds"
@@ -3446,7 +3458,7 @@
         :settings-page/sync "Синхронизация"
         :settings-page/enable-whiteboards "Интерактивные доски"
         :yes "Да"
-        
+
         :submit "Подтвердить"
         :cancel "Отмена"
         :close "Закрыть"
@@ -3463,7 +3475,7 @@
         :sync-from-local-files "Обновить"
         :sync-from-local-files-detail "Импортировать изменения из локальных файлов"
         :sync-from-local-changes-detected "При обновлении будут найдены и обработаны файлы, изменённые на диске и отличающиеся от текущего содержимого страниц Logseq. Продолжить?"
-        
+
         :search/publishing "Искать"
         :search "Искать или создать страницу"
         :whiteboard/link-whiteboard-or-block "Ссылка на доску/страницу/блок"
@@ -3518,9 +3530,9 @@
         :heading "Заголовок {1}"
         :auto-heading "Автоматический заголовок"
         :open-a-directory "Открыть локальный каталог"
-        
+
         :help/shortcut-page-title "Сочетания клавиш"
-        
+
         :plugin/installed "Установлено"
         :plugin/not-installed "Не установлено"
         :plugin/installing "Установка"
@@ -3554,33 +3566,33 @@
         :plugin.install-from-file/title "Установить расширения из plugins.edn"
         :plugin.install-from-file/notice "Следующие плагины заменят ваши плагины:"
         :plugin.install-from-file/success "Все расширения установлены!"
-        
+
         :pdf/copy-ref "Копировать ссылку"
         :pdf/copy-text "Копировать текст"
         :pdf/linked-ref "Связанные ссылки"
         :pdf/toggle-dashed "Пунктирный стиль для выделения области"
         :pdf/hl-block-colored "Цветная метка для выделенного блока"
         :pdf/doc-metadata "Метаданные документа"
-        
+
         :updater/new-version-install "Была загружена новая версия"
         :updater/quit-and-install "Перезапустить для установки"
-        
+
         :paginates/pages "Всего {1} страница"
         :paginates/prev "Предыдущая"
         :paginates/next "Следующая"
-        
+
         :tips/all-done "Все готово"
-        
+
         :command-palette/prompt "Введите команду"
         :select/default-prompt "Выберите"
         :select/default-select-multiple "Выберите один или несколько"
         :select.graph/prompt "Выберите граф"
         :select.graph/empty-placeholder-description "Нет подходящих графов. Хотите добавить другой?"
         :select.graph/add-graph "Да, добавить другой граф"
-        
+
         :file-sync/other-user-graph "Текущий локальный граф привязан к удаленному графу другого пользователя. Поэтому синхронизацию начать нельзя."
         :file-sync/graph-deleted "Текущий удаленный граф был удален"
-        
+
         :notification/clear-all "Очистить все"}
 
    :ja {:tutorial/text #?(:cljs (rc/inline "tutorial-ja.md")


### PR DESCRIPTION
Replace all explicit text with i18n text in the context menu, if missing, add new key to dicts.

Add shortcut key prompts to the context menu, if available.