### PR TITLE
fix(api): Revert `get_current_block` to previous state to repair functionality

### DIFF
--- a/src/main/logseq/api.cljs
+++ b/src/main/logseq/api.cljs
@@ -703,7 +703,7 @@
                                 (gdom/getElement (state/get-editing-block-dom-id)))
                             (.getAttribute "blockid")
                             (db-model/get-block-by-uuid)))]
-      (get_block (:block/uuid block) opts))))
+      (get_block (:db/id block) opts))))
 
 (def ^:export get_previous_sibling_block
   (fn [block-uuid]


### PR DESCRIPTION
Fixes #9359

Just some context, with the previous `:block/uuid` introduced in the recent commit today:

## Problem

![image](https://github.com/logseq/logseq/assets/5030059/5ff433cd-dfa4-4b60-9184-ccb78f413212)

If I try to call the `logseq.api.get_current_block()` method from the developer console, I get a `null` response, this was tested also with some plugins calling `@logseq/lib`'s `getCurrentBlock` method, with the same result:

![image](https://github.com/logseq/logseq/assets/5030059/4d916326-b792-45a9-aac1-324169685eb4)

---

## Solution

After reverting the affected line @706 and letting the app rebuild:
![image](https://github.com/logseq/logseq/assets/5030059/3e6a9861-7ae4-461a-b3db-a0ded3a4ecbd)

The `get_current_block` method works again as expected:

![image](https://github.com/logseq/logseq/assets/5030059/d7cd10e3-fe2e-4a95-a2b8-10b423eb092a)
