### PR TITLE
fix: wrong date fn usage in #10350

### DIFF
--- a/src/main/frontend/date.cljs
+++ b/src/main/frontend/date.cljs
@@ -155,6 +155,7 @@
 
 (defn normalize-journal-title
   "Normalize journal title at best effort. Return nil if title is not a valid date.
+   Return goog.date.Date.
 
    Return format: 20220812T000000"
   [title]
@@ -202,6 +203,7 @@
     (journal-title-> journal-title #(tf/unparse formatter %))))
 
 (defn date->file-name
+  "Date object to filename format"
   [date]
   (let [formatter (if-let [format (state/get-journal-file-name-format)]
                     (tf/formatter format)

--- a/src/main/frontend/modules/file/core.cljs
+++ b/src/main/frontend/modules/file/core.cljs
@@ -122,7 +122,7 @@
           whiteboard-page? (model/whiteboard-page? page-block)
           format (if whiteboard-page? "edn" format)
           journal-page? (date/valid-journal-title? title)
-          journal-title (date/journal-title->custom-format title)
+          journal-title (date/normalize-journal-title title)
           journal-page? (and journal-page? (not (string/blank? journal-title)))
           filename (if journal-page?
                      (date/date->file-name journal-title)


### PR DESCRIPTION
Wrong date fn usage introduced in #10350.


Error in dev mode:

```
Write file failed, please copy the changes to other editors in case of losing data.

Error: Error: Assert failed: (instance? goog.date.Date dt)
at Object.cljs_time$format$unparse [as unparse] (./js/cljs-runtime/cljs_time.format.js:686:8)
at Object.frontend$date$date__GT_file_name [as date__GT_file_name] (./js/cljs-runtime/frontend.date.js:235:25)
at Object.frontend$modules$file$core$transact_file_tx_if_not_exists_BANG_ [as transact_file_tx_if_not_exists_BANG_] (./js/cljs-runtime/frontend.modules.file.core.js:168:57)
at Object.frontend$modules$file$core$save_tree_BANG_ [as save_tree_BANG_] (./js/cljs-runtime/frontend.modules.file.core.js:245:35)
at Object.frontend$modules$outliner$file$do_write_file_BANG_ [as do_write_file_BANG_] (./js/cljs-runtime/frontend.modules.outliner.file.js:36:35)
at Object.frontend$modules$outliner$file$write_files_BANG_ [as write_files_BANG_] (./js/cljs-runtime/frontend.modules.outliner.file.js:97:36)
at eval (./js/cljs-runtime/frontend.modules.outliner.file.js:182:32)
at switch__27887__auto__ (./js/cljs-runtime/frontend.util.js:2224:122)
at eval (./js/cljs-runtime/frontend.util.js:2737:29)
at Function.frontend$util$state_machine__27888__auto____1 [as cljs$core$IFn$_invoke$arity$1] (./js/cljs-runtime/frontend.util.js:2759:4)
```