### PR TITLE
Enhance Logseq Sync: 2 stage file merge

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/util.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/util.cljs
@@ -213,6 +213,7 @@
   (second (re-find #"(?:\.)(\w+)[^.]*$" path-or-file-name)))
 
 (defn get-format
+  "File path to format keyword, :org, :markdown, etc."
   [file]
   (when file
     (normalize-format (keyword (some-> (path->file-ext file) string/lower-case)))))

--- a/deps/graph-parser/test/logseq/graph_parser/cli_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/cli_test.cljs
@@ -47,7 +47,7 @@
   (fs/mkdirSync (path/join dir "journals"))
   (fs/mkdirSync (path/join dir "pages")))
 
-(deftest ^:focus build-graph-files
+(deftest build-graph-files
   (create-logseq-graph "tmp/test-graph")
   ;; Create files that are recognized
   (fs/writeFileSync "tmp/test-graph/pages/foo.md" "")

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -519,7 +519,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 0.9.9;
+				MARKETING_VERSION = 0.9.10;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.logseq.logseq;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -546,7 +546,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 0.9.9;
+				MARKETING_VERSION = 0.9.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.logseq.logseq;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
@@ -571,7 +571,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 0.9.9;
+				MARKETING_VERSION = 0.9.10;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.logseq.logseq.ShareViewController;
@@ -598,7 +598,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 0.9.9;
+				MARKETING_VERSION = 0.9.10;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.logseq.logseq.ShareViewController;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/App/App/FsWatcher.swift
+++ b/ios/App/App/FsWatcher.swift
@@ -51,7 +51,6 @@ public class FsWatcher: CAPPlugin, PollingWatcherDelegate {
             return
         }
         // NOTE: Event in js {dir path content stat{mtime}}
-        print("url \(url) rel \(baseUrl)")
         switch event {
         case .Unlink:
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {

--- a/ios/App/App/FsWatcher.swift
+++ b/ios/App/App/FsWatcher.swift
@@ -51,6 +51,7 @@ public class FsWatcher: CAPPlugin, PollingWatcherDelegate {
             return
         }
         // NOTE: Event in js {dir path content stat{mtime}}
+        print("url \(url) rel \(baseUrl)")
         switch event {
         case .Unlink:
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         "@capawesome/capacitor-background-task": "^2.0.0",
         "@excalidraw/excalidraw": "0.12.0",
         "@hugotomazi/capacitor-navigation-bar": "^2.0.0",
-        "@logseq/capacitor-file-sync": "0.0.27",
+        "@logseq/capacitor-file-sync": "0.0.30",
         "@logseq/diff-merge": "^0.0.2",
         "@logseq/react-tweet-embed": "1.3.1-1",
         "@radix-ui/colors": "^0.1.8",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         "@capawesome/capacitor-background-task": "^2.0.0",
         "@excalidraw/excalidraw": "0.12.0",
         "@hugotomazi/capacitor-navigation-bar": "^2.0.0",
-        "@logseq/capacitor-file-sync": "0.0.24",
+        "@logseq/capacitor-file-sync": "0.0.27",
         "@logseq/diff-merge": "^0.0.2",
         "@logseq/react-tweet-embed": "1.3.1-1",
         "@radix-ui/colors": "^0.1.8",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
         "@excalidraw/excalidraw": "0.12.0",
         "@hugotomazi/capacitor-navigation-bar": "^2.0.0",
         "@logseq/capacitor-file-sync": "0.0.30",
-        "@logseq/diff-merge": "^0.0.2",
+        "@logseq/diff-merge": "^0.0.3",
         "@logseq/react-tweet-embed": "1.3.1-1",
         "@radix-ui/colors": "^0.1.8",
         "@sentry/react": "^6.18.2",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
         "highlight.js": "10.4.1",
         "ignore": "5.1.8",
         "jszip": "3.8.0",
-        "mldoc": "^1.5.5",
+        "mldoc": "1.5.7",
         "path": "0.12.7",
         "path-complete-extname": "1.0.0",
         "pixi-graph-fork": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
         "@excalidraw/excalidraw": "0.12.0",
         "@hugotomazi/capacitor-navigation-bar": "^2.0.0",
         "@logseq/capacitor-file-sync": "0.0.30",
-        "@logseq/diff-merge": "^0.0.3",
+        "@logseq/diff-merge": "0.1.0",
         "@logseq/react-tweet-embed": "1.3.1-1",
         "@radix-ui/colors": "^0.1.8",
         "@sentry/react": "^6.18.2",

--- a/resources/package.json
+++ b/resources/package.json
@@ -37,7 +37,7 @@
     "https-proxy-agent": "5.0.0",
     "@sentry/electron": "2.5.1",
     "posthog-js": "1.10.2",
-    "@logseq/rsapi": "0.0.70",
+    "@logseq/rsapi": "0.0.71",
     "electron-deeplink": "1.0.10",
     "abort-controller": "3.0.0",
     "fastify": "latest",

--- a/resources/package.json
+++ b/resources/package.json
@@ -37,7 +37,7 @@
     "https-proxy-agent": "5.0.0",
     "@sentry/electron": "2.5.1",
     "posthog-js": "1.10.2",
-    "@logseq/rsapi": "0.0.71",
+    "@logseq/rsapi": "0.0.73",
     "electron-deeplink": "1.0.10",
     "abort-controller": "3.0.0",
     "fastify": "latest",

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -38,6 +38,7 @@
                            frontend.modules.instrumentation.sentry/SENTRY-DSN #shadow/env "LOGSEQ_SENTRY_DSN"
                            frontend.modules.instrumentation.posthog/POSTHOG-TOKEN #shadow/env "LOGSEQ_POSTHOG_TOKEN"
                            frontend.config/ENABLE-PLUGINS #shadow/env ["ENABLE_PLUGINS" :as :bool :default true]
+                           ;; Set to switch file sync server to dev, set this to false in `yarn watch`
                            frontend.config/ENABLE-FILE-SYNC-PRODUCTION #shadow/env ["ENABLE_FILE_SYNC_PRODUCTION" :as :bool :default true]
                            frontend.config/TEST #shadow/env ["LOGSEQ_CI" :as :bool :default false]
                            frontend.config/REVISION #shadow/env ["LOGSEQ_REVISION" :default "dev"]} ;; set by git-revision-hook

--- a/src/electron/electron/file_sync_rsapi.cljs
+++ b/src/electron/electron/file_sync_rsapi.cljs
@@ -26,6 +26,9 @@
 (defn delete-local-files [graph-uuid base-path file-paths]
   (rsapi/deleteLocalFiles graph-uuid base-path (clj->js file-paths)))
 
+(defn fetch-remote-files [graph-uuid base-path file-paths token]
+  (rsapi/fetchRemoteFiles graph-uuid base-path (clj->js file-paths) token))
+
 (defn update-local-files [graph-uuid base-path file-paths token]
   (rsapi/updateLocalFiles graph-uuid base-path (clj->js file-paths) token))
 

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -96,6 +96,10 @@
     (catch :default _e
       false)))
 
+(defmethod handle :copyFile [_window [_ _repo from-path to-path]]
+  (logger/info ::copy-file from-path to-path)
+  (fs-extra/copy from-path to-path))
+
 (defmethod handle :writeFile [window [_ repo path content]]
   (let [^js Buf (.-Buffer buffer)
         ^js content (if (instance? js/ArrayBuffer content)
@@ -635,6 +639,9 @@
 
 (defmethod handle :delete-local-files [_ args]
   (apply rsapi/delete-local-files (rest args)))
+
+(defmethod handle :fetch-remote-files [_ args]
+  (apply rsapi/fetch-remote-files (rest args)))
 
 (defmethod handle :update-local-files [_ args]
   (apply rsapi/update-local-files (rest args)))

--- a/src/main/frontend/fs/diff_merge.cljs
+++ b/src/main/frontend/fs/diff_merge.cljs
@@ -64,7 +64,7 @@
               pos-meta (assoc pos-meta :end_pos end-pos)]
           (cond
             (gp-block/heading-block? block)
-            (let [content (gp-block/get-block-content encoded-content block format pos-meta block-pattern)]
+            (let [content (gp-block/get-block-content encoded-content (second block) format pos-meta block-pattern)]
               (recur (conj headings {:body  content
                                      :level (:level (second block))
                                      :uuid  (:id properties)})
@@ -80,6 +80,7 @@
             (recur headings (rest blocks) properties (:end_pos pos-meta))))
         (if (empty? properties)
           (reverse headings)
+          ;; Add pre-blocks
           (let [[block _] (first blocks)
                 pos-meta {:start_pos 0 :end_pos end-pos}
                 content (gp-block/get-block-content encoded-content block format pos-meta block-pattern)

--- a/src/main/frontend/fs/diff_merge.cljs
+++ b/src/main/frontend/fs/diff_merge.cljs
@@ -90,6 +90,14 @@
                   (reverse headings))))))))
 
 
+(defn- prepend-lines
+  "prepend prefix to every lines of content"
+  [prefix content]
+  (->> content
+       (string/split-lines)
+       (map (fn [line] (str prefix line)))
+       (string/join "\n")))
+
 (defn- rebuild-content
   "translate [[[op block]]] to merged content"
   [_base-diffblocks diffs format]
@@ -100,7 +108,7 @@
          ops-fn (fn [ops]
                   (map (fn [[op {:keys [body level]}]]
                          (when (or (= op 0) (= op 1)) ;; equal or insert
-                           (str (level-prefix-fn level) body)))
+                           (str (level-prefix-fn level) "-" (prepend-lines " " body))))
                        ops))]
     (->> diffs
          (mapcat ops-fn)
@@ -114,11 +122,11 @@
                            (gp-mldoc/->edn text (gp-mldoc/default-config :markdown))))
         merger (Merger.)
         base-ast (->ast base)
-        base-diffblocks (ast->diff-blocks base-ast base format {})
+        base-diffblocks (ast->diff-blocks base-ast base format {:block-pattern "-"})
         income-ast (->ast income)
-        income-diffblocks (ast->diff-blocks income-ast income format {})
+        income-diffblocks (ast->diff-blocks income-ast income format {:block-pattern "-"})
         current-ast (->ast current)
-        current-diffblocks (ast->diff-blocks current-ast current format {})
+        current-diffblocks (ast->diff-blocks current-ast current format {:block-pattern "-"})
         branch-diffblocks [income-diffblocks current-diffblocks]
         merged (.mergeBlocks merger (bean/->js base-diffblocks) (bean/->js branch-diffblocks))
         merged-diff (bean/->clj merged)

--- a/src/main/frontend/fs/diff_merge.cljs
+++ b/src/main/frontend/fs/diff_merge.cljs
@@ -107,7 +107,6 @@
          (filter seq)
          (string/join "\n"))))
 
