### PR TITLE
Fix: Alias pages not included in published subgraph

### DIFF
--- a/deps/publishing/test/logseq/publishing/db_test.cljs
+++ b/deps/publishing/test/logseq/publishing/db_test.cljs
@@ -36,7 +36,7 @@
 (deftest filter-only-public-pages-and-blocks
   (let [conn (ldb/start-conn)
         _ (graph-parser/parse-file conn "page1.md" "- b11\n- b12\n- ![awesome.png](../assets/awesome_1648822509908_0.png)")
-        _ (graph-parser/parse-file conn "page2.md" "public:: true\n- b21\n- ![thumb-on-fire.PNG](../assets/thumb-on-fire_1648822523866_0.PNG)")
+        _ (graph-parser/parse-file conn "page2.md" "alias:: page2-alias\npublic:: true\n- b21\n- ![thumb-on-fire.PNG](../assets/thumb-on-fire_1648822523866_0.PNG)")
         _ (graph-parser/parse-file conn "page3.md" "public:: true\n- b31")
         [filtered-db assets] (publish-db/filter-only-public-pages-and-blocks @conn)
         exported-pages (->> (d/q '[:find (pull ?b [*])
@@ -56,6 +56,8 @@
         "Contains all pages that have been marked public")
     (is (not (contains? exported-pages "page1"))
         "Doesn't contain private page")
+    (is (seq (d/entity filtered-db [:block/name "page2-alias"]))
+          "Alias of public page is exported")
     (is (= #{"page2" "page3"} exported-block-pages)
         "Only exports blocks from public pages")
     (is (= ["thumb-on-fire_1648822523866_0.PNG"] assets)


### PR DESCRIPTION
This PR fixes #4143. To reproduce:

1. create a public page with an alias
2. create another public page that has two links, one to the page and one to the page alias
3. Be sure logseq/config.edn has `:publishing/all-pages-public? false`
4. Run `bb dev:publishing ...` to build the publishing app per https://github.com/logseq/logseq/blob/master/docs/dev-practices.md#babashka-tasks
5. The aliased link should correctly redirect to the original page

For these first two steps, you can QA the exact pages I used by using the [logseq-export and logseq-import CLIs](https://github.com/logseq/bb-tasks/tree/main#clis) and the following export.edn content:
```
[#:file{:content
        "public:: true\n\n- https://github.com/logseq/logseq/issues/5280\n\t- [[page 5280]]\n\t- [[page 5280-alias]]",
        :path "journals/2023_06_06.md"}
 #:file{:content "alias:: page 5280-alias\npublic:: true\n\n- content",
        :path "pages/page 5280.md"}]
```