### PR TITLE
fix (pdf): Scroll to ref on dark theme

### DIFF
--- a/src/main/frontend/extensions/pdf/pdf.css
+++ b/src/main/frontend/extensions/pdf/pdf.css
@@ -734,9 +734,12 @@ input::-webkit-inner-spin-button {
     background-color: #042f3c;
 
     .pdfViewer {
-      -webkit-filter: invert(100%);
-      filter: invert(100%);
       background: transparent;
+
+      .page {
+        -webkit-filter: invert(100%);
+        filter: invert(100%);
+      }
     }
 
     .textLayer {


### PR DESCRIPTION
Resolves https://github.com/logseq/logseq/issues/10108

That seems like a stretch, but judging from the video, the only thing that resulted in this behavior was switching to the dark theme of the PDF viewer and trying to jump on a ref that requires scrolling. Opening the dev tools somehow makes the issue consistently reproducible, although it's not necessary. The filter rule creates a new stacking context that seems to mess with the auto scrolling. Moving the rule to the individual pages seems to fix this. This is not related to different page sizes within the same PDF, so we need to validate that the reported issue is fixed when this is released.