### PR TITLE
fix(graph-view): reset prev highlight after drag a new node

### DIFF
--- a/src/main/frontend/extensions/graph.cljs
+++ b/src/main/frontend/extensions/graph.cljs
@@ -6,26 +6,23 @@
             [goog.object :as gobj]
             [rum.core :as rum]))
 
+(defonce last-clicked-node (atom nil))
 (defn- highlight-neighbours!
-  [^js graph node focus-nodes _dark?]
+  [^js graph node focus-nodes style]
   (.forEachNeighbor
    (.-graph graph) node
    (fn [node attributes]
      (when-not (contains? focus-nodes node)
        (let [attributes (bean/->clj attributes)
-             attributes (assoc attributes
-                               :color "#6366F1"
-                               :border {:width 2
-                                        :color "#6366F1"})]
+             attributes (merge attributes style)]
          (.resetNodeStyle graph node (bean/->js attributes)))))))
 
 (defn- highlight-edges!
-  [^js graph node dark?]
+  [^js graph node style]
   (.forEachEdge
    (.-graph graph) node
    (fn [edge _attributes]
-     (.resetEdgeStyle graph edge (bean/->js {:width 1
-                                             :color (if dark? "#999" "#A5B4FC")})))))
+     (.resetEdgeStyle graph edge (bean/->js style)))))
 
 (defn on-click-handler [graph node event *focus-nodes *n-hops drag? dark?]
   ;; shift+click to select the page
@@ -35,10 +32,26 @@
         (swap! *focus-nodes ;; Don't trigger re-render
                (fn [v]
                  (vec (distinct (conj v node))))))
+
+      ;; before highlight new node, reset last-clicked-node styles
+      (when @last-clicked-node
+        (js/console.log "reset last-clicked-node" @last-clicked-node)
+        (.removeNodeAttribute (.-graph graph) @last-clicked-node "parent")
+        (highlight-neighbours! graph @last-clicked-node (set {}) {:color "#999999"
+                                                                  :border {:width 1
+                                                                           :color "#999999"}})
+        (highlight-edges! graph @last-clicked-node {:width 1
+                                                    :color (if dark? "#094b5a" "#cccccc")}))
+      
       ;; highlight current node
       (.setNodeAttribute (.-graph graph) node "parent" "ls-selected-nodes")
-      (highlight-neighbours! graph node (set @*focus-nodes) dark?)
-      (highlight-edges! graph node dark?))
+      (highlight-neighbours! graph node (set {}) {:color "#6366F1"
+                                                             :border {:width 2
+                                                                      :color "#6366F1"}})
+      (highlight-edges! graph node {:width 1
+                                    :color (if dark? "#999" "#A5B4FC")})
+      
+      (reset! last-clicked-node node))
     (when-not drag?
       (let [page-name (model/get-redirect-page-name node)]
         (.unhoverNode ^js graph node)


### PR DESCRIPTION
Introduced an atom to store the last clicked node and remove the usage of `*focus-nodes` to fix #8288 