### PR TITLE
fix(cmdk): shift key state handling

### DIFF
--- a/src/main/frontend/components/cmdk.cljs
+++ b/src/main/frontend/components/cmdk.cljs
@@ -600,7 +600,7 @@
                                     (util/stop-propagation e))
       :else nil)))
 
-(defn keyup-handler
+(defn- keyup-handler
   [state e]
   (let [shift? (.-shiftKey e)
         meta? (.-metaKey e)
@@ -778,9 +778,8 @@
        (mixins/on-key-down state {}
                            {:target ref
                             :all-handler (fn [e _key] (keydown-handler state e))})
-       (mixins/on-key-up state {}
-                         {:target ref
-                          :all-handler (fn [e _key] (keyup-handler state e))}))))
+       (mixins/on-key-up state {} (fn [e _key]
+                                    (keyup-handler state e))))))
   (rum/local false ::shift?)
   (rum/local false ::meta?)
   (rum/local false ::alt?)

--- a/src/main/frontend/mixins.cljs
+++ b/src/main/frontend/mixins.cljs
@@ -68,6 +68,7 @@
                 nil)))))
 
 (defn on-key-up
+  "Cation: This mixin uses a different args than on-key-down"
   [state keycode-map all-handler]
   (listen state js/window "keyup"
           (fn [e]


### PR DESCRIPTION
BUG: 

- when typing in all uppercase with shift, the `shift?` state is not cleared.  The page will be always open in side-bar.