### PR TITLE
Chore: Remove remaining :block/unordered that should've been deleted

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -560,12 +560,12 @@
                        :level (if unordered? (:level block) 1))
                 block)
         block (cond->
-                (-> (assoc block
-                           :uuid id
-                           :refs ref-pages-in-properties
-                           :format format
-                           :meta pos-meta)
-                    (dissoc :size))
+               (-> (assoc block
+                          :uuid id
+                          :refs ref-pages-in-properties
+                          :format format
+                          :meta pos-meta)
+                   (dissoc :size :unordered))
                 (or (seq (:properties properties)) markdown-heading?)
                 (assoc :properties (with-heading-property (:properties properties) markdown-heading? (:size block))
                        :properties-text-values (:properties-text-values properties)

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -527,7 +527,6 @@
                                 :block/properties-text-values properties-text-values
                                 :block/invalid-properties invalid-properties
                                 :block/pre-block? true
-                                :block/unordered true
                                 :block/macros (extract-macros-from-ast body)
                                 :block/body body}
                          {:keys [tags refs]}

--- a/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
@@ -153,7 +153,7 @@
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
     (is (= 303 (count files)) "Correct file count")
-    (is (= 69280 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 63632 (count (d/datoms db :eavt))) "Correct datoms count")
 
     (is (= 5866
            (ffirst

--- a/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/test/docs_graph_helper.cljs
@@ -153,7 +153,7 @@
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
     (is (= 303 (count files)) "Correct file count")
-    (is (= 69499 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 69280 (count (d/datoms db :eavt))) "Correct datoms count")
 
     (is (= 5866
            (ffirst

--- a/deps/graph-parser/src/logseq/graph_parser/whiteboard.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/whiteboard.cljs
@@ -78,14 +78,11 @@
   (let [shape? (shape-block? block)
         shape (block->shape block)
         default-page-ref {:block/name (gp-util/page-name-sanity-lc page-name)}]
-    (merge (if shape?
+    (merge (when shape?
              (merge
               {:block/uuid (uuid (:id shape))}
               (with-whiteboard-block-refs shape page-name)
-              (with-whiteboard-content shape))
-
-             ;; TODO: remove?
-             {:block/unordered true})
+              (with-whiteboard-content shape)))
            (when (nil? (:block/parent block)) {:block/parent default-page-ref})
            (when (nil? (:block/format block)) {:block/format :markdown}) ;; TODO: read from config
            {:block/page default-page-ref})))

--- a/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
@@ -24,19 +24,19 @@
              (not= (:uuid x) (:block/uuid result))
              (= (select-keys result
                              [:block/properties :block/content :block/properties-text-values :block/properties-order]) (gp-block/block-keywordize y))))
-    {:properties {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :tags [], :format :markdown, :meta {:start_pos 51, :end_pos 101}, :macros [], :unordered true, :content "bar\nid:: 63f199bc-c737-459f-983d-84acfcda14fe", :properties-text-values {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :level 1, :uuid #uuid "63f199bc-c737-459f-983d-84acfcda14fe", :properties-order [:id]}
+    {:properties {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :tags [], :format :markdown, :meta {:start_pos 51, :end_pos 101}, :macros [], :content "bar\nid:: 63f199bc-c737-459f-983d-84acfcda14fe", :properties-text-values {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :level 1, :uuid #uuid "63f199bc-c737-459f-983d-84acfcda14fe", :properties-order [:id]}
     {:properties {},
      :content "bar",
      :properties-text-values {},
      :properties-order []}
 
-    {:properties {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :tags [], :format :org, :meta {:start_pos 51, :end_pos 101}, :macros [], :unordered true, :content "bar\n:id: 63f199bc-c737-459f-983d-84acfcda14fe", :properties-text-values {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :level 1, :uuid #uuid "63f199bc-c737-459f-983d-84acfcda14fe", :properties-order [:id]}
+    {:properties {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :tags [], :format :org, :meta {:start_pos 51, :end_pos 101}, :macros [], :content "bar\n:id: 63f199bc-c737-459f-983d-84acfcda14fe", :properties-text-values {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :level 1, :uuid #uuid "63f199bc-c737-459f-983d-84acfcda14fe", :properties-order [:id]}
     {:properties {},
      :content "bar",
      :properties-text-values {},
      :properties-order []}
 
-    {:properties {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :tags [], :format :markdown, :meta {:start_pos 51, :end_pos 101}, :macros [], :unordered true, :content "bar\n  \n  id:: 63f199bc-c737-459f-983d-84acfcda14fe\nblock body", :properties-text-values {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :level 1, :uuid #uuid "63f199bc-c737-459f-983d-84acfcda14fe", :properties-order [:id]}
+    {:properties {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :tags [], :format :markdown, :meta {:start_pos 51, :end_pos 101}, :macros [], :content "bar\n  \n  id:: 63f199bc-c737-459f-983d-84acfcda14fe\nblock body", :properties-text-values {:id "63f199bc-c737-459f-983d-84acfcda14fe"}, :level 1, :uuid #uuid "63f199bc-c737-459f-983d-84acfcda14fe", :properties-order [:id]}
     {:properties {},
      :content "bar\nblock body",
      :properties-text-values {},

--- a/libs/src/LSPlugin.ts
+++ b/libs/src/LSPlugin.ts
@@ -178,7 +178,6 @@ export interface BlockEntity {
   left: IEntityID
   format: 'markdown' | 'org'
   parent: IEntityID
-  unordered: boolean
   content: string
   page: IEntityID
   properties?: Record<string, any>

--- a/src/main/frontend/modules/file/core.cljs
+++ b/src/main/frontend/modules/file/core.cljs
@@ -32,7 +32,7 @@
     content))
 
 (defn transform-content
-  [{:block/keys [collapsed? format pre-block? unordered content left page parent properties] :as b} level {:keys [heading-to-list?]}]
+  [{:block/keys [collapsed? format pre-block? content left page parent properties] :as b} level {:keys [heading-to-list?]}]
   (let [block-ref-not-saved? (and (seq (:block/_refs (db/entity (:db/id b))))
                                   (not (string/includes? content (str (:block/uuid b)))))
         heading (:heading properties)
@@ -50,7 +50,6 @@
                   :else
                   (let [markdown-top-heading? (and markdown?
                                                    (= parent page)
-                                                   (not unordered)
                                                    heading)
                         [prefix spaces-tabs]
                         (cond

--- a/src/test/frontend/handler/repo_conversion_test.cljs
+++ b/src/test/frontend/handler/repo_conversion_test.cljs
@@ -98,7 +98,7 @@
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
     (is (= 211 (count files)) "Correct file count")
-    (is (= 42200 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 38704 (count (d/datoms db :eavt))) "Correct datoms count")
 
     (is (= 3600
            (ffirst

--- a/src/test/frontend/handler/repo_conversion_test.cljs
+++ b/src/test/frontend/handler/repo_conversion_test.cljs
@@ -98,7 +98,7 @@
   ;; only increase over time as the docs graph rarely has deletions
   (testing "Counts"
     (is (= 211 (count files)) "Correct file count")
-    (is (= 42304 (count (d/datoms db :eavt))) "Correct datoms count")
+    (is (= 42200 (count (d/datoms db :eavt))) "Correct datoms count")
 
     (is (= 3600
            (ffirst


### PR DESCRIPTION
This PR deletes the remaining uses of :block/unordered as most of it was deleted in https://github.com/logseq/logseq/pull/3362