### PR TITLE
fix(editor): new block placeholder should accept tab and enter key

### DIFF
--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -151,7 +151,12 @@
 (rum/defc add-button
   [args]
   [:div.flex-1.flex-col.rounded-sm.add-button-link-wrap
-   {:on-click (fn [] (editor-handler/api-insert-new-block! "" args))}
+   {:on-click (fn [] (editor-handler/api-insert-new-block! "" args))
+    :on-key-down (fn [e]
+                    (when (= "Enter" (util/ekey e))
+                      (editor-handler/api-insert-new-block! "" args))
+                    (util/stop e))
+    :tab-index 0}
    [:div.flex.flex-row
     [:div.block {:style {:height      20
                          :width       20

--- a/src/main/frontend/components/page.css
+++ b/src/main/frontend/components/page.css
@@ -310,6 +310,11 @@ html.is-native-iphone-without-notch {
   }
 }
 
+.add-button-link-wrap:focus .add-button-link {
+  opacity: .8 !important;
+  transform: scale(.9);
+}
+
 .cp__right-sidebar .add-button-link {
   margin-left: 21px;
 }


### PR DESCRIPTION
Related: #11250

This should be a regression. I remember one day when I could use a keyboard to create new blocks.
The "Skip to main content" is also for keyboard-only operations.


This should be cherry-pick to db branch when merged.
