### PR TITLE
Enhance: Menu item for toggling theme mode in published graphs

### DIFF
--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -128,6 +128,11 @@
           :options {:href (rfe/href :bug-report)}
           :icon (ui/icon "bug")})
 
+       (when config/publishing?
+         {:title (t :toggle-theme)
+          :options {:on-click #(state/toggle-theme!)}
+          :icon (ui/icon "bulb")})
+
        (when (and (state/sub :auth/id-token) (user-handler/logged-in?))
          {:title (str (t :logout) " (" (user-handler/email) ")")
           :options {:on-click #(user-handler/logout)}

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -303,6 +303,7 @@
  :heading "Heading {1}"
  :auto-heading "Auto heading"
  :open-a-directory "Open a local directory"
+ :toggle-theme      "Toggle theme"
 
  :help/shortcut-page-title "Keyboard shortcuts"
 


### PR DESCRIPTION
This is an attempt to add a "Toggle theme" item in the options menu for published graphs. 

resolves https://github.com/logseq/logseq/issues/9240