### PR TITLE
enhance: pub-event! returns a promise

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1874,8 +1874,8 @@
       (and (= content "1. ") (= last-input-char " ") input-id edit-block
            (not (own-order-number-list? edit-block)))
       (p/do!
-        (state/pub-event! [:editor/toggle-own-number-list edit-block])
-        (state/set-edit-content! input-id ""))
+       (state/pub-event! [:editor/toggle-own-number-list edit-block])
+       (state/set-edit-content! input-id ""))
 
       (and (= last-input-char commands/command-trigger)
            (or (re-find #"(?m)^/" (str (.-value input))) (start-of-new-word? input pos)))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1873,10 +1873,9 @@
     (cond
       (and (= content "1. ") (= last-input-char " ") input-id edit-block
            (not (own-order-number-list? edit-block)))
-      (do
-        (state/set-edit-content! input-id "")
-        (-> (p/delay 10)
-            (p/then #(state/pub-event! [:editor/toggle-own-number-list edit-block]))))
+      (p/do!
+        (state/pub-event! [:editor/toggle-own-number-list edit-block])
+        (state/set-edit-content! input-id ""))
 
       (and (= last-input-char commands/command-trigger)
            (or (re-find #"(?m)^/" (str (.-value input))) (start-of-new-word? input pos)))

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -952,8 +952,7 @@
       (when-let [block (cond-> blocks batch? (first))]
         (if (editor-handler/own-order-number-list? block)
           (editor-handler/remove-block-own-order-list-type! block)
-          (editor-handler/make-block-as-own-order-list! block))))
-    :test))
+          (editor-handler/make-block-as-own-order-list! block))))))
 
 (defmethod handle :editor/remove-own-number-list [[_ block]]
   (when (some-> block (editor-handler/own-order-number-list?))

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -976,7 +976,6 @@
                    (p/resolve! d result)))
          (p/catch (fn [error]
                     (let [type :handle-system-events/failed]
-                      (js/console.error (str type) (clj->js payload) "\n" error)
                       (state/pub-event! [:capture-error {:error error
                                                          :payload {:type type
                                                                    :payload payload}}])

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -760,7 +760,7 @@ Similar to re-frame subscriptions"
   (when-let [graphs (seq (get-in @state [:file-sync/remote-graphs :graphs]))]
     (some #(when (= (:GraphUUID %) (str uuid)) %) graphs)))
 
-(defn get-remote-graph-usage 
+(defn get-remote-graph-usage
   []
   (when-let [graphs (seq (get-in @state [:file-sync/remote-graphs :graphs]))]
     (->> graphs
@@ -1721,8 +1721,10 @@ Similar to re-frame subscriptions"
 (defn pub-event!
   {:malli/schema [:=> [:cat vector?] :any]}
   [payload]
-  (let [chan (get-events-chan)]
-    (async/put! chan payload)))
+  (let [d (p/deferred)
+        chan (get-events-chan)]
+    (async/put! chan [payload d])
+    d))
 
 (defn get-export-block-text-indent-style []
   (:copy/export-block-text-indent-style @state))


### PR DESCRIPTION
This PR returns a promise for `(state/pub-event!)` so we can block waiting for the result and do other things.

It fixed the bug that typing `1. ` sometimes can result in `1. 1.`.

To reproduce it:
1. create a new block and type `1.`
2. wait for two seconds (the block will be saved automatically)
3. press `space`
Notice that the block is ordered now, but its content still has `1.`.