### PR TITLE
fix: add drag threshold for graph view

### DIFF
--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -666,7 +666,11 @@
        (fn [event node]
          (let [x (.-x event)
                y (.-y event)
-               drag? (not= [node x y] @last-node-position)]
+               drag? (not (let [[last-node last-x last-y] @last-node-position
+                                threshold 5]
+                            (and (= node last-node)
+                                 (<= (abs (- x last-x)) threshold)
+                                 (<= (abs (- y last-y)) threshold))))]
            (graph/on-click-handler graph node event focus-nodes n-hops drag? dark?))))
   (.on graph "nodeMousedown"
        (fn [event node]


### PR DESCRIPTION
I found that when I want to click on a node in the graph view to jump to the corresponding page, but with a slight mouse movement, unexpected behavior occurs: instead of jumping to the corresponding page, the node moves slightly.

Therefore, I added a threshold for nodeClick event handler, to temporarily solve this problem.