### PR TITLE
Fix (Whiteboards): Actions on converted shapes

### DIFF
--- a/e2e-tests/whiteboards.spec.ts
+++ b/e2e-tests/whiteboards.spec.ts
@@ -163,11 +163,25 @@ test('convert the first rectangle to ellipse', async ({ page }) => {
   await page.keyboard.press('Escape')
   await page.waitForTimeout(1000)
   await page.click('.logseq-tldraw .tl-box-container:first-of-type')
+  await page.mouse.move(0, 0)  // move mouse to trigger a rerender of the context bar
   await page.click('.tl-context-bar .tl-geometry-tools-pane-anchor')
   await page.click('.tl-context-bar .tl-geometry-toolbar [data-tool=ellipse]')
 
   await expect(page.locator('.logseq-tldraw .tl-ellipse-container')).toHaveCount(1)
   await expect(page.locator('.logseq-tldraw .tl-box-container')).toHaveCount(1)
+})
+
+test('change the color of the ellipse', async ({ page }) => {
+  await page.click('.tl-context-bar .tl-color-bg')
+  await page.click('.tl-context-bar .tl-color-palette .bg-red-500')
+
+  await expect(page.locator('.logseq-tldraw .tl-ellipse-container ellipse:last-of-type')).toHaveAttribute('fill', 'var(--ls-wb-background-color-red)')
+})
+
+test('undo the color switch', async ({ page }) => {
+  await page.keyboard.press(modKey + '+z')
+
+  await expect(page.locator('.logseq-tldraw .tl-ellipse-container ellipse:last-of-type')).toHaveAttribute('fill', 'var(--ls-wb-background-color-default)')
 })
 
 test('undo the conversion', async ({ page }) => {
@@ -176,7 +190,6 @@ test('undo the conversion', async ({ page }) => {
   await expect(page.locator('.logseq-tldraw .tl-box-container')).toHaveCount(2)
   await expect(page.locator('.logseq-tldraw .tl-ellipse-container')).toHaveCount(0)
 })
-
 
 test('locked elements should not be removed', async ({ page }) => {
   await page.keyboard.press('Escape')

--- a/e2e-tests/whiteboards.spec.ts
+++ b/e2e-tests/whiteboards.spec.ts
@@ -184,7 +184,7 @@ test('undo the color switch', async ({ page }) => {
   await expect(page.locator('.logseq-tldraw .tl-ellipse-container ellipse:last-of-type')).toHaveAttribute('fill', 'var(--ls-wb-background-color-default)')
 })
 
-test('undo the conversion', async ({ page }) => {
+test('undo the shape conversion', async ({ page }) => {
   await page.keyboard.press(modKey + '+z')
 
   await expect(page.locator('.logseq-tldraw .tl-box-container')).toHaveCount(2)

--- a/e2e-tests/whiteboards.spec.ts
+++ b/e2e-tests/whiteboards.spec.ts
@@ -159,6 +159,25 @@ test('undo the delete action', async ({ page }) => {
   await expect(page.locator('.logseq-tldraw .tl-line-container')).toHaveCount(1)
 })
 
+test('convert the first rectangle to ellipse', async ({ page }) => {
+  await page.keyboard.press('Escape')
+  await page.waitForTimeout(1000)
+  await page.click('.logseq-tldraw .tl-box-container:first-of-type')
+  await page.click('.tl-context-bar .tl-geometry-tools-pane-anchor')
+  await page.click('.tl-context-bar .tl-geometry-toolbar [data-tool=ellipse]')
+
+  await expect(page.locator('.logseq-tldraw .tl-ellipse-container')).toHaveCount(1)
+  await expect(page.locator('.logseq-tldraw .tl-box-container')).toHaveCount(1)
+})
+
+test('undo the conversion', async ({ page }) => {
+  await page.keyboard.press(modKey + '+z')
+
+  await expect(page.locator('.logseq-tldraw .tl-box-container')).toHaveCount(2)
+  await expect(page.locator('.logseq-tldraw .tl-ellipse-container')).toHaveCount(0)
+})
+
+
 test('locked elements should not be removed', async ({ page }) => {
   await page.keyboard.press('Escape')
   await page.waitForTimeout(1000)

--- a/src/main/frontend/extensions/tldraw.cljs
+++ b/src/main/frontend/extensions/tldraw.cljs
@@ -100,7 +100,7 @@
    :getBlockPageName #(:block/name (model/get-block-page (state/get-current-repo) (parse-uuid %)))
    :exportToImage (fn [page-name options] (state/set-modal! #(export/export-blocks page-name (merge (js->clj options :keywordize-keys true) {:whiteboard? true}))))
    :isWhiteboardPage model/whiteboard-page?
-   :isMobile (util/mobile?)
+   :isMobile util/mobile?
    :saveAsset save-asset-handler
    :makeAssetUrl editor-handler/make-asset-url
    :copyToClipboard (fn [text, html] (util/copy-to-clipboard! text :html html))

--- a/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
@@ -133,9 +133,7 @@ const LogseqPortalViewModeAction = observer(() => {
     <div className="flex">
       {collapsed ? 'Expand' : 'Collapse'}
       <KeyboardShortcut
-        action={
-          collapsed ? 'editor/expand-block-children' : 'editor/collapse-block-children'
-        }
+        action={collapsed ? 'editor/expand-block-children' : 'editor/collapse-block-children'}
       />
     </div>
   )

--- a/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
@@ -103,7 +103,7 @@ const AutoResizingAction = observer(() => {
       className="tl-button"
       pressed={pressed}
       onPressedChange={v => {
-        app.selectedShapesArray.forEach(s => {
+        shapes.forEach(s => {
           if (s.props.type === 'logseq-portal') {
             s.update({
               isAutoResizing: v,

--- a/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextBar/contextBarActionFactory.tsx
@@ -103,7 +103,7 @@ const AutoResizingAction = observer(() => {
       className="tl-button"
       pressed={pressed}
       onPressedChange={v => {
-        shapes.forEach(s => {
+        app.selectedShapesArray.forEach(s => {
           if (s.props.type === 'logseq-portal') {
             s.update({
               isAutoResizing: v,
@@ -253,7 +253,7 @@ const NoFillAction = observer(() => {
   const app = useApp<Shape>()
   const shapes = filterShapeByAction<BoxShape | PolygonShape | EllipseShape>('NoFill')
   const handleChange = React.useCallback((v: boolean) => {
-    shapes.forEach(s => s.update({ noFill: v }))
+    app.selectedShapesArray.forEach(s => s.update({ noFill: v }))
     app.persist()
   }, [])
 
@@ -279,14 +279,14 @@ const SwatchAction = observer(() => {
   >('Swatch')
 
   const handleSetColor = React.useCallback((color: string) => {
-    shapes.forEach(s => {
+    app.selectedShapesArray.forEach(s => {
       s.update({ fill: color, stroke: color })
     })
     app.persist()
   }, [])
 
   const handleSetOpacity = React.useCallback((opacity: number) => {
-    shapes.forEach(s => {
+    app.selectedShapesArray.forEach(s => {
       s.update({ opacity: opacity })
     })
     app.persist()

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/EllipseShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/EllipseShape.tsx
@@ -98,8 +98,11 @@ export class EllipseShape extends TLEllipseShape<EllipseShapeProps> {
       )
 
       return (
-        <div {...events} style={{ width: '100%', height: '100%', overflow: 'hidden' }}
-        className="tl-ellipse-container">
+        <div
+          {...events}
+          style={{ width: '100%', height: '100%', overflow: 'hidden' }}
+          className="tl-ellipse-container"
+        >
           <TextLabel
             font={font}
             text={label}

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/EllipseShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/EllipseShape.tsx
@@ -98,7 +98,8 @@ export class EllipseShape extends TLEllipseShape<EllipseShapeProps> {
       )
 
       return (
-        <div {...events} style={{ width: '100%', height: '100%', overflow: 'hidden' }}>
+        <div {...events} style={{ width: '100%', height: '100%', overflow: 'hidden' }}
+        className="tl-ellipse-container">
           <TextLabel
             font={font}
             text={label}

--- a/tldraw/packages/core/src/lib/TLApi/TLApi.ts
+++ b/tldraw/packages/core/src/lib/TLApi/TLApi.ts
@@ -428,6 +428,7 @@ export class TLApi<S extends TLShape = TLShape, K extends TLEventMap = TLEventMa
       return new ShapeClass({
         ...s.serialized,
         type: type,
+        nonce: Date.now(),
       })
     })
     this.app.currentPage.addShapes(...clones)

--- a/tldraw/packages/core/src/lib/tools/TLSelectTool/states/ContextMenuState.ts
+++ b/tldraw/packages/core/src/lib/tools/TLSelectTool/states/ContextMenuState.ts
@@ -17,11 +17,10 @@ export class ContextMenuState<
   onEnter = (info: TLEventInfo<S>) => {
     const {
       selectedIds,
-      selectedShapes,
       inputs: { shiftKey },
     } = this.app
 
-    if (info.type === TLTargetType.Shape && !selectedShapes.has(info.shape)) {
+    if (info.type === TLTargetType.Shape && !selectedIds.has(info.shape.id)) {
       const shape = this.app.getParentGroup(info.shape) ?? info.shape
       if (shiftKey) {
         this.app.setSelectedShapes([...Array.from(selectedIds.values()), shape.id])


### PR DESCRIPTION
The PR handles the following issues
- Create a rectangle, convert it to an ellipsis, and try to change its color or set its fill property. Those actions should work without resetting the element selection.
- Create a rectangle, convert it to an ellipsis, move the object and then undo the actions. The conversion should be a separate history action.
- Create multiple elements. Then create a rectangle and convert it to an ellipsis. Select all elements and right click on the converted shape. All elements should remain selected when the context menu should is triggered. 

The main problem was that in order to maintain the same id, a different shape instance with the same ID is created upon conversion.