### PR TITLE
Fix: Setting default sidebar pages on config

### DIFF
--- a/src/main/frontend/components/container.cljs
+++ b/src/main/frontend/components/container.cljs
@@ -587,7 +587,7 @@
                    (let [page (util/safe-page-name-sanity-lc page)
                          [db-id block-type] (if (= page "contents")
                                               ["contents" :contents]
-                                              [page :page])]
+                                              [(:db/id (db/pull [:block/name page])) :page])]
                      (state/sidebar-add-block! current-repo db-id block-type)))
                  (reset! sidebar-inited? true))))
            (when (state/mobile?)


### PR DESCRIPTION
Setting default sidebar pages on `config,edn` should work as described [here](https://github.com/logseq/logseq/blob/master/src/resources/templates/config.edn#L121-L135)
The problem was that `state/sidebar-add-block!` expects a `db-id`, not a page name.

Resolves #9950
Also related to #4416 that was automatically closed