### PR TITLE
fix(server): sometimes the API server autostart not working

### DIFF
--- a/src/main/frontend/handler.cljs
+++ b/src/main/frontend/handler.cljs
@@ -200,6 +200,8 @@
   (register-components-fns!)
   (user-handler/restore-tokens-from-localstorage)
   (state/set-db-restoring! true)
+  (when (util/electron?)
+    (el/listen!))
   (render)
   (i18n/start)
   (instrument/init)
@@ -236,8 +238,6 @@
 
    (when config/dev?
      (enable-datalog-console))
-   (when (util/electron?)
-     (el/listen!))
    (persist-var/load-vars)
    (js/setTimeout instrument! (* 60 1000))))
 


### PR DESCRIPTION
The listeners setup of Electron should be initialized before the render life phase.
- [x] fixed https://github.com/logseq/logseq/issues/8848