### PR TITLE
fix(whiteboard) page sidebar empty string

### DIFF
--- a/src/main/frontend/util/property.cljs
+++ b/src/main/frontend/util/property.cljs
@@ -361,7 +361,7 @@
 ;; The future plan is to separate those properties from the block' content.
 (defn remove-built-in-properties
   [format content]
-  (let [trim-content (string/trim content)]
+  (let [trim-content (some-> content string/trim)]
     (if (or
          (and (= format :markdown)
               (string/starts-with? trim-content "```")


### PR DESCRIPTION
I had this error https://github.com/logseq/logseq/issues/9784 and think the problem was trim in the null value. If is not would you guys give some input to fix this

