### PR TITLE
fix: multiple bugs with query builder construction

### DIFF
--- a/src/main/frontend/components/query/builder.cljs
+++ b/src/main/frontend/components/query/builder.cljs
@@ -449,8 +449,8 @@
                                                  block (db/pull [:block/uuid (:block/uuid block)])]
                                              (when block
                                                (let [content (string/replace (:block/content block)
-                                                                             (util/format "{{query %s" q-str)
-                                                                             (util/format "{{query %s" q))]
+                                                                             #"\{\{query[^}]+\}\}"
+                                                                             (util/format "{{query %s}}" q))]
                                                  (editor-handler/save-block! repo (:block/uuid block) content)))))))
              (assoc state ::tree *tree)))
    :will-mount (fn [state]


### PR DESCRIPTION
Bug was caused by query string updates relying on q-str which is only valid on initial render. Subsequent changes to query caused bugs

Fixes #10263, fixes #10264 and fixes #9159. This is also fixed a bug with deleting a filter e.g. add a property filter, delete it and then observe query string still has property filter