### PR TITLE
Refactor: iOS App start-up

### DIFF
--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -198,18 +198,6 @@
          ;; (sort-by last)
          (reverse))))
 
-(defn get-files-entity
-  [repo]
-  (when-let [db (conn/get-db repo)]
-    (->> (d/q
-          '[:find ?file ?path
-            :where
-            [?file :file/path ?path]]
-          db)
-         (seq)
-         ;; (sort-by last)
-         (reverse))))
-
 (defn get-files-blocks
   [repo-url paths]
   (let [paths (set paths)

--- a/src/main/frontend/db/persist.cljs
+++ b/src/main/frontend/db/persist.cljs
@@ -44,3 +44,14 @@
         (ipc/ipc "deleteGraph" key)
         (idb/remove-item! key))
      (idb/remove-item! key))))
+
+(defn rename-graph!
+  [old-repo new-repo]
+  (let [old-key (db-conn/datascript-db old-repo)
+        new-key (db-conn/datascript-db new-repo)]
+    (if (util/electron?)
+      (do
+        (js/console.error "rename-graph! is not supported in electron")
+        (idb/rename-item! old-key new-key))
+      (idb/rename-item! old-key new-key))))
+

--- a/src/main/frontend/fs/watcher_handler.cljs
+++ b/src/main/frontend/fs/watcher_handler.cljs
@@ -3,22 +3,25 @@
   (:require [clojure.set :as set]
             [clojure.string :as string]
             [frontend.config :as config]
+            [frontend.date :as date]
             [frontend.db :as db]
             [frontend.db.model :as model]
             [frontend.fs :as fs]
-            [logseq.common.path :as path]
+            [frontend.handler.editor :as editor-handler]
             [frontend.handler.editor.property :as editor-property]
             [frontend.handler.file :as file-handler]
+            [frontend.handler.global-config :as global-config-handler]
+            [frontend.handler.notification :as notification]
             [frontend.handler.page :as page-handler]
             [frontend.handler.ui :as ui-handler]
             [frontend.state :as state]
             [frontend.util :as util]
             [frontend.util.fs :as fs-util]
             [lambdaisland.glogi :as log]
+            [logseq.common.path :as path]
             [logseq.graph-parser.config :as gp-config]
             [logseq.graph-parser.util.block-ref :as block-ref]
-            [promesa.core :as p]
-            [frontend.handler.global-config :as global-config-handler]))
+            [promesa.core :as p]))
 
 ;; all IPC paths must be normalized! (via gp-util/path-normalize)
 
@@ -129,6 +132,55 @@
       ;; return nil, otherwise the entire db will be transferred by ipc
       nil)))
 
+(defn preload-graph-homepage-files!
+  "Preload the homepage file for the current graph.
+
+   Prerequisites:
+   - current graph is set
+   - config is loaded"
+  []
+  (when-let [repo (state/get-current-repo)]
+    (when (and (not (state/loading-files? repo))
+               (config/local-db? repo))
+      (let [repo-dir (config/get-repo-dir repo)
+            page-name (if (state/enable-journals? repo)
+                        (date/today)
+                        (or (:page (state/get-default-home)) "Contents"))
+            page-name (util/page-name-sanity-lc page-name)
+            file-rpath (or (:file/path (db/get-page-file page-name))
+                           (let [format (state/get-preferred-format repo)
+                                 ext (config/get-file-extension format)
+                                 file-name (if (state/enable-journals? repo)
+                                             (date/journal-title->default (date/today))
+                                             (or (:page (state/get-default-home)) "contents"))
+                                 parent-dir (if (state/enable-journals? repo)
+                                              (config/get-journals-directory)
+                                              (config/get-pages-directory))]
+                             (str parent-dir "/" file-name "." ext)))]
+        (prn ::preload-homepage repo-dir file-rpath)
+        (p/let [file-exists? (fs/file-exists? repo-dir file-rpath)
+                _ (when file-exists?
+                    ;; BUG: avoid active-editing block content overwrites incoming fs changes
+                    (editor-handler/escape-editing false))
+                file-content (when file-exists?
+                               (fs/read-file repo-dir file-rpath))
+                file-mtime (when file-exists?
+                             (:mtime (fs/stat repo-dir file-rpath)))
+                db-empty? (db/page-empty? repo page-name)
+                db-content (if-not db-empty?
+                             (db/get-file repo file-rpath)
+                             "")]
+          (cond
+            (and file-exists?
+                 db-empty?)
+            (handle-add-and-change! repo file-rpath file-content db-content file-mtime false)
+
+            (and file-exists?
+                 (not db-empty?)
+                 (not= file-content db-content))
+            (handle-add-and-change! repo file-rpath file-content db-content file-mtime true))
+          (ui-handler/re-render-root!))))))
+
 (defn load-graph-files!
   [graph]
   (when graph
@@ -157,26 +209,44 @@
                                                   {:content (str "The graph " graph " can not be read:" error)
                                                    :status :error
                                                    :clear? false}]))
