### PR TITLE
Enhance (Whiteboards): Auto enter edit mode when we create shapes

### DIFF
--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
@@ -554,7 +554,9 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
         <rect
           fill={
             this.props.fill && this.props.fill !== 'var(--ls-secondary-background-color)'
-              ? `var(--ls-highlight-color-${this.props.fill})`
+              ? isBuiltInColor(this.props.fill)
+                ? `var(--ls-highlight-color-${this.props.fill})`
+                : this.props.fill
               : 'var(--ls-secondary-background-color)'
           }
           stroke={getComputedColor(this.props.fill, 'background')}

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
@@ -64,7 +64,9 @@ const LogseqPortalShapeHeader = observer(
 
     const fillGradient =
         fill && fill !== 'var(--ls-secondary-background-color)'
-          ? `var(--ls-highlight-color-${fill})`
+          ? isBuiltInColor(fill)
+            ? `var(--ls-highlight-color-${fill})`
+            : fill
           : 'var(--ls-secondary-background-color)'
 
     return (

--- a/tldraw/packages/core/src/lib/tools/TLBoxTool/states/CreatingState.tsx
+++ b/tldraw/packages/core/src/lib/tools/TLBoxTool/states/CreatingState.tsx
@@ -87,8 +87,10 @@ export class CreatingState<
     this.tool.transition('idle')
     if (this.creatingShape) {
       this.app.setSelectedShapes([this.creatingShape as unknown as S])
+      this.app.api.editShape(this.creatingShape)
+    } else {
+      this.app.transition('select')
     }
-    this.app.transition('select')
     this.app.persist()
   }
 


### PR DESCRIPTION
Since Whiteboards are used in a note taking context, creating shapes without labels will be rare. Entering edit mode when we create a new shape makes sense. Arrows are not included in this category, which is fine in my opinion.

Also fixed the following
- Portal background color on previews, when we use custom colors
- Portal header background when we switch from a built-in to a custom color