### PR TITLE
fix delete across blocks broke outliner

### DIFF
--- a/e2e-tests/basic.spec.ts
+++ b/e2e-tests/basic.spec.ts
@@ -218,7 +218,17 @@ test('delete and backspace', async ({ page, block }) => {
   await page.keyboard.press('Delete')
   await page.waitForTimeout(100)
   await expect(page.locator('.warning')).toHaveCount(0)
+  expect(await page.inputValue('textarea >> nth=0')).toBe('1.1ref')
   expect(await block.selectionStart()).toBe('1.1'.length)
+  // the next block and the right block are not the same
+  await page.keyboard.press('ArrowUp', { delay: 50 })
+  await page.keyboard.press('End')
+  await page.waitForTimeout(100)
+  await page.keyboard.press('Delete')
+  await page.waitForTimeout(100)
+  await expect(page.locator('.warning')).toHaveCount(0)
+  expect(await page.inputValue('textarea >> nth=0')).toBe('11.1ref')
+  expect(await block.selectionStart()).toBe('1'.length)
 })
 
 

--- a/e2e-tests/basic.spec.ts
+++ b/e2e-tests/basic.spec.ts
@@ -229,6 +229,23 @@ test('delete and backspace', async ({ page, block }) => {
   await expect(page.locator('.warning')).toHaveCount(0)
   expect(await page.inputValue('textarea >> nth=0')).toBe('11.1ref')
   expect(await block.selectionStart()).toBe('1'.length)
+  // the current block is collapsed and has right block
+  await page.keyboard.press(modKey + '+z')
+  await page.waitForTimeout(100)
+  await page.keyboard.press('Escape')
+  await page.waitForTimeout(100)
+  await page.keyboard.press(modKey + '+ArrowUp')
+  await page.waitForTimeout(100)
+  await block.activeEditing(-2)
+  await page.keyboard.press('Enter')
+  await block.mustFill('2')
+  await page.keyboard.press('ArrowUp')
+  await page.waitForTimeout(100)
+  await page.keyboard.press('Delete')
+  await page.waitForTimeout(100)
+  await expect(page.locator('.warning')).toHaveCount(0)
+  expect(await page.inputValue('textarea >> nth=0')).toBe('12')
+  expect(await block.selectionStart()).toBe('1'.length)
 })
 
 

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2697,12 +2697,17 @@
       (and next-block (block-has-no-ref? (:db/id current-block)))
       (let [edit-block (state/get-edit-block)
             new-content (str value (:block/content next-block))
-            additional-tx (conj [{:db/id (:db/id next-block)
-                                  :block/left (:block/left current-block)
-                                  :block/parent (:block/parent current-block)}]
-                                (when (not= next-block (:data right))
-                                  {:db/id (:db/id (:data right))
-                                   :block/left (:db/id next-block)}))
+            additional-tx (filter some?
+                                  (conj [{:db/id (:db/id next-block)
+                                                :block/left (:block/left current-block)
+                                                :block/parent (:block/parent current-block)}]
+                                              (when (some-> right :data (not= next-block))
+                                                {:db/id (:db/id (:data right))
+                                                 :block/left (:db/id next-block)})
+                                              (when collapsed?
+                                                {:db/id (:db/id first-child)
+                                                 :block/left (:db/id next-block)
+                                                 :block/parent (:db/id next-block)})))
             transact-opts {:outliner-op :delete-block
                            :concat-data {:last-edit-block (:block/uuid edit-block)
                                          :end? true}

--- a/src/main/frontend/modules/outliner/datascript.cljc
+++ b/src/main/frontend/modules/outliner/datascript.cljc
@@ -59,8 +59,8 @@
                   (not (contains? (:file/unlinked-dirs @state/state)
                                   (config/get-repo-dir (state/get-current-repo)))))
 
-         ;; (prn "[DEBUG] Outliner transact:")
-         ;; (frontend.util/pprint txs)
+        ;;  (prn "[DEBUG] Outliner transact:" opts)
+        ;;  (frontend.util/pprint txs)
 
          (try
            (let [repo (get opts :repo (state/get-current-repo))


### PR DESCRIPTION
Fix 2 missing cases at https://github.com/logseq/logseq/pull/9125 will also broken outliner.

Case 1:
```
- 1
  - 1.1
- 2
```
Press delete after 1, the current block is 1, the next block is 1.1, the right block is 2, when the next and the right block are not the same will trigger the bug.

Case 2:
```
* 1
- 2
```
1 is a collapsed block, it also means has child blocks, and it has a right block which is 2, then press delete after 1, when the current block is collapsed and the right block exists will trigger the bug.