### PR TITLE
Enhance: Add :remove-block-children? query option for advanced queries and an advanced query :template fix

### DIFF
--- a/src/main/frontend/components/query/result.cljs
+++ b/src/main/frontend/components/query/result.cljs
@@ -9,7 +9,8 @@
             [frontend.util :as util]
             [clojure.string :as string]
             [promesa.core :as p]
-            [rum.core :as rum]))
+            [rum.core :as rum]
+            [frontend.modules.outliner.tree :as tree]))
 
 (defn trigger-custom-query!
   [state *query-error *query-triggered?]
@@ -66,7 +67,9 @@
             ;; exclude the current one, otherwise it'll loop forever
             remove-blocks (if current-block-uuid [current-block-uuid] nil)
             transformed-query-result (when query-result
-                                       (db/custom-query-result-transform query-result remove-blocks q))
+                                       (cond-> (db/custom-query-result-transform query-result remove-blocks q)
+                                         (get q :remove-block-children? true)
+                                         tree/filter-top-level-blocks))
             group-by-page? (get-group-by-page q options)
             result (if (and group-by-page? (:block/uuid (first transformed-query-result)))
                      (let [result (db-utils/group-by-page transformed-query-result)]

--- a/src/main/frontend/components/query/result.cljs
+++ b/src/main/frontend/components/query/result.cljs
@@ -67,9 +67,12 @@
             ;; exclude the current one, otherwise it'll loop forever
             remove-blocks (if current-block-uuid [current-block-uuid] nil)
             transformed-query-result (when query-result
-                                       (cond-> (db/custom-query-result-transform query-result remove-blocks q)
-                                         (get q :remove-block-children? true)
-                                         tree/filter-top-level-blocks))
+                                       (let [result (db/custom-query-result-transform query-result remove-blocks q)]
+                                         (if (and query-result (coll? result) (:block/uuid (first result)))
+                                           (cond-> result
+                                            (get q :remove-block-children? true)
+                                            tree/filter-top-level-blocks)
+                                           result)))
             group-by-page? (get-group-by-page q options)
             result (if (and group-by-page? (:block/uuid (first transformed-query-result)))
                      (let [result (db-utils/group-by-page transformed-query-result)]

--- a/src/main/frontend/components/query_table.cljs
+++ b/src/main/frontend/components/query_table.cljs
@@ -159,17 +159,15 @@
   (when current-block
     (let [select? (get state ::select?)
           *mouse-down? (::mouse-down? state)
-          ;; remove templates
-          result (remove (fn [b] (some? (get-in b [:block/properties :template]))) result)
-          result (if page? result (attach-clock-property result))
+          result' (if page? result (attach-clock-property result))
           clock-time-total (when-not page?
-                             (->> (map #(get-in % [:block/properties :clock-time] 0) result)
+                             (->> (map #(get-in % [:block/properties :clock-time] 0) result')
                                   (apply +)))
-          columns (get-columns current-block result {:page? page?})
+          columns (get-columns current-block result' {:page? page?})
           ;; Sort state needs to be in sync between final result and sortable title
           ;; as user needs to know if there result is sorted
           sort-state (get-sort-state current-block)
-          result' (sort-result result (assoc sort-state :page? page?))
+          sort-result (sort-result result (assoc sort-state :page? page?))
           property-separated-by-commas? (partial text/separated-by-commas? (state/get-config))]
       [:div.overflow-x-auto {:on-mouse-down (fn [e] (.stopPropagation e))
                              :style {:width "100%"}
@@ -184,7 +182,7 @@
                              (name column))]
               (sortable-title title column sort-state (:block/uuid current-block))))]]
         [:tbody
-         (for [row result']
+         (for [row sort-result]
            (let [format (:block/format row)]
              [:tr.cursor
               (for [column columns]

--- a/src/main/frontend/components/query_table.cljs
+++ b/src/main/frontend/components/query_table.cljs
@@ -12,8 +12,7 @@
             [frontend.format.block :as block]
             [medley.core :as medley]
             [rum.core :as rum]
-            [logseq.graph-parser.text :as text]
-            [frontend.modules.outliner.tree :as tree]))
+            [logseq.graph-parser.text :as text]))
 
 ;; Util fns
 ;; ========
@@ -158,8 +157,7 @@
   (rum/local false ::mouse-down?)
   [state config current-block result {:keys [page?]} map-inline page-cp ->elem inline-text]
   (when current-block
-    (let [result (tree/filter-top-level-blocks result)
-          select? (get state ::select?)
+    (let [select? (get state ::select?)
           *mouse-down? (::mouse-down? state)
           ;; remove templates
           result (remove (fn [b] (some? (get-in b [:block/properties :template]))) result)

--- a/src/test/frontend/components/query/result_test.cljs
+++ b/src/test/frontend/components/query/result_test.cljs
@@ -40,7 +40,7 @@
            ; User overrides transform to return grouped result
            {:result-transform '(partial sort-by :block/scheduled) :group-by-page? true}
            {{:db/id 1} sorted-result})
-      
+
       (testing "For table view"
         (are [query expected]
              (= expected (mock-get-query-result result query {:table? true}))
@@ -67,9 +67,9 @@
             "Current block is not included in results")))))
 
 (deftest get-query-result-with-remove-block-children-option
-  (let [result [{:db/id 1 :block/content "parent"}
-                {:db/id 2 :block/content "child" :block/parent {:db/id 1}}]]
-    (is (= [{:db/id 1 :block/content "parent"}]
+  (let [result [{:db/id 1 :block/content "parent" :block/uuid 1}
+                {:db/id 2 :block/content "child" :block/uuid 2 :block/parent {:db/id 1}}]]
+    (is (= [{:db/id 1 :block/content "parent" :block/uuid 1}]
            (mock-get-query-result result {:remove-block-children? true} {:table? true}))
         "Removes children when :remove-block-children? is true")
     (is (= result

--- a/src/test/frontend/components/query/result_test.cljs
+++ b/src/test/frontend/components/query/result_test.cljs
@@ -14,10 +14,12 @@
     (binding [rum/*reactions* (volatile! #{})]
       (#'query-result/get-query-result {} {} (atom nil) (atom nil) current-block-uuid query {:table? table?}))))
 
-(deftest get-query-result
-  (let [result [{:block/uuid (random-uuid) :block/scheduled 20230418 :block/page {:db/id 1}}
-                {:block/uuid (random-uuid) :block/scheduled 20230415 :block/page {:db/id 1}}
-                {:block/uuid (random-uuid) :block/scheduled 20230417 :block/page {:db/id 1}}]
+(deftest get-query-result-with-transforms-and-grouping
+  (let [result (mapv
+                #(assoc % :block/page {:db/id 1} :block/parent {:db/id 2})
+                [{:block/uuid (random-uuid) :block/scheduled 20230418}
+                 {:block/uuid (random-uuid) :block/scheduled 20230415}
+                 {:block/uuid (random-uuid) :block/scheduled 20230417}])
         sorted-result (sort-by :block/scheduled result)]
     (testing "For list view"
       (are [query expected]
@@ -63,3 +65,13 @@
                                         {:table? false
                                          :current-block-uuid (:block/uuid current-block)})))
             "Current block is not included in results")))))
+
+(deftest get-query-result-with-remove-block-children-option
+  (let [result [{:db/id 1 :block/content "parent"}
+                {:db/id 2 :block/content "child" :block/parent {:db/id 1}}]]
+    (is (= [{:db/id 1 :block/content "parent"}]
+           (mock-get-query-result result {:remove-block-children? true} {:table? true}))
+        "Removes children when :remove-block-children? is true")
+    (is (= result
+           (mock-get-query-result result {:remove-block-children? false} {:table? true}))
+        "Doesn't remove children when :remove-block-children? is false")))


### PR DESCRIPTION
This PR adds an option to make removing block children optional for a query and fixes bugs #3260 and #9045. The query option `:remove-block-children?` is added because there are times when we want to see block children e.g. when using the :current-block input. I still left children removal as the default as most users probably want the parent block when doing tag/page-ref searches e.g. https://github.com/logseq/logseq/issues/6406.  To QA this option, try:
```
- #+BEGIN_QUERY
{:title "Count under current block"
:inputs [:current-block]
:query [:find (count ?b)
  :in $ ?current-block
  :where [?b :block/parent ?current-block]]
  ;; This query only works when this option is added
:remove-block-children? false}
   - b1
   - b2
#+END_QUERY
```

The second commit removes the removal of template blocks as it prevents using from querying their template blocks e.g. https://github.com/logseq/logseq/issues/3260. 