### PR TITLE
fix(editor): drag and drop to dummy page

### DIFF
--- a/src/main/frontend/handler/dnd.cljs
+++ b/src/main/frontend/handler/dnd.cljs
@@ -1,5 +1,5 @@
 (ns frontend.handler.dnd
-  "Provides fns for drag n drop"
+  "Provides fns for drag and drop"
   (:require [frontend.handler.editor :as editor-handler]
             [frontend.handler.editor.property :as editor-property]
             [frontend.modules.outliner.core :as outliner-core]


### PR DESCRIPTION
See-also: #10104, #10262

- Add drop handler to `dummy-page` component
- Add the same style as `dnd-separator`(only top border, since incoming blocks always appear at the top of the page)

To Reproduce:
- Use any calendar plugin, click and nav to a non-exsit page, then `dummy-page` will shown.
- Drag a block from the right side bar to the "Click here to edit..." placeholder

