### PR TITLE
fix(editor): transition task from DOING to DONE on click

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1856,7 +1856,7 @@
                         "NOW" "LATER"
                         "LATER" "NOW"
                         "TODO" "DOING"
-                        "DOING" "TODO")]
+                        "DOING" "DONE")]
       [:a
        {:class (str "marker-switch block-marker " marker)
         :title (util/format "Change from %s to %s" marker next-marker)


### PR DESCRIPTION
When clicking on a task in state `DOING` transition to `DONE` instead of back to `TODO`.