### PR TITLE
enhance: logseq.api.update_block can preserve properties

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1231,10 +1231,17 @@
 
 (defn save-block!
   ([repo block-or-uuid content]
+    (save-block! repo block-or-uuid content {}))
+  ([repo block-or-uuid content {:keys [properties] :or {}}]
    (let [block (if (or (uuid? block-or-uuid)
                        (string? block-or-uuid))
                  (db-model/query-block-by-uuid block-or-uuid) block-or-uuid)]
-     (save-block! {:block block :repo repo} content)))
+     (save-block!
+       {:block block :repo repo}
+       (if (seq properties)
+          (property/insert-properties (:block/format block) content properties)
+        content)
+     )))
   ([{:keys [block repo] :as _state} value]
    (let [repo (or repo (state/get-current-repo))]
      (when (db/entity repo [:block/uuid (:block/uuid block)])

--- a/src/main/logseq/api.cljs
+++ b/src/main/logseq/api.cljs
@@ -652,13 +652,13 @@
       nil)))
 
 (def ^:export update_block
-  (fn [block-uuid content ^js _opts]
+  (fn [block-uuid content ^js opts]
     (let [repo       (state/get-current-repo)
           edit-input (state/get-edit-input-id)
           editing?   (and edit-input (string/ends-with? edit-input (str block-uuid)))]
       (if editing?
         (state/set-edit-content! edit-input content)
-        (editor-handler/save-block! repo (sdk-utils/uuid-or-throw-error block-uuid) content))
+        (editor-handler/save-block! repo (sdk-utils/uuid-or-throw-error block-uuid) content (bean/->clj opts)))
       nil)))
 
 (def ^:export move_block

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -248,7 +248,7 @@
          "Path-refs remain the same"))))
 
 (deftest save-block
-  (testing "Saving blocks"
+  (testing "Saving blocks with and without properties"
     (test-helper/load-test-files [{:file/path "foo.md"
                                    :file/content "# foo"}])
     (let [repo test-helper/test-db

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -4,10 +4,17 @@
             [clojure.test :refer [deftest is testing are use-fixtures]]
             [datascript.core :as d]
             [frontend.test.helper :as test-helper :refer [load-test-files]]
+            [frontend.db.model :as model]
             [frontend.state :as state]
             [frontend.util.cursor :as cursor]))
 
-(use-fixtures :each test-helper/start-and-destroy-db)
+(use-fixtures :each {:before (fn []
+                               ;; Set current-repo explicitly since it's not the default
+                               (state/set-current-repo! test-helper/test-db)
+                               (test-helper/start-test-db!))
+                     :after (fn []
+                              (state/set-current-repo! nil)
+                              (test-helper/destroy-test-db!))})
 
 (deftest extract-nearest-link-from-text-test
   (testing "Page, block and tag links"
@@ -239,3 +246,19 @@
      (is (= prev-path-refs
             (set (map :block/name (:block/path-refs updated-block))))
          "Path-refs remain the same"))))
+
+(deftest save-block
+  (testing "Saving blocks"
+    (test-helper/load-test-files [{:file/path "foo.md"
+                                   :file/content "# foo"}])
+    (let [repo test-helper/test-db
+          block-uuid (:block/uuid (model/get-block-by-page-name-and-block-route-name repo "foo" "foo"))
+          _ (let [_ (editor/save-block! repo block-uuid "# bar")
+                  block (model/query-block-by-uuid block-uuid)
+                  _ (is (= "# bar" (:block/content block)))])
+          _ (let [_ (editor/save-block! repo block-uuid "# foo" {:properties {:foo "bar"}})
+                  block (model/query-block-by-uuid block-uuid)
+                  _ (is (= "# foo\nfoo:: bar" (:block/content block)))])
+          _ (let [_ (editor/save-block! repo block-uuid "# bar")
+                  block (model/query-block-by-uuid block-uuid)
+                  _ (is (= "# bar" (:block/content block)))])])))


### PR DESCRIPTION
Update block properties similar to `api-insert-new-block` https://github.com/logseq/logseq/blob/master/src/main/frontend/handler/editor.cljs#L588.

Fixes #5298 