### PR TITLE
Chore: Rename temp :block keys to be explicit about their use

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/extract.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/extract.cljc
@@ -208,7 +208,7 @@
           pages (remove nil? pages)
           pages (map (fn [page] (assoc page :block/uuid (d/squuid))) pages)
           blocks (->> (remove nil? blocks)
-                      (map (fn [b] (dissoc b :block/title :block/body :block/level :block/children :block/meta :block/anchor))))]
+                      (map (fn [b] (dissoc b :block/title :block/body :block/level :block/children :block/meta))))]
       [pages blocks])
     (catch :default e
       (log/error :exception e))))

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1792,8 +1792,8 @@
          (or
            (and empty-content?
                 (not edit?)
-                (not (:block/top? block))
-                (not (:block/bottom? block))
+                (not (:block.temp/top? block))
+                (not (:block.temp/bottom? block))
                 (not (util/react *control-show?)))
            (and doc-mode?
                 (not collapsed?)
@@ -2779,7 +2779,8 @@
         block (if ref?
                 (merge block (db/sub-block (:db/id block)))
                 block)
-        {:block/keys [uuid children pre-block? top? refs level format content properties]} block
+        {:block/keys [uuid children pre-block? refs level format content properties]} block
+        {:block.temp/keys [top?]} block
         config (if navigated? (assoc config :id (str navigating-block)) config)
         block (merge block (block/parse-title-and-body uuid format pre-block? content))
         blocks-container-id (:blocks-container-id config)
@@ -2922,7 +2923,7 @@
 
    :should-update (fn [old-state new-state]
                     (let [compare-keys        [:block/uuid :block/content :block/parent :block/collapsed?
-                                               :block/properties :block/left :block/children :block/_refs :block/bottom? :block/top?]
+                                               :block/properties :block/left :block/children :block/_refs :block.temp/bottom? :block.temp/top?]
                           config-compare-keys [:show-cloze? :own-order-list-type :own-order-list-index]
                           b1                  (second (:rum/args old-state))
                           b2                  (second (:rum/args new-state))
@@ -3316,8 +3317,8 @@
   [config blocks idx item]
   (let [item (->
               (dissoc item :block/meta)
-              (assoc :block/top? (zero? idx)
-                     :block/bottom? (= (count blocks) (inc idx))))
+              (assoc :block.temp/top? (zero? idx)
+                     :block.temp/bottom? (= (count blocks) (inc idx))))
         config (assoc config :block/uuid (:block/uuid item))]
     (rum/with-key (block-container config item)
       (str (:blocks-container-id config) "-" (:block/uuid item)))))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -341,8 +341,8 @@
                         (select-keys properties (property/hidden-properties))
                         (:block/properties block))]
     (-> block
-        (dissoc :block/top?
-                :block/bottom?)
+        (dissoc :block.temp/top?
+                :block.temp/bottom?)
         (assoc :block/content content
                :block/properties new-properties)
         (merge (if level {:block/level level} {})))))
@@ -826,7 +826,7 @@
                        (let [prev-block' (if (seq (:block/_refs block-e))
                                            (assoc prev-block
                                                   :block/uuid (:block/uuid block)
-                                                  :block/additional-properties (:block/properties block))
+                                                  :block.temp/additional-properties (:block/properties block))
                                            prev-block)]
                          (delete-block-aux! block delete-children?)
                          (save-block! repo prev-block' new-content {:editor/op :delete}))
@@ -2646,7 +2646,7 @@
             edit-block' (if next-block-has-refs?
                           (assoc edit-block
                                  :block/uuid (:block/uuid next-block)
-                                 :block/additional-properties (dissoc (:block/properties next-block) :block/uuid))
+                                 :block.temp/additional-properties (dissoc (:block/properties next-block) :block/uuid))
                           edit-block)]
         (outliner-tx/transact! transact-opts
           (delete-block-aux! next-block false)
@@ -2691,7 +2691,7 @@
         repo (state/get-current-repo)
         top-block? (= (:block/left block) (:block/page block))
         single-block? (inside-of-single-block (.-target e))
-        root-block? (= (:block/container block) (str (:block/uuid block)))]
+        root-block? (= (:block.temp/container block) (str (:block/uuid block)))]
     (mark-last-input-time! repo)
     (cond
       (not= selected-start selected-end)

--- a/src/main/frontend/modules/outliner/core.cljs
+++ b/src/main/frontend/modules/outliner/core.cljs
@@ -140,7 +140,7 @@
     (assert (ds/outliner-txs-state? txs-state)
             "db should be satisfied outliner-tx-state?")
     (let [m (-> (:data this)
-                (dissoc :block/children :block/meta :block/top? :block/bottom?
+                (dissoc :block/children :block/meta :block.temp/top? :block.temp/bottom?
                         :block/title :block/body :block/level)
                 (gp-util/remove-nils))
           m (if (state/enable-block-timestamps?) (block-with-timestamps m) m)

--- a/src/main/frontend/modules/outliner/datascript.cljc
+++ b/src/main/frontend/modules/outliner/datascript.cljc
@@ -126,9 +126,12 @@
      (let [txs (remove-nil-from-transaction txs)
            txs (map (fn [m] (if (map? m)
                               (dissoc m
-                                      :block/children :block/meta :block/top? :block/bottom? :block/anchor
-                                      :block/title :block/body :block/level :block/container :db/other-tx
-                                      :block/additional-properties)
+                                      ;; TODO: Move these attributes to :block.temp when the risk is lower
+                                      :block/children :block/meta :block/title :block/body :block/level
+                                      :db/other-tx
+                                      ;; :block.temp is for temporary block attributes that aren't transacted
+                                      :block.temp/container :block.temp/top? :block.temp/bottom?
+                                      :block.temp/additional-properties)
                               m)) txs)
            txs (cond-> txs
                  (:uuid-changed opts)

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1808,7 +1808,7 @@ Similar to re-frame subscriptions"
             container (util/get-block-container block-element)
             block (if container
                     (assoc block
-                           :block/container (gobj/get container "id"))
+                           :block.temp/container (gobj/get container "id"))
                     block)
             content (string/trim (or content ""))]
         (swap! state


### PR DESCRIPTION
This PR is a refactor followup to https://github.com/logseq/logseq/pull/9406/files. This introduces a keyword ns to make temporary block keys more explicit. I chose :block.temp but we could also :block.tmp if preferred. I only renamed keys with low risk and that were easy to trace with grep