### PR TITLE
Feat: css classes for missing and alias links

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -541,7 +541,8 @@
         tag? (:tag? config)
         config (assoc config :whiteboard-page? whiteboard-page?)
         untitled? (model/untitled-page? page-name)
-        file-missing? (not (model/get-page-file page-name))]
+        file-missing? (not (model/get-page-file page-name))
+        page-alias? (not (= page-name redirect-page-name))]
         ; gradient-styles (state/sub-color-gradient-text-styles :09)]
 
     [:a
@@ -549,7 +550,7 @@
       :class (cond-> (if tag? "tag" "page-ref")
                (:property? config) (str " page-property-key block-property")
                untitled? (str " opacity-50")
-               file-missing? (str " page-missing")
+               file-missing? (str (if page-alias? " page-alias" " page-missing")))
       :data-ref page-name
       :draggable true
       :on-drag-start (fn [e] (editor-handler/block->data-transfer! page-name-in-block e))

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -540,15 +540,16 @@
   (let [[mouse-down? set-mouse-down!] (rum/use-state false) ;; avoid click event after drag
         tag? (:tag? config)
         config (assoc config :whiteboard-page? whiteboard-page?)
-        untitled? (model/untitled-page? page-name)]
+        untitled? (model/untitled-page? page-name)
+        file-missing? (not (model/get-page-file page-name))]
         ; gradient-styles (state/sub-color-gradient-text-styles :09)]
 
     [:a
      {:tabIndex "0"
       :class (cond-> (if tag? "tag" "page-ref")
-               (:property? config)
-               (str " page-property-key block-property")
-               untitled? (str " opacity-50"))
+               (:property? config) (str " page-property-key block-property")
+               untitled? (str " opacity-50")
+               file-missing? (str " page-missing")
       :data-ref page-name
       :draggable true
       :on-drag-start (fn [e] (editor-handler/block->data-transfer! page-name-in-block e))

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -307,6 +307,10 @@
   &:hover {
     color: var(--lx-accent-11, var(--ls-link-text-color, hsl(var(--primary))));
   }
+
+  &.page-missing {
+    color: hsl(from var(--lx-accent-11, var(--ls-link-text-color, hsl(var(--primary)))) h calc(s * 0.6) calc(l * 0.8));
+  }
 }
 
 .asset-ref {

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -309,7 +309,11 @@
   }
 
   &.page-missing {
-    color: hsl(from var(--lx-accent-11, var(--ls-link-text-color, hsl(var(--primary)))) h calc(s * 0.6) calc(l * 0.8));
+    color: hsl(from var(--lx-accent-11, var(--ls-link-text-color, hsl(var(--primary)))) h calc(s * 0.5) calc(l * 0.5));
+  }
+
+  &.page-alias {
+    color: hsl(from var(--lx-accent-11, var(--ls-link-text-color, hsl(var(--primary)))) h calc(s * 0.5) calc(l * 0.7));
   }
 }
 


### PR DESCRIPTION
As described here: https://discuss.logseq.com/t/add-css-class-for-links-to-empty-pages/29288

This adds css classes for alias links and for missing-page links, so that they can be styled differently.

I also added some default styling for these, which just darkens/desaturates the links.

First time coding in logseq/clojure, so I might be missing some better ways to do things, but it does seem to work.