### PR TITLE
fix: slides don't work on published sites that aren't under '/'

### DIFF
--- a/src/main/frontend/extensions/slide.cljs
+++ b/src/main/frontend/extensions/slide.cljs
@@ -80,7 +80,7 @@
                   (do
                     (reset! *loading? true)
                     (loader/load
-                     (config/asset-uri "/static/js/reveal.js")
+                     (config/asset-uri (if config/publishing? "static/js/reveal.js" "/static/js/reveal.js"))
                      (fn []
                        (reset! *loading? false)
                        (render!)))))


### PR DESCRIPTION
This fixes https://github.com/logseq/publish-spa/issues/11. To QA the fix locally:

* `bb dev:publishing /path/to/a/graph publish`
* `python3 -m http.server 8080`
* In another tab, open `http://localhost:8080/publish/#/page/home` in a browser
* Click on three dots menu in upper right and select 'View as slides' to see slides load a page's blocks correctly