### PR TITLE
[WIP] enhance: soft delete when cutting blocks

### DIFF
--- a/deps/db/src/logseq/db/schema.cljs
+++ b/deps/db/src/logseq/db/schema.cljs
@@ -22,6 +22,7 @@
    :block/left   {:db/valueType :db.type/ref
                   :db/index true}
    :block/collapsed? {:db/index true}
+   :block/cutted?    {:db/index true}
 
    ;; :markdown, :org
    :block/format {}

--- a/deps/db/src/logseq/db/schema.cljs
+++ b/deps/db/src/logseq/db/schema.cljs
@@ -22,7 +22,7 @@
    :block/left   {:db/valueType :db.type/ref
                   :db/index true}
    :block/collapsed? {:db/index true}
-   :block/cutted?    {:db/index true}
+   :block/cut?    {:db/index true}
 
    ;; :markdown, :org
    :block/format {}

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2887,7 +2887,7 @@
    :should-update (fn [old-state new-state]
                     (let [compare-keys [:block/uuid :block/content :block/parent :block/collapsed?
                                         :block/properties :block/left :block/children :block/_refs
-                                        :block/bottom? :block/top? :block/cutted?]
+                                        :block/bottom? :block/top? :block/cut?]
                           config-compare-keys [:show-cloze?]
                           b1 (second (:rum/args old-state))
                           b2 (second (:rum/args new-state))
@@ -2905,7 +2905,7 @@
                        (state/set-collapsed-block! block-id nil)))
                    state)}
   [state config block]
-  (when-not (:block/cutted? block)
+  (when-not (:block/cut? block)
     (let [repo (state/get-current-repo)
           ref? (:ref? config)
           custom-query? (boolean (:custom-query? config))]

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -370,6 +370,11 @@
       border-bottom-color: transparent;
     }
   }
+
+  &.cutted {
+    border-left: 1px solid;
+    border-left-color: #7f2323;
+  }
 }
 
 .ls-block,

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -370,11 +370,6 @@
       border-bottom-color: transparent;
     }
   }
-
-  &.cutted {
-    border-left: 1px solid;
-    border-left-color: #7f2323;
-  }
 }
 
 .ls-block,

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -42,7 +42,7 @@
 
    (ui/menu-link
     {:key "cut"
-     :on-click #(editor-handler/cut-selection-blocks true)}
+     :on-click editor-handler/copy-blocks-and-clear-selections!}
     (t :editor/cut)
     (ui/keyboard-shortcut-from-config :editor/cut))
    (ui/menu-link

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -54,7 +54,7 @@
     :block/scheduled
     :block/deadline
     :block/repeated?
-    :block/cutted?
+    :block/cut?
     :block/created-at
     :block/updated-at
     ;; TODO: remove this in later releases
@@ -1404,12 +1404,12 @@ independent of format as format specific heading characters are stripped"
                 [(get m :template) e]))
          (into {}))))
 
-(defn get-all-cutted-blocks
+(defn get-all-cut-blocks
   []
   (d/q
     '[:find [?b ...]
       :where
-      [?b :block/cutted? true]]
+      [?b :block/cut? true]]
     (conn/get-db)))
 
 (defn get-all-properties

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -54,6 +54,7 @@
     :block/scheduled
     :block/deadline
     :block/repeated?
+    :block/cutted?
     :block/created-at
     :block/updated-at
     ;; TODO: remove this in later releases
@@ -1402,6 +1403,14 @@ independent of format as format specific heading characters are stripped"
          (map (fn [[e m]]
                 [(get m :template) e]))
          (into {}))))
+
+(defn get-all-cutted-blocks
+  []
+  (d/q
+    '[:find [?b ...]
+      :where
+      [?b :block/cutted? true]]
+    (conn/get-db)))
 
 (defn get-all-properties
   []

--- a/src/main/frontend/handler/common.cljs
+++ b/src/main/frontend/handler/common.cljs
@@ -11,10 +11,10 @@
             ["ignore" :as Ignore]))
 
 (defn copy-to-clipboard-without-id-property!
-  [format raw-text html blocks]
+  [format raw-text html data]
   (util/copy-to-clipboard! (property/remove-id-property format raw-text)
                            :html html
-                           :blocks blocks))
+                           :data data))
 
 (defn config-with-document-mode
   [config]

--- a/src/main/frontend/handler/dnd.cljs
+++ b/src/main/frontend/handler/dnd.cljs
@@ -48,10 +48,10 @@
                      (tree/-get-left-id target-node))]
               (if first-child?
                 (let [parent (tree/-get-parent target-node)]
-                  (outliner-core/move-blocks! blocks (:data parent) false))
+                  (outliner-core/move-blocks! blocks (:data parent) {:sibling? false}))
                 (let [before-node (tree/-get-left target-node)]
-                  (outliner-core/move-blocks! blocks (:data before-node) true))))
-            (outliner-core/move-blocks! blocks target-block (not nested?)))))
+                  (outliner-core/move-blocks! blocks (:data before-node) {:sibling? true}))))
+            (outliner-core/move-blocks! blocks target-block {:sibling? (not nested?)}))))
 
       :else
       nil)))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2290,7 +2290,7 @@
       (outliner-tx/transact!
        {:outliner-op :move-blocks
         :real-outliner-op :indent-outdent}
-        (outliner-core/move-blocks! [(:data node)] (:data parent-node) true)))))
+        (outliner-core/move-blocks! [(:data node)] (:data parent-node) {:sibling? true})))))
 
 (defn- clear-cut-blocks-tx
   []
@@ -2306,7 +2306,10 @@
        :real-outliner-op :paste-cut-blocks
        :additional-tx (clear-cut-blocks-tx)}
       (save-current-block!)
