### PR TITLE
Fix: Preserve root node block refs when cutting + pasting.

### DIFF
--- a/src/main/frontend/modules/outliner/datascript.cljc
+++ b/src/main/frontend/modules/outliner/datascript.cljc
@@ -107,9 +107,7 @@
                                             {:tx [[:db/retract (:db/id ref) :block/refs (:db/id block)]
                                                   [:db/retract (:db/id ref) :block/path-refs (:db/id block)]
                                                   [:db/add id :block/content new-content]]
-                                             :revert-tx [[:db/add (:db/id ref) :block/refs (:db/id block)]
-                                                         [:db/add (:db/id ref) :block/path-refs (:db/id block)]
-                                                         [:db/add id :block/content (:block/content ref)]]})) refs)))
+                                             :revert-tx [[:db/add id :block/content (:block/content ref)]]})) refs)))
                                (apply concat))
              retracted-tx' (mapcat :tx retracted-tx)
              revert-tx (mapcat :revert-tx retracted-tx)]

--- a/src/main/frontend/modules/outliner/tree.cljs
+++ b/src/main/frontend/modules/outliner/tree.cljs
@@ -137,5 +137,7 @@
   [repo db-id]
   (when-let [root-block (db/pull db-id)]
     (let [blocks (db/get-block-and-children repo (:block/uuid root-block))
+          ; the root-block returned by db/pull misses :block/_refs therefore we use the one from db/get-block-and-children
+          root-block (first (filter (fn [b] (= (:db/id b) db-id)) blocks))
           blocks-exclude-root (remove (fn [b] (= (:db/id b) db-id)) blocks)]
       (sort-blocks blocks-exclude-root root-block))))


### PR DESCRIPTION
This is an attempt at a fix. There may be a better way to do this. When cutting + pasting the root node's references are not preserved. The problem is that the root-block returned by `db/pull` misses the `:block/_refs` while blocks returned by `db/get-block-and-children` contain `:block/_refs`. I know too little about the inner workings for Logseq and Datascript to know if this is expected. If someone could let me know whether or not this is expected or whether there is a way to modify `db/pull` to return `:block/_refs` that would be great.

More details can be found in this issue: https://github.com/logseq/logseq/issues/4491
