### PR TITLE
Fix: trim block whitespace for markdown files for a specific case

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -399,7 +399,8 @@
                                   (:start_pos meta)))
         content (when content
                   (let [content (text/remove-level-spaces content format block-pattern)]
-                    (if (:pre-block? block)
+                    (if (or (:pre-block? block)
+                            (= (:format block) :org))
                       content
                       (gp-mldoc/remove-indentation-spaces content (inc (:level block)) false))))]
     (if (= format :org)
@@ -613,7 +614,7 @@
                                                (str (gp-property/colons-org "id") " " (:block/uuid block)))))]
                            (string/replace-first c replace-str ""))))))
 
-(defn block-exists-in-another-page?
+(defn block-exists-in-another-page? 
   "For sanity check only.
    For renaming file externally, the file is actually deleted and transacted before-hand."
   [db block-uuid current-page-name]

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -399,8 +399,7 @@
                                   (:start_pos meta)))
         content (when content
                   (let [content (text/remove-level-spaces content format block-pattern)]
-                    (if (or (:pre-block? block)
-                            (= (:format block) :org))
+                    (if (:pre-block? block)
                       content
                       (gp-mldoc/remove-indentation-spaces content (inc (:level block)) false))))]
     (if (= format :org)
@@ -614,7 +613,7 @@
                                                (str (gp-property/colons-org "id") " " (:block/uuid block)))))]
                            (string/replace-first c replace-str ""))))))
 
-(defn block-exists-in-another-page? 
+(defn block-exists-in-another-page?
   "For sanity check only.
    For renaming file externally, the file is actually deleted and transacted before-hand."
   [db block-uuid current-page-name]

--- a/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
@@ -75,12 +75,21 @@
           js/JSON.stringify))))
 
 (defn remove-indentation-spaces
-  "Remove the indentation spaces from the content. Only for markdown."
+  "Remove the indentation spaces from the content. Only for markdown.
+   level - ast level + 1 (2 for the first level, 3 for the second level, etc., as the non-first line of multi-line block has 2 more space
+           Ex.
+              - level 1 multiline block first line
+                level 1 multiline block second line
+              \t- level 2 multiline block first line
+              \t  level 2 multiline block second line
+   remove-first-line? - apply the indentation removal to the first line or not"
   [s level remove-first-line?]
   (let [lines (string/split-lines s)
         [f & r] lines
         body (map (fn [line]
                     ;; Check if the indentation area only contains white spaces
+                    ;; Level = ast level + 1, 1-based indentation level
+                    ;; For markdown in Logseq, the indentation area for the non-first line of multi-line block is (ast level - 1) * "\t" + 2 * "(space)"
                     (if (string/blank? (gp-util/safe-subs line 0 level))
                       ;; If valid, then remove the indentation area spaces. Keep the rest of the line (might contain leading spaces)
                       (gp-util/safe-subs line level)

--- a/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
@@ -75,12 +75,16 @@
           js/JSON.stringify))))
 
 (defn remove-indentation-spaces
+  "Remove the indentation spaces from the content. Only for markdown."
   [s level remove-first-line?]
   (let [lines (string/split-lines s)
         [f & r] lines
         body (map (fn [line]
+                    ;; Check if the indentation area only contains white spaces
                     (if (string/blank? (gp-util/safe-subs line 0 level))
+                      ;; If valid, then remove the indentation area spaces. Keep the rest of the line (might contain leading spaces)
                       (gp-util/safe-subs line level)
+                      ;; Otherwise, trim these invalid spaces
                       (string/triml line)))
                (if remove-first-line? lines r))
         content (if remove-first-line? body (cons f body))]

--- a/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
@@ -81,7 +81,7 @@
         body (map (fn [line]
                     (if (string/blank? (gp-util/safe-subs line 0 level))
                       (gp-util/safe-subs line level)
-                      line))
+                      (string/triml line)))
                (if remove-first-line? lines r))
         content (if remove-first-line? body (cons f body))]
     (string/join "\n" content)))

--- a/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
@@ -119,6 +119,15 @@ body"
       (is ["@tag" "tag1" "tag2"] (sort (:filetags props)))
       (is ["@tag" "tag1" "tag2" "tag3"] (sort (:tags props))))))
 
+(deftest remove-indentation-spaces
+  (testing "Remove indentations for every line"
+    (let [s "block 1.1
+    line 1
+      line 2
+ line 3
+line 4"]
+      (= (gp-mldoc/remove-indentation-spaces s 2 false) "block 1.1\n  line 1\n    line 2\nline 3\nline 4"))))
+
 (deftest ^:integration test->edn
   (let [graph-dir "test/docs-0.9.2"
         _ (docs-graph-helper/clone-docs-repo-if-not-exists graph-dir "v0.9.2")

--- a/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
@@ -121,12 +121,21 @@ body"
 
 (deftest remove-indentation-spaces
   (testing "Remove indentations for every line"
-    (let [s "block 1.1
+    (is (=  "block 1.1\n  line 1\n    line 2\nline 3\nline 4"
+            (let [s "block 1.1
     line 1
       line 2
  line 3
 line 4"]
-      (= (gp-mldoc/remove-indentation-spaces s 2 false) "block 1.1\n  line 1\n    line 2\nline 3\nline 4"))))
+              (gp-mldoc/remove-indentation-spaces s 2 false)))) 
+    (is (=  "\t- block 1.1\n  line 1\n    line 2\nline 3\nline 4"
+            (let [s "\t- block 1.1
+\t    line 1
+\t      line 2
+\t line 3
+\tline 4"]
+              (gp-mldoc/remove-indentation-spaces s 3 false))))))
+    
 
 (deftest ^:integration test->edn
   (let [graph-dir "test/docs-0.9.2"


### PR DESCRIPTION
This PR removes the extra whitespaces when building `block/content`. Also `gp-mldoc/remove-indentation-spaces` is not called on org mode content.

Previously, the extra whitespace in line 2 will not be removed. 
```
- block 1
  - block 2
     line 1
 line 2
        line 3
```

Edit: Needed for 3-way merge to work in this situation