### PR TITLE
Feat: multi tab db worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
         "@logseq/capacitor-file-sync": "5.0.1",
         "@logseq/diff-merge": "0.2.2",
         "@logseq/react-tweet-embed": "1.3.1-1",
-        "@logseq/sqlite": "=0.1.3",
+        "@logseq/sqlite": "=0.1.4",
         "@radix-ui/colors": "^0.1.8",
         "@sentry/react": "^6.18.2",
         "@sentry/tracing": "^6.18.2",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
         "@logseq/capacitor-file-sync": "5.0.1",
         "@logseq/diff-merge": "0.2.2",
         "@logseq/react-tweet-embed": "1.3.1-1",
-        "@logseq/sqlite": "=0.1.4",
+        "@logseq/sqlite": "=0.1.5",
         "@radix-ui/colors": "^0.1.8",
         "@sentry/react": "^6.18.2",
         "@sentry/tracing": "^6.18.2",

--- a/src/main/frontend/db/restore.cljs
+++ b/src/main/frontend/db/restore.cljs
@@ -119,7 +119,6 @@
   [repo]
   (state/set-state! :graph/loading? true)
   (p/let [start-time (t/now)
-          ; data (ipc/ipc :get-initial-data repo)
           data (persist-db/<fetch-init-data repo)
           {:keys [conn uuid->db-id-map journal-blocks datoms-count]}
           (sqlite-restore/restore-initial-data data {:conn-from-datoms-fn

--- a/src/main/frontend/db_worker.cljs
+++ b/src/main/frontend/db_worker.cljs
@@ -50,7 +50,15 @@
    [_this repo]
    (p/do!
     (.ensure_init sqlite-db)
+    (.init_db sqlite-db repo) ;; close another and init this one
     (.new_db sqlite-db repo)))
+
+  (openDB
+   [_this repo]
+   (p/do!
+    (.ensure_init sqlite-db)
+    ;; close another and init this one
+    (.init_db sqlite-db repo)))
 
   (deleteBlocks
    [_this repo uuids]

--- a/src/main/frontend/db_worker.cljs
+++ b/src/main/frontend/db_worker.cljs
@@ -5,7 +5,7 @@
             [promesa.core :as p]
             [shadow.cljs.modern :refer [defclass]]))
 
-(def *inited (atom false))
+(def *wasm-loaded (atom false))
 
 #_:clj-kondo/ignore
 (defclass SQLiteDB
@@ -16,9 +16,18 @@
    (super))
 
   Object
+  (init
+   [_this]
+   (p/let [wasm-url (js/URL. "/static/js/logseq_sqlite_bg.wasm" (.. js/location -href))
+           _ (wasm-bindgen-init wasm-url)]
+     (prn ::init-ok
+          :has-opfs-support (.has_opfs_support sqlite-db)
+          :sqlite-version (.get_version sqlite-db))
+     (reset! *wasm-loaded true)))
+
   (inited
    [_this]
-   (boolean @*inited))
+   (boolean @*wasm-loaded))
 
   ;; dev-only, close all db connections and db files
   (unsafeDevCloseAll
@@ -39,47 +48,56 @@
 
   (newDB
    [_this repo]
-   (.new_db sqlite-db repo))
+   (p/do!
+    (.ensure_init sqlite-db)
+    (.new_db sqlite-db repo)))
 
   (deleteBlocks
    [_this repo uuids]
    (when (seq uuids)
-     (.delete_blocks sqlite-db repo uuids)))
+     (p/do!
+      (.ensure_init sqlite-db)
+      (.delete_blocks sqlite-db repo uuids))))
 
   (upsertBlocks
    [_this repo blocks]
-   (.upsert_blocks sqlite-db repo blocks))
+   (p/do!
+    (.ensure_init sqlite-db)
+    (.upsert_blocks sqlite-db repo blocks)))
 
   (fetchAllPages
    [_this repo]
-   (.fetch_all_pages sqlite-db repo))
+   (p/do!
+    (.ensure_init sqlite-db)
+    (.fetch_all_pages sqlite-db repo)))
 
   ;; fetch all blocks, return block id and page id
   (fetchAllBlocks
    [_this repo]
-   (.fetch_all_blocks sqlite-db repo))
+   (p/do!
+    (.ensure_init sqlite-db)
+    (.fetch_all_blocks sqlite-db repo)))
 
   (fetchRecentJournals
    [_this repo]
-   (.fetch_recent_journals sqlite-db repo))
+   (p/do!
+    (.ensure_init sqlite-db)
+    (.fetch_recent_journals sqlite-db repo)))
 
   (fetchInitData
    [_this repo]
-   (.fetch_init_data sqlite-db repo))
+   (p/do!
+    (.ensure_init sqlite-db)
+    (.fetch_init_data sqlite-db repo)))
 
   (fetchBlocksExcluding
    [_this repo excluding-uuids]
-   (.fetch_blocks_excluding sqlite-db repo excluding-uuids)))
+   (p/do!
+    (.ensure_init sqlite-db)
+    (.fetch_blocks_excluding sqlite-db repo excluding-uuids))))
 
 (defn init
   "web worker entry"
   []
-  (p/let [current-url (js/URL. "/static/js/logseq_sqlite_bg.wasm" (.. js/location -href))
-          ^js obj (SQLiteDB.) ;; call this
-          _ (Comlink/expose obj) ;; expose as early as possible
-          _ (wasm-bindgen-init current-url) ;; init wasm
-          _ (.init sqlite-db)]
-    (prn ::init-ok
-         :has-opfs-support (.has_opfs_support sqlite-db)
-         :sqlite-version (.get_version sqlite-db))
-    (reset! *inited true)))
+  (let [^js obj (SQLiteDB.)]
+    (Comlink/expose obj)))

