### PR TITLE
fix: remove `word-spacing` css rule for inline code, so they are actually monospace

### DIFF
--- a/src/main/frontend/common.css
+++ b/src/main/frontend/common.css
@@ -794,7 +794,6 @@ mark {
   letter-spacing: 0;
   background-color: var(--ls-page-inline-code-bg-color, #eee);
   color: var(--ls-page-inline-code-color);
-  word-spacing: -0.15em;
   text-rendering: optimizeSpeed;
 }
 


### PR DESCRIPTION
Remove `word-spacing: -0.15em;` CSS rule under `:not(pre) > code` selector, which is causing inline code to be not strictly monospace and can not align between lines:  
![Snipaste_2023-08-19_16-59-00](https://github.com/logseq/logseq/assets/13289283/e2ee9b4e-c3c6-4565-bb0b-2c679e68f0fb)

Close #10061.