### PR TITLE
fix: missing newline after multiline block when exporting a page #10930 

### DIFF
--- a/src/main/frontend/handler/export/text.cljs
+++ b/src/main/frontend/handler/export/text.cljs
@@ -359,6 +359,10 @@
             (when (and origin-ast newline-after-block? (not current-block-is-first-heading-block?))
               [(newline* 2)])
             (mapcatv inline-ast->simple-ast ast-content)
+            (let [last-element (last ast-content)
+                  [last-element-type] last-element]
+              (when (and newline-after-block? (= "Break_Line" last-element-type))
+                (inline-break-line)))
             [(newline* 1)]))
          "Paragraph_line"
          (assert false "Paragraph_line is mldoc internal ast")


### PR DESCRIPTION
In the case of blocks with multiple lines, we should add an extra inline break following the last simple ast.

Related issue: [#10930](https://github.com/logseq/logseq/issues/10930)