### PR TITLE
fix: add card hashtag to line without property

### DIFF
--- a/src/main/frontend/extensions/srs.cljs
+++ b/src/main/frontend/extensions/srs.cljs
@@ -68,6 +68,10 @@
   "any number between 0 and 1 (the greater it is the faster the changes of the OF matrix)"
   0.5)
 
+(def regex-firstl-no-prop
+  "RegEx used to add #card to the end of the first line without a property"
+  #"(?m)(?<!::.*) ?$")
+
 (defn- learning-fraction []
   (if-let [learning-fraction (:srs/learning-fraction (state/get-config))]
     (if (and (number? learning-fraction)
@@ -779,7 +783,7 @@
         (editor-handler/save-block!
          (state/get-current-repo)
          block-id
-         (str (string/trim content) " #" card-hash-tag))))))
+         (string/replace-first content regex-firstl-no-prop (str " #" card-hash-tag)))))))
 
 (defn batch-make-cards!
   ([] (batch-make-cards! (state/get-selection-block-ids)))
@@ -787,8 +791,8 @@
    (let [block-content-fn (fn [block]
                             [block (-> (property/remove-built-in-properties (:block/format block) (:block/content block))
                                        (drawer/remove-logbook)
-                                       string/trim
-                                       (str " #" card-hash-tag))])
+                                       (string/replace-first regex-firstl-no-prop (str " #" card-hash-tag))
+                                       )])
          blocks (->> block-ids
                      (map #(db/entity [:block/uuid %]))
                      (remove card-block?)


### PR DESCRIPTION
Fixes #9380

I neglected to add the suggested workaround for property-only blocks as I noticed the same issue occurs with e.g. /H1 command, which will add # to the property in the first line of a block; so this should probably be handled elsewhere in a more generic way.
![h1-behaviour](https://github.com/logseq/logseq/assets/36978885/c83e37ea-6c5d-42e6-92d5-15c590a3f1e6)


## Testing Video
![flashcard-tag-behaviour](https://github.com/logseq/logseq/assets/36978885/92a0ecf6-bce5-42de-8bb3-492caaef9366)