### PR TITLE
fix: Simplify fn translations in light of #10868

### DIFF
--- a/docs/contributing-to-translations.md
+++ b/docs/contributing-to-translations.md
@@ -84,7 +84,10 @@ Almost all translations are small. The only exceptions to this are the keys `:tu
 
 * Some translations may include punctuation like `:` or `!`. When translating them, please use the punctuation that makes the most sense for your language as you don't have to follow the English ones.
 * Some translations may include arguments/interpolations e.g. `{1}`. If you see them in a translation, be sure to include them. These arguments are substituted in the string and are usually used for something the app needs to calculate e.g. a number. See [these docs](https://github.com/tonsky/tongue#interpolation) for more examples.
-* Rarely, a translation may need to translate formatted text by returning [hiccup-style HTML](https://github.com/weavejester/hiccup#syntax). In this case, a Clojure function is the recommended approach. For example, a function translation would look like `(fn [] [:div "FOO"])`. See `:on-boarding/main-title` for an example.
+* Rarely, a translation is a function that calls code and look like `(fn ... )`
+    * The logic for these fns must be simple and can only use the following fns: `str`, `when`, `if` and `=`.
+    * These fn translations are usually used to handle pluralization or handle formatted text by returning [hiccup-style HTML](https://github.com/weavejester/hiccup#syntax). For example, a hiccup style translation would look like `(fn [] [:div "FOO"])`. See `:on-boarding/main-title` for more examples.
+
 ## Fix Mistakes
 
 There is a lint command to catch common translation mistakes - `bb

--- a/docs/dev-practices.md
+++ b/docs/dev-practices.md
@@ -90,8 +90,7 @@ translations here are some things to keep in mind:
   fn translation. Hiccup vectors are needed when word order matters for a
   translation and formatting is involved. See [this 3 word Turkish
   example](https://github.com/logseq/logseq/commit/1d932f07c4a0aad44606da6df03a432fe8421480#r118971415).
-* Translations can have arguments for interpolating strings. When they do, be
-  sure translators are using them correctly.
+* Translations can be anonymous fns with arguments for interpolating strings. Fns should be simple and only include the following fns: `str`, `when`, `if` and `=`.
 
 ### Spell Checker
 

--- a/src/main/frontend/context/i18n.cljs
+++ b/src/main/frontend/context/i18n.cljs
@@ -20,11 +20,11 @@
       (catch :default e
         (log/error :failed-translation {:arguments args
                                         :lang preferred-language})
-        (apply translate :en args)
         (state/pub-event! [:capture-error {:error e
                                            :payload {:type :failed-translation
                                                      :arguments args
-                                                     :lang preferred-language}}])))))
+                                                     :lang preferred-language}}])
+        (apply translate :en args)))))
 
 (defn- fetch-local-language []
   (.. js/window -navigator -language))

--- a/src/resources/dicts/fr.edn
+++ b/src/resources/dicts/fr.edn
@@ -172,7 +172,7 @@
     :linked-references/filter-excludes "Exclut : "
     :linked-references/filter-heading "Filtrer"
     :linked-references/filter-includes "Inclut : "
-    :linked-references/reference-count (fn [filtered-count total] (cond (= filtered-count nil) (cond (= total 0) "Aucune référence liée" (= total 1) "1 référence liée" :else (str total " références liées")) (= filtered-count 1) (str "1 référence liée / " total) :else (str filtered-count " références liées / " total) ))
+    :linked-references/reference-count (fn [filtered-count total] (str filtered-count (when filtered-count (if (= filtered-count 1) " référence liée" " références liées")) " parmi " total))
     :linked-references/filter-search "Rechercher dans les pages liées"
     :linked-references/unexpected-error "Références liées : erreur inattendue. Veuillez d'abord ré-indexer votre graphe."
     :on-boarding/add-graph "Ajouter un graphe"
@@ -806,15 +806,4 @@
     :settings-page/auto-chmod "Automatiquement changer les permissions du fichier"
     :settings-page/auto-chmod-desc "Désactiver pour permettre l'édition par plusieurs utilisateurs avec les permissions données par l'appartenance au groupe."
     :settings-page/tab-keymap "Raccourcis"
-    :unlinked-references/reference-count (fn [total]
-                                           (cond
-                                             (or (nil? total) (= total ""))
-                                             "Références non liées"
-                                             (= total 0)
-                                             "Aucune référence non liée"
-                                             (= total 1)
-                                             "1 référence non liée"
-                                             (> total 1)
-                                             (str total " références non liées")
-                                             :else
-                                             "Références non liées"))}
+    :unlinked-references/reference-count  (fn [total] (str total (if (= total 1) " référence non liée" " références non liées")))}


### PR DESCRIPTION
This PR reverted overly complex fn translations from #10810 and updates docs to emphasize that fn translations need to remain as simple as possible