### PR TITLE
enhance(fs): check graph folder for bad name and nested graph

### DIFF
--- a/deps/common/src/logseq/common/path.cljs
+++ b/deps/common/src/logseq/common/path.cljs
@@ -294,7 +294,7 @@
 ;; compat
 (defn basename
   [path]
-  (let [path (string/replace path #"/$" "")]
+  (let [path (string/replace path #"/+$" "")]
     (filename path)))
 
 (defn dirname


### PR DESCRIPTION
For compatibility, loading the graph is not prevented. Only show a warning notification box.

<img width="421" alt="image" src="https://github.com/logseq/logseq/assets/72891/9e1c1022-7869-40f2-b01b-bcb03ad86b8c">

