### PR TITLE
Chore: Update lint deps

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -15,6 +15,8 @@
   :aliased-namespace-symbol {:level :warning}
   ;; Disable until it doesn't trigger false positives on rum/defcontext
   :earmuffed-var-not-dynamic {:level :off}
+  ;; Disable until we decide to use conj! as recommended in docs
+  :unused-value {:level :off}
   :unresolved-symbol {:exclude [goog.DEBUG
                                 goog.string.unescapeEntities
                                 ;; TODO:lint: Fix when fixing all type hints

--- a/bb.edn
+++ b/bb.edn
@@ -5,13 +5,13 @@
   logseq/bb-tasks
   #_{:local/root "../bb-tasks"}
   {:git/url "https://github.com/logseq/bb-tasks"
-   :git/sha "4295d5df0458cc06a09c5d506510ee49b785407d"}
+   :git/sha "70d3edeb287f5cec7192e642549a401f7d6d4263"}
   logseq/graph-parser
   {:local/root "deps/graph-parser"}
   org.clj-commons/digest
   {:mvn/version "1.4.100"}}
  :pods
- {clj-kondo/clj-kondo {:version "2022.10.05"}
+ {clj-kondo/clj-kondo {:version "2023.05.26"}
   org.babashka/fswatcher {:version "0.0.3"}}
  :tasks
  {dev:desktop-watch

--- a/deps.edn
+++ b/deps.edn
@@ -54,5 +54,5 @@
                    :main-opts ["-m" "cljs-test-runner.main" "-d" "src/bench" "-n" "frontend.benchmark-test-runner"]}
 
            ;; Use :replace-deps for tools. See https://github.com/clj-kondo/clj-kondo/issues/1536#issuecomment-1013006889
-           :clj-kondo {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2022.12.08"}}
+           :clj-kondo {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2023.05.26"}}
                        :main-opts  ["-m" "clj-kondo.main"]}}}

--- a/deps/common/bb.edn
+++ b/deps/common/bb.edn
@@ -3,10 +3,10 @@
  {logseq/bb-tasks
   #_{:local/root "../../../bb-tasks"}
   {:git/url "https://github.com/logseq/bb-tasks"
-   :git/sha "0d49051909bfa0c6b414e86606d82b4ea54f382c"}}
+   :git/sha "70d3edeb287f5cec7192e642549a401f7d6d4263"}}
 
  :pods
- {clj-kondo/clj-kondo {:version "2023.03.17"}}
+ {clj-kondo/clj-kondo {:version "2023.05.26"}}
 
  :tasks
  {test:load-all-namespaces-with-nbb

--- a/deps/common/deps.edn
+++ b/deps/common/deps.edn
@@ -4,5 +4,5 @@
                        org.clojure/clojurescript {:mvn/version "1.11.54"}}
          :main-opts   ["-m" "cljs-test-runner.main"]}
   :clj-kondo
-  {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2022.12.08"}}
+  {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2023.05.26"}}
    :main-opts  ["-m" "clj-kondo.main"]}}}

--- a/deps/db/bb.edn
+++ b/deps/db/bb.edn
@@ -4,10 +4,10 @@
  {logseq/bb-tasks
   #_{:local/root "../../../bb-tasks"}
   {:git/url "https://github.com/logseq/bb-tasks"
-   :git/sha "1815db538241082a01e95601e23e4290dd64d0c0"}}
+   :git/sha "70d3edeb287f5cec7192e642549a401f7d6d4263"}}
 
  :pods
- {clj-kondo/clj-kondo {:version "2022.10.05"}}
+ {clj-kondo/clj-kondo {:version "2023.05.26"}}
 
  :tasks
  {test:load-all-namespaces-with-nbb

--- a/deps/db/deps.edn
+++ b/deps/db/deps.edn
@@ -3,5 +3,5 @@
  {datascript/datascript {:mvn/version "1.3.8"}}
  :aliases
  {:clj-kondo
-  {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2022.12.08"}}
+  {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2023.05.26"}}
    :main-opts  ["-m" "clj-kondo.main"]}}}

--- a/deps/graph-parser/bb.edn
+++ b/deps/graph-parser/bb.edn
@@ -3,10 +3,10 @@
  {logseq/bb-tasks
   #_{:local/root "../../../bb-tasks"}
   {:git/url "https://github.com/logseq/bb-tasks"
-   :git/sha "1815db538241082a01e95601e23e4290dd64d0c0"}}
+   :git/sha "70d3edeb287f5cec7192e642549a401f7d6d4263"}}
  
  :pods
