### PR TITLE
feat: add modal window for stylus settings

### DIFF
--- a/src/main/frontend/components/plugins.cljs
+++ b/src/main/frontend/components/plugins.cljs
@@ -460,6 +460,14 @@
                                 (state/set-state! [:electron/user-cfgs :settings/agent] opts)
                                 (state/close-sub-modal! :https-proxy-panel))))]]]))
 
+(rum/defc stylus-settings-panel []
+    [:div.cp__settings-stylus-panel
+     [:h1.mb-2.text-2xl.font-bold (t :settings-page/stylus)]
+     [:p.pt-2
+       (ui/button (t :save)
+                   :on-click (fn []
+                              (state/close-sub-modal! :stylus-panel)))]])
+
 (rum/defc auto-check-for-updates-control
   []
   (let [[enabled, set-enabled!] (rum/use-state (plugin-handler/get-enabled-auto-check-for-updates?))

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -429,6 +429,20 @@
           #(let [value (not enable-timetracking?)]
              (config-handler/set-config! :feature/enable-timetracking? value))))
 
+(rum/defc stylus-settings []
+  (ui/button [:span.flex.items-center
+              [:span.pr-1]
+              (ui/icon "edit")]
+             :class "text-sm p-1"
+             :on-click #(state/set-sub-modal!
+                         (fn [_] (plugins/stylus-settings-panel))
+                         {:id :stylus-panel :center? true})))
+
+(defn stylus-settings-row []
+  (row-with-button-action
+   {:left-label (t :settings-page/stylus)
+    :action (stylus-settings)}))
+
 (defn update-home-page
   [event]
   (let [value (util/evalue event)]
@@ -687,7 +701,8 @@
        (tooltip-row t enable-tooltip?))
      (timetracking-row t enable-timetracking?)
      (enable-all-pages-public-row t enable-all-pages-public?)
-     (auto-push-row t current-repo enable-git-auto-push?)]))
+     (auto-push-row t current-repo enable-git-auto-push?)
+     (stylus-settings-row)]))
 
 (rum/defc settings-git
   []

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -305,6 +305,7 @@
  :settings-page/preferred-pasting-file "Prefer pasting file"
  :settings-page/enable-shortcut-tooltip "Enable shortcut tooltip"
  :settings-page/enable-timetracking "Timetracking"
+ :settings-page/stylus "Stylus settings"
  :settings-page/enable-tooltip "Tooltips"
  :settings-page/enable-journals "Journals"
  :settings-page/enable-all-pages-public "All pages public when publishing"


### PR DESCRIPTION
Fixes #10359

This adds a new button in the editor settings menu to open a modal to change pen settings. In this PR, I would just add a setting for enabling pen mode by default, but the same window might be used for further expansion