### PR TITLE
fix: reduce page-history err when page doesn't have file-id yet

### DIFF
--- a/src/main/frontend/components/file_sync.cljs
+++ b/src/main/frontend/components/file_sync.cljs
@@ -588,7 +588,7 @@
          (async/go
            (set-loading? true)
            (try
-             (let [files (async/<! (file-sync-handler/fetch-page-file-versions graph-uuid page-entity))]
+             (let [files (async/<! (file-sync-handler/<fetch-page-file-versions graph-uuid page-entity))]
                (set-version-files files)
                (set-page-fn (first files))
                (set-list-ready? true))

--- a/src/main/frontend/handler/file_sync.cljs
+++ b/src/main/frontend/handler/file_sync.cljs
@@ -163,24 +163,24 @@
               version-file-paths)
              (remove nil?))))))))
 
-(defn fetch-page-file-versions [graph-uuid page]
+(defn <fetch-page-file-versions [graph-uuid page]
   []
   (let [file-id (:db/id (:block/file page))]
-    (when-let [path (:file/path (db/entity file-id))]
-      (let [base-path (config/get-repo-dir (state/get-current-repo))
-            base-path (if (string/starts-with? base-path "file://")
-                        (gp-util/safe-decode-uri-component base-path)
-                        base-path)
-            path*     (string/replace-first (string/replace-first path base-path "") #"^/" "")]
-        (go
-          (let [version-list       (:VersionList
-                                    (<! (sync/<get-remote-file-versions sync/remoteapi graph-uuid path*)))
-                local-version-list (<! (<list-file-local-versions page))
-                all-version-list   (->> (concat version-list local-version-list)
-                                        (sort-by #(or (:CreateTime %)
-                                                      (:create-time %))
-                                                 >))]
-            all-version-list))))))
+    (go
+      (when-let [path (:file/path (db/entity file-id))]
+        (let [base-path (config/get-repo-dir (state/get-current-repo))
+              base-path (if (string/starts-with? base-path "file://")
+                          (gp-util/safe-decode-uri-component base-path)
+                          base-path)
+              path*     (string/replace-first (string/replace-first path base-path "") #"^/" "")
+              version-list       (:VersionList
+                                  (<! (sync/<get-remote-file-versions sync/remoteapi graph-uuid path*)))
+              local-version-list (<! (<list-file-local-versions page))
+              all-version-list   (->> (concat version-list local-version-list)
+                                      (sort-by #(or (:CreateTime %)
+                                                    (:create-time %))
+                                               >))]
+          all-version-list)))))
 
 
 (defn init-remote-graph


### PR DESCRIPTION
`fetch-page-file-versions` return nil(expect async chan) when file-id is nil