### PR TITLE
chore(release): bump version 0.10.8

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.logseq.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 81
-        versionName "0.10.7"
+        versionCode 82
+        versionName "0.10.8"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -519,7 +519,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 0.10.7;
+				MARKETING_VERSION = 0.10.8;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.logseq.logseq;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -546,7 +546,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 0.10.7;
+				MARKETING_VERSION = 0.10.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.logseq.logseq;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
@@ -571,7 +571,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 0.10.7;
+				MARKETING_VERSION = 0.10.8;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.logseq.logseq.ShareViewController;
@@ -598,7 +598,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 0.10.7;
+				MARKETING_VERSION = 0.10.8;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.logseq.logseq.ShareViewController;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/resources/forge.config.js
+++ b/resources/forge.config.js
@@ -4,7 +4,7 @@ module.exports = {
   packagerConfig: {
     name: 'Logseq',
     icon: './icons/logseq_big_sur.icns',
-    buildVersion: 81,
+    buildVersion: 82,
     protocols: [
       {
         "protocol": "logseq",

--- a/resources/package.json
+++ b/resources/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Logseq",
   "productName": "Logseq",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "main": "electron.js",
   "author": "Logseq",
   "license": "AGPL-3.0",

--- a/src/main/frontend/version.cljs
+++ b/src/main/frontend/version.cljs
@@ -1,3 +1,3 @@
 (ns ^:no-doc frontend.version)
 
-(defonce version "0.10.7")
+(defonce version "0.10.8")


### PR DESCRIPTION
# Changes Since Latest tag: 0.10.7

## Bugfixes

- Fix toggling of task list #11046 [#11079](https://github.com/logseq/logseq/pull/11079)
- fix: missing newline after multiline block when exporting a page #10930  [#10934](https://github.com/logseq/logseq/pull/10934)
- fix(editor): incorrect cursor move for the emoji from the line head [#11112](https://github.com/logseq/logseq/pull/11112)
- fix(sync): logout and clear cognito keys [#11111](https://github.com/logseq/logseq/pull/11111)
- fix(ux): support href prop for the classical ui button component [#11068](https://github.com/logseq/logseq/pull/11068)
- Update rsapi and fix token expiration [#11088](https://github.com/logseq/logseq/pull/11088)

## Enhancements

- enhance: display username on Logout button [#11105](https://github.com/logseq/logseq/pull/11105)
- enhance(i18n): Fixed and added some zh-cn(Simplified Chinese) translation [#11119](https://github.com/logseq/logseq/pull/11119)
- enhance(i18n): update Turkish translation [#11063](https://github.com/logseq/logseq/pull/11063)

## Community Contributions

@Falldio * fix: missing newline after multiline block when exporting a page #10930  by @Falldio in [#10934](https://github.com/logseq/logseq/pull/10934)
@jramosg * Fix toggling of task list #11046 by @jramosg in [#11079](https://github.com/logseq/logseq/pull/11079)
@liymike * enhance(i18n): Fixed and added some zh-cn(Simplified Chinese) translation by @liymike in [#11119](https://github.com/logseq/logseq/pull/11119)
@queeup * enhance(i18n): update Turkish translation by @queeup in [#11063](https://github.com/logseq/logseq/pull/11063)
