### PR TITLE
Feat (Whiteboards): Pen mode (palm rejection)

### DIFF
--- a/src/main/frontend/components/container.css
+++ b/src/main/frontend/components/container.css
@@ -524,7 +524,7 @@ html[data-theme='dark'] {
   }
 
   &-btn {
-    @apply fixed bottom-4 right-8;
+    @apply fixed bottom-4 right-4 sm:right-8;
 
     > .inner {
       @apply font-bold

--- a/src/main/frontend/components/whiteboard.css
+++ b/src/main/frontend/components/whiteboard.css
@@ -205,7 +205,7 @@ input.tl-text-input {
 
   .tl-action-bar {
     left: 0.5rem;
-    bottom: 0.5rem;
+    bottom: 0;
   }
 
   .tl-primary-tools {

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -465,6 +465,7 @@
  :whiteboard/dashboard-card-edited "Edited "
  :whiteboard/toggle-grid "Toggle grid"
  :whiteboard/snap-to-grid "Snap to grid"
+ :whiteboard/toggle-pen-mode "Toggle pen mode"
  :flashcards/modal-welcome-title "Time to create a card!"
  :flashcards/modal-welcome-desc-1 "You can add \"#card\" to any block to turn it into a card or trigger \"/cloze\" to add some clozes."
  :flashcards/modal-welcome-desc-2 "You can "

--- a/tldraw/apps/tldraw-logseq/src/components/ActionBar/ActionBar.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ActionBar/ActionBar.tsx
@@ -17,6 +17,10 @@ export const ActionBar = observer(function ActionBar(): JSX.Element {
     handlers: { t },
   } = React.useContext(LogseqContext)
 
+  const {
+    handlers: { isMobile },
+  } = React.useContext(LogseqContext)
+
   const undo = React.useCallback(() => {
     app.api.undo()
   }, [app])
@@ -41,10 +45,14 @@ export const ActionBar = observer(function ActionBar(): JSX.Element {
     app.api.toggleSnapToGrid()
   }, [app])
 
+  const togglePenMode = React.useCallback(() => {
+    app.api.togglePenMode()
+  }, [app])
+
   return (
     <div className="tl-action-bar" data-html2canvas-ignore="true">
       {!app.readOnly && (
-        <div className="tl-toolbar tl-history-bar">
+        <div className="tl-toolbar tl-history-bar mr-4 mb-2">
           <Button tooltip={t('whiteboard/undo')} onClick={undo}>
             <TablerIcon name="arrow-back-up" />
           </Button>
@@ -54,7 +62,7 @@ export const ActionBar = observer(function ActionBar(): JSX.Element {
         </div>
       )}
 
-      <div className={`tl-toolbar tl-zoom-bar ${app.readOnly ? '' : 'ml-4'}`}>
+      <div className={'tl-toolbar tl-zoom-bar mr-4 mb-2'}>
         <Button tooltip={t('whiteboard/zoom-in')} onClick={zoomIn} id="tl-zoom-in">
           <TablerIcon name="plus" />
         </Button>
@@ -65,7 +73,7 @@ export const ActionBar = observer(function ActionBar(): JSX.Element {
         <ZoomMenu />
       </div>
 
-      <div className={'tl-toolbar tl-grid-bar ml-4'}>
+      <div className={'tl-toolbar tl-grid-bar mr-4 mb-2'}>
         <ToggleInput
             tooltip={t('whiteboard/toggle-grid')}
             className="tl-button"
@@ -88,6 +96,20 @@ export const ActionBar = observer(function ActionBar(): JSX.Element {
           </ToggleInput>
         )}
       </div>
+
+      {!app.readOnly && (
+        <div className="tl-toolbar tl-pen-mode-bar mb-2">
+          <ToggleInput
+            tooltip={t('whiteboard/toggle-pen-mode')}
+            className="tl-button"
+            pressed={app.settings.penMode}
+            id="tl-toggle-pen-mode"
+            onPressedChange={togglePenMode}
+          >
+          <TablerIcon name={app.settings.penMode ? "pencil" : "pencil-off"} />
+        </ToggleInput>
+        </div>
+      )}
     </div>
   )
 })

--- a/tldraw/apps/tldraw-logseq/src/components/ActionBar/ActionBar.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ActionBar/ActionBar.tsx
@@ -17,10 +17,6 @@ export const ActionBar = observer(function ActionBar(): JSX.Element {
     handlers: { t },
   } = React.useContext(LogseqContext)
 
-  const {
-    handlers: { isMobile },
-  } = React.useContext(LogseqContext)
-
   const undo = React.useCallback(() => {
     app.api.undo()
   }, [app])

--- a/tldraw/apps/tldraw-logseq/src/components/ActionBar/ActionBar.tsx
+++ b/tldraw/apps/tldraw-logseq/src/components/ActionBar/ActionBar.tsx
@@ -52,7 +52,7 @@ export const ActionBar = observer(function ActionBar(): JSX.Element {
   return (
     <div className="tl-action-bar" data-html2canvas-ignore="true">
       {!app.readOnly && (
-        <div className="tl-toolbar tl-history-bar mr-4 mb-2">
+        <div className="tl-toolbar tl-history-bar mr-2 mb-2">
           <Button tooltip={t('whiteboard/undo')} onClick={undo}>
             <TablerIcon name="arrow-back-up" />
           </Button>
@@ -62,7 +62,7 @@ export const ActionBar = observer(function ActionBar(): JSX.Element {
         </div>
       )}
 
-      <div className={'tl-toolbar tl-zoom-bar mr-4 mb-2'}>
+      <div className={'tl-toolbar tl-zoom-bar mr-2 mb-2'}>
         <Button tooltip={t('whiteboard/zoom-in')} onClick={zoomIn} id="tl-zoom-in">
           <TablerIcon name="plus" />
         </Button>
@@ -73,7 +73,7 @@ export const ActionBar = observer(function ActionBar(): JSX.Element {
         <ZoomMenu />
       </div>
 
-      <div className={'tl-toolbar tl-grid-bar mr-4 mb-2'}>
+      <div className={'tl-toolbar tl-grid-bar mr-2 mb-2'}>
         <ToggleInput
             tooltip={t('whiteboard/toggle-grid')}
             className="tl-button"

--- a/tldraw/apps/tldraw-logseq/src/styles.css
+++ b/tldraw/apps/tldraw-logseq/src/styles.css
@@ -166,7 +166,7 @@ html[data-theme='light'] {
 }
 
 .tl-action-bar {
-  @apply absolute bottom-0 flex items-center border-0 left-10 bottom-10;
+  @apply absolute flex items-center border-0 left-10 bottom-8 flex-wrap-reverse;
 
   z-index: 100000;
   user-select: none;

--- a/tldraw/apps/tldraw-logseq/src/styles.css
+++ b/tldraw/apps/tldraw-logseq/src/styles.css
@@ -166,7 +166,7 @@ html[data-theme='light'] {
 }
 
 .tl-action-bar {
-  @apply absolute flex items-center border-0 left-10 bottom-8 flex-wrap-reverse;
+  @apply absolute flex items-center border-0 left-10 bottom-8 flex-wrap-reverse pr-12;
 
   z-index: 100000;
   user-select: none;

--- a/tldraw/packages/core/src/lib/TLApi/TLApi.ts
+++ b/tldraw/packages/core/src/lib/TLApi/TLApi.ts
@@ -178,6 +178,13 @@ export class TLApi<S extends TLShape = TLShape, K extends TLEventMap = TLEventMa
     return this
   }
 
+
+  togglePenMode = (): this => {
+    const { settings } = this.app
+    settings.update({ penMode: !settings.penMode })
+    return this
+  }
+
   setColor = (color: string): this => {
     const { settings } = this.app
 

--- a/tldraw/packages/core/src/lib/TLSettings.ts
+++ b/tldraw/packages/core/src/lib/TLSettings.ts
@@ -4,6 +4,7 @@ import { observable, makeObservable, action } from 'mobx'
 export interface TLSettingsProps {
   mode: 'light' | 'dark'
   showGrid: boolean
+  penMode: boolean
   snapToGrid: boolean
   color: string
   scaleLevel: string
@@ -17,6 +18,7 @@ export class TLSettings implements TLSettingsProps {
   @observable mode: 'dark' | 'light' = 'light'
   @observable showGrid = true
   @observable snapToGrid = true
+  @observable penMode = false
   @observable scaleLevel = 'md'
   @observable color = ''
 

--- a/tldraw/packages/react/src/components/AppCanvas.tsx
+++ b/tldraw/packages/react/src/components/AppCanvas.tsx
@@ -27,6 +27,7 @@ export const AppCanvas = observer(function InnerApp<S extends TLReactShape>(
       shapes={app.shapes} // TODO: use shapes in viewport later?
       assets={app.assets}
       showGrid={app.settings.showGrid}
+      penMode={app.settings.penMode}
       showSelection={app.showSelection}
       showSelectionRotation={app.showSelectionRotation}
       showResizeHandles={app.showResizeHandles}

--- a/tldraw/packages/react/src/components/Canvas/Canvas.tsx
+++ b/tldraw/packages/react/src/components/Canvas/Canvas.tsx
@@ -58,6 +58,7 @@ export interface TLCanvasProps<S extends TLReactShape> {
   cursorRotation: number
   selectionRotation: number
   onEditingEnd: () => void
+  penMode: boolean
   showGrid: boolean
   showSelection: boolean
   showHandles: boolean

--- a/tldraw/packages/react/src/hooks/useCanvasEvents.ts
+++ b/tldraw/packages/react/src/hooks/useCanvasEvents.ts
@@ -13,7 +13,7 @@ export function useCanvasEvents() {
 
   const events = React.useMemo(() => {
     const onPointerMove: TLReactCustomEvents['pointer'] = e => {
-      if (app.settings.penMode && e.pointerType !== 'pen') {
+      if (app.settings.penMode && (e.pointerType !== 'pen' || !e.isPrimary)) {
         return
       }
 
@@ -22,7 +22,7 @@ export function useCanvasEvents() {
     }
 
     const onPointerDown: TLReactCustomEvents['pointer'] = e => {
-      if (app.settings.penMode && e.pointerType !== 'pen') {
+      if (app.settings.penMode && (e.pointerType !== 'pen' || !e.isPrimary)) {
         return
       }
 
@@ -49,7 +49,7 @@ export function useCanvasEvents() {
     }
 
     const onPointerUp: TLReactCustomEvents['pointer'] = e => {
-      if (app.settings.penMode && e.pointerType !== 'pen') {
+      if (app.settings.penMode && (e.pointerType !== 'pen' || !e.isPrimary)) {
         return
       }
 
@@ -59,7 +59,7 @@ export function useCanvasEvents() {
     }
 
     const onPointerEnter: TLReactCustomEvents['pointer'] = e => {
-      if (app.settings.penMode && e.pointerType !== 'pen') {
+      if (app.settings.penMode && (e.pointerType !== 'pen' || !e.isPrimary)) {
         return
       }
 
@@ -68,7 +68,7 @@ export function useCanvasEvents() {
     }
 
     const onPointerLeave: TLReactCustomEvents['pointer'] = e => {
-      if (app.settings.penMode && e.pointerType !== 'pen') {
+      if (app.settings.penMode && (e.pointerType !== 'pen' || !e.isPrimary)) {
         return
       }
 

--- a/tldraw/packages/react/src/hooks/useCanvasEvents.ts
+++ b/tldraw/packages/react/src/hooks/useCanvasEvents.ts
@@ -13,11 +13,19 @@ export function useCanvasEvents() {
 
   const events = React.useMemo(() => {
     const onPointerMove: TLReactCustomEvents['pointer'] = e => {
+      if (app.settings.penMode && e.pointerType !== 'pen') {
+        return
+      }
+
       const { order = 0 } = e
       callbacks.onPointerMove?.({ type: TLTargetType.Canvas, order }, e)
     }
 
     const onPointerDown: TLReactCustomEvents['pointer'] = e => {
+      if (app.settings.penMode && e.pointerType !== 'pen') {
+        return
+      }
+
       const { order = 0 } = e
       if (!order) e.currentTarget?.setPointerCapture(e.pointerId)
 
@@ -41,17 +49,29 @@ export function useCanvasEvents() {
     }
 
     const onPointerUp: TLReactCustomEvents['pointer'] = e => {
+      if (app.settings.penMode && e.pointerType !== 'pen') {
+        return
+      }
+
       const { order = 0 } = e
       if (!order) e.currentTarget?.releasePointerCapture(e.pointerId)
       callbacks.onPointerUp?.({ type: TLTargetType.Canvas, order }, e)
     }
 
     const onPointerEnter: TLReactCustomEvents['pointer'] = e => {
+      if (app.settings.penMode && e.pointerType !== 'pen') {
+        return
+      }
+
       const { order = 0 } = e
       callbacks.onPointerEnter?.({ type: TLTargetType.Canvas, order }, e)
     }
 
     const onPointerLeave: TLReactCustomEvents['pointer'] = e => {
+      if (app.settings.penMode && e.pointerType !== 'pen') {
+        return
+      }
+
       const { order = 0 } = e
       callbacks.onPointerLeave?.({ type: TLTargetType.Canvas, order }, e)
     }

--- a/tldraw/packages/react/src/hooks/useShapeEvents.ts
+++ b/tldraw/packages/react/src/hooks/useShapeEvents.ts
@@ -1,23 +1,33 @@
 import * as React from 'react'
 import { TLTargetType } from '@tldraw/core'
+import { useApp } from './useApp'
 import { useRendererContext } from '.'
 import { DOUBLE_CLICK_DURATION } from '../constants'
 import type { TLReactShape } from '../lib'
 import type { TLReactCustomEvents } from '../types'
 
 export function useShapeEvents<S extends TLReactShape>(shape: S) {
+  const app = useApp()
   const { inputs, callbacks } = useRendererContext()
 
   const rDoubleClickTimer = React.useRef<number>(-1)
 
   const events = React.useMemo(() => {
     const onPointerMove: TLReactCustomEvents['pointer'] = e => {
+      if (app.settings.penMode && e.pointerType !== 'pen') {
+        return
+      }
+
       const { order = 0 } = e
       callbacks.onPointerMove?.({ type: TLTargetType.Shape, shape, order }, e)
       e.order = order + 1
     }
 
     const onPointerDown: TLReactCustomEvents['pointer'] = e => {
+      if (app.settings.penMode && e.pointerType !== 'pen') {
+        return
+      }
+
       const { order = 0 } = e
       if (!order) e.currentTarget?.setPointerCapture(e.pointerId)
       callbacks.onPointerDown?.({ type: TLTargetType.Shape, shape, order }, e)
@@ -25,6 +35,10 @@ export function useShapeEvents<S extends TLReactShape>(shape: S) {
     }
 
     const onPointerUp: TLReactCustomEvents['pointer'] = e => {
+      if (app.settings.penMode && e.pointerType !== 'pen') {
+        return
+      }
+
       const { order = 0 } = e
       if (!order) e.currentTarget?.releasePointerCapture(e.pointerId)
       callbacks.onPointerUp?.({ type: TLTargetType.Shape, shape, order }, e)
@@ -42,12 +56,20 @@ export function useShapeEvents<S extends TLReactShape>(shape: S) {
     }
 
     const onPointerEnter: TLReactCustomEvents['pointer'] = e => {
+      if (app.settings.penMode && e.pointerType !== 'pen') {
+        return
+      }
+
       const { order = 0 } = e
       callbacks.onPointerEnter?.({ type: TLTargetType.Shape, shape, order }, e)
       e.order = order + 1
     }
 
     const onPointerLeave: TLReactCustomEvents['pointer'] = e => {
+      if (app.settings.penMode && e.pointerType !== 'pen') {
+        return
+      }
+
       const { order = 0 } = e
       callbacks.onPointerLeave?.({ type: TLTargetType.Shape, shape, order }, e)
       e.order = order + 1

--- a/tldraw/packages/react/src/hooks/useShapeEvents.ts
+++ b/tldraw/packages/react/src/hooks/useShapeEvents.ts
@@ -14,7 +14,7 @@ export function useShapeEvents<S extends TLReactShape>(shape: S) {
 
   const events = React.useMemo(() => {
     const onPointerMove: TLReactCustomEvents['pointer'] = e => {
-      if (app.settings.penMode && e.pointerType !== 'pen') {
+      if (app.settings.penMode && (e.pointerType !== 'pen' || !e.isPrimary)) {
         return
       }
 
@@ -24,7 +24,7 @@ export function useShapeEvents<S extends TLReactShape>(shape: S) {
     }
 
     const onPointerDown: TLReactCustomEvents['pointer'] = e => {
-      if (app.settings.penMode && e.pointerType !== 'pen') {
+      if (app.settings.penMode && (e.pointerType !== 'pen' || !e.isPrimary)) {
         return
       }
 
@@ -35,7 +35,7 @@ export function useShapeEvents<S extends TLReactShape>(shape: S) {
     }
 
     const onPointerUp: TLReactCustomEvents['pointer'] = e => {
-      if (app.settings.penMode && e.pointerType !== 'pen') {
+      if (app.settings.penMode && (e.pointerType !== 'pen' || !e.isPrimary)) {
         return
       }
 
@@ -56,7 +56,7 @@ export function useShapeEvents<S extends TLReactShape>(shape: S) {
     }
 
     const onPointerEnter: TLReactCustomEvents['pointer'] = e => {
-      if (app.settings.penMode && e.pointerType !== 'pen') {
+      if (app.settings.penMode && (e.pointerType !== 'pen' || !e.isPrimary)) {
         return
       }
 
@@ -66,7 +66,7 @@ export function useShapeEvents<S extends TLReactShape>(shape: S) {
     }
 
     const onPointerLeave: TLReactCustomEvents['pointer'] = e => {
-      if (app.settings.penMode && e.pointerType !== 'pen') {
+      if (app.settings.penMode && (e.pointerType !== 'pen' || !e.isPrimary)) {
         return
       }
 


### PR DESCRIPTION
A simplified approach to pen mode. When this mode is enabled, non 'pen' type pointer events will be rejected.
Although this feature needs to be explicitly enabled, it would be nice if we could test this on multiple different devices before release. It seems to work fine on my wacom tablet on linux. I also made some minor style adjustments to our bottom toolbars for mobile.

Resolves #9863

Also see
https://discuss.logseq.com/t/whiteboards-could-really-do-with-palm-rejection-for-use-on-tablets/16769
https://discuss.logseq.com/t/whiteboard-ipad-apple-pencil-support/17526

![Screenshot from 2023-09-15 10-59-59](https://github.com/logseq/logseq/assets/10744960/2379fe2c-f9b7-4bbd-88be-3dc30cef869e)

