### PR TITLE
enhance(electron): options to disable file watcher

### DIFF
--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -110,6 +110,12 @@
     true
     (cfgs/get-item :feature/enable-automatic-chmod?)))
 
+(defn- file-watcher-enabled?
+  []
+  (if (= nil (cfgs/get-item :feature/enable-file-watcher?))
+    true
+    (cfgs/get-item :feature/enable-file-watcher?)))
+
 (defmethod handle :copyFile [_window [_ _repo from-path to-path]]
   (logger/info ::copy-file from-path to-path)
   (fs-extra/copy from-path to-path))
@@ -589,7 +595,9 @@
   ;; Only close file watcher when:
   ;;    1. there is no one window on the same dir
   ;;    2. reset file watcher to resend `add` event on window refreshing
-  (when dir
+  (when (and dir
+             (or (file-watcher-enabled?)
+                 (:global-dir options)))
     (logger/debug ::watch-dir {:path dir})
     (watcher/watch-dir! dir options)
     nil))

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -681,6 +681,20 @@
        (ipc/ipc :userAppCfgs :feature/enable-automatic-chmod? (not enabled?)))
      [:span.text-sm.opacity-50 (t :settings-page/auto-chmod-desc)])))
 
+(rum/defcs file-watcher-switcher-row < rum/reactive
+  [state t]
+  (let [enabled? (if (= nil (state/sub [:electron/user-cfgs :feature/enable-file-watcher?]))
+                   true
+                   (state/sub [:electron/user-cfgs :feature/enable-file-watcher?]))]
+    (toggle
+     "file-watcher"
+     (t :settings-page/file-watcher)
+     enabled?
+     #(do
+       (state/set-state! [:electron/user-cfgs :feature/enable-file-watcher?] (not enabled?))
+       (ipc/ipc :userAppCfgs :feature/enable-file-watcher? (not enabled?)))
+     [:span.text-sm.opacity-50 (t :settings-page/file-watcher-desc)])))
+
 (defn filename-format-row []
   (row-with-button-action
    {:left-label (t :settings-page/filename-format)
@@ -789,6 +803,7 @@
      (when-not (mobile-util/native-platform?) (developer-mode-row t developer-mode?))
      (when (util/electron?) (https-user-agent-row https-agent-opts))
      (when (util/electron?) (auto-chmod-row t))
+     (when (util/electron?) (file-watcher-switcher-row t))
      (when (and (util/electron?) (not (config/demo-graph? current-repo))) (filename-format-row))
      (clear-cache-row t)
 

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -367,9 +367,10 @@
  :settings-page/update-error-1 "⚠️ Oops, Something Went Wrong!"
  :settings-page/update-error-2 " Please check out the "
  :settings-permission/start-granting "Grant"
-
  :settings-page/auto-chmod "Automatically change file permissions"
  :settings-page/auto-chmod-desc "Disable to allow editing by multiple users with permissions granted by group membership."
+ :settings-page/file-watcher "File changes watcher"
+ :settings-page/file-watcher-desc "Disable to prevent Logseq from watching local file changes, for compatibility with third-party disk management software. Restart Logseq to apply changes."
  :yes "Yes"
 
  :submit "Submit"


### PR DESCRIPTION
Rationale:

- Some Sync Disks wipe out files that are not visited frequently
- Some FS doesn't have file change notifications(NFS, external driver based FS)
- Encryption Disks might lock files and issue a file change event

Drawbacks:

- When the file is changed outside, "Content conflicting" warning will be shown