### PR TITLE
enhance: macro rendered result has unnecessary right margin [breaking change]

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -943,19 +943,23 @@
 
 (defn- render-macro
   [config name arguments macro-content format]
-  [:div.macro.inline-block {:data-macro-name name}
+  (let [attributes {:data-macro-name name}]
+    [:div.macro
 
-   (if macro-content
-     (let [ast (->> (mldoc/->edn macro-content (gp-mldoc/default-config format))
-                    (map first))
-           paragraph? (and (= 1 (count ast))
-                           (= "Paragraph" (ffirst ast)))]
-       (if (and (not paragraph?)
-                (mldoc/block-with-title? (ffirst ast)))
-         (markup-elements-cp (assoc config :block/format format) ast)
-         (inline-text {:add-margin? false} format macro-content)))
-     [:span.warning {:title (str "Unsupported macro name: " name)}
-      (macro->text name arguments)])])
+     (if macro-content
+       (let [ast (->> (mldoc/->edn macro-content (gp-mldoc/default-config format))
+                      (map first))
+             paragraph? (and (= 1 (count ast))
+                             (= "Paragraph" (ffirst ast)))]
+         (if (and (not paragraph?)
+                  (mldoc/block-with-title? (ffirst ast)))
+           (list attributes
+                 (markup-elements-cp (assoc config :block/format format) ast))
+           (list (assoc attributes :class "inline-block")
+                 (inline-text {:add-margin? false} format macro-content))))
+       (list attributes
+             [:span.warning {:title (str "Unsupported macro name: " name)}
+               (macro->text name arguments)]))]))
 
 (rum/defc nested-link < rum/reactive
   [config html-export? link]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -933,14 +933,12 @@
 
 (defn inline-text
   ([format v]
-   (inline-text {} format v false))
+   (inline-text {} format v))
   ([config format v]
-   (inline-text {} format v false))
-  ([config format v no-margin?]
    (when (string? v)
      (let [inline-list (gp-mldoc/inline->edn v (gp-mldoc/default-config format))]
        [:div.inline
-         (when (not no-margin?) {:class "mr-1"})
+         (when (get config :add-margin? true) {:class "mr-1"})
          (map-inline config inline-list)]))))
 
 (defn- render-macro
@@ -955,7 +953,7 @@
        (if (and (not paragraph?)
                 (mldoc/block-with-title? (ffirst ast)))
          (markup-elements-cp (assoc config :block/format format) ast)
-         (inline-text {} format macro-content true)))
+         (inline-text {:add-margin? false} format macro-content)))
      [:span.warning {:title (str "Unsupported macro name: " name)}
       (macro->text name arguments)])])
 

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -943,7 +943,7 @@
 
 (defn- render-macro
   [config name arguments macro-content format]
-  [:div.macro {:data-macro-name name}
+  [:div.macro.inline-block {:data-macro-name name}
 
    (if macro-content
      (let [ast (->> (mldoc/->edn macro-content (gp-mldoc/default-config format))

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -943,23 +943,24 @@
 
 (defn- render-macro
   [config name arguments macro-content format]
-  (let [attributes {:data-macro-name name}]
-    [:div.macro
-
-     (if macro-content
-       (let [ast (->> (mldoc/->edn macro-content (gp-mldoc/default-config format))
-                      (map first))
-             paragraph? (and (= 1 (count ast))
-                             (= "Paragraph" (ffirst ast)))]
-         (if (and (not paragraph?)
-                  (mldoc/block-with-title? (ffirst ast)))
-           (list attributes
-                 (markup-elements-cp (assoc config :block/format format) ast))
-           (list (assoc attributes :class "inline-block")
-                 (inline-text {:add-margin? false} format macro-content))))
-       (list attributes
-             [:span.warning {:title (str "Unsupported macro name: " name)}
-               (macro->text name arguments)]))]))
+  (vec
+   (cons
+    :div.macro
+    (let [attributes {:data-macro-name name}]
+       (if macro-content
+         (let [ast (->> (mldoc/->edn macro-content (gp-mldoc/default-config format))
+                        (map first))
+               paragraph? (and (= 1 (count ast))
+                               (= "Paragraph" (ffirst ast)))]
+           (if (and (not paragraph?)
+                    (mldoc/block-with-title? (ffirst ast)))
+             [attributes
+              (markup-elements-cp (assoc config :block/format format) ast)]
+             [(assoc attributes :class "inline-block")
+              (inline-text {:add-margin? false} format macro-content)]))
+         [attributes
+          [:span.warning {:title (str "Unsupported macro name: " name)}
+           (macro->text name arguments)]])))))
 
 (rum/defc nested-link < rum/reactive
   [config html-export? link]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -955,7 +955,7 @@
                     (mldoc/block-with-title? (ffirst ast)))
              [attributes
               (markup-elements-cp (assoc config :block/format format) ast)]
-             [(assoc attributes :class "inline-block")
+             [(assoc attributes :class "inline")
               (inline-text {:add-margin? false} format macro-content)]))
          [attributes
           [:span.warning {:title (str "Unsupported macro name: " name)}
@@ -3215,7 +3215,7 @@
        (markup-elements-cp config l))
       ["Raw_Html" content]
       (when (not html-export?)
-        [:div.raw_html {:dangerouslySetInnerHTML
+        [:div.raw_html.inline {:dangerouslySetInnerHTML
                         {:__html (security/sanitize-html content)}}])
       ["Export" "html" _options content]
       (when (not html-export?)
@@ -3225,7 +3225,7 @@
       (ui/catch-error
        [:div.warning {:title "Invalid hiccup"}
         content]
-       [:div.hiccup_html {:dangerouslySetInnerHTML
+       [:div.hiccup_html.inline {:dangerouslySetInnerHTML
                           {:__html (hiccup->html content)}}])
 
       ["Export" "latex" _options content]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -943,9 +943,8 @@
 
 (defn- render-macro
   [config name arguments macro-content format]
-  (vec
-   (cons
-    :div.macro
+  (into
+    [:div.macro]
     (let [attributes {:data-macro-name name}]
        (if macro-content
          (let [ast (->> (mldoc/->edn macro-content (gp-mldoc/default-config format))
@@ -960,7 +959,7 @@
               (inline-text {:add-margin? false} format macro-content)]))
          [attributes
           [:span.warning {:title (str "Unsupported macro name: " name)}
-           (macro->text name arguments)]])))))
+           (macro->text name arguments)]]))))
 
 (rum/defc nested-link < rum/reactive
   [config html-export? link]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -933,11 +933,15 @@
 
 (defn inline-text
   ([format v]
-   (inline-text {} format v))
+   (inline-text {} format v false))
   ([config format v]
+   (inline-text {} format v false))
+  ([config format v no-margin?]
    (when (string? v)
      (let [inline-list (gp-mldoc/inline->edn v (gp-mldoc/default-config format))]
-       [:div.inline.mr-1 (map-inline config inline-list)]))))
+       [:div.inline
+         (when (not no-margin?) {:class "mr-1"})
+         (map-inline config inline-list)]))))
 
 (defn- render-macro
   [config name arguments macro-content format]
@@ -951,7 +955,7 @@
        (if (and (not paragraph?)
                 (mldoc/block-with-title? (ffirst ast)))
          (markup-elements-cp (assoc config :block/format format) ast)
-         (inline-text format macro-content)))
+         (inline-text {} format macro-content true)))
      [:span.warning {:title (str "Unsupported macro name: " name)}
       (macro->text name arguments)])])
 


