### PR TITLE
Percent encoding of leading dots

### DIFF
--- a/src/main/frontend/util/fs.cljs
+++ b/src/main/frontend/util/fs.cljs
@@ -130,6 +130,7 @@
           gp-util/page-name-sanity ;; we want to preserve the case sensitive nature of most file systems, don't lowercase
           (string/replace gp-util/url-encoded-pattern encode-url-percent) ;; pre-encode % in title on demand
           (string/replace reserved-chars-pattern url-encode-file-name)
+          (string/replace #"^\." "%2E") ;; Force percent encoding to distinguish pages with a title starting with a dot from a hidden file.
           (escape-windows-reserved-filebodies) ;; do this before the lowbar encoding to avoid ambiguity
           (escape-namespace-slashes-and-multilowbars)))
 

--- a/src/test/frontend/db/name_sanity_test.cljs
+++ b/src/test/frontend/db/name_sanity_test.cljs
@@ -43,6 +43,7 @@
   (test-page-name "dsa&amp&semi;l dsalfjk jkl.")
   (test-page-name "hls__&amp&semi;l dsalfjk jkl.")
   (test-page-name "CON.")
+  (test-page-name ".NET.")
   (mapv test-page-name fs-util/windows-reserved-filebodies))
 
 (deftest new-path-computation-tests


### PR DESCRIPTION
Patch for  https://github.com/logseq/logseq/issues/9196

This patch resolves a problem that prevents Logseq from loading pages with titles beginning with a dot.

The solution is to force the percent-encoding of a leading dot.

Other solutions could be considered.  For example, distinguishing between a hidden file (e.g., ".bashrc") and a Logseq page file (e.g., ".NET.md")  might solve the issue, but it appears to impact the overall program significantly.

The good thing about this patch is its simplicity.  

Limitations of this approach:
- It cannot resolve existing files that start with a dot character. It resolves only newly created files.
- Until now, the page titled '.' was saved as '.___.md,' but from now on, it will be '%2E.md'.
- File names starting with '%2E' are somewhat unsightly.
