### PR TITLE
fix(fs): wrong bak fname on mobile fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         "@capawesome/capacitor-background-task": "^2.0.0",
         "@excalidraw/excalidraw": "0.12.0",
         "@hugotomazi/capacitor-navigation-bar": "^2.0.0",
-        "@logseq/capacitor-file-sync": "0.0.22",
+        "@logseq/capacitor-file-sync": "0.0.24",
         "@logseq/diff-merge": "^0.0.2",
         "@logseq/react-tweet-embed": "1.3.1-1",
         "@sentry/react": "^6.18.2",

--- a/src/main/frontend/fs/capacitor_fs.cljs
+++ b/src/main/frontend/fs/capacitor_fs.cljs
@@ -148,7 +148,7 @@
                                           "")
                           (string/replace (re-pattern (str "(?i)" (gstring/regExpEscape (str "." ext)) "$"))
                                           ""))]
-    (util/safe-path-join repo-dir (str bak-dir "/" relative-path))))
+    (path/path-join repo-dir bak-dir relative-path)))
 
 (defn- truncate-old-versioned-files!
   "reserve the latest 6 version files"
@@ -174,7 +174,8 @@
         dir (case dir
               :backup-dir (get-backup-dir repo-dir path backup-dir ext)
               :version-file-dir (get-backup-dir repo-dir path version-file-dir ext))
-        new-path (util/safe-path-join dir (str (string/replace (.toISOString (js/Date.)) ":" "_") "." (mobile-util/platform) "." ext))]
+        new-path (path/path-join dir (str (string/replace (.toISOString (js/Date.)) ":" "_") "." (mobile-util/platform) "." ext))]
+
     (<write-file-with-utf8 new-path content)
     (truncate-old-versioned-files! dir)))
 
@@ -187,14 +188,14 @@
                                (string/includes? repo-dir divider-schema))
         repo-dir          (if-not dir-schema?
                             (str file-schema divider-schema repo-dir) repo-dir)
-        backup-root       (util/safe-path-join repo-dir backup-dir)
+        backup-root       (path/path-join repo-dir backup-dir)
         backup-dir-parent (util/node-path.dirname file-path)
         backup-dir-parent (string/replace backup-dir-parent repo-dir "")
         backup-dir-name (util/node-path.name file-path)
         file-extname (.extname util/node-path file-path)
-        file-root (util/safe-path-join backup-root backup-dir-parent backup-dir-name)
-        file-path (util/safe-path-join file-root
-                                       (str (string/replace (.toISOString (js/Date.)) ":" "_") "." (mobile-util/platform) file-extname))]
+        file-root (path/path-join backup-root backup-dir-parent backup-dir-name)
+        file-path (path/path-join file-root
+                                  (str (string/replace (.toISOString (js/Date.)) ":" "_") "." (mobile-util/platform) file-extname))]
     (<write-file-with-utf8 file-path content)
     (truncate-old-versioned-files! file-root)))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,10 +487,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@logseq/capacitor-file-sync@0.0.22":
-  version "0.0.22"
-  resolved "https://registry.yarnpkg.com/@logseq/capacitor-file-sync/-/capacitor-file-sync-0.0.22.tgz#3fa94d40e5c44c70a12537ce17cf3089ff72f93b"
-  integrity sha512-lb0+43YAaWy0umBCP2mPKyAPlIr2YHrLBfqGkCJUGAbrhTCAj37KZzb3snwSqeLA8dUSks9PcAN3jSgS74VMMw==
+"@logseq/capacitor-file-sync@0.0.24":
+  version "0.0.24"
+  resolved "https://registry.yarnpkg.com/@logseq/capacitor-file-sync/-/capacitor-file-sync-0.0.24.tgz#be7b69492b92df9c4e899502c632deebe179746b"
+  integrity sha512-CBIXEPYVp1ddjyYN+Z2dTQ9gwF0KYwZwlvwnl+zmR0Q3ODXxg75BExh5vAU8khXkSNZjZXgZT/J61/kn9xN11w==
 
 "@logseq/diff-merge@^0.0.2":
   version "0.0.2"


### PR DESCRIPTION
- Use standard path-join fn when creating bak dir
- Update capacitor-file-sync, fix percent-encoding bug

Fix #9190
Fix #9174
Fix #9008