### PR TITLE
Fix positioning of swipe-left action bar on iOS mobile app

### DIFF
--- a/src/main/frontend/mobile/index.css
+++ b/src/main/frontend/mobile/index.css
@@ -28,7 +28,7 @@
 }
 
 .action-bar {
-  position: absolute;
+  position: fixed;
   bottom: 100px;
   height: 70px;
   padding: 6px;


### PR DESCRIPTION
# Issue
In the iOS mobile app, the swipe-left action menu would not adjust to the page's vertical scroll. The mobile web view seems to treat `position: absolute` differently than a normal mobile web browser

## Steps to Reproduce
- Create a page long enough that it needs to scroll the content
- Choose a block toward the bottom of the page (such that the page is scrolled down)
- Swipe left to trigger the mobile action-bar buttons
- At first it appears nothing happened, I cannot see the mobile action-bar
  - But if I scroll up I see that it is actually just higher up on the page
  - Appears to be positioned where it should be if the page were not scrolled at all.
      but the in-app web view seems to treat `position: absolute` different than a mobile browser would  

## The Fix
- The fix for this is pretty simple
  - The in-app web view seems to behave as expected when the action bar is`position: fixed`
  - this does not appear to have any negative effects on how the menu displays in a web browser

## Results

### Before
![image](https://github.com/logseq/logseq/assets/1904364/de36efb3-6790-4256-86ff-611cc5194da9)

### After
![image](https://github.com/logseq/logseq/assets/1904364/35edbd8b-9a58-48da-b624-75be3a7dade5)

