### PR TITLE
Revert "Feat: ordered(number) list blocks"

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/property.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/property.cljs
@@ -64,7 +64,7 @@
      :created-at :updated-at :last-modified-at :created_at :last_modified_at
      :query-table :query-properties :query-sort-by :query-sort-desc :ls-type
      :hl-type :hl-page :hl-stamp :hl-color :logseq.macro-name :logseq.macro-arguments
-     :logseq.order-list-type :logseq.tldraw.page :logseq.tldraw.shape
+     :logseq.tldraw.page :logseq.tldraw.shape
      ; task markers
      :todo :doing :now :later :done}
    @built-in-extended-properties))

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -147,7 +147,6 @@
    "Tomorrow" "TIME & DATE"
    "LATER" "TASK"
    "A" "PRIORITY"
-   "Number list" "LIST TYPE"
    "Query" "ADVANCED"
    "Quote" "ORG-MODE"})
 
@@ -251,12 +250,9 @@
      ["Current time" #(date/get-current-time) "Insert current time"]
      ["Date picker" [[:editor/show-date-picker]] "Pick a date and insert here"]]
 
-    ;; order list
-    [["Number list" [[:editor/clear-current-slash]
-                     [:editor/toggle-own-number-list]] "Number list"]]
-
     ;; task management
     (get-preferred-workflow)
+
     [["DONE" (->marker "DONE")]
      ["WAITING" (->marker "WAITING")]
      ["CANCELED" (->marker "CANCELED")]
@@ -657,18 +653,6 @@
   (let [input-id (state/get-edit-input-id)
         macro (youtube/gen-youtube-ts-macro)]
     (insert! input-id macro {})))
