### PR TITLE
fix(query): resolve current-page correctly when in journal (resolves #9954)

### DIFF
--- a/src/main/frontend/components/query/result.cljs
+++ b/src/main/frontend/components/query/result.cljs
@@ -18,6 +18,8 @@
         result-atom (atom nil)
         current-block-uuid (or (:block/uuid (:block config))
                                (:block/uuid config))
+        current-block-parent (or (:block/name (:block/page (:embed-parent config)))
+                                 (:block/name (:block/page (:block config))))
         _ (reset! *query-error nil)
         query-atom (try
                      (cond
@@ -40,7 +42,8 @@
                            (query-dsl/query (state/get-current-repo) q)))
 
                        :else
-                       (db/custom-query query {:current-block-uuid current-block-uuid}))
+                       (db/custom-query query { :current-block-uuid current-block-uuid
+                                                :current-block-parent current-block-parent }))
                      (catch :default e
                        (reset! *query-error e)
                        (atom nil)))]

--- a/src/main/frontend/db/query_react.cljs
+++ b/src/main/frontend/db/query_react.cljs
@@ -24,10 +24,11 @@
    (db-util/resolve-input db
                           input
                           (merge {:current-page-fn (fn []
-                                                     (or (state/get-current-page)
-                                                         (:page (state/get-default-home))
-                                                         (date/today)))}
-                                 opts))))
+                                                    (or (if (state/home?) (:current-block-parent opts) false)
+                                                        (state/get-current-page)
+                                                        (:page (state/get-default-home))
+                                                        (date/today)))}
+                                  opts))))
 
 (defn custom-query-result-transform
   [query-result remove-blocks q]
@@ -99,7 +100,7 @@
     (let [query (resolve-query query)
           repo (or repo (state/get-current-repo))
           db (conn/get-db repo)
-          resolve-with (select-keys query-opts [:current-page-fn :current-block-uuid])
+          resolve-with (select-keys query-opts [:current-page-fn :current-block-uuid :current-block-parent])
           resolved-inputs (mapv #(resolve-input db % resolve-with) inputs)
           inputs (cond-> resolved-inputs
                          rules


### PR DESCRIPTION
Resolves #9954

The issue seems to be caused by `state/get-current-page` returning `nil` when on the home page (i.e., `state/get-current-route` is `:home`). The input resolver then falls back on the current date.

The fix passes along the parent block within the current view if the route is `:home`.