### PR TITLE
chore(dep): Add nbb-logseq

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
         "@excalidraw/excalidraw": "0.12.0",
         "@hugotomazi/capacitor-navigation-bar": "^2.0.0",
         "@logseq/capacitor-file-sync": "0.0.22",
+        "@logseq/nbb-logseq": "^1.2.168",
         "@logseq/react-tweet-embed": "1.3.1-1",
         "@sentry/react": "^6.18.2",
         "@sentry/tracing": "^6.18.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -492,6 +492,13 @@
   resolved "https://registry.yarnpkg.com/@logseq/capacitor-file-sync/-/capacitor-file-sync-0.0.22.tgz#3fa94d40e5c44c70a12537ce17cf3089ff72f93b"
   integrity sha512-lb0+43YAaWy0umBCP2mPKyAPlIr2YHrLBfqGkCJUGAbrhTCAj37KZzb3snwSqeLA8dUSks9PcAN3jSgS74VMMw==
 
+"@logseq/nbb-logseq@^1.2.168":
+  version "1.2.168"
+  resolved "https://registry.yarnpkg.com/@logseq/nbb-logseq/-/nbb-logseq-1.2.168.tgz#e4120c4a7eb6c80737473292c1e20919b4453c91"
+  integrity sha512-lgZuAhck/74+9mT4vr6jVLkPcyRA/RO8ApBizq3d1L6LsPlPjdRp4nIaC2I1/p/AaIIB5vP89pMpqZfVsIHHQg==
+  dependencies:
+    import-meta-resolve "^2.1.0"
+
 "@logseq/react-tweet-embed@1.3.1-1":
   version "1.3.1-1"
   resolved "https://registry.yarnpkg.com/@logseq/react-tweet-embed/-/react-tweet-embed-1.3.1-1.tgz#119d22be8234de006fc35c3fa2a36f85634c5be6"
@@ -3635,6 +3642,11 @@ import-lazy@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
   integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
+
+import-meta-resolve@^2.1.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/import-meta-resolve/-/import-meta-resolve-2.2.2.tgz#75237301e72d1f0fbd74dbc6cca9324b164c2cc9"
+  integrity sha512-f8KcQ1D80V7RnqVm+/lirO9zkOxjGxhaTC1IPrBGd3MEfNgmNG67tSUO9gTi2F3Blr2Az6g1vocaxzkVnWl9MA==
 
 imurmurhash@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
- [x] Close #9060

Do you expect users to add it manually i.e. `yarn add nbb-logseq`? Not sure how much adding nbb-logseq impacts the deps size/download time. Alternatively, a check for system-wide nbb-logseq could be added.

CC: @logseq-cldwalker 