### PR TITLE
chore(deps): bump CodeMirror from 5.58.1 to 5.65.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "check-password-strength": "2.0.7",
         "chokidar": "3.5.1",
         "chrono-node": "2.2.4",
-        "codemirror": "5.58.1",
+        "codemirror": "5.65.13",
         "d3-force": "3.0.0",
         "diff": "5.0.0",
         "dompurify": "2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1965,10 +1965,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==
 
-codemirror@5.58.1:
-  version "5.58.1"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.58.1.tgz#ec6bf38ad2a17f74c61bd00cc6dc5a69bd167854"
-  integrity sha512-UGb/ueu20U4xqWk8hZB3xIfV2/SFqnSLYONiM3wTMDqko0bsYrsAkGGhqUzbRkYm89aBKPyHtuNEbVWF9FTFzw==
+codemirror@5.65.13:
+  version "5.65.13"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.65.13.tgz#c098a6f409db8b5a7c5722788bd9fa3bb2367f2e"
+  integrity sha512-SVWEzKXmbHmTQQWaz03Shrh4nybG0wXx2MEu3FO4ezbPW8IbnZEd5iGHGEffSUaitKYa3i+pHpBsSvw8sPHtzg==
 
 collection-map@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
codemirror v5.65.15 is the last version of codemirror 5. There are no breaking changes between the two releases.

changelog:
https://codemirror.net/5/doc/releases.html

codemirror v6 contains breaking changes (not tested w/ logseq)
https://codemirror.net/docs/migration/