### PR TITLE
chore(deps): Update datascript to latest version before our fork

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps
  {org.clojure/clojure                   {:mvn/version "1.11.1"}
   rum/rum                               {:mvn/version "0.12.9"}
-  datascript/datascript                 {:mvn/version "1.3.8"}
+  datascript/datascript                 {:mvn/version "1.5.3"}
   datascript-transit/datascript-transit {:mvn/version "0.3.0"}
   borkdude/rewrite-edn                  {:mvn/version "0.4.7"}
   funcool/promesa                       {:mvn/version "4.0.2"}

--- a/deps/db/deps.edn
+++ b/deps/db/deps.edn
@@ -1,6 +1,6 @@
 {:deps
  ;; External deps should be kept in sync with https://github.com/logseq/nbb-logseq/blob/main/bb.edn
- {datascript/datascript {:mvn/version "1.3.8"}}
+ {datascript/datascript {:mvn/version "1.5.3"}}
  :aliases
  {:clj-kondo
   {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2023.05.26"}}

--- a/src/main/frontend/db/utils.cljs
+++ b/src/main/frontend/db/utils.cljs
@@ -43,7 +43,7 @@
 
 (defn entity
   "This function will return nil if passed `id-or-lookup-ref` is an integer and
-  the entity doesn't exist in db (Datascript will return {:id id}).
+  the entity doesn't exist in db.
   `repo-or-db`: a repo string or a db,
   `id-or-lookup-ref`: same as d/entity."
   ([id-or-lookup-ref]
@@ -55,10 +55,7 @@
                      (conn/get-db repo))
                    ;; db
                    repo-or-db)]
-     (if (integer? id-or-lookup-ref)
-       (when (d/datoms db :eavt id-or-lookup-ref)
-         (d/entity db id-or-lookup-ref))
-       (d/entity db id-or-lookup-ref)))))
+     (d/entity db id-or-lookup-ref))))
 
 (defn pull
   ([eid]


### PR DESCRIPTION
Updating datascript version to derisk our datascript update in feat/db. [Changes since 1.3.8](https://github.com/tonsky/datascript/blob/master/CHANGELOG.md#138) should be backwards compatible except for `d/entity` which I've accounted for by updating `db/entity`