### PR TITLE
Fix: Header button drag region

### DIFF
--- a/src/main/frontend/components/header.css
+++ b/src/main/frontend/components/header.css
@@ -135,7 +135,9 @@
   position: relative;
 }
 
-.cp__header a, .cp__header svg {
+.cp__header a,
+.cp__header svg,
+.cp__header button {
   -webkit-app-region: no-drag;
 }
 


### PR DESCRIPTION
When we click on the header buttons around the inner icon, the action should be triggered instead of the window dragging.
See https://discord.com/channels/725182569297215569/802530020605820949/1129383697989251072