### PR TITLE
enhance: add a option "page-graph" for setting "default-home"

### DIFF
--- a/src/main/frontend/components/container.cljs
+++ b/src/main/frontend/components/container.cljs
@@ -583,8 +583,9 @@
                                      (remove string/blank?))]
                  (doseq [page pages]
                    (let [page (util/safe-page-name-sanity-lc page)
-                         [db-id block-type] (if (= page "contents")
-                                              ["contents" :contents]
+                         [db-id block-type] (case page
+                                              "contents" ["contents" :contents]
+                                              "page-graph" [page :page-graph]
                                               [page :page])]
                      (state/sidebar-add-block! current-repo db-id block-type)))
                  (reset! sidebar-inited? true))))


### PR DESCRIPTION
Add a option "page-graph" for setting `:default-home` in `logseq/config.edn`.

Want to open the "page graph" on the home page by default.

refer to here

https://github.com/logseq/logseq/blob/60fbfdf2f7756ac827ed08d9e495e35a7dd472a3/src/main/frontend/components/right_sidebar.cljs#L320-L325

But I am not sure about the grammar, please verify, thanks.