### PR TITLE
Fix (UX): Sub-pixel anti-aliasing

### DIFF
--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -28,7 +28,8 @@
    (let [win-state (windowStateKeeper (clj->js {:defaultWidth 980 :defaultHeight 700}))
          native-titlebar? (cfgs/get-item :window/native-titlebar?)
          win-opts  (cond->
-                     {:width                (.-width win-state)
+                     {:backgroundColor      "#fff" ; SEE https://www.electronjs.org/docs/latest/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do
+                      :width                (.-width win-state)
                       :height               (.-height win-state)
                       :frame                (or mac? native-titlebar?)
                       :titleBarStyle        "hiddenInset"


### PR DESCRIPTION
Quoting https://www.electronjs.org/docs/latest/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do

> Sub-pixel anti-aliasing needs a non-transparent background of the layer containing the font glyphs.

> Even if you don't see a difference, some of your users may. It is best to always set the background this way, unless you have reasons not to do so.

The background of the electron app upon loading is already white, so this change should not affect anything else.

Resolves #2813