### PR TITLE
Fix(fs): add unicode normalization to fs watcher on mobile platforms

### DIFF
--- a/android/app/src/main/java/com/logseq/app/FsWatcher.java
+++ b/android/app/src/main/java/com/logseq/app/FsWatcher.java
@@ -10,6 +10,8 @@ import android.net.Uri;
 
 import java.io.*;
 
+import java.net.URI;
+import java.text.Normalizer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Stack;
@@ -90,8 +92,11 @@ public class FsWatcher extends Plugin {
             shouldRead = true;
         }
 
-        obj.put("path", Uri.fromFile(f));
-        obj.put("dir", Uri.fromFile(new File(mPath)));
+        URI dir = (new File(mPath)).toURI();
+        URI fpath = f.toURI();
+
+        obj.put("path", Normalizer.normalize(dir.relativize(fpath).toString(), Normalizer.Form.NFC));
+        obj.put("dir", Uri.fromFile(new File(mPath))); // Uri is for Android. URI is for RFC compatible
         JSObject stat;
 
         switch (event) {

--- a/deps/common/src/logseq/common/path.cljs
+++ b/deps/common/src/logseq/common/path.cljs
@@ -6,7 +6,7 @@
 (defn- safe-decode-uri-component
   [uri]
   (try
-    (js/decodeURIComponent uri)
+    (.normalize (js/decodeURIComponent uri) "NFC")
     (catch :default _
       (js/console.error "decode-uri-component-failed" uri)
       uri)))
@@ -157,7 +157,6 @@
 (defn path-join
   "Join path segments, or URL base and path segments"
   [base & segments]
-
   (cond
     ;; For debugging
     ; (nil? base)
@@ -190,9 +189,10 @@
 (defn path-normalize
   "Normalize path or URL"
   [path]
-  (if (is-file-url? path)
-    (url-normalize path)
-    (path-normalize-internal path)))
+  (-> (if (is-file-url? path)
+        (url-normalize path)
+        (path-normalize-internal path))
+      (.normalize "NFC")))
 
 (defn url-to-path
   "Extract path part of a URL, decoded.

--- a/src/main/frontend/fs/capacitor_fs.cljs
+++ b/src/main/frontend/fs/capacitor_fs.cljs
@@ -238,8 +238,7 @@
              (when-not contents-matched?
                (backup-file repo-dir :backup-dir fpath disk-content))
              (db/set-file-last-modified-at! repo rpath mtime)
-             (p/let [content content]
-               (db/set-file-content! repo rpath content))
+             (db/set-file-content! repo rpath content)
              (when ok-handler
                (ok-handler repo fpath result))
              result)

--- a/src/main/frontend/handler/common/file.cljs
+++ b/src/main/frontend/handler/common/file.cljs
@@ -74,13 +74,13 @@
      :fs/reset-event - the event that triggered the file update
        :fs/local-file-change - file changed on local disk
        :fs/remote-file-change - file changed on remote"
-  [repo-url file content {:fs/keys [event] :as options}]
+  [repo-url file-path content {:fs/keys [event] :as options}]
   (let [db-conn (db/get-db repo-url false)]
     (case event
       ;; the file is already in db, so we can use the existing file's blocks
       ;; to do the diff-merge
       :fs/local-file-change
-      (graph-parser/parse-file db-conn file content (assoc-in options [:extract-options :resolve-uuid-fn] diff-merge-uuids-2ways))
+      (graph-parser/parse-file db-conn file-path content (assoc-in options [:extract-options :resolve-uuid-fn] diff-merge-uuids-2ways))
 
       ;; TODO Junyi: 3 ways to handle remote file change
       ;; The file is on remote, so we should have 
@@ -90,7 +90,7 @@
       ;;   2. a "remote version" just fetched from remote
 
       ;; default to parse the file
-      (graph-parser/parse-file db-conn file content options))))
+      (graph-parser/parse-file db-conn file-path content options))))
 
 (defn reset-file!
   "Main fn for updating a db with the results of a parsed file"

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -69,8 +69,7 @@
             [logseq.db.schema :as db-schema]
             [logseq.graph-parser.config :as gp-config]
             [promesa.core :as p]
-            [rum.core :as rum]
-            [logseq.common.path :as path]))
+            [rum.core :as rum]))
 
 ;; TODO: should we move all events here?
 
@@ -622,13 +621,7 @@
 
 (defmethod handle :mobile-file-watcher/changed [[_ ^js event]]
   (let [type (.-event event)
-        payload (js->clj event :keywordize-keys true)
-        dir (:dir payload)
-        payload (-> payload
-                    (update :path
-                           (fn [path]
-                             (when (string? path)
-                               (path/relative-path dir path)))))]
+        payload (js->clj event :keywordize-keys true)]
     (fs-watcher/handle-changed! type payload)
     (when (file-sync-handler/enable-sync?)
      (sync/file-watch-handler type payload))))


### PR DESCRIPTION
The file system (fs) watcher on mobile platforms accesses files using native URL or Uri.
Due to this, files with unnormalized Unicode characters such as diacritical letters are not handled correctly when URLs are used as file paths.  BUG: Unicode normalization should be applied after uri-decode.

Upon detecting a file modification event, the watcher treats the file as new due to the unnormalized characters and as such, results in lost history. Additionally, the screen keyboard bounces, causing issues.

In this fix:

- add a `catch-all` style fix to `logseq.common.path`
- Refactor mobile fs-watcher, use relative paths, add path normalization

Fix #9378