### PR TITLE
Chore: Eliminate some console errors and warnings

### DIFF
--- a/src/main/frontend/components/container.css
+++ b/src/main/frontend/components/container.css
@@ -536,6 +536,7 @@ html[data-theme='dark'] {
 
   .resizer {
     @apply absolute top-0 bottom-0;
+    touch-action: none;
     left: 0;
     width: 4px;
     user-select: none;

--- a/src/main/frontend/handler/editor/lifecycle.cljs
+++ b/src/main/frontend/handler/editor/lifecycle.cljs
@@ -27,7 +27,7 @@
       (js/setTimeout #(util/scroll-editor-cursor element) 50)))
   state)
 
-(defn did-remount!
+(defn will-remount!
   [_old-state state]
   (keyboards-handler/esc-save! state)
   state)
@@ -45,5 +45,5 @@
 
 (def lifecycle
   {:did-mount did-mount!
-   :did-remount did-remount!
+   :will-remount will-remount!
    :will-unmount will-unmount})

--- a/src/main/frontend/mixins.cljs
+++ b/src/main/frontend/mixins.cljs
@@ -99,7 +99,7 @@
      :did-mount (fn [state]
                   (attach-listeners state)
                   state)
-     :did-remount (fn [old-state new-state]
+     :will-remount (fn [old-state new-state]
                     (detach old-state)
                     (attach-listeners new-state)
                     new-state)})))

--- a/src/main/frontend/modules/shortcut/core.cljs
+++ b/src/main/frontend/modules/shortcut/core.cljs
@@ -145,7 +145,7 @@
      (let [install-id (install-shortcut! handler-id {:state state})]
        (assoc state ::install-id install-id)))
 
-   :did-remount (fn [old-state new-state]
+   :will-remount (fn [old-state new-state]
                   (uninstall-shortcut! (::install-id old-state))
                   (when-let [install-id (install-shortcut! handler-id {:state new-state})]
                     (assoc new-state ::install-id install-id)))

--- a/tldraw/apps/tldraw-logseq/src/components/inputs/ColorInput.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/inputs/ColorInput.tsx
@@ -34,6 +34,10 @@ export function ColorInput({
     )
   }
 
+  function isHexColor(color: string) {
+    return /^#(?:[0-9a-f]{3}){1,2}$/i.test(color)
+  }
+
   const handleChangeDebounced = React.useMemo(() => {
     let latestValue = ''
 
@@ -78,7 +82,7 @@ export function ColorInput({
                 className="color-input cursor-pointer"
                 id="tl-custom-color-input"
                 type="color"
-                value={color}
+                value={isHexColor(color) ? color : "#000000"}
                 onChange={handleChangeDebounced}
                 style={{ opacity: isBuiltInColor(color) ? 0 : 1 }}
                 {...rest}

--- a/tldraw/apps/tldraw-logseq/src/components/inputs/ColorInput.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/inputs/ColorInput.tsx
@@ -85,7 +85,7 @@ export function ColorInput({
               />
             </div>
           </div>
-          <label for="tl-custom-color-input" className="cursor-pointer">
+          <label htmlFor="tl-custom-color-input" className="cursor-pointer">
             Select custom color
           </label>
         </div>

--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/IFrameShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/IFrameShape.tsx
@@ -70,7 +70,7 @@ export class IFrameShape extends TLBoxShape<IFrameShapeProps> {
                 height="100%"
                 src={`${this.props.url}`}
                 frameBorder="0"
-                sandbox="allow-scripts allow-same-origin"
+                sandbox="allow-scripts allow-same-origin allow-presentation"
               />
             </div>
           )}


### PR DESCRIPTION
- https://github.com/logseq/logseq/commit/d8fc304143b198830c70ee6056debc931d7863c6 `:did-remount is deprecated and was renamed to :will-remount, semantics didn't change, it was always called in componentWillReceiveProps`
- https://github.com/logseq/logseq/commit/6ecfc222888aa4dae4b9125b2d7fb7d4ff310fc6 `interact.min.js:2 [interact.js] Consider adding CSS "touch-action: none" to this element`
- https://github.com/logseq/logseq/commit/31c1ce6318c8e435021a2536fa4a500ac9251d2c `Warning: Invalid DOM property 'for'. Did you mean 'htmlFor'?`
- https://github.com/logseq/logseq/commit/fc6194e27390c23778e0b38c74fa3de41a97c181 `Uncaught DOMException: Failed to construct 'PresentationRequest': The document is sandboxed and lacks the 'allow-presentation' flag.`
- https://github.com/logseq/logseq/commit/26000e49e0c10251f22c7dbab854286778e1ca6c `The specified value "pink" does not conform to the required format.  The format is "#rrggbb" where rr, gg, bb are two-digit hexadecimal numbers.`
