### PR TITLE
chore(electron): use logger instead of console.log

### DIFF
--- a/src/electron/electron/configs.cljs
+++ b/src/electron/electron/configs.cljs
@@ -1,9 +1,9 @@
 (ns electron.configs
-  (:require
-    ["fs-extra" :as ^js fs]
-    ["path" :as ^js node-path]
-    ["electron" :refer [^js app] :as electron]
-    [cljs.reader :as reader]))
+  (:require ["electron" :refer [^js app] :as electron]
+            ["fs-extra" :as ^js fs]
+            ["path" :as ^js node-path]
+            [cljs.reader :as reader]
+            [electron.logger :as logger]))
 
 ;; FIXME: move configs.edn to where it should be
 (defonce dot-root (.join node-path (.getPath app "home") ".logseq"))
@@ -17,14 +17,14 @@
     (let [body (.toString (.readFileSync fs cfg-path))]
       (if (seq body) (reader/read-string body) {}))
     (catch :default e
-      (js/console.error :cfg-error e))))
+      (logger/error :cfg-error e))))
 
 (defn- write-cfg!
   [cfg]
   (try
     (.writeFileSync fs cfg-path (pr-str cfg)) cfg
     (catch :default e
-      (js/console.error :cfg-error e))))
+      (logger/error :cfg-error e))))
 
 (defn set-item!
   [k v]

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -244,7 +244,7 @@
                                   (.toString (.readFileSync fs txid-path)))]
           (reader/read-string sync-meta))))
     (catch :default e
-      (js/console.debug "[read txid meta] #" root (.-message e)))))
+      (logger/error "[read txid meta] #" root (.-message e)))))
 
 (defmethod handle :inflateGraphsInfo [_win [_ graphs]]
   (if (seq graphs)


### PR DESCRIPTION
A log from a user without further info.

```
[2023-09-10 19:10:11.581] [debug] :electron.handler/watch-dir {:path "C:/Users/user/Documents/Logseq"}
[2023-09-10 19:10:12.369] [error] IPC error:  {:event #object[Object [object Object]], :args #js ["inflateGraphsInfo" #js [#js {:url "logseq_local_C:/Users/user/Documents/Logseq", :root "C:/Users/user/Documents/Logseq", :nfs? true}]]} Error:                                                                                      is not ISeqable
    at $cljs$core$seq$$ (C:\Users\user\AppData\Local\Logseq\app-0.9.17\resources\app\electron.js:1535:9)
    at $cljs$core$rest$$ (C:\Users\user\AppData\Local\Logseq\app-0.9.17\resources\app\electron.js:1548:356)
    at $cljs$core$next$$ (C:\Users\user\AppData\Local\Logseq\app-0.9.17\resources\app\electron.js:1552:290)
    at $cljs$core$second$$ (C:\Users\user\AppData\Local\Logseq\app-0.9.17\resources\app\electron.js:2039:29)
    at C:\Users\user\AppData\Local\Logseq\app-0.9.17\resources\app\electron.js:15367:301
    at C:\Users\user\AppData\Local\Logseq\app-0.9.17\resources\app\electron.js:15368:12
    at $JSCompiler_StaticMethods_sval$$ (C:\Users\user\AppData\Local\Logseq\app-0.9.17\resources\app\electron.js:3246:301)
    at $JSCompiler_prototypeAlias$$.$cljs$core$ISeqable$_seq$arity$1$ (C:\Users\user\AppData\Local\Logseq\app-0.9.17\resources\app\electron.js:3320:3)
    at $cljs$core$seq$$ (C:\Users\user\AppData\Local\Logseq\app-0.9.17\resources\app\electron.js:1524:40)
```

```console
> npx source-map-cli resolve -c 10 electron.js.map 15367 301

Maps to electron/handler.cljs:254:27 (cljs.core/second)

          (reader/read-string sync-meta))))
    (catch :default e
      (js/console.debug "[read txid meta] #" root (.-message e)))))

(defmethod handle :inflateGraphsInfo [_win [_ graphs]]
  (if (seq graphs)
    (for [{:keys [root] :as graph} graphs]
      (if-let [sync-meta (read-txid-info! root)]
        (assoc graph
               :sync-meta sync-meta
               :GraphUUID (second sync-meta))
                           ^
        graph))
    []))

(defmethod handle :readGraphTxIdInfo [_win [_ root]]
  (read-txid-info! root))

(defn- get-graph-path
  [graph-name]
  (when graph-name
    (let [graph-name (sanitize-graph-name graph-name)
```