--- a/src/main/frontend/handler.cljs
+++ b/src/main/frontend/handler.cljs
@@ -107,7 +107,7 @@
             (p/finally
               (fn []
                 ;; install after config is restored
-                (shortcut/refresh!)
+                (shortcut/refresh-immediately!)
 
                 (cond
                   (and (not (seq (db/get-files config/local-repo)))

--- a/src/main/frontend/handler.cljs
+++ b/src/main/frontend/handler.cljs
@@ -107,7 +107,7 @@
             (p/finally
               (fn []
                 ;; install after config is restored
-                (shortcut/refresh-immediately!)
+                (shortcut/refresh!)
 
                 (cond
                   (and (not (seq (db/get-files config/local-repo)))

--- a/src/main/frontend/modules/shortcut/core.cljs
+++ b/src/main/frontend/modules/shortcut/core.cljs
@@ -237,7 +237,7 @@
      (listen-all!)
      state)})
 
-(defn refresh-internal!
+(defn refresh-immediately!
   "Always use this function to refresh shortcuts"
   []
   (when-not (:ui/shortcut-handler-refreshing? @state/state)
@@ -251,7 +251,7 @@
     (state/pub-event! [:shortcut-handler-refreshed])
     (state/set-state! :ui/shortcut-handler-refreshing? false)))
 
-(def refresh! (debounce refresh-internal! 1000))
+(def refresh! (debounce refresh-immediately! 1000))
 
 (defn- name-with-meta [e]
   (let [ctrl (.-ctrlKey e)

--- a/src/main/frontend/modules/shortcut/core.cljs
+++ b/src/main/frontend/modules/shortcut/core.cljs
@@ -237,7 +237,7 @@
      (listen-all!)
      state)})
 
-(defn refresh-immediately!
+(defn refresh!
   "Always use this function to refresh shortcuts"
   []
   (when-not (:ui/shortcut-handler-refreshing? @state/state)
@@ -250,8 +250,6 @@
       (install-shortcuts! nil))
     (state/pub-event! [:shortcut-handler-refreshed])
     (state/set-state! :ui/shortcut-handler-refreshing? false)))
-
-(def refresh! (debounce refresh-immediately! 1000))
 
 (defn- name-with-meta [e]
   (let [ctrl (.-ctrlKey e)

--- a/src/main/frontend/persist_db/browser.cljs
+++ b/src/main/frontend/persist_db/browser.cljs
@@ -10,11 +10,11 @@
             [frontend.config :as config]
             [promesa.core :as p]
             [frontend.util :as util]
-            [frontend.handler.notification :as notification]))
+            [frontend.handler.notification :as notification]
+            [clojure.string :as string]))
 
 (defonce *sqlite (atom nil))
 (defonce *inited (atom false))
-
 
 (when-not (or (util/electron?) config/publishing? util/node-test?)
   (defonce _do_not_reload_worker
@@ -95,24 +95,33 @@
 
 (comment
   (defn dev-stop!
-  "For dev env only, stop opfs backend, close all sqlite connections and OPFS sync access handles."
-  []
-  (println "[persis-db] Dev: close all sqlite connections")
-  (when-not (util/electron?)
-    (when @*sqlite
-      (.unsafeDevCloseAll ^js @*sqlite)))))
+    "For dev env only, stop opfs backend, close all sqlite connections and OPFS sync access handles."
+    []
+    (println "[persis-db] Dev: close all sqlite connections")
+    (when-not (util/electron?)
+      (when @*sqlite
+        (.unsafeDevCloseAll ^js @*sqlite)))))
 
 
 (defrecord InBrowser []
   protocol/PersistentDB
   (<new [_this repo]
     (prn ::new-repo repo)
-    (p/let [^js sqlite (ensure-sqlite-init)]
-      (.newDB sqlite repo)))
+    (-> (p/let [^js sqlite (ensure-sqlite-init)]
+          (.newDB sqlite repo))
+        (p/catch (fn [error]
+                   (if (string/includes? (str error) "NoModificationAllowedError")
+                     (notification/show! [:div (str "Avoid opening the same graph in multi-tabs. Error: " error)] :error)
+                     (notification/show! [:div (str "SQLiteDB backend error: " error)] :error))
+
+                   nil))))
 
   (<list-db [_this]
-    (p/let [^js sqlite (ensure-sqlite-init)]
-      (.listDB sqlite)))
+    (-> (p/let [^js sqlite (ensure-sqlite-init)]
+          (.listDB sqlite))
+        (p/catch (fn [error]
+                   (notification/show! [:div (str "SQLiteDB error: " error)] :error)
+                   []))))
 
   (<unsafe-delete [_this repo]
     (p/let [^js sqlite (ensure-sqlite-init)]
@@ -127,16 +136,25 @@
             (.upsertBlocks sqlite repo upsert-blocks))))
 
   (<fetch-initital-data [_this repo _opts]
-    (p/let [^js sqlite (ensure-sqlite-init)
-            all-pages (.fetchAllPages sqlite repo)
-            all-blocks (.fetchAllBlocks sqlite repo)
-            journal-blocks (.fetchRecentJournals sqlite repo)
-            init-data (.fetchInitData sqlite repo)]
+    (-> (p/let [^js sqlite (ensure-sqlite-init)
+            ;; <fetch-initital-data is called when init/re-loading graph
+            ;; the underlying DB should be opened
+                _ (.openDB sqlite repo)
+                all-pages (.fetchAllPages sqlite repo)
+                all-blocks (.fetchAllBlocks sqlite repo)
+                journal-blocks (.fetchRecentJournals sqlite repo)
+                init-data (.fetchInitData sqlite repo)]
 
-      #js {:all-blocks all-blocks
-           :all-pages all-pages
-           :journal-blocks journal-blocks
-           :init-data init-data}))
+          #js {:all-blocks all-blocks
+               :all-pages all-pages
+               :journal-blocks journal-blocks
+               :init-data init-data})
+        (p/catch (fn [error]
+                   (if (string/includes? (str error) "NoModificationAllowedError")
+                     (notification/show! [:div (str "Avoid opening the same graph in multi-tabs. Error: " error)] :error)
+                     (notification/show! [:div (str "SQLiteDB backend error: " error)] :error))
+
+                   {}))))
   (<fetch-blocks-excluding [_this repo exclude-uuids _opts]
     (p/let [^js sqlite (ensure-sqlite-init)]
       (.fetchBlocksExcluding sqlite repo (clj->js exclude-uuids)))))

