### PR TITLE
fix(editor): wrong xml prettify implementation

### DIFF
--- a/src/main/frontend/utils.js
+++ b/src/main/frontend/utils.js
@@ -395,5 +395,7 @@ export const prettifyXml = function(sourceXml)
     xsltProcessor.importStylesheet(xsltDoc);
     var resultDoc = xsltProcessor.transformToDocument(xmlDoc);
     var resultXml = new XMLSerializer().serializeToString(resultDoc);
-    return resultXml;
+    // if it has parsererror, then return the original text
+    return resultXml.indexOf('<parsererror') === -1 ? resultXml : sourceXml;
+
 };


### PR DESCRIPTION
Introduced: #8968

To reproduce: copy any block which contains a `&`