### PR TITLE
Fix: content overwritten caused by diff merge on mobile platforms

### DIFF
--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -1655,7 +1655,7 @@
                                                                     (p/catch (fn [_] nil)))
                                                 current-content (or current-content "")
                                                 incoming-content (fs/read-file repo-dir incoming-file)
-                                                merged-content (diff-merge/three-way-merge current-content current-content incoming-content format)]
+                                                merged-content (diff-merge/three-way-merge "" incoming-content current-content format)]
                                           (if (= incoming-content merged-content)
                                             (p/do!
                                              (fs/copy! repo

--- a/src/main/frontend/mobile/core.cljs
+++ b/src/main/frontend/mobile/core.cljs
@@ -12,7 +12,8 @@
             [frontend.state :as state]
             [frontend.util :as util]
             [cljs-bean.core :as bean]
-            [frontend.config :as config]))
+            [frontend.config :as config]
+            [frontend.handler.repo :as repo-handler]))
 
 (def *url (atom nil))
 ;; FIXME: `appUrlOpen` are fired twice when receiving a same intent.
@@ -71,14 +72,14 @@
   (.addListener App "backButton"
                 #(let [href js/window.location.href]
                    (when (true? (cond
-                                  (state/get-left-sidebar-open?)
-                                  (state/set-left-sidebar-open! false)
-
                                   (state/settings-open?)
                                   (state/close-settings!)
 
                                   (state/modal-opened?)
                                   (state/close-modal!)
+
+                                  (state/get-left-sidebar-open?)
+                                  (state/set-left-sidebar-open! false)
 
                                   :else true))
 
@@ -103,7 +104,8 @@
   (when (state/get-current-repo)
     (let [is-active? (.-isActive state)]
       (when-not is-active?
-        (editor-handler/save-current-block!))
+        (editor-handler/save-current-block!)
+        (repo-handler/persist-db!))
       (state/set-mobile-app-state-change is-active?))))
 
 (defn- general-init


### PR DESCRIPTION
Root Cause: 

On mobile platforms, DB is not persisted if the app goes inactive or gets killed. So DB(datascript transit files) will lose sync with the disk files if the App is closed by system UI or launcher.
This is very different from the Desktop version, where transit files are saved when closing-app/switching-graph.

