### PR TITLE
fix: clicking to edit a block from the right sidebar or a whiteboard can't jump to the correct position

### DIFF
--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -1,7 +1,7 @@
 .block-content-wrapper {
   /* 38px is the width of block-control */
   width: calc(100% - 22px);
-
+  user-select: text;
   @screen sm {
     width: calc(100% - 33px);
     overflow-x: visible;

--- a/tldraw/apps/tldraw-logseq/src/styles.css
+++ b/tldraw/apps/tldraw-logseq/src/styles.css
@@ -32,6 +32,10 @@
   user-select: none;
 }
 
+.logseq-tldraw .block-content-wrapper * {
+  user-select: text;
+}
+
 .dark-theme,
 html[data-theme='dark'] {
   --ls-wb-background-color-gray: var(--color-gray-800, gray);


### PR DESCRIPTION
This PR fixes an annoying bug: clicking to edit a block from the right sidebar or a whiteboard can't jump to the correct position.

The cause is `user-select: none`, I changed it to `text`.

To reproduce, you can open or create a block in either the right sidebar or a whiteboard and click a middle position (end position sometimes works).