### PR TITLE
fix: disable content selection when blocks have been selected

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -867,7 +867,8 @@
         (let [title [:span.block-ref
                      (block-content (assoc config :block-ref? true :stop-events? stop-inner-events?)
                                     block nil (:block/uuid block)
-                                    (:slide? config))]
+                                    (:slide? config)
+                                    false)]
               inner (if label
                       (->elem
                        :span.block-ref

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -872,7 +872,7 @@
         has-next? (< current total-pages)
         prev-page (if (= 1 current) 1 (dec current))
         next-page (if (= total-pages current) total-pages (inc current))]
-    [:div.flex.items-center.noselect
+    [:div.flex.items-center.select-none
      (when has-prev?
        [[:a.fade-link.flex
          {:on-click #(on-change 1)}


### PR DESCRIPTION
Bug:
<img width="394" alt="CleanShot 2023-06-21 at 18 38 25@2x" src="https://github.com/logseq/logseq/assets/479169/1ee8b2a5-f9e5-46c0-b554-85b6c8fb413d">
