### PR TITLE
Enhance cut and copy blocks

### DIFF
--- a/e2e-tests/editor.spec.ts
+++ b/e2e-tests/editor.spec.ts
@@ -818,3 +818,44 @@ test.describe('Auto-pair symbols only with text selection', () => {
     })
   }
 })
+
+test('copy blocks should remove all ref-related values', async ({ page, block }) => {
+  await createRandomPage(page)
+
+  await block.mustFill('test')
+  await page.keyboard.press(modKey + '+c', { delay: 10 })
+  await block.clickNext()
+  await page.keyboard.press(modKey + '+v')
+  await expect(page.locator('.open-block-ref-link')).toHaveCount(1)
+
+  await page.keyboard.press('ArrowUp')
+  await page.waitForTimeout(100)
+  await page.keyboard.press('Escape')
+  await expect(page.locator('.ls-block.selected')).toHaveCount(1)
+  await page.keyboard.press(modKey + '+c', { delay: 10 })
+  await block.clickNext()
+  await page.keyboard.press(modKey + '+v', { delay: 10 })
+  await block.clickNext() // let 3rd block leave editing state
+  await expect(page.locator('.open-block-ref-link')).toHaveCount(1)
+})
+
+test('undo cut block should recover refs', async ({ page, block }) => {
+  await createRandomPage(page)
+
+  await block.mustFill('test')
+  await page.keyboard.press(modKey + '+c', { delay: 10 })
+  await block.clickNext()
+  await page.keyboard.press(modKey + '+v')
+  await expect(page.locator('.open-block-ref-link')).toHaveCount(1)
+
+  await page.keyboard.press('ArrowUp')
+  await page.waitForTimeout(100)
+  await page.keyboard.press('Escape')
+  await expect(page.locator('.ls-block.selected')).toHaveCount(1)
+  await page.keyboard.press(modKey + '+x', { delay: 10 })
+  await expect(page.locator('.ls-block')).toHaveCount(1)
+  await page.keyboard.press(modKey + '+z')
+  await page.waitForTimeout(100)
+  await expect(page.locator('.ls-block')).toHaveCount(2)
+  await expect(page.locator('.open-block-ref-link')).toHaveCount(1)
+})

--- a/e2e-tests/editor.spec.ts
+++ b/e2e-tests/editor.spec.ts
@@ -828,7 +828,7 @@ test('copy blocks should remove all ref-related values', async ({ page, block })
   await page.keyboard.press(modKey + '+v')
   await expect(page.locator('.open-block-ref-link')).toHaveCount(1)
 
-  await page.keyboard.press('ArrowUp')
+  await page.keyboard.press('ArrowUp', { delay: 10 })
   await page.waitForTimeout(100)
   await page.keyboard.press('Escape')
   await expect(page.locator('.ls-block.selected')).toHaveCount(1)
@@ -848,7 +848,7 @@ test('undo cut block should recover refs', async ({ page, block }) => {
   await page.keyboard.press(modKey + '+v')
   await expect(page.locator('.open-block-ref-link')).toHaveCount(1)
 
-  await page.keyboard.press('ArrowUp')
+  await page.keyboard.press('ArrowUp', { delay: 10 })
   await page.waitForTimeout(100)
   await page.keyboard.press('Escape')
   await expect(page.locator('.ls-block.selected')).toHaveCount(1)

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2078,8 +2078,6 @@
                                                                           :outliner-op :paste
                                                                           :replace-empty-target? replace-empty-target?
                                                                           :keep-uuid? keep-uuid?})]
