### PR TITLE
Fix: Stale children block's path-refs when parent's refs change

### DIFF
--- a/src/main/frontend/modules/outliner/pipeline.cljs
+++ b/src/main/frontend/modules/outliner/pipeline.cljs
@@ -6,7 +6,8 @@
             [frontend.db.model :as db-model]
             [frontend.db.react :as react]
             [frontend.db :as db]
-            [clojure.set :as set]))
+            [clojure.set :as set]
+            [datascript.core :as d]))
 
 (defn updated-page-hook
   [tx-report page]
@@ -24,7 +25,7 @@
 ;; 1. For each changed block, new-refs = its page + :block/refs + parents :block/refs
 ;; 2. Its children' block/path-refs might need to be updated too.
 (defn compute-block-path-refs
-  [{:keys [tx-meta]} blocks]
+  [{:keys [tx-meta db-before]} blocks]
   (let [repo (state/get-current-repo)
         blocks (remove :block/name blocks)]
     (when (:outliner-op tx-meta)
@@ -36,7 +37,7 @@
                       (let [parents (db-model/get-block-parents repo (:block/uuid block))
                             parents-refs (->> (mapcat :block/path-refs parents)
                                               (map :db/id))
-                            old-refs (set (map :db/id (:block/path-refs block)))
+                            old-refs (set (map :db/id (:block/path-refs (d/entity db-before (:db/id block)))))
                             new-refs (set (util/concat-without-nil
                                            [(:db/id (:block/page block))]
                                            (map :db/id (:block/refs block))

--- a/src/test/frontend/modules/outliner/pipeline_test.cljs
+++ b/src/test/frontend/modules/outliner/pipeline_test.cljs
@@ -1,0 +1,54 @@
+(ns frontend.modules.outliner.pipeline-test
+  (:require [cljs.test :refer [deftest is use-fixtures testing]]
+            [datascript.core :as d]
+            [frontend.state :as state]
+            [frontend.db :as db]
+            [frontend.modules.outliner.pipeline :as pipeline]
+            [frontend.test.helper :as test-helper :refer [load-test-files]]))
+
+(use-fixtures :each {:before (fn []
+                               ;; Set current-repo explicitly since it's not the default
+                               (state/set-current-repo! test-helper/test-db)
+                               (test-helper/start-test-db!))
+                     :after (fn []
+                              (state/set-current-repo! nil)
+                              (test-helper/destroy-test-db!))})
+
+(defn- get-blocks [db]
+  (->> (d/q '[:find (pull ?b [* {:block/path-refs [:block/name :db/id]}])
+              :in $
+              :where [?b :block/content] [(missing? $ ?b :block/pre-block?)]]
+            db)
+       (map first)))
+
+(deftest compute-block-path-refs
+  (load-test-files [{:file/path "pages/page1.md"
+                     :file/content "prop:: #bar
+- parent #foo
+  - child #baz
+    - grandchild #bing"}])
+  (testing "when a block's :refs change, descendants of block have correct :block/path-refs"
+    (let [conn (db/get-db test-helper/test-db false)
+          blocks (get-blocks @conn)
+          ;; Update parent block to replace #foo with #bar
+          new-tag-id (:db/id (d/entity @conn [:block/name "bar"]))
+          modified-blocks (map #(if (= "parent #foo" (:block/content %))
+                                  (assoc %
+                                         :block/refs [{:db/id new-tag-id}]
+                                         :block/path-refs [{:db/id new-tag-id}])
+                                  %)
+                               blocks)
+          refs-tx (pipeline/compute-block-path-refs {:tx-meta {:outliner-op :save-block}} modified-blocks)
+          _ (d/transact! conn (concat (map (fn [m] [:db/retract (:db/id m) :block/path-refs]) refs-tx)
+                                      refs-tx))
+          updated-blocks (->> (get-blocks @conn)
+                              (map #(hash-map :block/content (:block/content %)
+                                              :path-ref-names (mapv :block/name (:block/path-refs %)))))]
+      (is (= [;; still have old parent content b/c we're only testing :block/path-refs updates
+              {:block/content "parent #foo"
+               :path-ref-names ["page1" "bar"]}
+              {:block/content "child #baz"
+               :path-ref-names ["page1" "bar" "baz"]}
+              {:block/content "grandchild #bing"
+               :path-ref-names ["page1" "bar" "baz" "bing"]}]
+             updated-blocks)))))


### PR DESCRIPTION
This fixes a longstanding bug where a child block's :block/path-refs holds on to old path-refs when a parent's refs change. Fixes #5759, #5992, #6990, #8430 and #4116. Since this bug allowed stale refs data, this lead to stale data in query results, linked references and maybe other places. To QA, add these blocks:
```
- parent #foo
	- child #baz
		- grandchild #bing
- {{query (and [[foo]] <% current page %>)}}
```
Observe that changing `#foo` to `#bar` cleanly removes all the blocks from the query results. Another case to QA is toggle task states with children blocks as described in #5992
