### PR TITLE
fix: port range should be 1 ~ 65535

### DIFF
--- a/src/main/frontend/components/server.cljs
+++ b/src/main/frontend/components/server.cljs
@@ -92,7 +92,7 @@
         {:auto-focus true
          :value      port
          :min        "1"
-         :max        "65536"
+         :max        "65535"
          :type       "number"
          :on-change  #(let [value (.-value (.-target %))]
                         (swap! *configs assoc :port value))}]]]

--- a/src/main/frontend/components/server.cljs
+++ b/src/main/frontend/components/server.cljs
@@ -87,7 +87,7 @@
                        (swap! *configs assoc :host value))}]]
 
       [:label
-       [:strong "Port (0 ~ 65536)"]
+       [:strong "Port (1 ~ 65535)"]
        [:input.form-input
         {:auto-focus true
          :value      port


### PR DESCRIPTION
The api server port range should between 1 and 65535.


It is no possible setting at 65536 and 0.

<img width="393" alt="image" src="https://user-images.githubusercontent.com/13883964/233829158-becfb981-b03e-4bf2-9d68-3c48f3f92934.png">
