### PR TITLE
fix: Update French translations

### DIFF
--- a/src/resources/dicts/fr.edn
+++ b/src/resources/dicts/fr.edn
@@ -172,7 +172,7 @@
     :linked-references/filter-excludes "Exclut : "
     :linked-references/filter-heading "Filtrer"
     :linked-references/filter-includes "Inclut : "
-    :linked-references/reference-count (fn [filtered-count total] (str filtered-count (when filtered-count (if (= filtered-count 1) " référence liée" " références liées")) " parmi " total))
+    :linked-references/reference-count (fn [filtered-count total] (cond (= filtered-count nil) (cond (= total 0) "Aucune référence liée" (= total 1) "1 référence liée" :else (str total " références liées")) (= filtered-count 1) (str "1 référence liée / " total) :else (str filtered-count " références liées / " total) ))
     :linked-references/filter-search "Rechercher dans les pages liées"
     :linked-references/unexpected-error "Références liées : erreur inattendue. Veuillez d'abord ré-indexer votre graphe."
     :on-boarding/add-graph "Ajouter un graphe"
@@ -806,5 +806,5 @@
     :settings-page/auto-chmod "Automatiquement changer les permissions du fichier"
     :settings-page/auto-chmod-desc "Désactiver pour permettre l'édition par plusieurs utilisateurs avec les permissions données par l'appartenance au groupe."
     :settings-page/tab-keymap "Raccourcis"
-    :unlinked-references/reference-count (fn [total] (str total (if (= total 1) " référence non liée" " références non liées")))
+    :unlinked-references/reference-count (fn [total] (cond (= total "") "Références non liées" (= total 0) "Aucune référence non liée" (= total 1) "1 référence non liée" (> total 1) (str total " références non liées")))
 }


### PR DESCRIPTION
Handle more plural forms (0, "", nil).

- `""` is used as argument `total` in `unlinked-references/reference-count`
- `nil` is used as argument `filtered-count` in `linked-references/reference-count`

Expressions were tested at `https://tryclojure.org/`.