### PR TITLE
Enhance: Disable close window shortcut

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -190,18 +190,11 @@
                        {:role "editMenu"}
                        {:role "viewMenu"}
                        {:role "windowMenu"
-                        :submenu (if mac?
-                                   [{:role "minimize"}
-                                    {:role "zoom"}
-                                    {:type "separator"}
-                                    {:role "front"}
-                                    {:type "separator"}
-                                    {:role "window"}]
-                                   [{:role "minimize"}
-                                    {:role "zoom"}
-                                    ;; Disable Control+W shortcut
-                                    {:role "close"
-                                     :accelerator false}])})
+                        :submenu (when-not mac? [{:role "minimize"}
+                                                 {:role "zoom"}
+                                                 ;; Disable Control+W shortcut
+                                                 {:role "close"
+                                                  :accelerator false}])})
         ;; Windows has no about role
         template (conj template
                        (if mac?

--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -183,11 +183,25 @@
                                                   ;; Avoid conflict with `Control+N` shortcut to move down in the text editor on Windows/Linux
                                                   "Shift+CommandOrControl+N")}
                                   (if mac?
-                                    {:role "close"}
+                                    ;; Disable Command+W shortcut
+                                    {:role "close"
+                                     :accelerator false}
                                     {:role "quit"})]}
                        {:role "editMenu"}
                        {:role "viewMenu"}
-                       {:role "windowMenu"})
+                       {:role "windowMenu"
+                        :submenu (if mac?
+                                   [{:role "minimize"}
+                                    {:role "zoom"}
+                                    {:type "separator"}
+                                    {:role "front"}
+                                    {:type "separator"}
+                                    {:role "window"}]
+                                   [{:role "minimize"}
+                                    {:role "zoom"}
+                                    ;; Disable Control+W shortcut
+                                    {:role "close"
+                                     :accelerator false}])})
         ;; Windows has no about role
         template (conj template
                        (if mac?


### PR DESCRIPTION
Based on [this comment](https://github.com/logseq/logseq/pull/9735#issuecomment-1607101801), we override the default [Window and File menu](https://www.electronjs.org/docs/latest/api/menu#examples) to disable the close window shortcut on all platforms. This binding seems to annoy a lot of users, and multi-window workflow is not properly supported yet. The menu item itself is preserved. `CmdOrCtrl+Q` will now be the only shortcut that closes the window. `CmdOrCtrl+W` is free to be used by plugins or Logseq to dismiss panes etc.

Resolves #3967