### PR TITLE
fix(ui): Issue#9315 - About dialog shows the version number twice (MacOS)

### DIFF
--- a/resources/forge.config.js
+++ b/resources/forge.config.js
@@ -4,6 +4,7 @@ module.exports = {
   packagerConfig: {
     name: 'Logseq',
     icon: './icons/logseq_big_sur.icns',
+    buildVersion: 63,
     protocols: [
       {
         "protocol": "logseq",

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -34,7 +34,7 @@ V_PATCH=${BASE_LIST[2]}
 
 echo -e "${NOTICE_FLAG} Current version: ${WHITE}$BASE_VERSION"
 echo -e "${NOTICE_FLAG} Latest commit hash: ${WHITE}$LATEST_HASH"
-echo -e "${NOTICE_FLAG} Current versionCode(Android): ${WHITE}$VERSION_CODE"
+echo -e "${NOTICE_FLAG} Current versionCode(Android) / buildVersion(MacOS): ${WHITE}$VERSION_CODE"
 
 # V_MINOR=$((V_MINOR + 1))
 # V_PATCH=0
@@ -50,7 +50,7 @@ fi
 NEW_VERSION_CODE=$(($VERSION_CODE + 1))
 
 echo -e "${NOTICE_FLAG} Will set new version to be ${WHITE}$INPUT_STRING"
-echo -e "${NOTICE_FLAG} Will set new versionCode to be ${WHITE}$VERSION_CODE"
+echo -e "${NOTICE_FLAG} Will set new versionCode to be ${WHITE}$NEW_VERSION_CODE"
 
 NEW_VERSION=$INPUT_STRING
 
@@ -58,6 +58,7 @@ $SED -i 's/defonce version ".*"/defonce version "'${NEW_VERSION}'"/g' src/main/f
 $SED -i 's/"version": ".*"/"version": "'${NEW_VERSION}'"/g' resources/package.json
 $SED -i 's/versionName ".*"/versionName "'${NEW_VERSION}'"/g' android/app/build.gradle
 $SED -i 's/versionCode .*/versionCode '${NEW_VERSION_CODE}'/g' android/app/build.gradle
+$SED -i 's/buildVersion: .*/buildVersion: '${NEW_VERSION_CODE}',/g' resources/forge.config.js
 $SED -i 's/MARKETING_VERSION = .*;/MARKETING_VERSION = '${NEW_VERSION}';/g' ios/App/App.xcodeproj/project.pbxproj
 
 git --no-pager diff -U0


### PR DESCRIPTION
The version number "isn't" displayed twice.  Since Logseq is using the native about dialog, what we see is the version number follow by the build number between parentheses: "Version Number (Build Number)".

By default, Electron Forge will use the same value for the version number and the build number unless we specify otherwise.

In this pull request, I added the required configuration to have a build version in the release.  Since there is already a "Code version" in the codebase, I choose to use the same number to keep thing simple.

Apple Documentation on Version Numbers and Build Numbers : 
https://developer.apple.com/library/archive/technotes/tn2420/_index.html


BONUS: The bump-version.sh script displayed the old Code Version (line 53) instead of the new one.  I fix that as well.