-
 (defn three-way-merge
   [base income current format]
   (let [->ast (fn [text] (if (= format :org)

--- a/src/main/frontend/fs/diff_merge.cljs
+++ b/src/main/frontend/fs/diff_merge.cljs
@@ -119,7 +119,7 @@
 
                   content-2 (get-sub-content-from-pos-meta utf8-encoded-content fixed-pos-meta)]
               (recur (conj headings {:body  content
-                                     :raw-body content-2
+                                     :raw-body (string/trimr content-2)
                                      :level (:level (second block))
                                      :uuid  (:id properties)})
                      (rest blocks)
@@ -145,6 +145,7 @@
               content (gp-block/get-block-content utf8-encoded-content block format pos-meta block-pattern)
               uuid (:id properties)]
           (cons {:body content
+                 :raw-body (string/trimr content)
                  :level 1
                  :uuid uuid}
                 (reverse headings)))))))
@@ -152,6 +153,7 @@
 (defn- rebuild-content
   "translate [[[op block]]] to merged content"
   [_base-diffblocks diffs _format]
+  (prn ::rebuild diffs)
   ;; [[[0 {:body "attrib:: xxx", :level 1, :uuid nil}] ...] ...]
   (let  [ops-fn (fn [ops]
                   (map (fn [[op {:keys [raw-body]}]]
@@ -161,7 +163,7 @@
     (->> diffs
          (mapcat ops-fn)
          (filter seq)
-         (string/join ""))))
+         (string/join "\n"))))
 
 (defn three-way-merge
   [base income current format]

--- a/src/main/frontend/fs/diff_merge.cljs
+++ b/src/main/frontend/fs/diff_merge.cljs
@@ -116,10 +116,9 @@
           (cond
             (gp-block/heading-block? block)
             (let [content (gp-block/get-block-content utf8-encoded-content (second block) format fixed-pos-meta block-pattern)
-
-                  content-2 (get-sub-content-from-pos-meta utf8-encoded-content fixed-pos-meta)]
+                  content-raw (get-sub-content-from-pos-meta utf8-encoded-content fixed-pos-meta)]
               (recur (conj headings {:body  content
-                                     :raw-body (string/trimr content-2)
+                                     :raw-body (string/trimr content-raw)
                                      :level (:level (second block))
                                      :uuid  (:id properties)})
                      (rest blocks)
@@ -143,9 +142,10 @@
         (let [[block _] (first blocks)
               pos-meta {:start_pos 0 :end_pos end-pos}
               content (gp-block/get-block-content utf8-encoded-content block format pos-meta block-pattern)
+              content-raw (get-sub-content-from-pos-meta utf8-encoded-content pos-meta)
               uuid (:id properties)]
           (cons {:body content
-                 :raw-body (string/trimr content)
+                 :raw-body (string/trimr content-raw)
                  :level 1
                  :uuid uuid}
                 (reverse headings)))))))
