### PR TITLE
FIX(editor): Fix delete character which has more than one UTF-16 code unit using `Delete` key. close  the issue #9834

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2696,7 +2696,8 @@
             (delete-concat current-block)))
 
         :else
-        (delete-and-update input current-pos (inc current-pos))))))
+        (delete-and-update 
+          input current-pos (util/safe-inc-current-pos-from-end (.-value input) current-pos))))))
 
 (defn keydown-backspace-handler
   [cut? e]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2697,7 +2697,7 @@
 
         :else
         (delete-and-update 
-          input current-pos (util/safe-inc-current-pos-from-end (.-value input) current-pos))))))
+          input current-pos (util/safe-inc-current-pos-from-start (.-value input) current-pos))))))
 
 (defn keydown-backspace-handler
   [cut? e]


### PR DESCRIPTION
Fix delete character which has more than one UTF-16 code unit using `Delete` key. close the issue #9834

such as delete 🤔(U+1F914), 𠀅(U+20005) using `Delete` will not get � , instead a empty string ""

> **Note**
>I haven't build app locally to test the issue is fixed realy, but i think it's enough according to #3822 