### PR TITLE
doc: Add a URL to a Logseq plugin kit to Plugin document

### DIFF
--- a/libs/README.md
+++ b/libs/README.md
@@ -25,6 +25,7 @@ import "@logseq/libs"
 1. https://github.com/pengx17/logseq-plugin-template-react
 2. https://github.com/pengx17/logseq-plugin-template-svelte
 3. https://github.com/tiensonqin/logseq-cljs-playground
+4. https://github.com/YU000jp/logseq-plugin-sample-kit-typescript
 
 #### Feedback
 If you have any feedback or encounter any issues, feel free to join Logseq's discord group.


### PR DESCRIPTION
Add to this document: https://logseq.github.io/plugins/

I created a simple Logseq plugin kit that does not require React or any other tools.
https://github.com/YU000jp/logseq-plugin-sample-kit-typescript