### PR TITLE
fix(mobile): refer policy of img tag

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -298,6 +298,7 @@
        [:img.rounded-sm.relative
         (merge
          {:loading "lazy"
+          :referrerPolicy "no-referrer"
           :src     src
           :title   title}
          metadata)]


### PR DESCRIPTION
Fix #9860

MDN: https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/referrerPolicy