### PR TITLE
Fix android back button closing order

### DIFF
--- a/src/main/frontend/mobile/action_bar.cljs
+++ b/src/main/frontend/mobile/action_bar.cljs
@@ -1,4 +1,5 @@
 (ns frontend.mobile.action-bar
+  "Block Action bar, activated when swipe on a block"
   (:require
    [frontend.db :as db]
    [frontend.extensions.srs :as srs]

--- a/src/main/frontend/mobile/core.cljs
+++ b/src/main/frontend/mobile/core.cljs
@@ -82,8 +82,16 @@
                                   (state/get-left-sidebar-open?)
                                   (state/set-left-sidebar-open! false)
 
-                                  :else true))
+                                  (state/action-bar-open?)
+                                  (state/set-state! :mobile/show-action-bar? false)
 
+                                  (not-empty (state/get-selection-blocks))
+                                  (editor-handler/clear-selection!)
+
+                                  (state/editing?)
+                                  (editor-handler/escape-editing)
+
+                                  :else true))
                      (if (or (string/ends-with? href "#/")
                              (string/ends-with? href "/")
                              (not (string/includes? href "#/")))

--- a/src/main/frontend/mobile/index.css
+++ b/src/main/frontend/mobile/index.css
@@ -35,6 +35,7 @@
   border-radius: 10px;
   background-color: var(--ls-secondary-background-color);
   overflow-x: overlay;
+  overflow-y: hidden;
   box-shadow: rgba(0, 0, 0, 0.02) 0px 1px 1px 0px, rgba(27, 31, 35, 0.10) 0px 0px 0px 1px;
   z-index: 100;
 

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1896,6 +1896,10 @@ Similar to re-frame subscriptions"
             (when (or (util/mobile?) (mobile-util/native-platform?))
               (set-state! :mobile/show-action-bar? false)))))))))
 
+(defn action-bar-open?
+  []
+  (:mobile/show-action-bar? @state))
+
 (defn remove-watch-state [key]
   (remove-watch state key))
 


### PR DESCRIPTION
- back button should close the action bar
- Should not quit when editing
- Should not quit when selection is active
- Avoid vertical scroll bar of action bar

Fix #10341