-      (outliner-core/move-blocks! blocks editing-block true))))
+      (outliner-core/move-blocks! blocks editing-block {:sibling? true
+                                                        :outliner-op :move-blocks
+                                                        :keep-uuid? true
+                                                        :replace-empty-target? true}))))
 
 (defn clear-cut-blocks
   []

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1051,11 +1051,11 @@
         (recur (remove (set (map :block/uuid result)) (rest ids)) result))
       result)))
 
-(defn- cutted-blocks-tx
+(defn- cut-blocks-tx
   [ids]
   (for [id ids]
     {:block/uuid id
-     :block/cutted? true}))
+     :block/cut? true}))
 
 (defn copy-selection-blocks
   [html? & {:keys [op] :as opts}]
@@ -1072,7 +1072,7 @@
             (outliner-tx/transact!
               {:outliner-op :move-blocks
                :real-outliner-op :cut-blocks
-               :additional-tx (cutted-blocks-tx top-level-block-uuids)}))
+               :additional-tx (cut-blocks-tx top-level-block-uuids)}))
           (common-handler/copy-to-clipboard-without-id-property! (:block/format block) content (when html? html)
                                                                  (merge
                                                                   {:op :copy
@@ -1296,7 +1296,7 @@
                                                               :blocks [block]})
       (outliner-tx/transact!
         {:outliner-op :cut-block
-         :additional-tx (cutted-blocks-tx [block-id])}))))
+         :additional-tx (cut-blocks-tx [block-id])}))))
 
 (defn clear-last-selected-block!
   []
@@ -2292,27 +2292,27 @@
         :real-outliner-op :indent-outdent}
         (outliner-core/move-blocks! [(:data node)] (:data parent-node) true)))))
 
-(defn- clear-cutted-blocks-tx
+(defn- clear-cut-blocks-tx
   []
-  (let [ids (db-model/get-all-cutted-blocks)]
-    (map (fn [id] [:db/retract id :block/cutted?]) ids)))
+  (let [ids (db-model/get-all-cut-blocks)]
+    (map (fn [id] [:db/retract id :block/cut?]) ids)))
 
-(defn paste-cutted-blocks
+(defn paste-cut-blocks
   [blocks]
   (when-let [editing-block (state/get-edit-block)]
     (state/clear-edit!)
     (outliner-tx/transact!
       {:outliner-op :move-blocks
        :real-outliner-op :paste-cut-blocks
-       :additional-tx (clear-cutted-blocks-tx)}
+       :additional-tx (clear-cut-blocks-tx)}
       (save-current-block!)
       (outliner-core/move-blocks! blocks editing-block true))))
 
-(defn clear-cutted-blocks
+(defn clear-cut-blocks
   []
   (outliner-tx/transact!
-    {:outliner-op :clear-cutted-blocks
-     :additional-tx (clear-cutted-blocks-tx)}))
+    {:outliner-op :clear-cut-blocks
+     :additional-tx (clear-cut-blocks-tx)}))
 
 (defn- last-top-level-child?
   [{:keys [id]} current-node]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3167,7 +3167,7 @@
     (cut-selection-blocks)
     (clear-selection!)))
 
-(defn- copy-blocks-and-clear-selections!
+(defn copy-blocks-and-clear-selections!
   []
   (when-not (get-in @state/state [:ui/find-in-page :active?])
     (copy-selection-blocks true :op :cut)

--- a/src/main/frontend/handler/history.cljs
+++ b/src/main/frontend/handler/history.cljs
@@ -37,15 +37,19 @@
        (route-handler/redirect! prev-route-data))
      (swap! state/state merge state))))
 
