### PR TITLE
fix: twitter badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
         <img src="https://img.shields.io/discord/725182569297215569?color=%2385c8c8&label=Discord&logo=discord&style=for-the-badge"
             alt="chat on Discord"></a>
     <a href="https://twitter.com/intent/follow?screen_name=logseq">
-        <img src="https://img.shields.io/twitter/follow/logseq?color=%2385c8c8&label=%40logseq&logo=twitter&style=for-the-badge"
+        <img src="https://img.shields.io/badge/twitter-%40logseq-blue.svg?&color=%2385c8c8&logo=twitter&style=for-the-badge"
             alt="follow on Twitter"></a>
 </p>
 


### PR DESCRIPTION
Change the link to shields.io for a cleaner look of the twitter badge.