### PR TITLE
fix: unable to change theme mode in theme row for zh-cn lang

### DIFF
--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -295,11 +295,11 @@
 
 (defn theme-modes-row [t switch-theme system-theme? dark?]
   (let [pick-theme [:ul.theme-modes-options
-                    [:li {:on-click (partial state/use-theme-mode! (t :settings-page/theme-light))
+                    [:li {:on-click (partial state/use-theme-mode! "light")
                           :class    (classnames [{:active (and (not system-theme?) (not dark?))}])} [:i.mode-light] [:strong (t :settings-page/theme-light)]]
-                    [:li {:on-click (partial state/use-theme-mode! (t :settings-page/theme-dark))
+                    [:li {:on-click (partial state/use-theme-mode! "dark")
                           :class    (classnames [{:active (and (not system-theme?) dark?)}])} [:i.mode-dark] [:strong (t :settings-page/theme-dark)]]
-                    [:li {:on-click (partial state/use-theme-mode! (t :settings-page/theme-system))
+                    [:li {:on-click (partial state/use-theme-mode! "system")
                           :class    (classnames [{:active system-theme?}])} [:i.mode-system] [:strong (t :settings-page/theme-system)]]]]
     (row-with-button-action {:left-label (t :right-side-bar/switch-theme (string/capitalize switch-theme))
                              :-for       "toggle_theme"


### PR DESCRIPTION
fixed https://github.com/logseq/logseq/issues/9875

`state/use-theme-mode!` don't need i18n.

I don't know Clojure, is this the right way to modify the code?