### PR TITLE
dev: Allow plugins to access custom format clipboard data

### DIFF
--- a/resources/js/preload.js
+++ b/resources/js/preload.js
@@ -24,8 +24,8 @@ function getFilePathFromClipboard () {
  * @returns Buffer containing the contents of the clipboard for the specified format, or null if not available.
  */
 function getClipboardData (format) {
-  if (clipboard.has(mime, "clipboard")) {
-    return clipboard.readBuffer(mime)
+  if (clipboard.has(format, "clipboard")) {
+    return clipboard.readBuffer(format)
   }
   else {
     return null;

--- a/resources/js/preload.js
+++ b/resources/js/preload.js
@@ -18,6 +18,20 @@ function getFilePathFromClipboard () {
   }
 }
 
+/**
+ * Read the contents of the clipboard for a custom format.
+ * @param  {string} format The custom format to read.
+ * @returns Buffer containing the contents of the clipboard for the specified format, or null if not available.
+ */
+function getClipboardData (format) {
+  if (clipboard.has(mime, "clipboard")) {
+    return clipboard.readBuffer(mime)
+  }
+  else {
+    return null;
+  }
+}
+
 contextBridge.exposeInMainWorld('apis', {
   doAction: async (arg) => {
     return await ipcRenderer.invoke('main', arg)
@@ -171,6 +185,8 @@ contextBridge.exposeInMainWorld('apis', {
   },
 
   getFilePathFromClipboard,
+
+  getClipboardData,
 
   setZoomFactor (factor) {
     webFrame.setZoomFactor(factor)


### PR DESCRIPTION
It is currently possible for plugins to access clipboard data from a small set of supported formats, e.g. `text/plain`, `text/html`. However, it is not possible to access custom formats like `application/custom` (for more context, see [here](https://bugs.chromium.org/p/chromium/issues/detail?id=487266)). For a plugin I am currently developing I want to provide interoperability with an application that uses such a custom clipboard data format.

This change adds a function that allows for accessing this data to `preload.js`. It exposes this function to the main world. I believe this change would also be useful for the development of other plugins.