### PR TITLE
chore(deps): update capacitor-diff-merge; fix android parameter check

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         "@capawesome/capacitor-background-task": "^2.0.0",
         "@excalidraw/excalidraw": "0.12.0",
         "@hugotomazi/capacitor-navigation-bar": "^2.0.0",
-        "@logseq/capacitor-file-sync": "0.0.31",
+        "@logseq/capacitor-file-sync": "0.0.32",
         "@logseq/diff-merge": "0.1.0",
         "@logseq/react-tweet-embed": "1.3.1-1",
         "@radix-ui/colors": "^0.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,10 +486,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@logseq/capacitor-file-sync@0.0.31":
-  version "0.0.31"
-  resolved "https://registry.yarnpkg.com/@logseq/capacitor-file-sync/-/capacitor-file-sync-0.0.31.tgz#c35915bc31c60584c683c9ccc259d42ad121a46a"
-  integrity sha512-2JCj9PjxgHBfCIBlbedwBhk/JnEm8bCMo26z5UetFzbO7WA8b5XBGTu7tXgSURhf6F3JRAeCvbBhI00oHrflkQ==
+"@logseq/capacitor-file-sync@0.0.32":
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/@logseq/capacitor-file-sync/-/capacitor-file-sync-0.0.32.tgz#fcb978e5e62f1b61a8ac22e57d5e96a39adffa7a"
+  integrity sha512-WA0O+NAHJkZZTXqCRDXFRW9VNADsXJXBoMGuMnPimenxoZimpqgX3awT30AcIWxRppLz/H9vFumQyZF10rojTA==
 
 "@logseq/diff-merge@0.1.0":
   version "0.1.0"


### PR DESCRIPTION
Somehow, under bad network connection, a null is passed in.

See-also: https://github.com/logseq/capacitor-file-sync/commit/304758ea75b51eae9a241da199eca7911331d055

Related: #9790