### PR TITLE
Fix: shift clicking on "Pages tagged with" page link doesn't open in sidebar

### DIFF
--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -208,8 +208,7 @@
          [:ul.mt-2
           (for [[original-name name] (sort-by last pages)]
             [:li {:key (str "tagged-page-" name)}
-             [:a {:href (rfe/href :page {:name name})}
-              original-name]])]
+             (component-block/page-cp {} {:block/name name :block/original-name original-name})])]
          {:default-collapsed? false})]])))
 
 (rum/defc page-title-editor < rum/reactive


### PR DESCRIPTION
This PR fixes https://github.com/logseq/logseq/issues/8678, fixes #2796, fixes #2848 and fixes #6080

Use the `page-cp` component so that the link behaves the same as other page links in the app

**After**
[Screen recording 2023-06-04 1.33.00 PM.webm](https://github.com/logseq/logseq/assets/11085079/394d4963-e586-4368-87d9-3d6045887d4b)

If there's anything I can help provide for this, please let me know. Thanks!