### PR TITLE
Fix mock text disordered

### DIFF
--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -645,7 +645,7 @@
    (let [content (str content "0")
          graphemes (util/split-graphemes content)
          graphemes-char-index (reductions #(+ %1 (count %2)) 0 graphemes)]
-     (for [[idx c] (zipmap graphemes-char-index graphemes)]
+     (for [[idx c] (into (sorted-map) (zipmap graphemes-char-index graphemes))]
        (if (= c "\n")
          [:span {:id (str "mock-text_" idx)
                  :key idx} "0" [:br]]


### PR DESCRIPTION
Right now, the mock text maybe disordered if it's long enough.

If the block contains a long text, click the block to make it editable will generate a mock span per character to help calc cursor postion, the spans should be ordered as the content.