### PR TITLE
fix: input-selection-end is not firing correctly

### DIFF
--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -89,7 +89,7 @@
                 (let [^js el (rum/dom-node state)]
                   ;; Passing aria-label as a prop to TextareaAutosize removes the dash
                   (.setAttribute el "aria-label" "editing block")
-                  (. el addEventListener "mouseup"
+                  (. el addEventListener "select"
                      #(let [start (util/get-selection-start el)
                             end (util/get-selection-end el)]
                         (when (and start end)


### PR DESCRIPTION
Fixes #10106

This PR uses the `select` event instead of the `mouseup` event for firing the `input-selection-end` event (`logseq.Editor.onInputSelectionEnd`). This eliminates some unexpected behaviors reported in #10106 and enables keyboard interactions.

Manually tested and it works. And the selection of multiple blocks is not affected.