@@ -153,7 +153,6 @@
 (defn- rebuild-content
   "translate [[[op block]]] to merged content"
   [_base-diffblocks diffs _format]
-  (prn ::rebuild diffs)
   ;; [[[0 {:body "attrib:: xxx", :level 1, :uuid nil}] ...] ...]
   (let  [ops-fn (fn [ops]
                   (map (fn [[op {:keys [raw-body]}]]
@@ -185,13 +184,3 @@
         merged-diff (bean/->clj merged)
         merged-content (rebuild-content base-diffblocks merged-diff format)]
     merged-content))
-
-;; (defn diff-merge
-;;   "N-ways diff & merge
-;;    Accept: blocks
-;;    https://github.com/logseq/blob/44546f2427f20bd417b898c8ba7b7d10a9254774/lib/mldoc.ts#L17-L22
-;;    https://github.com/logseq/blob/85ca7e9bf7740d3880ed97d535a4f782a963395d/lib/merge.ts#L40"
-;;   [base & branches]
-;;   ()
-;;   (let [merger (Merger.)]
-;;     (.mergeBlocks merger (bean/->js base) (bean/->js branches))))

--- a/src/main/frontend/fs/diff_merge.cljs
+++ b/src/main/frontend/fs/diff_merge.cljs
@@ -39,6 +39,7 @@
                     blocks levels)]
     blocks))
 
+;; TODO: Switch to ast->diff-blocks-alt
 ;; Diverged from gp-block/extract-blocks for decoupling
 ;; The process of doing 2 way diff is like:
 ;; 1. Given a base ver. of page (AST in DB), and a branch ver. of page (externally modified file content)
@@ -97,6 +98,8 @@
   (let [{:keys [start_pos end_pos]} pos-meta]
     (utf8/substring raw-content start_pos end_pos)))
 
+;; Diverged from ast->diff-blocks
+;; Add :meta :raw-body to the block
 (defn- ast->diff-blocks-alt
   "Prepare the blocks for diff-merge
    blocks: ast of blocks
@@ -145,7 +148,7 @@
               content-raw (get-sub-content-from-pos-meta utf8-encoded-content pos-meta)
               uuid (:id properties)]
           (cons {:body content
-                 :raw-body (string/trimr content-raw)
+                 :meta {:raw-body (string/trimr content-raw)}
                  :level 1
                  :uuid uuid}
                 (reverse headings)))))))

--- a/src/main/frontend/fs/diff_merge.cljs
+++ b/src/main/frontend/fs/diff_merge.cljs
@@ -118,7 +118,7 @@
             (let [content (gp-block/get-block-content utf8-encoded-content (second block) format fixed-pos-meta block-pattern)
                   content-raw (get-sub-content-from-pos-meta utf8-encoded-content fixed-pos-meta)]
               (recur (conj headings {:body  content
-                                     :raw-body (string/trimr content-raw)
+                                     :meta  {:raw-body (string/trimr content-raw)}
                                      :level (:level (second block))
                                      :uuid  (:id properties)})
                      (rest blocks)
@@ -155,9 +155,9 @@
   [_base-diffblocks diffs _format]
   ;; [[[0 {:body "attrib:: xxx", :level 1, :uuid nil}] ...] ...]
   (let  [ops-fn (fn [ops]
-                  (map (fn [[op {:keys [raw-body]}]]
+                  (map (fn [[op {:keys [meta]}]]
                          (when (or (= op 0) (= op 1)) ;; equal or insert
-                           raw-body))
+                           (:raw-body meta)))
                        ops))]
     (->> diffs
          (mapcat ops-fn)
@@ -181,6 +181,13 @@
         current-diffblocks (ast->diff-blocks-alt current-ast current format options)
         branch-diffblocks [income-diffblocks current-diffblocks]
         merged (.mergeBlocks merger (bean/->js base-diffblocks) (bean/->js branch-diffblocks))
+        ;; For extracting diff-merge test cases
+        ;; _ (prn "input:")
+        ;; _ (prn (js/JSON.stringify (bean/->js base-diffblocks)))
+        ;; _ (prn (js/JSON.stringify (bean/->js branch-diffblocks)))
+        ;; _ (prn "logseq diff merge version: " version)
+        ;; _ (prn "output:")
+        ;; _ (prn (js/JSON.stringify merged))
         merged-diff (bean/->clj merged)
         merged-content (rebuild-content base-diffblocks merged-diff format)]
     merged-content))

--- a/src/main/frontend/fs/node.cljs
+++ b/src/main/frontend/fs/node.cljs
@@ -118,7 +118,10 @@
 
   (rename! [_this _repo old-path new-path]
     (ipc/ipc "rename" old-path new-path))
-
+  ;; copy with overwrite, without confirmation
+  (copy! [_this repo old-path new-path]
+         (prn ::copy-file old-path new-path)
+    (ipc/ipc "copyFile" repo old-path new-path))
   (stat [_this fpath]
     (-> (ipc/ipc "stat" fpath)
         (p/then bean/->clj)))

--- a/src/main/frontend/fs/node.cljs
+++ b/src/main/frontend/fs/node.cljs
@@ -120,7 +120,6 @@
     (ipc/ipc "rename" old-path new-path))
   ;; copy with overwrite, without confirmation
   (copy! [_this repo old-path new-path]
-         (prn ::copy-file old-path new-path)
     (ipc/ipc "copyFile" repo old-path new-path))
   (stat [_this fpath]
     (-> (ipc/ipc "stat" fpath)

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -958,7 +958,15 @@
                                                                      :token token})))))))
   (<fetch-remote-files [this graph-uuid base-path filepaths]
     (js/console.error "unimpl")
-    (prn ::todo))
+    (go
+      (let [token (<! (<get-token this))
+            r (<! (<retry-rsapi
+                   #(p->c (.fetchRemoteFiles mobile-util/file-sync
+                                             (clj->js {:graphUUID graph-uuid
+                                                       :basePath base-path
+                                                       :filePaths filepaths
+                                                       :token token})))))]
+        (js->clj (.-value r)))))
   (<download-version-files [this graph-uuid base-path filepaths]
     (go
       (let [token (<! (<get-token this))
@@ -994,12 +1002,13 @@
             r
             (get (js->clj r) "txid"))))))
 
