### PR TITLE
Fix: inline images are not saved in excalidraw

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
         "@capacitor/status-bar": "^5.0.0",
         "@capawesome/capacitor-background-task": "^5.0.0",
         "@capgo/capacitor-navigation-bar": "^6.0.0",
-        "@excalidraw/excalidraw": "0.15.3",
+        "@excalidraw/excalidraw": "0.16.1",
         "@highlightjs/cdn-assets": "10.4.1",
         "@isomorphic-git/lightning-fs": "^4.6.0",
         "@logseq/capacitor-file-sync": "5.0.1",

--- a/src/main/frontend/extensions/excalidraw.cljs
+++ b/src/main/frontend/extensions/excalidraw.cljs
@@ -106,7 +106,7 @@
                  :height (if wide-mode? 650 500)}}
         (excalidraw
          (merge
-          {:on-change (fn [elements app-state]
+          {:on-change (fn [elements app-state files]
                         (when-not (or (= "down" (gobj/get app-state "cursorButton"))
                                       (gobj/get app-state "draggingElement")
                                       (gobj/get app-state "editingElement")
@@ -118,7 +118,7 @@
                               (reset! *elements elements->clj)
                               (draw/save-excalidraw!
                                file
-                               (serializeAsJSON elements app-state))))))
+                               (serializeAsJSON elements app-state files "local"))))))
 
            :zen-mode-enabled @*zen-mode?
            :view-mode-enabled @*view-mode?

--- a/src/main/frontend/fs/node.cljs
+++ b/src/main/frontend/fs/node.cljs
@@ -83,7 +83,7 @@
     (-> (ipc/ipc "mkdir" dir)
         (p/then (fn [_] (js/console.log (str "Directory created: " dir))))
         (p/catch (fn [error]
-                   (when (not= (.-code error) "EEXIST")
+                   (when-not (string/includes? (str error) "EEXIST")
                      (js/console.error (str "Error creating directory: " dir) error))))))
 
   (mkdir-recur! [_this dir]

--- a/yarn.lock
+++ b/yarn.lock
@@ -350,10 +350,10 @@
   optionalDependencies:
     global-agent "^3.0.0"
 
-"@excalidraw/excalidraw@0.15.3":
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/@excalidraw/excalidraw/-/excalidraw-0.15.3.tgz#5dea570f76451adf68bc24d4bfdd67a375cfeab1"
-  integrity sha512-/gpY7fgMO/AEaFLWnPqzbY8H7ly+/zocFf7D0Is5sWNMD2mhult5tana12lXKLSJ6EAz7ubo1A7LajXzvJXJDA==
+"@excalidraw/excalidraw@0.16.1":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@excalidraw/excalidraw/-/excalidraw-0.16.1.tgz#a928945d567a1f5c0aa75bd1b1c05b50329eb27a"
+  integrity sha512-4zirHk7dNx6SVq2jQmYOLliqAa1h3WPVqHM5qtJyhD769VsOqwlkopAcnZMb3G1PeIMm6cf2F31quS5MVqvoOQ==
 
 "@highlightjs/cdn-assets@10.4.1":
   version "10.4.1"


### PR DESCRIPTION
- Fix #7321
- Update excalidraw to 0.16.1 (0.17 is not possible due to CLJS compiler does not support the newest JS standard)
- Fix wrong EEXISTS reporting for mkdir


See-also: https://github.com/excalidraw/excalidraw/blob/557add5bf7dd1d682e5802e5a6289cdb895b1593/src/data/json.ts#L42-L65