### PR TITLE
docs/develop-logseq.md: specify that dependencies in /static also exist (fix #11192)

### DIFF
--- a/docs/develop-logseq.md
+++ b/docs/develop-logseq.md
@@ -55,6 +55,9 @@ The released files will be at `static/` directory.
 
 ``` bash
 yarn install
+cd static
+yarn install
+cd ..
 ```
 
 2. Compile to JavaScript and open the dev app


### PR DESCRIPTION
This only specifies in `docs/develop-logseq.md` that there are also dependencies in `/static` that need to be `yarn install`'d.