### PR TITLE
chore(deps): Fix CVE-2023-2931 in Electron 24 [minor change]

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
         "d3-force": "3.0.0",
         "diff": "5.0.0",
         "dompurify": "2.4.0",
-        "electron": "24.6.2",
+        "electron": "24.6.3",
         "electron-dl": "3.3.0",
         "fs": "0.0.1-security",
         "fs-extra": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
         "d3-force": "3.0.0",
         "diff": "5.0.0",
         "dompurify": "2.4.0",
-        "electron": "24.3.1",
+        "electron": "24.6.2",
         "electron-dl": "3.3.0",
         "fs": "0.0.1-security",
         "fs-extra": "9.1.0",

--- a/resources/package.json
+++ b/resources/package.json
@@ -13,7 +13,7 @@
     "electron:make": "electron-forge make",
     "electron:make-macos-arm64": "electron-forge make --platform=darwin --arch=arm64",
     "electron:publish:github": "electron-forge publish",
-    "rebuild:all": "electron-rebuild -v 24.3.1 -f",
+    "rebuild:all": "electron-rebuild -v 24.6.2 -f",
     "postinstall": "install-app-deps"
   },
   "config": {
@@ -52,12 +52,12 @@
     "@electron-forge/maker-squirrel": "^6.0.4",
     "@electron-forge/maker-zip": "^6.0.4",
     "@electron/rebuild": "3.2.10",
-    "electron": "24.3.1",
+    "electron": "24.6.2",
     "electron-builder": "^22.11.7",
     "electron-forge-maker-appimage": "https://github.com/logseq/electron-forge-maker-appimage.git"
   },
   "resolutions": {
-    "**/electron": "24.3.1",
+    "**/electron": "24.6.2",
     "**/node-gyp": "9.0.0"
   }
 }

--- a/resources/package.json
+++ b/resources/package.json
@@ -13,7 +13,7 @@
     "electron:make": "electron-forge make",
     "electron:make-macos-arm64": "electron-forge make --platform=darwin --arch=arm64",
     "electron:publish:github": "electron-forge publish",
-    "rebuild:all": "electron-rebuild -v 24.6.2 -f",
+    "rebuild:all": "electron-rebuild -v 24.6.3 -f",
     "postinstall": "install-app-deps"
   },
   "config": {
@@ -52,12 +52,12 @@
     "@electron-forge/maker-squirrel": "^6.0.4",
     "@electron-forge/maker-zip": "^6.0.4",
     "@electron/rebuild": "3.2.10",
-    "electron": "24.6.2",
+    "electron": "24.6.3",
     "electron-builder": "^22.11.7",
     "electron-forge-maker-appimage": "https://github.com/logseq/electron-forge-maker-appimage.git"
   },
   "resolutions": {
-    "**/electron": "24.6.2",
+    "**/electron": "24.6.3",
     "**/node-gyp": "9.0.0"
   }
 }

--- a/static/yarn.lock
+++ b/static/yarn.lock
@@ -2086,10 +2086,10 @@ electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@*, electron@24.3.1:
-  version "24.3.1"
-  resolved "https://registry.npmjs.org/electron/-/electron-24.3.1.tgz#f7d7d2018088d98b629c196b3a59e09a3a156c4a"
-  integrity sha512-lKfC0umie1k5LW48troHzpPKJrqPEW+5j14/CPTC41K9+dJA98oUPt/05G7QAe8OGD4fHjQQuulfRdZ9MjjXeQ==
+electron@*, electron@24.6.2:
+  version "24.6.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-24.6.2.tgz#c7958fd05efcb6d4f9854862f8c6146791d1fdc2"
+  integrity sha512-HC0lE1u9GYfj82Tt60Y/T+ELTdBKlvfPwLCzB6mWsyqYvrb2mtBy5fBSNtlfT0MWZOMh6J2of/AEYaLitniNCQ==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"

--- a/static/yarn.lock
+++ b/static/yarn.lock
@@ -2086,10 +2086,10 @@ electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@*, electron@24.6.2:
-  version "24.6.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-24.6.2.tgz#c7958fd05efcb6d4f9854862f8c6146791d1fdc2"
-  integrity sha512-HC0lE1u9GYfj82Tt60Y/T+ELTdBKlvfPwLCzB6mWsyqYvrb2mtBy5fBSNtlfT0MWZOMh6J2of/AEYaLitniNCQ==
+electron@*, electron@24.6.3:
+  version "24.6.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-24.6.3.tgz#fc41279a5ec7b0aa3d48128df61fa29ca8a21199"
+  integrity sha512-hWy2ot0987DRzhOxIyv9tgybd0yrAcc9MRFYZ+znjXgdmbvcSveXdcGKGdtpgw1EW/TKUonJMH3VfDNeAmdPUg==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2570,10 +2570,10 @@ electron-to-chromium@^1.4.251:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz#61046d1e4cab3a25238f6bf7413795270f125592"
   integrity sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==
 
-electron@24.3.1:
-  version "24.3.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-24.3.1.tgz#f7d7d2018088d98b629c196b3a59e09a3a156c4a"
-  integrity sha512-lKfC0umie1k5LW48troHzpPKJrqPEW+5j14/CPTC41K9+dJA98oUPt/05G7QAe8OGD4fHjQQuulfRdZ9MjjXeQ==
+electron@24.6.2:
+  version "24.6.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-24.6.2.tgz#c7958fd05efcb6d4f9854862f8c6146791d1fdc2"
+  integrity sha512-HC0lE1u9GYfj82Tt60Y/T+ELTdBKlvfPwLCzB6mWsyqYvrb2mtBy5fBSNtlfT0MWZOMh6J2of/AEYaLitniNCQ==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2570,10 +2570,10 @@ electron-to-chromium@^1.4.251:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz#61046d1e4cab3a25238f6bf7413795270f125592"
   integrity sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==
 
-electron@24.6.2:
-  version "24.6.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-24.6.2.tgz#c7958fd05efcb6d4f9854862f8c6146791d1fdc2"
-  integrity sha512-HC0lE1u9GYfj82Tt60Y/T+ELTdBKlvfPwLCzB6mWsyqYvrb2mtBy5fBSNtlfT0MWZOMh6J2of/AEYaLitniNCQ==
+electron@24.6.3:
+  version "24.6.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-24.6.3.tgz#fc41279a5ec7b0aa3d48128df61fa29ca8a21199"
+  integrity sha512-hWy2ot0987DRzhOxIyv9tgybd0yrAcc9MRFYZ+znjXgdmbvcSveXdcGKGdtpgw1EW/TKUonJMH3VfDNeAmdPUg==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"


### PR DESCRIPTION
The version of Electron 24 used by logseq contains a critical vulnerability. 

- https://security.snyk.io/vuln/SNYK-JS-ELECTRON-5663563
- https://www.cve.org/CVERecord?id=CVE-2023-2931

OS compatibility checks:
- [x] Windows
- [x] macOS
- [x] Linux

Changes:
https://releases.electronjs.org/release/compare/v24.3.1/v24.6.3