### PR TITLE
Enhance: Tweak login wording to let users know that email login works

### DIFF
--- a/packages/amplify/src/LSAuthenticator.tsx
+++ b/packages/amplify/src/LSAuthenticator.tsx
@@ -9,6 +9,12 @@ export function LSAuthenticator({ termsLink, children }: any) {
           username: { order: 2 },
           password: { order: 3 },
           confirm_password: { order: 4 },
+        },
+        signIn: {
+          username: {
+            placeholder: 'Enter your Username or Email',
+            label: 'Username or Email'
+          }
         }
       }}
       loginMechanisms={['username']}

--- a/packages/amplify/src/amplify.ts
+++ b/packages/amplify/src/amplify.ts
@@ -5,7 +5,6 @@ import { dict } from 'aws-amplify-react/lib-esm/AmplifyI18n'
 
 // fix i18n
 dict.zh['Reset Password'] = '重置密码'
-dict.zh['Enter your username'] = '请输入用户名'
 dict.zh['Enter your email'] = '请输入邮箱'
 dict.zh['Enter your password'] = '请输入密码'
 dict.zh['Confirm Password'] = '确认密码'
@@ -26,7 +25,7 @@ const fixesMapping = {
   'Forgot Password': ['Forgot your password?'],
   'Enter your email': ['Enter your Email'],
   'Enter your password': ['Enter your Password'],
-  'Enter your username': ['Enter your Username']
+  'Enter your username': ['Enter your Username or Email']
 }
 
 Object.keys(dict).forEach((k) => {


### PR DESCRIPTION
As requested by @logseqramses, this would allow more users to login without needing support