### PR TITLE
Fix: Two bugs with graph parsing for CLIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ ios/App/App/capacitor.config.json
 startup.png
 
 /src/main/frontend/tldraw-logseq.js
-/src/test/docs
+/src/test/docs*
 ~*~
 
 ios/App/App/capacitor.config.json

--- a/deps/graph-parser/.gitignore
+++ b/deps/graph-parser/.gitignore
@@ -1,3 +1,3 @@
 /.clj-kondo/.cache
 cljs-test-runner-out
-/test/docs
+/test/docs*

--- a/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
@@ -65,6 +65,8 @@
     (is (= (->> files
                 ;; logseq files aren't saved under :block/file
                 (remove #(string/includes? % (str "/" gp-config/app-name "/")))
+                ;; edn files being listed in docs by parse-graph aren't graph files
+                (remove #(and (not (gp-config/whiteboard? %)) (string/ends-with? % ".edn")))
                 set)
            (->> (d/q '[:find (pull ?b [* {:block/file [:file/path]}])
                        :where [?b :block/name] [?b :block/file]]
@@ -83,7 +85,7 @@
                 ffirst))
         "Journal page count on disk equals count in db")
 
-    (is (= {"CANCELED" 2 "DONE" 6 "LATER" 4 "NOW" 5}
+    (is (= {"CANCELED" 2 "DONE" 6 "LATER" 4 "NOW" 5 "TODO" 22}
            (->> (d/q '[:find (pull ?b [*]) :where [?b :block/marker]]
                      db)
                 (map first)
@@ -92,29 +94,30 @@
                 (into {})))
         "Task marker counts")
 
-    (is (= {:markdown 3143 :org 460} ;; 2 pages for namespaces are not parsed
+    (is (= {:markdown 5495 :org 457} ;; 2 pages for namespaces are not parsed
            (get-block-format-counts db))
         "Block format counts")
 
-    (is (= {:title 98 :id 98
-            :updated-at 47 :created-at 47
-            :card-last-score 6 :card-repeats 6 :card-next-schedule 6
-            :card-last-interval 6 :card-ease-factor 6 :card-last-reviewed 6
-            :alias 6 :logseq.macro-arguments 94 :logseq.macro-name 94 :heading 64}
+    (is (= {:description 81, :updated-at 46, :tags 5, :logseq.macro-arguments 104
+            :logseq.tldraw.shape 79, :card-last-score 6, :card-repeats 6,
+            :card-next-schedule 6, :ls-type 79, :card-last-interval 6, :type 107,
+            :template 5, :title 114, :alias 41, :supports 5, :id 145, :url 5,
+            :card-ease-factor 6, :logseq.macro-name 104, :created-at 46,
+            :card-last-reviewed 6, :platforms 51, :initial-version 8, :heading 226}
            (get-top-block-properties db))
         "Counts for top block properties")
 
-    (is (= {:title 98
-            :alias 6
-            :tags 2 :permalink 2
-            :name 1 :type 1 :related 1 :sample 1 :click 1 :id 1 :example 1}
+    (is (= {:description 77, :tags 5, :permalink 1, :ls-type 1, :type 104,
+            :related 1, :source 1, :title 113, :author 1, :sample 1, :alias 41,
+            :logseq.tldraw.page 1, :supports 5, :url 5, :platforms 50,
+            :initial-version 7, :full-title 1}
            (get-all-page-properties db))
         "Counts for all page properties")
 
     (is (= {:block/scheduled 2
             :block/priority 4
             :block/deadline 1
-            :block/collapsed? 22
+            :block/collapsed? 80
             :block/repeated? 1}
            (->> [:block/scheduled :block/priority :block/deadline :block/collapsed?
                  :block/repeated?]
@@ -125,13 +128,13 @@
                 (into {})))
         "Counts for blocks with common block attributes")
 
-    (is (= #{"term" "setting" "book" "templates" "Query" "Query/table" "page"}
+    (is (= #{"term" "setting" "book" "templates" "Query table" "page"
+             "Whiteboard" "Whiteboard/Tool" "Community" "Tweet"}
            (->> (d/q '[:find (pull ?n [*]) :where [?b :block/namespace ?n]] db)
                 (map (comp :block/original-name first))
                 set))
         "Has correct namespaces")))
 
-;; TODO update me to the number of the latest version of doc when namespace is updated
 (defn docs-graph-assertions
   "These are common assertions that should pass in both graph-parser and main
   logseq app. It is important to run these in both contexts to ensure that the
@@ -141,15 +144,15 @@
   ;; Counts assertions help check for no major regressions. These counts should
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
-    (is (= 211 (count files)) "Correct file count")
-    (is (= 42110 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 306 (count files)) "Correct file count")
+    (is (= 69679 (count (d/datoms db :eavt))) "Correct datoms count")
 
-    (is (= 3600
+    (is (= 5866
            (ffirst
             (d/q '[:find (count ?b)
                    :where [?b :block/path-refs ?bp] [?bp :block/name]] db)))
         "Correct referenced blocks count")
-    (is (= 21
+    (is (= 23
            (ffirst
             (d/q '[:find (count ?b)
                    :where [?b :block/content ?content]

--- a/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
@@ -59,6 +59,15 @@
        (map (fn [[k v]] [k (count v)]))
        (into {})))
 
+(defn- get-journal-page-count [db]
+  (->> (d/q '[:find (count ?b)
+              :where
+              [?b :block/journal? true]
+              [?b :block/name]
+              [?b :block/file]]
+            db)
+       ffirst))
+
 (defn- query-assertions
   [db files]
   (testing "Query based stats"
@@ -76,13 +85,7 @@
         "Files on disk should equal ones in db")
 
     (is (= (count (filter #(re-find #"journals/" %) files))
-           (->> (d/q '[:find (count ?b)
-                       :where
-                       [?b :block/journal? true]
-                       [?b :block/name]
-                       [?b :block/file]]
-                     db)
-                ffirst))
+           (get-journal-page-count db))
         "Journal page count on disk equals count in db")
 
     (is (= {"CANCELED" 2 "DONE" 6 "LATER" 4 "NOW" 5 "TODO" 22}

--- a/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
@@ -94,8 +94,7 @@
                 (into {})))
         "Task marker counts")
 
-    (is (= {:markdown 5495 :org 457} ;; 2 pages for namespaces are not parsed
-           (get-block-format-counts db))
+    (is (= {:markdown 5499 :org 457} (get-block-format-counts db))
         "Block format counts")
 
     (is (= {:description 81, :updated-at 46, :tags 5, :logseq.macro-arguments 104
@@ -129,11 +128,17 @@
         "Counts for blocks with common block attributes")
 
     (is (= #{"term" "setting" "book" "templates" "Query table" "page"
-             "Whiteboard" "Whiteboard/Tool" "Community" "Tweet"}
+             "Whiteboard" "Whiteboard/Tool" "Whiteboard/Tool/Shape" "Whiteboard/Object"
+             "Whiteboard/Property" "Community" "Tweet"}
            (->> (d/q '[:find (pull ?n [*]) :where [?b :block/namespace ?n]] db)
                 (map (comp :block/original-name first))
                 set))
-        "Has correct namespaces")))
+        "Has correct namespaces")
+
+    (is (empty? (->> (d/q '[:find ?n :where [?b :block/name ?n]] db)
+                     (map first)
+                     (filter #(string/includes? % "___"))))
+        "Block names don't have the slash/triple-lowbar delimiter")))
 
 (defn docs-graph-assertions
   "These are common assertions that should pass in both graph-parser and main
@@ -145,7 +150,7 @@
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
     (is (= 306 (count files)) "Correct file count")
-    (is (= 69679 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 69508 (count (d/datoms db :eavt))) "Correct datoms count")
 
     (is (= 5866
            (ffirst

--- a/deps/graph-parser/test/logseq/graph_parser/cli_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/cli_test.cljs
@@ -6,9 +6,8 @@
 
 ;; Integration test that test parsing a large graph like docs
 (deftest ^:integration parse-graph
-  (let [graph-dir "test/docs"
-        ;; TODO update docs filename rules to the latest version when the namespace PR is released
-        _ (docs-graph-helper/clone-docs-repo-if-not-exists graph-dir "v0.6.7")
+  (let [graph-dir "test/docs-0.9.2"
+        _ (docs-graph-helper/clone-docs-repo-if-not-exists graph-dir "v0.9.2")
         {:keys [conn files asts]} (gp-cli/parse-graph graph-dir {:verbose false})] ;; legacy parsing
 
     (docs-graph-helper/docs-graph-assertions @conn files)
@@ -19,6 +18,8 @@
           "There's an ast returned for every file processed")
       (is (empty? (remove #(or
                             (seq (:ast %))
+                            ;; edn files don't have ast
+                            (string/ends-with? (:file %) ".edn")
                             ;; logseq files don't have ast
                             ;; could also used gp-config but API isn't public yet
                             (string/includes? (:file %) (str graph-dir "/logseq/")))

--- a/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
@@ -120,8 +120,8 @@ body"
       (is ["@tag" "tag1" "tag2" "tag3"] (sort (:tags props))))))
 
 (deftest ^:integration test->edn
-  (let [graph-dir "test/docs"
-        _ (docs-graph-helper/clone-docs-repo-if-not-exists graph-dir "v0.6.7")
+  (let [graph-dir "test/docs-0.9.2"
+        _ (docs-graph-helper/clone-docs-repo-if-not-exists graph-dir "v0.9.2")
         files (gp-cli/build-graph-files graph-dir)
         asts-by-file (->> files
                           (map (fn [{:file/keys [path content]}]
@@ -131,21 +131,20 @@ body"
                                     (gp-mldoc/->edn content
                                                     (gp-mldoc/default-config format))])))
                           (into {}))]
-    (is (= {"CommentBlock" 1,
-            "Custom" 41,
+    (is (= {"Custom" 50,
             "Displayed_Math" 1,
             "Drawer" 1,
             "Example" 20,
             "Footnote_Definition" 2,
-            "Heading" 3496,
-            "Hiccup" 15,
-            "List" 37,
-            "Paragraph" 417,
-            "Properties" 91,
-            "Property_Drawer" 201,
-            "Quote" 9,
-            "Raw_Html" 12,
-            "Src" 56,
-            "Table" 4}
+            "Heading" 5648,
+            "Hiccup" 9,
+            "List" 22,
+            "Paragraph" 573,
+            "Properties" 87,
+            "Property_Drawer" 423,
+            "Quote" 24,
+            "Raw_Html" 18,
+            "Src" 79,
+            "Table" 8}
            (->> asts-by-file (mapcat val) (map ffirst) frequencies))
         "AST node type counts")))

--- a/deps/publishing/src/logseq/publishing/html.cljs
+++ b/deps/publishing/src/logseq/publishing/html.cljs
@@ -132,7 +132,10 @@ necessary db filtering"
   "Given the graph's db, filters the db using the given options and returns the
 generated index.html string and assets used by the html"
   [db* {:keys [app-state repo-config html-options]}]
-  (let [[db asset-filenames'] (if (:publishing/all-pages-public? repo-config)
+  (let [all-pages-public? (if-let [val (:publishing/all-pages-public? repo-config)]
+                            val
+                            (:all-pages-public? repo-config))
+        [db asset-filenames'] (if all-pages-public?
                                 (db/clean-export! db*)
                                 (db/filter-only-public-pages-and-blocks db*))
         asset-filenames (remove nil? asset-filenames')

--- a/src/main/frontend/handler/common/file.cljs
+++ b/src/main/frontend/handler/common/file.cljs
@@ -54,6 +54,7 @@
          options (merge (dissoc options :verbose)
                         {:new? new?
                          :delete-blocks-fn (partial validate-and-get-blocks-to-delete repo-url)
+                         ;; Options here should also be present in gp-cli/parse-graph
                          :extract-options (merge
                                            {:user-config (state/get-config)
                                             :date-formatter (state/get-date-formatter)

--- a/src/test/frontend/handler/repo_test.cljs
+++ b/src/test/frontend/handler/repo_test.cljs
@@ -11,11 +11,9 @@
 (use-fixtures :each {:before test-helper/start-test-db!
                      :after test-helper/destroy-test-db!})
 
-;; TODO update docs filename rules to the latest version when the namespace PR is released
 (deftest ^:integration parse-and-load-files-to-db
-  (let [graph-dir "src/test/docs"
-        ;; TODO update me to the latest version of doc when namespace is updated
-        _ (docs-graph-helper/clone-docs-repo-if-not-exists graph-dir "v0.6.7")
+  (let [graph-dir "src/test/docs-0.9.2"
+        _ (docs-graph-helper/clone-docs-repo-if-not-exists graph-dir "v0.9.2")
         files (gp-cli/build-graph-files graph-dir)
         _ (repo-handler/parse-files-and-load-to-db! test-helper/test-db files {:re-render? false :verbose false})
         db (conn/get-db test-helper/test-db)]

--- a/src/test/frontend/handler/repo_test.cljs
+++ b/src/test/frontend/handler/repo_test.cljs
@@ -2,20 +2,31 @@
   (:require [cljs.test :refer [deftest use-fixtures testing is]]
             [frontend.handler.repo :as repo-handler]
             [frontend.test.helper :as test-helper :refer [load-test-files]]
+            [frontend.state :as state]
             [logseq.graph-parser.cli :as gp-cli]
             [logseq.graph-parser.test.docs-graph-helper :as docs-graph-helper]
             [logseq.graph-parser.util.block-ref :as block-ref]
             [frontend.db.model :as model]
-            [frontend.db.conn :as conn]))
+            [frontend.db.conn :as conn]
+            [clojure.edn :as edn]
+            ["path" :as node-path]
+            ["fs" :as fs]))
 
-(use-fixtures :each {:before test-helper/start-test-db!
-                     :after test-helper/destroy-test-db!})
+(use-fixtures :each {:before (fn []
+                               ;; Set current-repo explicitly since it's not the default
+                               (state/set-current-repo! test-helper/test-db)
+                               (test-helper/start-test-db!))
+                     :after (fn []
+                              (state/set-current-repo! nil)
+                              (test-helper/destroy-test-db!))})
 
 (deftest ^:integration parse-and-load-files-to-db
   (let [graph-dir "src/test/docs-0.9.2"
         _ (docs-graph-helper/clone-docs-repo-if-not-exists graph-dir "v0.9.2")
         files (gp-cli/build-graph-files graph-dir)
-        _ (repo-handler/parse-files-and-load-to-db! test-helper/test-db files {:re-render? false :verbose false})
+        repo-config (edn/read-string (str (fs/readFileSync (node-path/join graph-dir "logseq/config.edn"))))
+        _ (test-helper/with-config repo-config
+            (repo-handler/parse-files-and-load-to-db! test-helper/test-db files {:re-render? false :verbose false}))
         db (conn/get-db test-helper/test-db)]
 
     (docs-graph-helper/docs-graph-assertions db (map :file/path files))))


### PR DESCRIPTION
This PR fixes two bugs I encountered while publishing our docs with https://github.com/logseq/publish-spa:
* the :file/name-format option wasn't being used which resulted in namespace bugs
* the older :all-pages-public? config wasn't being picked up by publishing