### PR TITLE
Fix (Whiteboards): Skip snapping to preserve aspect ratio

### DIFF
--- a/tldraw/packages/core/src/lib/tools/TLBoxTool/states/CreatingState.tsx
+++ b/tldraw/packages/core/src/lib/tools/TLBoxTool/states/CreatingState.tsx
@@ -69,17 +69,18 @@ export class CreatingState<
     if (!this.creatingShape) throw Error('Expected a creating shape.')
     const { initialBounds } = this
     const { currentPoint, originPoint, shiftKey } = this.app.inputs
+    const isAspectRatioLocked = shiftKey ||
+      this.creatingShape.props.isAspectRatioLocked ||
+      !this.creatingShape.canChangeAspectRatio
     let bounds = BoundsUtils.getTransformedBoundingBox(
       initialBounds,
       TLResizeCorner.BottomRight,
       Vec.sub(currentPoint, originPoint),
       0,
-      shiftKey ||
-        this.creatingShape.props.isAspectRatioLocked ||
-        !this.creatingShape.canChangeAspectRatio
+      isAspectRatioLocked
     )
 
-    if (this.app.settings.snapToGrid) {
+    if (this.app.settings.snapToGrid && !isAspectRatioLocked) {
       bounds = BoundsUtils.snapBoundsToGrid(bounds, GRID_SIZE)
     }
 

--- a/tldraw/packages/core/src/lib/tools/TLSelectTool/states/ResizingState.ts
+++ b/tldraw/packages/core/src/lib/tools/TLSelectTool/states/ResizingState.ts
@@ -218,7 +218,7 @@ export class ResizingState<
       //   relativeBounds = BoundsUtils.centerBounds(relativeBounds, center)
       // }
 
-      if (this.app.settings.snapToGrid) {
+      if (this.app.settings.snapToGrid && !isAspectRatioLocked) {
         relativeBounds = BoundsUtils.snapBoundsToGrid(relativeBounds, GRID_SIZE)
       }
 


### PR DESCRIPTION
When we scale shapes with locked aspect ratio (e.g. images, videos), or when we hold the shift key while creating geometric shapes, the aspect ratio needs to be preserved. Combining snapping while resizing with locked aspect ratio is possible. This PR will just skip snapping for now, to avoid messing with existing proportions, until we have a better solution.