### PR TITLE
Enhance: version control settings description update

### DIFF
--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -680,7 +680,7 @@
     [:span.text-sm.opacity-50.my-4
      " for version control."]
     [:span.text-sm.opacity-50.my-4
-     "General issues about Git usage is not supported by the Logseq team and should be used at own risk"]]
+     "Use Git at your own risk as general Git issues are not supported by the Logseq team"]]
    [:br]
    (switch-git-auto-commit-row t)
    (git-auto-commit-seconds t)

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -827,9 +827,7 @@
               [[:general "general" (t :settings-page/tab-general) (ui/icon "adjustments")]
                [:editor "editor" (t :settings-page/tab-editor) (ui/icon "writing")]
 
-               (when (and
-                      (util/electron?)
-                      (not (file-sync-handler/synced-file-graph? current-repo)))
+               (when (util/electron?)
                  [:git "git" (t :settings-page/tab-version-control) (ui/icon "history")])
 
                ;; (when (util/electron?)

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -667,14 +667,20 @@
   []
   [:div.panel-wrap
    [:div.text-sm.my-4
+    (ui/admonition
+     :tip
+     [:p "If you have Logseq Sync enabled, you can view a page's edit history directly. This section is for tech-savvy only."])
+    [:span.text-sm.opacity-50.my-4 
+     "To view page's edit history, click the three horizontal dots in the top-right corner and select \"View page history\"."]
+    [:br][:br]
     [:span.text-sm.opacity-50.my-4
-     "You can view a page's edit history by clicking the three horizontal dots "
-     "in the top-right corner and selecting \"View page history\". "
-     "Logseq uses "]
+     "For professional users, Logseq also supports using "]
     [:a {:href "https://git-scm.com/" :target "_blank"}
      "Git"]
     [:span.text-sm.opacity-50.my-4
-     " for version control."]]
+     " for version control."]
+    [:span.text-sm.opacity-50.my-4
+     "General issues about Git usage is not supported by the Logseq team and should be used at own risk"]]
    [:br]
    (switch-git-auto-commit-row t)
    (git-auto-commit-seconds t)


### PR DESCRIPTION
Fix https://github.com/logseq/logseq/issues/9361

The current logic for the version control tab is awful: 
- If a graph has Logseq sync setup, just block the entry to the version control setting. 
- The git auto commit is a global config (stored in electron cfg)
- It can come to a dead case that a user has git auto commit enabled, then activate the Logseq Sync service, thus unable to change the setting anymore.

This PR do:
1. Remove the blocking (allow pro users continue to use Git while having Logseq Sync enabled)
2. Use text box to hint users about the page history feature for Logseq Sync users instead:
![image](https://github.com/logseq/logseq/assets/9862022/29302e3e-5ec9-4a78-abf8-f7648f7625d8)

Suggestion on logic / wordings are welcome :)
