### PR TITLE
Fix: Page search is not updated after changing the capitalization of the page name

### DIFF
--- a/e2e-tests/hotkey.spec.ts
+++ b/e2e-tests/hotkey.spec.ts
@@ -1,9 +1,10 @@
 import { expect } from '@playwright/test'
 import { test } from './fixtures'
-import { createRandomPage, enterNextBlock, lastBlock, modKey, IsLinux } from './utils'
+import { createRandomPage, enterNextBlock, lastBlock, modKey, IsLinux, closeSearchBox } from './utils'
 
 test('open search dialog', async ({ page }) => {
   await page.waitForTimeout(200)
+  await closeSearchBox(page)
   await page.keyboard.press(modKey + '+k')
 
   await page.waitForSelector('[placeholder="Search or create page"]')

--- a/e2e-tests/page-rename.spec.ts
+++ b/e2e-tests/page-rename.spec.ts
@@ -67,12 +67,12 @@ test('page rename test', async ({ page }) => {
   // The page name in page search are not updated after changing the capitalization of the page name #9577
   // https://github.com/logseq/logseq/issues/9577
   // Expect the page name to be updated in the search results
-  await page_rename_test(page, "DcBA", "dCBA")
-  const results = await searchPage(page, "DcBA")
+  await page_rename_test(page, "DcBA_", "dCBA_")
+  const results = await searchPage(page, "DcBA_")
   // search result 0 is the new page & 1 is the new whiteboard
   const thirdResultRow = await results[2].innerText()
-  expect(thirdResultRow).toContain("dCBA");
-  expect(thirdResultRow).not.toContain("DcBA");
+  expect(thirdResultRow).toContain("dCBA_");
+  expect(thirdResultRow).not.toContain("DcBA_");
 })
 
 // TODO introduce more samples when #4722 is fixed

--- a/e2e-tests/page-rename.spec.ts
+++ b/e2e-tests/page-rename.spec.ts
@@ -1,6 +1,6 @@
 import { expect, Page } from '@playwright/test'
 import { test } from './fixtures'
-import { createPage, randomLowerString, randomString, renamePage } from './utils'
+import { createPage, randomLowerString, randomString, renamePage, searchPage } from './utils'
 
 /***
  * Test rename feature
@@ -64,6 +64,15 @@ test('page rename test', async ({ page }) => {
   await page_rename_test(page, "abcd", "a.b.c.d")
   await page_rename_test(page, "abcd", "a/b/c/d")
 
+  // The page name in page search are not updated after changing the capitalization of the page name #9577
+  // https://github.com/logseq/logseq/issues/9577
+  // Expect the page name to be updated in the search results
+  await page_rename_test(page, "DcBA", "dCBA")
+  const results = await searchPage(page, "DcBA")
+  // search result 0 is the new page & 1 is the new whiteboard
+  const thirdResultRow = await results[2].innerText()
+  expect(thirdResultRow).toContain("dCBA");
+  expect(thirdResultRow).not.toContain("DcBA");
 })
 
 // TODO introduce more samples when #4722 is fixed

--- a/e2e-tests/page-rename.spec.ts
+++ b/e2e-tests/page-rename.spec.ts
@@ -1,6 +1,6 @@
 import { expect, Page } from '@playwright/test'
 import { test } from './fixtures'
-import { createPage, randomLowerString, randomString, renamePage, searchPage } from './utils'
+import { closeSearchBox, createPage, randomLowerString, randomString, renamePage, searchPage } from './utils'
 
 /***
  * Test rename feature
@@ -73,6 +73,7 @@ test('page rename test', async ({ page }) => {
   const thirdResultRow = await results[2].innerText()
   expect(thirdResultRow).toContain("dCBA_");
   expect(thirdResultRow).not.toContain("DcBA_");
+  await closeSearchBox(page)
 })
 
 // TODO introduce more samples when #4722 is fixed

--- a/e2e-tests/util/search-modal.ts
+++ b/e2e-tests/util/search-modal.ts
@@ -1,9 +1,15 @@
 import { Page, Locator, ElementHandle } from '@playwright/test'
 import { randomString } from './basic'
 
+export async function closeSearchBox(page: Page): Promise<void> {
+    await page.keyboard.press("Escape") // escape (potential) search box typing
+    await page.waitForTimeout(500)
+    await page.keyboard.press("Escape") // escape modal
+}
+
 export async function createRandomPage(page: Page) {
     const randomTitle = randomString(20)
-  
+    await closeSearchBox(page)
     // Click #search-button
     await page.click('#search-button')
     // Fill [placeholder="Search or create page"]
@@ -16,9 +22,10 @@ export async function createRandomPage(page: Page) {
     await page.waitForSelector('textarea >> nth=0', { state: 'visible' })
   
     return randomTitle;
-  }
+}
   
-  export async function createPage(page: Page, page_name: string) {// Click #search-button
+export async function createPage(page: Page, page_name: string) {// Click #search-button
+    await closeSearchBox(page)
     await page.click('#search-button')
     // Fill [placeholder="Search or create page"]
     await page.fill('[placeholder="Search or create page"]', page_name)
@@ -30,30 +37,25 @@ export async function createRandomPage(page: Page) {
     return page_name;
   }
   
-  export async function searchAndJumpToPage(page: Page, pageTitle: string) {
+export async function searchAndJumpToPage(page: Page, pageTitle: string) {
+    await closeSearchBox(page)
     await page.click('#search-button')
     await page.type('[placeholder="Search or create page"]', pageTitle)
     await page.waitForSelector(`[data-page-ref="${pageTitle}"]`, { state: 'visible' })
     page.click(`[data-page-ref="${pageTitle}"]`)
     await page.waitForNavigation()
     return pageTitle;
-  }
-  
-  export async function closeSearchBox(page: Page): Promise<void> {
-    await page.keyboard.press("Escape") // escape (potential) search box typing
-    await page.waitForTimeout(500)
-    await page.keyboard.press("Escape") // escape modal
-  }
+}
 
-  /**
-   * type a search query into the search box
-   * stop at the point where search box shows up
-   * 
-   * @param page the pw page object
-   * @param query the search query to type into the search box
-   * @returns the HTML element for the search results ui
-   */
-  export async function searchPage(page: Page, query: string): Promise<ElementHandle<SVGElement | HTMLElement>[]>{
+/**
+ * type a search query into the search box
+ * stop at the point where search box shows up
+ * 
+ * @param page the pw page object
+ * @param query the search query to type into the search box
+ * @returns the HTML element for the search results ui
+ */
+export async function searchPage(page: Page, query: string): Promise<ElementHandle<SVGElement | HTMLElement>[]>{
     await closeSearchBox(page)
     await page.click('#search-button')
     await page.waitForSelector('[placeholder="Search or create page"]')
@@ -61,4 +63,4 @@ export async function createRandomPage(page: Page) {
     await page.waitForTimeout(2000) // wait longer for search contents to render
   
     return page.$$('#ui__ac-inner>div');
-  }
+}

--- a/e2e-tests/util/search-modal.ts
+++ b/e2e-tests/util/search-modal.ts
@@ -39,6 +39,12 @@ export async function createRandomPage(page: Page) {
     return pageTitle;
   }
   
+  export async function closeSearchBox(page: Page): Promise<void> {
+    await page.keyboard.press("Escape") // escape (potential) search box typing
+    await page.waitForTimeout(500)
+    await page.keyboard.press("Escape") // escape modal
+  }
+
   /**
    * type a search query into the search box
    * stop at the point where search box shows up
@@ -48,16 +54,11 @@ export async function createRandomPage(page: Page) {
    * @returns the HTML element for the search results ui
    */
   export async function searchPage(page: Page, query: string): Promise<ElementHandle<SVGElement | HTMLElement>[]>{
+    await closeSearchBox(page)
     await page.click('#search-button')
     await page.waitForSelector('[placeholder="Search or create page"]')
     await page.type('[placeholder="Search or create page"]', query, { delay: 10 })
     await page.waitForTimeout(2000) // wait longer for search contents to render
   
     return page.$$('#ui__ac-inner>div');
-  }
-  
-  export async function closeSearchBox(page: Page): Promise<void> {
-    await page.keyboard.press("Escape") // escape (potential) search box typing
-    await page.waitForTimeout(500)
-    await page.keyboard.press("Escape") // escape modal
   }

--- a/src/main/frontend/search.cljs
+++ b/src/main/frontend/search.cljs
@@ -260,12 +260,14 @@
   (let [data (:tx-data tx-report)
         datoms (filter
                 (fn [datom]
-                  (contains? #{:block/name :block/content} (:a datom)))
+                  (contains? #{:block/name :block/original-name :block/content} (:a datom)))
                 data)]
     (when (seq datoms)
       (let [datoms (group-by :a datoms)
             blocks (:block/content datoms)
-            pages (:block/name datoms)]
+            pages (concat
+                   (:block/name datoms)
+                   (:block/original-name datoms))]
         (merge (get-blocks-from-datoms-impl blocks)
                (get-pages-from-datoms-impl pages))))))
 

--- a/src/main/frontend/search.cljs
+++ b/src/main/frontend/search.cljs
@@ -261,12 +261,13 @@
   (let [data (:tx-data tx-report)
         datoms (filter
                 (fn [datom]
+                  ;; Capture any direct change on page display title, page ref or block content
                   (contains? #{:block/name :block/original-name :block/content} (:a datom)))
                 data)]
     (when (seq datoms)
       (let [datoms (group-by :a datoms)
             blocks (:block/content datoms)
-            pages (concat
+            pages (concat ;; Duplicated eids are handled in `get-pages-from-datoms-impl`
                    (:block/name datoms)
                    (:block/original-name datoms))]
         (merge (get-blocks-from-datoms-impl blocks)

--- a/src/main/frontend/search.cljs
+++ b/src/main/frontend/search.cljs
@@ -227,7 +227,8 @@
                           (remove string/blank?)
                           (map search-db/original-page-name->index))
         pages-to-remove-set (->> (remove :added pages)
-                                 (map :v))
+                                 (map :v)
+                                 set)
         pages-to-remove-id-set (->> (remove :added pages)
                                     (map :e)
                                     set)]


### PR DESCRIPTION
fix #9577 

The root cause is that the corresponding title indices were not updated when only `:block/origin-name` was updated (i.e., only the title case changed).

The PR fixes `datoms` filtering logic under `get-direct-blocks-and-pages`. Below are some common renaming cases. The cause of this bug is that it didn't care about the transactions with only `:block/origin-name`.

| Case | Renaming |
| --- | --- |
| Only origin-name is updated | apple -> Apple |
| Both name and origin-name are updated | apple -> banana |