### PR TITLE
feat: add ability to change graph forces via UI

### DIFF
--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -691,8 +691,8 @@
             open?
             [:div
              [:p.text-sm.opacity-70.px-4
-              (let [c1 (count (:nodes graph))
-                    s1 (if (> c1 1) "s" "")
+              (let [;; c1 (count (:nodes graph))
+                    ;; s1 (if (> c1 1) "s" "")
                     c2 (count (:links graph))
                     s2 (if (> c2 1) "s" "")
                     ]

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -547,7 +547,7 @@
 (defonce *builtin-pages? (atom nil))
 (defonce *excluded-pages? (atom true))
 (defonce *show-journals-in-page-graph? (atom nil))
-(defonce *link-dist (atom 180))
+(defonce *link-dist (atom 75))
 
 (rum/defc ^:large-vars/cleanup-todo graph-filters < rum/reactive
   [graph settings forcesettings n-hops]
@@ -708,16 +708,17 @@
                           (ui/slider link-dist
                                      {:min 5
                                       :max 180
-                                      :on-change #(reset! *link-dist (int %))}))]
-                                      ;; :on-change #(let [value (util/evalue %)]
-                                      ;;               (set-setting! :link-dist value))}))]
+                                      ;; :on-change #(reset! *link-dist (int %))}))]
+                                      :on-change #(let [value (int %)]
+                                                    (reset! *link-dist value)
+                                                    (set-forcesetting! :link-dist value))}))]
                                       ;; :on-change #(let [value (util/evalue %)]
                                       ;;                (reset! *link-dist value)
                                       ;;                (set-forcesetting! :link-dist value))}))]
 
               [:a.opacity-70.opacity-100 {:on-click (fn []
                                                       (swap! *graph-reset? not)
-                                                      (reset! *link-dist 180))}
+                                                      (reset! *link-dist 75))}
                "Reset Graph"]]]))
          {})
         (graph-filter-section

--- a/src/main/frontend/extensions/graph.cljs
+++ b/src/main/frontend/extensions/graph.cljs
@@ -51,9 +51,9 @@
   {:did-update pixi/render!
    :should-update (fn [old-state new-state]
                     (not= (select-keys (first (:rum/args old-state))
-                                       [:nodes :links :dark? :link-dist])
+                                       [:nodes :links :dark? :link-dist :charge-strength])
                           (select-keys (first (:rum/args new-state))
-                                       [:nodes :links :dark? :link-dist])))
+                                       [:nodes :links :dark? :link-dist :charge-strength])))
    :will-unmount (fn [state]
                    (reset! pixi/*graph-instance nil)
                    state)}

--- a/src/main/frontend/extensions/graph.cljs
+++ b/src/main/frontend/extensions/graph.cljs
@@ -51,9 +51,9 @@
   {:did-update pixi/render!
    :should-update (fn [old-state new-state]
                     (not= (select-keys (first (:rum/args old-state))
-                                       [:nodes :links :dark? :link-dist :charge-strength])
+                                       [:nodes :links :dark? :link-dist :charge-strength :charge-range])
                           (select-keys (first (:rum/args new-state))
-                                       [:nodes :links :dark? :link-dist :charge-strength])))
+                                       [:nodes :links :dark? :link-dist :charge-strength :charge-range])))
    :will-unmount (fn [state]
                    (reset! pixi/*graph-instance nil)
                    state)}

--- a/src/main/frontend/extensions/graph.cljs
+++ b/src/main/frontend/extensions/graph.cljs
@@ -51,9 +51,9 @@
   {:did-update pixi/render!
    :should-update (fn [old-state new-state]
                     (not= (select-keys (first (:rum/args old-state))
-                                       [:nodes :links :dark?])
+                                       [:nodes :links :dark? :link-dist])
                           (select-keys (first (:rum/args new-state))
-                                       [:nodes :links :dark?])))
+                                       [:nodes :links :dark? :link-dist])))
    :will-unmount (fn [state]
                    (reset! pixi/*graph-instance nil)
                    state)}

--- a/src/main/frontend/extensions/graph/pixi.cljs
+++ b/src/main/frontend/extensions/graph/pixi.cljs
@@ -55,7 +55,7 @@
 
 (defn layout!
   "Node forces documentation can be read in more detail here https://d3js.org/d3-force"
-  [nodes links link-dist]
+  [nodes links link-dist charge-strength]
   (let [nodes-count (count nodes)
         simulation (forceSimulation nodes)]
     (-> simulation 
@@ -82,7 +82,7 @@
                     (.theta 0.5)
                     ;; A positive value causes nodes to attract each other, similar to gravity, 
                     ;; while a negative value causes nodes to repel each other, similar to electrostatic charge.
-                    (.strength -600)))
+                    (.strength charge-strength)))
         (.force "collision"
                 (-> (forceCollide)
                     (.radius (+ 8 18))
@@ -185,7 +185,7 @@
     (when @*graph-instance
       (clear-nodes! (:graph @*graph-instance))
       (destroy-instance!))
-    (let [{:keys [nodes links style hover-style height register-handlers-fn dark? link-dist]} (first (:rum/args state))
+    (let [{:keys [nodes links style hover-style height register-handlers-fn dark? link-dist charge-strength]} (first (:rum/args state))
           style                                                                     (or style (default-style dark?))
           hover-style                                                               (or hover-style (default-hover-style dark?))
           graph                                                                     (Graph.)
@@ -200,7 +200,7 @@
           links                                                                     (remove (fn [{:keys [source target]}] (or (nil? source) (nil? target))) links)
           nodes-js                                                                  (bean/->js nodes)
           links-js                                                                  (bean/->js links)
-          simulation                                                                (layout! nodes-js links-js link-dist)]
+          simulation                                                                (layout! nodes-js links-js link-dist charge-strength)]
       (doseq [node nodes-js]
         (try (.addNode graph (.-id node) node)
           (catch :default e

--- a/src/main/frontend/extensions/graph/pixi.cljs
+++ b/src/main/frontend/extensions/graph/pixi.cljs
@@ -93,7 +93,7 @@
         ;; The decay factor is akin to atmospheric friction; after the application of any forces during a tick, 
         ;; each node’s velocity is multiplied by 1 - decay. As with lowering the alpha decay rate, 
         ;; less velocity decay may converge on a better solution, but risks numerical instabilities and oscillation.
-        (.velocityDecay 0.8))
+        (.velocityDecay 0.5))
     (reset! *simulation simulation)
     simulation))
 

--- a/src/main/frontend/extensions/graph/pixi.cljs
+++ b/src/main/frontend/extensions/graph/pixi.cljs
@@ -54,14 +54,14 @@
    :edge {:color "#A5B4FC"}})
 
 (defn layout!
-  [nodes links]
+  [nodes links link-dist]
   (let [nodes-count (count nodes)
         simulation (forceSimulation nodes)]
-    (-> simulation
+    (-> simulation 
         (.force "link"
                 (-> (forceLink)
                     (.id (fn [d] (.-id d)))
-                    (.distance 180)
+                    (.distance link-dist)
                     (.links links)))
         (.force "charge"
                 (-> (forceManyBody)
@@ -167,7 +167,7 @@
     (when @*graph-instance
       (clear-nodes! (:graph @*graph-instance))
       (destroy-instance!))
-    (let [{:keys [nodes links style hover-style height register-handlers-fn dark?]} (first (:rum/args state))
+    (let [{:keys [nodes links style hover-style height register-handlers-fn dark? link-dist]} (first (:rum/args state))
           style                                                                     (or style (default-style dark?))
           hover-style                                                               (or hover-style (default-hover-style dark?))
           graph                                                                     (Graph.)
@@ -182,7 +182,7 @@
           links                                                                     (remove (fn [{:keys [source target]}] (or (nil? source) (nil? target))) links)
           nodes-js                                                                  (bean/->js nodes)
           links-js                                                                  (bean/->js links)
-          simulation                                                                (layout! nodes-js links-js)]
+          simulation                                                                (layout! nodes-js links-js link-dist)]
       (doseq [node nodes-js]
         (try (.addNode graph (.-id node) node)
           (catch :default e

--- a/src/main/frontend/extensions/graph/pixi.cljs
+++ b/src/main/frontend/extensions/graph/pixi.cljs
@@ -55,7 +55,7 @@
 
 (defn layout!
   "Node forces documentation can be read in more detail here https://d3js.org/d3-force"
-  [nodes links link-dist charge-strength]
+  [nodes links link-dist charge-strength charge-range]
   (let [nodes-count (count nodes)
         simulation (forceSimulation nodes)]
     (-> simulation 
@@ -76,7 +76,7 @@
                     (.distanceMin 1)
                     ;; The maximum distance between nodes over which this force is considered.
                     ;; Specifying a finite maximum distance improves performance and produces a more localized layout.
-                    (.distanceMax (if (> nodes-count 500) 4000 600))
+                    (.distanceMax charge-range)
                     ;; For a cluster of nodes that is far away, the charge force can be approximated by treating the cluster as a single, larger node.
                     ;; The theta parameter determines the accuracy of the approximation
                     (.theta 0.5)
@@ -185,7 +185,7 @@
     (when @*graph-instance
       (clear-nodes! (:graph @*graph-instance))
       (destroy-instance!))
-    (let [{:keys [nodes links style hover-style height register-handlers-fn dark? link-dist charge-strength]} (first (:rum/args state))
+    (let [{:keys [nodes links style hover-style height register-handlers-fn dark? link-dist charge-strength charge-range]} (first (:rum/args state))
           style                                                                     (or style (default-style dark?))
           hover-style                                                               (or hover-style (default-hover-style dark?))
           graph                                                                     (Graph.)
@@ -200,7 +200,7 @@
           links                                                                     (remove (fn [{:keys [source target]}] (or (nil? source) (nil? target))) links)
           nodes-js                                                                  (bean/->js nodes)
           links-js                                                                  (bean/->js links)
-          simulation                                                                (layout! nodes-js links-js link-dist charge-strength)]
+          simulation                                                                (layout! nodes-js links-js link-dist charge-strength charge-range)]
       (doseq [node nodes-js]
         (try (.addNode graph (.-id node) node)
           (catch :default e

--- a/src/main/frontend/schema/handler/common_config.cljc
+++ b/src/main/frontend/schema/handler/common_config.cljc
@@ -63,6 +63,7 @@
     [:ref/default-open-blocks-level :int]
     [:ref/linked-references-collapsed-threshold :int]
     [:graph/settings [:map-of :keyword :boolean]]
+    [:graph/forcesettings [:map-of :keyword :int]]
     [:favorites [:vector :string]]
     ;; There isn't a :float yet
     [:srs/learning-fraction float?]

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -645,6 +645,10 @@ Similar to re-frame subscriptions"
   []
   (:graph/settings (sub-config)))
 
+(defn graph-forcesettings
+  []
+  (:graph/forcesettings (sub-config)))
+
 ;; Enable by default
 (defn show-brackets?
   []

--- a/src/resources/templates/config.edn
+++ b/src/resources/templates/config.edn
@@ -295,8 +295,8 @@
  ;; Example usage:
  ;; :graph/forcesettings
  ;; {:link-dist       180    ; Default value: 180
- ;;  :charge-strength -600}  ; Default value: -600
- 
+ ;;  :charge-strength -600   ; Default value: -600
+ ;;  :charge-range    600}   ; Default value: 600
 
  ;; Favorites to list on the left sidebar
  :favorites []

--- a/src/resources/templates/config.edn
+++ b/src/resources/templates/config.edn
@@ -291,6 +291,11 @@
  ;;  :excluded-pages? false  ; Default value: false
  ;;  :journal?        false} ; Default value: false
 
+ ;; Graph view configuration.
+ ;; Example usage:
+ ;; :graph/forcesettings
+ ;; {:link-dist       180}  ; Default value: 180
+
  ;; Favorites to list on the left sidebar
  :favorites []
 

--- a/src/resources/templates/config.edn
+++ b/src/resources/templates/config.edn
@@ -294,7 +294,9 @@
  ;; Graph view configuration.
  ;; Example usage:
  ;; :graph/forcesettings
- ;; {:link-dist       180}  ; Default value: 180
+ ;; {:link-dist       180    ; Default value: 180
+ ;;  :charge-strength -600}  ; Default value: -600
+ 
 
  ;; Favorites to list on the left sidebar
  :favorites []


### PR DESCRIPTION
This MR adds the ability to change graph forces in the graph view, under a new dropdown menu item called "Forces"

![image](https://github.com/logseq/logseq/assets/16655368/ff2a04e4-435b-41a0-8a6b-e1c73a58e0ac)

This resolves requests for a customisable/better graph algorithm:

- https://discuss.logseq.com/t/extracting-more-understanding-from-graph-view-additional-graph-layout-algorithms/16841
- https://discuss.logseq.com/t/improve-graph-view-relationship-types-link-styling-and-graph-parameters-like-in-cosma/7023
- https://discuss.logseq.com/t/how-the-graph-view-could-improve-creativity/5579

This should also resolve some a number of user issues related to the graph layout being messy/not being very useful:

- https://discuss.logseq.com/t/graph-overlapping-problems/1726
- https://discuss.logseq.com/t/better-graph-make-sure-the-edges-of-graph-do-not-cross-like-obsidian/16862


Users resorted to manually dragging nodes to where they want them to be, and then requesting that the graph does not reset/re-render each time you click back to it. The ability to change graph forces means users can now customise the default force values, thus the default layout of their graph, using the config.edn default parameters. This indirectly resolves the requests to have a layout-persistant graph option:

- https://discuss.logseq.com/t/have-nodes-in-graph-view-stay-put-unless-moved/7942
- https://discuss.logseq.com/t/predictable-graph-layout-and-journal-nodes/3431
- https://discuss.logseq.com/t/ensuring-that-graphs-dont-revert-to-their-default-messy-state-when-i-click-away/3954/3
- https://discuss.logseq.com/t/persisting-graph-shape-keeping-nodes-position-after-navigating-away/3209
- https://discuss.logseq.com/t/is-it-possible-to-open-a-page-in-the-sidebar-from-the-graph-view/15283


To not overload the number of options, although more are possible using the same structure, I implemented the key ones:

-  link distance _(The link force pushes linked nodes together or apart according to the desired link distance)_
- charge strength _(The many-body (or n-body) force applies mutually amongst all nodes. A positive value causes nodes to attract each other, similar to gravity, while a negative value causes nodes to repel each other, similar to electrostatic charge)_
- charge range _(The maximum distance between nodes over which this force is considered)_

![image](https://github.com/logseq/logseq/assets/16655368/100ac2d6-722b-4b28-b8c2-ef131f94e510)

The graph is reactive to the sliders, and the graph forces can be reset back to defaults using the "Reset forces" button, similar to "Reset graph" for the n-hops slider.

Force values, in general, default to the same value they were previously, so that the default experience is the same as it was before. Exceptions;
- link distance has been reduced from 180 to 70. This makes graphs significantly cleaner
- the velocity decay when dragging nodes has been reduced from 0.8 to 0.5 to allow the graph to better converge on a clean layout. This (partially) resolves issues like:

- https://discuss.logseq.com/t/better-graph-make-sure-the-edges-of-graph-do-not-cross-like-obsidian/16862
- https://discuss.logseq.com/t/how-the-graph-view-could-improve-creativity/5579/2?u=mapping_world
- https://discuss.logseq.com/t/graph-view-nodes-should-move-with-their-parents/1929

I set the sliders to have a stepsize proportional to the value size (e.g. 5, 10 or 100), to prevent too much rendering of large graphs. It would be more efficient to have the graph render on slider release (instead of on value change), however I would need someone more familiar with Clojure to assist with this.

Cheers,
mp-v2

Here is my personal graph using the master branch:
![image](https://github.com/logseq/logseq/assets/16655368/a2be7fe2-5e81-448b-98f0-b77065fad3ef)

Here is the same graph with default forces in this branch (with lower velocity decay, allowing better convergence on a clean solution):
![image](https://github.com/logseq/logseq/assets/16655368/2a20f9d6-8fa9-4aee-a42d-a170cb9ad766)

Now with adjusted forces based on personal preference. These changes are persistant, even when changing to note pages and returning to the graph view:
![image](https://github.com/logseq/logseq/assets/16655368/e1339161-91da-4ab6-b544-b41f0f464d1a)


Examples from a large graph are much more exciting, but some examples below show options now available

Small link distance:
![image](https://github.com/logseq/logseq/assets/16655368/c4c96ac5-3cab-41c5-96c8-45ec17332353)

Large link distance:
![image](https://github.com/logseq/logseq/assets/16655368/0e35b7a9-da41-4d90-aefc-e4b1649f462d)

Default negative charge (repulsion) changed to positive (gravity) causes orphan pages to come to the centre:
![image](https://github.com/logseq/logseq/assets/16655368/cdc0c314-51c8-407b-bccc-e1551f50c1a3)

A positive charge strength, and long link distance, will group chuild nodes together from one node:
![image](https://github.com/logseq/logseq/assets/16655368/a8dcd853-c8a3-4f7f-b9b5-f62f35959c7a)

