### PR TITLE
Use flex-col for schedule modal on smaller screens

### DIFF
--- a/src/main/frontend/components/datetime.cljs
+++ b/src/main/frontend/components/datetime.cljs
@@ -152,7 +152,7 @@
                                               (string/lower-case current-command)))
         date (state/sub :date-picker/date)]
     [:div#date-time-picker.flex.flex-col.sm:flex-row {:on-click (fn [e] (util/stop e))
-                                          :on-mouse-down (fn [e] (.stopPropagation e))}
+                                                      :on-mouse-down (fn [e] (.stopPropagation e))}
      (ui/datepicker
       date
       {:deadline-or-schedule? deadline-or-schedule?

--- a/src/main/frontend/components/datetime.cljs
+++ b/src/main/frontend/components/datetime.cljs
@@ -151,7 +151,7 @@
                                    (contains? #{"deadline" "scheduled"}
                                               (string/lower-case current-command)))
         date (state/sub :date-picker/date)]
-    [:div#date-time-picker.flex.flex-row {:on-click (fn [e] (util/stop e))
+    [:div#date-time-picker.flex.flex-col.sm:flex-row {:on-click (fn [e] (util/stop e))
                                           :on-mouse-down (fn [e] (.stopPropagation e))}
      (ui/datepicker
       date

--- a/src/main/frontend/components/editor.css
+++ b/src/main/frontend/components/editor.css
@@ -77,10 +77,10 @@ pre {
 }
 
 #time-repeater {
-  width: 135px;
+  min-width: 300px;
 
   @screen sm {
-    min-width: 300px;
+    width: 135px;
   }
 }
 


### PR DESCRIPTION
# Issue 
As a Logseq user on mobile I noticed that the schedule modal is very scrunched when setting repeater. I was unable to see what was in the inputs.

# Fix
- Use tailwind classes `flex-col.sm:flex-row`
(uses `flex-direction: column` for small screens, `flex-direction: row` for anything larger)
- Fix small width stying rules in `editor.css`

## before PR on mobile-sized screen
<img width="290" alt="Screenshot 2023-06-30 at 8 40 45 PM" src="https://github.com/logseq/logseq/assets/1904364/5e952def-6f0e-4d32-b960-9ef42662250e">

## after PR
<img width="284" alt="Screenshot 2023-06-30 at 8 34 12 PM" src="https://github.com/logseq/logseq/assets/1904364/0129bf1d-5679-4370-89f5-3de0928f0fb9">

Thank you for your consideration
