### PR TITLE
Enhance: Whiteboard Pen Pressure support

### DIFF
--- a/tldraw/packages/core/src/lib/TLApp/TLApp.ts
+++ b/tldraw/packages/core/src/lib/TLApp/TLApp.ts
@@ -937,7 +937,7 @@ export class TLApp<
 
     if ('clientX' in e) {
       this.inputs.onPointerDown(
-        [...this.viewport.getPagePoint([e.clientX, e.clientY]), 0.5],
+        [...this.viewport.getPagePoint([e.clientX, e.clientY]), e.pressure],
         e as K['pointer']
       )
     }
@@ -953,7 +953,7 @@ export class TLApp<
 
     if ('clientX' in e) {
       this.inputs.onPointerUp(
-        [...this.viewport.getPagePoint([e.clientX, e.clientY]), 0.5],
+        [...this.viewport.getPagePoint([e.clientX, e.clientY]), e.pressure],
         e as K['pointer']
       )
     }
@@ -961,7 +961,7 @@ export class TLApp<
 
   readonly onPointerMove: TLEvents<S, K>['pointer'] = (info, e) => {
     if ('clientX' in e) {
-      this.inputs.onPointerMove([...this.viewport.getPagePoint([e.clientX, e.clientY]), 0.5], e)
+      this.inputs.onPointerMove([...this.viewport.getPagePoint([e.clientX, e.clientY]), e.pressure], e)
     }
   }
 


### PR DESCRIPTION
Hey! My first PR ever here. 

I really wanted to have pen pressure support for the whiteboard, since having an infinitely scrolling canvas is much more convenient than a bunch of excalidraw drawings. I looked around in the tldraw code, and it seems that the onPointer handlers have the pressure hardcoded to 0.5, hence why pressure is simulated even with a pressure-sensitive display tablet.

Changing it to e.pressure seems to do the trick, at least with the development webapp and the Windows electron app. I have zero idea if this quick change would also work on iOS, but maybe!

Here's a quick demo:

https://github.com/logseq/logseq/assets/21244249/01435ead-ff4b-4d49-a089-a8b600bd6904
