### PR TITLE
feature: new keybinding for "toggle expand/collapse this block"

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3586,6 +3586,43 @@
                (doseq [{:block/keys [uuid]} blocks-to-collapse]
                  (collapse-block! uuid))))))))))
 
+(defn toggle-collapse!
+  ([e] (toggle-collapse! e false))
+  ([e clear-selection?]
+    (when e (util/stop e))
+    (cond
+      (state/editing?)
+      (when-let [block (state/get-edit-block)]
+        ;; get-edit-block doesn't track the latest collapsed state, so we need to reload from db.
+        (let [block-id (:block/uuid block)
+              block (db/pull [:block/uuid block-id])]
+          (if (:block/collapsed? block)
+            (expand! e clear-selection?)
+            (collapse! e clear-selection?))))
+
+      (state/selection?)
+      (do
+        (let [block-ids (map #(-> % (dom/attr "blockid") uuid) (get-selected-blocks))
+              first-block-id (first block-ids)]
+          (when first-block-id
+            ;; If multiple blocks are selected, they may not have all the same collapsed state.
+            ;; For simplicity, use the first block's state to decide whether to collapse/expand all.
+            (let [first-block (db/pull [:block/uuid first-block-id])]
+              (if (:block/collapsed? first-block)
+                (doseq [block-id block-ids] (expand-block! block-id))
+                (doseq [block-id block-ids] (collapse-block! block-id))))))
+        (and clear-selection? (clear-selection!)))
+
+      (whiteboard?)
+      ;; TODO: Looks like detecting the whiteboard selection's collapse state will take more work.
+      ;; Leaving unimplemented for now.
+      nil
+
+      :else
+      ;; If no block is being edited or selected, the "toggle" action doesn't make sense,
+      ;; so we no-op here, unlike in the expand! & collapse! functions.
+      nil)))
+
 (defn collapse-all!
   ([]
    (collapse-all! nil {}))

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -313,6 +313,9 @@
    :editor/collapse-block-children          {:binding "mod+up"
                                              :fn      editor-handler/collapse!}
 
+   :editor/toggle-block-children            {:binding "mod+;"
+                                             :fn      editor-handler/toggle-collapse!}
+
    :editor/indent                           {:binding "tab"
                                              :fn      (editor-handler/keydown-tab-handler :right)}
 
@@ -667,6 +670,7 @@
             :editor/delete-selection
             :editor/expand-block-children
             :editor/collapse-block-children
+            :editor/toggle-block-children
             :editor/indent
             :editor/outdent
             :editor/copy
@@ -782,6 +786,7 @@
       :editor/right
       :editor/collapse-block-children
       :editor/expand-block-children
+      :editor/toggle-block-children
       :editor/toggle-open-blocks
       :go/backward
       :go/forward

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -742,6 +742,7 @@
   :editor/delete-selection        "Delete selected blocks"
   :editor/expand-block-children   "Expand"
   :editor/collapse-block-children "Collapse"
+  :editor/toggle-block-children   "Toggle expand/collapse"
   :editor/indent                  "Indent block"
   :editor/outdent                 "Outdent block"
   :editor/copy                    "Copy (copies either selection, or block reference)"


### PR DESCRIPTION
This PR adds a keyboard shortcut to toggle the expanded/collapsed state of the currently edited or selected block(s), addressing requests made here:

- https://discuss.logseq.com/t/toggle-block-expanded-shortcut/2161
- https://github.com/logseq/logseq/issues/9676

The new keybinding defaults to `mod + ;` by default. It works by checking whether the focused block is currently expanded or collapsed, and invoking `collapse!` or `expand!` respectively. Scenarios where the whiteboard UI is active, or where no block is currently being edited/selected, are left as no-ops for now.