### PR TITLE
Fix (Whiteboards): Exporting from context menu

### DIFF
--- a/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ContextMenu/ContextMenu.tsx
@@ -21,9 +21,8 @@ export const ContextMenu = observer(function ContextMenu({
   collisionRef,
 }: ContextMenuProps) {
   const app = useApp()
-  const {
-    handlers: { t },
-  } = React.useContext(LogseqContext)
+  const { handlers } = React.useContext(LogseqContext)
+  const t = handlers.t
   const rContent = React.useRef<HTMLDivElement>(null)
 
   const runAndTransition = (f: Function) => {


### PR DESCRIPTION
Fixes a bug introduced on #9567 that doesn't allow us to export images using the whiteboards' context menu.