### PR TITLE
Fix (Whiteboard): Various issues

### DIFF
--- a/tldraw/apps/tldraw-logseq/src/lib/shapes/TextShape.tsx
+++ b/tldraw/apps/tldraw-logseq/src/lib/shapes/TextShape.tsx
@@ -132,7 +132,6 @@ export class TextShape extends TLTextShape<TextShapeProps> {
     const handleBlur = React.useCallback(
       (e: React.FocusEvent<HTMLTextAreaElement>) => {
         if (!isEditing) return
-        e.currentTarget.setSelectionRange(0, 0)
         onEditingEnd?.()
       },
       [onEditingEnd]

--- a/tldraw/packages/core/src/lib/TLApp/TLApp.ts
+++ b/tldraw/packages/core/src/lib/TLApp/TLApp.ts
@@ -399,7 +399,6 @@ export class TLApp<
 
   @action addAssets<T extends TLAsset>(assets: T[]): this {
     assets.forEach(asset => (this.assets[asset.id] = asset))
-    this.persist()
     return this
   }
 


### PR DESCRIPTION
- b80bf088d2204222e982e4d5a74113c96c2286c2 This should fix the long standing `Maximum call stack size exceeded` error that was triggered on mobile devices. To reproduce this, create a text element on iOS, type something and then tap outside to exit the editing mode. The app will hang for some seconds until the stack size error is thrown. 
- 2b227177e535ce2cfe52430484e6a2c1979bc4d5 Remove unneeded persist call. This was triggered multiple times on load and on window resize, on whiteboards with image assets. To reproduce this, open the console log and load a whiteboard with images (like the onboarding).