### PR TITLE
dev(e2e): Log and ignore net errors

### DIFF
--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -27,12 +27,13 @@ const consoleLogWatcher = (msg: ConsoleMessage) => {
 
   // List of error messages to ignore
   const ignoreErrors = [
-    /net::ERR_CONNECTION_REFUSED/,
+    /net/,
     /^Error with Permissions-Policy header:/
   ];
 
   // If the text matches any of the ignoreErrors, return early
   if (ignoreErrors.some(error => text.match(error))) {
+    console.log(`WARN:: ${text}\n`)
     return;
   }
 


### PR DESCRIPTION
When there is no connection available or if Google trackers are blocked, playwright tests fail to work due to the youtube video link in the demo graph page. To address this issue previously, I added an exception for a specific network error.

This PR ignores all network-related errors as they do not affect the E2E tests and will only show up in a restricted environment where Google might be blocked.

Instead of completely ignoring the errors, they are now logged as warnings in the console.

CC: @cnrpman please TAL when you have the time :\)

Example output:
```log
WARN:: Failed to load resource: net::ERR_FILE_NOT_FOUND

WARN:: Error with Permissions-Policy header: Unrecognized feature: 'ch-ua-form-factor'.

WARN:: Failed to load resource: net::ERR_CONNECTION_REFUSED
```