### PR TITLE
Enhance (UX): Electron loading (fixed)

### DIFF
--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -6,6 +6,7 @@
             ["buffer" :as buffer]
             ["diff-match-patch" :as google-diff]
             ["electron" :refer [app autoUpdater dialog ipcMain shell]]
+            ["electron-window-state" :as windowStateKeeper]
             ["fs" :as fs]
             ["fs-extra" :as fs-extra]
             ["os" :as os]
@@ -617,6 +618,10 @@
 
 (defmethod handle :window-close [^js win]
   (.close win))
+
+(defmethod handle :theme-loaded [^js win]
+  (.manage (windowStateKeeper) win)
+  (.show win))
 
 ;;;;;;;;;;;;;;;;;;;;;;;
 ;; file-sync-rs-apis ;;

--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -35,6 +35,7 @@
                       :titleBarStyle        "hiddenInset"
                       :trafficLightPosition {:x 16 :y 16}
                       :autoHideMenuBar      (not mac?)
+                      :show                 false
                       :webPreferences
                       {:plugins                 true        ; pdf
                        :nodeIntegration         false
@@ -55,7 +56,6 @@
                      linux?
                      (assoc :icon (node-path/join js/__dirname "icons/logseq.png")))
          win       (BrowserWindow. (clj->js win-opts))]
-     (.manage win-state win)
      (.onBeforeSendHeaders (.. session -defaultSession -webRequest)
                            (clj->js {:urls (array "*://*.youtube.com/*")})
                            (fn [^js details callback]

--- a/src/main/frontend/components/theme.cljs
+++ b/src/main/frontend/components/theme.cljs
@@ -1,5 +1,6 @@
 (ns frontend.components.theme
-  (:require [frontend.extensions.pdf.core :as pdf]
+  (:require [electron.ipc :as ipc]
+            [frontend.extensions.pdf.core :as pdf]
             [frontend.config :as config]
             [frontend.handler.plugin :as plugin-handler]
             [frontend.handler.plugin-config :as plugin-config-handler]
@@ -33,7 +34,8 @@
 
     (rum/use-effect!
      #(let [doc js/document.documentElement]
-        (.setAttribute doc "lang" preferred-language)))
+        (.setAttribute doc "lang" preferred-language)
+        (js/setTimeout (fn [] (ipc/ipc "theme-loaded")) 100))) ; Wait for the theme to be applied
 
     (rum/use-effect!
      #(when (and restored-sidebar?

--- a/src/main/frontend/components/theme.cljs
+++ b/src/main/frontend/components/theme.cljs
@@ -34,8 +34,10 @@
 
     (rum/use-effect!
      #(let [doc js/document.documentElement]
-        (.setAttribute doc "lang" preferred-language)
-        (js/setTimeout (fn [] (ipc/ipc "theme-loaded")) 100)) ; Wait for the theme to be applied
+        (.setAttribute doc "lang" preferred-language)))
+
+    (rum/use-effect!
+     #(js/setTimeout (fn [] (ipc/ipc "theme-loaded")) 100) ; Wait for the theme to be applied
      [])
 
     (rum/use-effect!

--- a/src/main/frontend/components/theme.cljs
+++ b/src/main/frontend/components/theme.cljs
@@ -35,7 +35,8 @@
     (rum/use-effect!
      #(let [doc js/document.documentElement]
         (.setAttribute doc "lang" preferred-language)
-        (js/setTimeout (fn [] (ipc/ipc "theme-loaded")) 100))) ; Wait for the theme to be applied
+        (js/setTimeout (fn [] (ipc/ipc "theme-loaded")) 100)) ; Wait for the theme to be applied
+     [])
 
     (rum/use-effect!
      #(when (and restored-sidebar?


### PR DESCRIPTION
Initial PR https://github.com/logseq/logseq/pull/10049
Introduced bug https://github.com/logseq/logseq/issues/10162

Reverted the [revert](https://github.com/logseq/logseq/pull/10165) and pushed a fix. The issue was that use-effect was triggered on window resize. Added an empty list as a second param to `use-effect!` to ensure that it is only triggered once. 

Tested on Linux and macOS. I am experiencing issues with my Windows VM. It would be nice if we could also test this on Windows before merging, to make sure it's working properly on all platforms.

To QA, open Logseq, maximize the window and close the app. Re-open the application and try to unmaximize and resize the window. 