### PR TITLE
Fix (Whiteboards): Performance of persist

### DIFF
--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -134,9 +134,7 @@
         shapes (.-shapes ^js tl-page)
         shapes-index (zipmap (mapv #(gobj/get % "id") shapes) (range (.-length shapes)))
         new-id-nonces (set (map (fn [shape]
-                                  (let [id (.-id shape)
-                                        _ (js/console.log id)
-                                        _ (js/console.log (get shapes-index id))]
+                                  (let [id (.-id shape)]
                                     {:id id
                                      :nonce (if (= shape.id (get shapes-index id))
                                               (.-nonce shape)

--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -88,7 +88,7 @@
   [^js app ^js tl-page new-id-nonces db-id-nonces page-name replace?]
   (let [assets (js->clj-keywordize (.getCleanUpAssets app))
         new-shapes (.-shapes tl-page)
-        shapes-index (mapv #(gobj/get % "id") new-shapes)
+        shapes-index (map #(gobj/get % "id") new-shapes)
         shape-id->index (zipmap shapes-index (range (.-length new-shapes)))
         upsert-shapes (->> (set/difference new-id-nonces db-id-nonces)
                            (map (fn [{:keys [id]}]

--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -91,7 +91,7 @@
                            (map (fn [{:keys [id]}]
                                   (-> (.-serialized ^js (.getShapeById tl-page id))
                                       js->clj-keywordize
-                                      (assoc :index (get id shapes-index)))))
+                                      (assoc :index (get shapes-index id)))))
                            (set))
         old-ids (set (map :id db-id-nonces))
         new-ids (set (map :id new-id-nonces))
@@ -134,9 +134,11 @@
         shapes (.-shapes ^js tl-page)
         shapes-index (zipmap (mapv #(gobj/get % "id") shapes) (range (.-length shapes)))
         new-id-nonces (set (map (fn [shape]
-                                  (let [id (.-id shape)]
+                                  (let [id (.-id shape)
+                                        _ (js/console.log id)
+                                        _ (js/console.log (get shapes-index id))]
                                     {:id id
-                                     :nonce (if (= shape.id (get id shapes-index))
+                                     :nonce (if (= shape.id (get shapes-index id))
                                               (.-nonce shape)
                                               (js/Date.now))})) shapes))
         repo (state/get-current-repo)

--- a/tldraw/packages/core/src/lib/tools/TLSelectTool/states/TranslatingState.ts
+++ b/tldraw/packages/core/src/lib/tools/TLSelectTool/states/TranslatingState.ts
@@ -125,7 +125,6 @@ export class TranslatingState<
   onExit = () => {
     // Resume the history when we exit
     this.app.history.resume()
-    this.app.persist()
 
     // Reset initial data
     this.didClone = false


### PR DESCRIPTION
Fixed a bug introduced on #8885 that was marking all shapes as updated, slowing down persist on element heavy boards. Also replaced `indexOf` that is slow, and removed an unneeded persist call. 

Related to https://discord.com/channels/725182569297215569/1001746361303187466/1105943246611419197