### PR TITLE
fix(android): sync crash caused by wrong logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "@excalidraw/excalidraw": "0.16.1",
         "@highlightjs/cdn-assets": "10.4.1",
         "@isomorphic-git/lightning-fs": "^4.6.0",
-        "@logseq/capacitor-file-sync": "5.0.1",
+        "@logseq/capacitor-file-sync": "5.0.2",
         "@logseq/diff-merge": "0.2.2",
         "@logseq/react-tweet-embed": "1.3.1-1",
         "@radix-ui/colors": "^0.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -496,10 +496,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@logseq/capacitor-file-sync@5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@logseq/capacitor-file-sync/-/capacitor-file-sync-5.0.1.tgz#e154f715597785518ccd7d058f353acb67fbc2b8"
-  integrity sha512-C1fLSS53orxsUWBsNb6LKwuOdlEU9ZhxkweMjNKG9VaSkLFTFqpjFG36OTso23WQ7hC5e45jjXq79aoWuqJaKA==
+"@logseq/capacitor-file-sync@5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@logseq/capacitor-file-sync/-/capacitor-file-sync-5.0.2.tgz#10c56e35b41b1a0afd293c9b045fbcfe150c3477"
+  integrity sha512-FymsTeRtF66zG+oeO+ohZxWICMQMC8An4n9pdI0zz1WaGLer4oWC/lUghlC2DpztRLA32p0CH28tEzF5+2jARg==
 
 "@logseq/diff-merge@0.2.2":
   version "0.2.2"


### PR DESCRIPTION
See-also: https://github.com/logseq/rsapi/commit/a95f2b79dc72364376b52d2921c87b001e35e4f5

- Close #10916
- Close #10828
