### PR TITLE
Fix: Close button visibility

### DIFF
--- a/src/main/frontend/components/container.css
+++ b/src/main/frontend/components/container.css
@@ -682,14 +682,6 @@ html[data-theme='dark'] {
       }
     }
 
-    &:not(:hover) {
-      ::-webkit-scrollbar-thumb,
-      ::-webkit-scrollbar,
-      ::-webkit-scrollbar-thumb:active {
-        background-color: transparent;
-      }
-    }
-
     .initial {
       flex: 1;
     }
@@ -698,18 +690,9 @@ html[data-theme='dark'] {
       @apply h-full;
 
       .button {
-        @apply hidden p-0 ml-2 flex items-center;
+        @apply p-0 ml-2 flex items-center;
 
         &:focus {
-          @apply flex;
-        }
-      }
-    }
-
-    .is-mobile &,
-    &:hover {
-      .item-actions {
-        .button {
           @apply flex;
         }
       }


### PR DESCRIPTION
I am indifferent towards this, so I decided to push a fix since the requested change was trivial. The team can test this and decide to merge or reject it. The action buttons of the sidebar panes will now always be visible to resolve [this discord feedback](https://discord.com/channels/725182569297215569/802530020605820949/1148255023676006440) and also indirectly fix two bugs, because of the visibility change. The buttons were already visible on mobile devices, but that does not include desktops or laptops with touchscreens.

Resolves #10053
Resolves #10051