### PR TITLE
Fix: iOS sync download progress; refine iOS share intent

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -8,6 +8,7 @@ const config: CapacitorConfig = {
   appName: 'Logseq',
   bundledWebRuntime: false,
   webDir: 'public',
+  loggingBehavior: 'debug',
   plugins: {
     SplashScreen: {
       launchShowDuration: 500,

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         "@highlightjs/cdn-assets": "10.4.1",
         "@hugotomazi/capacitor-navigation-bar": "^2.0.0",
         "@isomorphic-git/lightning-fs": "^4.6.0",
-        "@logseq/capacitor-file-sync": "0.0.32",
+        "@logseq/capacitor-file-sync": "0.0.33",
         "@logseq/diff-merge": "0.2.2",
         "@logseq/react-tweet-embed": "1.3.1-1",
         "@radix-ui/colors": "^0.1.8",

--- a/src/main/frontend/fs/capacitor_fs.cljs
+++ b/src/main/frontend/fs/capacitor_fs.cljs
@@ -66,8 +66,8 @@
 
 (defn- <readdir [path]
   (-> (p/chain (.readdir Filesystem (clj->js {:path path}))
-              #(js->clj % :keywordize-keys true)
-              :files)
+               #(js->clj % :keywordize-keys true)
+               :files)
       (p/catch (fn [error]
                  (js/console.error "readdir Error: " path ": " error)
                  nil))))
@@ -98,7 +98,7 @@
     result))
 
 (defn- get-files
-  "get all files recursively"
+  "get all files and contents recursively"
   [path]
   (p/let [result (p/loop [result []
                           dirs [path]]
@@ -150,17 +150,18 @@
                                           ""))]
     (path/path-join repo-dir bak-dir relative-path)))
 
-(defn- truncate-old-versioned-files!
+(defn- <truncate-old-versioned-files!
   "reserve the latest 6 version files"
   [dir]
-  (->
-   (p/let [files (get-files dir)
-           files (js->clj files :keywordize-keys true)
-           old-versioned-files (drop 6 (reverse (sort-by :mtime files)))]
-     (mapv (fn [file]
-             (.deleteFile Filesystem (clj->js {:path (:path file)})))
-           old-versioned-files))
-   (p/catch (fn [_]))))
+  (-> (p/let [files (.readdir Filesystem (clj->js {:path dir}))
+
+              files (:files (js->clj files :keywordize-keys true))]
+        (drop 6 (reverse (sort-by :mtime files))))
+      (p/then (fn [old-version-files]
+                (p/all (mapv (fn [file]
+                               (.deleteFile Filesystem (clj->js {:path (:uri file)})))
+                             old-version-files))))
+      (p/catch (fn [_]))))
 
 ;; TODO: move this to FS protocol
 (defn backup-file
@@ -177,7 +178,7 @@
         new-path (path/path-join dir (str (string/replace (.toISOString (js/Date.)) ":" "_") "." (mobile-util/platform) "." ext))]
 
     (<write-file-with-utf8 new-path content)
-    (truncate-old-versioned-files! dir)))
+    (<truncate-old-versioned-files! dir)))
 
 (defn backup-file-handle-changed!
   [repo-dir file-path content]
@@ -197,7 +198,7 @@
         file-path (path/path-join file-root
                                   (str (string/replace (.toISOString (js/Date.)) ":" "_") "." (mobile-util/platform) file-extname))]
     (<write-file-with-utf8 file-path content)
-    (truncate-old-versioned-files! file-root)))
+    (<truncate-old-versioned-files! file-root)))
 
 (defn- write-file-impl!
   [repo dir rpath content {:keys [ok-handler error-handler old-content skip-compare?]} stat]
@@ -303,7 +304,7 @@
               (state/pub-event! [:modal/show-instruction]))
           exists? (<dir-exists? path)
           _ (when-not exists?
-             (p/rejected (str "Cannot access selected directory: " path)))
+              (p/rejected (str "Cannot access selected directory: " path)))
           _ (when (mobile-util/is-iCloud-container-path? path)
               (p/rejected (str "Please avoid accessing the top-level iCloud container path: " path)))
           path (if (mobile-util/native-ios?)

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -836,19 +836,19 @@
                               (config/get-file-extension format))
               repo-dir (config/get-repo-dir repo)
               template (state/get-default-journal-template)]
