### PR TITLE
fix(export): remove prefix spaces when no-indent

### DIFF
--- a/src/main/frontend/handler/export/common.cljs
+++ b/src/main/frontend/handler/export/common.cljs
@@ -605,6 +605,19 @@
       ;; else
       [inline-ast])))
 
+(defn remove-prefix-spaces-in-Plain
+  ":mapcat-fns-on-inline-ast"
+  [inline-ast]
+  (let [[ast-type ast-content] inline-ast]
+    (case ast-type
+      "Plain"
+      (let [content (string/triml ast-content)]
+        (if (empty? content)
+          []
+          [["Plain" content]]))
+      ;; else
+      [inline-ast])))
+
 ;;; inline transformers (ends)
 
 ;;; walk on block-ast, apply inline transformers

--- a/src/main/frontend/handler/export/common.cljs
+++ b/src/main/frontend/handler/export/common.cljs
@@ -567,6 +567,7 @@
       :result-ast-tcoll
       persistent!))
 
+
 ;;; inline transformers
 
 (defn remove-emphasis
@@ -606,26 +607,34 @@
       [inline-ast])))
 
 (defn remove-prefix-spaces-in-Plain
-  ":mapcat-fns-on-inline-ast"
-  [inline-ast]
-  (let [[ast-type ast-content] inline-ast]
-    (case ast-type
-      "Plain"
-      (let [content (string/triml ast-content)]
-        (if (empty? content)
-          []
-          [["Plain" content]]))
-      ;; else
-      [inline-ast])))
+  [inline-coll]
+  (:r
+   (reduce
+    (fn [{:keys [r after-break-line?]} ast]
+      (let [[ast-type ast-content] ast]
+        (case ast-type
+          "Plain"
+          (let [trimmed-content (string/triml ast-content)]
+            (if after-break-line?
+              (if (empty? trimmed-content)
+                {:r r :after-break-line? false}
+                {:r (conj r ["Plain" trimmed-content]) :after-break-line? false})
+              {:r (conj r ast) :after-break-line? false}))
+          ("Break_Line" "Hard_Break_Line")
+          {:r (conj r ast) :after-break-line? true}
+        ;; else
+          {:r (conj r ast) :after-break-line? false})))
+    {:r [] :after-break-line? true}
+    inline-coll)))
 
 ;;; inline transformers (ends)
 
 ;;; walk on block-ast, apply inline transformers
 
 (defn- walk-block-ast-helper
-  [inline-coll map-fns-on-inline-ast mapcat-fns-on-inline-ast]
+  [inline-coll map-fns-on-inline-ast mapcat-fns-on-inline-ast fns-on-inline-coll]
   (->>
-   inline-coll
+   (reduce (fn [inline-coll f] (f inline-coll)) inline-coll fns-on-inline-coll)
    (mapv #(reduce (fn [inline-ast f] (f inline-ast)) % map-fns-on-inline-ast))
    (mapcatv #(reduce
               (fn [inline-ast-coll f] (mapcatv f inline-ast-coll)) [%] mapcat-fns-on-inline-ast))))
@@ -648,18 +657,20 @@
    list-items))
 
 (defn walk-block-ast
-  [{:keys [map-fns-on-inline-ast mapcat-fns-on-inline-ast] :as fns}
+  [{:keys [map-fns-on-inline-ast mapcat-fns-on-inline-ast fns-on-inline-coll] :as fns}
    block-ast]
   (let [[ast-type ast-content] block-ast]
     (case ast-type
       "Paragraph"
-      (mk-paragraph-ast (walk-block-ast-helper ast-content map-fns-on-inline-ast mapcat-fns-on-inline-ast) (meta block-ast))
+      (mk-paragraph-ast
+       (walk-block-ast-helper ast-content map-fns-on-inline-ast mapcat-fns-on-inline-ast fns-on-inline-coll)
+       (meta block-ast))
       "Heading"
       (let [{:keys [title]} ast-content]
         ["Heading"
          (assoc ast-content
                 :title
-                (walk-block-ast-helper title map-fns-on-inline-ast mapcat-fns-on-inline-ast))])
+                (walk-block-ast-helper title map-fns-on-inline-ast mapcat-fns-on-inline-ast fns-on-inline-coll))])
       "List"
       ["List" (walk-block-ast-for-list ast-content map-fns-on-inline-ast mapcat-fns-on-inline-ast)]
       "Quote"
@@ -667,11 +678,11 @@
       "Footnote_Definition"
       (let [[name contents] (rest block-ast)]
         ["Footnote_Definition"
-         name (walk-block-ast-helper contents map-fns-on-inline-ast mapcat-fns-on-inline-ast)])
+         name (walk-block-ast-helper contents map-fns-on-inline-ast mapcat-fns-on-inline-ast fns-on-inline-coll)])
       "Table"
       (let [{:keys [header groups]} ast-content
             header* (mapv
-                     #(walk-block-ast-helper % map-fns-on-inline-ast mapcat-fns-on-inline-ast)
+                     #(walk-block-ast-helper % map-fns-on-inline-ast mapcat-fns-on-inline-ast fns-on-inline-coll)
                      header)
             groups* (mapv
                      (fn [group]
@@ -679,7 +690,7 @@
                         (fn [row]
                           (mapv
                            (fn [col]
-                             (walk-block-ast-helper col map-fns-on-inline-ast mapcat-fns-on-inline-ast))
+                             (walk-block-ast-helper col map-fns-on-inline-ast mapcat-fns-on-inline-ast fns-on-inline-coll))
                            row))
                         group))
                      groups)]

