### PR TITLE
fix: Garbled text in sidebar and dropdown menus on Linux 

### DIFF
--- a/src/main/frontend/components/container.css
+++ b/src/main/frontend/components/container.css
@@ -226,7 +226,7 @@
         li {
           margin: 0;
         }
-        
+
         a {
           width: 100%;
           padding: 4px 24px;
@@ -621,6 +621,13 @@ html[data-theme='dark'] {
   .title-wrap {
     line-height: 1.2em;
     padding: 1px 0;
+  }
+}
+
+/* Workaround for Linux Intel GPU text rendering issue GH#7233 */
+.is-electron.is-linux .cp__menubar-repos {
+  #repo-switch, .nav-header .flex-1 {
+    position: relative;
   }
 }
 

--- a/src/main/frontend/components/header.css
+++ b/src/main/frontend/components/header.css
@@ -128,6 +128,11 @@
   padding-left: 1rem;
 }
 
+/* Workaround for Linux Intel GPU text rendering issue GH#7233 */
+.is-electron.is-linux .cp__header .dropdown-wrapper .title-wrap {
+  position: relative;
+}
+
 .cp__header a, .cp__header svg {
   -webkit-app-region: no-drag;
 }

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -353,6 +353,7 @@
     (when config/publishing? (.add cl "is-publish-mode"))
     (when util/mac? (.add cl "is-mac"))
     (when util/win32? (.add cl "is-win32"))
+    (when util/linux? (.add cl "is-linux"))
     (when (util/electron?) (.add cl "is-electron"))
     (when (util/ios?) (.add cl "is-ios"))
     (when (util/mobile?) (.add cl "is-mobile"))

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -915,6 +915,9 @@
 (defonce win32? #?(:cljs goog.userAgent/WINDOWS
                    :clj nil))
 
+(defonce linux? #?(:cljs goog.userAgent/LINUX
+                   :clj nil))
+
 (defn default-content-with-title
   [text-format]
   (case (name text-format)


### PR DESCRIPTION
Linux users with Intel GPUs have been reporting issues with garbled text
in the sidebar nav and header dropdown menu.

The exact cause is unknown but likely a Electron rendering issue with
Intel GPUs when opacity is set with SVG and text elements.

To workaround the problem we can set the required opacity directly to
the text element.

Added a new `is-linux` ui class to narrow the workaround to Linux only, not strictly required but thought it would be useful to denote an OS specific workaround.

Fixes #7233 