### PR TITLE
fix(cmdk): enter key while ime composing

### DIFF
--- a/src/main/frontend/components/cmdk.cljs
+++ b/src/main/frontend/components/cmdk.cljs
@@ -561,6 +561,7 @@
         keyname (.-key e)
         enter? (= keyname "Enter")
         esc? (= keyname "Escape")
+        composing? (util/event-is-composing? e)
         highlighted-group @(::highlighted-group state)
         show-less (fn [] (swap! (::results state) assoc-in [highlighted-group :show] :less))
         show-more (fn [] (swap! (::results state) assoc-in [highlighted-group :show] :more))
@@ -585,9 +586,9 @@
       as-keyup? (if meta?
                   (show-less)
                   (move-highlight state -1))
-      enter? (do
-               (handle-action :default state e)
-               (util/stop-propagation e))
+      (and enter? (not composing?)) (do
+                                      (handle-action :default state e)
+                                      (util/stop-propagation e))
       esc? (let [filter @(::filter state)]
              (when (or (and filter @(::input-changed? state))
                        (not (string/blank? input)))


### PR DESCRIPTION
BUG:

- In CMDK search input: page jumps when ENTER key is pressed while IME composing.
- Expected: handle composing finished event(pass event to system)

https://github.com/logseq/logseq/assets/72891/e0d0ed5d-0fc7-47b2-9de9-3e581275dba9

