### PR TITLE
feat: Cancel todo on alt+click.

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1840,10 +1840,13 @@
                     :checked checked?
                     :on-mouse-down (fn [e]
                                      (util/stop-propagation e))
-                    :on-change (fn [_e]
-                                 (if checked?
-                                   (editor-handler/uncheck block)
-                                   (editor-handler/check block)))}))))
+                    :on-change (fn [e]
+                                 (let [alt-pressed? (gobj/get (.-nativeEvent e) "altKey")]
+                                   (if checked?
+                                     (editor-handler/uncheck block)
+                                     (if (not alt-pressed?)
+                                       (editor-handler/check block)
+                                       (editor-handler/cancel block)))))}))))
 
 (defn list-checkbox
   [config checked?]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -723,6 +723,15 @@
       (state/set-edit-content! input-id new-content)
       (save-block-if-changed! block new-content))))
 
+(defn cancel
+  [{:block/keys [marker content uuid] :as block}]
+  (let [new-content (string/replace-first content marker "CANCELED")
+        input-id (state/get-edit-input-id)]
+    (if (and input-id
+             (string/ends-with? input-id (str uuid)))
+      (state/set-edit-content! input-id new-content)
+      (save-block-if-changed! block new-content))))
+
 (defn get-selected-blocks
   []
   (distinct (seq (state/get-selection-blocks))))


### PR DESCRIPTION
When cancelling a larger set of todos it can be convenient to be able to click them to cancel them. This is possible in task managers like Things 3 where you can hold down alt when clicking. This PR adds a small change to also allow users to alt + click a task block to cancel it instead of marking it as done.