### PR TITLE
Fix: Org mode pages in aliased links not creating pages

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -56,6 +56,7 @@
 
                   (and (= url-type "Search")
                        (= format :org)
+                       (not (gp-config/local-asset? value))
                        value)
 
                   (and

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -35,27 +35,31 @@
          (string/join))))
 
 (defn- get-page-reference
-  [block]
+  [block format]
   (let [page (cond
                (and (vector? block) (= "Link" (first block)))
-               (let [typ (first (:url (second block)))
+               (let [url-type (first (:url (second block)))
                      value (second (:url (second block)))]
                  ;; {:url ["File" "file:../pages/hello_world.org"], :label [["Plain" "hello world"]], :title nil}
                  (or
                   (and
-                   (= typ "Page_ref")
+                   (= url-type "Page_ref")
                    (and (string? value)
                         (not (or (gp-config/local-asset? value)
                                  (gp-config/draw? value))))
                    value)
 
                   (and
-                   (= typ "Search")
+                   (= url-type "Search")
                    (page-ref/page-ref? value)
                    (text/page-ref-un-brackets! value))
 
+                  (and (= url-type "Search")
+                       (= format :org)
+                       value)
+
                   (and
-                   (= typ "File")
+                   (= url-type "File")
                    (second (first (:label (second block)))))))
 
                (and (vector? block) (= "Nested_link" (first block)))
@@ -327,7 +331,7 @@
        (when-not (and (vector? form)
                       (= (first form) "Custom")
                       (= (second form) "query"))
-         (when-let [page (get-page-reference form)]
+         (when-let [page (get-page-reference form (:format block))]
            (swap! *refs conj page))
          (when-let [tag (get-tag form)]
            (let [tag (text/page-ref-un-brackets! tag)]

--- a/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
@@ -153,7 +153,7 @@
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
     (is (= 306 (count files)) "Correct file count")
-    (is (= 69500 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 69508 (count (d/datoms db :eavt))) "Correct datoms count")
 
     (is (= 5866
            (ffirst

--- a/deps/graph-parser/test/logseq/graph_parser_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser_test.cljs
@@ -117,7 +117,7 @@
                          :where
                          [?b :block/name ?name]
                          [?b :block/type "whiteboard"]]
-                    @conn)]
+                       @conn)]
         (is (= pages #{["foo"] ["bar"]}))))))
 
 (defn- test-property-order [num-properties]
@@ -153,11 +153,11 @@
                                    "- desc:: \"#foo is not a ref\""
                                    {:extract-options {:user-config {}}})
         block (->> (d/q '[:find (pull ?b [* {:block/refs [*]}])
-                       :in $
-                       :where [?b :block/properties]]
-                     @conn)
-                (map first)
-                first)]
+                          :in $
+                          :where [?b :block/properties]]
+                        @conn)
+                   (map first)
+                   first)]
     (is (= {:desc "\"#foo is not a ref\""}
            (:block/properties block))
         "Quoted value is unparsed")
@@ -274,9 +274,9 @@
                    set)
               (set refs))
            ; pre-block/page has expected refs
-           db-properties (first (map :block/refs blocks))
+        db-properties (first (map :block/refs blocks))
            ;; block has expected refs
-           block-db-properties (second (map :block/refs blocks))))))
+        block-db-properties (second (map :block/refs blocks))))))
 
 (deftest property-relationships
   (let [properties {:single-link "[[bar]]"
@@ -324,7 +324,7 @@
                 (map #(select-keys % [:block/properties :block/invalid-properties]))))
         "Has correct (in)valid page properties")))
 
-(deftest correct-page-names-created
+(deftest correct-page-names-created-from-title
   (testing "from title"
     (let [conn (ldb/start-conn)
           built-in-pages (set (map string/lower-case default-db/built-in-pages-names))]
@@ -358,22 +358,39 @@
                        @conn)
                   (map (comp :block/original-name first))
                   (remove built-in-pages)
-                  set)))))
+                  set))))))
 
-  (testing "for file, mailto, web and other uris"
+(deftest correct-page-names-created-from-page-refs
+  (testing "for file, mailto, web and other uris in markdown"
     (let [conn (ldb/start-conn)
           built-in-pages (set (map string/lower-case default-db/built-in-pages-names))]
       (graph-parser/parse-file conn
                                "foo.md"
-                               (str "- [foo]([[bar]])\n"
+                               (str "- [title]([[bar]])\n"
                                     ;; all of the uris below do not create pages
                                     "- ![image.png](../assets/image_1630480711363_0.png)\n"
                                     "- [Filename.txt](file:///E:/test/Filename.txt)\n"
                                     "- [mail](mailto:test@test.com?subject=TestSubject)\n"
                                     "- [onenote link](onenote:https://d.docs.live.net/b2127346582e6386a/blablabla/blablabla/blablabla%20blablabla.one#Etat%202019&section-id={133DDF16-9A1F-4815-9A05-44303784442E6F94}&page-id={3AAB677F0B-328F-41D0-AFF5-66408819C085}&end)\n"
                                     "- [lock file](deps/graph-parser/yarn.lock)"
-                                    "- [example](https://example.com)")
-                               {})
+                                    "- [example](https://example.com)"))
+      (is (= #{"foo" "bar"}
+             (->> (d/q '[:find (pull ?b [*])
+                         :in $
+                         :where [?b :block/name]]
+                       @conn)
+                  (map (comp :block/name first))
+                  (remove built-in-pages)
+                  set)))))
+
+(testing "for web and page uris in org"
+    (let [conn (ldb/start-conn)
+          built-in-pages (set (map string/lower-case default-db/built-in-pages-names))]
+      (graph-parser/parse-file conn
+                               "foo.org"
+                               (str "* [[bar][title]]\n"
+                                    ;; all of the uris below do not create pages
+                                    "* [[https://example.com][example]]"))
       (is (= #{"foo" "bar"}
              (->> (d/q '[:find (pull ?b [*])
                          :in $

--- a/deps/graph-parser/test/logseq/graph_parser_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser_test.cljs
@@ -390,7 +390,8 @@
                                "foo.org"
                                (str "* [[bar][title]]\n"
                                     ;; all of the uris below do not create pages
-                                    "* [[https://example.com][example]]"))
+                                    "* [[https://example.com][example]]\n"
+                                    "* [[../assets/conga_parrot.gif][conga]]"))
       (is (= #{"foo" "bar"}
              (->> (d/q '[:find (pull ?b [*])
                          :in $

--- a/src/test/frontend/handler/repo_conversion_test.cljs
+++ b/src/test/frontend/handler/repo_conversion_test.cljs
@@ -98,7 +98,7 @@
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
     (is (= 211 (count files)) "Correct file count")
-    (is (= 42296 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 42304 (count (d/datoms db :eavt))) "Correct datoms count")
 
     (is (= 3600
            (ffirst


### PR DESCRIPTION
This PR fixes #9367 which was introduced with #9353. #9367 has good QA instructions