### PR TITLE
youtube.cljs: allow for single-digit minutes and seconds in youtube-timestamp (addresses #9920)

### DIFF
--- a/src/main/frontend/extensions/video/youtube.cljs
+++ b/src/main/frontend/extensions/video/youtube.cljs
@@ -119,7 +119,7 @@ Remember: You can paste a raw YouTube url as embedded video on mobile."
 
 
 (defn parse-timestamp [timestamp]
-  (let [reg #"^(?:(\d+):)?([0-5]\d):([0-5]\d)$"
+  (let [reg #"^(?:(\d+):)?([0-5]?\d):([0-5]?\d)$"
         reg-number #"^\d+$"
         timestamp (str timestamp)
         total-seconds (some-> (re-matches reg-number timestamp)
@@ -144,8 +144,8 @@ Remember: You can paste a raw YouTube url as embedded video on mobile."
 
 (comment
   ;; hh:mm:ss
-  (re-matches #"^(?:(\d+):)?([0-5]\d):([0-5]\d)$" "123:22:23") ;; => ["123:22:23" "123" "22" "23"]
-  (re-matches #"^(?:(\d+):)?([0-5]\d):([0-5]\d)$" "30:23") ;; => ["30:23" nil "30" "23"]
+  (re-matches #"^(?:(\d+):)?([0-5]?\d):([0-5]?\d)$" "123:22:23") ;; => ["123:22:23" "123" "22" "23"]
+  (re-matches #"^(?:(\d+):)?([0-5]?\d):([0-5]?\d)$" "30:23") ;; => ["30:23" nil "30" "23"]
 
   (parse-timestamp "01:23") ;; => 83
 

--- a/src/main/frontend/extensions/video/youtube.cljs
+++ b/src/main/frontend/extensions/video/youtube.cljs
@@ -133,12 +133,6 @@ Remember: You can paste a raw YouTube url as embedded video on mobile."
       (and minutes seconds)
       (+ (* 3600 hours) (* 60 minutes) seconds)
 
-      minutes
-      (+ (* 3600 hours) (* 60 minutes))
-
-      hours
-      (* 3600 hours)
-
       :else
       nil)))
 

--- a/src/main/frontend/extensions/video/youtube.cljs
+++ b/src/main/frontend/extensions/video/youtube.cljs
@@ -125,7 +125,7 @@ Remember: You can paste a raw YouTube url as embedded video on mobile."
         total-seconds (some-> (re-matches reg-number timestamp)
                               util/safe-parse-int)
         [_ hours minutes seconds] (re-matches reg timestamp)
-        [hours minutes seconds] (map util/safe-parse-int [hours minutes seconds])]
+        [hours minutes seconds] (map #(if (nil? %) 0 (util/safe-parse-int %)) [hours minutes seconds])]
     (cond
       total-seconds
       total-seconds

--- a/src/main/frontend/extensions/video/youtube.cljs
+++ b/src/main/frontend/extensions/video/youtube.cljs
@@ -125,7 +125,7 @@ Remember: You can paste a raw YouTube url as embedded video on mobile."
         total-seconds (some-> (re-matches reg-number timestamp)
                               util/safe-parse-int)
         [_ hours minutes seconds] (re-matches reg timestamp)
-        [hours minutes seconds] (map util/safe-parse-int (remove nil? [hours minutes seconds]))]
+        [hours minutes seconds] (map util/safe-parse-int [hours minutes seconds])]
     (cond
       total-seconds
       total-seconds

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -263,11 +263,17 @@
 
 #?(:cljs
    (defn safe-parse-int
-     "Use if arg could be an int or string. If arg is only a string, use `parse-long`."
+     "Use if arg could be an int or string, or nil. If arg is only a string, use `parse-long`. If arg is nil, return 0."
      {:malli/schema [:=> [:cat [:or :int :string]] :int]}
      [x]
-     (if (string? x)
+     (cond
+       (string? x)
        (parse-long x)
+
+       (nil? x)
+       0
+
+       :else
        x)))
 
 #?(:cljs

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -263,17 +263,11 @@
 
 #?(:cljs
    (defn safe-parse-int
-     "Use if arg could be an int or string, or nil. If arg is only a string, use `parse-long`. If arg is nil, return 0."
+     "Use if arg could be an int or string. If arg is only a string, use `parse-long`."
      {:malli/schema [:=> [:cat [:or :int :string]] :int]}
      [x]
-     (cond
-       (string? x)
+     (if (string? x)
        (parse-long x)
-
-       (nil? x)
-       0
-
-       :else
        x)))
 
 #?(:cljs


### PR DESCRIPTION
NOTE: I'm not sure if this fixes case 2 (see #9920) where "NN:NN" is interpreted as "hour:min", instead of "min:sec"...  If it does not, I apologize. I'm just recalling my LISP and trying to figure out this ClojureScript thing. It's possible that case 2 is not resolved (I don't see how my modification would change anything if case 2 was already an issue), and if so, would appreciate some guidance or help.