### PR TITLE
Add: user confirmation before inserting a journal template

### DIFF
--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -132,6 +132,20 @@
               :border-top (if hover
                             "3px solid #ccc"
                             nil)}}
+     (when (state/journal-template-user-submit?)
+       (when (state/get-default-journal-template)
+         [:div.flex.flex-row.pt-10
+          [:div.flex.flex-row.items-center.mr-2.ml-1 {:style {:height 24}}
+           [:span.bullet-container.cursor
+            [:span.bullet]]]
+          [:div.flex.flex-1.pb-12
+           [:span.mb-10
+            {:on-click click-handler-fn}
+            ((ui/make-confirm-modal
+              {:title    (t :on-boarding/insert-today-journal)
+               :tag     "insert-today-journal"
+               :on-confirm #((state/pub-event! [:journal/insert-template page-name true]))}))]]]))
+
      [:div.flex.flex-row
       [:div.flex.flex-row.items-center.mr-2.ml-1 {:style {:height 24}}
        [:span.bullet-container.cursor
@@ -166,7 +180,7 @@
                    (when (and (db/journal-page? page-name)
                               (>= (date/journal-title->int page-name)
                                   (date/journal-title->int (date/today))))
-                     (state/pub-event! [:journal/insert-template page-name])))
+                     (state/pub-event! [:journal/insert-template page-name false])))
                  state)}
   [repo page-e {:keys [sidebar? whiteboard?] :as config}]
   (when page-e
@@ -206,7 +220,7 @@
 (rum/defc today-queries < rum/reactive
   [repo today? sidebar?]
   (when (and today? (not sidebar?))
-    (let [queries (get-in (state/sub-config repo) [:default-queries :journals])]
+    (let [queries (get-in (state/sub-config repo) [:default-queries :journals])] ;; TODO: defalut-queries on sidebar
       (when (seq queries)
         [:div#today-queries.mt-10
          (for [query queries]

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -146,7 +146,7 @@
                          :on-drop drop-handler-fn
                          :on-drag-leave #(set-hover! false)}
        [:span.opacity-70
-        "Click here to edit..."]]]]))
+        (t :on-boarding/click-here-to-edit-block)]]]]))
 
 (rum/defc add-button
   [args]

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -220,7 +220,7 @@
 (rum/defc today-queries < rum/reactive
   [repo today? sidebar?]
   (when (and today? (not sidebar?))
-    (let [queries (get-in (state/sub-config repo) [:default-queries :journals])] ;; TODO: defalut-queries on sidebar
+    (let [queries (get-in (state/sub-config repo) [:default-queries :journals])]
       (when (seq queries)
         [:div#today-queries.mt-10
          (for [query queries]

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -458,6 +458,12 @@
           show-full-blocks?
           config-handler/toggle-show-full-blocks!))
 
+(defn journal-template-user-submit [enabled?]
+  (toggle "journal_template_user_submit"
+          (t :settings-page/journal-template-user-submit)
+          enabled?
+          config-handler/toggle-journal-template-user-submit!))
+
 (defn preferred-pasting-file [t preferred-pasting-file?]
   (toggle "preferred_pasting_file"
           [(t :settings-page/preferred-pasting-file)
@@ -719,7 +725,9 @@
      (when (config/global-config-enabled?) (edit-global-config-edn))
      (when current-repo (edit-config-edn))
      (when current-repo (edit-custom-css))
-     (when current-repo (edit-export-css))]))
+     (when current-repo (edit-export-css))
+     (when (and current-repo (util/electron?)) (journal-template-user-submit (state/journal-template-user-submit?)))
+     ]))
 
 (rum/defcs settings-editor < rum/reactive
   [_state current-repo]

--- a/src/main/frontend/handler/config.cljs
+++ b/src/main/frontend/handler/config.cljs
@@ -42,6 +42,10 @@
   (let [show-full-blocks? (state/show-full-blocks?)]
     (set-config! :ui/show-full-blocks? (not show-full-blocks?))))
 
+(defn toggle-journal-template-user-submit! []
+  (let [enabled? (state/journal-template-user-submit?)]
+    (set-config! :journal-template/user-submit? (not enabled?))))
+
 (defn toggle-auto-expand-block-refs! []
   (let [auto-expand-block-refs? (state/auto-expand-block-refs?)]
     (set-config! :ui/auto-expand-block-refs? (not auto-expand-block-refs?))))

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -720,15 +720,16 @@
                   opts))
    {:center? true :close-btn? false :close-backdrop? false}))
 
-(defmethod handle :journal/insert-template [[_ page-name]]
+(defmethod handle :journal/insert-template [[_ page-name user-submit]]
   (let [page-name (util/page-name-sanity-lc page-name)]
     (when-let [page (db/pull [:block/name page-name])]
       (when (db/page-empty? (state/get-current-repo) page-name)
         (when-let [template (state/get-default-journal-template)]
-          (editor-handler/insert-template!
-           nil
-           template
-           {:target page}))))))
+            (when (or (not (state/journal-template-user-submit?)) user-submit)
+                (editor-handler/insert-template!
+                 nil
+                 template
+                 {:target page})))))))
 
 (defmethod handle :editor/set-org-mode-heading [[_ block heading]]
   (when-let [id (:block/uuid block)]

--- a/src/main/frontend/schema/handler/common_config.cljc
+++ b/src/main/frontend/schema/handler/common_config.cljc
@@ -43,6 +43,7 @@
     [:ui/show-command-doc? :boolean]
     [:ui/show-empty-bullets? :boolean]
     [:ui/show-full-blocks? :boolean]
+    [:journal-template/user-submit? :boolean]
     [:ui/auto-expand-block-refs? :boolean]
     [:query/views [:map-of
                    :keyword

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -303,7 +303,9 @@
      :whiteboard/pending-tx-data            {}
      :history/page-only-mode?               false
      ;; db tx-id -> editor cursor
-     :history/tx->editor-cursor             {}})))
+     :history/tx->editor-cursor             {}
+     
+     })))
 
 ;; Block ast state
 ;; ===============
