### PR TITLE
Fix: Clicking on recently opened whiteboards

### DIFF
--- a/src/main/frontend/components/container.cljs
+++ b/src/main/frontend/components/container.cljs
@@ -89,7 +89,7 @@
                (:db/id page-entity)
                :page))
             (if whiteboard-page?
-              (route-handler/redirect-to-whiteboard! name)
+              (route-handler/redirect-to-whiteboard! name {:click-from-recent? recent?})
               (route-handler/redirect-to-page! name {:click-from-recent? recent?})))))}
      [:span.page-icon.ml-3.justify-center (if whiteboard-page? (ui/icon "whiteboard" {:extension? true}) icon)]
      [:span.page-title {:class (when untitiled? "opacity-50")}

--- a/src/main/frontend/handler/route.cljs
+++ b/src/main/frontend/handler/route.cljs
@@ -87,10 +87,10 @@
 (defn redirect-to-whiteboard!
   ([name]
    (redirect-to-whiteboard! name nil))
-  ([name {:keys [block-id new-whiteboard?]}]
+  ([name {:keys [block-id new-whiteboard? click-from-recent?]}]
    ;; Always skip onboarding when loading an existing whiteboard
    (when-not new-whiteboard? (state/set-onboarding-whiteboard! true))
-   (recent-handler/add-page-to-recent! (state/get-current-repo) name false)
+   (recent-handler/add-page-to-recent! (state/get-current-repo) name click-from-recent?)
    (if (= name (state/get-current-whiteboard))
      (state/focus-whiteboard-shape block-id)
      (redirect! {:to :whiteboard


### PR DESCRIPTION
Clicking on a recently opened whiteboard on the left sidebar, should not push the whiteboard at the top of the list.