### PR TITLE
fix(pdf): highlights text layer is overlaid by the pdfjs built-in annotation layer

### DIFF
--- a/src/main/frontend/extensions/pdf/pdf.css
+++ b/src/main/frontend/extensions/pdf/pdf.css
@@ -1000,11 +1000,6 @@ html.is-system-window {
 }
 
 .annotationLayer {
-  position: absolute;
-  top: 0;
-
-  z-index: 3;
-
   .highlightAnnotation, .underlineAnnotation {
     display: none;
   }


### PR DESCRIPTION
related #9926 

A reproduced pdf file: 
[Error when pdf annotation and reference · Issue #8304 · logseq_logseq.pdf](https://github.com/logseq/logseq/files/12257232/Error.when.pdf.annotation.and.reference.Issue.8304.logseq_logseq.pdf)
