### PR TITLE
fix(editor): display of embedded drawing

### DIFF
--- a/src/main/frontend/extensions/excalidraw.cljs
+++ b/src/main/frontend/extensions/excalidraw.cljs
@@ -41,7 +41,10 @@
         nil
 
         (..  el -classList (contains "block-content"))
-        (let [width (.-clientWidth el)]
+        (let [client-width (.-clientWidth el)
+              width (if (zero? client-width)
+                      (.-width (.-getBoundingClientRect el))
+                      client-width)]
           (reset! (::draw-width state) width))
 
         :else


### PR DESCRIPTION
See-also #9533

`(.-clientWidth el)` is 0 in ref-block.