### PR TITLE
Chore: Add test to prevent regression on property query

### DIFF
--- a/deps/db/src/logseq/db/rules.cljc
+++ b/deps/db/src/logseq/db/rules.cljc
@@ -134,6 +134,7 @@
      [(str ?val) ?str-val]
      (or [(= ?v ?val)]
          [(contains? ?v ?val)]
+         ;; For integer pages that aren't strings
          [(contains? ?v ?str-val)])]
 
    :page-ref


### PR DESCRIPTION
To QA, try the old version of `property` from #9119