-                             [nil nil])))]
-        (prn ::init-watcher repo-dir {:deleted (count deleted-files)
-                                      :total (count files)})
+                             [nil nil])))
+              ;; notifies user when large initial change set is detected
+              ;; NOTE: this is an estimation, not accurate
+              notification-uid (when (or (> (abs (- (count db-files) (count files)))
+                                            100)
+                                         (> (count deleted-files)
+                                            100))
+                                 (prn ::init-watcher-large-change-set)
+                                 (notification/show! "Loading changes from disk..."
+                                                     :info
+                                                     false))]
+        (prn ::initial-watcher repo-dir {:deleted (count deleted-files)
+                                         :total (count files)})
         (when (seq deleted-files)
           (let [delete-tx-data (->> (db/delete-files deleted-files)
                                     (concat (db/delete-blocks graph deleted-files nil))
                                     (remove nil?))]
             (db/transact! graph delete-tx-data {:delete-files? true})))
-        (doseq [file-rpath files]
-          (when-let [_ext (util/get-file-ext file-rpath)]
-            (->
-             (p/let [content (fs/read-file repo-dir file-rpath)
-                     stat (fs/stat repo-dir file-rpath)
-                     type (if (db/file-exists? graph file-rpath)
-                            "change"
-                            "add")]
-               (handle-changed! type
-                                {:dir repo-dir
-                                 :path file-rpath
-                                 :content content
-                                 :stat stat}))
-             (p/catch (fn [error]
-                        (js/console.dir error))))))))))
+        (-> (p/delay 500) ;; workaround for notification ui not showing
+            (p/then #(p/all (map (fn [file-rpath]
+                                   (p/let [stat (fs/stat repo-dir file-rpath)
+                                           content (fs/read-file repo-dir file-rpath)
+                                           type (if (db/file-exists? graph file-rpath)
+                                                  "change"
+                                                  "add")]
+                                     (handle-changed! type
+                                                      {:dir repo-dir
+                                                       :path file-rpath
+                                                       :content content
+                                                       :stat stat})))
+                                 files)))
+            (p/then (fn []
+                      (when notification-uid
+                        (prn ::init-notify)
+                        (notification/clear! notification-uid)
+                        (state/pub-event! [:notification/show {:content (str "The graph " graph " is loaded.")
+                                                               :status :success
+                                                               :clear? true}]))))
+            (p/catch (fn [error]
+                       (js/console.dir error))))))))
+

--- a/src/main/frontend/fs/watcher_handler.cljs
+++ b/src/main/frontend/fs/watcher_handler.cljs
@@ -141,10 +141,15 @@
                   (p/chain (fn [files]
                              (->> files
                                   (map #(path/relative-path repo-dir %))
-                                  (remove #(fs-util/ignored-path? repo-dir %))))
+                                  (remove #(fs-util/ignored-path? repo-dir %))
+                                  (sort-by (fn [f] [(not (string/starts-with? f "logseq/"))
+                                                    (not (string/starts-with? f "journals/"))
+                                                    (not (string/starts-with? f "pages/"))
+                                                    (string/lower-case f)]))))
                            (fn [files]
                              (let [deleted-files (set/difference (set db-files) (set files))]
-                               [files deleted-files])))
+                               [files
+                                deleted-files])))
                   (p/catch (fn [error]
                              (when-not (config/demo-graph? graph)
                                (js/console.error "reading" graph)

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -10,7 +10,6 @@
             [clojure.core.async.interop :refer [p->c]]
             [clojure.set :as set]
             [clojure.string :as string]
-            [datascript.core :as d]
             [frontend.commands :as commands]
             [frontend.components.command-palette :as command-palette]
             [frontend.components.conversion :as conversion-component]
@@ -507,22 +506,7 @@
       (when-let [toolbar (.querySelector main-node "#mobile-editor-toolbar")]
         (set! (.. toolbar -style -bottom) 0)))))
 
