### PR TITLE
Fix (Whiteboards): Export grouped elements and zoom to fit selection shortcut

### DIFF
--- a/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
@@ -140,7 +140,7 @@ export const ContextMenu = observer(function ContextMenu({
                 Zoom to fit
                 <div className="tl-menu-right-slot">
                   <span className="keyboard-shortcut">
-                    <code>{MOD_KEY}</code> <code>⇧</code> <code>1</code>
+                    <code>⇧</code> <code>2</code>
                   </span>
                 </div>
               </ReactContextMenu.Item>
@@ -241,27 +241,31 @@ export const ContextMenu = observer(function ContextMenu({
               </div>
             </ReactContextMenu.Item>
           )}
-          <ReactContextMenu.Separator className="menu-separator" />
-          <ReactContextMenu.Item
-            className="tl-menu-item"
-            onClick={() =>
-              runAndTransition(() =>
-                handlers.exportToImage(app.currentPageId, {
-                  x: app.selectionBounds.minX + app.viewport.camera.point[0] - EXPORT_PADDING,
-                  y: app.selectionBounds.minY + app.viewport.camera.point[1] - EXPORT_PADDING,
-                  width: app.selectionBounds?.width + EXPORT_PADDING * 2,
-                  height: app.selectionBounds?.height + EXPORT_PADDING * 2,
-                  zoom: app.viewport.camera.zoom,
-                })
-              )
-            }
-          >
-            <TablerIcon className="tl-menu-icon" name="file-export" />
-            Export
-            <div className="tl-menu-right-slot">
-              <span className="keyboard-shortcut"></span>
-            </div>
-          </ReactContextMenu.Item>
+          {app.selectedShapes?.size > 0 && (
+            <>
+              <ReactContextMenu.Separator className="menu-separator" />
+              <ReactContextMenu.Item
+                className="tl-menu-item"
+                onClick={() =>
+                  runAndTransition(() =>
+                    handlers.exportToImage(app.currentPageId, {
+                      x: app.selectionBounds.minX + app.viewport.camera.point[0] - EXPORT_PADDING,
+                      y: app.selectionBounds.minY + app.viewport.camera.point[1] - EXPORT_PADDING,
+                      width: app.selectionBounds?.width + EXPORT_PADDING * 2,
+                      height: app.selectionBounds?.height + EXPORT_PADDING * 2,
+                      zoom: app.viewport.camera.zoom,
+                    })
+                  )
+                }
+              >
+                <TablerIcon className="tl-menu-icon" name="file-export" />
+                Export
+                <div className="tl-menu-right-slot">
+                  <span className="keyboard-shortcut"></span>
+                </div>
+              </ReactContextMenu.Item>
+            </>
+          )}
           <ReactContextMenu.Separator className="menu-separator" />
           <ReactContextMenu.Item
             className="tl-menu-item"

--- a/tldraw/apps/tldraw-logseq/src/components/ZoomMenu/ZoomMenu.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ZoomMenu/ZoomMenu.tsx
@@ -41,7 +41,7 @@ export const ZoomMenu = observer(function ZoomMenu(): JSX.Element {
           Zoom to fit selection
           <div className="tl-menu-right-slot">
             <span className="keyboard-shortcut">
-              <code>{MOD_KEY}</code> <code>⇧</code> <code>1</code>
+              <code>⇧</code> <code>2</code>
             </span>
           </div>
         </DropdownMenuPrimitive.Item>

--- a/tldraw/packages/core/src/lib/TLApp/TLApp.ts
+++ b/tldraw/packages/core/src/lib/TLApp/TLApp.ts
@@ -113,7 +113,7 @@ export class TLApp<
         fn: () => this.api.zoomToFit(),
       },
       {
-        keys: 'mod+shift+1',
+        keys: 'shift+2',
         fn: () => this.api.zoomToSelection(),
       },
       {

--- a/tldraw/packages/react/src/components/Shape/Shape.tsx
+++ b/tldraw/packages/react/src/components/Shape/Shape.tsx
@@ -38,10 +38,14 @@ export const Shape = observer(function Shape({
   } = shape
   const app = useApp<Shape>()
   const events = useShapeEvents(shape)
+  const parentGroup = app.getParentGroup(shape)
+  const isParentGrpupSelected = app.selectedIds.has(parentGroup?.id)
+  const ignoreExport = !isSelected && !isParentGrpupSelected && app.selectedShapes.size !== 0 || null
+
   return (
     <Container
       data-shape-id={shape.id}
-      data-html2canvas-ignore={(!isSelected && app.selectedShapes.size !== 0) || null}
+      data-html2canvas-ignore={ignoreExport}
       zIndex={zIndex}
       data-type="Shape"
       bounds={bounds}


### PR DESCRIPTION
This fixes exporting selected groups to image (see https://discord.com/channels/725182569297215569/1099184966971166802/1099184966971166802), and also changes the shortcut of `zoom to fit selection`, that is in conflict with the default shortcut that toggles the input command dialog (see https://discord.com/channels/725182569297215569/1099050768977379439/1099050768977379439). I also disable the export option on the context menu, if there are no selected elements.