### PR TITLE
chore: tooltips to choose the answer button when using FSRS

### DIFF
--- a/src/main/frontend/extensions/fsrs.cljs
+++ b/src/main/frontend/extensions/fsrs.cljs
@@ -175,13 +175,13 @@
                                          [:dd "We got the answer wrong. Automatically means that we have forgotten the card. This is a lapse in memory."]]
                                         [:dl
                                          [:dt "Hard"]
-                                         [:dd "The answer was only partially correct and/or we took too long to recall it."]]
+                                         [:dd "The answer was correct but we were not confident about it and/or took too long to recall."]]
                                         [:dl
                                          [:dt "Good"]
-                                         [:dd "The answer was correct but we were not confident about it."]]
+                                         [:dd "The answer was correct but we took some mental effort to recall it."]]
                                         [:dl
                                          [:dt "Easy"]
-                                         [:dd "The answer was correct and we were confident and quick in our recall."]]])
+                                         [:dd "The answer was correct and we were confident and quick in our recall without mental effort."]]])
                                      {:align "start"}))}
       (ui/icon "info-circle"))]))
 


### PR DESCRIPTION
I improved the wording about how to choose the answer button based on following guide:

# How to choose the answer button

- Again should be pressed if your answer is incorrect. If your answer is partially correct, you should be strict with yourself: if it would count as a fail in real-life context outside of Anki, then it counts as a fail in Anki as well. You'll typically use this button about 5-20% of the time.
- Hard should be pressed if your answer is correct, but you had doubts about it or it took a long time to recall.
- Good should be pressed if your answer is correct, but it took some mental effort to recall it. When Anki is used properly, this should be the most commonly used button. You'll typically use this button about 80-95% of the time.
- Easy should be pressed if your answer is correct and it took no mental effort to recall it.

Simply put, press Again if your answer was not completely correct, and press Hard, Good, or Easy otherwise. If you don't feel confident in your ability to decide precisely how difficult a card is, you can only use Again and Good, which is a perfectly valid way of using Anki.

https://docs.ankiweb.net/studying.html?highlight=choose#how-to-choose-the-answer-button