### PR TITLE
fix: substitute date/text in all quick-capture templates

### DIFF
--- a/src/main/frontend/mobile/intent.cljs
+++ b/src/main/frontend/mobile/intent.cljs
@@ -65,6 +65,7 @@
   (p/let [basename (node-path/basename url)
           label (-> basename util/node-path.name)
           time (date/get-current-time)
+          date-ref-name (date/today)
           path (editor-handler/get-asset-path basename)
           _file (p/catch
                  (.copy Filesystem (clj->js {:from url :to path}))
@@ -76,12 +77,15 @@
                            [:quick-capture-templates :media]
                            "**{time}** [[quick capture]]: {url}")]
     (-> (string/replace template "{time}" time)
+        (string/replace template "{date}" date-ref-name)
+        (string/replace template "{text}" "")
         (string/replace "{url}" (or url "")))))
 
 (defn- embed-text-file
   "Store external content with url into Logseq repo"
   [url title]
   (p/let [time (date/get-current-time)
+          date-ref-name (date/today)
           title (some-> (or title (node-path/basename url))
                         gp-util/safe-decode-uri-component
                         util/node-path.name
@@ -99,6 +103,8 @@
                            [:quick-capture-templates :text]
                            "**{time}** [[quick capture]]: {url}")]
     (-> (string/replace template "{time}" time)
+        (string/replace template "{date}" date-ref-name)
+        (string/replace template "{text}" "")
         (string/replace "{url}" (or url "")))))
 
 (defn- handle-received-media [result]

--- a/src/main/frontend/mobile/intent.cljs
+++ b/src/main/frontend/mobile/intent.cljs
@@ -76,9 +76,10 @@
           template (get-in (state/get-config)
                            [:quick-capture-templates :media]
                            "**{time}** [[quick capture]]: {url}")]
-    (-> (string/replace template "{time}" time)
-        (string/replace template "{date}" date-ref-name)
-        (string/replace template "{text}" "")
+    (-> template
+        (string/replace "{time}" time)
+        (string/replace "{date}" date-ref-name)
+        (string/replace "{text}" "")
         (string/replace "{url}" (or url "")))))
 
 (defn- embed-text-file
@@ -92,8 +93,8 @@
                         ;; make the title more user friendly
                         gp-util/page-name-sanity)
           path (node-path/join (config/get-repo-dir (state/get-current-repo))
-                          (config/get-pages-directory)
-                          (str (js/encodeURI (fs-util/file-name-sanity title)) (node-path/extname url)))
+                               (config/get-pages-directory)
+                               (str (js/encodeURI (fs-util/file-name-sanity title)) (node-path/extname url)))
           _ (p/catch
              (.copy Filesystem (clj->js {:from url :to path}))
              (fn [error]
@@ -102,9 +103,10 @@
           template (get-in (state/get-config)
                            [:quick-capture-templates :text]
                            "**{time}** [[quick capture]]: {url}")]
-    (-> (string/replace template "{time}" time)
-        (string/replace template "{date}" date-ref-name)
-        (string/replace template "{text}" "")
+    (-> template
+        (string/replace "{time}" time)
+        (string/replace "{date}" date-ref-name)
+        (string/replace "{text}" "")
         (string/replace "{url}" (or url "")))))
 
 (defn- handle-received-media [result]


### PR DESCRIPTION
Previously, sharing media to logseq via an android intent only substituted the url/time. Now it substitutes the date and replaces the text with nothing (which seems like a reasonable default when there is no text).