### PR TITLE
fix: Highlight page aliases in search results

### DIFF
--- a/deps/shui/src/logseq/shui/list_item/v1.cljs
+++ b/deps/shui/src/logseq/shui/list_item/v1.cljs
@@ -77,7 +77,7 @@
 
 (rum/defc root [{:keys [icon icon-theme query text info shortcut value-label value
                         title highlighted on-highlight on-highlight-dep header on-click
-                        hoverable compact rounded on-mouse-enter component-opts] :as _props
+                        hoverable compact rounded on-mouse-enter component-opts source-page] :as _props
                  :or {hoverable true rounded true}}
                 {:keys [app-config] :as context}]
   (let [ref (rum/create-ref)
@@ -124,7 +124,13 @@
       [:div.flex.flex-1.flex-col
        (when title
          [:div.text-sm.pb-2.font-bold.text-gray-11 (highlight-query title)])
-       [:div {:class "text-sm font-medium text-gray-12"} (highlight-query text)
+       [:div {:class "text-sm font-medium text-gray-12"}
+        (if (and (= icon "page") (not= text source-page)) ;; alias
+          [:div.flex.flex-row.items-center.gap-2
+            (highlight-query text)
+            [:div.opacity-50.font-normal "alias of"]
+            source-page]
+          (highlight-query text))
         (when info
           [:span.text-xs.text-gray-11 " — " (highlight-query info)])]]
       (when (or value-label value)

--- a/src/main/frontend/components/cmdk.cljs
+++ b/src/main/frontend/components/cmdk.cljs
@@ -227,13 +227,10 @@
                                 source-page (model/get-alias-source-page repo page)]
                             (hash-map :icon (if whiteboard? "whiteboard" "page")
                                       :icon-theme :gray
-                                      :text (if source-page
-                                              [:div.flex.flex-row.items-center.gap-2
-                                               page
-                                               [:div.opacity-50.font-normal "alias of"]
-                                               (:block/original-name source-page)]
-                                              page)
-                                      :source-page page)))))]
+                                      :text page
+                                      :source-page (if source-page
+                                              (:block/original-name source-page)
+                                              page))))))]
       (swap! !results update group        merge {:status :success :items items}))))
 
 (defmethod load-results :whiteboards [group state]


### PR DESCRIPTION
Fixes #10698 

# Cause of problem
Page aliases were getting formatted in the `cmdk.cljs` file, so when those results were being rendered as `list_item`, the `text` property wasn't a string. Thus, nothing would get highlighted.

# Proposed solution
A lot of the search result formatting (of headers for blocks and whatnot) are already taking place in the `list_item/v1.cljs` file so we can just move the alias formatting there so that the highlighting works the same as for non-alias results.