### PR TITLE
enhance(sync): refine network checking

### DIFF
--- a/src/main/frontend/components/plugins.cljs
+++ b/src/main/frontend/components/plugins.cljs
@@ -433,6 +433,8 @@
                           (assoc opts :test (util/trim-safe (util/evalue %))))
           :value       (:test opts)}]
         [:datalist#proxy-test-url-datalist
+         [:option "https://api.logseq.com/logseq/version"]
+         [:option "https://logseq-connectivity-testing-prod.s3.us-east-1.amazonaws.com/logseq-connectivity-testing"]
          [:option "https://www.google.com"]
          [:option "https://s3.amazonaws.com"]
          [:option "https://clients3.google.com/generate_204"]]]


### PR DESCRIPTION
Follow-up of #10134

- Fix green state is not reliable: stop sync when ws-connection is not available
  - If the outgoing internet connection is cut(WiFi/wired connection still available), the ws-connection retries forever. The sync icon stays green.
- Close network connectivity warning notification when the network is available
- Add testing URLs to the Proxy Setting dialog
- Fix: Retry sync connection even when app starts without a network connection(sync state is nil)