### PR TITLE
tiny style fix: polish color circles in block context menu

### DIFF
--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -69,11 +69,11 @@
   [:div.flex.flex-row.justify-between.py-1.px-2.items-center
    [:div.flex.flex-row.justify-between.flex-1.mx-2.mt-2
     (for [color block-background-colors]
-      [:a.shadow-sm
+      [:a
        {:title (t (keyword "color" color))
         :on-click #(add-bgcolor-fn color)}
        [:div.heading-bg {:style {:background-color (str "var(--ls-highlight-color-" color)}}]])
-    [:a.shadow-sm
+    [:a
      {:title (t :remove-background)
       :on-click rm-bgcolor-fn}
      [:div.heading-bg.remove "-"]]]])

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -72,7 +72,7 @@
       [:a.shadow-sm
        {:title (t (keyword "color" color))
         :on-click #(add-bgcolor-fn color)}
-       [:div.heading-bg {:style {:background-color (str "var(--color-" color "-500)")}}]])
+       [:div.heading-bg {:style {:background-color (str "var(--ls-highlight-color-" color)}}]])
     [:a.shadow-sm
      {:title (t :remove-background)
       :on-click rm-bgcolor-fn}

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -72,7 +72,7 @@
       [:a
        {:title (t (keyword "color" color))
         :on-click #(add-bgcolor-fn color)}
-       [:div.heading-bg {:style {:background-color (str "var(--ls-highlight-color-" color)}}]])
+       [:div.heading-bg {:style {:background-color (str "var(--color-" color "-500)")}}]])
     [:a
      {:title (t :remove-background)
       :on-click rm-bgcolor-fn}


### PR DESCRIPTION
### Adapt bullet context menu color circles to theme highlight colors

|Before|After|
|:---:|:---:|
|<img width="250px" src="https://user-images.githubusercontent.com/1984175/234269947-295f9baf-aeed-407c-8c5c-2ca04d520751.png"/>|<img width="250px" src="https://user-images.githubusercontent.com/1984175/234269970-d4f2c31d-9341-4074-bea7-3ab346366dd2.png"/>|

### Remove shadows

||||
|:---:|:---:|:---:|
|Before|<img width="245px" src="https://user-images.githubusercontent.com/1984175/234272232-293d5e22-c137-45e6-bdfe-de9cf8184c37.png"/>|<img width="100px" src="https://user-images.githubusercontent.com/1984175/234272672-9b648399-9172-4dd0-9073-b4e56d75916d.png"/>|
|After|<img width="245px" src="https://user-images.githubusercontent.com/1984175/234271992-8bafa70d-e8d6-4260-aeea-3783b1201c02.png"/>|<img width="100px" src="https://user-images.githubusercontent.com/1984175/234272827-edb43d92-54a7-4de1-b6d5-8cb05fd33ea5.png"/>|

## Note
- This changes are theme-independent.
- Examples provided with [☕️ BuJo Theme](https://github.com/stdword/logseq-bujo-theme#readme) (_Sepia_)