--- a/src/main/frontend/handler/export/html.cljs
+++ b/src/main/frontend/handler/export/html.cljs
@@ -402,7 +402,10 @@
                                         (update :map-fns-on-inline-ast conj common/remove-page-ref-brackets)
 
                                         (get-in *state* [:export-options :remove-tags?])
-                                        (update :mapcat-fns-on-inline-ast conj common/remove-tags))
+                                        (update :mapcat-fns-on-inline-ast conj common/remove-tags)
+
+                                        (= "no-indent" (get-in *state* [:export-options :indent-style]))
+                                        (update :mapcat-fns-on-inline-ast conj common/remove-prefix-spaces-in-Plain))
             ast*** (if-not (empty? config-for-walk-block-ast)
                      (util/profile :walk-block-ast (mapv (partial common/walk-block-ast config-for-walk-block-ast) ast**))
                      ast**)

--- a/src/main/frontend/handler/export/opml.cljs
+++ b/src/main/frontend/handler/export/opml.cljs
@@ -420,7 +420,10 @@
                                         (update :map-fns-on-inline-ast conj common/remove-page-ref-brackets)
 
                                         (get-in *state* [:export-options :remove-tags?])
-                                        (update :mapcat-fns-on-inline-ast conj common/remove-tags))
+                                        (update :mapcat-fns-on-inline-ast conj common/remove-tags)
+
+                                        (= "no-indent" (get-in *state* [:export-options :indent-style]))
+                                        (update :mapcat-fns-on-inline-ast conj common/remove-prefix-spaces-in-Plain))
             ast*** (if-not (empty? config-for-walk-block-ast)
                      (mapv (partial common/walk-block-ast config-for-walk-block-ast) ast**)
                      ast**)

--- a/src/main/frontend/handler/export/text.cljs
+++ b/src/main/frontend/handler/export/text.cljs
@@ -463,7 +463,6 @@
             ast** (if (= "no-indent" (get-in *state* [:export-options :indent-style]))
                     (mapv common/replace-Heading-with-Paragraph ast*)
                     ast*)
-            _ (def xxx ast**)
             config-for-walk-block-ast (cond-> {}
                                         (get-in *state* [:export-options :remove-emphasis?])
                                         (update :mapcat-fns-on-inline-ast conj common/remove-emphasis)

--- a/src/main/frontend/handler/export/text.cljs
+++ b/src/main/frontend/handler/export/text.cljs
@@ -104,14 +104,18 @@
      l)))
 
 (defn- block-src
-  [{:keys [lines language]}]
-  (let [level (dec (get *state* :current-level 1))]
-    (concatv
-     [(indent-with-2-spaces level) (raw-text "```")]
-     (when language [(raw-text language)])
-     [(newline* 1)]
-     (mapv raw-text lines)
-     [(indent-with-2-spaces level) (raw-text "```") (newline* 1)])))
+  [{:keys [lines language full_content]}]
+  (if (= "no-indent" (get-in *state* [:export-options :indent-style]))
+    ;; when "no-indent", just use :full_content in 'Src' ast
+    [(raw-text full_content) (newline* 1)]
+
+    (let [level (dec (get *state* :current-level 1))]
+      (concatv
+       [(indent-with-2-spaces level) (raw-text "```")]
+       (when language [(raw-text language)])
+       [(newline* 1)]
+       (mapv raw-text lines)
+       [(indent-with-2-spaces level) (raw-text "```") (newline* 1)]))))
 
 (defn- block-quote
   [block-coll]
@@ -459,6 +463,7 @@
             ast** (if (= "no-indent" (get-in *state* [:export-options :indent-style]))
                     (mapv common/replace-Heading-with-Paragraph ast*)
                     ast*)
+            _ (def xxx ast**)
             config-for-walk-block-ast (cond-> {}
                                         (get-in *state* [:export-options :remove-emphasis?])
                                         (update :mapcat-fns-on-inline-ast conj common/remove-emphasis)
@@ -470,7 +475,7 @@
                                         (update :mapcat-fns-on-inline-ast conj common/remove-tags)
 
                                         (= "no-indent" (get-in *state* [:export-options :indent-style]))
-                                        (update :mapcat-fns-on-inline-ast conj common/remove-prefix-spaces-in-Plain))
+                                        (update :fns-on-inline-coll conj common/remove-prefix-spaces-in-Plain))
             ast*** (if-not (empty? config-for-walk-block-ast)
                      (mapv (partial common/walk-block-ast config-for-walk-block-ast) ast**)
                      ast**)

--- a/src/test/frontend/handler/export_test.cljs
+++ b/src/test/frontend/handler/export_test.cljs
@@ -129,6 +129,23 @@
 	- 4")
     "97a00e55-48c3-48d8-b9ca-417b16e3a616"))
 
+(deftest export-blocks-as-markdown-no-indent
+  (are [expect content]
+      (= (string/trim expect)
+         (string/trim (#'export-text/export-helper (string/trim content) :markdown {:indent-style "no-indent"})))
+      "
+1
+2
+3
+4
+5"
+      "
+- 1
+  2
+  3
+  - 4
+    5"))
+
 
 (deftest-async export-files-as-markdown
   (p/do!


### PR DESCRIPTION
when export with "no-indent" style
export:
```
- 1
  2
  - 3
    4
```
result:
```
1
2
3
4
```
before-fix:
```
1
  2  
3
	  4
```