### PR TITLE
refactor: rename fn params in `frontend.db.model`

### DIFF
--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -906,14 +906,14 @@ independent of format as format specific heading characters are stripped"
             (= "" (:block/content (db-utils/pull (:e (first datoms))))))))))
 
 (defn parents-collapsed?
-  [repo block-id]
-  (when-let [block (:block/parent (get-block-parents-v2 repo block-id))]
+  [repo block-uuid]
+  (when-let [block (:block/parent (get-block-parents-v2 repo block-uuid))]
     (->> (tree-seq map? (fn [x] [(:block/parent x)]) block)
          (some util/collapsed?))))
 
 (defn get-block-page
-  [repo block-id]
-  (when-let [block (db-utils/entity repo [:block/uuid block-id])]
+  [repo block-uuid]
+  (when-let [block (db-utils/entity repo [:block/uuid block-uuid])]
     (db-utils/entity repo (:db/id (:block/page block)))))
 
 (defn get-pages-by-name-partition


### PR DESCRIPTION
Background: when I were preparing the PR #9154, I found that there is some naming mistake in the fn param in `frontend.db.model`
 
For example, the second param in `parents-collapsed?` should be `block-uuid`, instead of `block-id`.

https://github.com/logseq/logseq/blob/6771a88781f54d90491719d593d3863c3b796228/src/main/frontend/mobile/action_bar.cljs#L43