### PR TITLE
Fix: table v2 and view properties not hidden on display

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/property.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/property.cljs
@@ -7,11 +7,11 @@
             [goog.string.format]))
 
 (def colons "Property delimiter for markdown mode" "::")
-(defn colons-org 
+(defn colons-org
   "Property delimiter for org mode"
   [property]
   (str ":" property ":"))
- 
+
 (defn ->block-content
   "Creates a block content string from properties map"
   [properties]
@@ -47,19 +47,23 @@
   "Properties used by logseq that user can edit and that can have linkable property values"
   #{:alias :aliases :tags})
 
+(def editable-view-and-table-properties
+  "Properties used by view and table component"
+  #{;; view props
+    :logseq.color
+    ;; table props
+    :logseq.table.version :logseq.table.compact :logseq.table.headers :logseq.table.hover
+    :logseq.table.borders :logseq.table.stripes :logseq.table.max-width})
+
 (defn editable-built-in-properties
   "Properties used by logseq that user can edit"
   []
-  (into #{:title :icon :template :template-including-parent :public :filters :exclude-from-graph-view
-          :logseq.query/nlp-date 
-          ;; view props 
-          :logseq.color
-          ;; table props
-          :logseq.table.version :logseq.table.compact :logseq.table.headers :logseq.table.hover 
-          :logseq.table.borders :logseq.table.stripes :logseq.table.max-width
+  (set/union #{:title :icon :template :template-including-parent :public :filters :exclude-from-graph-view
+               :logseq.query/nlp-date
           ;; org-mode only
-          :macro :filetags}
-        editable-linkable-built-in-properties))
+               :macro :filetags}
+             editable-linkable-built-in-properties
+             editable-view-and-table-properties))
 
 (defn hidden-built-in-properties
   "Properties used by logseq that user can't edit or see"

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2066,7 +2066,8 @@
 
 (def hidden-editable-block-properties
   "Properties that are hidden in a block (block property)"
-  #{:logseq.query/nlp-date})
+  (into #{:logseq.query/nlp-date}
+        gp-property/editable-view-and-table-properties))
 
 (assert (set/subset? hidden-editable-block-properties (gp-property/editable-built-in-properties))
         "Hidden editable page properties must be valid editable properties")


### PR DESCRIPTION
This PR fixes #9489, where table v2 properties aren't hiding on display. I forgot to give this advice when reviewing #8532. To QA, follow steps in #9489 