### PR TITLE
feat(whiteboard): Add default pen mode toggle

### DIFF
--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -601,6 +601,13 @@
    {:left-label (t :settings-page/network-proxy)
     :action (user-proxy-settings agent-opts)}))
 
+(defn pen-mode-default-row [t pen-mode-default?]
+  (toggle "pen_mode_default"
+          (t :settings-page/pen-mode-default)
+          pen-mode-default?
+          #(let [value (not pen-mode-default?)]
+             (config-handler/set-config! :feature/pen-mode-default? value))))
+
 (rum/defcs auto-chmod-row < rum/reactive
   [state t]
   (let [enabled? (if (= nil (state/sub [:electron/user-cfgs :feature/enable-automatic-chmod?]))
@@ -691,10 +698,10 @@
 
 (rum/defcs settings-input < rum/reactive
   [_state current-repo]
-  (let []
+  (let [pen-mode-default? (state/pen-mode-default?)]
 
-    [:div.panel-wrap.is-editor
-     ]))
+    [:div.panel-wrap.is-input
+      (pen-mode-default-row t pen-mode-default?)]))
 
 (rum/defc settings-git
   []

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -697,9 +697,8 @@
      (auto-push-row t current-repo enable-git-auto-push?)]))
 
 (rum/defcs settings-input < rum/reactive
-  [_state current-repo]
+  [_state _current-repo]
   (let [pen-mode-default? (state/pen-mode-default?)]
-
     [:div.panel-wrap.is-input
       (pen-mode-default-row t pen-mode-default?)]))
 

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -689,6 +689,13 @@
      (enable-all-pages-public-row t enable-all-pages-public?)
      (auto-push-row t current-repo enable-git-auto-push?)]))
 
+(rum/defcs settings-input < rum/reactive
+  [_state current-repo]
+  (let []
+
+    [:div.panel-wrap.is-editor
+     ]))
+
 (rum/defc settings-git
   []
   [:div.panel-wrap
@@ -1098,6 +1105,7 @@
                [:general "general" (t :settings-page/tab-general) (ui/icon "adjustments")]
                [:editor "editor" (t :settings-page/tab-editor) (ui/icon "writing")]
                [:keymap "keymap" (t :settings-page/tab-keymap) (ui/icon "keyboard")]
+               [:input "input" (t :settings-page/tab-input) (ui/icon "ballpen")]
 
                (when (util/electron?)
                  [:version-control "git" (t :settings-page/tab-version-control) (ui/icon "history")])
@@ -1143,6 +1151,9 @@
 
          :keymap
          (shortcut2/shortcut-keymap-x)
+
+         :input
+         (settings-input current-repo)
 
          :version-control
          (settings-git)

--- a/src/main/frontend/extensions/tldraw.cljs
+++ b/src/main/frontend/extensions/tldraw.cljs
@@ -139,6 +139,7 @@
         [loaded-app set-loaded-app] (rum/use-state nil)
         on-mount (fn [^js tln]
                    (when tln
+                     (set! (.-appPenModeDefault tln) (state/pen-mode-default?))
                      (set! (.-appUndo tln) undo)
                      (set! (.-appRedo tln) redo)
                      (when-let [^js api (gobj/get tln "api")]

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -2219,3 +2219,7 @@ Similar to re-frame subscriptions"
   [page-name]
   (when-not (string/blank? page-name)
     (sub [:db/properties-changed-pages page-name])))
+
+(defn pen-mode-default?
+  []
+  (not (false? (:feature/pen-mode-default? (sub-config)))))

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -298,6 +298,7 @@
  :settings-page/auto-updater "Auto updater"
  :settings-page/disable-sentry "Send usage data and diagnostics to Logseq"
  :settings-page/disable-sentry-desc "Logseq will never collect your local graph database or sell your data."
+ :settings-page/pen-mode-default "Enable pen mode by default"
  :settings-page/preferred-outdenting "Logical outdenting"
  :settings-page/preferred-outdenting-tip "The left side shows outdenting with the default setting, and the right shows outdenting with logical outdenting enabled "
  :settings-page/preferred-outdenting-tip-more "→ Learn more"

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -326,6 +326,7 @@
  :settings-page/current-version "Current version"
  :settings-page/tab-general "General"
  :settings-page/tab-editor "Editor"
+ :settings-page/tab-input "Input"
  :settings-page/tab-keymap "Keymap"
  :settings-page/tab-version-control "Version control"
  :settings-page/tab-account "Account"

--- a/tldraw/apps/tldraw-logseq/src/app.tsx
+++ b/tldraw/apps/tldraw-logseq/src/app.tsx
@@ -71,6 +71,12 @@ const AppImpl = () => {
   const ref = React.useRef<HTMLDivElement>(null)
   const app = useApp()
 
+  React.useEffect(() => {
+    if (app.appPenModeDefault) {
+      app.settings.update({ penMode: app.appPenModeDefault })
+    }
+  }, [app])
+
   const components = React.useMemo(
     () => ({
       ContextBar,


### PR DESCRIPTION
Fixes #10359

The new option is seperated into a new settings tab to allow for further expansion (button bindings for pens, pressure sensitivity,...).