### PR TITLE
Enhance/minor UI tweaks

### DIFF
--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -206,7 +206,7 @@
   margin-top: 0;
 
   &.is-order-list {
-    @apply relative right-0 mr-0;
+    @apply relative right-[6px] mr-0;
   }
 }
 
@@ -532,7 +532,7 @@
   }
 
   &.as-order-list {
-    @apply w-[28px] whitespace-nowrap justify-start pl-[3px];
+    @apply w-[28px] whitespace-nowrap justify-center pl-[3px];
   }
 
   .bullet {

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -202,11 +202,11 @@
 
 .block-control-wrap {
   height: 24px;
-  min-width: 50px;
+  min-width: 44px;
   margin-top: 0;
 
   &.is-order-list {
-    @apply relative right-[6px] mr-0;
+    @apply relative right-[3px] mr-0;
   }
 }
 
@@ -532,7 +532,7 @@
   }
 
   &.as-order-list {
-    @apply w-[28px] whitespace-nowrap justify-center pl-[3px];
+    @apply w-[22px] whitespace-nowrap justify-center pl-[3px];
   }
 
   .bullet {


### PR DESCRIPTION
- smaller space for the number list marker with block content
<img width="520" alt="CleanShot 2023-05-15 at 15 05 31@2x" src="https://github.com/logseq/logseq/assets/1779837/6f1b3a10-fed0-441a-8eba-12b6fed35c63">