-          (frontend.util/pprint blocks)
-          (frontend.util/pprint blocks')
           (state/set-block-op-type! nil)
           (edit-last-block-after-inserted! result))))))
 

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -991,7 +991,7 @@
       (when block
         (let [html (export-html/export-blocks-as-html repo top-level-block-uuids nil)
               copied-blocks (get-all-blocks-by-ids repo top-level-block-uuids)
-              selected-blocks (dom/sel ".ls-block.selected.noselect")
+              selected-blocks (dom/sel ".ls-block.selected")
               selected-block-ids (->> selected-blocks
                                       (reduce
                                        (fn [selected-block-ids selected-block]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2024,8 +2024,7 @@
                   target-block
                   sibling?
                   keep-uuid?
-                  cut-paste?
-                  revert-cut-tx]
+                  revert-cut-txs]
            :or {exclude-properties []}}]
   (let [editing-block (when-let [editing-block (state/get-edit-block)]
                         (some-> (db/pull [:block/uuid (:block/uuid editing-block)])
@@ -2074,7 +2073,6 @@
                              (paste-block-cleanup block page exclude-properties format content-update-fn keep-uuid?))
                         blocks)
               result (outliner-core/insert-blocks! blocks' target-block' {:sibling? sibling?
-                                                                          :cut-paste? cut-paste?
                                                                           :outliner-op :paste
                                                                           :replace-empty-target? replace-empty-target?
                                                                           :keep-uuid? keep-uuid?})]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -801,6 +801,10 @@
 
 (declare save-block!)
 
+(defn- block-has-no-ref?
+  [eid]
+  (empty? (:block/_refs (db/entity eid))))
+
 (defn delete-block!
   ([repo]
    (delete-block! repo true))
@@ -988,6 +992,7 @@
         (let [html (export-html/export-blocks-as-html repo top-level-block-uuids nil)
               copied-blocks (get-all-blocks-by-ids repo top-level-block-uuids)]
           (common-handler/copy-to-clipboard-without-id-property! (:block/format block) content (when html? html) copied-blocks))
+        (state/set-block-op-type! :copy)
         (notification/show! "Copied!" :success)))))
 
 (defn copy-block-refs
@@ -1056,6 +1061,7 @@
 (defn cut-selection-blocks
   [copy?]
   (when copy? (copy-selection-blocks true))
+  (state/set-block-op-type! :cut)
   (when-let [blocks (seq (get-selected-blocks))]
     ;; remove embeds, references and queries
     (let [dom-blocks (remove (fn [block]
@@ -1204,6 +1210,7 @@
           html (export-html/export-blocks-as-html repo [block-id] nil)
           sorted-blocks (tree/get-sorted-block-and-children repo (:db/id block))]
       (common-handler/copy-to-clipboard-without-id-property! (:block/format block) md-content html sorted-blocks)
+      (state/set-block-op-type! :cut)
       (delete-block-aux! block true))))
 
 (defn highlight-selection-area!
@@ -2018,16 +2025,16 @@
         empty-target? (string/blank? (:block/content target-block))
         paste-nested-blocks? (nested-blocks blocks)
         target-block-has-children? (db/has-children? (:block/uuid target-block))
-        replace-empty-target? (if (and paste-nested-blocks? empty-target? target-block-has-children?)
-                                false
-                                true)
-        target-block' (if replace-empty-target? target-block
-                          (db/pull (:db/id (:block/left target-block))))
+        replace-empty-target? (and empty-target?
+                                   (or (not target-block-has-children?)
+                                       (and target-block-has-children? (= (count blocks) 1)))
+                                   (block-has-no-ref? (:db/id target-block)))
+        target-block' (if (and empty-target? target-block-has-children? paste-nested-blocks?)
+                        (db/pull (:db/id (:block/left target-block)))
+                        target-block)
         sibling? (cond
                    (and paste-nested-blocks? empty-target?)
-                   (if (= (:block/parent target-block') (:block/parent target-block))
-                     true
-                     false)
+                   (= (:block/parent target-block') (:block/parent target-block))
 
                    (some? sibling?)
                    sibling?
@@ -2056,6 +2063,7 @@
                                                                           :outliner-op :paste
                                                                           :replace-empty-target? replace-empty-target?
                                                                           :keep-uuid? keep-uuid?})]
+          (state/set-block-op-type! nil)
           (edit-last-block-after-inserted! result))))))
 
 (defn- block-tree->blocks

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2066,7 +2066,7 @@
 
     (outliner-tx/transact!
       {:outliner-op :insert-blocks
-       :additional-tx revert-cut-tx}
+       :additional-tx revert-cut-txs}
       (when target-block'
         (let [format (or (:block/format target-block') (state/get-preferred-format))
               blocks' (map (fn [block]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -975,7 +975,8 @@
   (loop [ids ids
          result []]
     (if (seq ids)
-      (let [blocks (db/get-block-and-children repo (first ids))
+      (let [db-id (:db/id (db/entity [:block/uuid (first ids)]))
+            blocks (tree/get-sorted-block-and-children repo db-id)
             result (vec (concat result blocks))]
         (recur (remove (set (map :block/uuid result)) (rest ids)) result))
       result)))
@@ -990,20 +991,7 @@
           block (db/entity [:block/uuid (first ids)])]
       (when block
         (let [html (export-html/export-blocks-as-html repo top-level-block-uuids nil)
-              copied-blocks (get-all-blocks-by-ids repo top-level-block-uuids)
-              selected-blocks (dom/sel ".ls-block.selected")
-              selected-block-ids (->> selected-blocks
-                                      (reduce
-                                       (fn [selected-block-ids selected-block]
-                                         (let [selected-block-id (dom/attr selected-block "blockid")]
-                                           (if (some #(= selected-block-id %) selected-block-ids)
-                                             selected-block-ids
-                                             (reduce #(conj %1 (dom/attr %2 "blockid"))
-                                                     (conj selected-block-ids selected-block-id)
-                                                     (seq (dom/by-class selected-block "ls-block"))))))
-                                       [])
-                                      (map uuid))
-              copied-blocks (sort-by #(.indexOf selected-block-ids (:block/uuid %)) copied-blocks)]
+              copied-blocks (get-all-blocks-by-ids repo top-level-block-uuids)]
           (common-handler/copy-to-clipboard-without-id-property! (:block/format block) content (when html? html) copied-blocks))
         (state/set-block-op-type! :copy)
         (notification/show! "Copied!" :success)))))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1987,16 +1987,18 @@
         (cond->> new-content
              (not keep-uuid?) (property/remove-property format "id")
              true             (property/remove-property format "custom_id"))]
-    (merge (dissoc block
-                   :block/pre-block?
-                   :block/meta)
+    (merge (apply dissoc block (conj (when-not keep-uuid? [:block/_refs]) :block/pre-block? :block/meta))
            {:block/page {:db/id (:db/id page)}
             :block/format format
             :block/properties (apply dissoc (:block/properties block)
-                                (concat
-                                  (when (not keep-uuid?) [:id])
-                                  [:custom_id :custom-id]
-                                  exclude-properties))
+                                     (concat
+                                      (when-not keep-uuid? [:id])
+                                      [:custom_id :custom-id]
+                                      exclude-properties))
+            :block/properties-text-values (apply dissoc (:block/properties-text-values block)
+                                                 (concat
+                                                  (when-not keep-uuid? [:id])
+                                                  exclude-properties))
             :block/content new-content})))
 
 (defn- edit-last-block-after-inserted!
@@ -2076,6 +2078,8 @@
                                                                           :outliner-op :paste
                                                                           :replace-empty-target? replace-empty-target?
                                                                           :keep-uuid? keep-uuid?})]
