### PR TITLE
fix(search): fine tune page title search strategy

### DIFF
--- a/src/main/frontend/search/db.cljs
+++ b/src/main/frontend/search/db.cljs
@@ -113,6 +113,8 @@
                         (clj->js {:keys ["name"]
                                   :shouldSort true
                                   :tokenize true
+                                  :distance 1024
+                                  :threshold 0.5 ;; search for 50% match from the start
                                   :minMatchCharLength 1}))]
       (swap! indices assoc-in [repo :pages] indice)
       indice)))


### PR DESCRIPTION
See-also: https://www.fusejs.io/api/options.html#ignorelocation


Improve search relevance by finding terms anywhere within the PR title's first 500 characters.

Previously, searches were limited to the first 60 characters of the title.