### PR TITLE
Fix (Whiteboards): Page name sanitization

### DIFF
--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -182,7 +182,7 @@
 
 (defn get-default-new-whiteboard-tx
   [page-name id]
-  [#:block{:name page-name,
+  [#:block{:name (util/page-name-sanity-lc page-name),
            :type "whiteboard",
            :properties
            {:ls-type :whiteboard-page,


### PR DESCRIPTION
See https://discord.com/channels/725182569297215569/1001746361303187466/1101128680664743956
To reproduce this, press mod+K and create a new whiteboard that contains capitalized letters.