### PR TITLE
fix: cannot undo redo in codemirror

### DIFF
--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -140,8 +140,7 @@
             [frontend.schema.handler.common-config :refer [Config-edn]]
             [malli.util :as mu]
             [malli.core :as m]
-            [rum.core :as rum]
-            [frontend.modules.editor.undo-redo :as undo-redo]))
+            [rum.core :as rum]))
 
 ;; codemirror
 


### PR DESCRIPTION
Background: fix #9036 

This bug was introduced in [src/main/frontend/modules/shortcut/config.cljs](https://github.com/logseq/logseq/pull/7786/files#diff-b3ebcab17041ddd88e90b63f3f6edc1db33b5dd469a91fed5ed3d4432bfe677a) in PR #7786 because it placed `:editor/undo` and `:editor/redo` into `global-prevent-default`. It causes codemirror can not handle its own undo/redo when  since it ignore the `cmd+z` and `cmd+shift+z` keypress.
