### PR TITLE
Fix: Show marker when block text is empty

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2334,7 +2334,7 @@
        (when-not plugin-slotted?
          [:div.flex-1.w-full
           (cond
-            (seq title)
+            (or (seq title) (:block/marker block))
             (build-block-title config block)
 
             :else


### PR DESCRIPTION
This tiny code change fixes a minor bug where if you type
```
- TODO
```
(or LATER, DOING, etc; any marker), it will simply show nothing when you exit edit mode. With this fix, it shows the checkbox and the marker now instead.

Before:
<img width="172" alt="Screen Shot 2023-04-15 at 02 29 49" src="https://user-images.githubusercontent.com/491376/232190642-d95a78b4-15a5-4301-a739-956d353116a7.png">
<img width="189" alt="Screen Shot 2023-04-15 at 02 29 53" src="https://user-images.githubusercontent.com/491376/232190643-32f47c39-4505-484b-bbbf-9247d021a058.png">


After:
<img width="186" alt="Screen Shot 2023-04-15 at 02 29 11" src="https://user-images.githubusercontent.com/491376/232190619-3a041aa7-d5d0-451e-b643-e414dd2c94d9.png">
<img width="179" alt="Screen Shot 2023-04-15 at 02 29 14" src="https://user-images.githubusercontent.com/491376/232190620-a7eab303-8627-4310-9d10-abd8192029bc.png">


The code that actually causes the checkbox to appear is here:
https://github.com/logseq/logseq/blob/89bd707f41dd99b904868ebdf6f1abb632d63198/src/main/frontend/components/block.cljs#L1910-L1912
https://github.com/logseq/logseq/blob/89bd707f41dd99b904868ebdf6f1abb632d63198/src/main/frontend/components/block.cljs#L1974

(discussed briefly on [discord](https://discord.com/channels/725182569297215569/802530020605820949/1096615875005665331))