### PR TITLE
Add "Search with Google Translate" to string context-menu

### DIFF
--- a/src/electron/electron/context_menu.cljs
+++ b/src/electron/electron/context_menu.cljs
@@ -43,6 +43,12 @@
                                  :click #(let [url (js/URL. "https://www.google.com/search")]
                                            (.. url -searchParams (set "q" selection-text))
                                            (.. shell (openExternal (.toString url))))}))
+              (. menu append (MenuItem. #js {:type "separator"}))
+              (. menu append
+                 (MenuItem. #js {:label "Search with Google Translate"
+                                 :click #(let [url (js/URL. "https://translate.google.com")]
+                                           (.. url -searchParams (set "q" selection-text))
+                                           (.. shell (openExternal (.toString url))))}))
               (. menu append (MenuItem. #js {:type "separator"})))
 
             (when editable?


### PR DESCRIPTION
It would be nice if there was an item to search with Google Translate when a string is selected.
![image](https://github.com/logseq/logseq/assets/111847207/e81821e6-bb16-4670-b360-4987dd39d021)
