### PR TITLE
dev: remove obsolete "@tailwindcss/line-clamp" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
         "@playwright/test": "=1.31.0",
         "@tailwindcss/aspect-ratio": "0.4.2",
         "@tailwindcss/forms": "0.5.3",
-        "@tailwindcss/line-clamp": "0.4.2",
         "@tailwindcss/typography": "0.5.7",
         "@types/gulp": "^4.0.7",
         "autoprefixer": "^10.4.13",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -140,7 +140,6 @@ module.exports = {
     require('@tailwindcss/forms'),
     require('@tailwindcss/typography'),
     require('@tailwindcss/aspect-ratio'),
-    require('@tailwindcss/line-clamp'),
     require('tailwind-capitalize-first-letter'),
     require('tailwindcss-animate'),
     exposeColorsToCssVars

--- a/yarn.lock
+++ b/yarn.lock
@@ -886,11 +886,6 @@
   dependencies:
     mini-svg-data-uri "^1.2.3"
 
-"@tailwindcss/line-clamp@0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/line-clamp/-/line-clamp-0.4.2.tgz#f353c5a8ab2c939c6267ac5b907f012e5ee130f9"
-  integrity sha512-HFzAQuqYCjyy/SX9sLGB1lroPzmcnWv1FHkIpmypte10hptf4oPUfucryMKovZh2u0uiS9U5Ty3GghWfEJGwVw==
-
 "@tailwindcss/typography@0.5.7":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.7.tgz#e0b95bea787ee14c5a34a74fc824e6fe86ea8855"


### PR DESCRIPTION
`yarn watch` says:

```
warn - As of Tailwind CSS v3.3, the `@tailwindcss/line-clamp` plugin is now included by default.
warn - Remove it from the `plugins` array in your configuration to eliminate this warning.
```

This modification removes the warning, and avoids a dependency that is no longer useful.