### PR TITLE
enhance(editor): restore scroll position new adding newline in a block

### DIFF
--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -403,17 +403,23 @@
         edit-content (gobj/get input "value")
         current-pos (cursor/pos input)
         prefix (subs edit-content 0 current-pos)
+        surfix (subs edit-content current-pos)
         new-value (str prefix
                        value
-                       (subs edit-content current-pos))
+                       surfix)
         new-pos (- (+ (count prefix)
                       (count value)
                       (or forward-pos 0))
                    (or backward-pos 0))]
-    (state/set-block-content-and-last-pos! id new-value new-pos)
-    (cursor/move-cursor-to input new-pos)
-    (when check-fn
-      (check-fn new-value (dec (count prefix)) new-pos))))
+    (state/set-edit-content! (state/get-edit-input-id)
+                             (str prefix value))
+    ;; HACK: save scroll-pos of current pos, then add trailing content
+    (let [scroll-pos (.-scrollTop (gdom/getElement "main-content-container"))]
+      (state/set-block-content-and-last-pos! id new-value new-pos)
+      (cursor/move-cursor-to input new-pos)
+      (set! (.-scrollTop (gdom/getElement "main-content-container")) scroll-pos)
+      (when check-fn
+        (check-fn new-value (dec (count prefix)) new-pos)))))
 
 (defn simple-replace!
   [id value selected

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -414,10 +414,11 @@
     (state/set-edit-content! (state/get-edit-input-id)
                              (str prefix value))
     ;; HACK: save scroll-pos of current pos, then add trailing content
-    (let [scroll-pos (.-scrollTop (gdom/getElement "main-content-container"))]
+    (let [scroll-container (util/nearest-scrollable-container input)
+          scroll-pos (.-scrollTop scroll-container)]
       (state/set-block-content-and-last-pos! id new-value new-pos)
       (cursor/move-cursor-to input new-pos)
-      (set! (.-scrollTop (gdom/getElement "main-content-container")) scroll-pos)
+      (set! (.-scrollTop scroll-container) scroll-pos)
       (when check-fn
         (check-fn new-value (dec (count prefix)) new-pos)))))
 

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1555,7 +1555,7 @@
          "$" "$"
          ":" ":"))
 
-(defn autopair
+(defn- autopair
   [input-id prefix _format _option]
   (let [value (get autopair-map prefix)
         selected (util/get-selected-text)
@@ -1592,11 +1592,11 @@
 (defn- autopair-left-paren?
   [input key]
   (and (= key "(")
-       (or
-         (surround-by? input :start "")
-         (surround-by? input " " "")
-         (surround-by? input "]" "")
-         (surround-by? input "(" ""))))
+       (or (surround-by? input :start "")
+           (surround-by? input "\n" "")
+           (surround-by? input " " "")
+           (surround-by? input "]" "")
+           (surround-by? input "(" ""))))
 
 (defn wrapped-by?
   [input before end]
@@ -2226,6 +2226,7 @@
        (state/set-edit-content! (state/get-edit-input-id)
                                 (str s1 insertion))
        ;; HACK: save scroll-pos of current pos, then add trailing content
+       ;; This logic is also in commands/simple-insert!
        (let [scroll-container (util/nearest-scrollable-container input)
              scroll-pos (.-scrollTop scroll-container)]
          (state/set-edit-content! (state/get-edit-input-id)
@@ -2866,11 +2867,11 @@
             (contains? key)
             (or (autopair-left-paren? input key)))
         (let [curr (get-current-input-char input)
-                  prev (util/nth-safe value (dec pos))]
-            (util/stop e)
-            (if (and (= key "`") (= "`" curr) (not= "`" prev))
-              (cursor/move-cursor-forward input)
-              (autopair input-id key format nil)))
+              prev (util/nth-safe value (dec pos))]
+          (util/stop e)
+          (if (and (= key "`") (= "`" curr) (not= "`" prev))
+            (cursor/move-cursor-forward input)
+            (autopair input-id key format nil)))
 
         (let [sym "$"]
           (and (= key sym)

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2226,11 +2226,12 @@
        (state/set-edit-content! (state/get-edit-input-id)
                                 (str s1 insertion))
        ;; HACK: save scroll-pos of current pos, then add trailing content
-       (let [scroll-pos (.-scrollTop (gdom/getElement "main-content-container"))]
+       (let [scroll-container (util/nearest-scrollable-container input)
+             scroll-pos (.-scrollTop scroll-container)]
          (state/set-edit-content! (state/get-edit-input-id)
                                   (str s1 insertion s2))
          (cursor/move-cursor-to input (+ selected-start (count insertion)))
-         (set! (.-scrollTop (gdom/getElement "main-content-container")) scroll-pos))))))
+         (set! (.-scrollTop scroll-container) scroll-pos))))))
 
 (defn- keydown-new-line
   "Insert newline to current cursor position"

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2224,10 +2224,16 @@
            s1 (subs value 0 selected-start)
            s2 (subs value selected-end)]
        (state/set-edit-content! (state/get-edit-input-id)
-                                (str s1 insertion s2))
-       (cursor/move-cursor-to input (+ selected-start (count insertion)))))))
+                                (str s1 insertion))
+       ;; HACK: save scroll-pos of current pos, then add trailing content
+       (let [scroll-pos (.-scrollTop (gdom/getElement "main-content-container"))]
+         (state/set-edit-content! (state/get-edit-input-id)
+                                  (str s1 insertion s2))
+         (cursor/move-cursor-to input (+ selected-start (count insertion)))
+         (set! (.-scrollTop (gdom/getElement "main-content-container")) scroll-pos))))))
 
 (defn- keydown-new-line
+  "Insert newline to current cursor position"
   []
   (insert "\n"))
 

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -399,6 +399,13 @@
      (when e (.stopPropagation e))))
 
 #?(:cljs
+   (defn nearest-scrollable-container [^js/HTMLElement element]
+     (some #(when-let [overflow-y (.-overflowY (js/window.getComputedStyle %))]
+              (when (contains? #{"auto" "scroll" "overlay"} overflow-y)
+                %))
+           (take-while (complement nil?) (iterate #(.-parentElement %) element)))))
+
+#?(:cljs
    (defn element-top [elem top]
      (when elem
        (if (.-offsetParent elem)


### PR DESCRIPTION
To reproduce, add/edit a block with many lines.

Then press `shift+enter` in the middle of the block content. Thee page will scroll to the bottom of the block.

- [x] newline with `shift+enter`
- [x] pasting - handle `simple-insert!`
- [x] right sidebar


## BUG
https://github.com/logseq/logseq/assets/72891/38fc402e-a08a-4ddc-93d5-41d7bb97167e