+          (frontend.util/pprint blocks)
+          (frontend.util/pprint blocks')
           (state/set-block-op-type! nil)
           (edit-last-block-after-inserted! result))))))
 

--- a/src/main/frontend/handler/history.cljs
+++ b/src/main/frontend/handler/history.cljs
@@ -42,6 +42,8 @@
   (util/stop e)
   (state/set-editor-op! :undo)
   (state/clear-editor-action!)
+  (state/set-block-op-type! nil)
+  (state/set-state! [:editor/last-replace-ref-content-tx (state/get-current-repo)] nil)
   (editor/save-current-block!)
   (let [{:keys [editor-cursor app-state]} (undo-redo/undo)]
     (restore-cursor! editor-cursor)

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -105,7 +105,7 @@
   [text]
   (boolean (util/safe-re-find #"(?m)^\s*\*+\s+" text)))
 
-(defn- get-revert-cut-tx
+(defn- get-revert-cut-txs
   "Get reverted previous cut tx when paste"
   [blocks]
   (let [{:keys [retracted-block-ids revert-tx]} (get-in @state/state [:editor/last-replace-ref-content-tx (state/get-current-repo)])
@@ -183,10 +183,10 @@
    (p/let [copied-blocks (get-copied-blocks)]
      (if (seq copied-blocks)
        ;; Handle internal paste
-       (let [revert-cut-tx (get-revert-cut-tx copied-blocks)
-             cut-paste? (boolean (seq revert-cut-tx))
+       (let [revert-cut-txs (get-revert-cut-txs copied-blocks)
+             cut-paste? (boolean (seq revert-cut-txs))
              keep-uuid? (= (state/get-block-op-type) :cut)]
-         (editor-handler/paste-blocks copied-blocks {:revert-cut-tx revert-cut-tx
+         (editor-handler/paste-blocks copied-blocks {:revert-cut-txs revert-cut-txs
                                                      :cut-paste? cut-paste?
                                                      :keep-uuid? keep-uuid?}))
        (paste-copied-text input text html)))

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -184,10 +184,8 @@
      (if (seq copied-blocks)
        ;; Handle internal paste
        (let [revert-cut-txs (get-revert-cut-txs copied-blocks)
-             cut-paste? (boolean (seq revert-cut-txs))
              keep-uuid? (= (state/get-block-op-type) :cut)]
          (editor-handler/paste-blocks copied-blocks {:revert-cut-txs revert-cut-txs
-                                                     :cut-paste? cut-paste?
                                                      :keep-uuid? keep-uuid?}))
        (paste-copied-text input text html)))
    (p/catch (fn [error]

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -185,7 +185,7 @@
        ;; Handle internal paste
        (let [revert-cut-tx (get-revert-cut-tx copied-blocks)
              cut-paste? (boolean (seq revert-cut-tx))
-             keep-uuid? cut-paste?]
+             keep-uuid? (= (state/get-block-op-type) :cut)]
          (editor-handler/paste-blocks copied-blocks {:revert-cut-tx revert-cut-tx
                                                      :cut-paste? cut-paste?
                                                      :keep-uuid? keep-uuid?}))

--- a/src/main/frontend/modules/outliner/core.cljs
+++ b/src/main/frontend/modules/outliner/core.cljs
@@ -528,11 +528,10 @@
                     For example, if `blocks` are from internal copy, the uuids
                     need to be changed, but there's no need for internal cut or drag & drop.
       `outliner-op`: what's the current outliner operation.
-      `cut-paste?`: whether it's pasted from cut blocks
       `replace-empty-target?`: If the `target-block` is an empty block, whether
                                to replace it, it defaults to be `false`.
     ``"
-  [blocks target-block {:keys [sibling? keep-uuid? outliner-op replace-empty-target? cut-paste?] :as opts}]
+  [blocks target-block {:keys [sibling? keep-uuid? outliner-op replace-empty-target?] :as opts}]
   {:pre [(seq blocks)
          (s/valid? ::block-map-or-entity target-block)]}
   (let [target-block' (get-target-block target-block)

--- a/src/main/frontend/modules/outliner/core.cljs
+++ b/src/main/frontend/modules/outliner/core.cljs
@@ -466,7 +466,7 @@
                       (if keep-uuid?
                         block-uuids
                         (repeatedly random-uuid)))
-        uuids (if replace-empty-target?
+        uuids (if (and (not keep-uuid?) replace-empty-target?)
                 (assoc uuids (:block/uuid (first blocks)) (:block/uuid target-block))
                 uuids)
         id->new-uuid (->> (map (fn [block] (when-let [id (:db/id block)]
@@ -505,7 +505,7 @@
                                        :block/parent parent
                                        :block/left left})
                          ;; We'll keep the original `:db/id` if it's a move operation,
-                         ;; e.g. drag and drop shouldn't change the ids.
+                         ;; e.g. internal cut or drag and drop shouldn't change the ids.
                          (not move?)
                          (dissoc :db/id)))))
                  blocks)))
@@ -526,7 +526,7 @@
       `sibling?`: as siblings (true) or children (false).
       `keep-uuid?`: whether to replace `:block/uuid` from the parameter `blocks`.
                     For example, if `blocks` are from internal copy, the uuids
-                    need to be changed, but there's no need for drag & drop.
+                    need to be changed, but there's no need for internal cut or drag & drop.
       `outliner-op`: what's the current outliner operation.
       `cut-paste?`: whether it's pasted from cut blocks
       `replace-empty-target?`: If the `target-block` is an empty block, whether
@@ -586,10 +586,7 @@
                       (when-let [left (last (filter (fn [b] (= 1 (:block/level b))) tx))]
                         [{:block/uuid (tree/-get-id next)
                           :block/left (:db/id left)}]))
-            cut-target-tx (when (and cut-paste? replace-empty-target?)
-                            [{:db/id (:db/id target-block')
-                              :block/uuid (:block/uuid (first blocks'))}])
-            full-tx (util/concat-without-nil uuids-tx tx next-tx cut-target-tx)]
+            full-tx (util/concat-without-nil (if (and keep-uuid? replace-empty-target?) (rest uuids-tx) uuids-tx) tx next-tx)]
         (when (and replace-empty-target? (state/editing?))
           (state/set-edit-content! (state/get-edit-input-id) (:block/content (first blocks))))
         {:tx-data full-tx

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -123,6 +123,7 @@
      :editor/args                           nil
      :editor/on-paste?                      false
      :editor/last-key-code                  nil
+     :editor/block-op-type                  nil             ;; :cut, :copy
 
      ;; Stores deleted refed blocks, indexed by repo
      :editor/last-replace-ref-content-tx    nil
@@ -1858,6 +1859,14 @@ Similar to re-frame subscriptions"
 (defn get-last-key-code
   []
   (:editor/last-key-code @state))
+
+(defn set-block-op-type!
+  [op-type]
+  (set-state! :editor/block-op-type op-type))
+
+(defn get-block-op-type
+  []
+  (:editor/block-op-type @state))
 
 (defn feature-http-server-enabled?
   []

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -975,7 +975,7 @@ Similar to re-frame subscriptions"
    (set-selection-blocks! blocks :down))
   ([blocks direction]
    (when (seq blocks)
-     (let [blocks (util/sort-by-height (remove nil? blocks))]
+     (let [blocks (vec (util/sort-by-height (remove nil? blocks)))]
        (swap! state assoc
              :selection/mode true
              :selection/blocks blocks
@@ -1023,7 +1023,8 @@ Similar to re-frame subscriptions"
   (swap! state assoc
          :selection/mode true
          :selection/blocks (-> (conj (vec (:selection/blocks @state)) block)
-                               (util/sort-by-height))
+                               util/sort-by-height
+                               vec)
          :selection/direction direction))
 
 (defn drop-last-selection-block!
@@ -1034,9 +1035,11 @@ Similar to re-frame subscriptions"
         last-block (if up?
                      (first blocks)
                      (peek (vec blocks)))
-        blocks' (if up?
-                  (rest blocks)
-                  (pop (vec blocks)))]
+        blocks' (-> (if up?
+                      (rest blocks)
+                      (pop (vec blocks)))
+                    util/sort-by-height
+                    vec)]
     (swap! state assoc
            :selection/mode true
            :selection/blocks blocks')


### PR DESCRIPTION
Fixed:
 - Cutting or copying multiple blocks in a non-consistent page order with the ID order in the database can result in display errors on the page. 

Related issues (not necessarily fixed by this PR): #4491, #1389, #3929 and #8188


Before

https://user-images.githubusercontent.com/824436/231724312-80f766cf-3df6-4fbd-bc20-7e87933e3da7.mp4

After

https://user-images.githubusercontent.com/824436/231751640-50bf763d-c7bd-45fb-9feb-dee864d0e1bb.mp4

Improve:
- Remove all ref-related values when copying blocks, including :id and exclude-properties in :block/properties-text-values, :block/_refs.
- Preserve the UUID when cutting blocks to avoid ref broken.
- Replace the target block if has no refs and empty content as much as possible when cutting or copying blocks, including target block has no children or only 1 block need to be pasted.