### PR TITLE
Fix (Whiteboards): Onboarding triggered on existing whiteboard

### DIFF
--- a/src/main/frontend/extensions/tldraw.cljs
+++ b/src/main/frontend/extensions/tldraw.cljs
@@ -128,7 +128,7 @@
 
 (rum/defc tldraw-app
   [page-name block-id]
-  (let [populate-onboarding?  (whiteboard-handler/should-populate-onboarding-whiteboard? page-name)
+  (let [populate-onboarding?  (whiteboard-handler/should-populate-onboarding-whiteboard?)
         data (whiteboard-handler/page-name->tldr! page-name)
         [loaded-app set-loaded-app] (rum/use-state nil)
         on-mount (fn [^js tln]

--- a/src/main/frontend/extensions/tldraw.cljs
+++ b/src/main/frontend/extensions/tldraw.cljs
@@ -128,7 +128,7 @@
 
 (rum/defc tldraw-app
   [page-name block-id]
-  (let [populate-onboarding?  (whiteboard-handler/should-populate-onboarding-whiteboard?)
+  (let [populate-onboarding? (whiteboard-handler/should-populate-onboarding-whiteboard? page-name)
         data (whiteboard-handler/page-name->tldr! page-name)
         [loaded-app set-loaded-app] (rum/use-state nil)
         on-mount (fn [^js tln]

--- a/src/main/frontend/handler/route.cljs
+++ b/src/main/frontend/handler/route.cljs
@@ -86,7 +86,9 @@
 (defn redirect-to-whiteboard!
   ([name]
    (redirect-to-whiteboard! name nil))
-  ([name {:keys [block-id]}]
+  ([name {:keys [block-id new-whiteboard?]}]
+   ;; Always skip onboarding when loading an existing whiteboard
+   (when-not new-whiteboard? (state/set-onboarding-whiteboard! true))
    (recent-handler/add-page-to-recent! (state/get-current-repo) name false)
    (if (= name (state/get-current-whiteboard))
      (state/focus-whiteboard-shape block-id)

--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -328,13 +328,10 @@
                                                     :assets assets
                                                     :bindings bindings})))))
 (defn should-populate-onboarding-whiteboard?
-  "When there is not whiteboard, or there is only whiteboard that is the given page name, we should populate the onboarding whiteboard"
-  [page-name]
+  "When there is not whiteboard, we should populate the onboarding whiteboard"
+  []
   (let [whiteboards (model/get-all-whiteboards (state/get-current-repo))]
-    (and (or (empty? whiteboards)
-             (and
-              (= 1 (count whiteboards))
-              (= page-name (:block/name (first whiteboards)))))
+    (and (empty? whiteboards)
          (not (state/get-onboarding-whiteboard?)))))
 
 (defn populate-onboarding-whiteboard

--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -328,7 +328,7 @@
                                                     :assets assets
                                                     :bindings bindings})))))
 (defn should-populate-onboarding-whiteboard?
-  "When there is no whiteboard, or there is only one whiteboard that is the given page name, we should populate the onboarding shapes"
+  "When there is no whiteboard, or there is only one whiteboard that has the given page name, we should populate the onboarding shapes"
   [page-name]
   (let [whiteboards (model/get-all-whiteboards (state/get-current-repo))]
     (and (or (empty? whiteboards)

--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -224,7 +224,7 @@
   ([name]
    (when-not config/publishing?
      (create-new-whiteboard-page! name)
-     (route-handler/redirect-to-whiteboard! name))))
+     (route-handler/redirect-to-whiteboard! name {:new-whiteboard? true}))))
 
 (defn ->logseq-portal-shape
   [block-id point]
@@ -328,10 +328,13 @@
                                                     :assets assets
                                                     :bindings bindings})))))
 (defn should-populate-onboarding-whiteboard?
-  "When there is no whiteboard, we should populate the onboarding shapes"
-  []
+  "When there is no whiteboard, or there is only one whiteboard that is the given page name, we should populate the onboarding shapes"
+  [page-name]
   (let [whiteboards (model/get-all-whiteboards (state/get-current-repo))]
-    (and (empty? whiteboards)
+    (and (or (empty? whiteboards)
+             (and
+              (= 1 (count whiteboards))
+              (= page-name (:block/name (first whiteboards)))))
          (not (state/get-onboarding-whiteboard?)))))
 
 (defn populate-onboarding-whiteboard

--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -328,7 +328,7 @@
                                                     :assets assets
                                                     :bindings bindings})))))
 (defn should-populate-onboarding-whiteboard?
-  "When there is not whiteboard, we should populate the onboarding whiteboard"
+  "When there is no whiteboard, we should populate the onboarding shapes"
   []
   (let [whiteboards (model/get-all-whiteboards (state/get-current-repo))]
     (and (empty? whiteboards)


### PR DESCRIPTION
Resolves #9481

I managed to reproduce this without enabling sync
- Make sure you already have created an onboarding whiteboard on your machine. The `ls-onboarding-whiteboard?` local storage key should be set to `true`
- Create a new graph with an empty Whiteboards folder
- Create your first Whiteboard and add some shapes to it (the onboarding whiteboard should not be triggered)
- Manually delete the `ls-onboarding-whiteboard?` local storage key, or clear all local storage data
- Reload the app and open the previously created Whiteboard

The onboarding shapes will be populated on top of the existing whiteboard.