-
-(defmethod handle-step :editor/toggle-children-number-list [[_]]
-  (when-let [block (state/get-edit-block)]
-    (state/pub-event! [:editor/toggle-children-number-list block])))
-
-(defmethod handle-step :editor/toggle-own-number-list [[_]]
-  (when-let [block (state/get-edit-block)]
-    (state/pub-event! [:editor/toggle-own-number-list block])))
-
-(defmethod handle-step :editor/remove-own-number-list [[_]]
-  (when-let [block (state/get-edit-block)]
-    (state/pub-event! [:editor/remove-own-number-list block])))
 
 (defmethod handle-step :editor/show-date-picker [[_ type]]
   (if (and

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1691,10 +1691,10 @@
 
 (rum/defc block-children < rum/reactive
   [config block children collapsed?]
-  (let [ref?        (:ref? config)
-        query?      (:custom-query? config)
-        children    (when (coll? children)
-                      (remove nil? children))]
+  (let [ref? (:ref? config)
+        query? (:custom-query? config)
+        children (when (coll? children)
+                   (remove nil? children))]
     (when (and (coll? children)
                (seq children)
                (not collapsed?))
@@ -1728,17 +1728,12 @@
 
 (rum/defcs block-control < rum/reactive
   [state config block uuid block-id collapsed? *control-show? edit? has-child?]
-  (let [doc-mode?          (state/sub :document/mode?)
-        control-show?      (util/react *control-show?)
-        ref?               (:ref? config)
-        empty-content?     (block-content-empty? block)
-        fold-button-right? (state/enable-fold-button-right?)
-        own-number-list?   (:own-order-number-list? config)
-        order-list?        (boolean own-number-list?)
-        order-list-idx     (:own-order-list-index config)]
+  (let [doc-mode? (state/sub :document/mode?)
+        control-show? (util/react *control-show?)
+        ref? (:ref? config)
+        empty-content? (block-content-empty? block)
+        fold-button-right? (state/enable-fold-button-right?)]
     [:div.block-control-wrap.mr-1.flex.flex-row.items-center.sm:mr-2
-     {:class (util/classnames [{:is-order-list order-list?
-                                :bullet-closed collapsed?}])}
      (when (or (not fold-button-right?) has-child?)
        [:a.block-control
         {:id       (str "control-" uuid)
@@ -1750,15 +1745,13 @@
                        (if collapsed?
                          (editor-handler/expand-block! uuid)
                          (editor-handler/collapse-block! uuid))))}
-        [:span {:class (if (or (and control-show?
-                                    (or collapsed?
-                                        (editor-handler/collapsable? uuid {:semantic? true})))
-                               (and collapsed? order-list?))
-                         "control-show cursor-pointer"
-                         "control-hide")}
+        [:span {:class (if (and control-show?
+                                (or collapsed?
+                                    (editor-handler/collapsable? uuid {:semantic? true}))) "control-show cursor-pointer" "control-hide")}
          (ui/rotating-arrow collapsed?)]])
 
-     (let [bullet [:a.bullet-link-wrap {:on-click #(bullet-on-click % block uuid)}
+     (let [bullet [:a {:on-click (fn [event]
+                                   (bullet-on-click event block uuid))}
                    [:span.bullet-container.cursor
                     {:id (str "dot-" uuid)
                      :draggable true
@@ -1766,14 +1759,11 @@
                                       (bullet-drag-start event block uuid block-id))
                      :blockid (str uuid)
                      :class (str (when collapsed? "bullet-closed")
+                                 " "
                                  (when (and (:document/mode? config)
                                             (not collapsed?))
-                                   " hide-inner-bullet")
-                                 (when order-list? " as-order-list typed-list"))}
-
-                    [:span.bullet {:blockid (str uuid)}
-                     (when order-list?
-                       [:label (str order-list-idx ".")])]]]]
+                                   "hide-inner-bullet"))}
+                    [:span.bullet {:blockid (str uuid)}]]]]
        (cond
          (and (or (mobile-util/native-platform?)
                   (:ui/show-empty-bullets? (state/get-config)))
@@ -1781,14 +1771,14 @@
          bullet
 
          (or
-           (and empty-content?
-                (not edit?)
-                (not (:block/top? block))
-                (not (:block/bottom? block))
-                (not (util/react *control-show?)))
-           (and doc-mode?
-                (not collapsed?)
-                (not (util/react *control-show?))))
+          (and empty-content?
+               (not edit?)
+               (not (:block/top? block))
+               (not (:block/bottom? block))
+               (not (util/react *control-show?)))
+          (and doc-mode?
+               (not collapsed?)
+               (not (util/react *control-show?))))
          ;; hidden
          [:span.bullet-container]
 
@@ -2775,7 +2765,6 @@
         config (if (nil? (:query-result config))
                  (assoc config :query-result (atom nil))
                  config)
-        config (if ref? (block-handler/attach-order-list-state config block) config)
         heading? (:heading properties)
         *control-show? (get state ::control-show?)
         db-collapsed? (util/collapsed? block)
@@ -2876,12 +2865,6 @@
 
      (dnd-separator-wrapper block block-id slide? false false)]))
 
-(defn- attach-order-list-state!
-  [cp-state]
-  (let [args (:rum/args cp-state)]
-    (assoc cp-state
-      :rum/args (assoc (vec args) 0 (block-handler/attach-order-list-state (first args) (second args))))))
-
 (rum/defcs block-container < rum/reactive
   (rum/local false ::show-block-left-menu?)
   (rum/local false ::show-block-right-menu?)
@@ -2898,26 +2881,20 @@
 
                :else
                nil)
-             (-> (assoc state
-                   ::control-show? (atom false)
-                   ::navigating-block (atom (:block/uuid block)))
-                 (attach-order-list-state!))))
-
-   :will-remount (fn [_old-state new-state]
-                   (-> new-state
-                       (attach-order-list-state!)))
-
+             (assoc state
+                    ::control-show? (atom false)
+                    ::navigating-block (atom (:block/uuid block)))))
    :should-update (fn [old-state new-state]
-                    (let [compare-keys        [:block/uuid :block/content :block/parent :block/collapsed?
-                                               :block/properties :block/left :block/children :block/_refs :block/bottom? :block/top?]
-                          config-compare-keys [:show-cloze? :own-order-list-type :own-order-list-index]
-                          b1                  (second (:rum/args old-state))
-                          b2                  (second (:rum/args new-state))
-                          result              (or
-                                                (not= (select-keys b1 compare-keys)
-                                                      (select-keys b2 compare-keys))
-                                                (not= (select-keys (first (:rum/args old-state)) config-compare-keys)
-                                                      (select-keys (first (:rum/args new-state)) config-compare-keys)))]
+                    (let [compare-keys [:block/uuid :block/content :block/parent :block/collapsed?
+                                        :block/properties :block/left :block/children :block/_refs :block/bottom? :block/top?]
+                          config-compare-keys [:show-cloze?]
+                          b1 (second (:rum/args old-state))
+                          b2 (second (:rum/args new-state))
+                          result (or
+                                  (not= (select-keys b1 compare-keys)
+                                        (select-keys b2 compare-keys))
+                                  (not= (select-keys (first (:rum/args old-state)) config-compare-keys)
+                                        (select-keys (first (:rum/args new-state)) config-compare-keys)))]
                       (boolean result)))
    :will-unmount (fn [state]
                    ;; restore root block's collapsed state
@@ -2927,8 +2904,8 @@
                        (state/set-collapsed-block! block-id nil)))
                    state)}
   [state config block]