--- a/src/main/frontend/persist_db/node.cljs
+++ b/src/main/frontend/persist_db/node.cljs
@@ -10,6 +10,7 @@
   (<new [_this repo]
     (prn ::new repo)
     (ipc/ipc :db-new repo))
+
   (<list-db [_this]
     (js/console.warn "TODO: list-db for electron is not implemented")
     [])

--- a/yarn.lock
+++ b/yarn.lock
@@ -552,10 +552,10 @@
   resolved "https://registry.yarnpkg.com/@logseq/react-tweet-embed/-/react-tweet-embed-1.3.1-1.tgz#119d22be8234de006fc35c3fa2a36f85634c5be6"
   integrity sha512-9O0oHs5depCvh6ZQvwtl1xb7B80YG5rUfY10uSUat5itOlcE3IWaYYpe6p/tcHErqHWnWgkXHitAB9M29FMbQg==
 
-"@logseq/sqlite@=0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@logseq/sqlite/-/sqlite-0.1.4.tgz#eba6aec015ec857487d000eb47803d1f79e686d0"
-  integrity sha512-N7hRBgLmKpjhU6Hi9RLYaXIwTD/iwV9fhCtPNkqu2oZcq2LJPB4Vf6m+doDdqw7M+TqPZxxb54HrVYQ9hgN2Qg==
+"@logseq/sqlite@=0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@logseq/sqlite/-/sqlite-0.1.5.tgz#c61eda74dd4493adfb22ee1099643311bdc5693a"
+  integrity sha512-MFZjXVEKxmTHnLJVYIxAloFUoGP6at2h1sUKDZfitsbtqgPnNIg1it4Rly74edSjismyif+AO8zn/AXjl3buDA==
 
 "@mapbox/node-pre-gyp@^1.0.0":
   version "1.0.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -552,10 +552,10 @@
   resolved "https://registry.yarnpkg.com/@logseq/react-tweet-embed/-/react-tweet-embed-1.3.1-1.tgz#119d22be8234de006fc35c3fa2a36f85634c5be6"
   integrity sha512-9O0oHs5depCvh6ZQvwtl1xb7B80YG5rUfY10uSUat5itOlcE3IWaYYpe6p/tcHErqHWnWgkXHitAB9M29FMbQg==
 
-"@logseq/sqlite@=0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@logseq/sqlite/-/sqlite-0.1.3.tgz#b1213b680d3caf776652a5059abf9a0731d4cd7b"
-  integrity sha512-7NOFsDt1MqQvBB5p9bRLgCKLMlVJ2coeXEShQS+G7NsIKQ+lIzv7X4bu+69qTdAeeK2+jAVTZjbBX58r8TRgHQ==
+"@logseq/sqlite@=0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@logseq/sqlite/-/sqlite-0.1.4.tgz#eba6aec015ec857487d000eb47803d1f79e686d0"
+  integrity sha512-N7hRBgLmKpjhU6Hi9RLYaXIwTD/iwV9fhCtPNkqu2oZcq2LJPB4Vf6m+doDdqw7M+TqPZxxb54HrVYQ9hgN2Qg==
 
 "@mapbox/node-pre-gyp@^1.0.0":
   version "1.0.11"


### PR DESCRIPTION
See-also: https://github.com/logseq/sqlite-db

Changes:

- Use a different file set for each graph (db, journal, wal, shm. This also leaves space for the search index, maybe vector db in the future)
- Split async init and sync loading logic