### PR TITLE
Fix paste text to link

### DIFF
--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -126,7 +126,7 @@
                                    (get-whiteboard-tldr-from-text html))
                           ;; text should always be prepared block-ref generated in tldr
                           text)
-        {:keys [value selection] :as selection-and-format} (editor-handler/get-selection-and-format)
+        {:keys [selection] :as selection-and-format} (editor-handler/get-selection-and-format)
         text-url? (gp-util/url? text)
         selection-url? (gp-util/url? selection)]
     (cond
@@ -139,9 +139,8 @@
           (and text-url? selection-url?))
       (replace-text-f text)
 
-      ;; Pastes a formatted link over selected text
-      (and (or text-url?
-               (and value (gp-util/url? (string/trim value))))
+      ;; Paste a formatted link over selected text or paste text over a selected formatted link
+      (and (or text-url? selection-url?)
            (not (string/blank? (util/get-selected-text))))
       (editor-handler/html-link-format! text)
 

--- a/src/test/frontend/handler/paste_test.cljs
+++ b/src/test/frontend/handler/paste_test.cljs
@@ -122,6 +122,28 @@
           (is (= expected-paste result))
           (reset))))))
 
+(deftest-async editor-on-paste-with-text-over-link
+  (testing "Paste text over a selected formatted link"
+    (let [actual-text (atom nil)
+          clipboard "logseq"
+          selected-text "https://logseq.com"
+          block-content (str selected-text " is awesome")
+          expected-paste "[logseq](https://logseq.com) is awesome"]
+      (test-helper/with-reset
+        reset
+        [;; paste-copied-blocks-or-text mocks below
+         util/stop (constantly nil)
+         util/get-selected-text (constantly selected-text)
+         editor-handler/get-selection-and-format
+         (constantly {:selection-start 0 :selection-end (count selected-text)
+                      :selection selected-text :format :markdown :value block-content})
+         state/set-edit-content! (fn [_ new-value] (reset! actual-text new-value))
+         cursor/move-cursor-to (constantly nil)]
+        (p/let [_ ((paste-handler/editor-on-paste! nil)
+                   #js {:clipboardData #js {:getData (constantly clipboard)}})]
+          (is (= expected-paste @actual-text))
+          (reset))))))
+
 (deftest-async editor-on-paste-with-selected-text-and-special-link
   (testing "Formatted paste with special link on selected text pastes a formatted link"
     (let [actual-text (atom nil)


### PR DESCRIPTION
If you paste some text over a link, it should transfer the link to named link. However, if the content of the block does not only contain a link, this process will fail now, this PR fix that.

How to reproduce:
https://www.loom.com/share/3ad28e87363e42238c7b7397a5d6538e