### PR TITLE
Fix: mailto and other protocols creating invalid pages

### DIFF
--- a/deps/graph-parser/.carve/ignore
+++ b/deps/graph-parser/.carve/ignore
@@ -46,3 +46,7 @@ logseq.graph-parser.text/get-file-basename
 logseq.graph-parser.mldoc/mldoc-link?
 ;; public var
 logseq.graph-parser.schema.mldoc/block-ast-coll-schema
+;; API
+logseq.graph-parser.config/img-formats
+;; API
+logseq.graph-parser.config/text-formats

--- a/deps/graph-parser/src/logseq/graph_parser.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser.cljs
@@ -89,7 +89,6 @@ Options available:
          {:keys [tx ast]}
          (let [extract-options' (merge {:block-pattern (gp-config/get-block-pattern format)
                                         :date-formatter "MMM do, yyyy"
-                                        :supported-formats (gp-config/supported-formats)
                                         :uri-encoded? false
                                         :filename-format :legacy}
                                        extract-options

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -55,19 +55,6 @@
                    (text/page-ref-un-brackets! value))
 
                   (and
-                   (= typ "Search")
-                   (not (contains? #{\# \* \/ \[} (first value)))
-                   ;; FIXME: use `gp-util/get-format` instead
-                   (let [ext (some-> (gp-util/get-file-ext value) keyword)]
-                     (when (and (not (string/starts-with? value "http:"))
-                                (not (string/starts-with? value "https:"))
-                                (not (string/starts-with? value "file:"))
-                                (not (gp-config/local-asset? value))
-                                (or (#{:excalidraw :tldr} ext)
-                                    (not (contains? supported-formats ext))))
-                       value)))
-
-                  (and
                    (= typ "File")
                    (second (first (:label (second block)))))))
 

--- a/deps/graph-parser/src/logseq/graph_parser/cli.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/cli.cljs
@@ -48,7 +48,6 @@ TODO: Fail fast when process exits 1"
   [conn files {:keys [config] :as options}]
   (let [extract-options (merge {:date-formatter (gp-config/get-date-formatter config)
                                 :user-config config
-                                :supported-formats (gp-config/supported-formats)
                                 :filename-format (or (:file/name-format config) :legacy)
                                 :extracted-block-ids (atom #{})}
                                (select-keys options [:verbose]))]

--- a/deps/graph-parser/src/logseq/graph_parser/config.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/config.cljs
@@ -1,7 +1,6 @@
 (ns logseq.graph-parser.config
   "App config that is shared between graph-parser and rest of app"
-  (:require [clojure.set :as set]
-            [clojure.string :as string]
+  (:require [clojure.string :as string]
             [goog.object :as gobj]))
 
 (def app-name
@@ -67,11 +66,6 @@
 (defn img-formats
   []
   #{:gif :svg :jpeg :ico :png :jpg :bmp :webp})
-
-(defn supported-formats
-  []
-  (set/union (text-formats)
-             (img-formats)))
 
 (defn get-date-formatter
   [config]

--- a/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
@@ -153,7 +153,7 @@
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
     (is (= 306 (count files)) "Correct file count")
-    (is (= 69508 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 69500 (count (d/datoms db :eavt))) "Correct datoms count")
 
     (is (= 5866
            (ffirst

--- a/deps/graph-parser/test/logseq/graph_parser_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser_test.cljs
@@ -360,15 +360,21 @@
                   (remove built-in-pages)
                   set)))))
 
-  (testing "for file and web uris"
+  (testing "for file, mailto, web and other uris"
     (let [conn (ldb/start-conn)
           built-in-pages (set (map string/lower-case default-db/built-in-pages-names))]
       (graph-parser/parse-file conn
                                "foo.md"
-                               (str "- [Filename.txt](file:///E:/test/Filename.txt)\n"
+                               (str "- [foo]([[bar]])\n"
+                                    ;; all of the uris below do not create pages
+                                    "- ![image.png](../assets/image_1630480711363_0.png)\n"
+                                    "- [Filename.txt](file:///E:/test/Filename.txt)\n"
+                                    "- [mail](mailto:test@test.com?subject=TestSubject)\n"
+                                    "- [onenote link](onenote:https://d.docs.live.net/b2127346582e6386a/blablabla/blablabla/blablabla%20blablabla.one#Etat%202019&section-id={133DDF16-9A1F-4815-9A05-44303784442E6F94}&page-id={3AAB677F0B-328F-41D0-AFF5-66408819C085}&end)\n"
+                                    "- [lock file](deps/graph-parser/yarn.lock)"
                                     "- [example](https://example.com)")
                                {})
-      (is (= #{"foo"}
+      (is (= #{"foo" "bar"}
              (->> (d/q '[:find (pull ?b [*])
                          :in $
                          :where [?b :block/name]]

--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -9,7 +9,6 @@
             [frontend.handler.notification :as notification]
             [frontend.state :as state]
             [logseq.graph-parser.block :as gp-block]
-            [logseq.graph-parser.config :as gp-config]
             [logseq.graph-parser.property :as gp-property]
             [logseq.graph-parser.mldoc :as gp-mldoc]
             [lambdaisland.glogi :as log]))
@@ -23,7 +22,6 @@ and handles unexpected failure."
     (gp-block/extract-blocks blocks content with-id? format
                              {:user-config (state/get-config)
                               :block-pattern (config/get-block-pattern format)
-                              :supported-formats (gp-config/supported-formats)
                               :db (db/get-db (state/get-current-repo))
                               :date-formatter (state/get-date-formatter)
                               :page-name page-name})

--- a/src/main/frontend/handler/common/file.cljs
+++ b/src/main/frontend/handler/common/file.cljs
@@ -5,7 +5,6 @@
             [frontend.db :as db]
             [logseq.graph-parser :as graph-parser]
             [logseq.graph-parser.util :as gp-util]
-            [logseq.graph-parser.config :as gp-config]
             [frontend.fs.diff-merge :as diff-merge]
             [frontend.fs :as fs]
             [frontend.context.i18n :refer [t]]
@@ -107,7 +106,6 @@
                                            {:user-config (state/get-config)
                                             :date-formatter (state/get-date-formatter)
                                             :block-pattern (config/get-block-pattern (gp-util/get-format file-path))
-                                            :supported-formats (gp-config/supported-formats)
                                             :filename-format (state/get-filename-format repo-url)}
                                            ;; To avoid skipping the `:or` bounds for keyword destructuring
                                            (when (some? extracted-block-ids) {:extracted-block-ids extracted-block-ids})

--- a/src/test/frontend/handler/repo_conversion_test.cljs
+++ b/src/test/frontend/handler/repo_conversion_test.cljs
@@ -98,7 +98,7 @@
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
     (is (= 211 (count files)) "Correct file count")
-    (is (= 42312 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 42296 (count (d/datoms db :eavt))) "Correct datoms count")
 
     (is (= 3600
            (ffirst


### PR DESCRIPTION
This PR fixes #9346 and #5926. It also fixes an issue where relative paths for unsupported formats like `deps/graph-parser/yarn.lock` would result in multiple invalid pages e.g. deps, deps/graph-parser and deps/graph-parser/yarn.lock. To QA, try any of the added test examples and confirm that they do not create any invalid pages