### PR TITLE
fix(ui): prevent button in modal from being clicked twice when pressing enter key

### DIFF
--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -1039,9 +1039,23 @@
 (defn button
   [text & {:keys []
            :as   opts}]
-  (if (map? text)
-    (button-inner nil text)
-    (button-inner text opts)))
+  (let [origin-on-key-down (get opts :on-key-down)
+        class-name (get opts :class)
+        wrapped-on-key-down (if (and
+                                 class-name
+                                 ;; hint: mixins/on-key-down defined in ui/modal
+                                 (string/includes? class-name "ui__modal-enter"))
+                              (fn [e]
+                                (when origin-on-key-down (origin-on-key-down e))
+                                (let [key-code (.-keyCode e)]
+                                  (cond
+                                    ;; enter
+                                    (= key-code 13) (util/stop-propagation e))))
+                              origin-on-key-down)
+        opts (assoc opts :on-key-down wrapped-on-key-down)]
+    (if (map? text)
+      (button-inner nil text)
+      (button-inner text opts))))
 
 (rum/defc point
   ([] (point "bg-red-600" 5 nil))

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -635,7 +635,8 @@
      (mixins/on-key-down
       state
       {;; enter
-       13 (fn [state _e]
+       13 (fn [state e]
+            (.preventDefault e)
             (some->
              (.querySelector (rum/dom-node state) "button.ui__modal-enter")
              (.click)))})))

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -1039,23 +1039,9 @@
 (defn button
   [text & {:keys []
            :as   opts}]
-  (let [origin-on-key-down (get opts :on-key-down)
-        class-name (get opts :class)
-        wrapped-on-key-down (if (and
-                                 class-name
-                                 ;; hint: mixins/on-key-down defined in ui/modal
-                                 (string/includes? class-name "ui__modal-enter"))
-                              (fn [e]
-                                (when origin-on-key-down (origin-on-key-down e))
-                                (let [key-code (.-keyCode e)]
-                                  (cond
-                                    ;; enter
-                                    (= key-code 13) (util/stop-propagation e))))
-                              origin-on-key-down)
-        opts (assoc opts :on-key-down wrapped-on-key-down)]
-    (if (map? text)
-      (button-inner nil text)
-      (button-inner text opts))))
+  (if (map? text)
+    (button-inner nil text)
+    (button-inner text opts)))
 
 (rum/defc point
   ([] (point "bg-red-600" 5 nil))


### PR DESCRIPTION
close #10635 

Through my investigation, I found that pressing the Enter key while focusing on a button triggers the click event twice, with the second click happening within the `mixins/on-key-down` function of the modal.

https://github.com/logseq/logseq/blob/ab37d30e2d64dfcc889329276dd8ca310d7429ba/src/main/frontend/ui.cljs#L635-L641

The idea to fix issues is to stop the propagation of keydown event in `ui/button` when it is assigned `ui__modal-enter` classname.

<img width="720" alt="image" src="https://github.com/logseq/logseq/assets/28241963/6d7a35db-c176-4ba6-8a34-ac0e3c17b1d9">

