### PR TITLE
fix(editor): show block bullet when a blank block has children

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1781,7 +1781,9 @@
                        [:label (str order-list-idx ".")])]]]]
        (cond
          (and (or (mobile-util/native-platform?)
-                  (:ui/show-empty-bullets? (state/get-config)))
+                  (:ui/show-empty-bullets? (state/get-config))
+                  collapsed?
+                  collapsable?)
               (not doc-mode?))
          bullet
 


### PR DESCRIPTION

## Before(Current master) - collapsed & expanded
<img width="276" alt="image" src="https://github.com/logseq/logseq/assets/72891/01c7c388-b65e-4622-8382-61689f7ed2a6">
<img width="284" alt="image" src="https://github.com/logseq/logseq/assets/72891/221c5905-6447-4da3-82c0-c3517dd579ec">

## After this fix - collapsed & expanded

<img width="245" alt="image" src="https://github.com/logseq/logseq/assets/72891/44bc6cdc-ce36-4187-aff5-8a9fa4107a94">
<img width="440" alt="image" src="https://github.com/logseq/logseq/assets/72891/6ff05caf-cca6-4dbc-9371-4fdade4d5010">

## Rationale

- UI indicator for hidden content
