### PR TITLE
Feat (Whiteboards): Element locking

### DIFF
--- a/e2e-tests/whiteboards.spec.ts
+++ b/e2e-tests/whiteboards.spec.ts
@@ -159,6 +159,18 @@ test('undo the delete action', async ({ page }) => {
   await expect(page.locator('.logseq-tldraw .tl-line-container')).toHaveCount(1)
 })
 
+test('locked elements should not be removed', async ({ page }) => {
+  await page.keyboard.press('Escape')
+  await page.waitForTimeout(1000)
+  await page.click('.logseq-tldraw .tl-box-container:first-of-type')
+  await page.keyboard.press(`${modKey}+l`)
+  await page.keyboard.press('Delete')
+  await page.keyboard.press(`${modKey}+Shift+l`)
+
+  await expect(page.locator('.logseq-tldraw .tl-box-container')).toHaveCount(2)
+
+})
+
 test('move arrow to back', async ({ page }) => {
   await page.keyboard.press('Escape')
   await page.waitForTimeout(1000)

--- a/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
@@ -90,8 +90,10 @@ export const withFillShapes = Object.entries(shapeMapping)
   })
   .map(([key]) => key) as ShapeType[]
 
-function filterShapeByAction<S extends Shape>(shapes: Shape[], type: ContextBarActionType): S[] {
-  return shapes.filter(shape => shapeMapping[shape.props.type]?.includes(type)) as S[]
+function filterShapeByAction<S extends Shape>(type: ContextBarActionType) {
+  const app = useApp<Shape>()
+  const unlockedSelectedShapes = app.selectedShapesArray.filter(s => !s.props.isLocked)
+  return unlockedSelectedShapes.filter(shape => shapeMapping[shape.props.type]?.includes(type))
 }
 
 const EditAction = observer(() => {
@@ -100,7 +102,7 @@ const EditAction = observer(() => {
   } = React.useContext(LogseqContext)
 
   const app = useApp<Shape>()
-  const shape = filterShapeByAction(app.selectedShapesArray, 'Edit')[0]
+  const shape = filterShapeByAction('Edit')[0]
 
   const iconName =
     ('label' in shape.props && shape.props.label) || ('text' in shape.props && shape.props.text)
@@ -144,10 +146,7 @@ const EditAction = observer(() => {
 
 const AutoResizingAction = observer(() => {
   const app = useApp<Shape>()
-  const shapes = filterShapeByAction<LogseqPortalShape | TextShape | HTMLShape>(
-    app.selectedShapesArray,
-    'AutoResizing'
-  )
+  const shapes = filterShapeByAction<LogseqPortalShape | TextShape | HTMLShape>('AutoResizing')
 
   const pressed = shapes.every(s => s.props.isAutoResizing)
 
@@ -177,10 +176,7 @@ const AutoResizingAction = observer(() => {
 
 const LogseqPortalViewModeAction = observer(() => {
   const app = useApp<Shape>()
-  const shapes = filterShapeByAction<LogseqPortalShape>(
-    app.selectedShapesArray,
-    'LogseqPortalViewMode'
-  )
+  const shapes = filterShapeByAction<LogseqPortalShape>('LogseqPortalViewMode')
 
   const collapsed = shapes.every(s => s.collapsed)
   const ViewModeOptions: ToggleGroupInputOption[] = [
@@ -215,8 +211,7 @@ const ScaleLevelAction = observer(() => {
     handlers: { isMobile },
   } = React.useContext(LogseqContext)
 
-  const app = useApp<Shape>()
-  const shapes = filterShapeByAction<LogseqPortalShape>(app.selectedShapesArray, 'ScaleLevel')
+  const shapes = filterShapeByAction<LogseqPortalShape>('ScaleLevel')
   const scaleLevel = new Set(shapes.map(s => s.scaleLevel)).size > 1 ? '' : shapes[0].scaleLevel
 
   return <ScaleInput scaleLevel={scaleLevel} compact={isMobile()} />
@@ -224,7 +219,7 @@ const ScaleLevelAction = observer(() => {
 
 const IFrameSourceAction = observer(() => {
   const app = useApp<Shape>()
-  const shape = filterShapeByAction<IFrameShape>(app.selectedShapesArray, 'IFrameSource')[0]
+  const shape = filterShapeByAction<IFrameShape>('IFrameSource')[0]
 
   const handleChange = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     shape.onIFrameSourceChange(e.target.value.trim().toLowerCase())
@@ -255,7 +250,7 @@ const IFrameSourceAction = observer(() => {
 
 const YoutubeLinkAction = observer(() => {
   const app = useApp<Shape>()
-  const shape = filterShapeByAction<YouTubeShape>(app.selectedShapesArray, 'YoutubeLink')[0]
+  const shape = filterShapeByAction<YouTubeShape>('YoutubeLink')[0]
   const handleChange = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     shape.onYoutubeLinkChange(e.target.value)
     app.persist()
@@ -282,7 +277,7 @@ const YoutubeLinkAction = observer(() => {
 
 const TwitterLinkAction = observer(() => {
   const app = useApp<Shape>()
-  const shape = filterShapeByAction<TweetShape>(app.selectedShapesArray, 'TwitterLink')[0]
+  const shape = filterShapeByAction<TweetShape>('TwitterLink')[0]
   const handleChange = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     shape.onTwitterLinkChange(e.target.value)
     app.persist()
@@ -309,10 +304,7 @@ const TwitterLinkAction = observer(() => {
 
 const NoFillAction = observer(() => {
   const app = useApp<Shape>()
-  const shapes = filterShapeByAction<BoxShape | PolygonShape | EllipseShape>(
-    app.selectedShapesArray,
-    'NoFill'
-  )
+  const shapes = filterShapeByAction<BoxShape | PolygonShape | EllipseShape>('NoFill')
   const handleChange = React.useCallback((v: boolean) => {
     shapes.forEach(s => s.update({ noFill: v }))
     app.persist()
@@ -337,7 +329,7 @@ const SwatchAction = observer(() => {
   // Placeholder
   const shapes = filterShapeByAction<
     BoxShape | PolygonShape | EllipseShape | LineShape | PencilShape | TextShape
-  >(app.selectedShapesArray, 'Swatch')
+  >('Swatch')
 
   const handleSetColor = React.useCallback((color: string) => {
     shapes.forEach(s => {
@@ -369,7 +361,7 @@ const StrokeTypeAction = observer(() => {
   const app = useApp<Shape>()
   const shapes = filterShapeByAction<
     BoxShape | PolygonShape | EllipseShape | LineShape | PencilShape
-  >(app.selectedShapesArray, 'StrokeType')
+  >('StrokeType')
 
   const StrokeTypeOptions: ToggleGroupInputOption[] = [
     {
@@ -409,7 +401,7 @@ const StrokeTypeAction = observer(() => {
 
 const ArrowModeAction = observer(() => {
   const app = useApp<Shape>()
-  const shapes = filterShapeByAction<LineShape>(app.selectedShapesArray, 'ArrowMode')
+  const shapes = filterShapeByAction<LineShape>('ArrowMode')
 
   const StrokeTypeOptions: ToggleGroupInputOption[] = [
     {
@@ -453,7 +445,7 @@ const ArrowModeAction = observer(() => {
 
 const TextStyleAction = observer(() => {
   const app = useApp<Shape>()
-  const shapes = filterShapeByAction<TextShape>(app.selectedShapesArray, 'TextStyle')
+  const shapes = filterShapeByAction<TextShape>('TextStyle')
 
   const bold = shapes.every(s => s.props.fontWeight > 500)
   const italic = shapes.every(s => s.props.italic)

--- a/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
@@ -56,7 +56,7 @@ export const ContextMenu = observer(function ContextMenu({
         tabIndex={-1}
       >
         <div>
-          {app.selectedShapes?.size > 1 && !app.readOnly && (
+          {app.selectedShapes?.size > 1 && !app.readOnly && app.selectedShapesArray?.some(s => !s.props.isLocked) && (
             <>
               <ReactContextMenu.Item>
                 <div className="tl-menu-button-row pb-0">
@@ -145,6 +145,7 @@ export const ContextMenu = observer(function ContextMenu({
           )}
           {(app.selectedShapesArray.some(s => s.type === 'group' || app.getParentGroup(s)) ||
             app.selectedShapesArray.length > 1) &&
+            app.selectedShapesArray?.some(s => !s.props.isLocked) &&
             !app.readOnly && (
               <>
                 {app.selectedShapesArray.some(s => s.type === 'group' || app.getParentGroup(s)) && (
@@ -161,7 +162,7 @@ export const ContextMenu = observer(function ContextMenu({
                     </div>
                   </ReactContextMenu.Item>
                 )}
-                {app.selectedShapesArray.length > 1 && (
+                {app.selectedShapesArray.length > 1 && app.selectedShapesArray?.some(s => !s.props.isLocked) && (
                   <ReactContextMenu.Item
                     className="tl-menu-item"
                     onClick={() => runAndTransition(app.api.doGroup)}
@@ -178,7 +179,7 @@ export const ContextMenu = observer(function ContextMenu({
                 <ReactContextMenu.Separator className="menu-separator" />
               </>
             )}
-          {app.selectedShapes?.size > 0 && (
+          {app.selectedShapes?.size > 0 && app.selectedShapesArray?.some(s => !s.props.isLocked) && (
             <>
               {!app.readOnly && (
                 <ReactContextMenu.Item
@@ -276,7 +277,25 @@ export const ContextMenu = observer(function ContextMenu({
               Deselect all
             </ReactContextMenu.Item>
           )}
-          {app.selectedShapes?.size > 0 && !app.readOnly && (
+          {app.selectedShapes?.size > 0 && app.selectedShapesArray?.some(s => !s.props.isLocked) && (
+            <ReactContextMenu.Item
+              className="tl-menu-item"
+              onClick={() => runAndTransition(() => app.setLock(true))}
+            >
+              <TablerIcon className="tl-menu-icon" name="lock" />
+              Lock
+            </ReactContextMenu.Item>
+          )}
+          {app.selectedShapes?.size > 0 && app.selectedShapesArray?.some(s => s.props.isLocked) && (
+            <ReactContextMenu.Item
+              className="tl-menu-item"
+              onClick={() => runAndTransition(() => app.setLock(false))}
+            >
+              <TablerIcon className="tl-menu-icon" name="lock-open" />
+              Unlock
+            </ReactContextMenu.Item>
+          )}
+          {app.selectedShapes?.size > 0 && !app.readOnly && app.selectedShapesArray?.some(s => !s.props.isLocked) && (
             <>
               <ReactContextMenu.Item
                 className="tl-menu-item"

--- a/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
@@ -280,7 +280,7 @@ export const ContextMenu = observer(function ContextMenu({
           {app.selectedShapes?.size > 0 && app.selectedShapesArray?.some(s => !s.props.isLocked) && (
             <ReactContextMenu.Item
               className="tl-menu-item"
-              onClick={() => runAndTransition(() => app.setLock(true))}
+              onClick={() => runAndTransition(() => app.setLocked(true))}
             >
               <TablerIcon className="tl-menu-icon" name="lock" />
               Lock
@@ -289,7 +289,7 @@ export const ContextMenu = observer(function ContextMenu({
           {app.selectedShapes?.size > 0 && app.selectedShapesArray?.some(s => s.props.isLocked) && (
             <ReactContextMenu.Item
               className="tl-menu-item"
-              onClick={() => runAndTransition(() => app.setLock(false))}
+              onClick={() => runAndTransition(() => app.setLocked(false))}
             >
               <TablerIcon className="tl-menu-icon" name="lock-open" />
               Unlock

--- a/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
@@ -289,6 +289,11 @@ export const ContextMenu = observer(function ContextMenu({
             >
               <TablerIcon className="tl-menu-icon" name="lock" />
               Lock
+              <div className="tl-menu-right-slot">
+                <span className="keyboard-shortcut">
+                <code>{MOD_KEY}</code> <code>L</code>
+                </span>
+              </div>
             </ReactContextMenu.Item>
           )}
           {app.selectedShapes?.size > 0 && app.selectedShapesArray?.some(s => s.props.isLocked) && (
@@ -298,6 +303,11 @@ export const ContextMenu = observer(function ContextMenu({
             >
               <TablerIcon className="tl-menu-icon" name="lock-open" />
               Unlock
+              <div className="tl-menu-right-slot">
+                <span className="keyboard-shortcut">
+                <code>{MOD_KEY}</code> <code>⇧</code> <code>L</code>
+                </span>
+              </div>
             </ReactContextMenu.Item>
           )}
           {app.selectedShapes?.size > 0 &&

--- a/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
@@ -56,77 +56,81 @@ export const ContextMenu = observer(function ContextMenu({
         tabIndex={-1}
       >
         <div>
-          {app.selectedShapes?.size > 1 && !app.readOnly && app.selectedShapesArray?.some(s => !s.props.isLocked) && (
-            <>
-              <ReactContextMenu.Item>
-                <div className="tl-menu-button-row pb-0">
-                  <Button
-                    tooltip="Align left"
-                    onClick={() => runAndTransition(() => app.align(AlignType.Left))}
-                  >
-                    <TablerIcon name="layout-align-left" />
-                  </Button>
-                  <Button
-                    tooltip="Align center horizontally"
-                    onClick={() => runAndTransition(() => app.align(AlignType.CenterHorizontal))}
-                  >
-                    <TablerIcon name="layout-align-center" />
-                  </Button>
-                  <Button
-                    tooltip="Align right"
-                    onClick={() => runAndTransition(() => app.align(AlignType.Right))}
-                  >
-                    <TablerIcon name="layout-align-right" />
-                  </Button>
-                  <Separator.Root className="tl-toolbar-separator" orientation="vertical" />
-                  <Button
-                    tooltip="Distribute horizontally"
-                    onClick={() =>
-                      runAndTransition(() => app.distribute(DistributeType.Horizontal))
-                    }
-                  >
-                    <TablerIcon name="layout-distribute-vertical" />
-                  </Button>
-                </div>
-                <div className="tl-menu-button-row pt-0">
-                  <Button
-                    tooltip="Align top"
-                    onClick={() => runAndTransition(() => app.align(AlignType.Top))}
-                  >
-                    <TablerIcon name="layout-align-top" />
-                  </Button>
-                  <Button
-                    tooltip="Align center vertically"
-                    onClick={() => runAndTransition(() => app.align(AlignType.CenterVertical))}
-                  >
-                    <TablerIcon name="layout-align-middle" />
-                  </Button>
-                  <Button
-                    tooltip="Align bottom"
-                    onClick={() => runAndTransition(() => app.align(AlignType.Bottom))}
-                  >
-                    <TablerIcon name="layout-align-bottom" />
-                  </Button>
-                  <Separator.Root className="tl-toolbar-separator" orientation="vertical" />
-                  <Button
-                    tooltip="Distribute vertically"
-                    onClick={() => runAndTransition(() => app.distribute(DistributeType.Vertical))}
-                  >
-                    <TablerIcon name="layout-distribute-horizontal" />
-                  </Button>
-                </div>
-              </ReactContextMenu.Item>
-              <ReactContextMenu.Separator className="menu-separator" />
-              <ReactContextMenu.Item
-                className="tl-menu-item"
-                onClick={() => runAndTransition(app.packIntoRectangle)}
-              >
-                <TablerIcon className="tl-menu-icon" name="layout-grid" />
-                Pack into rectangle
-              </ReactContextMenu.Item>
-              <ReactContextMenu.Separator className="menu-separator" />
-            </>
-          )}
+          {app.selectedShapes?.size > 1 &&
+            !app.readOnly &&
+            app.selectedShapesArray?.some(s => !s.props.isLocked) && (
+              <>
+                <ReactContextMenu.Item>
+                  <div className="tl-menu-button-row pb-0">
+                    <Button
+                      tooltip="Align left"
+                      onClick={() => runAndTransition(() => app.align(AlignType.Left))}
+                    >
+                      <TablerIcon name="layout-align-left" />
+                    </Button>
+                    <Button
+                      tooltip="Align center horizontally"
+                      onClick={() => runAndTransition(() => app.align(AlignType.CenterHorizontal))}
+                    >
+                      <TablerIcon name="layout-align-center" />
+                    </Button>
+                    <Button
+                      tooltip="Align right"
+                      onClick={() => runAndTransition(() => app.align(AlignType.Right))}
+                    >
+                      <TablerIcon name="layout-align-right" />
+                    </Button>
+                    <Separator.Root className="tl-toolbar-separator" orientation="vertical" />
+                    <Button
+                      tooltip="Distribute horizontally"
+                      onClick={() =>
+                        runAndTransition(() => app.distribute(DistributeType.Horizontal))
+                      }
+                    >
+                      <TablerIcon name="layout-distribute-vertical" />
+                    </Button>
+                  </div>
+                  <div className="tl-menu-button-row pt-0">
+                    <Button
+                      tooltip="Align top"
+                      onClick={() => runAndTransition(() => app.align(AlignType.Top))}
+                    >
+                      <TablerIcon name="layout-align-top" />
+                    </Button>
+                    <Button
+                      tooltip="Align center vertically"
+                      onClick={() => runAndTransition(() => app.align(AlignType.CenterVertical))}
+                    >
+                      <TablerIcon name="layout-align-middle" />
+                    </Button>
+                    <Button
+                      tooltip="Align bottom"
+                      onClick={() => runAndTransition(() => app.align(AlignType.Bottom))}
+                    >
+                      <TablerIcon name="layout-align-bottom" />
+                    </Button>
+                    <Separator.Root className="tl-toolbar-separator" orientation="vertical" />
+                    <Button
+                      tooltip="Distribute vertically"
+                      onClick={() =>
+                        runAndTransition(() => app.distribute(DistributeType.Vertical))
+                      }
+                    >
+                      <TablerIcon name="layout-distribute-horizontal" />
+                    </Button>
+                  </div>
+                </ReactContextMenu.Item>
+                <ReactContextMenu.Separator className="menu-separator" />
+                <ReactContextMenu.Item
+                  className="tl-menu-item"
+                  onClick={() => runAndTransition(app.packIntoRectangle)}
+                >
+                  <TablerIcon className="tl-menu-icon" name="layout-grid" />
+                  Pack into rectangle
+                </ReactContextMenu.Item>
+                <ReactContextMenu.Separator className="menu-separator" />
+              </>
+            )}
           {app.selectedShapes?.size > 0 && (
             <>
               <ReactContextMenu.Item
@@ -162,20 +166,21 @@ export const ContextMenu = observer(function ContextMenu({
                     </div>
                   </ReactContextMenu.Item>
                 )}
-                {app.selectedShapesArray.length > 1 && app.selectedShapesArray?.some(s => !s.props.isLocked) && (
-                  <ReactContextMenu.Item
-                    className="tl-menu-item"
-                    onClick={() => runAndTransition(app.api.doGroup)}
-                  >
-                    <TablerIcon className="tl-menu-icon" name="group" />
-                    Group
-                    <div className="tl-menu-right-slot">
-                      <span className="keyboard-shortcut">
-                        <code>{MOD_KEY}</code> <code>G</code>
-                      </span>
-                    </div>
-                  </ReactContextMenu.Item>
-                )}
+                {app.selectedShapesArray.length > 1 &&
+                  app.selectedShapesArray?.some(s => !s.props.isLocked) && (
+                    <ReactContextMenu.Item
+                      className="tl-menu-item"
+                      onClick={() => runAndTransition(app.api.doGroup)}
+                    >
+                      <TablerIcon className="tl-menu-icon" name="group" />
+                      Group
+                      <div className="tl-menu-right-slot">
+                        <span className="keyboard-shortcut">
+                          <code>{MOD_KEY}</code> <code>G</code>
+                        </span>
+                      </div>
+                    </ReactContextMenu.Item>
+                  )}
                 <ReactContextMenu.Separator className="menu-separator" />
               </>
             )}
@@ -295,83 +300,85 @@ export const ContextMenu = observer(function ContextMenu({
               Unlock
             </ReactContextMenu.Item>
           )}
-          {app.selectedShapes?.size > 0 && !app.readOnly && app.selectedShapesArray?.some(s => !s.props.isLocked) && (
-            <>
-              <ReactContextMenu.Item
-                className="tl-menu-item"
-                onClick={() => runAndTransition(app.api.deleteShapes)}
-              >
-                <TablerIcon className="tl-menu-icon" name="backspace" />
-                Delete
-                <div className="tl-menu-right-slot">
-                  <span className="keyboard-shortcut">
-                    <code>Del</code>
-                  </span>
-                </div>
-              </ReactContextMenu.Item>
-              {app.selectedShapes?.size > 1 && !app.readOnly && (
-                <>
-                  <ReactContextMenu.Separator className="menu-separator" />
-                  <ReactContextMenu.Item
-                    className="tl-menu-item"
-                    onClick={() => runAndTransition(app.flipHorizontal)}
-                  >
-                    <TablerIcon className="tl-menu-icon" name="flip-horizontal" />
-                    Flip horizontally
-                  </ReactContextMenu.Item>
-                  <ReactContextMenu.Item
-                    className="tl-menu-item"
-                    onClick={() => runAndTransition(app.flipVertical)}
-                  >
-                    <TablerIcon className="tl-menu-icon" name="flip-vertical" />
-                    Flip vertically
-                  </ReactContextMenu.Item>
-                </>
-              )}
-              {!app.readOnly && (
-                <>
-                  <ReactContextMenu.Separator className="menu-separator" />
-                  <ReactContextMenu.Item
-                    className="tl-menu-item"
-                    onClick={() => runAndTransition(app.bringToFront)}
-                  >
-                    Move to front
-                    <div className="tl-menu-right-slot">
-                      <span className="keyboard-shortcut">
-                        <code>⇧</code> <code>]</code>
-                      </span>
-                    </div>
-                  </ReactContextMenu.Item>
-                  <ReactContextMenu.Item
-                    className="tl-menu-item"
-                    onClick={() => runAndTransition(app.sendToBack)}
-                  >
-                    Move to back
-                    <div className="tl-menu-right-slot">
-                      <span className="keyboard-shortcut">
-                        <code>⇧</code> <code>[</code>
-                      </span>
-                    </div>
-                  </ReactContextMenu.Item>
-                </>
-              )}
-
-              {developerMode && (
+          {app.selectedShapes?.size > 0 &&
+            !app.readOnly &&
+            app.selectedShapesArray?.some(s => !s.props.isLocked) && (
+              <>
                 <ReactContextMenu.Item
                   className="tl-menu-item"
-                  onClick={() => {
-                    if (app.selectedShapesArray.length === 1) {
-                      console.log(toJS(app.selectedShapesArray[0].serialized))
-                    } else {
-                      console.log(app.selectedShapesArray.map(s => toJS(s.serialized)))
-                    }
-                  }}
+                  onClick={() => runAndTransition(app.api.deleteShapes)}
                 >
-                  (Dev) Print shape props
+                  <TablerIcon className="tl-menu-icon" name="backspace" />
+                  Delete
+                  <div className="tl-menu-right-slot">
+                    <span className="keyboard-shortcut">
+                      <code>Del</code>
+                    </span>
+                  </div>
                 </ReactContextMenu.Item>
-              )}
-            </>
-          )}
+                {app.selectedShapes?.size > 1 && !app.readOnly && (
+                  <>
+                    <ReactContextMenu.Separator className="menu-separator" />
+                    <ReactContextMenu.Item
+                      className="tl-menu-item"
+                      onClick={() => runAndTransition(app.flipHorizontal)}
+                    >
+                      <TablerIcon className="tl-menu-icon" name="flip-horizontal" />
+                      Flip horizontally
+                    </ReactContextMenu.Item>
+                    <ReactContextMenu.Item
+                      className="tl-menu-item"
+                      onClick={() => runAndTransition(app.flipVertical)}
+                    >
+                      <TablerIcon className="tl-menu-icon" name="flip-vertical" />
+                      Flip vertically
+                    </ReactContextMenu.Item>
+                  </>
+                )}
+                {!app.readOnly && (
+                  <>
+                    <ReactContextMenu.Separator className="menu-separator" />
+                    <ReactContextMenu.Item
+                      className="tl-menu-item"
+                      onClick={() => runAndTransition(app.bringToFront)}
+                    >
+                      Move to front
+                      <div className="tl-menu-right-slot">
+                        <span className="keyboard-shortcut">
+                          <code>⇧</code> <code>]</code>
+                        </span>
+                      </div>
+                    </ReactContextMenu.Item>
+                    <ReactContextMenu.Item
+                      className="tl-menu-item"
+                      onClick={() => runAndTransition(app.sendToBack)}
+                    >
+                      Move to back
+                      <div className="tl-menu-right-slot">
+                        <span className="keyboard-shortcut">
+                          <code>⇧</code> <code>[</code>
+                        </span>
+                      </div>
+                    </ReactContextMenu.Item>
+                  </>
+                )}
+
+                {developerMode && (
+                  <ReactContextMenu.Item
+                    className="tl-menu-item"
+                    onClick={() => {
+                      if (app.selectedShapesArray.length === 1) {
+                        console.log(toJS(app.selectedShapesArray[0].serialized))
+                      } else {
+                        console.log(app.selectedShapesArray.map(s => toJS(s.serialized)))
+                      }
+                    }}
+                  >
+                    (Dev) Print shape props
+                  </ReactContextMenu.Item>
+                )}
+              </>
+            )}
         </div>
       </ReactContextMenu.Content>
     </ReactContextMenu.Root>

--- a/tldraw/apps/tldraw-logseq/src/hooks/usePaste.ts
+++ b/tldraw/apps/tldraw-logseq/src/hooks/usePaste.ts
@@ -399,6 +399,7 @@ const handleCreatingShapes = async (
     return {
       ...shape,
       parentId: app.currentPageId,
+      isLocked: false,
       id: validUUID(shape.id) ? shape.id : uniqueId(),
     }
   })

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/BoxShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/BoxShape.tsx
@@ -166,12 +166,13 @@ export class BoxShape extends TLBoxShape<BoxShapeProps> {
       props: {
         size: [w, h],
         borderRadius,
+        isLocked,
       },
     } = this
 
     return (
       <g>
-        <rect width={w} height={h} rx={borderRadius} ry={borderRadius} fill="transparent" />
+        <rect width={w} height={h} rx={borderRadius} ry={borderRadius} fill="transparent" strokeDasharray={isLocked ? '8 2' : undefined} />
       </g>
     )
   })

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/BoxShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/BoxShape.tsx
@@ -172,7 +172,14 @@ export class BoxShape extends TLBoxShape<BoxShapeProps> {
 
     return (
       <g>
-        <rect width={w} height={h} rx={borderRadius} ry={borderRadius} fill="transparent" strokeDasharray={isLocked ? '8 2' : undefined} />
+        <rect
+          width={w}
+          height={h}
+          rx={borderRadius}
+          ry={borderRadius}
+          fill="transparent"
+          strokeDasharray={isLocked ? '8 2' : undefined}
+        />
       </g>
     )
   })

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/DotShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/DotShape.tsx
@@ -43,8 +43,8 @@ export class DotShape extends TLDotShape<DotShapeProps> {
   })
 
   ReactIndicator = observer(() => {
-    const { radius } = this.props
-    return <circle cx={radius} cy={radius} r={radius} pointerEvents="all" />
+    const { radius, isLocked } = this.props
+    return <circle cx={radius} cy={radius} r={radius} pointerEvents="all" strokeDasharray={isLocked ? "8 2" : "undefined"} />
   })
 
   validateProps = (props: Partial<DotShapeProps>) => {

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/DotShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/DotShape.tsx
@@ -44,7 +44,15 @@ export class DotShape extends TLDotShape<DotShapeProps> {
 
   ReactIndicator = observer(() => {
     const { radius, isLocked } = this.props
-    return <circle cx={radius} cy={radius} r={radius} pointerEvents="all" strokeDasharray={isLocked ? "8 2" : "undefined"} />
+    return (
+      <circle
+        cx={radius}
+        cy={radius}
+        r={radius}
+        pointerEvents="all"
+        strokeDasharray={isLocked ? '8 2' : 'undefined'}
+      />
+    )
   })
 
   validateProps = (props: Partial<DotShapeProps>) => {

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/EllipseShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/EllipseShape.tsx
@@ -159,7 +159,15 @@ export class EllipseShape extends TLEllipseShape<EllipseShapeProps> {
 
     return (
       <g>
-        <ellipse cx={w / 2} cy={h / 2} rx={w / 2} ry={h / 2} strokeWidth={2} fill="transparent" strokeDasharray={isLocked ? "8 2" : "undefined"}/>
+        <ellipse
+          cx={w / 2}
+          cy={h / 2}
+          rx={w / 2}
+          ry={h / 2}
+          strokeWidth={2}
+          fill="transparent"
+          strokeDasharray={isLocked ? '8 2' : 'undefined'}
+        />
       </g>
     )
   })

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/EllipseShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/EllipseShape.tsx
@@ -154,11 +154,12 @@ export class EllipseShape extends TLEllipseShape<EllipseShapeProps> {
   ReactIndicator = observer(() => {
     const {
       size: [w, h],
+      isLocked,
     } = this.props
 
     return (
       <g>
-        <ellipse cx={w / 2} cy={h / 2} rx={w / 2} ry={h / 2} strokeWidth={2} fill="transparent" />
+        <ellipse cx={w / 2} cy={h / 2} rx={w / 2} ry={h / 2} strokeWidth={2} fill="transparent" strokeDasharray={isLocked ? "8 2" : "undefined"}/>
       </g>
     )
   })

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/HTMLShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/HTMLShape.tsx
@@ -136,9 +136,10 @@ export class HTMLShape extends TLBoxShape<HTMLShapeProps> {
     const {
       props: {
         size: [w, h],
+        isLocked,
       },
     } = this
-    return <rect width={w} height={h} fill="transparent" />
+    return <rect width={w} height={h} fill="transparent"  strokeDasharray={isLocked ? "8 2" : "undefined"}/>
   })
 
   validateProps = (props: Partial<HTMLShapeProps>) => {

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/HTMLShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/HTMLShape.tsx
@@ -139,7 +139,14 @@ export class HTMLShape extends TLBoxShape<HTMLShapeProps> {
         isLocked,
       },
     } = this
-    return <rect width={w} height={h} fill="transparent"  strokeDasharray={isLocked ? "8 2" : "undefined"}/>
+    return (
+      <rect
+        width={w}
+        height={h}
+        fill="transparent"
+        strokeDasharray={isLocked ? '8 2' : 'undefined'}
+      />
+    )
   })
 
   validateProps = (props: Partial<HTMLShapeProps>) => {

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/HighlighterShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/HighlighterShape.tsx
@@ -83,8 +83,8 @@ export class HighlighterShape extends TLDrawShape<HighlighterShapeProps> {
   }
 
   ReactIndicator = observer(() => {
-    const { pointsPath } = this
-    return <path d={pointsPath} fill="none" />
+    const { pointsPath, props } = this
+    return <path d={pointsPath} fill="none"  strokeDasharray={props.isLocked ? "8 2" : "undefined"}/>
   })
 
   validateProps = (props: Partial<HighlighterShapeProps>) => {

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/HighlighterShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/HighlighterShape.tsx
@@ -84,7 +84,9 @@ export class HighlighterShape extends TLDrawShape<HighlighterShapeProps> {
 
   ReactIndicator = observer(() => {
     const { pointsPath, props } = this
-    return <path d={pointsPath} fill="none"  strokeDasharray={props.isLocked ? "8 2" : "undefined"}/>
+    return (
+      <path d={pointsPath} fill="none" strokeDasharray={props.isLocked ? '8 2' : 'undefined'} />
+    )
   })
 
   validateProps = (props: Partial<HighlighterShapeProps>) => {

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/IFrameShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/IFrameShape.tsx
@@ -82,8 +82,9 @@ export class IFrameShape extends TLBoxShape<IFrameShapeProps> {
     const {
       props: {
         size: [w, h],
+        isLocked,
       },
     } = this
-    return <rect width={w} height={h} fill="transparent" rx={8} ry={8} />
+    return <rect width={w} height={h} fill="transparent" rx={8} ry={8}  strokeDasharray={isLocked ? "8 2" : "undefined"}/>
   })
 }

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/IFrameShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/IFrameShape.tsx
@@ -85,6 +85,15 @@ export class IFrameShape extends TLBoxShape<IFrameShapeProps> {
         isLocked,
       },
     } = this
-    return <rect width={w} height={h} fill="transparent" rx={8} ry={8}  strokeDasharray={isLocked ? "8 2" : "undefined"}/>
+    return (
+      <rect
+        width={w}
+        height={h}
+        fill="transparent"
+        rx={8}
+        ry={8}
+        strokeDasharray={isLocked ? '8 2' : 'undefined'}
+      />
+    )
   })
 }

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/ImageShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/ImageShape.tsx
@@ -74,9 +74,10 @@ export class ImageShape extends TLImageShape<ImageShapeProps> {
     const {
       props: {
         size: [w, h],
+        isLocked,
       },
     } = this
-    return <rect width={w} height={h} fill="transparent" />
+    return <rect width={w} height={h} fill="transparent" strokeDasharray={isLocked ? "8 2" : "undefined"}/>
   })
 
   getShapeSVGJsx({ assets }: { assets: TLAsset[] }) {

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/ImageShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/ImageShape.tsx
@@ -77,7 +77,14 @@ export class ImageShape extends TLImageShape<ImageShapeProps> {
         isLocked,
       },
     } = this
-    return <rect width={w} height={h} fill="transparent" strokeDasharray={isLocked ? "8 2" : "undefined"}/>
+    return (
+      <rect
+        width={w}
+        height={h}
+        fill="transparent"
+        strokeDasharray={isLocked ? '8 2' : 'undefined'}
+      />
+    )
   })
 
   getShapeSVGJsx({ assets }: { assets: TLAsset[] }) {

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LineShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LineShape.tsx
@@ -146,6 +146,7 @@ export class LineShape extends TLLineShape<LineShapeProps> {
       fontSize,
       fontWeight,
       handles: { start, end },
+      isLocked,
     } = this.props
     const bounds = this.getBounds()
     const labelSize =
@@ -176,6 +177,7 @@ export class LineShape extends TLLineShape<LineShapeProps> {
             decorations?.start,
             decorations?.end
           )}
+          strokeDasharray={isLocked ? "8 2" : "undefined"}
         />
         {label && !isEditing && (
           <rect

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LineShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LineShape.tsx
@@ -77,7 +77,7 @@ export class LineShape extends TLLineShape<LineShapeProps> {
     const labelSize =
       label || isEditing
         ? getTextLabelSize(
-            label || "Enter text",
+            label || 'Enter text',
             { fontFamily: 'var(--ls-font-family)', fontSize, lineHeight: 1, fontWeight },
             6
           )
@@ -99,7 +99,11 @@ export class LineShape extends TLLineShape<LineShapeProps> {
       [label]
     )
     return (
-      <div {...events} style={{ width: '100%', height: '100%', overflow: 'hidden' }} className="tl-line-container">
+      <div
+        {...events}
+        style={{ width: '100%', height: '100%', overflow: 'hidden' }}
+        className="tl-line-container"
+      >
         <TextLabel
           font={font}
           text={label}
@@ -177,7 +181,7 @@ export class LineShape extends TLLineShape<LineShapeProps> {
             decorations?.start,
             decorations?.end
           )}
-          strokeDasharray={isLocked ? "8 2" : "undefined"}
+          strokeDasharray={isLocked ? '8 2' : 'undefined'}
         />
         {label && !isEditing && (
           <rect

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
@@ -536,7 +536,7 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
 
   ReactIndicator = observer(() => {
     const bounds = this.getBounds()
-    return <rect width={bounds.width} height={bounds.height} fill="transparent" rx={8} ry={8} />
+    return <rect width={bounds.width} height={bounds.height} fill="transparent" rx={8} ry={8}  strokeDasharray={this.props.isLocked ? "8 2" : "undefined"}/>
   })
 
   validateProps = (props: Partial<LogseqPortalShapeProps>) => {

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
@@ -63,11 +63,11 @@ const LogseqPortalShapeHeader = observer(
         : 'var(--ls-tertiary-background-color)'
 
     const fillGradient =
-        fill && fill !== 'var(--ls-secondary-background-color)'
-          ? isBuiltInColor(fill)
-            ? `var(--ls-highlight-color-${fill})`
-            : fill
-          : 'var(--ls-secondary-background-color)'
+      fill && fill !== 'var(--ls-secondary-background-color)'
+        ? isBuiltInColor(fill)
+          ? `var(--ls-highlight-color-${fill})`
+          : fill
+        : 'var(--ls-secondary-background-color)'
 
     return (
       <div
@@ -79,7 +79,8 @@ const LogseqPortalShapeHeader = observer(
           className="absolute inset-0 tl-logseq-portal-header-bg"
           style={{
             opacity,
-            background: type === 'P' ? bgColor : `linear-gradient(0deg, ${fillGradient}, ${bgColor})`,
+            background:
+              type === 'P' ? bgColor : `linear-gradient(0deg, ${fillGradient}, ${bgColor})`,
           }}
         ></div>
         <div className="relative">{children}</div>
@@ -536,7 +537,16 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
 
   ReactIndicator = observer(() => {
     const bounds = this.getBounds()
-    return <rect width={bounds.width} height={bounds.height} fill="transparent" rx={8} ry={8}  strokeDasharray={this.props.isLocked ? "8 2" : "undefined"}/>
+    return (
+      <rect
+        width={bounds.width}
+        height={bounds.height}
+        fill="transparent"
+        rx={8}
+        ry={8}
+        strokeDasharray={this.props.isLocked ? '8 2' : 'undefined'}
+      />
+    )
   })
 
   validateProps = (props: Partial<LogseqPortalShapeProps>) => {

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
@@ -347,9 +347,9 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
   })
 
   ReactComponent = observer((componentProps: TLComponentProps) => {
-    const { events, isErasing, isEditing, isBinding, isLocked } = componentProps
+    const { events, isErasing, isEditing, isBinding } = componentProps
     const {
-      props: { opacity, pageId, fill, scaleLevel, strokeWidth, size },
+      props: { opacity, pageId, fill, scaleLevel, strokeWidth, size, isLocked },
     } = this
 
     const app = useApp<Shape>()
@@ -518,7 +518,7 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
                 {targetNotFound && <div className="tl-target-not-found">Target not found</div>}
                 {showingPortal && <PortalComponent {...componentProps} />}
               </div>
-              {!app.readOnly && isLocked && (
+              {!app.readOnly && !isLocked && (
                 <CircleButton
                   active={!!this.collapsed}
                   style={{ opacity: isSelected ? 1 : 0 }}

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/LogseqPortalShape.tsx
@@ -347,7 +347,7 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
   })
 
   ReactComponent = observer((componentProps: TLComponentProps) => {
-    const { events, isErasing, isEditing, isBinding } = componentProps
+    const { events, isErasing, isEditing, isBinding, isLocked } = componentProps
     const {
       props: { opacity, pageId, fill, scaleLevel, strokeWidth, size },
     } = this
@@ -518,7 +518,7 @@ export class LogseqPortalShape extends TLBoxShape<LogseqPortalShapeProps> {
                 {targetNotFound && <div className="tl-target-not-found">Target not found</div>}
                 {showingPortal && <PortalComponent {...componentProps} />}
               </div>
-              {!app.readOnly && (
+              {!app.readOnly && isLocked && (
                 <CircleButton
                   active={!!this.collapsed}
                   style={{ opacity: isSelected ? 1 : 0 }}

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/PenShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/PenShape.tsx
@@ -66,7 +66,7 @@ export class PenShape extends TLDrawShape<PenShapeProps> {
 
   ReactIndicator = observer(() => {
     const { pointsPath } = this
-    return <path d={pointsPath} />
+    return <path d={pointsPath} strokeDasharray={this.props.isLocked ? "8 2" : "undefined"}/>
   })
 
   validateProps = (props: Partial<PenShapeProps>) => {

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/PenShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/PenShape.tsx
@@ -66,7 +66,7 @@ export class PenShape extends TLDrawShape<PenShapeProps> {
 
   ReactIndicator = observer(() => {
     const { pointsPath } = this
-    return <path d={pointsPath} strokeDasharray={this.props.isLocked ? "8 2" : "undefined"}/>
+    return <path d={pointsPath} strokeDasharray={this.props.isLocked ? '8 2' : 'undefined'} />
   })
 
   validateProps = (props: Partial<PenShapeProps>) => {

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/PencilShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/PencilShape.tsx
@@ -133,7 +133,7 @@ export class PencilShape extends TLDrawShape<PencilShapeProps> {
 
   ReactIndicator = observer(() => {
     const { pointsPath } = this
-    return <path d={pointsPath} />
+    return <path d={pointsPath} strokeDasharray={this.props.isLocked ? "8 2" : "undefined"}/>
   })
 
   validateProps = (props: Partial<PencilShapeProps>) => {

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/PencilShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/PencilShape.tsx
@@ -133,7 +133,7 @@ export class PencilShape extends TLDrawShape<PencilShapeProps> {
 
   ReactIndicator = observer(() => {
     const { pointsPath } = this
-    return <path d={pointsPath} strokeDasharray={this.props.isLocked ? "8 2" : "undefined"}/>
+    return <path d={pointsPath} strokeDasharray={this.props.isLocked ? '8 2' : 'undefined'} />
   })
 
   validateProps = (props: Partial<PencilShapeProps>) => {

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/PolygonShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/PolygonShape.tsx
@@ -168,7 +168,7 @@ export class PolygonShape extends TLPolygonShape<PolygonShapeProps> {
   ReactIndicator = observer(() => {
     const {
       offset: [x, y],
-      props: { strokeWidth },
+      props: { strokeWidth, isLocked },
     } = this
 
     return (
@@ -176,6 +176,7 @@ export class PolygonShape extends TLPolygonShape<PolygonShapeProps> {
         <polygon
           transform={`translate(${x}, ${y})`}
           points={this.getVertices(strokeWidth / 2).join()}
+          strokeDasharray={isLocked ? "8 2" : "undefined"}
         />
       </g>
     )

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/PolygonShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/PolygonShape.tsx
@@ -176,7 +176,7 @@ export class PolygonShape extends TLPolygonShape<PolygonShapeProps> {
         <polygon
           transform={`translate(${x}, ${y})`}
           points={this.getVertices(strokeWidth / 2).join()}
-          strokeDasharray={isLocked ? "8 2" : "undefined"}
+          strokeDasharray={isLocked ? '8 2' : 'undefined'}
         />
       </g>
     )

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/TextShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/TextShape.tsx
@@ -240,7 +240,7 @@ export class TextShape extends TLTextShape<TextShapeProps> {
 
   ReactIndicator = observer(({ isEditing }: TLComponentProps) => {
     const {
-      props: { borderRadius },
+      props: { borderRadius, isLocked },
       bounds,
     } = this
     return isEditing ? null : (
@@ -250,6 +250,7 @@ export class TextShape extends TLTextShape<TextShapeProps> {
         rx={borderRadius}
         ry={borderRadius}
         fill="transparent"
+        strokeDasharray={isLocked ? "8 2" : "undefined"}
       />
     )
   })

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/TextShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/TextShape.tsx
@@ -250,7 +250,7 @@ export class TextShape extends TLTextShape<TextShapeProps> {
         rx={borderRadius}
         ry={borderRadius}
         fill="transparent"
-        strokeDasharray={isLocked ? "8 2" : "undefined"}
+        strokeDasharray={isLocked ? '8 2' : 'undefined'}
       />
     )
   })

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/TweetShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/TweetShape.tsx
@@ -103,9 +103,10 @@ export class TweetShape extends TLBoxShape<TweetShapeProps> {
     const {
       props: {
         size: [w, h],
+        isLocked,
       },
     } = this
-    return <rect width={w} height={h} fill="transparent" rx={8} ry={8} />
+    return <rect width={w} height={h} fill="transparent" rx={8} ry={8} strokeDasharray={isLocked ? "8 2" : "undefined"}/>
   })
 
   useComponentSize<T extends HTMLElement>(ref: React.RefObject<T> | null, selector = '') {

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/TweetShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/TweetShape.tsx
@@ -90,10 +90,10 @@ export class TweetShape extends TLBoxShape<TweetShapeProps> {
           }}
         >
           {this.embedId ? (
-              <div ref={cpRefContainer}>
-                <Tweet tweetId={this.embedId}/>
-              </div>
-          ) : (null)}
+            <div ref={cpRefContainer}>
+              <Tweet tweetId={this.embedId} />
+            </div>
+          ) : null}
         </div>
       </HTMLContainer>
     )
@@ -106,7 +106,16 @@ export class TweetShape extends TLBoxShape<TweetShapeProps> {
         isLocked,
       },
     } = this
-    return <rect width={w} height={h} fill="transparent" rx={8} ry={8} strokeDasharray={isLocked ? "8 2" : "undefined"}/>
+    return (
+      <rect
+        width={w}
+        height={h}
+        fill="transparent"
+        rx={8}
+        ry={8}
+        strokeDasharray={isLocked ? '8 2' : 'undefined'}
+      />
+    )
   })
 
   useComponentSize<T extends HTMLElement>(ref: React.RefObject<T> | null, selector = '') {
@@ -192,12 +201,7 @@ export class TweetShape extends TLBoxShape<TweetShapeProps> {
     if (embedId) {
       return (
         <g>
-          <rect
-            width={bounds.width}
-            height={bounds.height}
-            fill="#15202b"
-            rx={8}
-            ry={8} />
+          <rect width={bounds.width} height={bounds.height} fill="#15202b" rx={8} ry={8} />
           <svg
             x={bounds.width / 4}
             y={bounds.height / 4}

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/VideoShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/VideoShape.tsx
@@ -90,8 +90,9 @@ export class VideoShape extends TLBoxShape<VideoShapeProps> {
     const {
       props: {
         size: [w, h],
+        isLocked,
       },
     } = this
-    return <rect width={w} height={h} fill="transparent" />
+    return <rect width={w} height={h} fill="transparent" strokeDasharray={isLocked ? "8 2" : "undefined"}/>
   })
 }

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/VideoShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/VideoShape.tsx
@@ -93,6 +93,13 @@ export class VideoShape extends TLBoxShape<VideoShapeProps> {
         isLocked,
       },
     } = this
-    return <rect width={w} height={h} fill="transparent" strokeDasharray={isLocked ? "8 2" : "undefined"}/>
+    return (
+      <rect
+        width={w}
+        height={h}
+        fill="transparent"
+        strokeDasharray={isLocked ? '8 2' : 'undefined'}
+      />
+    )
   })
 }

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/YouTubeShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/YouTubeShape.tsx
@@ -119,9 +119,10 @@ export class YouTubeShape extends TLBoxShape<YouTubeShapeProps> {
     const {
       props: {
         size: [w, h],
+        isLocked,
       },
     } = this
-    return <rect width={w} height={h} fill="transparent" rx={8} ry={8} />
+    return <rect width={w} height={h} fill="transparent" rx={8} ry={8} strokeDasharray={isLocked ? "8 2" : "undefined"} />
   })
 
   validateProps = (props: Partial<YouTubeShapeProps>) => {

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/YouTubeShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/YouTubeShape.tsx
@@ -122,7 +122,16 @@ export class YouTubeShape extends TLBoxShape<YouTubeShapeProps> {
         isLocked,
       },
     } = this
-    return <rect width={w} height={h} fill="transparent" rx={8} ry={8} strokeDasharray={isLocked ? "8 2" : "undefined"} />
+    return (
+      <rect
+        width={w}
+        height={h}
+        fill="transparent"
+        rx={8}
+        ry={8}
+        strokeDasharray={isLocked ? '8 2' : 'undefined'}
+      />
+    )
   })
 
   validateProps = (props: Partial<YouTubeShapeProps>) => {

--- a/tldraw/apps/tldraw-logseq/src/styles.css
+++ b/tldraw/apps/tldraw-logseq/src/styles.css
@@ -1214,6 +1214,10 @@ button.tl-shape-links-panel-item-remove-button {
   fill: var(--ls-secondary-background-color);
 }
 
+.tl-locked {
+  stroke-dasharray: calc(3px * var(--tl-scale)) calc(3px * var(--tl-scale));
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;

--- a/tldraw/packages/core/src/lib/TLApi/TLApi.ts
+++ b/tldraw/packages/core/src/lib/TLApi/TLApi.ts
@@ -11,8 +11,10 @@ export class TLApi<S extends TLShape = TLShape, K extends TLEventMap = TLEventMa
     this.app = app
   }
 
-  editShape = (shape: string | S | undefined): this => {
-    this.app.transition('select').selectedTool.transition('editingShape', { shape })
+  editShape = (shape: S | undefined): this => {
+    if (!shape?.props.isLocked)
+      this.app.transition('select').selectedTool.transition('editingShape', { shape })
+
     return this
   }
 

--- a/tldraw/packages/core/src/lib/TLApi/TLApi.ts
+++ b/tldraw/packages/core/src/lib/TLApi/TLApi.ts
@@ -176,7 +176,7 @@ export class TLApi<S extends TLShape = TLShape, K extends TLEventMap = TLEventMa
     settings.update({ color: color })
 
     this.app.selectedShapesArray.forEach(s => {
-      s.update({ fill: color, stroke: color })
+      if (!s.props.isLocked) s.update({ fill: color, stroke: color })
     })
     this.app.persist()
 

--- a/tldraw/packages/core/src/lib/TLApi/TLApi.ts
+++ b/tldraw/packages/core/src/lib/TLApi/TLApi.ts
@@ -189,7 +189,7 @@ export class TLApi<S extends TLShape = TLShape, K extends TLEventMap = TLEventMa
     settings.update({ scaleLevel })
 
     this.app.selectedShapes.forEach(shape => {
-      shape.setScaleLevel(scaleLevel)
+      if (!shape.props.isLocked) shape.setScaleLevel(scaleLevel)
     })
     this.app.persist()
 

--- a/tldraw/packages/core/src/lib/TLApp/TLApp.ts
+++ b/tldraw/packages/core/src/lib/TLApp/TLApp.ts
@@ -197,6 +197,18 @@ export class TLApp<
           this.api.toggleGrid()
         },
       },
+      {
+        keys: 'mod+l',
+        fn: () => {
+          this.setLocked(true)
+        },
+      },
+      {
+        keys: 'mod+shift+l',
+        fn: () => {
+          this.setLocked(false)
+        },
+      },
     ]
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/tldraw/packages/core/src/lib/TLApp/TLApp.ts
+++ b/tldraw/packages/core/src/lib/TLApp/TLApp.ts
@@ -336,9 +336,11 @@ export class TLApp<
   }
 
   @action updateShapes = <T extends S>(shapes: ({ id: string } & Partial<T['props']>)[]): this => {
-    if (this.readOnly ) return this
+    if (this.readOnly) return this
 
-    const shapesToUpdate = shapes.map(shape => this.getShapeById(shape.id)).filter(shape => shape?.props.isLocked)
+    const shapesToUpdate = shapes
+      .map(shape => this.getShapeById(shape.id))
+      .filter(shape => shape?.props.isLocked)
 
     if (shapesToUpdate.length === 0) return this
 

--- a/tldraw/packages/core/src/lib/TLApp/TLApp.ts
+++ b/tldraw/packages/core/src/lib/TLApp/TLApp.ts
@@ -347,16 +347,12 @@ export class TLApp<
     return this
   }
 
+
+
   @action updateShapes = <T extends S>(shapes: ({ id: string } & Partial<T['props']>)[]): this => {
-    if (this.readOnly) return this
+    if (this.readOnly ) return this
 
-    const shapesToUpdate = shapes
-      .map(shape => this.getShapeById(shape.id))
-      .filter(shape => shape?.props.isLocked)
-
-    if (shapesToUpdate.length === 0) return this
-
-    shapesToUpdate.forEach(shape => shape?.update(shape))
+    shapes.forEach(shape => this.getShapeById(shape.id)?.update(shape))
     this.persist()
     return this
   }
@@ -539,11 +535,11 @@ export class TLApp<
     return this
   }
 
-  setLocked = (isLocked: boolean): this => {
+  setLocked = (locked: boolean): this => {
     if (this.selectedShapesArray.length === 0 || this.readOnly) return this
 
     this.selectedShapesArray.forEach(shape => {
-      shape.update({ isLocked })
+      shape.update({ isLocked: locked })
     })
 
     this.persist()

--- a/tldraw/packages/core/src/lib/TLApp/TLApp.ts
+++ b/tldraw/packages/core/src/lib/TLApp/TLApp.ts
@@ -525,7 +525,7 @@ export class TLApp<
     return this
   }
 
-  setLock = (isLocked: boolean): this => {
+  setLocked = (isLocked: boolean): this => {
     if (this.selectedShapesArray.length === 0 || this.readOnly) return this
 
     this.selectedShapesArray.forEach(shape => {

--- a/tldraw/packages/core/src/lib/tools/TLSelectTool/states/HoveringSelectionHandleState.ts
+++ b/tldraw/packages/core/src/lib/tools/TLSelectTool/states/HoveringSelectionHandleState.ts
@@ -74,7 +74,7 @@ export class HoveringSelectionHandleState<
     if (!isSingle) return
     const selectedShape = getFirstFromSet(this.app.selectedShapes)
 
-    if (selectedShape.canEdit && !this.app.readOnly) {
+    if (selectedShape.canEdit && !this.app.readOnly && !selectedShape.props.isLocked) {
       switch (info.type) {
         case TLTargetType.Shape: {
           this.tool.transition('editingShape', info)

--- a/tldraw/packages/core/src/lib/tools/TLSelectTool/states/IdleState.ts
+++ b/tldraw/packages/core/src/lib/tools/TLSelectTool/states/IdleState.ts
@@ -124,7 +124,7 @@ export class IdleState<
     if (info.order || this.app.selectedShapesArray.length !== 1 || this.app.readOnly) return
 
     const selectedShape = this.app.selectedShapesArray[0]
-    if (!selectedShape.canEdit) return
+    if (!selectedShape.canEdit || selectedShape.props.isLocked) return
 
     switch (info.type) {
       case TLTargetType.Shape: {

--- a/tldraw/packages/core/src/lib/tools/TLSelectTool/states/PointingSelectedShapeState.ts
+++ b/tldraw/packages/core/src/lib/tools/TLSelectTool/states/PointingSelectedShapeState.ts
@@ -49,6 +49,7 @@ export class PointingSelectedShapeState<
       selectedShapesArray.length === 1 &&
       this.pointedSelectedShape.canEdit &&
       !this.app.readOnly &&
+      !this.pointedSelectedShape.props.isLocked &&
       this.pointedSelectedShape instanceof TLBoxShape &&
       PointUtils.pointInBounds(currentPoint, this.pointedSelectedShape.bounds)
     ) {

--- a/tldraw/packages/core/src/lib/tools/TLSelectTool/states/TranslatingState.ts
+++ b/tldraw/packages/core/src/lib/tools/TLSelectTool/states/TranslatingState.ts
@@ -30,7 +30,6 @@ export class TranslatingState<
 
   private moveSelectedShapesToPointer() {
     const {
-      selectedShapes,
       inputs: { shiftKey, originPoint, currentPoint },
     } = this.app
 
@@ -47,7 +46,7 @@ export class TranslatingState<
     }
 
     transaction(() => {
-      this.app.allSelectedShapes.forEach(shape => {
+      this.app.allSelectedShapesArray.filter(s => !s.props.isLocked).forEach(shape => {
         shape.update({ point: Vec.add(initialPoints[shape.id], delta) })
       })
     })

--- a/tldraw/packages/core/src/lib/tools/TLSelectTool/states/TranslatingState.ts
+++ b/tldraw/packages/core/src/lib/tools/TLSelectTool/states/TranslatingState.ts
@@ -46,8 +46,8 @@ export class TranslatingState<
     }
 
     transaction(() => {
-      this.app.allSelectedShapesArray.filter(s => !s.props.isLocked).forEach(shape => {
-        shape.update({ point: Vec.add(initialPoints[shape.id], delta) })
+      this.app.allSelectedShapesArray.forEach(shape => {
+        if (!shape.props.isLocked) shape.update({ point: Vec.add(initialPoints[shape.id], delta) })
       })
     })
   }
@@ -65,6 +65,7 @@ export class TranslatingState<
           type: shape.type,
           point: this.initialPoints[shape.id],
           rotation: shape.props.rotation,
+          isLocked: false,
         })
         return clone
       })

--- a/tldraw/packages/react/src/components/Canvas/Canvas.tsx
+++ b/tldraw/packages/react/src/components/Canvas/Canvas.tsx
@@ -168,6 +168,7 @@ export const Canvas = observer(function Renderer<S extends TLReactShape>({
                 isHovered={false}
                 isBinding={false}
                 isSelected={true}
+                isLocked={shape.props.isLocked}
               />
             ))}
           {hoveredShapes.map(
@@ -194,7 +195,7 @@ export const Canvas = observer(function Renderer<S extends TLReactShape>({
                   zIndex={editingShape && selectedShapes.includes(editingShape) ? 1002 : 10002}
                 >
                   <components.SelectionForeground
-                    shapes={selectedShapes}
+                    shapes={selectedShapes.filter(shape => !shape.props.isLocked)}
                     bounds={selectionBounds}
                     showResizeHandles={showResizeHandles}
                     showRotateHandles={showRotateHandles}

--- a/tldraw/packages/react/src/components/Canvas/Canvas.tsx
+++ b/tldraw/packages/react/src/components/Canvas/Canvas.tsx
@@ -252,7 +252,7 @@ export const Canvas = observer(function Renderer<S extends TLReactShape>({
             {selectedShapes && components.ContextBar && (
               <ContextBarContainer
                 key={'context' + selectedShapes.map(shape => shape.id).join('')}
-                shapes={selectedShapes}
+                shapes={selectedShapes.filter(s => !s.props.isLocked)}
                 hidden={!showContextBar}
                 bounds={singleSelectedShape ? singleSelectedShape.bounds : selectionBounds}
                 rotation={singleSelectedShape ? singleSelectedShape.props.rotation : 0}

--- a/tldraw/packages/react/src/components/Indicator/Indicator.tsx
+++ b/tldraw/packages/react/src/components/Indicator/Indicator.tsx
@@ -10,6 +10,7 @@ interface IndicatorProps {
   isSelected?: boolean
   isBinding?: boolean
   isEditing?: boolean
+  isLocked?: boolean
   meta?: any
 }
 
@@ -19,6 +20,7 @@ export const Indicator = observer(function Shape({
   isSelected = false,
   isBinding = false,
   isEditing = false,
+  isLocked = false,
   meta,
 }: IndicatorProps) {
   const {
@@ -38,11 +40,12 @@ export const Indicator = observer(function Shape({
       zIndex={isEditing ? 1000 : 10000}
     >
       <SVGContainer>
-        <g className={`tl-indicator-container ${isSelected ? 'tl-selected' : 'tl-hovered'}`}>
+        <g className={`tl-indicator-container ${isSelected ? 'tl-selected' : 'tl-hovered'} ${isLocked ? 'tl-locked' : ''}`}>
           <ReactIndicator
             isEditing={isEditing}
             isBinding={isBinding}
             isHovered={isHovered}
+            isLocked={isLocked}
             isSelected={isSelected}
             isErasing={false}
             meta={meta}

--- a/tldraw/packages/react/src/components/Indicator/Indicator.tsx
+++ b/tldraw/packages/react/src/components/Indicator/Indicator.tsx
@@ -40,7 +40,11 @@ export const Indicator = observer(function Shape({
       zIndex={isEditing ? 1000 : 10000}
     >
       <SVGContainer>
-        <g className={`tl-indicator-container ${isSelected ? 'tl-selected' : 'tl-hovered'} ${isLocked ? 'tl-locked' : ''}`}>
+        <g
+          className={`tl-indicator-container ${isSelected ? 'tl-selected' : 'tl-hovered'} ${
+            isLocked ? 'tl-locked' : ''
+          }`}
+        >
           <ReactIndicator
             isEditing={isEditing}
             isBinding={isBinding}

--- a/tldraw/packages/react/src/components/ui/SelectionForeground/SelectionForeground.tsx
+++ b/tldraw/packages/react/src/components/ui/SelectionForeground/SelectionForeground.tsx
@@ -26,7 +26,8 @@ export const SelectionForeground = observer(function SelectionForeground<S exten
   const borderRadius = app.editingShape?.props['borderRadius'] ?? 0
 
   return (
-    <SVGContainer>
+    <>
+    {shapes.length > 0 && <SVGContainer>
       {!app.editingShape && (<rect
         className="tl-bounds-fg"
         width={Math.max(width, 1)}
@@ -139,6 +140,7 @@ export const SelectionForeground = observer(function SelectionForeground<S exten
           />
         </>
       )}
-    </SVGContainer>
+    </SVGContainer>}
+    </>
   )
 })

--- a/tldraw/packages/react/src/components/ui/SelectionForeground/SelectionForeground.tsx
+++ b/tldraw/packages/react/src/components/ui/SelectionForeground/SelectionForeground.tsx
@@ -27,120 +27,124 @@ export const SelectionForeground = observer(function SelectionForeground<S exten
 
   return (
     <>
-    {shapes.length > 0 && <SVGContainer>
-      {!app.editingShape && (<rect
-        className="tl-bounds-fg"
-        width={Math.max(width, 1)}
-        height={Math.max(height, 1)}
-        rx={borderRadius}
-        ry={borderRadius}
-        pointerEvents="none"
-      />)}
-      <EdgeHandle
-        x={targetSize * 2}
-        y={0}
-        width={width - targetSize * 4}
-        height={0}
-        targetSize={targetSize}
-        edge={TLResizeEdge.Top}
-        disabled={!canResize[1]}
-        isHidden={!showResizeHandles}
-      />
-      <EdgeHandle
-        x={width}
-        y={targetSize * 2}
-        width={0}
-        height={height - targetSize * 4}
-        targetSize={targetSize}
-        edge={TLResizeEdge.Right}
-        disabled={!canResize[0]}
-        isHidden={!showResizeHandles}
-      />
-      <EdgeHandle
-        x={targetSize * 2}
-        y={height}
-        width={width - targetSize * 4}
-        height={0}
-        targetSize={targetSize}
-        edge={TLResizeEdge.Bottom}
-        disabled={!canResize[1]}
-        isHidden={!showResizeHandles}
-      />
-      <EdgeHandle
-        x={0}
-        y={targetSize * 2}
-        width={0}
-        height={height - targetSize * 4}
-        targetSize={targetSize}
-        edge={TLResizeEdge.Left}
-        disabled={!canResize[0]}
-        isHidden={!showResizeHandles}
-      />
-      <RotateCornerHandle
-        cx={0}
-        cy={0}
-        targetSize={targetSize}
-        corner={TLRotateCorner.TopLeft}
-        isHidden={!showRotateHandles}
-      />
-      <RotateCornerHandle
-        cx={width + targetSize * 2}
-        cy={0}
-        targetSize={targetSize}
-        corner={TLRotateCorner.TopRight}
-        isHidden={!showRotateHandles}
-      />
-      <RotateCornerHandle
-        cx={width + targetSize * 2}
-        cy={height + targetSize * 2}
-        targetSize={targetSize}
-        corner={TLRotateCorner.BottomRight}
-        isHidden={!showRotateHandles}
-      />
-      <RotateCornerHandle
-        cx={0}
-        cy={height + targetSize * 2}
-        targetSize={targetSize}
-        corner={TLRotateCorner.BottomLeft}
-        isHidden={!showRotateHandles}
-      />
-      {canResize?.every(r => r) && (
-        <>
-          <CornerHandle
+      {shapes.length > 0 && (
+        <SVGContainer>
+          {!app.editingShape && (
+            <rect
+              className="tl-bounds-fg"
+              width={Math.max(width, 1)}
+              height={Math.max(height, 1)}
+              rx={borderRadius}
+              ry={borderRadius}
+              pointerEvents="none"
+            />
+          )}
+          <EdgeHandle
+            x={targetSize * 2}
+            y={0}
+            width={width - targetSize * 4}
+            height={0}
+            targetSize={targetSize}
+            edge={TLResizeEdge.Top}
+            disabled={!canResize[1]}
+            isHidden={!showResizeHandles}
+          />
+          <EdgeHandle
+            x={width}
+            y={targetSize * 2}
+            width={0}
+            height={height - targetSize * 4}
+            targetSize={targetSize}
+            edge={TLResizeEdge.Right}
+            disabled={!canResize[0]}
+            isHidden={!showResizeHandles}
+          />
+          <EdgeHandle
+            x={targetSize * 2}
+            y={height}
+            width={width - targetSize * 4}
+            height={0}
+            targetSize={targetSize}
+            edge={TLResizeEdge.Bottom}
+            disabled={!canResize[1]}
+            isHidden={!showResizeHandles}
+          />
+          <EdgeHandle
+            x={0}
+            y={targetSize * 2}
+            width={0}
+            height={height - targetSize * 4}
+            targetSize={targetSize}
+            edge={TLResizeEdge.Left}
+            disabled={!canResize[0]}
+            isHidden={!showResizeHandles}
+          />
+          <RotateCornerHandle
             cx={0}
             cy={0}
-            size={size}
             targetSize={targetSize}
-            corner={TLResizeCorner.TopLeft}
-            isHidden={!showResizeHandles}
+            corner={TLRotateCorner.TopLeft}
+            isHidden={!showRotateHandles}
           />
-          <CornerHandle
-            cx={width}
+          <RotateCornerHandle
+            cx={width + targetSize * 2}
             cy={0}
-            size={size}
             targetSize={targetSize}
-            corner={TLResizeCorner.TopRight}
-            isHidden={!showResizeHandles}
+            corner={TLRotateCorner.TopRight}
+            isHidden={!showRotateHandles}
           />
-          <CornerHandle
-            cx={width}
-            cy={height}
-            size={size}
+          <RotateCornerHandle
+            cx={width + targetSize * 2}
+            cy={height + targetSize * 2}
             targetSize={targetSize}
-            corner={TLResizeCorner.BottomRight}
-            isHidden={!showResizeHandles}
+            corner={TLRotateCorner.BottomRight}
+            isHidden={!showRotateHandles}
           />
-          <CornerHandle
+          <RotateCornerHandle
             cx={0}
-            cy={height}
-            size={size}
+            cy={height + targetSize * 2}
             targetSize={targetSize}
-            corner={TLResizeCorner.BottomLeft}
-            isHidden={!showResizeHandles}
+            corner={TLRotateCorner.BottomLeft}
+            isHidden={!showRotateHandles}
           />
-        </>
+          {canResize?.every(r => r) && (
+            <>
+              <CornerHandle
+                cx={0}
+                cy={0}
+                size={size}
+                targetSize={targetSize}
+                corner={TLResizeCorner.TopLeft}
+                isHidden={!showResizeHandles}
+              />
+              <CornerHandle
+                cx={width}
+                cy={0}
+                size={size}
+                targetSize={targetSize}
+                corner={TLResizeCorner.TopRight}
+                isHidden={!showResizeHandles}
+              />
+              <CornerHandle
+                cx={width}
+                cy={height}
+                size={size}
+                targetSize={targetSize}
+                corner={TLResizeCorner.BottomRight}
+                isHidden={!showResizeHandles}
+              />
+              <CornerHandle
+                cx={0}
+                cy={height}
+                size={size}
+                targetSize={targetSize}
+                corner={TLResizeCorner.BottomLeft}
+                isHidden={!showResizeHandles}
+              />
+            </>
+          )}
+        </SVGContainer>
       )}
-    </SVGContainer>}
     </>
   )
 })

--- a/tldraw/packages/react/src/lib/TLReactShape.tsx
+++ b/tldraw/packages/react/src/lib/TLReactShape.tsx
@@ -8,6 +8,7 @@ export interface TLCommonShapeProps<M = unknown> {
   isHovered: boolean
   isSelected: boolean
   isErasing: boolean
+  isLocked: boolean
   asset?: TLAsset
 }
 


### PR DESCRIPTION
See https://discord.com/channels/725182569297215569/1061347691281535026/1061347691281535026

You can lock/unlock the selected elements using the context menu, or by pressing `mod+l` and `mod+shift+l` respectively. Selected locked elements can be distinguished by the dashed bounds indicator. Deleting, editing and updating should be prevented. Copying and cloning should be allowed. The pasted/cloned elements shouldn't be locked. The context bar and context menu actions that depend on the selected elements, should be properly filtered.

[Screencast from 2023-04-18 18-25-22.webm](https://user-images.githubusercontent.com/10744960/232826014-50b0f3c4-23c4-4469-97af-6ca1b0da2aec.webm)