### PR TITLE
chore: add marker prop to BlockEntity interface

### DIFF
--- a/libs/src/LSPlugin.ts
+++ b/libs/src/LSPlugin.ts
@@ -192,6 +192,7 @@ export interface BlockEntity {
   level?: number
   meta?: { timestamps: any; properties: any; startPos: number; endPos: number }
   title?: Array<any>
+	marker?: string
 }
 
 /**


### PR DESCRIPTION
The current `BlockEntity` interface does not have a marker prop.

This PR adds the marker prop (optional string) for better typing. 