-(defn update-file-path [deprecated-repo current-repo deprecated-app-id current-app-id]
-  (let [files (db-model/get-files-entity deprecated-repo)
-        conn (conn/get-db deprecated-repo false)
-        tx (mapv (fn [[id path]]
-                   (let [new-path (string/replace path deprecated-app-id current-app-id)]
-                     {:db/id id
-                      :file/path new-path}))
-                 files)]
-    (d/transact! conn tx)
-    (reset! conn/conns
-            (update-keys @conn/conns
-                         (fn [key] (if (string/includes? key deprecated-repo)
-                                     (string/replace key deprecated-repo current-repo)
-                                     key))))))
-
-(defn get-ios-app-id
+(defn- get-ios-app-id
   [repo-url]
   (when repo-url
     (let [app-id (-> (first (string/split repo-url "/Documents"))
@@ -532,11 +516,12 @@
 
 (defmethod handle :validate-appId [[_ graph-switch-f graph]]
   (when-let [deprecated-repo (or graph (state/get-current-repo))]
-    ;; Installation is not changed for iCloud
     (if (mobile-util/in-iCloud-container-path? deprecated-repo)
+      ;; Installation is not changed for iCloud
       (when graph-switch-f
         (graph-switch-f graph true)
         (state/pub-event! [:graph/ready (state/get-current-repo)]))
+      ;; Installation is changed for App Documents directory
       (p/let [deprecated-app-id (get-ios-app-id deprecated-repo)
               current-document-url (.getUri Filesystem #js {:path ""
                                                             :directory (.-Documents Directory)})
@@ -545,24 +530,34 @@
         (if (= deprecated-app-id current-app-id)
           (when graph-switch-f (graph-switch-f graph true))
           (do
+            (notification/show! [:div "Migrating from previous App installation..."]
+                                :warning
+                                true)
+            (prn ::migrate-app-id :from deprecated-app-id :to current-app-id)
             (file-sync-stop!)
             (.unwatch mobile-util/fs-watcher)
             (let [current-repo (string/replace deprecated-repo deprecated-app-id current-app-id)
                   current-repo-dir (config/get-repo-dir current-repo)]
               (try
-                (update-file-path deprecated-repo current-repo deprecated-app-id current-app-id)
-                (db-persist/delete-graph! deprecated-repo)
+                ;; replace app-id part of repo url
+                (reset! conn/conns
+                        (update-keys @conn/conns
+                                     (fn [key]
+                                       (if (string/includes? key deprecated-app-id)
+                                         (string/replace key deprecated-app-id current-app-id)
+                                         key))))
+                (db-persist/rename-graph! deprecated-repo current-repo)
                 (search/remove-db! deprecated-repo)
-                (state/delete-repo! {:url deprecated-repo})
                 (state/add-repo! {:url current-repo :nfs? true})
+                (state/delete-repo! {:url deprecated-repo})
                 (catch :default e
                   (js/console.error e)))
               (state/set-current-repo! current-repo)
               (db/listen-and-persist! current-repo)
               (db/persist-if-idle! current-repo)
               (repo-config-handler/restore-repo-config! current-repo)
-              (.watch mobile-util/fs-watcher #js {:path current-repo-dir})
               (when graph-switch-f (graph-switch-f current-repo true))
+              (.watch mobile-util/fs-watcher #js {:path current-repo-dir})
               (file-sync-restart!))))
         (state/pub-event! [:graph/ready (state/get-current-repo)])))))
 

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -143,7 +143,7 @@
   (when (= (:url repo) current-repo)
     (file-sync-restart!)))
 
-;; FIXME: awful multi-arty function.
+;; FIXME(andelf): awful multi-arty function.
 ;; Should use a `-impl` function instead of the awful `skip-ios-check?` param with nested callback.
 (defn- graph-switch
   ([graph]
@@ -380,10 +380,12 @@
       (when (and (not dir-exists?)
                  (not util/nfs?))
         (state/pub-event! [:graph/dir-gone dir]))))
-  ;; FIXME: an ugly implementation for redirecting to page on new window is restored
-  (repo-handler/graph-ready! repo)
-  ;; Replace initial fs watcher
-  (fs-watcher/load-graph-files! repo)
+  (p/do!
+   (fs-watcher/preload-graph-homepage-files!)
+   ;; FIXME: an ugly implementation for redirecting to page on new window is restored
+   (repo-handler/graph-ready! repo)
+   ;; This replaces the former initial fs watcher
+   (fs-watcher/load-graph-files! repo))
   ;; TODO(junyi): Notify user to update filename format when the UX is smooth enough
   ;; (when-not config/test?
   ;;   (js/setTimeout

--- a/src/main/frontend/idb.cljs
+++ b/src/main/frontend/idb.cljs
@@ -40,6 +40,14 @@
   (when (and key @store)
     (idb-keyval/set key value @store)))
 
+(defn rename-item!
+  [old-key new-key]
+  (when (and old-key new-key @store)
+    (p/let [value (idb-keyval/get old-key @store)]
+      (when value
+        (idb-keyval/set new-key value @store)
+        (idb-keyval/del old-key @store)))))
+
 (defn set-batch!
   [items]
   (when (and (seq items) @store)


### PR DESCRIPTION
Related #10028 

- Refine app-id change handling:  Since fs refactor, db stores file names as relative paths. Thus make it possible to reuse old db directly, no db migration is needed.
- fs initial watcher's performance is not acceptable(actually it's not a watcher, is a recursive directory scan)
- `:graph/ready` should be after `watcher-handler/load-graph-files!`: trade-off between responsiveness and correctness

Changes in this PR:

- Refine iOS app-id change handling
- Add "homepage-preload": refresh today's journal or homepage as early as possible
- Reorder initial watcher incoming files: journals first, then pages
- Add notification when initial watcher receives a large changeset.

