### PR TITLE
Fix NEXT query

### DIFF
--- a/src/resources/templates/config.edn
+++ b/src/resources/templates/config.edn
@@ -231,7 +231,7 @@
             :where
             [?h :block/marker ?marker]
             [(contains? #{"NOW" "LATER" "TODO"} ?marker)]
-            [?h :block/page ?p]
+            [?h :block/ref-pages ?p]
             [?p :block/journal? true]
             [?p :block/journal-day ?d]
             [(> ?d ?start)]


### PR DESCRIPTION
The NEXT query is not shown in today's journal. After replacing `:block/page` with `:block/ref-pages` it is displayed.

<img width="895" alt="Screenshot 2023-06-12 at 11 07 12" src="https://github.com/logseq/logseq/assets/7611700/15506ac8-fdec-43f7-a963-3e3b74d967d9">
