### PR TITLE
enhance(plugin API): Add support for ES Modules in loadScripts method

### DIFF
--- a/libs/src/modules/LSPlugin.Experiments.ts
+++ b/libs/src/modules/LSPlugin.Experiments.ts
@@ -40,7 +40,20 @@ export class LSPluginExperiments {
     })
 
     scripts.unshift(this.ctx.baseInfo.id)
-    await this.invokeExperMethod('loadScripts', ...scripts)
+
+    // Load the remaining scripts with the original method
+    await this.invokeExperMethod('loadScripts', ...scripts);
+
+    // Load all .mjs scripts with import()
+    const modulePromises = scripts
+      .filter(script => script.endsWith('.mjs'))
+      .map(script => import(script));
+
+    // Wait for all .mjs scripts to be loaded
+    const modules = await Promise.allSettled(modulePromises);
+
+    // Return the modules for further use if necessary
+    return modules;
   }
 
   registerFencedCodeRenderer(


### PR DESCRIPTION
This pull request adds support for ES Modules (`.mjs` files) in the `loadScripts` method of the `logseq.Experiments` class. 

Previously, the method only supported loading regular JavaScript files. However, some plugin developers may want to import `.mjs` files as well. This update allows them to do so.

The changes include checking the file extension of each script and using dynamic import (`import()`) for `.mjs` files while keeping the original loading method for regular JavaScript files. The scripts are loaded concurrently and in the order they appear in the `scripts` array.

This enhancement allows plugin developers to take advantage of ES Modules and makes the `loadScripts` method more versatile and future-proof.


CC: @xyhp915 