### PR TITLE
chore(release): bump version 0.10.10

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.logseq.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 83
-        versionName "0.10.9"
+        versionCode 84
+        versionName "0.10.10"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/resources/forge.config.js
+++ b/resources/forge.config.js
@@ -5,7 +5,7 @@ module.exports = {
   packagerConfig: {
     name: 'Logseq',
     icon: './icons/logseq_big_sur.icns',
-    buildVersion: 83,
+    buildVersion: 84,
     protocols: [
       {
         "protocol": "logseq",

--- a/resources/package.json
+++ b/resources/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Logseq",
   "productName": "Logseq",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "main": "electron.js",
   "author": "Logseq",
   "license": "AGPL-3.0",

--- a/src/main/frontend/version.cljs
+++ b/src/main/frontend/version.cljs
@@ -1,3 +1,3 @@
 (ns ^:no-doc frontend.version)
 
-(defonce version "0.10.9")
+(defonce version "0.10.10")


### PR DESCRIPTION
Draft of changelog:

# Changes Since Latest tag: 0.10.9


## Features



## Bugfixes

- fix(mobile): incorrect theme color for the android status bar [#11272](https://github.com/logseq/logseq/pull/11272)
- fix(sync): cannot delete some nested files [#11280](https://github.com/logseq/logseq/pull/11280)

## Enhancements

- enhance(ux): better highlights page name for the search result items [#11271](https://github.com/logseq/logseq/pull/11271)

## Others(TODO, sorting to above)

- Add MSI build for windows [#11301](https://github.com/logseq/logseq/pull/11301)
- Update Electron 28 [#11304](https://github.com/logseq/logseq/pull/11304)
- Update Tldraw regex to detect both x.com AND twitter.com urls to preserve embed capabilities [#11321](https://github.com/logseq/logseq/pull/11321)

## Community Contributions

@mattmazzola * Update Tldraw regex to detect both x.com AND twitter.com urls to preserve embed capabilities by @mattmazzola in [#11321](https://github.com/logseq/logseq/pull/11321)
