### PR TITLE
Enhance: Introduce customizable close window shortcut

### DIFF
--- a/src/main/frontend/components/window_controls.cljs
+++ b/src/main/frontend/components/window_controls.cljs
@@ -1,26 +1,10 @@
 (ns frontend.components.window-controls
-  (:require [electron.ipc :as ipc]
-            [frontend.components.svg :as svg]
+  (:require [frontend.components.svg :as svg]
             [frontend.context.i18n :refer [t]]
+            [frontend.handler.window :as window-handler]
             [frontend.state :as state]
             [frontend.ui :as ui]
             [rum.core :as rum]))
-
-(defn minimize
-  []
-  (ipc/ipc "window-minimize"))
-
-(defn toggle-maximized
-  []
-  (ipc/ipc "window-toggle-maximized"))
-
-(defn close
-  []
-  (ipc/ipc "window-close"))
-
-(defn toggle-fullscreen
-  []
-  (ipc/ipc "window-toggle-fullscreen"))
 
 (rum/defc container < rum/reactive
   []
@@ -30,23 +14,23 @@
      (if fullscreen?
        [:button.button.icon.fullscreen-toggle
         {:title (t :window/exit-fullscreen)
-         :on-click toggle-fullscreen}
+         :on-click window-handler/toggle-fullscreen!}
         (ui/icon "arrows-minimize")]
        [:<>
         [:button.button.icon.minimize
          {:title (t :window/minimize)
-          :on-click minimize}
+          :on-click window-handler/minimize!}
          (svg/window-minimize)]
 
         [:button.button.icon.maximize-toggle
          {:title (if maximized? (t :window/restore) (t :window/maximize))
           :class (if maximized? "restore" "maximize")
-          :on-click toggle-maximized}
+          :on-click window-handler/toggle-maximized!}
          (if maximized?
            (svg/window-restore)
            (svg/window-maximize))]
 
         [:button.button.icon.close
          {:title (t :window/close)
-          :on-click close}
+          :on-click window-handler/close!}
          (svg/window-close)]])]))

--- a/src/main/frontend/handler/whiteboard.cljs
+++ b/src/main/frontend/handler/whiteboard.cljs
@@ -246,8 +246,8 @@
           point (-> (.getShapeById app source-shape)
                     (.-bounds)
                     ((fn [bounds] (if bottom?
-                                    [(.-minX bounds) (+ 64 (.-maxY bounds))]
-                                    [(+ 64 (.-maxX bounds)) (.-minY bounds)]))))
+                                    [(.-minX ^js bounds) (+ 64 (.-maxY ^js bounds))]
+                                    [(+ 64 (.-maxX ^js bounds)) (.-minY ^js bounds)]))))
           shape (->logseq-portal-shape block-uuid point)]
       (when (uuid? block-uuid) (editor-handler/set-blocks-id! [block-uuid]))
       (.createShapes api (clj->js shape))

--- a/src/main/frontend/handler/window.cljs
+++ b/src/main/frontend/handler/window.cljs
@@ -1,0 +1,18 @@
+(ns frontend.handler.window
+  (:require [electron.ipc :as ipc]))
+
+(defn minimize!
+  []
+  (ipc/ipc "window-minimize"))
+
+(defn toggle-maximized!
+  []
+  (ipc/ipc "window-toggle-maximized"))
+
+(defn close!
+  []
+  (ipc/ipc "window-close"))
+
+(defn toggle-fullscreen!
+  []
+  (ipc/ipc "window-toggle-fullscreen"))

--- a/src/main/frontend/handler/window.cljs
+++ b/src/main/frontend/handler/window.cljs
@@ -1,4 +1,5 @@
 (ns frontend.handler.window
+  "Window management ns"
   (:require [electron.ipc :as ipc]))
 
 (defn minimize!

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -16,6 +16,7 @@
             [frontend.handler.export :as export-handler]
             [frontend.handler.whiteboard :as whiteboard-handler]
             [frontend.handler.plugin-config :as plugin-config-handler]
+            [frontend.handler.window :as window-handler]
             [frontend.modules.editor.undo-redo :as undo-redo]
             [frontend.dicts :as dicts]
             [frontend.modules.shortcut.before :as m]
@@ -497,6 +498,10 @@
                                              :inactive (not (util/electron?))
                                              :fn       #(page-handler/copy-page-url)}
 
+   :window/close                            {:binding  "mod+w"
+                                             :inactive (not (util/electron?))
+                                             :fn       window-handler/close!}
+
    :ui/toggle-wide-mode                     {:binding "t w"
                                              :fn      ui-handler/toggle-wide-mode!}
 
@@ -706,6 +711,7 @@
            :editor/open-file-in-directory
            :editor/copy-current-file
            :editor/copy-page-url
+           :window/close
            :editor/new-whiteboard
            :ui/toggle-wide-mode
            :ui/select-theme-color
@@ -883,6 +889,7 @@
      :editor/open-file-in-default-app
      :editor/open-file-in-directory
      :editor/copy-page-url
+     :window/close
      :auto-complete/prev
      :auto-complete/next
      :auto-complete/complete

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -823,4 +823,5 @@
   :dev/show-block-data             "(Dev) Show block data"
   :dev/show-block-ast              "(Dev) Show block AST"
   :dev/show-page-data              "(Dev) Show page data"
-  :dev/show-page-ast               "(Dev) Show page AST"}}
+  :dev/show-page-ast               "(Dev) Show page AST"
+  :window/close                    "Close window"}}


### PR DESCRIPTION
Continuing on #10096. Now that the default keyboard behavior is deactivated, users will be able to remove the introduced binding if they want to.  I moved the window handlers to a dedicated file to clean up the code. The binding was added to `:shortcut.handler/global-non-editing-only` to avoid closing the window while editing, which might be questionable. I can move it to global bindings if that's not what we want. I also suppressed some random infer build warnings here 6d15483051ce3621d31dcdf1f288b1b2c51972a1.

Resolves https://github.com/logseq/logseq/issues/10176