- {clj-kondo/clj-kondo {:version "2022.10.05"}}
+ {clj-kondo/clj-kondo {:version "2023.05.26"}}
 
  :tasks
  {test:load-all-namespaces-with-nbb

--- a/deps/graph-parser/deps.edn
+++ b/deps/graph-parser/deps.edn
@@ -20,5 +20,5 @@
                        org.clojure/clojurescript {:mvn/version "1.11.54"}}
          :main-opts   ["-m" "cljs-test-runner.main"]}
 
-  :clj-kondo {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2022.12.08"}}
+  :clj-kondo {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2023.05.26"}}
               :main-opts    ["-m" "clj-kondo.main"]}}}

--- a/deps/publishing/bb.edn
+++ b/deps/publishing/bb.edn
@@ -3,10 +3,10 @@
  {logseq/bb-tasks
   #_{:local/root "../../../bb-tasks"}
   {:git/url "https://github.com/logseq/bb-tasks"
-   :git/sha "0d49051909bfa0c6b414e86606d82b4ea54f382c"}}
+   :git/sha "70d3edeb287f5cec7192e642549a401f7d6d4263"}}
 
  :pods
- {clj-kondo/clj-kondo {:version "2023.03.17"}}
+ {clj-kondo/clj-kondo {:version "2023.05.26"}}
 
  :tasks
  {test:load-all-namespaces-with-nbb

--- a/deps/publishing/deps.edn
+++ b/deps/publishing/deps.edn
@@ -3,5 +3,5 @@
  {logseq/db {:local/root "../db"}}
 
  :aliases
- {:clj-kondo {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2023.03.17"}}
+ {:clj-kondo {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2023.05.26"}}
               :main-opts    ["-m" "clj-kondo.main"]}}}

--- a/src/main/frontend/components/shortcut.cljs
+++ b/src/main/frontend/components/shortcut.cljs
@@ -35,7 +35,7 @@
            :on-click (fn []
                        (dh/remove-shortcut k)
                        (shortcut/refresh!)
-                       (swap! *keypress (fn [] ""))          ;; Clear local state
+                       (swap! *keypress (constantly ""))          ;; Clear local state
                        )}
           "Reset"])]]
      [:div.cancel-save-buttons.text-right.mt-4

--- a/src/main/frontend/db/react.cljs
+++ b/src/main/frontend/db/react.cljs
@@ -52,10 +52,10 @@
 (defonce query-state (atom {}))
 
 ;; Current dynamic component
-(def ^:dynamic *query-component*)
+(def ^:dynamic *query-component* nil)
 
 ;; Which reactive queries are triggered by the current component
-(def ^:dynamic *reactive-queries*)
+(def ^:dynamic *reactive-queries* nil)
 
 ;; component -> query-key
 (defonce query-components (atom {}))

--- a/src/main/frontend/extensions/pdf/toolbar.cljs
+++ b/src/main/frontend/extensions/pdf/toolbar.cljs
@@ -21,6 +21,7 @@
 (def *area-dashed? (atom ((fnil identity false) (storage/get (str "ls-pdf-area-is-dashed")))))
 (def *area-mode? (atom false))
 (def *highlight-mode? (atom false))
+#_:clj-kondo/ignore
 (rum/defcontext *highlights-ctx*)
 
 (rum/defc pdf-settings

--- a/src/main/frontend/modules/outliner/tree.cljs
+++ b/src/main/frontend/modules/outliner/tree.cljs
@@ -88,13 +88,16 @@
 
 (defn block-entity->map
   [e]
-  {:db/id (:db/id e)
-   :block/uuid (:block/uuid e)
-   :block/parent {:db/id (:db/id (:block/parent e))}
-   :block/left {:db/id (:db/id (:block/left e))}
-   :block/page (:block/page e)
-   :block/refs (:block/refs e)
-   :block/children (:block/children e)})
+  (cond-> {:db/id (:db/id e)
+           :block/uuid (:block/uuid e)
+           :block/parent {:db/id (:db/id (:block/parent e))}
+           :block/page (:block/page e)}
+    (:db/id (:block/left e))
+    (assoc :block/left {:db/id (:db/id (:block/left e))})
+    (:block/refs e)
+    (assoc :block/refs (:block/refs e))
+    (:block/children e)
+    (assoc :block/children (:block/children e))))
 
 (defn filter-top-level-blocks
   [blocks]

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -284,7 +284,7 @@
                                                              :block-uuid (:block/uuid block)}]))]
       (editor/delete-block! test-helper/test-db false))))
 
