### PR TITLE
Linux ARM64 build support

### DIFF
--- a/.github/workflows/build-desktop-release.yml
+++ b/.github/workflows/build-desktop-release.yml
@@ -222,7 +222,7 @@ jobs:
           DEBUG: "pw:api"
           RELEASE: true # skip dev only test
 
-  build-linux:
+  build-linux-x64:
     runs-on: ubuntu-20.04
     needs: [ compile-cljs ]
     steps:
@@ -265,7 +265,61 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: logseq-linux-builds
+          name: logseq-linux-x64-builds
+          path: builds
+
+  build-linux-arm64:
+    runs-on: ubuntu-20.04
+    needs: [ compile-cljs ]
+    steps:
+      - name: Download The Static Asset
+        uses: actions/download-artifact@v3
+        with:
+          name: static
+          path: static
+
+      - name: Retrieve tag version
+        id: ref
+        run: |
+          pkgver=$(cat ./static/VERSION)
+          echo "version=$pkgver" >> $GITHUB_OUTPUT
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Fetch deps
+        env:
+          npm_config_arch: arm64
+        run: |
+          yarn install --target_arch=arm64 --target_platform=linux
+          rsapi_version=`node -e 'console.log(require("@logseq/rsapi/package.json").optionalDependencies["@logseq/rsapi-linux-arm64-gnu"])'`
+          temp_dir=`mktemp -d`
+          cd "$temp_dir"
+          echo '{"dependencies": {"@logseq/rsapi-linux-arm64-gnu": "'"$rsapi_version"'"}}' > package.json
+          yarn install --ignore-platform
+          cd -
+          mv "$temp_dir/node_modules/@logseq/rsapi-linux-arm64-gnu" node_modules/@logseq/rsapi-linux-arm64-gnu
+          rm -rf "$temp_dir" "node_modules/@logseq/rsapi-linux-x64-gnu"
+        working-directory: ./static
+
+      - name: Build/Release Electron App
+        run: yarn electron:make-linux-arm64
+        working-directory: ./static
+
+      - name: Save artifacts
+        run: |
+          mkdir -p builds
+          # NOTE: save VERSION file to builds directory
+          cp static/VERSION ./builds/VERSION
+          # mv static/out/make/*-*.AppImage ./builds/Logseq-linux-arm64-${{ steps.ref.outputs.version }}.AppImage
+          mv static/out/make/zip/linux/arm64/*-linux-arm64-*.zip ./builds/Logseq-linux-arm64-${{ steps.ref.outputs.version }}.zip
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: logseq-linux-arm64-builds
           path: builds
 
   build-windows:
@@ -498,7 +552,7 @@ jobs:
 
   nightly-release:
     if: ${{ github.event_name == 'schedule' || github.event.inputs.build-target == 'nightly' }}
-    needs: [ build-macos-x64, build-macos-arm64, build-linux, build-windows, build-android, e2e-test ]
+    needs: [ build-macos-x64, build-macos-arm64, build-linux-x64, build-linux-arm64, build-windows, build-android, e2e-test ]
     runs-on: ubuntu-20.04
     steps:
       - name: Download MacOS x64 Artifacts
@@ -513,10 +567,16 @@ jobs:
           name: logseq-darwin-arm64-builds
           path: ./
 
-      - name: Download The Linux Artifacts
+      - name: Download The Linux x64 Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: logseq-linux-builds
+          name: logseq-linux-x64-builds
+          path: ./
+
+      - name: Download The Linux arm64 Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: logseq-linux-arm64-builds
           path: ./
 
       - name: Download The Windows Artifact
@@ -565,7 +625,7 @@ jobs:
   release:
     # NOTE: For now, we only have beta channel to be released on Github
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build-target == 'beta' }}
-    needs: [ build-macos-x64, build-macos-arm64, build-linux, build-windows, e2e-test ]
+    needs: [ build-macos-x64, build-macos-arm64, build-linux-x64, build-linux-arm64, build-windows, e2e-test ]
     runs-on: ubuntu-20.04
     steps:
       - name: Download MacOS x64 Artifacts
@@ -580,10 +640,16 @@ jobs:
           name: logseq-darwin-arm64-builds
           path: ./
 
-      - name: Download The Linux Artifacts
+      - name: Download The Linux x64 Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: logseq-linux-builds
+          name: logseq-linux-x64-builds
+          path: ./
+
+      - name: Download The Linux arm64 Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: logseq-linux-arm64-builds
           path: ./
 
       - name: Download The Windows Artifact

--- a/resources/package.json
+++ b/resources/package.json
@@ -28,7 +28,7 @@
     "chokidar": "^3.5.1",
     "command-exists": "1.2.9",
     "diff-match-patch": "1.0.5",
-    "dugite": "2.5.0",
+    "dugite": "2.5.1",
     "electron-deeplink": "1.0.10",
     "electron-dl": "3.3.0",
     "electron-log": "4.3.1",

--- a/resources/package.json
+++ b/resources/package.json
@@ -11,6 +11,7 @@
     "electron:dev": "electron-forge start",
     "electron:debug": "electron-forge start --inspect-electron",
     "electron:make": "electron-forge make",
+    "electron:make-linux-arm64": "electron-forge make --platform=linux --arch=arm64",
     "electron:make-macos-arm64": "electron-forge make --platform=darwin --arch=arm64",
     "electron:publish:github": "electron-forge publish",
     "rebuild:all": "electron-rebuild -v 27.1.3 -f",

--- a/static/yarn.lock
+++ b/static/yarn.lock
@@ -1851,10 +1851,10 @@ ds-store@^0.1.5:
     macos-alias "~0.2.5"
     tn1150 "^0.1.0"
 
-dugite@2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-2.5.0.tgz#8b235564fdf8692688283c714149a59d9da79865"
-  integrity sha512-sYsSOqV7NidthDtMUPgKCvqMGqswKkcyAxOMhwEswlcGZ+kHadT2SEDFUJOy0AVR/yTJL6wBF7q1OiySfU0gGA==
+dugite@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-2.5.1.tgz#6ab808ebf321809edf42d974e62eea9c9e256722"
+  integrity sha512-9OjUguynzq8v3GSmp01kbVcMmErc65ZZ0OssO/0PM2RyhD8Dzb8cCuy3z72+IxLwPwNi754jZ0FtMLAFA3D0qA==
   dependencies:
     progress "^2.0.3"
     tar "^6.1.11"


### PR DESCRIPTION
This PR intoduces [long-awaited](https://github.com/logseq/logseq/issues/6623) linux-arm64 builds!

A few notes on the PR:
1. Dugite was updated from 2.5.0 to 2.5.1. There should be no incompatibilities (see UPD2 below) between this versions but [2.5.1 has linux-arm64 support](https://github.com/logseq/logseq/issues/6623#issuecomment-1731775174). Please kindly check if everything works as expected before merging this upgrade to upstream.
2. Since AppImage [builder has hardcoded x64 architecture](https://github.com/logseq/electron-forge-maker-appimage/blob/master/src/MakerAppimage.ts#L123) specified in build settings, I have commented-out moving AppImage to builds directory. After (if?) it will be fixed it's possible to just uncomment related line and everything should work just fine. Currently x64 AppImage _may_ work on arm64 machine with help of something like Box64 to initially unpack the image and start native binaries after unpacking.
3. Yarn doesn't have options like `--os` and `--architecture` (which npm has) to specify which architecture to select when installing optional dependencies. Instead it has `--ignore-platform` option. But when using it on the whole package, it will also tell Yarn to (try to) install ALL the optional packages, for all the architectures and it will have significant impact on the resulting archive size and dependency installation time. That's why I'm using a little bit hacky approach - creating a temporary dir and installing the only required package for the only architecture we need and then moving it to original project's node_modules dir.

Binaries was tested on ThinkPad X13s laptop with Manjaro-ARM on board (Snapdragon 8cx Gen 3, 16GB RAM) but should work fine on any other ARM64 device.

Resolves #6623

UPD: Here's also a [release created](https://github.com/KaMeHb-UA/logseq-linux-arm64/releases/tag/0.10.8) so you can see that everything works as expected.

UPD2: Looks like there is [no changes in dugite API between v2.5.0 and v2.5.1](https://github.com/desktop/dugite/compare/v2.5.0...v2.5.1) so everything is expected to work fine.