### PR TITLE
fix(editor): template expansion if auto-completion ui is blurred

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2161,15 +2161,21 @@
 
                          :else
                          true)]
-         (outliner-tx/transact!
-           {:outliner-op :insert-blocks
-            :created-from-journal-template? journal?}
-           (save-current-block!)
-           (let [result (outliner-core/insert-blocks! blocks'
-                                                      target
-                                                      (assoc opts
-                                                             :sibling? sibling?'))]
-             (edit-last-block-after-inserted! result))))))))
+         (try
+           (outliner-tx/transact!
+            {:outliner-op :insert-blocks
+             :created-from-journal-template? journal?}
+            (save-current-block!)
+            (let [result (outliner-core/insert-blocks! blocks'
+                                                       target
+                                                       (assoc opts
+                                                              :sibling? sibling?'))]
+              (edit-last-block-after-inserted! result)))
+           (catch :default ^js/Error e
+             (notification/show!
+              [:p.content
+               (util/format "Template insert error: %s" (.-message e))]
+              :error))))))))
 
 (defn template-on-chosen-handler
   [element-id]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2139,7 +2139,7 @@
                     sorted-blocks
                     (drop 1 sorted-blocks))]
        (when element-id
-         (insert-command! element-id "" format {}))
+         (insert-command! element-id "" format {:end-pattern commands/command-trigger}))
        (let [exclude-properties [:id :template :template-including-parent]
              content-update-fn (fn [content]
                                  (->> content
@@ -2696,7 +2696,7 @@
             (delete-concat current-block)))
 
         :else
-        (delete-and-update 
+        (delete-and-update
           input current-pos (util/safe-inc-current-pos-from-start (.-value input) current-pos))))))
 
 (defn keydown-backspace-handler


### PR DESCRIPTION
See-also: #8728

This is tricky to fix.

- When second-stage-style auto-completion UI is triggered, say, template expansion
- If the AC popup disappears then re-appears, (caused by an empty search result, then delete some search prefix chars to let search result shown again)
- The component state is cleared. So the default "orig-prefix" calculation in `commands/insert!` is reset, leads to wrong state
- `(insert-command! element-id "" format {})` fails to clear block content.
- Template will be inserted in a new block, current block is not cleared
