### PR TITLE
fix: table column width calculation with latex markup

### DIFF
--- a/deps/shui/src/logseq/shui/table/v2.cljs
+++ b/deps/shui/src/logseq/shui/table/v2.cljs
@@ -334,7 +334,8 @@
                         (get-in opts [:dynamic-widths col-index]))]
     ;; Whenever the cell changes, we need to calculate new bounds for the given content 
     ;; -innerText is used here to strip out formatting, this may turn out to not work for all given block types
-    (rum/use-layout-effect! #(->> (.. cell-ref -current -innerText) 
+    (rum/use-layout-effect! #(->> (-> (.. cell-ref -current -innerText)
+                                      (str/replace #"\\[^\s]+" " "))
                                   (count) 
                                   (handle-cell-width-change col-index))
                             [cell])


### PR DESCRIPTION
closes #10913 

Changes:
- `innerText` for table cell having latex markup return the actual markup, instead of the rendered character. e.g. for omega symbol "\Omega" is returned instead of "Ω". This results in incorrect width calculation. I have added a regex replace function call to replace markup text with a single character.