### PR TITLE
fix(editor): incorrect handling of pasting html list

### DIFF
--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -160,14 +160,14 @@
                                          nil)))]
                         (if (string/blank? result) nil result))
             text-blocks? (if (= format :markdown) markdown-blocks? org-blocks?)
-            blocks? (text-blocks? text)
             text' (or html-text
                       (when (gp-util/url? text)
                         (wrap-macro-url text))
-                      text)]
+                      text)
+            blocks? (text-blocks? text')]
         (cond
           blocks?
-          (paste-text-parseable format text)
+          (paste-text-parseable format text')
 
           (util/safe-re-find #"(?:\r?\n){2,}" text')
           (paste-segmented-text format text')


### PR DESCRIPTION
I believe this is a typo in the original logic.

Bug: Only multi-level HTML lists can be pasted. When all items are at the same level, only raw markdown is parsed.

- Fix "Full content is not displayed, Logseq doesn't support multiple unordered lists or headings in a block."