### PR TITLE
fix(ui): theme details

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -3504,7 +3504,7 @@
                  {:debug-id page})])))))]
 
      (and (:ref? config) (:group-by-page? config))
-     [:div.flex.flex-col
+     [:div.flex.flex-col.references-blocks-wrap
       (let [blocks (sort-by (comp :block/journal-day first) > blocks)]
         (for [[page page-blocks] blocks]
           (ui/lazy-visible
@@ -3513,7 +3513,7 @@
                    page (db/entity (:db/id page))
                    ;; FIXME: parents need to be sorted
                    parent-blocks (group-by :block/parent page-blocks)]
-               [:div.my-2 {:key (str "page-" (:db/id page))}
+               [:div.my-2.references-blocks-item {:key (str "page-" (:db/id page))}
                 (ui/foldable
                  [:div
                   (page-cp config page)

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -479,6 +479,7 @@
 
 .color-level {
   background-color: or(--ls-right-sidebar-content-background, --lx-gray-02, --color-level-1);
+
   .dark & {
     background-color: or(--ls-right-sidebar-content-background, --lx-gray-01, --color-level-1);
   }
@@ -738,5 +739,21 @@ html.is-mac {
     .block-content {
       cursor: pointer;
     }
+  }
+}
+
+.references-blocks {
+  &-wrap {
+    .foldable-title {
+      @apply ml-3;
+
+      .block-control {
+        @apply relative right-[-5px] top-[1px];
+      }
+    }
+  }
+
+  &-item {
+    @apply bg-gray-03 rounded p-4;
   }
 }

--- a/src/main/frontend/components/container.css
+++ b/src/main/frontend/components/container.css
@@ -683,7 +683,7 @@
   }
 
   .references {
-    margin-left: 12px;
+    @apply mx-[28px];
   }
 
   .sidebar-drop-indicator {
@@ -756,6 +756,10 @@
         }
       }
     }
+  }
+
+  .page-hierarchy {
+    @apply pl-[28px];
   }
 }
 

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -795,7 +795,7 @@
                 (when-let [f (:init-collapsed (last (:rum/args state)))]
                   (f (::collapsed? state)))
                 state)}
-  [state header content {:keys [title-trigger? on-mouse-down
+  [state header content {:keys [title-trigger? on-mouse-down class
                                 _default-collapsed? _init-collapsed]}]
   (let [collapsed? (get state ::collapsed?)
         on-mouse-down (fn [e]
@@ -804,6 +804,7 @@
                         (when on-mouse-down
                           (on-mouse-down @collapsed?)))]
     [:div.flex.flex-col
+     {:class class}
      (foldable-title {:on-mouse-down on-mouse-down
                       :header header
                       :title-trigger? title-trigger?


### PR DESCRIPTION
- [x] fix: missing background color for the linked(unlinked) references blocks item container
- [x] fix: alignment of the linked references pane & the hierarchy pane from the right sidebar

### After
![CleanShot 2023-11-30 at 12 03 27@2x](https://github.com/logseq/logseq/assets/1779837/d124c17e-3981-4c74-9216-d90db560fc21)
