### PR TITLE
fix(editor): copy page url with shortcut

### DIFF
--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -418,7 +418,7 @@
 
    :editor/copy-page-url            {:binding false
                                      :inactive (not (util/electron?))
-                                     :fn      page-handler/copy-page-url}
+                                     :fn      #(page-handler/copy-page-url)}
 
    :ui/toggle-wide-mode             {:binding "t w"
                                      :fn      ui-handler/toggle-wide-mode!}

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -348,7 +348,7 @@
                                                 (state/pub-event! [:command/run]))}
 
    :go/home                        {:binding "g h"
-                                    :fn      route-handler/redirect-to-home!}
+                                    :fn      #(route-handler/redirect-to-home!)}
 
    :go/all-pages                   {:binding "g a"
                                     :fn      route-handler/redirect-to-all-pages!}


### PR DESCRIPTION
Fix #9253

Root cause: fn with 1 or more args will be called with `[event]` or `[state event]` by shortcut handlers.

- Also checked all the other shortcut handlers for this type of misuse

@logseq-cldwalker Is it possible to check fn type using some lint rules?