-(deftest ^:focus delete-block!
+(deftest delete-block!
   (testing "backspace deletes empty block"
     (load-test-files [{:file/path "pages/page1.md"
                        :file/content "\n

--- a/src/test/frontend/modules/outliner/core_test.cljs
+++ b/src/test/frontend/modules/outliner/core_test.cljs
@@ -245,7 +245,7 @@
                    :db/id 147,
                    :block/parent #:db{:id 144},
                    :block/page #:db{:id 144}}]]
-      (= blocks (outliner-core/fix-top-level-blocks blocks)))))
+      (is (= blocks (outliner-core/fix-top-level-blocks blocks))))))
 
 (deftest test-outdent-blocks
   (testing "
@@ -735,41 +735,42 @@ tags:: tag1, tag2
                  :block/uuid #uuid "62f4b8c6-072e-4133-90e2-0591021a7fea",
                  :block/parent #:db{:id 2333},
                  :db/id 2334}]]
-    (= (tree/non-consecutive-blocks->vec-tree blocks)
-       '({:db/id 2315,
-          :block/uuid #uuid "62f49b4c-f9f0-4739-9985-8bd55e4c68d4",
-          :block/parent #:db{:id 2313},
-          :block/page #:db{:id 2313},
-          :block/level 1,
-          :block/children
-          [{:db/id 2316,
-            :block/uuid #uuid "62f49b4c-aa84-416e-9554-b486b4e59b1b",
-            :block/parent #:db{:id 2315},
-            :block/page #:db{:id 2313},
-            :block/level 2,
-            :block/children
-            [{:db/id 2317,
-              :block/uuid #uuid "62f49b4c-f80c-49b4-ae83-f78c4520c071",
-              :block/parent #:db{:id 2316},
-              :block/page #:db{:id 2313},
-              :block/level 3,
-              :block/children
-              [{:db/id 2318,
-                :block/uuid #uuid "62f49b4c-8f5b-4a04-b749-68d34b28bcf2",
-                :block/parent #:db{:id 2317},
-                :block/page #:db{:id 2313},
-                :block/level 4}]}]}
-           {:db/id 2333,
-            :block/uuid #uuid "62f4b8c1-a99b-434f-84c3-011d6afc48ba",
-            :block/parent #:db{:id 2315},
-            :block/page #:db{:id 2313},
-            :block/level 2,
-            :block/children
-            [{:db/id 2334,
-              :block/uuid #uuid "62f4b8c6-072e-4133-90e2-0591021a7fea",
-              :block/parent #:db{:id 2333},
-              :block/page #:db{:id 2313},
-              :block/level 3}]}]}))))
+    (is
+     (= (tree/non-consecutive-blocks->vec-tree blocks)
+        '({:db/id 2315,
+           :block/uuid #uuid "62f49b4c-f9f0-4739-9985-8bd55e4c68d4",
+           :block/parent #:db{:id 2313},
+           :block/page #:db{:id 2313},
+           :block/level 1,
+           :block/children
+           [{:db/id 2316,
+             :block/uuid #uuid "62f49b4c-aa84-416e-9554-b486b4e59b1b",
+             :block/parent #:db{:id 2315},
+             :block/page #:db{:id 2313},
+             :block/level 2,
+             :block/children
+             [{:db/id 2317,
+               :block/uuid #uuid "62f49b4c-f80c-49b4-ae83-f78c4520c071",
+               :block/parent #:db{:id 2316},
+               :block/page #:db{:id 2313},
+               :block/level 3,
+               :block/children
+               [{:db/id 2318,
+                 :block/uuid #uuid "62f49b4c-8f5b-4a04-b749-68d34b28bcf2",
+                 :block/parent #:db{:id 2317},
+                 :block/page #:db{:id 2313},
+                 :block/level 4}]}]}
+            {:db/id 2333,
+             :block/uuid #uuid "62f4b8c1-a99b-434f-84c3-011d6afc48ba",
+             :block/parent #:db{:id 2315},
+             :block/page #:db{:id 2313},
+             :block/level 2,
+             :block/children
+             [{:db/id 2334,
+               :block/uuid #uuid "62f4b8c6-072e-4133-90e2-0591021a7fea",
+               :block/parent #:db{:id 2333},
+               :block/page #:db{:id 2313},
+               :block/level 3}]}]})))))
 
 (comment
   (dotimes [i 5]

--- a/src/test/frontend/util/clocktime_test.cljs
+++ b/src/test/frontend/util/clocktime_test.cljs
@@ -14,4 +14,4 @@
                [0, 17, 45, 53],
                [5, 14, 41, 22],
                [27, 17, 8, 23]]]
-    (map #(is (= (clock/s->dhms-util %1) %2)) inputs want)))
+    (mapv #(is (= (clock/s->dhms-util %1) %2)) inputs want)))


### PR DESCRIPTION
This PR updates our clj-kondo and logseq/bb-tasks deps used for linting. Looking [through clj-kondo's changelog](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md), there aren't any breaking changes that effect us and there are a few new linters. One new linter catches tests without assertions which is handy and caught a couple of our tests that accidentally didn't test anything