+(defn restore-app-state-and-cursor!
+  [{:keys [editor-cursor app-state]}]
+  (restore-cursor! editor-cursor)
+  (restore-app-state! app-state))
+
 (defn undo!
   [e]
   (util/stop e)
   (state/set-editor-op! :undo)
   (state/clear-editor-action!)
   (editor/save-current-block!)
-  (let [{:keys [editor-cursor app-state]} (undo-redo/undo)]
-    (restore-cursor! editor-cursor)
-    (restore-app-state! app-state))
+  (let [e (undo-redo/undo)]
+    (restore-app-state-and-cursor! e))
   (state/set-editor-op! nil))
 
 (defn redo!
@@ -53,7 +57,6 @@
   (util/stop e)
   (state/set-editor-op! :redo)
   (state/clear-editor-action!)
-  (let [{:keys [editor-cursor app-state]} (undo-redo/redo)]
-    (restore-cursor! editor-cursor)
-    (restore-app-state! app-state))
+  (let [e (undo-redo/redo)]
+    (restore-app-state-and-cursor! e))
   (state/set-editor-op! nil))

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -9,7 +9,6 @@
             [clojure.string :as string]
             [frontend.util :as util]
             [frontend.handler.editor :as editor-handler]
-            [frontend.modules.outliner.core :as outliner-core]
             [frontend.extensions.html-parser :as html-parser]
             [goog.object :as gobj]
             [frontend.mobile.util :as mobile-util]

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -109,7 +109,7 @@
            editing-block (state/get-edit-block)]
        (cond
          (and internal-paste? (= op :cut) editing-block)
-         (editor-handler/paste-cutted-blocks blocks)
+         (editor-handler/paste-cut-blocks blocks)
 
          internal-paste?
          (editor-handler/paste-blocks copied-blocks {})

--- a/src/main/frontend/mobile/action_bar.cljs
+++ b/src/main/frontend/mobile/action_bar.cljs
@@ -54,7 +54,7 @@
        [:div.action-bar-commands
         (action-command "infinity" "Card" #(srs/make-block-a-card! (:block/uuid block)))
         (action-command "copy" "Copy" #(editor-handler/copy-selection-blocks false))
-        (action-command "cut" "Cut" #(editor-handler/cut-selection-blocks true))
+        (action-command "cut" "Cut" editor-handler/copy-blocks-and-clear-selections!)
         (action-command "trash" "Delete" #(editor-handler/delete-block-aux! block true))
         (action-command "registered" "Copy ref"
                         (fn [_event] (editor-handler/copy-block-ref! uuid block-ref/->block-ref)))

--- a/src/main/frontend/modules/outliner/core.cljs
+++ b/src/main/frontend/modules/outliner/core.cljs
@@ -443,6 +443,11 @@
                       (if keep-uuid?
                         block-uuids
                         (repeatedly random-uuid)))
+        replace-empty-target? (if (and move? replace-empty-target?
+                                       (contains? (set (map :db/id blocks))
+                                                  (:db/id (:block/left target-block))))
+                                false
+                                replace-empty-target?)
         uuids (if (and replace-empty-target? (not move?))
                 (assoc uuids (:block/uuid (first blocks)) (:block/uuid target-block))
                 uuids)

--- a/src/main/frontend/modules/outliner/core.cljs
+++ b/src/main/frontend/modules/outliner/core.cljs
@@ -684,6 +684,8 @@
                 (:db/id target-block))
              sibling?)))
 
+;; TODO: support replace-empty-target?
+;; Which is useful for cutting and pasting blocks
 (defn move-blocks
   "Move `blocks` to `target-block` as siblings or children."
   [blocks target-block {:keys [sibling? outliner-op]}]

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -238,7 +238,7 @@
                                     :fn      editor-handler/shortcut-cut}
 
    :editor/clear-cut               {:binding "mod+shift+x"
-                                    :fn      editor-handler/clear-cutted-blocks}
+                                    :fn      editor-handler/clear-cut-blocks}
 
    :editor/undo                    {:binding "mod+z"
                                     :fn      history/undo!}

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -237,6 +237,9 @@
    :editor/cut                     {:binding "mod+x"
                                     :fn      editor-handler/shortcut-cut}
 
+   :editor/clear-cut               {:binding "mod+shift+x"
+                                    :fn      editor-handler/clear-cutted-blocks}
+
    :editor/undo                    {:binding "mod+z"
                                     :fn      history/undo!}
 
@@ -580,6 +583,7 @@
                           :editor/copy
                           :editor/copy-text
                           :editor/cut
+                          :editor/clear-cut
                           :command/toggle-favorite])
      (with-meta {:before m/enable-when-not-component-editing!}))
 
@@ -671,7 +675,8 @@
     :editor/redo
     :editor/copy
     :editor/copy-text
