### PR TITLE
Fix/markdown heading export

### DIFF
--- a/src/main/frontend/modules/file/core.cljs
+++ b/src/main/frontend/modules/file/core.cljs
@@ -48,7 +48,9 @@
                     (str content "\n"))
 
                   :else
-                  (let [markdown-top-heading? (and markdown?
+                  (let [
+                        ;; first block is a heading, Markdown users prefer to remove the `-` before the content
+                        markdown-top-heading? (and markdown?
                                                    (= parent page left)
                                                    heading)
                         [prefix spaces-tabs]

--- a/src/main/frontend/modules/file/core.cljs
+++ b/src/main/frontend/modules/file/core.cljs
@@ -49,7 +49,7 @@
 
                   :else
                   (let [markdown-top-heading? (and markdown?
-                                                   (= parent page)
+                                                   (= parent page left)
                                                    heading)
                         [prefix spaces-tabs]
                         (cond


### PR DESCRIPTION
To reproduce:

1. Create a new page 
2. Create a block with some random content
3. Create another block below and set it to a heading `/h1`
4. Notice there's no `- ` in the page's corresponding markdown file for the second block.