### PR TITLE
Added more variable-rules for templates

### DIFF
--- a/src/main/frontend/template.cljs
+++ b/src/main/frontend/template.cljs
@@ -9,9 +9,13 @@
 
 (defn- variable-rules
   []
-  {"today" (page-ref/->page-ref (date/today))
+  {"random-uuid" (str (random-uuid))
+   "today" (page-ref/->page-ref (date/today))
+   "today-string" (date/today)
    "yesterday" (page-ref/->page-ref (date/yesterday))
+   "yesterday-string" (date/yesterday)
    "tomorrow" (page-ref/->page-ref (date/tomorrow))
+   "tomorrow-string" (date/tomorrow)
    "time" (date/get-current-time)
    "current page" (when-let [current-page (or
                                            (state/get-current-page)


### PR DESCRIPTION
This patch adds the ability to insert a new UUID as well as a few `-string` versions of time-related variables so that we can get them without the brackets.