### PR TITLE
Fix (draw): Remove outdated styles

### DIFF
--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -837,15 +837,6 @@ a.tooltip-priority {
   font-size: 13px;
 }
 
-/* excalidraw */
-.Island > div > div > div {
-  width: 44px;
-}
-
-.excalidraw hr {
-  margin: 0;
-}
-
 .text-link {
   color: var(--ls-primary-text-color);
 }


### PR DESCRIPTION
Those styles were introduced on #1431. The excalidraw version was `0.4.2` and now it's `0.12.0`
There are no `hr` elements and  the `.Island` selector is too vague.

See the resolved issue to reproduce the problem.
Resolves #9940