### PR TITLE
fix(mobile): commit composing text before cycle todo

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -740,21 +740,17 @@
    (let [[new-content _] (marker/cycle-marker content marker new-marker format (state/get-preferred-workflow))]
      (save-block-if-changed! block new-content))))
 
-(defn cycle-todo-by-block-ids!
-  [ids]
-  (when-let [ids (filter uuid? (distinct ids))]
-    (outliner-tx/transact! {:outliner-op :cycle-todos}
-                           (doseq [id ids]
-                             (let [block (db/pull [:block/uuid id])]
-                               (when (not-empty (:block/content block))
-                                 (set-marker block)))))))
-
 (defn cycle-todos!
   []
   (when-let [blocks (seq (get-selected-blocks))]
-    (let [ids (map #(when-let [id (dom/attr % "blockid")]
-                      (uuid id)) blocks)]
-      (cycle-todo-by-block-ids! ids))))
+    (let [ids (->> (distinct (map #(when-let [id (dom/attr % "blockid")]
+                                     (uuid id)) blocks))
+                   (remove nil?))]
+      (outliner-tx/transact! {:outliner-op :cycle-todos}
+        (doseq [id ids]
+          (let [block (db/pull [:block/uuid id])]
+            (when (not-empty (:block/content block))
+              (set-marker block))))))))
 
 (defn cycle-todo!
   []

--- a/src/main/frontend/mobile/mobile_bar.cljs
+++ b/src/main/frontend/mobile/mobile_bar.cljs
@@ -91,7 +91,16 @@
         (command #(if (state/sub :document/mode?)
                     (editor-handler/insert-new-block! nil)
                     (commands/simple-insert! parent-id "\n" {})) {:icon "arrow-back"})
-        (command editor-handler/cycle-todo! {:icon "checkbox"} true)
+        ;; On mobile devies, some IME(keyboard) uses composing mode.
+        ;; The composing text can be committed by losing focus.
+        ;; 100ms is enough to commit the composing text to db.
+        (command #(when-let [block-id (:block/uuid (state/get-edit-block))]
+                    (editor-handler/escape-editing true)
+                    (js/setTimeout
+                     (fn []
+                       (editor-handler/cycle-todo-by-block-ids! [block-id]))
+                     100))
+                 {:icon "checkbox"} true)
         (command #(mobile-camera/embed-photo parent-id) {:icon "camera"} true)
         (command history/undo! {:icon "rotate" :class "rotate-180"} true)
         (command history/redo! {:icon "rotate-clockwise" :class "rotate-180"} true)

--- a/src/main/frontend/mobile/mobile_bar.cljs
+++ b/src/main/frontend/mobile/mobile_bar.cljs
@@ -13,11 +13,21 @@
             [goog.dom :as gdom]
             [rum.core :as rum]))
 
+
+(defn- blur-if-compositing
+  "Call blur on the textarea if it is in composition mode, let the IME commit the composing text"
+  []
+  (when-let [edit-input-id (and (state/editor-in-composition?)
+                                (state/get-edit-input-id))]
+    (let [textarea-el (gdom/getElement edit-input-id)]
+      (.blur textarea-el))))
+
 (rum/defc indent-outdent [indent? icon]
   [:div
    [:button.bottom-action
     {:on-mouse-down (fn [e]
                       (util/stop e)
+                      (blur-if-compositing)
                       (editor-handler/indent-outdent indent?))}
     (ui/icon icon {:size ui/icon-size})]])
 
@@ -94,12 +104,9 @@
         ;; On mobile devies, some IME(keyboard) uses composing mode.
         ;; The composing text can be committed by losing focus.
         ;; 100ms is enough to commit the composing text to db.
-        (command #(when-let [block-id (:block/uuid (state/get-edit-block))]
-                    (editor-handler/escape-editing true)
-                    (js/setTimeout
-                     (fn []
-                       (editor-handler/cycle-todo-by-block-ids! [block-id]))
-                     100))
+        (command #(do
+                    (blur-if-compositing)
+                    (editor-handler/cycle-todo!))
                  {:icon "checkbox"} true)
         (command #(mobile-camera/embed-photo parent-id) {:icon "camera"} true)
         (command history/undo! {:icon "rotate" :class "rotate-180"} true)


### PR DESCRIPTION
- Close #10879
- Close #8503
- Close #10013

NOTE: This is a behavior change. When clicking the "cycle todo" button, the App will exit editing mode.
This is OK for mobile devices.