@@ -702,6 +704,10 @@ Similar to re-frame subscriptions"
 (defn show-full-blocks?
   []
   (:ui/show-full-blocks? (sub-config)))
+
+(defn journal-template-user-submit?
+  []
+  (:journal-template/user-submit? (sub-config)))
 
 (defn preferred-pasting-file?
   []

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -67,6 +67,7 @@
  :on-boarding/section-phone "phone"
  :on-boarding/section-app "APP Internal"
  :on-boarding/section-config "Config File"
+ :on-boarding/click-here-to-edit-block "Click here to edit..."
  :query/config-property-settings "Properties settings for this query:"
  :bug-report/main-title "Bug report"
  :bug-report/clipboard-inspector-title "Clipboard data inspector"

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -67,6 +67,7 @@
  :on-boarding/section-phone "phone"
  :on-boarding/section-app "APP Internal"
  :on-boarding/section-config "Config File"
+ :on-boarding/insert-today-journal "Insert journal template?"
  :on-boarding/click-here-to-edit-block "Click here to edit..."
  :query/config-property-settings "Properties settings for this query:"
  :bug-report/main-title "Bug report"
@@ -368,7 +369,7 @@
  :settings-page/update-error-1 "⚠️ Oops, Something Went Wrong!"
  :settings-page/update-error-2 " Please check out the "
  :settings-permission/start-granting "Grant"
-
+ :settings-page/journal-template-user-submit "Enable user confirmation before inserting a journal template"
  :settings-page/auto-chmod "Automatically change file permissions"
  :settings-page/auto-chmod-desc "Disable to allow editing by multiple users with permissions granted by group membership."
  :yes "Yes"

--- a/src/resources/dicts/ja.edn
+++ b/src/resources/dicts/ja.edn
@@ -67,6 +67,7 @@
  :on-boarding/section-phone "スマートフォン"
  :on-boarding/section-app "内部アプリ"
  :on-boarding/section-config "設定ファイル"
+ :on-boarding/insert-today-journal "日誌テンプレートを挿入しますか？"
  :on-boarding/click-here-to-edit-block "クリックして編集..."
  :query/config-property-settings "このクエリにおけるプロパティの設定："
  :bug-report/main-title "バグ報告"
@@ -348,7 +349,7 @@
  :settings-page/update-error-1 "⚠️ なにか問題が発生しました"
  :settings-page/update-error-2 "次のリンクをご確認ください："
  :settings-permission/start-granting "認証"
-
+ :settings-page/journal-template-user-submit "日誌テンプレートを挿入する前のユーザー確認を有効にする"
  :settings-page/auto-chmod "ファイルの権限を自動で変更する"
  :settings-page/auto-chmod-desc "グループ メンバーシップを用いて、複数人のユーザに編集を許可する権限を与えたい場合、この機能を無効にしてください。"
  :yes "はい"

--- a/src/resources/dicts/ja.edn
+++ b/src/resources/dicts/ja.edn
@@ -67,6 +67,7 @@
  :on-boarding/section-phone "スマートフォン"
  :on-boarding/section-app "内部アプリ"
  :on-boarding/section-config "設定ファイル"
+ :on-boarding/click-here-to-edit-block "クリックして編集..."
  :query/config-property-settings "このクエリにおけるプロパティの設定："
  :bug-report/main-title "バグ報告"
  :bug-report/clipboard-inspector-title "クリップボードのデータを調査"


### PR DESCRIPTION
Turn on the toggle in the Settings to enable this feature. The reason for this feature is that there will be days when users do not write in their journals. And to prevent the journal template from being forcibly applied.

![Logseq-for-journal-template-insert](https://github.com/logseq/logseq/assets/111847207/0f130e7d-a321-44c0-a7e6-4360a1604b83)

* [x] A confirmation button will be installed in the display area called "dummy-block".
  > ⚠️At this stage, it is a draft.

TODO:
1. [ ] Apply the journal template when accessing a past date
https://github.com/logseq/logseq/issues/9341
https://github.com/logseq/logseq/issues/4037
2.  [ ] Apply the journal template when accessing a future date
https://github.com/logseq/logseq/issues/9827
3. [ ] Gracefully stops the execution of a insert process that runs every few seconds
   > I don't understand the need for the current spec of "trying to insert a template multiple times", so I don't think it should be changed, but it could also be a bug.