### PR TITLE
enhance(zotero): better multi-profile experience

### DIFF
--- a/src/main/frontend/extensions/pdf/core.cljs
+++ b/src/main/frontend/extensions/pdf/core.cljs
@@ -945,11 +945,14 @@
          (case (.-name error)
            "MissingPDFException"
            (do
-             (notification/show!
-              (str "Error: " (.-message error) "\n Is this the correct path?")
-              :error
-              false)
-             (state/set-state! :pdf/current nil))
+              (if (pdf-assets/handle-missing-pdf-error! pdf-current)
+                (set-loader-state! {:error nil})
+                (do
+                  (notification/show!
+                  (str "Error: " (.-message error) "\n Is this the correct path?")
+                  :error
+                  false)
+                  (state/set-state! :pdf/current nil))))
 
            "InvalidPDFException"
            (do


### PR DESCRIPTION
This commit handles  the `MissingPDFException` frequently encountered in using multiple profiles.

add: `function handle-missing-pdf-error!`

`:file-path` property of a PDF highlight page (the "hls_xxx.md" page) will now be  updated based on the profile selected.

<!--
Thank you for the pull request. Please provide a description. Screenshots and gifs are appreciated for UX enhancements, new features and bug fixes!

For bug fixes and new features, please include tests and possibly benchmarks.
-->