-          (p/let [file-exists? (fs/file-exists? repo-dir file-rpath)
-                  file-content (when file-exists?
-                                 (fs/read-file repo-dir file-rpath))]
-            (when (and (db/page-empty? repo today-page)
-                       (or (not file-exists?)
-                           (and file-exists? (string/blank? file-content))))
-              (create! title {:redirect? false
-                              :split-namespace? false
-                              :create-first-block? (not template)
-                              :journal? true})
-              (state/pub-event! [:journal/insert-template today-page])
-              (ui-handler/re-render-root!)
-              (plugin-handler/hook-plugin-app :today-journal-created {:title today-page}))))))))
+          (when (db/page-empty? repo today-page)
+            (p/let [file-exists? (fs/file-exists? repo-dir file-rpath)
+                    file-content (when file-exists?
+                                   (fs/read-file repo-dir file-rpath))]
+              (when (or (not file-exists?)
+                        (and file-exists? (string/blank? file-content)))
+                (create! title {:redirect? false
+                                :split-namespace? false
+                                :create-first-block? (not template)
+                                :journal? true})
+                (state/pub-event! [:journal/insert-template today-page])
+                (ui-handler/re-render-root!)
+                (plugin-handler/hook-plugin-app :today-journal-created {:title today-page})))))))))
 
 (defn open-today-in-sidebar
   []

--- a/src/main/frontend/handler/repo.cljs
+++ b/src/main/frontend/handler/repo.cljs
@@ -530,4 +530,5 @@
 (defn graph-ready!
   ;; FIXME: Call electron that the graph is loaded, an ugly implementation for redirect to page when graph is restored
   [graph]
-  (ipc/ipc "graphReady" graph))
+  (when (util/electron?)
+    (ipc/ipc "graphReady" graph)))

--- a/src/main/frontend/search/agency.cljs
+++ b/src/main/frontend/search/agency.cljs
@@ -46,12 +46,10 @@
       (protocol/rebuild-blocks-indice! e1)))
 
   (transact-blocks! [_this data]
-    (println "D:Search > Transact blocks!:" repo)
     (doseq [e (get-flatten-registered-engines repo)]
       (protocol/transact-blocks! e data)))
 
   (transact-pages! [_this data]
-    (println "D:Search > Transact pages!:" repo)
     (doseq [e (get-flatten-registered-engines repo)]
       (protocol/transact-pages! e data)))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -509,10 +509,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@logseq/capacitor-file-sync@0.0.32":
-  version "0.0.32"
-  resolved "https://registry.yarnpkg.com/@logseq/capacitor-file-sync/-/capacitor-file-sync-0.0.32.tgz#fcb978e5e62f1b61a8ac22e57d5e96a39adffa7a"
-  integrity sha512-WA0O+NAHJkZZTXqCRDXFRW9VNADsXJXBoMGuMnPimenxoZimpqgX3awT30AcIWxRppLz/H9vFumQyZF10rojTA==
+"@logseq/capacitor-file-sync@0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@logseq/capacitor-file-sync/-/capacitor-file-sync-0.0.33.tgz#2406c315a0fa0bb1c46cdd970d46cb70896b7b3a"
+  integrity sha512-/6xYQ0t1XBSufe0Pwl7MLdceZph/VV8z2gBOwU8bKPZzNlikwEcfizkf03SxkXaobkieubFv3hUcfRvrjZGuIw==
 
 "@logseq/diff-merge@0.2.2":
   version "0.2.2"


### PR DESCRIPTION
Follow up of #10081

- Fix iOS Logseq Sync download progress notification
- Refactor iOS's initial appOpenUrl handling using `preinit-homepage` introduced in #10081 
- Do not read out all version files when backing up files
- Avoid unnecessary file-reading when calling create-today-journal!