### PR TITLE
Fix: Fix broken reactivity of certain queries [WIP]

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1240,7 +1240,7 @@
 (defn- macro-function-cp
   [config arguments]
   (or
-   (some-> (:query-result config) rum/react (block-macros/function-macro arguments))
+   (some-> (:query-function-result config) rum/react (block-macros/function-macro arguments))
    [:span.warning
     (util/format "{{function %s}}" (first arguments))]))
 
@@ -2705,16 +2705,30 @@
        (= (:id config)
           (str (:block/uuid block)))))
 
-(rum/defc ^:large-vars/cleanup-todo block-container-inner < rum/reactive db-mixins/query
-  [state repo config block]
-  (let [ref? (:ref? config)
-        custom-query? (boolean (:custom-query? config))
-        ref-or-custom-query? (or ref? custom-query?)
-        *navigating-block (get state ::navigating-block)
-        navigating-block (rum/react *navigating-block)
-        navigated? (and (not= (:block/uuid block) navigating-block) navigating-block)
-        block (if (or (and custom-query?
-                           (empty? (:block/children block))
+(defn- build-config [config block {:keys [navigating-block navigated?]}]
+  (cond-> config
+    navigated?
+    (assoc :id (str navigating-block))
+
+    true
+    (update :block merge block)
+
+    ;; Each block might have multiple queries, but we store only the first
+    ;; query's result
+    (nil? (:query-result config))
+    (assoc :query-result (atom nil))
+
+    ;; Store block's first query result for use with {{function}}.
+    ;; Independent of :query-result to avoid reactive bugs
+    (nil? (:query-function-result config))
+    (assoc :query-function-result (atom nil))
+
+    (:ref? config)
+    (block-handler/attach-order-list-state block)))
+
+(defn- build-block [repo config block* {:keys [navigating-block navigated?]}]
+  (let [block (if (or (and (:custom-query? config)
+                           (empty? (:block/children block*))
                            (not (and (:dsl-query? config)
                                      (string/includes? (:query config) "not"))))
                       navigated?)
@@ -2723,21 +2737,26 @@
                                                       {:scoped-block-id (:db/id block)})
                       tree (tree/blocks->vec-tree blocks (:block/uuid (first blocks)))]
                   (first tree))
-                block)
-        block (if ref?
-                (merge block (db/sub-block (:db/id block)))
-                block)
-        {:block/keys [uuid children pre-block? refs level format content properties]} block
+                block*)
+        {:block/keys [pre-block? format content] :as block'}
+        (if (:ref? config)
+          (merge block (db/sub-block (:db/id block)))
+          block)]
+    (merge block' (block/parse-title-and-body uuid format pre-block? content))))
+
+(rum/defc ^:large-vars/cleanup-todo block-container-inner < rum/reactive db-mixins/query
+  [state repo config* block*]
+  (let [ref? (:ref? config*)
+        custom-query? (boolean (:custom-query? config*))
+        ref-or-custom-query? (or ref? custom-query?)
+        *navigating-block (get state ::navigating-block)
+        navigating-block (rum/react *navigating-block)
+        navigated? (and (not= (:block/uuid block*) navigating-block) navigating-block)
+        block (build-block repo config* block* {:navigating-block navigating-block :navigated? navigated?})
+        {:block/keys [uuid children pre-block? refs level content properties]} block
         {:block.temp/keys [top?]} block
-        config (if navigated? (assoc config :id (str navigating-block)) config)
-        block (merge block (block/parse-title-and-body uuid format pre-block? content))
+        config (build-config config* block {:navigated? navigated? :navigating-block navigating-block})
         blocks-container-id (:blocks-container-id config)
-        config (update config :block merge block)
-        ;; Each block might have multiple queries, but we store only the first query's result
-        config (if (nil? (:query-result config))
-                 (assoc config :query-result (atom nil))
-                 config)
-        config (if ref? (block-handler/attach-order-list-state config block) config)
         heading? (:heading properties)
         *control-show? (get state ::control-show?)
         db-collapsed? (util/collapsed? block)

--- a/src/main/frontend/components/query/result.cljs
+++ b/src/main/frontend/components/query/result.cljs
@@ -80,7 +80,7 @@
                          (dissoc result nil)
                          result))
                      transformed-query-result)]
-        (when-let [query-result (:query-result config)]
+        (when-let [query-result (:query-function-result config)]
           (reset! query-result result))
         (when query-atom
           (util/safe-with-meta result (meta @query-atom))))))

--- a/src/test/frontend/components/query/result_test.cljs
+++ b/src/test/frontend/components/query/result_test.cljs
@@ -78,8 +78,8 @@
 
 (deftest get-query-result-sets-result-in-config
   (let [result [{:db/id 1 :block/content "parent" :block/uuid 1}]
-        config {:query-result (atom nil)}]
+        config {:query-function-result (atom nil)}]
     (is (= result
            (mock-get-query-result result {} {:table? true :config config})))
-    (is (= result @(:query-result config))
-        "Result is set in config for downstream use e.g. query table fn")))
+    (is (= result @(:query-function-result config))
+        "Result is set in config for downstream use e.g. query fn")))


### PR DESCRIPTION
This PR fixes #9670, fixes #9656 and fixes #9679. This was caused by [this two line change](https://github.com/logseq/logseq/pull/9563/files#diff-a4926f5508c1b552480ec764f1e319f3f43e119b1bfe1a28afad18357f8545e4). For now the solution is to avoid touching the :query-result atom and instead use a separate atom for the query function

* [ ] Fully understand the fix
* [ ] Add a regression test

