### PR TITLE
Fix datepicker deadline entry

### DIFF
--- a/e2e-tests/basic.spec.ts
+++ b/e2e-tests/basic.spec.ts
@@ -307,10 +307,9 @@ test('Block content should be preserved when adding a deadline via datepicker', 
   }
 
   async function validateDatePickerInput(kind, step) {
-    // Expect datepicker to disappear
+    // Expect:
     //        previously edited block to still be in editing mode
-    //        content of block to be complete with scheduled date
-    // TODO - add expects
+    //        content of block to be complete with scheduled date (if scheduled/deadline)
     await expect(await block.isEditing()).toBe(true);
 
     var content = page.locator('textarea >> nth=0');
@@ -337,24 +336,11 @@ test('Block content should be preserved when adding a deadline via datepicker', 
   await datePicker.getByText('Submit').click();
   await validateDatePickerInput('deadline', step);
 
+  // Test date picker refocusing
   await block.enterNext();
   step = 'Test a date entered using the keyboard';
   await block.mustType(step);
   datePicker = await openDatePicker('date');
   await page.keyboard.press('Enter');
   await validateDatePickerInput('date', step );
-
-  // await block.enterNext()
-  // await page.waitForTimeout(500)
-  // await block.escapeEditing()
-
-  // // Open date picker
-  // await page.click('a.opacity-80')
-  // await page.waitForTimeout(500)
-  // expect(page.locator('text=May 2000')).toBeVisible()
-  // expect(page.locator('td:has-text("6").active')).toBeVisible()
-
-  // // Close date picker
-  // await page.click('a.opacity-80')
-  // await page.waitForTimeout(500)
 })

--- a/src/main/frontend/components/datetime.cljs
+++ b/src/main/frontend/components/datetime.cljs
@@ -109,20 +109,14 @@
         block-id (or (:block/uuid block)
                      editing-block-id)
         typ (or @commands/*current-command typ)]
-    (if (and true
-         ;;(or 
-          ;;(state/editing?)
-          ;;(let [active-elem (.-activeElement js/document)]
-          ;;)) 
-         (= editing-block-id block-id) )
+    (if (= editing-block-id block-id) 
       (do
         (editor-handler/set-editing-block-timestamp! typ
                                                      text)
         (restore-focus!))
-      (do
       (editor-handler/set-block-timestamp! block-id
                                            typ
-                                           text))
+                                           text)
     )
 
     (when show?

--- a/src/main/frontend/components/datetime.cljs
+++ b/src/main/frontend/components/datetime.cljs
@@ -10,6 +10,7 @@
             [frontend.ui :as ui]
             [frontend.util :as util]
             [frontend.mixins :as mixins]
+            [goog.dom :as gdom]
             [rum.core :as rum]
             [logseq.graph-parser.util.page-ref :as page-ref]))
 
@@ -78,6 +79,13 @@
                                        :duration "d"}))}
        "Add repeater"])))
 
+(defn restore-focus!
+  "Restore focus to the active input that triggered the date-picker."
+  []
+  (when-let [input (state/get-input)]
+    (when-let [current-input (gdom/getElement input)]
+      (.focus current-input))))
+
 (defn- clear-timestamp!
   []
   (reset! *timestamp default-timestamp-value)
@@ -101,12 +109,21 @@
         block-id (or (:block/uuid block)
                      editing-block-id)
         typ (or @commands/*current-command typ)]
-    (if (and (state/editing?) (= editing-block-id block-id))
-      (editor-handler/set-editing-block-timestamp! typ
-                                                   text)
+    (if (and true
+         ;;(or 
+          ;;(state/editing?)
+          ;;(let [active-elem (.-activeElement js/document)]
+          ;;)) 
+         (= editing-block-id block-id) )
+      (do
+        (editor-handler/set-editing-block-timestamp! typ
+                                                     text)
+        (restore-focus!))
+      (do
       (editor-handler/set-block-timestamp! block-id
                                            typ
                                            text))
+    )
 
     (when show?
       (reset! show? false)))
@@ -169,6 +186,8 @@
                                              format
                                              {:command :page-ref})
              (state/clear-editor-action!)
-             (reset! commands/*current-command nil))))})
+             (reset! commands/*current-command nil)
+             (restore-focus!)
+             )))})
      (when deadline-or-schedule?
        (time-repeater))]))


### PR DESCRIPTION
Fixes #8485

As discussed and demod here: https://github.com/logseq/logseq/issues/8485#issuecomment-1558573922, this PR slightly modifies the behavior of datepicker. The expected behavior is that after the date is selected via the keyboard OR the mouse, editing focus is returned to the block and the user has to hit Enter to move to the next block.

Personally, I prefer this as the current behavior loses focus after any mouse interactions with datepicker and you have to manually re-select the block to continue editing/typing.