-  (<delete-remote-files [this graph-uuid _base-path filepaths local-txid]
+  (<delete-remote-files [this graph-uuid base-path filepaths local-txid]
     (let [normalized-filepaths (mapv path-normalize filepaths)]
       (go
         (let [token (<! (<get-token this))
               r (<! (p->c (.deleteRemoteFiles mobile-util/file-sync
                                               (clj->js {:graphUUID graph-uuid
+                                                        :basePath base-path
                                                         :filePaths normalized-filepaths
                                                         :txid local-txid
                                                         :token token}))))]

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -856,7 +856,6 @@
       (let [token (<! (<get-token this))]
         (<! (p->c (ipc/ipc "update-local-files" graph-uuid base-path filepaths token))))))
   (<fetch-remote-files [this graph-uuid base-path filepaths]
-    (println "fetch-remote-files" graph-uuid base-path filepaths)
     (go
       (<! (<rsapi-cancel-all-requests))
       (let [token (<! (<get-token this))]
@@ -957,7 +956,6 @@
                                                                      :filePaths filepaths'
                                                                      :token token})))))))
   (<fetch-remote-files [this graph-uuid base-path filepaths]
-    (js/console.error "mobile <fetch-remote-files")
     (go
       (let [token (<! (<get-token this))
             r (<! (<retry-rsapi
@@ -1592,7 +1590,6 @@
                                       (fs/unlink! repo (path/path-join repo-dir base-file) {}))
                                      ;; base-content != current-content, merge, do not delete
                                      (p/let [merged-content (diff-merge/three-way-merge base-content "" current-content format)]
-                                       (prn "local changed, merge deletion")
                                        (fs/write-file! repo repo-dir current-change-file merged-content {:skip-compare? true})
                                        (file-handler/alter-file repo current-change-file merged-content {:re-render-root? true
                                                                                                          :from-disk? true

--- a/src/main/frontend/handler/common/file.cljs
+++ b/src/main/frontend/handler/common/file.cljs
@@ -72,8 +72,8 @@
    Decide how to treat the parsed file based on the file's triggering event
    options - 
      :fs/reset-event - the event that triggered the file update
-       :fs/local-file-change - file changed on local disk
-       :fs/remote-file-change - file changed on remote"
+     :fs/local-file-change - file changed on local disk
+     :fs/remote-file-change - file changed on remote"
   [repo-url file-path content {:fs/keys [event] :as options}]
   (let [db-conn (db/get-db repo-url false)]
     (case event

--- a/src/test/frontend/fs/diff_merge_test.cljs
+++ b/src/test/frontend/fs/diff_merge_test.cljs
@@ -1,13 +1,13 @@
 (ns frontend.fs.diff-merge-test
-  (:require [cljs.test :refer [deftest are is]]
-            [logseq.db :as ldb]
-            [logseq.graph-parser :as graph-parser]
-            [logseq.graph-parser.text :as text]
+  (:require [cljs-bean.core :as bean]
+            [cljs.test :refer [are deftest is]]
+            [frontend.db.conn :as conn]
             [frontend.fs.diff-merge :as fs-diff]
             [frontend.handler.common.file :as file-common-handler]
-            [frontend.db.conn :as conn]
+            [logseq.db :as ldb]
+            [logseq.graph-parser :as graph-parser]
             [logseq.graph-parser.mldoc :as gp-mldoc]
-            [cljs-bean.core :as bean]))
+            [logseq.graph-parser.text :as text]))
 
 (defn test-db->diff-blocks
   "A hijacked version of db->diff-blocks for testing.
@@ -29,18 +29,18 @@
 :ID:       72289d9a-eb2f-427b-ad97-b605a4b8c59b
 :END:
 #+tItLe: Well parsed!"
-[{:body ":PROPERTIES:\n:ID:       72289d9a-eb2f-427b-ad97-b605a4b8c59b\n:END:\n#+tItLe: Well parsed!" 
-  :uuid "72289d9a-eb2f-427b-ad97-b605a4b8c59b" 
+[{:body ":PROPERTIES:\n:ID:       72289d9a-eb2f-427b-ad97-b605a4b8c59b\n:END:\n#+tItLe: Well parsed!"
+  :uuid "72289d9a-eb2f-427b-ad97-b605a4b8c59b"
   :level 1}]
-    
+
     "#+title: Howdy"
     [{:body "#+title: Howdy" :uuid nil :level 1}]
-    
+
     ":PROPERTIES:
 :fiction: [[aldsjfklsda]]
 :END:\n#+title: Howdy"
-    [{:body ":PROPERTIES:\n:fiction: [[aldsjfklsda]]\n:END:\n#+title: Howdy" 
-      :uuid nil 
+    [{:body ":PROPERTIES:\n:fiction: [[aldsjfklsda]]\n:END:\n#+title: Howdy"
+      :uuid nil
       :level 1}]))
 
 (deftest db<->ast-diff-blocks-test
@@ -85,7 +85,7 @@
 \t\t\t- nice
 \t\t\t- bingo
 \t\t\t- world"
-  [{:body "## hello" :uuid nil :level 2}
+  [{:body "## hello" :uuid nil :level 1}
    {:body "world" :uuid nil :level 2}
    {:body "nice" :uuid nil :level 3}
    {:body "nice" :uuid nil :level 4}
@@ -103,20 +103,20 @@
 \t- i
 - j"
   [{:body "# a" :uuid nil :level 1}
-   {:body "## b" :uuid nil :level 2}
-   {:body "### c" :uuid nil :level 3}
-   {:body "#### d" :uuid nil :level 4}
-   {:body "### e" :uuid nil :level 3}
+   {:body "## b" :uuid nil :level 1}
+   {:body "### c" :uuid nil :level 1}
+   {:body "#### d" :uuid nil :level 1}
+   {:body "### e" :uuid nil :level 1}
    {:body "f" :uuid nil :level 1}
    {:body "g" :uuid nil :level 2}
    {:body "h" :uuid nil :level 3}
    {:body "i" :uuid nil :level 2}
    {:body "j" :uuid nil :level 1}]
-  
+
     "- a\n  id:: 63e25526-3612-4fb1-8cf9-f66db1254a58
 \t- b
 \t\t- c"
-[{:body "a\nid:: 63e25526-3612-4fb1-8cf9-f66db1254a58" 
+[{:body "a\nid:: 63e25526-3612-4fb1-8cf9-f66db1254a58"
   :uuid "63e25526-3612-4fb1-8cf9-f66db1254a58" :level 1}
  {:body "b" :uuid nil :level 2}
  {:body "c" :uuid nil :level 3}]))
@@ -142,10 +142,10 @@
     ;; See https://github.com/logseq/diff-merge#usage
     [[]
      [[-1 {:body "## hello"
-          :level 2
+          :level 1
           :uuid nil}]
       [1  {:body "## Halooooo"
-          :level 2
+          :level 1
           :uuid nil}]]
      [[0 {:body "world"
          :level 2
@@ -162,7 +162,7 @@
      [[0 {:body "world"
          :level 4
          :uuid nil}]]]
-    
+
     "## hello
 \t- world
 \t  id:: 63e25526-3612-4fb1-8cf9-abcd12354abc
@@ -180,10 +180,10 @@
 ;; See https://github.com/logseq/diff-merge#usage
 [[]
  [[-1 {:body "## hello"
-       :level 2
+       :level 1
        :uuid nil}]
   [1  {:body "## Halooooo"
-       :level 2
+       :level 1
        :uuid nil}]
   [1 {:body "world"
       :level 2
@@ -234,7 +234,7 @@
 
       "bar"
       [{:body "ghi\nid:: 11451411-1111-1111-1111-111111111111" :uuid  "11451411-1111-1111-1111-111111111111" :level 1}
-       {:body "jkl\nid:: 63241234-1234-1234-1234-123412341234" :uuid  "63241234-1234-1234-1234-123412341234" :level 2}]) 
+       {:body "jkl\nid:: 63241234-1234-1234-1234-123412341234" :uuid  "63241234-1234-1234-1234-123412341234" :level 2}])
 
     (are [page-name text new-uuids] (= (let [old-blks (test-db->diff-blocks conn page-name)
                                              new-blks (text->diffblocks text)
@@ -271,7 +271,7 @@
     [[["Properties" [["TiTlE" "Howdy" []]]] nil]]
     "#+title: Howdy"
     [{:body "#+title: Howdy", :level 1, :uuid nil}])
-  
+
   (are [ast text diff-blocks]
        (= (fs-diff/ast->diff-blocks ast text :org {:block-pattern "-" :user-config {:property-pages/enabled? true}})
           diff-blocks)
@@ -349,7 +349,7 @@
       foo-new-content
       "foo-persist"
       (fn [db-uuids] (conj db-uuids nil))
-      
+
       ;; Prepend a new line to bar
       (gp-mldoc/->edn new-bar-content (gp-mldoc/default-config :markdown))
       new-bar-content
@@ -379,7 +379,7 @@
 (deftest test-remove-indentation-spaces
   (is (= "" (gp-mldoc/remove-indentation-spaces "" 0 false)))
   (is (= "" (gp-mldoc/remove-indentation-spaces "" 3 true)))
-  
+
   (is (= "- nice\n  happy" (gp-mldoc/remove-indentation-spaces "\t\t\t- nice\n\t\t\t  happy" 3 true)))
   (is (= "\t\t\t- nice\n  happy" (gp-mldoc/remove-indentation-spaces "\t\t\t- nice\n\t\t\t  happy" 3 false)))
   (is (= "\t\t\t- nice\n\t\t\t  happy" (gp-mldoc/remove-indentation-spaces "\t\t\t- nice\n\t\t\t  happy" 0 true))))
@@ -389,3 +389,11 @@
   (is (= "nice\n\t\t\t  good" (text/remove-level-spaces "\t\t\t- nice\n\t\t\t  good" :markdown "-")))
   (is (= "- nice" (text/remove-level-spaces "\t\t\t- nice" :markdown "")))
   (is (= "nice" (text/remove-level-spaces "\t\t\t- nice" :markdown "-"))))
+
+(deftest test-three-way-merge
+  (is (= (fs-diff/three-way-merge
+          "- a\n  id:: 648ab5e6-5e03-4c61-95d4-dd904a0a007f\n- b"
+          "- a\n  id:: 648ab5e6-5e03-4c61-95d4-dd904a0a007f\n  aaa:: 111\n- b"
+          "- c"
+          :markdown)
+         "- a\n  id:: 648ab5e6-5e03-4c61-95d4-dd904a0a007f\n  aaa:: 111\n- c")))

--- a/src/test/frontend/fs/sync_test.cljs
+++ b/src/test/frontend/fs/sync_test.cljs
@@ -27,17 +27,19 @@
     #{(sync/->FileMetadata 1 2 "3" 4 5 nil nil nil)}
     #{(sync/->FileMetadata 1 2 "3" 4 5 nil nil nil)}
 
-    #{}
+    #{(sync/->FileMetadata 1 2 "3" 4 5 nil nil nil)}
     #{(sync/->FileMetadata 1 2 "3" 4 5 nil nil nil)}
     #{(sync/->FileMetadata 1 22 "3" 4 6 nil nil nil)}
 
     #{(sync/->FileMetadata 1 2 "3" 4 5 nil nil nil)}
     #{(sync/->FileMetadata 1 2 "3" 4 5 nil nil nil)}
-    #{(sync/->FileMetadata 1 22 "3" 4 4 nil nil nil) (sync/->FileMetadata 1 22 "3" 44 5 nil nil nil)}
+    #{(sync/->FileMetadata 1 22 "3" 4 4 nil nil nil) 
+      (sync/->FileMetadata 1 22 "3" 44 5 nil nil nil)}
 
     #{}
     #{(sync/->FileMetadata 1 2 "3" 4 5 nil nil nil)}
-    #{(sync/->FileMetadata 1 2 "3" 4 4 nil nil nil) (sync/->FileMetadata 1 2 "3" 4 6 nil nil nil)}
+    #{(sync/->FileMetadata 1 2 "3" 4 4 nil nil nil) 
+      (sync/->FileMetadata 1 2 "3" 4 6 nil nil nil)}
 
     )
   )

--- a/static/yarn.lock
+++ b/static/yarn.lock
@@ -400,47 +400,47 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@logseq/rsapi-darwin-arm64@0.0.71":
-  version "0.0.71"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi-darwin-arm64/-/rsapi-darwin-arm64-0.0.71.tgz#daf9437f60b595a93f8126ba69c1a46bd0f5a7fa"
-  integrity sha512-SFZPnIXGrpIJhGAirobv1gLUVCxRvfud1ZkVKgfDCNmvByuYZ/OUIPYSG+OKY0HzyiIhVFLbRD25/+XxlD4hQg==
+"@logseq/rsapi-darwin-arm64@0.0.73":
+  version "0.0.73"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi-darwin-arm64/-/rsapi-darwin-arm64-0.0.73.tgz#4753f05e2dc70f37a31dfb7440e9b2601acb7696"
+  integrity sha512-TvFwh3/fnwRAZwourk1UUgptcNN7FqmOcL07F373M2rWhTIOba/u1eBwjW9wNMRcXtgLWacaXzBmC4ENvAKDpg==
 
-"@logseq/rsapi-darwin-x64@0.0.71":
-  version "0.0.71"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi-darwin-x64/-/rsapi-darwin-x64-0.0.71.tgz#7c8cfb23886943f3184922d5e8d64b22c52a6262"
-  integrity sha512-JvhZ/ZSJwaDELtocvVRMBXeNOwvUB3+uQSRIwXu5P1/6wqnyNtH+3CR8v8b/gwdY1lzGGG/S4bP/IksaeiwLUA==
+"@logseq/rsapi-darwin-x64@0.0.73":
+  version "0.0.73"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi-darwin-x64/-/rsapi-darwin-x64-0.0.73.tgz#44180532e3ccf62a7fe597e385ee85a700b14bea"
+  integrity sha512-tnOSgQ1qgerwDTnR5v1TMbHnVXVabzZf9i3bxon0y9ItwlIY7j7OW80+1AfNoHu9Fbo/e+3bFg5Muq3/Gm7Yrw==
 
-"@logseq/rsapi-freebsd-x64@0.0.71":
-  version "0.0.71"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi-freebsd-x64/-/rsapi-freebsd-x64-0.0.71.tgz#53a2002febf8e6da1da2eb1b7151d4236ee0911a"
-  integrity sha512-a7mdN6Ot1M+H0Gaem6eQMaGo+S/6J6dhwlu8gOuQvy7hcTCWND34NhZ05KgMxWZIfOUK7sqhWc5ghTcHJloBCg==
+"@logseq/rsapi-freebsd-x64@0.0.73":
+  version "0.0.73"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi-freebsd-x64/-/rsapi-freebsd-x64-0.0.73.tgz#3ff4f720eb05d9ffd32a5391ddf33034a05f42e0"
+  integrity sha512-YAjggQHzVCZYhXDybR/37Y5czTQbYDE5A5piwsg09Xt4/m5REFSVKqdeQpnOb2LX7wBGbnPxMhsg6QUV/y/eHA==
 
-"@logseq/rsapi-linux-arm64-gnu@0.0.71":
-  version "0.0.71"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi-linux-arm64-gnu/-/rsapi-linux-arm64-gnu-0.0.71.tgz#f8e0eced5e6631af4263ac1a80735ada8adab02c"
-  integrity sha512-VE1fE3LrEYcIF5mC79wq0kCYB6kOjFpNjyLumxCzf1WawRFGNaxmpyCMIXG0raLq2fj7YZX7VnM+/ge3IIS5PQ==
+"@logseq/rsapi-linux-arm64-gnu@0.0.73":
+  version "0.0.73"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi-linux-arm64-gnu/-/rsapi-linux-arm64-gnu-0.0.73.tgz#1f423e296ca69e6e92a06afbb25f9f2f0e452b69"
+  integrity sha512-t5W9SBraKYU2iGPzBgUhSzVPtH98RwuE1tLW2MpAJh0QNb2DI4/axbc9nrC1IVc1dqAmTkuL8GGGN80VONisUA==
 
-"@logseq/rsapi-linux-x64-gnu@0.0.71":
-  version "0.0.71"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi-linux-x64-gnu/-/rsapi-linux-x64-gnu-0.0.71.tgz#e1ca0eb21f24731823a800a9c1c2463ef2d728f4"
-  integrity sha512-OkYV+ANFJqRCJoDI+KI2pYduUXTi9+ZM05RV58GUpPlKGWC/0RYBnc0IlvaBV/ke/eba5++yKYxXTyjMMpEqfg==
+"@logseq/rsapi-linux-x64-gnu@0.0.73":
+  version "0.0.73"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi-linux-x64-gnu/-/rsapi-linux-x64-gnu-0.0.73.tgz#d33e621d7ea24089a9b863809e6dfbe4362443d5"
+  integrity sha512-WidDZv4mnG6Ys90KYLzJl0fwMWj/kEItGHjfR3FoDAVKkvu3mezNDWCsd+I2kMrh1dlIpPqcP+BJ9evI4Gbwkw==
 
-"@logseq/rsapi-win32-x64-msvc@0.0.71":
-  version "0.0.71"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi-win32-x64-msvc/-/rsapi-win32-x64-msvc-0.0.71.tgz#9b1c2c4f561626150c3ae851a7ec0c473f83840f"
-  integrity sha512-LS4h6sn/R/A/DCgEDs+g9mPcFTgJ1COmW7r7eKXxB/9WWsezdTqS8rpSBts5GaTxwq/hABGYY7MgXQ0hufHP3A==
+"@logseq/rsapi-win32-x64-msvc@0.0.73":
+  version "0.0.73"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi-win32-x64-msvc/-/rsapi-win32-x64-msvc-0.0.73.tgz#7734187c1b56da6373c947680a65b21551134bec"
+  integrity sha512-YQTE4ZMtlrbuDVfD/6DWtnsiC2uUZpNDqcy6LIN6Ui98yeZ88ktOsEV/lQJF4+4cAflrzW7Xr8ejl2SWSdX6EQ==
 
-"@logseq/rsapi@0.0.71":
-  version "0.0.71"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi/-/rsapi-0.0.71.tgz#a711809f691c7819e6b85a0b658cd618712daeed"
-  integrity sha512-MmQJCmw4NrTQoyX22tqOu2c2uURtqD/zSQ64tbHvSUUIOUQZyADfQtUhyc5wgyesc7pCTu0j5IA+tnGuOa4pbQ==
+"@logseq/rsapi@0.0.73":
+  version "0.0.73"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi/-/rsapi-0.0.73.tgz#b02fc017bb12df3afa0fce60ba13e1b01bbf4342"
+  integrity sha512-ppQCCzc1pAgqlxkYg2CprcU5RTz01fWqba9lhEVg2FpeF9l8IVVCXhbBIUnWPEFTqkoySiwXpMU8kbkTgvEPIg==
   optionalDependencies:
-    "@logseq/rsapi-darwin-arm64" "0.0.71"
-    "@logseq/rsapi-darwin-x64" "0.0.71"
-    "@logseq/rsapi-freebsd-x64" "0.0.71"
-    "@logseq/rsapi-linux-arm64-gnu" "0.0.71"
-    "@logseq/rsapi-linux-x64-gnu" "0.0.71"
-    "@logseq/rsapi-win32-x64-msvc" "0.0.71"
+    "@logseq/rsapi-darwin-arm64" "0.0.73"
+    "@logseq/rsapi-darwin-x64" "0.0.73"
+    "@logseq/rsapi-freebsd-x64" "0.0.73"
+    "@logseq/rsapi-linux-arm64-gnu" "0.0.73"
+    "@logseq/rsapi-linux-x64-gnu" "0.0.73"
+    "@logseq/rsapi-win32-x64-msvc" "0.0.73"
 
 "@malept/cross-spawn-promise@^1.0.0", "@malept/cross-spawn-promise@^1.1.0":
   version "1.1.1"

--- a/static/yarn.lock
+++ b/static/yarn.lock
@@ -400,47 +400,47 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@logseq/rsapi-darwin-arm64@0.0.70":
-  version "0.0.70"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi-darwin-arm64/-/rsapi-darwin-arm64-0.0.70.tgz#9f0214d0d61081d287dee2d75c33b272270c82f1"
-  integrity sha512-N3wNhAwyoZuXu8O83y69vTzDxolciPpeoMJAmkokXq0+3L8+74lRm9+d/Rn2xzRoXwdPyogvRvG75HpG+vC2Ww==
+"@logseq/rsapi-darwin-arm64@0.0.71":
+  version "0.0.71"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi-darwin-arm64/-/rsapi-darwin-arm64-0.0.71.tgz#daf9437f60b595a93f8126ba69c1a46bd0f5a7fa"
+  integrity sha512-SFZPnIXGrpIJhGAirobv1gLUVCxRvfud1ZkVKgfDCNmvByuYZ/OUIPYSG+OKY0HzyiIhVFLbRD25/+XxlD4hQg==
 
-"@logseq/rsapi-darwin-x64@0.0.70":
-  version "0.0.70"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi-darwin-x64/-/rsapi-darwin-x64-0.0.70.tgz#270940af25f168a463d0e4eee68613aabe84a837"
-  integrity sha512-ZsvZymdUDMrRM4QYKG8yOBJn8CDpZhWu6CrwHX8FfXyCJfglZT9V4KPt97ortAyyTlnKpr8/flYTd9mOs+eUcg==
+"@logseq/rsapi-darwin-x64@0.0.71":
+  version "0.0.71"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi-darwin-x64/-/rsapi-darwin-x64-0.0.71.tgz#7c8cfb23886943f3184922d5e8d64b22c52a6262"
+  integrity sha512-JvhZ/ZSJwaDELtocvVRMBXeNOwvUB3+uQSRIwXu5P1/6wqnyNtH+3CR8v8b/gwdY1lzGGG/S4bP/IksaeiwLUA==
 
-"@logseq/rsapi-freebsd-x64@0.0.70":
-  version "0.0.70"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi-freebsd-x64/-/rsapi-freebsd-x64-0.0.70.tgz#8785dc753068074d16e7de17115d5c004a1ded4c"
-  integrity sha512-jkUXBlm+Z4VTJUtqenwTV4THFww2lNnHkfXDyFS4Zghnby2Cg/jDe/eUwVvgUIY9fPDTivkwWwx37SLtgMCIsA==
+"@logseq/rsapi-freebsd-x64@0.0.71":
+  version "0.0.71"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi-freebsd-x64/-/rsapi-freebsd-x64-0.0.71.tgz#53a2002febf8e6da1da2eb1b7151d4236ee0911a"
+  integrity sha512-a7mdN6Ot1M+H0Gaem6eQMaGo+S/6J6dhwlu8gOuQvy7hcTCWND34NhZ05KgMxWZIfOUK7sqhWc5ghTcHJloBCg==
 
-"@logseq/rsapi-linux-arm64-gnu@0.0.70":
-  version "0.0.70"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi-linux-arm64-gnu/-/rsapi-linux-arm64-gnu-0.0.70.tgz#5a25ef4cdd758a04a625a7d265674681314d5c7c"
-  integrity sha512-OXDwjfpT/oKrLEucnVxeIu1hIdAO4B371uA/33qCH8pNVCPNZffSITGfgPKY0dXJ3zT2i5s5+Z06AJMcsjiReg==
+"@logseq/rsapi-linux-arm64-gnu@0.0.71":
+  version "0.0.71"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi-linux-arm64-gnu/-/rsapi-linux-arm64-gnu-0.0.71.tgz#f8e0eced5e6631af4263ac1a80735ada8adab02c"
+  integrity sha512-VE1fE3LrEYcIF5mC79wq0kCYB6kOjFpNjyLumxCzf1WawRFGNaxmpyCMIXG0raLq2fj7YZX7VnM+/ge3IIS5PQ==
 
-"@logseq/rsapi-linux-x64-gnu@0.0.70":
-  version "0.0.70"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi-linux-x64-gnu/-/rsapi-linux-x64-gnu-0.0.70.tgz#e453448bfadfd195df02f0c3b148b815010b61ea"
-  integrity sha512-rvCjREn2uHLESR3+UAgoKfkST7ysge9L4m4pol5eABczPB4BNiEGy0xpB3ML3/M/8t9Iaw9LcLdq2en80FM3fA==
+"@logseq/rsapi-linux-x64-gnu@0.0.71":
+  version "0.0.71"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi-linux-x64-gnu/-/rsapi-linux-x64-gnu-0.0.71.tgz#e1ca0eb21f24731823a800a9c1c2463ef2d728f4"
+  integrity sha512-OkYV+ANFJqRCJoDI+KI2pYduUXTi9+ZM05RV58GUpPlKGWC/0RYBnc0IlvaBV/ke/eba5++yKYxXTyjMMpEqfg==
 
-"@logseq/rsapi-win32-x64-msvc@0.0.70":
-  version "0.0.70"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi-win32-x64-msvc/-/rsapi-win32-x64-msvc-0.0.70.tgz#c855a9e0aed512ae8c465c55ec698855f888deed"
-  integrity sha512-wRNBJblaZjX8G1cl7Nvn8b8uMuItqaHkrblyfGzsoEOzALyJIZB95zrJvC2tk8Kc47sriK/KzH16+bW/OBxbOA==
+"@logseq/rsapi-win32-x64-msvc@0.0.71":
+  version "0.0.71"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi-win32-x64-msvc/-/rsapi-win32-x64-msvc-0.0.71.tgz#9b1c2c4f561626150c3ae851a7ec0c473f83840f"
+  integrity sha512-LS4h6sn/R/A/DCgEDs+g9mPcFTgJ1COmW7r7eKXxB/9WWsezdTqS8rpSBts5GaTxwq/hABGYY7MgXQ0hufHP3A==
 
-"@logseq/rsapi@0.0.70":
-  version "0.0.70"
-  resolved "https://registry.yarnpkg.com/@logseq/rsapi/-/rsapi-0.0.70.tgz#4eca5606318b2ab8c92611dc301cbb722281878c"
-  integrity sha512-w6eSfCLrewZ/8qE+b/GF8YIdvm+4vDurz/haHAR2qmscsXsZr7XoYOcT2eC2FcHyYYforzAppBvxpK9t7FO2ZA==
+"@logseq/rsapi@0.0.71":
+  version "0.0.71"
+  resolved "https://registry.yarnpkg.com/@logseq/rsapi/-/rsapi-0.0.71.tgz#a711809f691c7819e6b85a0b658cd618712daeed"
+  integrity sha512-MmQJCmw4NrTQoyX22tqOu2c2uURtqD/zSQ64tbHvSUUIOUQZyADfQtUhyc5wgyesc7pCTu0j5IA+tnGuOa4pbQ==
   optionalDependencies:
-    "@logseq/rsapi-darwin-arm64" "0.0.70"
-    "@logseq/rsapi-darwin-x64" "0.0.70"
-    "@logseq/rsapi-freebsd-x64" "0.0.70"
-    "@logseq/rsapi-linux-arm64-gnu" "0.0.70"
-    "@logseq/rsapi-linux-x64-gnu" "0.0.70"
-    "@logseq/rsapi-win32-x64-msvc" "0.0.70"
+    "@logseq/rsapi-darwin-arm64" "0.0.71"
+    "@logseq/rsapi-darwin-x64" "0.0.71"
+    "@logseq/rsapi-freebsd-x64" "0.0.71"
+    "@logseq/rsapi-linux-arm64-gnu" "0.0.71"
+    "@logseq/rsapi-linux-x64-gnu" "0.0.71"
+    "@logseq/rsapi-win32-x64-msvc" "0.0.71"
 
 "@malept/cross-spawn-promise@^1.0.0", "@malept/cross-spawn-promise@^1.1.0":
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,10 +487,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@logseq/capacitor-file-sync@0.0.24":
-  version "0.0.24"
-  resolved "https://registry.yarnpkg.com/@logseq/capacitor-file-sync/-/capacitor-file-sync-0.0.24.tgz#be7b69492b92df9c4e899502c632deebe179746b"
-  integrity sha512-CBIXEPYVp1ddjyYN+Z2dTQ9gwF0KYwZwlvwnl+zmR0Q3ODXxg75BExh5vAU8khXkSNZjZXgZT/J61/kn9xN11w==
+"@logseq/capacitor-file-sync@0.0.27":
+  version "0.0.27"
+  resolved "https://registry.yarnpkg.com/@logseq/capacitor-file-sync/-/capacitor-file-sync-0.0.27.tgz#01f499943769dbeebd681f290ef86000d3b078b5"
+  integrity sha512-6gqKElG5qpN7HzEPMO1lpfJLhu7+xdMRB5DbJQdXwK5Di0XGsNGU7wu38quJVLeRFJJmbp1oNxdjHemIeTAAMw==
 
 "@logseq/diff-merge@^0.0.2":
   version "0.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -492,10 +492,10 @@
   resolved "https://registry.yarnpkg.com/@logseq/capacitor-file-sync/-/capacitor-file-sync-0.0.30.tgz#9441ad5689f6139acbc7444530b11e0648a586b3"
   integrity sha512-rrk4CdSyS8y1M3WgqkFtdtoP3YWRhuaaQOPtO18roOTztbwdu/w7/+uEt7RDVcV92rwCjhCeg4yaTxbmgWwFYw==
 
-"@logseq/diff-merge@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@logseq/diff-merge/-/diff-merge-0.0.2.tgz#0bf29a550921311f63754db65ea83b82c54b16c8"
-  integrity sha512-c6V7rTg/pEoqhByJxRv7yyZ7q3LylKmkiKxoU99R7Fr7Cf5j9dn7GUQW/RlOs68IqYv76BkTHR6EhrLf6cKtZg==
+"@logseq/diff-merge@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@logseq/diff-merge/-/diff-merge-0.0.3.tgz#bf60de2142d95b8343d7420914f9558b003a09e6"
+  integrity sha512-/2fwGWK9GXM1zHq4+GUToTT5eyYWo+A4IzRDIU+Rsp9mlEfeWcUBFkGR0YHRgxAL16X1F1pp+B2OKQ0CXuGYqQ==
 
 "@logseq/react-tweet-embed@1.3.1-1":
   version "1.3.1-1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,10 +487,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@logseq/capacitor-file-sync@0.0.27":
-  version "0.0.27"
-  resolved "https://registry.yarnpkg.com/@logseq/capacitor-file-sync/-/capacitor-file-sync-0.0.27.tgz#01f499943769dbeebd681f290ef86000d3b078b5"
-  integrity sha512-6gqKElG5qpN7HzEPMO1lpfJLhu7+xdMRB5DbJQdXwK5Di0XGsNGU7wu38quJVLeRFJJmbp1oNxdjHemIeTAAMw==
+"@logseq/capacitor-file-sync@0.0.30":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@logseq/capacitor-file-sync/-/capacitor-file-sync-0.0.30.tgz#9441ad5689f6139acbc7444530b11e0648a586b3"
+  integrity sha512-rrk4CdSyS8y1M3WgqkFtdtoP3YWRhuaaQOPtO18roOTztbwdu/w7/+uEt7RDVcV92rwCjhCeg4yaTxbmgWwFYw==
 
 "@logseq/diff-merge@^0.0.2":
   version "0.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4667,10 +4667,10 @@ mkdirp@^1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mldoc@^1.5.5:
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/mldoc/-/mldoc-1.5.5.tgz#2f18439740cbcf474bf7d59266d4d98bbbc89412"
-  integrity sha512-hBVLgzlh/648l0b0Y2rkQ9KK65EBf4T+IINNFGERpn2MccXwIAiXTCZXuMIe4xfhWQ2C8KHb+k4Wb2Nw5O1TKQ==
+mldoc@1.5.7:
+  version "1.5.7"
+  resolved "https://registry.yarnpkg.com/mldoc/-/mldoc-1.5.7.tgz#9b316f633a3032ce217a339621b98e70bb229235"
+  integrity sha512-Ph9y8t195UWtkn0hK/VVNvi/wjZUJCLXAaUGVE80KmaE9Rwp9wWBMSEg4wPgjCac3edMjaONucD52fHOFTU9UA==
   dependencies:
     yargs "^12.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -492,10 +492,10 @@
   resolved "https://registry.yarnpkg.com/@logseq/capacitor-file-sync/-/capacitor-file-sync-0.0.30.tgz#9441ad5689f6139acbc7444530b11e0648a586b3"
   integrity sha512-rrk4CdSyS8y1M3WgqkFtdtoP3YWRhuaaQOPtO18roOTztbwdu/w7/+uEt7RDVcV92rwCjhCeg4yaTxbmgWwFYw==
 
-"@logseq/diff-merge@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@logseq/diff-merge/-/diff-merge-0.0.3.tgz#bf60de2142d95b8343d7420914f9558b003a09e6"
-  integrity sha512-/2fwGWK9GXM1zHq4+GUToTT5eyYWo+A4IzRDIU+Rsp9mlEfeWcUBFkGR0YHRgxAL16X1F1pp+B2OKQ0CXuGYqQ==
+"@logseq/diff-merge@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@logseq/diff-merge/-/diff-merge-0.1.0.tgz#fca282e3ff7c256a1f447d0463d78fb23ebee1d9"
+  integrity sha512-VNAJI7Mo/xHEw2LN6rpoWf/BbVfsC1wRpyyLbvm1jQbRxcwRgqYwWkSIVS0t1wswquDS64ZolJkCIFXeNXQbTA==
 
 "@logseq/react-tweet-embed@1.3.1-1":
   version "1.3.1-1"


### PR DESCRIPTION
This is a follow-up of @cnrpman 's diff-merge implementation, to use a three-way merge implementation when handling file conflicts.

- [x] rsapi 0.0.71
- [x] frontend part
- [x] Electron part
- [x] capacitor-file-sync
  - [x] android
  - [x] iOS
- [x] android
- [x] iOS


This should apply to the following scenario:

- Edit before the local files update to newest(currently, any edits before updating to newest is overwritten)
- Quick capture to a non-updated graph(the same as above)
- Edit simultaneously from 2 or more clients, which should reach a final consistent state