### PR TITLE
fix: reject promise on child error

### DIFF
--- a/libs/src/LSPlugin.core.ts
+++ b/libs/src/LSPlugin.core.ts
@@ -924,7 +924,7 @@ class PluginLocal extends EventEmitter<
           )
           this.emit('beforeunload', eventBeforeUnload)
         } catch (e) {
-          this.logger.error('[beforeunload Error]', e)
+          this.logger.error('[beforeunload]', e)
         }
 
         await this.dispose()

--- a/libs/src/LSPlugin.user.ts
+++ b/libs/src/LSPlugin.user.ts
@@ -513,7 +513,7 @@ export class LSPluginUser
         cb && (await cb(rest))
         actor?.resolve(null)
       } catch (e) {
-        console.debug(`${_caller.debugTag} [beforeunload] `, e)
+        this.logger.error(`[beforeunload] `, e)
         actor?.reject(e)
       }
     })

--- a/libs/src/postmate/index.ts
+++ b/libs/src/postmate/index.ts
@@ -137,13 +137,17 @@ export class ParentAPI {
   }
 
   get(property, ...args) {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       // Extract data from response and kill listeners
       const uid = generateNewMessageId()
       const transact = (e) => {
         if (e.data.uid === uid && e.data.postmate === 'reply') {
           this.parent.removeEventListener('message', transact, false)
-          resolve(e.data.value)
+          if (e.data.error) {
+            reject(e.data.error)
+          } else {
+            resolve(e.data.value)
+          }
         }
       }
 
@@ -242,6 +246,17 @@ export class ChildAPI {
             type: messageType,
             uid,
             value,
+          },
+          e.origin
+        )
+      }).catch((error) => {
+        ;(e.source as WindowProxy).postMessage(
+          {
+            property,
+            postmate: 'reply',
+            type: messageType,
+            uid,
+            error,
           },
           e.origin
         )


### PR DESCRIPTION
Fixes #10107

If there is an error in the child iframe `beforeunload`, the promise will never resolve, making us wait infinitely. Therefore, the `try{}catch{}` block is not working as expected:

https://github.com/logseq/logseq/blob/361d08debe9e0f0b274f8f7ec6c9103be55550dc/libs/src/LSPlugin.core.ts#L920-L928

This PR rejects child promise on error so that the `try{}catch{}` block is catching the error.

To test it, follow #10107 but change `@logseq/libs` to the development one.

One question, should I update `LSPlugin.core.js` in this PR?