### PR TITLE
fix: Improve error handling in `mkdir` function

### DIFF
--- a/src/main/frontend/fs.cljs
+++ b/src/main/frontend/fs.cljs
@@ -194,17 +194,12 @@
 
 (defn mkdir-if-not-exists
   [dir]
-  (->
-   (when dir
-     (util/p-handle
-      (stat dir)
-      (fn [_stat])
-      (fn [_error]
-        (mkdir! dir))))
-   (p/catch (fn [error]
-              (if (= (.-code error) "EEXIST")
-                (js/console.log "Directory already exists")
-                (js/console.error error))))))
+  (when dir
+    (util/p-handle
+     (stat dir)
+     (fn [_stat])
+     (fn [_error]
+       (mkdir! dir)))))
 
 ;; FIXME: counterintuitive return value
 (defn create-if-not-exists

--- a/src/main/frontend/fs.cljs
+++ b/src/main/frontend/fs.cljs
@@ -201,7 +201,10 @@
       (fn [_stat])
       (fn [_error]
         (mkdir! dir))))
-   (p/catch (fn [error] (js/console.error error)))))
+   (p/catch (fn [error]
+              (if (= (.-code error) "EEXIST")
+                (js/console.log "Directory already exists")
+                (js/console.error error))))))
 
 ;; FIXME: counterintuitive return value
 (defn create-if-not-exists

--- a/src/main/frontend/fs/node.cljs
+++ b/src/main/frontend/fs/node.cljs
@@ -83,8 +83,7 @@
     (-> (ipc/ipc "mkdir" dir)
         (p/then (fn [_] (js/console.log (str "Directory created: " dir))))
         (p/catch (fn [error]
-                   (if (= (.-code error) "EEXIST")
-                     (js/console.log (str "Directory already exists: " dir))
+                   (when (not= (.-code error) "EEXIST")
                      (js/console.error (str "Error creating directory: " dir) error))))))
 
   (mkdir-recur! [_this dir]

--- a/src/main/frontend/fs/node.cljs
+++ b/src/main/frontend/fs/node.cljs
@@ -80,24 +80,34 @@
 (defrecord Node []
   protocol/Fs
   (mkdir! [_this dir]
-    (ipc/ipc "mkdir" dir))
+    (-> (ipc/ipc "mkdir" dir)
+        (p/then (fn [_] (js/console.log (str "Directory created: " dir))))
+        (p/catch (fn [error]
+                   (if (= (.-code error) "EEXIST")
+                     (js/console.log (str "Directory already exists: " dir))
+                     (js/console.error (str "Error creating directory: " dir) error))))))
+
   (mkdir-recur! [_this dir]
     (ipc/ipc "mkdir-recur" dir))
+
   (readdir [_this dir]                   ; recursive
     (p/then (ipc/ipc "readdir" dir)
             bean/->clj))
+
   (unlink! [_this repo path _opts]
     (ipc/ipc "unlink"
              (config/get-repo-dir repo)
              path))
   (rmdir! [_this _dir]
-    ;; Too dangerious!!! We'll never implement this.
+    ;; !Too dangerous! We'll never implement this.
     nil)
+
   (read-file [_this dir path _options]
     (let [path (if (nil? dir)
                  path
                  (path/path-join dir path))]
       (ipc/ipc "readFile" path)))
+
   (write-file! [this repo dir path content opts]
     (p/let [fpath (path/path-join dir path)
             stat (p/catch
@@ -106,18 +116,24 @@
             parent-dir (path/parent fpath)
             _ (protocol/mkdir-recur! this parent-dir)]
       (write-file-impl! repo dir path content opts stat)))
+
   (rename! [_this _repo old-path new-path]
     (ipc/ipc "rename" old-path new-path))
+
   (stat [_this fpath]
     (-> (ipc/ipc "stat" fpath)
         (p/then bean/->clj)))
+
   (open-dir [_this dir]
     (open-dir dir))
+
   (get-files [_this dir]
     (-> (ipc/ipc "getFiles" dir)
         (p/then (fn [result]
                   (:files (bean/->clj result))))))
+
   (watch-dir! [_this dir options]
     (ipc/ipc "addDirWatcher" dir options))
+
   (unwatch-dir! [_this dir]
     (ipc/ipc "unwatchDir" dir)))


### PR DESCRIPTION
This PR is an attempt to improve the error handling in the `mkdir-if-not-exists` function by ignoring the "EEXIST" error (which indicates the directory already exists) instead of throwing it. Other errors will continue to be handled as before.
- [x] closes #9182

![image](https://user-images.githubusercontent.com/25513724/234496437-0af28f73-3aef-4e40-94ed-08ab1eac0fdd.png)
