### PR TITLE
fix(editor): avoid nav to empty page name

### DIFF
--- a/src/main/frontend/handler/route.cljs
+++ b/src/main/frontend/handler/route.cljs
@@ -73,15 +73,16 @@
    (redirect-to-page! page-name {}))
   ([page-name {:keys [anchor push click-from-recent?]
                :or {click-from-recent? false}}]
-   (recent-handler/add-page-to-recent! (state/get-current-repo) page-name
-                                       click-from-recent?)
-   (let [m (cond->
-            (default-page-route page-name)
-            anchor
-            (assoc :query-params {:anchor anchor})
-            push
-            (assoc :push push))]
-     (redirect! m))))
+   (when (seq page-name)
+     (recent-handler/add-page-to-recent! (state/get-current-repo) page-name
+                                         click-from-recent?)
+     (let [m (cond->
+              (default-page-route page-name)
+               anchor
+               (assoc :query-params {:anchor anchor})
+               push
+               (assoc :push push))]
+       (redirect! m)))))
 
 (defn redirect-to-whiteboard!
   ([name]


### PR DESCRIPTION
Follow up of #10018

The whole app becomes a blank page when navigating to `#/page/`.

Caused by opening the following whiteboard in the right sidebar:


```clojure
{:blocks (
{:block/uuid #uuid "64da1ec9-7b45-47f2-a1e2-c4660c53e0c1"
:block/properties 
{}
:block/updated-at 1692016333246
:block/created-at 1692016333246
:block/format :markdown
:block/content "Test on block"
:block/parent 
{:block/uuid "64da1ebc-d5ea-408b-9986-18ecadfd3f8b"}} 
{:block/properties 
{:ls-type :whiteboard-shape
:logseq.tldraw.shape 
{:blockType "B"
:stroke ""
:collapsed false
:borderRadius 8
:index 0
:scale [1 1]
:pageId "64da1ec9-7b45-47f2-a1e2-c4660c53e0c1"
:scaleLevel "md"
:fill ""
:compact true
:isAutoResizing true
:type "logseq-portal"
:size [400 41]
:strokeType "line"
:strokeWidth 2
:opacity 1
:id "93b3c520-3a9e-11ee-b4c6-679a02f6a1e1"
:noFill false
:point [120 256]
:parentId ""
:collapsedHeight 0
:nonce 1692016325238}}
:block/updated-at 1692016347859
:block/created-at 1692016347859} 
{:block/properties 
{:ls-type :whiteboard-shape
:logseq.tldraw.shape 
{:stroke ""
:borderRadius 2
:index 1
:scale [1 1]
:scaleLevel "md"
:fill ""
:type "box"
:size [320 72]
:strokeType "line"
:strokeWidth 2
:opacity 1
:label "Text on shape"
:id "9d931550-3a9e-11ee-b4c6-679a02f6a1e1"
:fontWeight 400
:noFill false
:point [136 440]
:fontSize 20
:parentId ""
:nonce 1692016341853
:italic false}}
:block/updated-at 1692016347859
:block/created-at 1692016347859})
:pages (
{:block/uuid "64da1ebc-d5ea-408b-9986-18ecadfd3f8b"
:block/properties 
{:ls-type :whiteboard-page
:logseq.tldraw.page 
{:id ""
:name nil
:bindings 
{}
:nonce 0
:assets []
:shapes-index ("93b3c520-3a9e-11ee-b4c6-679a02f6a1e1" "9d931550-3a9e-11ee-b4c6-679a02f6a1e1")}}
:block/updated-at 1692016347859
:block/created-at 1692016347859
:block/type "whiteboard"
:block/name "64da1ebc-d5ea-408b-9986-18ecadfd3f8b"
:block/original-name "64da1ebc-d5ea-408b-9986-18ecadfd3f8b"})}
```