### PR TITLE
fix: Deprecate :graph/current in the electron state

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -186,7 +186,7 @@
                        {:role "fileMenu"
                         :submenu [{:label "New Window"
                                    :click (fn []
-                                            (p/let [graph-name (get-graph-name (state/get-graph-path))
+                                            (p/let [graph-name (get-graph-name (state/get-active-window-graph-path))
                                                     _ (handler/broadcast-persist-graph! graph-name)]
                                               (handler/open-new-window!)))
                                    :accelerator (if mac?

--- a/src/electron/electron/git.cljs
+++ b/src/electron/electron/git.cljs
@@ -13,8 +13,8 @@
 (def log-error (partial logger/error "[Git]"))
 
 (defn get-graph-git-dir
-  []
-  (when-let [graph-path (some-> (state/get-graph-path)
+  [graph-path]
+  (when-let [graph-path (some-> graph-path
                                 (string/replace "/" "_")
                                 (string/replace ":" "comma"))]
     (let [dir (.join node-path (.homedir os) ".logseq" "git" graph-path ".git")]
@@ -22,38 +22,35 @@
       dir)))
 
 (defn run-git!
-  [commands]
-  (when-let [path (state/get-graph-path)]
-    (when (fs/existsSync path)
-      (p/let [result (.exec GitProcess commands path)]
-        (if (zero? (gobj/get result "exitCode"))
-          (let [result (gobj/get result "stdout")]
-            (p/resolved result))
-          (let [error (gobj/get result "stderr")]
-            (when-not (string/blank? error)
-              (log-error error))
-            (p/rejected error)))))))
+  [graph-path commands]
+  (when (and graph-path (fs/existsSync graph-path))
+    (p/let [result (.exec GitProcess commands graph-path)]
+      (if (zero? (gobj/get result "exitCode"))
+        (let [result (gobj/get result "stdout")]
+          (p/resolved result))
+        (let [error (gobj/get result "stderr")]
+          (when-not (string/blank? error)
+            (log-error error))
+          (p/rejected error))))))
 
 (defn run-git2!
-  [commands]
-  (when-let [path (state/get-graph-path)]
-    (when (fs/existsSync path)
-      (p/let [^js result (.exec GitProcess commands path)]
-        result))))
+  [graph-path commands]
+  (when (and graph-path (fs/existsSync graph-path))
+    (p/let [^js result (.exec GitProcess commands graph-path)]
+      result)))
 
 (defn git-dir-exists?
-  []
+  [graph-path]
   (try
-    (let [p (.join node-path (state/get-graph-path) ".git")]
+    (let [p (.join node-path graph-path ".git")]
       (.isDirectory (fs/statSync p)))
     (catch :default _e
       nil)))
 
 (defn remove-dot-git-file!
-  []
+  [graph-path]
   (try
-    (let [graph-path (state/get-graph-path)
-          _ (when (string/blank? graph-path)
+    (let [_ (when (string/blank? graph-path)
               (utils/send-to-renderer :setCurrentGraph {})
               (throw (js/Error. "Empty graph path")))
           p (.join node-path graph-path ".git")]
@@ -70,23 +67,23 @@
       (log-error e))))
 
 (defn init!
-  []
-  (let [_ (remove-dot-git-file!)
-        separate-git-dir (get-graph-git-dir)
+  [graph-path]
+  (let [_ (remove-dot-git-file! graph-path)
+        separate-git-dir (get-graph-git-dir graph-path)
         args (cond
-               (git-dir-exists?)
+               (git-dir-exists? graph-path)
                ["init"]
                separate-git-dir
                ["init" (str "--separate-git-dir=" separate-git-dir)]
                :else
                ["init"])]
-    (p/let [_ (run-git! (clj->js args))]
+    (p/let [_ (run-git! graph-path (clj->js args))]
       (when utils/win32?
-        (run-git! #js ["config" "core.safecrlf" "false"])))))
+        (run-git! graph-path #js ["config" "core.safecrlf" "false"])))))
 
 (defn add-all!
-  []
-  (-> (run-git! #js ["add" "--ignore-errors" "./*"])
+  [graph-path]
+  (-> (run-git! graph-path #js ["add" "--ignore-errors" "./*"])
       (p/catch (fn [error]
                  (let [error (string/lower-case (str error))]
                    (if (or (string/includes? error "permission denied")
@@ -97,34 +94,38 @@
 ;; git log -100 --oneline -p ~/Desktop/org/pages/contents.org
 
 (defn commit!
-  [message]
+  [graph-path message]
   (p/do!
-   (run-git! #js ["config" "core.quotepath" "false"])
-   (run-git! #js ["commit" "-m" message])))
+   (run-git! graph-path #js ["config" "core.quotepath" "false"])
+   (run-git! graph-path #js ["commit" "-m" message])))
+
+(defn add-all-and-commit-single-graph!
+  [graph-path message]
+  (let [message (if (string/blank? message)
+                  "Auto saved by Logseq"
+                  message)]
+    (->
+     (p/let [_ (init! graph-path)
+             _ (add-all! graph-path)]
+       (commit! graph-path message))
+     (p/catch (fn [error]
+                (when (and
+                       (string? error)
+                       (not (string/blank? error)))
+                  (if (string/starts-with? error "Author identity unknown")
+                    (utils/send-to-renderer "setGitUsernameAndEmail" {:type "git"})
+                    (utils/send-to-renderer "notification" {:type "error"
+                                                            :payload (str error "\nIf you don't want to see those errors or don't need git, you can disable the \"Git auto commit\" feature on Settings > Version control.")}))))))))
 
 (defn add-all-and-commit!
   ([]
    (add-all-and-commit! nil))
   ([message]
-   (let [message (if (string/blank? message)
-                   "Auto saved by Logseq"
-                   message)]
-     (->
-      (p/let [_ (init!)
-              _ (add-all!)]
-        (commit! message))
-      (p/catch (fn [error]
-                 (when (and
-                        (string? error)
-                        (not (string/blank? error)))
-                   (if (string/starts-with? error "Author identity unknown")
-                     (utils/send-to-renderer "setGitUsernameAndEmail" {:type "git"})
-                     (utils/send-to-renderer "notification" {:type "error"
-                                                             :payload (str error "\nIf you don't want to see those errors or don't need git, you can disable the \"Git auto commit\" feature on Settings > Version control.")})))))))))
+   (doseq [path (state/get-all-graph-paths)] (add-all-and-commit-single-graph! path message))))
 
 (defn short-status!
-  []
-  (run-git! #js ["status" "--porcelain"]))
+  [graph-path]
+  (run-git! graph-path #js ["status" "--porcelain"]))
 
 (defonce quotes-regex #"\"[^\"]+\"")
 (defn wrapped-by-quotes?
@@ -152,8 +153,8 @@
          (remove string/blank?))))
 
 (defn raw!
-  [args]
-  (init!)
+  [graph-path args]
+  (init! graph-path)
   (let [args (if (string? args)
                (split-args args)
                args)
@@ -166,8 +167,8 @@
                           (p/rejected error)))]
     (->
      (p/let [_ (when (= (first args) "commit")
-                 (add-all!))
-             result (run-git! (clj->js args))]
+                 (add-all! graph-path))
+             result (run-git! graph-path (clj->js args))]
        (p/resolved result))
      (p/catch error-handler))))
 

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -461,7 +461,6 @@
   (let [old-path (state/get-window-graph-path window)]
     (when (and old-path graph-path (not= old-path graph-path))
       (close-watcher-when-orphaned! window old-path))
-    (swap! state/state assoc :graph/current graph-path)
     (swap! state/state assoc-in [:window/graph window] graph-path)
     nil))
 
@@ -469,14 +468,14 @@
   (when graph-name
     (set-current-graph! window (utils/get-graph-dir graph-name))))
 
-(defmethod handle :runGit [_ [_ args]]
-  (when (seq args)
-    (git/raw! args)))
+(defmethod handle :runGit [_ [_ {:keys [repo command]}]]
+  (when (seq command)
+    (git/raw! (utils/get-graph-dir repo) command)))
 
-(defmethod handle :runGitWithinCurrentGraph [_ [_ args]]
-  (when (seq args)
-    (git/init!)
-    (git/run-git2! (clj->js args))))
+(defmethod handle :runGitWithinCurrentGraph [_ [_ {:keys [repo command]}]]
+  (when (seq command)
+    (git/init! (utils/get-graph-dir repo))
+    (git/run-git2! (utils/get-graph-dir repo) (clj->js command))))
 
 (defmethod handle :runCli [window [_ {:keys [command args returnResult]}]]
   (try
@@ -499,8 +498,8 @@
 (defmethod handle :gitCommitAll [_ [_ message]]
   (git/add-all-and-commit! message))
 
-(defmethod handle :gitStatus [_ [_]]
-  (git/short-status!))
+(defmethod handle :gitStatus [_ [_ repo]]
+  (git/short-status! (utils/get-graph-dir repo)))
 
 (def debounced-configure-auto-commit! (debounce git/configure-auto-commit! 5000))
 (defmethod handle :setGitAutoCommit []

--- a/src/electron/electron/state.cljs
+++ b/src/electron/electron/state.cljs
@@ -48,6 +48,16 @@
   [window]
   (get (:window/graph @state) window))
 
+(defn get-active-window-graph-path
+  "Get the path of the graph of the currently focused window (might be `nil`)"
+  []
+  (let [windows (:window/graph @state)
+        active-windows-pairs (filter #(.isFocused (first %)) windows)
+        active-window-pair (first active-windows-pairs)
+        path (second active-window-pair)]
+    path)
+  )
+
 (defn close-window!
   [window]
   (swap! state medley/dissoc-in [:window/graph window]))

--- a/src/electron/electron/state.cljs
+++ b/src/electron/electron/state.cljs
@@ -8,9 +8,6 @@
 (defonce state
   (atom {:config (config/get-config)
 
-         ;; FIXME: replace with :window/graph
-         :graph/current nil
-
          ;; window -> current graph
          :window/graph {}
 
@@ -39,14 +36,15 @@
   []
   (get-in @state [:config :git/commit-on-close?] false))
 
-(defn get-graph-path
-  []
-  (:graph/current @state))
-
 (defn get-window-graph-path
   "Get the path of the graph of a window (might be `nil`)"
   [window]
   (get (:window/graph @state) window))
+
+(defn get-all-graph-paths
+  "Get the paths of all graphs currently open in all windows."
+  []
+  (set (vals (:window/graph @state))))
 
 (defn get-active-window-graph-path
   "Get the path of the graph of the currently focused window (might be `nil`)"

--- a/src/main/frontend/components/commit.cljs
+++ b/src/main/frontend/components/commit.cljs
@@ -39,7 +39,7 @@
 (rum/defcs add-commit-message < rum/reactive
   (rum/local nil ::git-status)
   {:will-mount (fn [state]
-                 (-> (ipc/ipc "gitStatus")
+                 (-> (ipc/ipc "gitStatus" (state/get-current-repo))
                      (p/then (fn [status]
                                (reset! (get state ::git-status) status))))
                  state)

--- a/src/main/frontend/handler/shell.cljs
+++ b/src/main/frontend/handler/shell.cljs
@@ -11,11 +11,13 @@
 
 (defn run-git-command!
   [command]
-  (ipc/ipc :runGit command))
+  (ipc/ipc :runGit {:repo (state/get-current-repo)
+                    :command command}))
 
 (defn run-git-command2!
   [command]
-  (ipc/ipc :runGitWithinCurrentGraph command))
+  (ipc/ipc :runGitWithinCurrentGraph {:repo (state/get-current-repo) 
+                                      :command command}))
 
 (defn run-cli-command!
   [command args]


### PR DESCRIPTION
This removes all use of `:graph/current` in the electron state, and fixes the issue where git autocommit will only work on the last opened graph. Fixes #11011.