### PR TITLE
fix(ux): make linked references filters reactive when the page properties changed

### DIFF
--- a/src/main/frontend/components/reference.cljs
+++ b/src/main/frontend/components/reference.cljs
@@ -244,7 +244,7 @@
                      frequencies)]
       (reset! *ref-pages ref-pages)
       (when (or (seq filter-state) (> filter-n 0))
-        [:div.references.page-linked.flex-1.flex-row.border.rounded-xl.p-6
+        [:div.references.page-linked.flex-1.flex-row
          (sub-page-properties-changed page-name page-props-v filters-atom)
          [:div.content.pt-6
           (references-cp page-name filters filters-atom filter-state total filter-n filtered-ref-blocks' *ref-pages)]]))))

--- a/src/main/frontend/components/reference.cljs
+++ b/src/main/frontend/components/reference.cljs
@@ -183,16 +183,25 @@
             (concat children (rest blocks))
             (conj result fb))))))))
 
+(rum/defc sub-page-properties-changed < rum/static
+  [page-name v filters-atom]
+  (rum/use-effect!
+    (fn []
+      (reset! filters-atom
+              (page-handler/get-filters (util/page-name-sanity-lc page-name))))
+    [page-name v filters-atom])
+  [:<>])
+
 (rum/defcs references* < rum/reactive db-mixins/query
   (rum/local nil ::ref-pages)
   {:init (fn [state]
            (let [page-name (first (:rum/args state))
-                 filters (when page-name
-                           (atom (page-handler/get-filters (util/page-name-sanity-lc page-name))))]
+                 filters (when page-name (atom nil))]
              (assoc state ::filters filters)))}
   [state page-name]
   (when page-name
     (let [page-name (util/page-name-sanity-lc page-name)
+          page-props-v (state/sub-page-properties-changed page-name)
           *ref-pages (::ref-pages state)
           repo (state/get-current-repo)
           filters-atom (get state ::filters)
@@ -235,7 +244,8 @@
                      frequencies)]
       (reset! *ref-pages ref-pages)
       (when (or (seq filter-state) (> filter-n 0))
-        [:div.references.page-linked.flex-1.flex-row
+        [:div.references.page-linked.flex-1.flex-row.border.rounded-xl.p-6
+         (sub-page-properties-changed page-name page-props-v filters-atom)
          [:div.content.pt-6
           (references-cp page-name filters filters-atom filter-state total filter-n filtered-ref-blocks' *ref-pages)]]))))
 

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -137,6 +137,7 @@
 
      :editor/code-block-context             {}
 
+     :db/properties-changed-pages           {}
      :db/last-transact-time                 {}
      ;; whether database is persisted
      :db/persisted?                         {}
@@ -2183,3 +2184,13 @@ Similar to re-frame subscriptions"
 (defn clear-user-info!
   []
   (storage/remove :user-groups))
+
+(defn set-page-properties-changed!
+  [page-name]
+  (when-not (string/blank? page-name)
+    (update-state! [:db/properties-changed-pages page-name] #(inc %))))
+
+(defn sub-page-properties-changed
+  [page-name]
+  (when-not (string/blank? page-name)
+    (sub [:db/properties-changed-pages page-name])))


### PR DESCRIPTION
## Before

https://github.com/logseq/logseq/assets/1779837/77a9ccfc-cad3-4c0b-95c0-ef8ad9a1753f

## After

https://github.com/logseq/logseq/assets/1779837/89488b6b-4219-4e40-8199-07d6ff5fb928

