### PR TITLE
fix: add .heic to media type

### DIFF
--- a/src/main/frontend/config.cljs
+++ b/src/main/frontend/config.cljs
@@ -116,7 +116,7 @@
   #{:doc :docx :xls :xlsx :ppt :pptx :one :pdf :epub})
 
 (def image-formats
-  #{:png :jpg :jpeg :bmp :gif :webp :svg})
+  #{:png :jpg :jpeg :bmp :gif :webp :svg :heic})
 
 (def audio-formats
   #{:mp3 :ogg :mpeg :wav :m4a :flac :wma :aac})


### PR DESCRIPTION
See-also #11010

This is not a fix, instead, this PR allows sharing and saving an heic file.
Heic file requires some polyfill to be displayed on a webview.