### PR TITLE
Enhance (UX): Electron loading

### DIFF
--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -6,6 +6,7 @@
             ["buffer" :as buffer]
             ["diff-match-patch" :as google-diff]
             ["electron" :refer [app autoUpdater dialog ipcMain shell]]
+            ["electron-window-state" :as windowStateKeeper]
             ["fs" :as fs]
             ["fs-extra" :as fs-extra]
             ["os" :as os]
@@ -619,6 +620,7 @@
   (.close win))
 
 (defmethod handle :db-restored [^js win]
+  (.manage (windowStateKeeper) win)
   (.show win))
 
 ;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -618,7 +618,7 @@
 (defmethod handle :window-close [^js win]
   (.close win))
 
-(defmethod handle :theme-loaded [^js win]
+(defmethod handle :db-restored [^js win]
   (.show win))
 
 ;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -619,7 +619,7 @@
 (defmethod handle :window-close [^js win]
   (.close win))
 
-(defmethod handle :db-restored [^js win]
+(defmethod handle :theme-loaded [^js win]
   (.manage (windowStateKeeper) win)
   (.show win))
 

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -618,6 +618,9 @@
 (defmethod handle :window-close [^js win]
   (.close win))
 
+(defmethod handle :theme-loaded [^js win]
+  (.show win))
+
 ;;;;;;;;;;;;;;;;;;;;;;;
 ;; file-sync-rs-apis ;;
 ;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -56,7 +56,6 @@
                      linux?
                      (assoc :icon (node-path/join js/__dirname "icons/logseq.png")))
          win       (BrowserWindow. (clj->js win-opts))]
-     (.manage win-state win)
      (.onBeforeSendHeaders (.. session -defaultSession -webRequest)
                            (clj->js {:urls (array "*://*.youtube.com/*")})
                            (fn [^js details callback]

--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -35,6 +35,7 @@
                       :titleBarStyle        "hiddenInset"
                       :trafficLightPosition {:x 16 :y 16}
                       :autoHideMenuBar      (not mac?)
+                      :show                 false
                       :webPreferences
                       {:plugins                 true        ; pdf
                        :nodeIntegration         false

--- a/src/main/frontend/components/theme.cljs
+++ b/src/main/frontend/components/theme.cljs
@@ -1,5 +1,6 @@
 (ns frontend.components.theme
-  (:require [frontend.extensions.pdf.core :as pdf]
+  (:require [electron.ipc :as ipc]
+            [frontend.extensions.pdf.core :as pdf]
             [frontend.config :as config]
             [frontend.handler.plugin :as plugin-handler]
             [frontend.handler.plugin-config :as plugin-config-handler]
@@ -28,7 +29,8 @@
           (.add cls "dark")
           (.remove cls "dark"))
         (ui/apply-custom-theme-effect! theme)
-        (plugin-handler/hook-plugin-app :theme-mode-changed {:mode theme}))
+        (plugin-handler/hook-plugin-app :theme-mode-changed {:mode theme})
+        (ipc/ipc "theme-loaded"))
      [theme])
 
     (rum/use-effect!

--- a/src/main/frontend/components/theme.cljs
+++ b/src/main/frontend/components/theme.cljs
@@ -34,12 +34,8 @@
 
     (rum/use-effect!
      #(let [doc js/document.documentElement]
-        (.setAttribute doc "lang" preferred-language)))
-
-    (rum/use-effect!
-     #(when-not db-restoring?
-        (ipc/ipc "db-restored"))
-     [db-restoring?])
+        (.setAttribute doc "lang" preferred-language)
+        (js/setTimeout (fn [] (ipc/ipc "theme-loaded")) 100))) ; Wait for the theme to be applied
 
     (rum/use-effect!
      #(when (and restored-sidebar?

--- a/src/main/frontend/components/theme.cljs
+++ b/src/main/frontend/components/theme.cljs
@@ -29,13 +29,17 @@
           (.add cls "dark")
           (.remove cls "dark"))
         (ui/apply-custom-theme-effect! theme)
-        (plugin-handler/hook-plugin-app :theme-mode-changed {:mode theme})
-        (ipc/ipc "theme-loaded"))
+        (plugin-handler/hook-plugin-app :theme-mode-changed {:mode theme}))
      [theme])
 
     (rum/use-effect!
      #(let [doc js/document.documentElement]
         (.setAttribute doc "lang" preferred-language)))
+
+    (rum/use-effect!
+     #(when-not db-restoring?
+        (ipc/ipc "db-restored"))
+     [db-restoring?])
 
     (rum/use-effect!
      #(when (and restored-sidebar?


### PR DESCRIPTION
Based on the[ electron docs](https://www.electronjs.org/docs/latest/api/browser-window#using-the-ready-to-show-event), we keep the window hidden until the app is loaded to avoid the theme blinking state. The only downside of this approach is that the initial display of the app will be delayed. Although we could show a loading banner until the app is fully loaded, I am not sure if the delay is long enough to justify that. Improving the loading speed might also be possible.

Regarding the event hook, `ready-to-show` fires too soon in our case. I also tried `did-finish-load` with similar results, which is why I decided to use the `theme-loaded` event. If there is a more appropriate event that does the same thing time-wise, I would be happy to try it.

The `manage` call of `windowStateKeeper` was also moved to handle maximized windows. `:show false` won't work on maximized windows, and `windowStateKeeper` seems to restore the state of the window on `manage`. If the window was maximized when we closed it, it would appear visible on init without this change. As stated on [the documentation of window maximize](https://www.electronjs.org/docs/latest/api/browser-window#winmaximize)
> Maximizes the window. This will also show (but not focus) the window if it isn't being displayed already.

Try using custom themes and both theme modes (dark/light) to test this. When the app is visible, the active theme should be already loaded. We also need to make sure that `show` is always triggered, and that the loading time is acceptable. Persisting and restoring the window state should also work properly.

Resolves #570