### PR TITLE
enhance: `main/frontend/dicts` improve RU translation

### DIFF
--- a/src/main/frontend/dicts.cljc
+++ b/src/main/frontend/dicts.cljc
@@ -3568,7 +3568,7 @@
         :settings-page/disable-sentry "Отправлять данные использования и диагностики в Logseq"
         :settings-page/disable-sentry-desc "Logseq никогда не будет собирать вашу локальную базу данных графов или продавать ваши данные"
         :settings-page/preferred-outdenting "Логические отступы"
-        :settings-page/show-full-blocks "Показать все ссылки на блок"
+        :settings-page/show-full-blocks "Показать все строки в ссылке на блок"
         :settings-page/auto-expand-block-refs "Автоматически раскрывать ссылки на блок при увеличении масштаба"
         :settings-page/custom-date-format "Формат даты"
         :settings-page/custom-date-format-warning "Требуется переиндексация! Существующие ссылки на журналы будут нарушены!"
@@ -3725,11 +3725,11 @@
         :updater/new-version-install "Была загружена новая версия"
         :updater/quit-and-install "Перезапустить для установки"
 
-        :paginates/pages "Всего {1} страница"
+        :paginates/pages "Всего {1} страниц(а)"
         :paginates/prev "Предыдущая"
         :paginates/next "Следующая"
 
-        :tips/all-done "Все готово"
+        :tips/all-done "Всё готово"
 
         :command-palette/prompt "Введите команду"
         :select/default-prompt "Выберите"
@@ -3741,7 +3741,7 @@
         :file-sync/other-user-graph "Текущий локальный граф привязан к удаленному графу другого пользователя. Поэтому синхронизацию начать нельзя."
         :file-sync/graph-deleted "Текущий удаленный граф был удален"
 
-        :notification/clear-all "Очистить все"}
+        :notification/clear-all "Очистить всё"}
 
    :ja {:tutorial/text #?(:cljs (rc/inline "tutorial-ja.md")
                           :default "tutorial-ja.md")


### PR DESCRIPTION
Original request [here](https://discord.com/channels/725182569297215569/1093226739024531637/1102875663398084670)

`Показать все ссылки на блок` not correct, as it does not make sense according to feature [itself](https://discord.com/channels/725182569297215569/735747000649252894/1102832326657978440)

Proposal translation make more sense.

Also improved few other words.
`ё` is important letter, it should exist :smile_cat: 