### PR TITLE
enhance: remove the need to add a space to trigger search command

### DIFF
--- a/src/main/frontend/components/cmdk.cljs
+++ b/src/main/frontend/components/cmdk.cljs
@@ -95,7 +95,7 @@
                             (take 5 items))))
         page-exists? (when-not (string/blank? input)
                        (db/entity [:block/name (string/trim input)]))
-        filter-mode? (or (string/includes? input " /")
+        filter-mode? (or (string/includes? input "/")
                          (string/starts-with? input "/"))
         order* (cond
                  (= search-mode :graph)
@@ -275,7 +275,7 @@
   [input]
   (or (when (string/starts-with? input "/")
         (subs input 1))
-      (last (gp-util/split-last " /" input))))
+      (last (gp-util/split-last "/" input))))
 
 (defmethod load-results :filters [group state]
   (let [!results (::results state)
@@ -389,8 +389,8 @@
 (defn- get-filter-user-input
   [input]
   (cond
-    (string/includes? input " /")
-    (first (gp-util/split-last " /" input))
+    (string/includes? input "/")
+    (first (gp-util/split-last "/" input))
     (string/starts-with? input "/")
     ""
     :else

--- a/src/main/frontend/components/cmdk.cljs
+++ b/src/main/frontend/components/cmdk.cljs
@@ -95,17 +95,24 @@
                             (take 5 items))))
         page-exists? (when-not (string/blank? input)
                        (db/entity [:block/name (string/trim input)]))
-        filter-mode? (or (string/includes? input "/")
-                         (string/starts-with? input "/"))
+        include-slash? (or (string/includes? input "/")
+                           (string/starts-with? input "/"))
         order* (cond
                  (= search-mode :graph)
                  [["Pages"          :pages          (visible-items :pages)]]
 
-                 filter-mode?
-                 [["Filters"        :filters        (visible-items :filters)]
-                  ["Pages"          :pages          (visible-items :pages)]
+                 include-slash?
+                 [(if page-exists?
+                    ["Pages"          :pages          (visible-items :pages)]
+                    ["Filters"        :filters        (visible-items :filters)])
+                  (if page-exists?
+                    ["Filters"        :filters        (visible-items :filters)]
+                    ["Pages"          :pages          (visible-items :pages)])
                   (when-not page-exists?
-                    ["Create"         :create         (create-items input)])]
+                    ["Create"         :create         (create-items input)])
+                  ["Current page"   :current-page   (visible-items :current-page)]
+                  ["Blocks"         :blocks         (visible-items :blocks)]
+                  ["Files"          :files          (visible-items :files)]]
 
                  filter-group
                  [(when (= filter-group :blocks)

--- a/src/main/frontend/components/cmdk.cljs
+++ b/src/main/frontend/components/cmdk.cljs
@@ -573,7 +573,7 @@
                (util/stop e)
                (reset! (::filter state) nil)
                (when-not filter (handle-input-change state nil ""))))
-      (= keyname "c") (copy-block-ref state)
+      (and meta? (= keyname "c")) (copy-block-ref state)
       :else nil)))
 
 (defn keyup-handler
@@ -783,7 +783,7 @@
             :style {:background "var(--lx-gray-02)"}}
 
       (when group-filter
-        [:div.flex.flex-col.p-3.opacity-50.text-sm
+        [:div.flex.flex-col.px-3.py-1.opacity-70.text-sm
          (search-only state (name group-filter))])
 
       (let [items (filter


### PR DESCRIPTION
Previously, a user has to type `/ ` to trigger the filters.