### PR TITLE
Dev(plugins): fix space in overflow menu 

### DIFF
--- a/src/main/frontend/components/plugins.cljs
+++ b/src/main/frontend/components/plugins.cljs
@@ -589,7 +589,7 @@
                     :options {:on-click
                               #(p/let [root (plugin-handler/get-ls-dotdir-root)]
                                  (js/apis.openPath (str root "/preferences.json")))}}
-                   {:title   [:span.flex.items-center (ui/icon "bug") "Open " [:code " ~/.logseq"]]
+                   {:title   [:span.flex.items-center (ui/icon "bug") "Open\u00A0" [:code "~/.logseq"]]
                     :options {:on-click
                               #(p/let [root (plugin-handler/get-ls-dotdir-root)]
                                  (js/apis.openPath root))}}]))


### PR DESCRIPTION
Use non-breaking space to ensure that space within the inline element `open ~/.logseq` is correctly rendered.

|before | After |
| ----- | ------|
|![image](https://github.com/Alistair10123/logseq_p/assets/25513724/9486b519-b1d8-48c2-a6d1-cf38fa2f9451)| ![image](https://github.com/Alistair10123/logseq_p/assets/25513724/7f0caf09-ac61-40b0-a643-a280b9ae82d9)|

@xyhp915, please TAL when you get a chance. It's a minor UI change.
