### PR TITLE
Update develop-logseq-on-windows.md to warn about Choco

### DIFF
--- a/docs/develop-logseq-on-windows.md
+++ b/docs/develop-logseq-on-windows.md
@@ -2,6 +2,17 @@
 
 This is a guide on setting up Logseq development dependencies on Windows.  Once these dependencies are installed, you can follow the  [develop-logseq](develop-logseq.md) docs for build instructions.
 
+## [scoop](https://scoop.sh/)
+
+Scoop provides a `clojure.exe` shim which works in Command Prompt and Powershell windows.
+
+```
+scoop bucket add scoop-clojure https://github.com/littleli/scoop-clojure
+scoop bucket add extras
+scoop bucket add java
+scoop install java/openjdk clj-deps babashka leiningen nodejs-lts
+```
+
 ## Winget
 
 Winget is a package manager installed by default on windows.
@@ -19,6 +30,10 @@ An installer for clojure is available from [casselc/clj-msi](https://github.com/
 
 ## [chocolatey](https://chocolatey.org/)
 
+Chocolatey installs Clojure as a PowerShell module and alias, and does not provide `clojure` for `cmd.exe`.
+
+[@andelf has written a wrapper utility](https://github.com/andelf/clojure-cli) which you can install with `cargo install --git https://github.com/andelf/clojure-cli.git` instead.
+
 ```
 choco install nvm
 nvm install 18
@@ -27,16 +42,6 @@ npm install -g yarn
 choco install visualstudio2022community
 choco install javaruntime
 choco install clojure
-```
-
-
-## [scoop](https://scoop.sh/)
-
-```
-scoop bucket add scoop-clojure https://github.com/littleli/scoop-clojure
-scoop bucket add extras
-scoop bucket add java
-scoop install java/openjdk clojure clj-deps babashka leiningen nodejs-lts
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
The scoop `clojure` package being deprecated in favor of `clj-deps` which is already included.

Following up on https://github.com/logseq/logseq/pull/8857:
> - re-add scoop and choco instructions (these are untested)

The choco instructions do not work **for cmd.exe** ; more specifically, the `choco install clojure` command does not provide the `clojure` CLI utility **for cmd.exe**:
  ```
  C:\dev\logseq>yarn watch
  yarn run v1.22.19
  $ run-p gulp:watch cljs:watch
  $ gulp watch
  $ clojure -M:cljs watch app electron
  'clojure' is not recognized as an internal or external command
  ```

After running the the scoop install commands, it works OK:
  ```
  C:\dev\logseq>yarn watch
  yarn run v1.22.19
  $ run-p gulp:watch cljs:watch
  $ gulp watch
  $ clojure -M:cljs watch app electron
  Downloading: org/clojure/clojurescript/1.11.54/clojurescript-1.11.54.pom from central
  Downloading: cider/cider-nrepl/0.29.0/cider-nrepl-0.29.0.pom from clojars
  Downloading: org/clojars/knubie/cljs-run-test/1.0.1/cljs-run-test-1.0.1.pom from clojars
  [11:19:49] Using gulpfile C:\dev\logseq\gulpfile.js
  [11:19:49] Starting 'watch'...
  ```

Looks like scoop adds a `clojure.exe` shim, which the choco package does not:
![image](https://github.com/djm2k/logseq/assets/36978885/40d5d5e4-2916-4e6d-a4c5-ba9036cc8db0)
