### PR TITLE
chore: update nginx version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN yarn config set network-timeout 240000 -g && yarn install
 RUN  yarn release 
 
 # Web App Runner image
-FROM nginx:1.23.3-alpine
+FROM nginx:1.24.0-alpine3.17
 
 COPY --from=builder /data/static /usr/share/nginx/html
 


### PR DESCRIPTION
Update Nginx image version in `Dockerfile` to solve some vulnerabilities.
Before:
`docker run aquasec/trivy image nginx:1.23.3-alpine`
```
nginx:1.23.3-alpine (alpine 3.17.2)
===================================
Total: 45 (UNKNOWN: 0, LOW: 0, MEDIUM: 30, HIGH: 11, CRITICAL: 4)
```

After:
`docker run aquasec/trivy image nginx:1.24.0-alpine3.17`
```
nginx:1.24.0-alpine3.17 (alpine 3.17.3)
=======================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```