### PR TITLE
enhance(electron): ctrl or cmd + = to zoom

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -207,6 +207,10 @@
                                     {:role "about"
                                      :label "About Logseq"
                                      :click about-fn}]}))
+        ;; Enable Cmd/Ctrl+= Zoom In
+        template (conj template 
+                       {:role "zoomin"
+                        :accelerator "CommandOrControl+="})
         menu (.buildFromTemplate Menu (clj->js template))]
     (.setApplicationMenu Menu menu)))
 


### PR DESCRIPTION
I've modified the source to enable zooming as per this issue: #5637 

It is a longstanding issue from the electron project, found and implemented a workaround as per the [docs](https://github.com/electron/electron/blob/main/docs/tutorial/keyboard-shortcuts.md).

> To configure a local keyboard shortcut, you need to specify an [accelerator](https://github.com/electron/electron/blob/main/docs/api/accelerator.md) property when creating a [MenuItem](https://github.com/electron/electron/blob/main/docs/api/menu-item.md) within the [Menu](https://github.com/electron/electron/blob/main/docs/api/menu.md) module.