### PR TITLE
Fix: Current block losing path-refs if refs don't change

### DIFF
--- a/deps/db/src/logseq/db/schema.cljs
+++ b/deps/db/src/logseq/db/schema.cljs
@@ -105,7 +105,6 @@
 (def retract-attributes
   #{
     :block/refs
-    :block/path-refs
     :block/tags
     :block/alias
     :block/marker

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -1,8 +1,13 @@
 (ns frontend.handler.editor-test
   (:require [frontend.handler.editor :as editor]
-            [clojure.test :refer [deftest is testing are]]
+            [frontend.db :as db]
+            [clojure.test :refer [deftest is testing are use-fixtures]]
+            [datascript.core :as d]
+            [frontend.test.helper :as test-helper :refer [load-test-files]]
             [frontend.state :as state]
             [frontend.util.cursor :as cursor]))
+
+(use-fixtures :each test-helper/start-and-destroy-db)
 
 (deftest extract-nearest-link-from-text-test
   (testing "Page, block and tag links"
@@ -213,3 +218,24 @@
         "No page search within backticks"))
   ;; Reset state
   (state/set-editor-action! nil))
+
+(deftest save-block-aux!
+  (load-test-files [{:file/path "pages/page1.md"
+                     :file/content "\n
+- b1 #foo"}])
+  (testing "updating block's content changes content and preserves path-refs"
+   (let [conn (db/get-db test-helper/test-db false)
+         block (->> (d/q '[:find (pull ?b [* {:block/path-refs [:block/name]}])
+                           :where [?b :block/content "b1 #foo"]]
+                         @conn)
+                    ffirst)
+         prev-path-refs (set (map :block/name (:block/path-refs block)))
+         _ (assert (= #{"page1" "foo"} prev-path-refs)
+                   "block has expected :block/path-refs")
+         ;; Use same options as edit-box-on-change!
+         _ (editor/save-block-aux! block "b12 #foo" {:skip-properties? true})
+         updated-block (d/pull @conn '[* {:block/path-refs [:block/name]}] [:block/uuid (:block/uuid block)])]
+     (is (= "b12 #foo" (:block/content updated-block)) "Content updated correctly")
+     (is (= prev-path-refs
+            (set (map :block/name (:block/path-refs updated-block))))
+         "Path-refs remain the same"))))

--- a/src/test/frontend/handler/repo_test.cljs
+++ b/src/test/frontend/handler/repo_test.cljs
@@ -2,7 +2,6 @@
   (:require [cljs.test :refer [deftest use-fixtures testing is]]
             [frontend.handler.repo :as repo-handler]
             [frontend.test.helper :as test-helper :refer [load-test-files]]
-            [frontend.state :as state]
             [logseq.graph-parser.cli :as gp-cli]
             [logseq.graph-parser.test.docs-graph-helper :as docs-graph-helper]
             [logseq.graph-parser.util.block-ref :as block-ref]
@@ -12,13 +11,7 @@
             ["path" :as node-path]
             ["fs" :as fs]))
 
-(use-fixtures :each {:before (fn []
-                               ;; Set current-repo explicitly since it's not the default
-                               (state/set-current-repo! test-helper/test-db)
-                               (test-helper/start-test-db!))
-                     :after (fn []
-                              (state/set-current-repo! nil)
-                              (test-helper/destroy-test-db!))})
+(use-fixtures :each test-helper/start-and-destroy-db)
 
 (deftest ^:integration parse-and-load-files-to-db
   (let [graph-dir "src/test/docs-0.9.2"

--- a/src/test/frontend/modules/outliner/pipeline_test.cljs
+++ b/src/test/frontend/modules/outliner/pipeline_test.cljs
@@ -1,18 +1,11 @@
 (ns frontend.modules.outliner.pipeline-test
   (:require [cljs.test :refer [deftest is use-fixtures testing]]
             [datascript.core :as d]
-            [frontend.state :as state]
             [frontend.db :as db]
             [frontend.modules.outliner.pipeline :as pipeline]
             [frontend.test.helper :as test-helper :refer [load-test-files]]))
 
-(use-fixtures :each {:before (fn []
-                               ;; Set current-repo explicitly since it's not the default
-                               (state/set-current-repo! test-helper/test-db)
-                               (test-helper/start-test-db!))
-                     :after (fn []
-                              (state/set-current-repo! nil)
-                              (test-helper/destroy-test-db!))})
+(use-fixtures :each test-helper/start-and-destroy-db)
 
 (defn- get-blocks [db]
   (->> (d/q '[:find (pull ?b [* {:block/path-refs [:block/name :db/id]}])

--- a/src/test/frontend/test/helper.cljs
+++ b/src/test/frontend/test/helper.cljs
@@ -1,6 +1,7 @@
 (ns frontend.test.helper
   "Common helper fns for tests"
   (:require [frontend.handler.repo :as repo-handler]
+            [frontend.state :as state]
             [frontend.db.conn :as conn]))
 
 (defonce test-db "test-db")
@@ -22,3 +23,15 @@ This can be called in synchronous contexts as no async fns should be invoked"
    files
    ;; Set :refresh? to avoid creating default files in after-parse
    {:re-render? false :verbose false :refresh? true}))
+
+(defn start-and-destroy-db
+  "Sets up a db connection and current repo like fixtures/reset-datascript. It
+  also seeds the db with the same default data that the app does and destroys a db
+  connection when done with it."
+  [f]
+  ;; Set current-repo explicitly since it's not the default
+  (state/set-current-repo! test-db)
+  (start-test-db!)
+  (f)
+  (state/set-current-repo! nil)
+  (destroy-test-db!))


### PR DESCRIPTION
This PR fixes #9365 which was introduced in #9254.  ~~This brings back the previous behavior where the current block always has it's :block/path-refs transacted as noticed in https://github.com/logseq/logseq/pull/9254#discussion_r1178247609 . It seems this is needed.~~ This PR fixes this by no longer having :block/path-refs as a retracted attribute. To QA, you can reproduce with the first minute of the video in #9365. You can also QA with:
- Create a block `foo #bar`
- Run `show block data` command on the block and note its :block/path-refs
- Change block to `fooz #bar`
- Rerun `show block data` command on the block and its :block/path-refs should not change

~~I'll see if I can do a test for this on Monday~~