### PR TITLE
fix(ui): incorrect arrangement of ui items from pagebar

### DIFF
--- a/src/main/frontend/components/plugins.css
+++ b/src/main/frontend/components/plugins.css
@@ -836,6 +836,16 @@
     > .injected-ui-item-pagebar {
       @apply pr-3 opacity-30 hover:opacity-100 transition-opacity;
     }
+
+    > .list-wrap {
+      @apply flex items-center flex-nowrap overflow-x-hidden pt-[14px];
+    }
+
+    a.button {
+      @apply flex items-center;
+
+      color: var(--ls-primary-text-color);
+    }
   }
 
   .toolbar-plugins-manager {


### PR DESCRIPTION
## Before
<img width="1156" alt="CleanShot 2023-05-12 at 17 32 48@2x" src="https://github.com/logseq/logseq/assets/1779837/a9c7e3e6-7298-47a6-8cf4-d1a6630346e3">

## After
<img width="921" alt="CleanShot 2023-05-12 at 17 33 52@2x" src="https://github.com/logseq/logseq/assets/1779837/0c5de9d9-d4e1-433c-98c8-4c0b95a55529">