-  (let [repo          (state/get-current-repo)
-        ref?          (:ref? config)
+  (let [repo (state/get-current-repo)
+        ref? (:ref? config)
         custom-query? (boolean (:custom-query? config))]
     (if (and (or ref? custom-query?) (not (:ref-query-child? config)))
       (ui/lazy-visible
@@ -2938,11 +2915,11 @@
 
 (defn divide-lists
   [[f & l]]
-  (loop [l        l
+  (loop [l l
          ordered? (:ordered f)
-         result   [[f]]]
+         result [[f]]]
     (if (seq l)
-      (let [cur          (first l)
+      (let [cur (first l)
             cur-ordered? (:ordered cur)]
         (if (= ordered? cur-ordered?)
           (recur

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -116,7 +116,6 @@
       position: relative;
       top: 4px;
     }
-
     a {
       color: var(--ls-primary-text-color);
 
@@ -203,10 +202,6 @@
 .block-control-wrap {
   height: 24px;
   margin-top: 0;
-
-  &.is-order-list {
-    @apply relative right-0;
-  }
 }
 
 .block-control, .block-control:hover {
@@ -530,13 +525,6 @@
     background-color: var(--ls-block-bullet-color, #8fbc8f);
   }
 
-  &.as-order-list {
-    min-width: 16px;
-    width: auto;
-    white-space: nowrap;
-    justify-content: end;
-  }
-
   .bullet {
     border-radius: 50%;
     width: 6px;
@@ -545,32 +533,17 @@
     transition: transform 0.2s;
   }
 
-  &:not(.typed-list) {
-    &.bullet-closed {
-      background-color: var(--ls-block-bullet-border-color, #ced9e0);
-    }
-  }
-
-  &.typed-list:not(:focus-within) {
-    .bullet {
-      background-color: unset;
-      height: unset;
-      width: unset;
-      box-shadow: none;
-    }
+  &.bullet-closed {
+    background-color: var(--ls-block-bullet-border-color, #ced9e0);
   }
 }
 
-.bullet-link-wrap {
-  color: var(--ls-primary-text-color);
+a:hover > .bullet-container .bullet {
+  transform: scale(1.4);
+}
 
-  &:hover > .bullet-container .bullet {
-    transform: scale(1.4);
-  }
-
-  &:hover > .bullet-container:not(.typed-list) {
-    background-color: var(--ls-block-bullet-border-color, #ced9e0);
-  }
+a:hover > .bullet-container {
+  background-color: var(--ls-block-bullet-border-color, #ced9e0);
 }
 
 .content.doc-mode {

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -353,8 +353,7 @@
      (mixins/listen state js/window "contextmenu"
                     (fn [e]
                       (let [target (gobj/get e "target")
-                            block-el (.closest target ".bullet-container[blockid]")
-                            block-id (some-> block-el (.getAttribute "blockid"))
+                            block-id (d/attr target "blockid")
                             {:keys [block block-ref]} (state/sub :block-ref/context)
                             {:keys [page]} (state/sub :page-title/context)]
                         (cond

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -948,16 +948,6 @@
 (defmethod handle :editor/quick-capture [[_ args]]
   (quick-capture/quick-capture args))
 
-(defmethod handle :editor/toggle-own-number-list [[_ block]]
-  (when block
-    (if (editor-handler/own-order-number-list? block)
-      (editor-handler/remove-block-own-order-list-type! block)
-      (editor-handler/make-block-as-own-order-list! block))))
-
-(defmethod handle :editor/remove-own-number-list [[_ block]]
-  (when (some-> block (editor-handler/own-order-number-list?))
-    (editor-handler/remove-block-own-order-list-type! block)))
-
 (defn run!
   []
   (let [chan (state/get-events-chan)]


### PR DESCRIPTION
Reverts logseq/logseq#9141

- Drag & Drop from normal blocks to ordered blocks is broken
- DWIM for list should be disabled