### PR TITLE
enhance(pdf): support `shift + enter` to pick the previous searching results highlight

### DIFF
--- a/src/main/frontend/extensions/pdf/toolbar.cljs
+++ b/src/main/frontend/extensions/pdf/toolbar.cljs
@@ -218,8 +218,8 @@
           :on-key-up   (fn [^js e]
                          (case (.-which e)
                            13                               ;; enter
-                           (do
-                             (do-find! :again)
+                           (let [shift? (.-shiftKey e)]
+                             (do-find! {:type :again :prev? shift?})
                              (set-entered-active? true))
 
                            27                               ;; esc


### PR DESCRIPTION
- fixed https://github.com/logseq/logseq/issues/9970