### PR TITLE
Add copy button to code-mirror

### DIFF
--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -129,9 +129,12 @@
             ["codemirror/mode/z80/z80"]
             [frontend.commands :as commands]
             [frontend.db :as db]
+            [frontend.ui :as ui]
             [frontend.extensions.calc :as calc]
             [frontend.handler.editor :as editor-handler]
             [frontend.handler.code :as code-handler]
+            [frontend.handler.notification :as notification]
+            [frontend.context.i18n :refer [t]]
             [frontend.state :as state]
             [frontend.util :as util]
             [frontend.config :as config]
@@ -535,8 +538,21 @@
   [:div.extensions__code
    (when-let [mode (:data-lang attr)]
      (when-not (= mode "calc")
-       [:div.extensions__code-lang
-        (string/lower-case mode)]))
+       [[:div.extensions__code-lang
+         (string/lower-case mode)]
+        [:div.extensions__code-copy-button
+         (when code
+           [:button
+            {:title (str "Shift-Click " (t :editor/copy))
+             :on-mouse-down (fn [e]
+                              [(util/stop e)
+                               (.focus e)])
+             :on-click (fn [e]
+                         (util/stop e)
+                         [(util/copy-to-clipboard! code)
+                          (notification/show! (t :editor/copy) :success)])}
+            [(ui/icon "copy" {:size 16
+                              :class "ml-2"})]])]]))
    [:div.code-editor.flex.flex-1.flex-row.w-full
     [:textarea (merge {:id id
                        ;; Expose the textarea associated with the CodeMirror instance via

--- a/src/main/frontend/extensions/code.css
+++ b/src/main/frontend/extensions/code.css
@@ -1,7 +1,8 @@
 .extensions__code {
   @apply relative z-0 flex flex-row flex-nowrap justify-between;
 
-  &-lang {
+  &-lang,
+  &-copy-button {
     @apply p-1 text-sm;
     background: var(--ls-secondary-background-color);
     word-break: keep-all;
@@ -22,6 +23,10 @@
       opacity: 1;
       user-select: none;
     }
+  }
+
+  &-copy-button {
+    top: 1.2em;
   }
 
   &-calc {


### PR DESCRIPTION
to feat-db

Should make copy button built-in to code mirror
![image](https://github.com/user-attachments/assets/a5d31a23-d325-420d-98f7-1d7452ccfcbd)

https://discuss.logseq.com/t/copy-code-from-code-block-by-button-like-seen-on-github-markdown-codeblocks/2308

Of course, ‘Copy Code’ plugin is excellent. However, it can be assumed that copy-pasting is generally done in code mirrors, so it should be a built-in feature.


This is a draft of the feat-db branch. Right now it only works with Shift-click. To make it a normal click, I need to change the event listener of the parent element, but I didn't know which part to change. Please correct me if you know. 🫡
