### PR TITLE
e2e-test: add "DEBUG=pw:api" to "e2e-test" script in package.json (fix #11195)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "dev-electron-app": "gulp electron",
         "release-electron": "run-s gulp:build && gulp electronMaker",
         "debug-electron": "cd static/ && yarn electron:debug",
-        "e2e-test": "cross-env CI=true npx playwright test --reporter github",
+        "e2e-test": "cross-env 'DEBUG=pw:api' CI=true npx playwright test --reporter github",
         "run-android-release": "yarn clean && yarn release-app && rm -rf ./public/static && rm -rf ./static/js/*.map && mv static ./public && npx cap sync android && npx cap run android",
         "run-ios-release": "yarn clean && yarn release-app && rm -rf ./public/static && rm -rf ./static/js/*.map && mv static ./public && npx cap sync ios && npx cap run ios",
         "clean": "gulp clean",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "dev-electron-app": "gulp electron",
         "release-electron": "run-s gulp:build && gulp electronMaker",
         "debug-electron": "cd static/ && yarn electron:debug",
-        "e2e-test": "cross-env 'DEBUG=pw:api' CI=true npx playwright test --reporter github",
+        "e2e-test": "cross-env DEBUG=pw:api CI=true npx playwright test --reporter github",
         "run-android-release": "yarn clean && yarn release-app && rm -rf ./public/static && rm -rf ./static/js/*.map && mv static ./public && npx cap sync android && npx cap run android",
         "run-ios-release": "yarn clean && yarn release-app && rm -rf ./public/static && rm -rf ./static/js/*.map && mv static ./public && npx cap sync ios && npx cap run ios",
         "clean": "gulp clean",


### PR DESCRIPTION
This only adds `DEBUG=pw:api` to the environment variables set by `cross-env` for the `e2e-test` script, as mentioned [here](https://github.com/logseq/logseq/issues/11195#issuecomment-2034200367).