### PR TITLE
Save transactions to disk db to avoid data-loss

### DIFF
--- a/deps/db/src/logseq/db/sqlite/db.cljs
+++ b/deps/db/src/logseq/db/sqlite/db.cljs
@@ -15,13 +15,29 @@
 ;; Reference same sqlite default class in cljs + nbb without needing .cljc
 (def sqlite (if (find-ns 'nbb.core) (aget sqlite3 "default") sqlite3))
 
+;; sqlite databases
+(defonce databases (atom nil))
+;; datascript conns
+(defonce conns (atom nil))
+
+(defn close!
+  []
+  (when @databases
+    (doseq [[_ database] @databases]
+      (.close database))
+    (reset! databases nil)))
+
 (defn sanitize-db-name
   [db-name]
   (-> db-name
       (string/replace sqlite-util/db-version-prefix "")
       (string/replace "/" "_")
       (string/replace "\\" "_")
-      (string/replace ":" "_"))) ;; windows
+      (string/replace ":" "_")))
+
+(defn get-conn
+  [repo]
+  (get @conns (sanitize-db-name repo)))
 
 (defn get-db-full-path
   [graphs-dir db-name]
@@ -72,9 +88,16 @@
   needed sqlite tables if not created and returns a datascript connection that's
   connected to the sqlite db"
   [graphs-dir db-name]
-  (let [[_db-sanitized-name db-full-path] (get-db-full-path graphs-dir db-name)
+  (let [[db-sanitized-name db-full-path] (get-db-full-path graphs-dir db-name)
         db (new sqlite db-full-path nil)]
     (sqlite-common-db/create-kvs-table! db)
+    (swap! databases assoc db-sanitized-name db)
     (let [storage (new-sqlite-storage db)
           conn (sqlite-common-db/get-storage-conn storage)]
+      (swap! conns assoc db-sanitized-name conn)
       conn)))
+
+(defn transact!
+  [repo tx-data tx-meta]
+  (when-let [conn (get-conn repo)]
+    (d/transact! conn tx-data tx-meta)))

--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -308,6 +308,7 @@
 (defn main []
   (if-not (.requestSingleInstanceLock app)
     (do
+      (db/close!)
       (search/close!)
       (.quit app))
     (let [privileges {:standard        true
@@ -337,6 +338,7 @@
                                      (logger/debug "window-all-closed" "Quitting...")
                                      (try
                                        (fs-watcher/close-watcher!)
+                                       (db/close!)
                                        (search/close!)
                                        (catch :default e
                                          (logger/error "window-all-closed" e)))

--- a/src/electron/electron/db.cljs
+++ b/src/electron/electron/db.cljs
@@ -3,9 +3,11 @@
   (:require ["path" :as node-path]
             ["fs-extra" :as fs]
             ["electron" :refer [app]]
-            ;; [electron.logger :as logger]
+            [electron.logger :as logger]
             [logseq.db.sqlite.db :as sqlite-db]
             [electron.backup-file :as backup-file]))
+
+(def close! sqlite-db/close!)
 
 (defn get-graphs-dir
   []
@@ -22,6 +24,14 @@
   (let [graph-dir (node-path/join (get-graphs-dir) (sqlite-db/sanitize-db-name db-name))]
     (fs/ensureDirSync graph-dir)
     graph-dir))
+
+(defn open-db!
+  [db-name]
+  (let [graphs-dir (get-graphs-dir)]
+    (try (sqlite-db/open-db! graphs-dir db-name)
+         (catch :default e
+           (js/console.error e)
+           (logger/error (str e ": " db-name))))))
 
 (defn save-db!
   [db-name data]

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -227,14 +227,6 @@
     (fs-extra/ensureDirSync dir)
     dir))
 
-(defn- get-db-based-graphs-dir
-  []
-  (let [dir (if utils/ci?
-              (.resolve node-path js/__dirname "../tmp/graphs")
-              (.join node-path (.homedir os) "logseq" "graphs"))]
-    (fs-extra/ensureDirSync dir)
-    dir))
-
 ;; TODO: move file based graphs to "~/logseq/graphs" too
 (defn- get-file-based-graphs
   "Returns all graph names in the cache directory (starting with `logseq_local_`)"
@@ -245,20 +237,9 @@
          (map #(node-path/basename % ".transit"))
          (map graph-name->path))))
 
-(defn- get-db-based-graphs
-  "Returns all graph names in the cache directory"
-  []
-  (let [dir (get-db-based-graphs-dir)]
-    (->> (common-graph/read-directories dir)
-         (remove (fn [s] (= s db/unlinked-graphs-dir)))
-         (map graph-name->path)
-         (map (fn [s] (str sqlite-util/db-version-prefix s))))))
-
 (defn- get-graphs
   []
-  (concat
-   (get-file-based-graphs)
-   (get-db-based-graphs)))
+  (get-file-based-graphs))
 
 ;; TODO support alias mechanism
 (defn get-graph-name

--- a/src/main/frontend/db_worker.cljs
+++ b/src/main/frontend/db_worker.cljs
@@ -18,6 +18,14 @@
 (defonce *datascript-conns (atom nil))
 (defonce *opfs-pools (atom nil))
 
+(defn sanitize-db-name
+  [db-name]
+  (-> db-name
+      (string/replace " " "_")
+      (string/replace "/" "_")
+      (string/replace "\\" "_")
+      (string/replace ":" "_")))
+
 (defn- get-sqlite-conn
   [repo]
   (get @*sqlite-conns repo))
@@ -33,7 +41,7 @@
 (defn- <get-opfs-pool
   [graph]
   (or (get-opfs-pool graph)
-      (p/let [^js pool (.installOpfsSAHPoolVfs @*sqlite #js {:name (str "logseq-pool-" graph)
+      (p/let [^js pool (.installOpfsSAHPoolVfs @*sqlite #js {:name (str "logseq-pool-" (sanitize-db-name graph))
                                                              :initialCapacity 10})]
         (swap! *opfs-pools assoc graph pool)
         pool)))
@@ -54,7 +62,7 @@
 
 (defn- get-repo-path
   [repo]
-  (str "/" repo ".sqlite"))
+  (str "/" (sanitize-db-name repo) ".sqlite"))
 
 (defn- <export-db-file
   [repo]

--- a/src/main/frontend/db_worker.cljs
+++ b/src/main/frontend/db_worker.cljs
@@ -212,11 +212,11 @@
                           (string/replace-first (.-name file) ".logseq-pool-" "")))
                       all-files)
                 distinct)]
-     (prn :debug :all-files (map #(.-name %) all-files))
-     (prn :debug :all-files-count (count (filter
-                                          #(= (.-kind %) "file")
-                                          all-files)))
-     (prn :dbs dbs)
+     ;; (prn :debug :all-files (map #(.-name %) all-files))
+     ;; (prn :debug :all-files-count (count (filter
+     ;;                                      #(= (.-kind %) "file")
+     ;;                                      all-files)))
+     ;; (prn :dbs dbs)
      (bean/->js dbs)))
 
   (createOrOpenDB

--- a/src/main/frontend/db_worker.cljs
+++ b/src/main/frontend/db_worker.cljs
@@ -213,17 +213,18 @@
    (p/let [_ (close-other-dbs! repo)]
      (create-or-open-db! repo)))
 
+  (getMaxTx
+   [_this repo]
+   (when-let [conn (get-datascript-conn repo)]
+     (:max-tx @conn)))
+
   (transact
    [_this repo tx-data tx-meta]
    (when-let [conn (get-datascript-conn repo)]
-     (try
-       (let [tx-data (edn/read-string tx-data)
-             tx-meta (edn/read-string tx-meta)]
-         (d/transact! conn tx-data tx-meta)
-         nil)
-       (catch :default e
-         (prn :debug :error)
-         (js/console.error e)))))
+     (let [tx-data (edn/read-string tx-data)
+           tx-meta (edn/read-string tx-meta)]
+       (d/transact! conn tx-data tx-meta)
+       nil)))
 
   (getInitialData
    [_this repo]

--- a/src/main/frontend/handler.cljs
+++ b/src/main/frontend/handler.cljs
@@ -247,7 +247,6 @@
                _ (mobile-util/hide-splash) ;; hide splash as early as ui is stable
                repo (or (state/get-current-repo) (:url (first repos)))
                _ (restore-and-setup! repo repos)]
-         (persist-db/run-export-periodically!)
          (when (mobile-util/native-platform?)
            (state/restore-mobile-theme!)))
        (p/catch (fn [e]

--- a/src/main/frontend/persist_db.cljs
+++ b/src/main/frontend/persist_db.cljs
@@ -43,16 +43,4 @@
 ;; @shuyu Do we still need this?
 (defn <new [repo]
   {:pre [(<= (count repo) 56)]}
-  (p/let [_ (protocol/<new (get-impl) repo)]
-    (<export-db repo {})))
-
-(defn run-export-periodically!
-  []
-  (js/setInterval
-   (fn []
-     (when-let [repo (state/get-current-repo)]
-       (when (and (util/electron?) (config/db-based-graph? repo))
-         (println :debug :save-db-to-disk repo)
-         (<export-db repo {}))))
-   ;; every 10 minutes
-   (* 10 60 1000)))
+  (protocol/<new (get-impl) repo))

--- a/src/main/frontend/persist_db/browser.cljs
+++ b/src/main/frontend/persist_db/browser.cljs
@@ -59,8 +59,7 @@
   protocol/PersistentDB
   (<new [_this repo]
     (when-let [^js sqlite @*sqlite]
-      (.createOrOpenDB sqlite repo)
-      (ipc/ipc :db-open repo)))
+      (.createOrOpenDB sqlite repo)))
 
   (<list-db [_this]
     (when-let [^js sqlite @*sqlite]
@@ -88,8 +87,7 @@
 
   (<fetch-initial-data [_this repo _opts]
     (when-let [^js sqlite @*sqlite]
-      (-> (p/let [_ (.createOrOpenDB sqlite repo)
-                  _ (ipc/ipc :db-open repo)]
+      (-> (p/let [_ (.createOrOpenDB sqlite repo)]
             (.getInitialData sqlite repo))
           (p/catch sqlite-error-handler))))
 

--- a/src/main/frontend/persist_db/browser.cljs
+++ b/src/main/frontend/persist_db/browser.cljs
@@ -44,7 +44,7 @@
     (ipc/ipc :db-export repo data)
 
     ;; TODO: browser nfs-supported? auto backup
-    
+
     ;;
     :else
     nil))
@@ -82,14 +82,8 @@
           tx-data' (pr-str tx-data)
           tx-meta' (pr-str tx-meta)]
       (p/do!
-       (p/let [start (util/time-ms)
-               _ (ipc/ipc :db-transact repo tx-data' tx-meta')]
-         (prn :debug :disk-db-transact-time-ms (- (util/time-ms) start)))
-       (p/let [start (util/time-ms)
-               _ (when sqlite (.transact sqlite repo tx-data' tx-meta'))]
-         (prn :debug :opfs-db-transact-time-ms (- (util/time-ms) start)
-              {:tx-data tx-data
-               :tx-meta tx-meta}))
+       (ipc/ipc :db-transact repo tx-data' tx-meta')
+       (when sqlite (.transact sqlite repo tx-data' tx-meta'))
        nil)))
 
   (<fetch-initial-data [_this repo _opts]


### PR DESCRIPTION
This PR writes the transaction data to both the db backed by OPFS and another one on disk, to avoid any data-loss in case the app crashes.

One caveat is that any transaction will be repeated to 3 dbs (memory, OPFS, disk), it doesn't slow down the UI because writing to OPFS and disk is asynchronous, in the future, we'd like to skip writing to the memory db, writes will go directly to OPFS. Chrome doesn't support specifying a folder on disk to use OPFS (in our case `~/logseq/graphs`), so we still need to write to disk, hopefully, this'll be changed soon so that we can write once.