### PR DESCRIPTION
I've added styles to leverage one-liner macros. Fixes #8623

|before PR|after PR|
|:--:|:--:|
|<img width="200px" src="https://github.com/logseq/logseq/assets/1984175/b841e9fd-73d3-4a06-91d7-e7f00a0ff23b"/>|<img width="220px" src="https://user-images.githubusercontent.com/1984175/235907263-29a60c10-b0eb-473f-852f-c605065cc09d.png"/>|


**NOTE**: This message is a summary and was updated. In the comments below you can find a history of all the changes during working on this PR.


# Changes:
1) macro alignment in one line (add `.inline` class)
2) macro with headings left intact (no addition of `.inline` class)
3) remove right margin (`.mr-1`)
4) change styles for root div of hiccup & html syntax to «one-line» them too (add `.inline` class)

# Test data
```edn
 :macros {
    "theme-test-macro0" "<b>macro</b>",
    "theme-test-macro1" "[:b \"macro\"]",
    "theme-test-macro2" "macro",
    "theme-test-macro3" "header\nmacro",
    
    "iframe" "<iframe src='$1' style='height:320px'></iframe>",
 }
```

```edn
- before {{theme-test-macro0}} after
- before {{theme-test-macro1}} after
- before {{theme-test-macro2}} after
- before {{theme-test-macro3}} after
- {{iframe https://wikipedia.com}}  ;; iframe should be as wide as Logseq block
```

# Related discussions
- https://discuss.logseq.com/t/macro-for-inline-html-is-rendered-as-block/11466
- https://discuss.logseq.com/t/macros-hiccup-and-block-embeds/13930

# ⚠️ Caveats
- This is my first **_clojure_** PR. I feel myself unsure on how I write this code. Please point me to issues if need be