### PR TITLE
enhance(editor): delete selected text when pressing enter

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -407,10 +407,10 @@
            (save-block-inner! block value opts)))))))
 
 (defn- compute-fst-snd-block-text
-  [value pos]
+  [value selection-start selection-end]
   (when (string? value)
-    (let [fst-block-text (subs value 0 pos)
-          snd-block-text (string/triml (subs value pos))]
+    (let [fst-block-text (subs value 0 selection-start)
+          snd-block-text (string/triml (subs value selection-end))]
       [fst-block-text snd-block-text])))
 
 (declare save-current-block!)
@@ -471,8 +471,9 @@
     :as _opts}]
   (let [block-self? (block-self-alone-when-insert? config uuid)
         input (gdom/getElement (state/get-edit-input-id))
-        pos (cursor/pos input)
-        [fst-block-text snd-block-text] (compute-fst-snd-block-text value pos)
+        selection-start (util/get-selection-start input)
+        selection-end (util/get-selection-end input)
+        [fst-block-text snd-block-text] (compute-fst-snd-block-text value selection-start selection-end)
         current-block (assoc block :block/content fst-block-text)
         current-block (apply dissoc current-block db-schema/retract-attributes)
         current-block (wrap-parse-block current-block)
@@ -526,8 +527,9 @@
                        block)
              block-self? (block-self-alone-when-insert? config block-id)
              input (gdom/getElement (state/get-edit-input-id))
-             pos (cursor/pos input)
-             [fst-block-text snd-block-text] (compute-fst-snd-block-text value pos)
+             selection-start (util/get-selection-start input)
+             selection-end (util/get-selection-end input)
+             [fst-block-text snd-block-text] (compute-fst-snd-block-text value selection-start selection-end)
              insert-fn (cond
                          block-self?
                          insert-new-block-aux!


### PR DESCRIPTION
Closes #3295 

As in common text editors, selected text should be deleted when pressing "enter".
At the moment, Logseq deletes selected text only when a new line is inserted within a block ("shift+enter", if not in document mode).
This PR enhances the insertion of a new block when "enter" is pressed, deleting selected text. If there is no selection (i.e. `util/get-selection-start` and `util/get-selection-end` return the same value), the behavior is as before.

Before:

https://github.com/logseq/logseq/assets/16477970/11c266e8-2d41-4721-8b6b-8f6d361877f7

After:

https://github.com/logseq/logseq/assets/16477970/a58c030f-1d79-44f3-bfd5-2ab47824e8eb