-    :editor/cut]
+    :editor/cut
+    :editor/clear-cut]
 
    :shortcut.category/formatting
    [:editor/bold

--- a/src/main/frontend/modules/shortcut/dicts.cljc
+++ b/src/main/frontend/modules/shortcut/dicts.cljc
@@ -71,6 +71,7 @@
    :editor/copy                    "Copy (copies either selection, or block reference)"
    :editor/copy-text               "Copy selections as text"
    :editor/cut                     "Cut"
+   :editor/clear-cut               "Clear cut"
    :editor/undo                    "Undo"
    :editor/redo                    "Redo"
    :editor/insert-link             "HTML Link"

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -770,15 +770,15 @@
 
 #?(:cljs
    (defn copy-to-clipboard!
-     [text & {:keys [html blocks owner-window]}]
-     (let [data (clj->js
-                 (gp-util/remove-nils-non-nested
-                  {:text text
-                   :html html
-                   :blocks (when (seq blocks) (pr-str blocks))}))]
+     [text & {:keys [html data owner-window]}]
+     (let [data' (clj->js
+                  (gp-util/remove-nils-non-nested
+                   {:text text
+                    :html html
+                    :blocks (when (seq data) (pr-str data))}))]
        (if owner-window
-         (utils/writeClipboard data owner-window)
-         (utils/writeClipboard data)))))
+         (utils/writeClipboard data' owner-window)
+         (utils/writeClipboard data')))))
 
 (defn drop-nth [n coll]
   (keep-indexed #(when (not= %1 n) %2) coll))

--- a/src/test/frontend/handler/paste_test.cljs
+++ b/src/test/frontend/handler/paste_test.cljs
@@ -132,7 +132,7 @@
       [state/get-input (constantly #js {:value "block"})
        ;; paste-copied-blocks-or-text mocks below
        util/stop (constantly nil)
-       paste-handler/get-copied-blocks (constantly (p/resolved expected-blocks))
+       paste-handler/get-internal-copy-data (constantly (p/resolved {:blocks expected-blocks}))
        editor-handler/paste-blocks (fn [blocks _] (reset! actual-blocks blocks))]
       (p/let [_ ((paste-handler/editor-on-paste! nil)
                       #js {:clipboardData #js {:getData (constantly clipboard)}})]

--- a/src/test/frontend/modules/outliner/core_test.cljs
+++ b/src/test/frontend/modules/outliner/core_test.cljs
@@ -136,7 +136,7 @@
     (transact-tree! tree)
     (outliner-tx/transact!
       {:graph test-db}
-      (outliner-core/move-blocks! [(get-block 3)] (get-block 14) true))
+      (outliner-core/move-blocks! [(get-block 3)] (get-block 14) {:sibling? true}))
     (is (= [6 9] (get-children 2)))
     (is (= [13 14 3 15] (get-children 12))))
 
@@ -157,7 +157,7 @@
       (transact-tree! tree)
       (outliner-tx/transact!
         {:graph test-db}
-        (outliner-core/move-blocks! [(get-block 3)] (get-block 12) false))
+        (outliner-core/move-blocks! [(get-block 3)] (get-block 12) {:sibling? false}))
       (is (= [6 9] (get-children 2)))
       (is (= [3 13 14 15] (get-children 12))))))
 
@@ -551,7 +551,7 @@
           (when (seq blocks)
             (let [target (get-random-block)]
               (outliner-tx/transact! {:graph test-db}
-                (outliner-core/move-blocks! blocks target (gen/generate gen/boolean)))
+                (outliner-core/move-blocks! blocks target {:sibling? (gen/generate gen/boolean)}))
               (let [total (get-blocks-count)]
                 (is (= total (count @*random-blocks)))))))))))
 
@@ -619,7 +619,7 @@
                  (let [blocks (get-random-successive-blocks)]
                    (when (seq blocks)
                      (outliner-tx/transact! {:graph test-db}
-                       (outliner-core/move-blocks! blocks (get-random-block) (gen/generate gen/boolean))))))
+                       (outliner-core/move-blocks! blocks (get-random-block) {:sibling? (gen/generate gen/boolean)})))))
 
                ;; move up down
                (fn []


### PR DESCRIPTION
This PR set a property `:block/cut?` to `true` when cutting blocks instead of removing the blocks from the db. The benefit is that there are no broken refs when cutting blocks.

Currently, cut blocks will still be in the plain-text files, this may be against the user's intention because usually, people use `cut` to delete blocks permanently. We can skip those cut blocks when exporting to plain-text files, but it has a problem that re-index the graph(or related files) will not have those cut blocks back, which can lead to broken block refs.

Master:
https://www.loom.com/share/24f4431134ce42798a1a7f2ad5ac9c1a

This branch:
https://www.loom.com/share/57fd474e83344d1ab5eef19f0f2e550a