### PR TITLE
fix(journal): handle non standard journal name page-ref

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -44,7 +44,6 @@
             [frontend.handler.plugin :as plugin-handler]
             [frontend.handler.repeated :as repeated]
             [frontend.handler.route :as route-handler]
-            [frontend.handler.page :as page-handler]
             [frontend.handler.ui :as ui-handler]
             [frontend.handler.whiteboard :as whiteboard-handler]
             [frontend.handler.export.common :as export-common-handler]

--- a/src/main/frontend/components/search.cljs
+++ b/src/main/frontend/components/search.cljs
@@ -154,7 +154,7 @@
     ;; If it's a journal title or journal file name, translate the title
     :new-page
     (if-let [journal-title (date/journal-title->custom-format search-q)]
-        (page-handler/create! journal-title {:redirect? true})
+        (page-handler/create! journal-title {:redirect? true :journal? true})
         (page-handler/create! search-q {:redirect? true}))
 
     :new-whiteboard


### PR DESCRIPTION
Fix #10432

This is an old bug. When using non-current journal names in page-ref, it can't navigate.
This is coupled with page-cp logic.

This fix:

- Guard at final click logic(This avoids calculating date formats for all page-refs)
- This original warning text still exists to denote a warning state: `page-inner's page-entity is nil, given page-name:  2023_10_28  page-name-in-block:  2023_10_28`