### PR TITLE
feat: asset-sync init impl

### DIFF
--- a/src/dev-cljs/shadow/user.clj
+++ b/src/dev-cljs/shadow/user.clj
@@ -16,13 +16,20 @@
   ([]
    (when-let [runtime-id (->> (api/repl-runtimes :app)
                               (filter (fn [runtime] (= :browser-worker (:host runtime))))
-                              first
-                              :client-id)]
-     (prn :worker-runtime-id runtime-id)
+                              (map :client-id)
+                              (apply max))]
      (worker-repl runtime-id)))
-  ([runtime-id]
-   (assert runtime-id "runtime-id shouldn't be empty")
-   (api/repl :app {:runtime-id runtime-id})))
+  ([runtime-id-or-which]
+   (assert runtime-id-or-which "runtime-id shouldn't be empty")
+   (if
+    (number? runtime-id-or-which)
+     (do (prn :worker-runtime-id runtime-id-or-which)
+         (api/repl :app {:runtime-id runtime-id-or-which}))
+     (let [runtime-ids (->> (api/repl-runtimes :app)
+                            (filter (fn [runtime] (= :browser-worker (:host runtime))))
+                            (map :client-id))
+           runtime-id (apply (if (= :old runtime-id-or-which) min max) runtime-ids)]
+       (worker-repl runtime-id)))))
 
 (defn runtime-id-list
   []

--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -150,7 +150,8 @@
                      :icon (ui/icon "bulb")})
 
                   ;; Disable login on Web until RTC is ready
-                  (when (and (not login?) (not util/web-platform?))
+                  (when (and (not login?) (or (not util/web-platform?)
+                                              config/dev?))
                     {:title (t :login)
                      :options {:on-click #(state/pub-event! [:user/login])}
                      :icon (ui/icon "user")})

--- a/src/main/frontend/config.cljs
+++ b/src/main/frontend/config.cljs
@@ -508,6 +508,11 @@
   (when-let [repo-dir (get-repo-dir (state/get-current-repo))]
     (path/path-join repo-dir "assets")))
 
+(defn get-repo-assets-root
+  [repo]
+  (when-let [repo-dir (get-repo-dir repo)]
+    (path/path-join repo-dir "assets")))
+
 (defn get-custom-js-path
   ([]
    (get-custom-js-path (state/get-current-repo)))

--- a/src/main/frontend/handler/assets.cljs
+++ b/src/main/frontend/handler/assets.cljs
@@ -280,7 +280,8 @@
 (defn new-task--rtc-download-asset
   [repo asset-block-uuid-str asset-type get-url]
   (m/sp
-    (let [{:keys [status body] :as r} (c.m/<? (http/get get-url {:with-credentials? false}))]
+    (let [{:keys [status body] :as r} (c.m/<? (http/get get-url {:with-credentials? false
+                                                                 :response-type :array-buffer}))]
       (if-not (http/unexceptional-status? status)
         {:ex-data {:type :rtc.exception/download-asset-failed :data r}}
         (do (c.m/<? (<write-asset repo asset-block-uuid-str asset-type body))

--- a/src/main/frontend/handler/assets.cljs
+++ b/src/main/frontend/handler/assets.cljs
@@ -217,7 +217,7 @@
   []
   (when-let [path (config/get-current-repo-assets-root)]
     (p/let [result (p/catch (fs/readdir path {:path-only? true})
-                       (fn [_e] nil))]
+                            (fn [_e] nil))]
       (p/all (map (fn [path]
                     (p/let [data (fs/read-file path "" {})]
                       (let [path' (util/node-path.join "assets" (util/node-path.basename path))]
@@ -240,7 +240,7 @@
   [repo]
   (when-let [path (config/get-repo-assets-root repo)]
     (p/catch (fs/readdir path {:path-only? true})
-        (fn [_e] nil))))
+             (fn [_e] nil))))
 
 (defn <read-asset
   [repo asset-block-id asset-type]
@@ -249,6 +249,14 @@
         file-path (path/path-join common-config/local-assets-dir
                                   (str asset-block-id-str "." asset-type))]
     (fs/read-file repo-dir file-path {})))
+
+(defn <get-asset-file-metadata
+  [repo asset-block-id asset-type]
+  (-> (p/let [file (<read-asset repo asset-block-id asset-type)
+              blob (js/Blob. (array file) (clj->js {:type "image"}))
+              checksum (get-file-checksum blob)]
+        {:checksum checksum})
+      (p/catch (fn [_e] nil))))
 
 (defn <write-asset
   [repo asset-block-id asset-type data]

--- a/src/main/frontend/handler/assets.cljs
+++ b/src/main/frontend/handler/assets.cljs
@@ -244,10 +244,9 @@
 
 (defn <read-asset
   [repo asset-block-id asset-type]
-  (let [asset-block-id-str (str asset-block-id)
-        repo-dir (config/get-repo-dir repo)
+  (let [repo-dir (config/get-repo-dir repo)
         file-path (path/path-join common-config/local-assets-dir
-                                  (str asset-block-id-str "." asset-type))]
+                                  (str asset-block-id "." asset-type))]
     (fs/read-file repo-dir file-path {})))
 
 (defn <get-asset-file-metadata
@@ -265,6 +264,13 @@
         file-path (path/path-join common-config/local-assets-dir
                                   (str asset-block-id-str "." asset-type))]
     (fs/write-file! repo repo-dir file-path data {})))
+
+(defn <unlink-asset
+  [repo asset-block-id asset-type]
+  (let [repo-dir (config/get-repo-dir repo)
+        file-path (path/path-join common-config/local-assets-dir
+                                  (str asset-block-id "." asset-type))]
+    (fs/unlink! repo-dir file-path {})))
 
 (defn new-task--rtc-upload-asset
   [repo asset-block-uuid-str asset-type put-url]

--- a/src/main/frontend/handler/assets.cljs
+++ b/src/main/frontend/handler/assets.cljs
@@ -216,7 +216,8 @@
 (defn <get-all-assets
   []
   (when-let [path (config/get-current-repo-assets-root)]
-    (p/let [result (fs/readdir path {:path-only? true})]
+    (p/let [result (p/catch (fs/readdir path {:path-only? true})
+                       (fn [_e] nil))]
       (p/all (map (fn [path]
                     (p/let [data (fs/read-file path "" {})]
                       (let [path' (util/node-path.join "assets" (util/node-path.basename path))]
@@ -234,6 +235,12 @@
   [filename]
   (p/let [[repo-dir assets-dir] (ensure-assets-dir! (state/get-current-repo))]
     (path/path-join repo-dir assets-dir filename)))
+
+(defn <get-all-asset-file-paths
+  [repo]
+  (when-let [path (config/get-repo-assets-root repo)]
+    (p/catch (fs/readdir path {:path-only? true})
+        (fn [_e] nil))))
 
 (defn <read-asset
   [repo asset-block-id asset-type]

--- a/src/main/frontend/handler/assets.cljs
+++ b/src/main/frontend/handler/assets.cljs
@@ -260,15 +260,16 @@
                                      :body asset-file
                                      :with-credentials? false}))]
       (when-not (http/unexceptional-status? status)
-        (throw (ex-info "upload asset failed" {:type :rtc.exception/upload-asset-failed :data r}))))))
+        {:ex-data {:type :rtc.exception/upload-asset-failed :data r}}))))
 
 (defn new-task--rtc-download-asset
   [repo asset-block-uuid-str asset-type get-url]
   (m/sp
     (let [{:keys [status body] :as r} (c.m/<? (http/get get-url {:with-credentials? false}))]
-      (when-not (http/unexceptional-status? status)
-        (throw (ex-info "download asset failed" {:type :rtc.exception/download-asset-failed :data r})))
-      (c.m/<? (<write-asset repo asset-block-uuid-str asset-type body)))))
+      (if-not (http/unexceptional-status? status)
+        {:ex-data {:type :rtc.exception/download-asset-failed :data r}}
+        (do (c.m/<? (<write-asset repo asset-block-uuid-str asset-type body))
+            nil)))))
 
 (comment
   ;; read asset

--- a/src/main/frontend/handler/assets.cljs
+++ b/src/main/frontend/handler/assets.cljs
@@ -217,7 +217,7 @@
   []
   (when-let [path (config/get-current-repo-assets-root)]
     (p/let [result (p/catch (fs/readdir path {:path-only? true})
-                            (fn [_e] nil))]
+                       (constantly nil))]
       (p/all (map (fn [path]
                     (p/let [data (fs/read-file path "" {})]
                       (let [path' (util/node-path.join "assets" (util/node-path.basename path))]
@@ -240,7 +240,7 @@
   [repo]
   (when-let [path (config/get-repo-assets-root repo)]
     (p/catch (fs/readdir path {:path-only? true})
-             (fn [_e] nil))))
+             (constantly nil))))
 
 (defn <read-asset
   [repo asset-block-id asset-type]
@@ -255,7 +255,7 @@
               blob (js/Blob. (array file) (clj->js {:type "image"}))
               checksum (get-file-checksum blob)]
         {:checksum checksum})
-      (p/catch (fn [_e] nil))))
+      (p/catch (constantly nil))))
 
 (defn <write-asset
   [repo asset-block-id asset-type data]

--- a/src/main/frontend/handler/assets.cljs
+++ b/src/main/frontend/handler/assets.cljs
@@ -256,7 +256,7 @@
   (m/sp
     (let [asset-file (c.m/<? (<read-asset repo asset-block-uuid-str asset-type))
           {:keys [status] :as r}
-          (c.m/<? (http/put put-url {:headers {"x-amz-meta-checksum" "TODO-CHECKSUM-HERE"}
+          (c.m/<? (http/put put-url {:headers {"x-amz-meta-checksum" "TEST-CHECKSUM"}
                                      :body asset-file
                                      :with-credentials? false}))]
       (when-not (http/unexceptional-status? status)

--- a/src/main/frontend/handler/assets.cljs
+++ b/src/main/frontend/handler/assets.cljs
@@ -267,10 +267,10 @@
 
 (defn <unlink-asset
   [repo asset-block-id asset-type]
-  (let [repo-dir (config/get-repo-dir repo)
-        file-path (path/path-join common-config/local-assets-dir
+  (let [file-path (path/path-join (config/get-repo-dir repo)
+                                  common-config/local-assets-dir
                                   (str asset-block-id "." asset-type))]
-    (fs/unlink! repo-dir file-path {})))
+    (p/catch (fs/unlink! repo file-path {}) (constantly nil))))
 
 (defn new-task--rtc-upload-asset
   [repo asset-block-uuid-str asset-type checksum put-url]

--- a/src/main/frontend/handler/assets.cljs
+++ b/src/main/frontend/handler/assets.cljs
@@ -273,11 +273,13 @@
     (fs/unlink! repo-dir file-path {})))
 
 (defn new-task--rtc-upload-asset
-  [repo asset-block-uuid-str asset-type put-url]
+  [repo asset-block-uuid-str asset-type checksum put-url]
+  (assert (and asset-type checksum))
   (m/sp
     (let [asset-file (c.m/<? (<read-asset repo asset-block-uuid-str asset-type))
           {:keys [status] :as r}
-          (c.m/<? (http/put put-url {:headers {"x-amz-meta-checksum" "TEST-CHECKSUM"}
+          (c.m/<? (http/put put-url {:headers {"x-amz-meta-checksum" checksum
+                                               "x-amz-meta-type" asset-type}
                                      :body asset-file
                                      :with-credentials? false}))]
       (when-not (http/unexceptional-status? status)

--- a/src/main/frontend/handler/assets.cljs
+++ b/src/main/frontend/handler/assets.cljs
@@ -231,3 +231,38 @@
   [filename]
   (p/let [[repo-dir assets-dir] (ensure-assets-dir! (state/get-current-repo))]
     (path/path-join repo-dir assets-dir filename)))
+
+(defn <read-asset
+  [repo asset-block-id asset-type]
+  (let [asset-block-id-str (str asset-block-id)
+        repo-dir (config/get-repo-dir repo)
+        file-path (path/path-join common-config/local-assets-dir
+                                  (str asset-block-id-str "." asset-type))]
+    (fs/read-file repo-dir file-path {})))
+
+(defn <write-asset
+  [repo asset-block-id asset-type data]
+  (let [asset-block-id-str (str asset-block-id)
+        repo-dir (config/get-repo-dir repo)
+        file-path (path/path-join common-config/local-assets-dir
+                                  (str asset-block-id-str "." asset-type))]
+    (fs/write-file! repo repo-dir file-path data {})))
+
+(comment
+  ;; read asset
+  (p/let [repo "logseq_db_demo"
+          ;; Existing asset block's id
+          asset-block-id-str "672c5a1d-8171-4259-9f35-470c3c67e37f"
+          asset-type "png"
+          data (<read-asset repo asset-block-id-str asset-type)]
+    (js/console.dir data))
+
+  ;; write asset
+  (p/let [repo "logseq_db_demo"
+          ;; Existing asset block's id
+          asset-block-id-str "672c5a1d-8171-4259-9f35-470c3c67e37f"
+          asset-type "png"
+          data (<read-asset repo asset-block-id-str asset-type)
+          new-asset-id (random-uuid)
+          result (<write-asset repo new-asset-id asset-type data)]
+    (js/console.dir result)))

--- a/src/main/frontend/handler/worker.cljs
+++ b/src/main/frontend/handler/worker.cljs
@@ -53,7 +53,7 @@
           (let [data (.-data event)]
             (if (= data "keepAliveResponse")
               (.postMessage worker "keepAliveRequest")
-              (when-not (= (.-type data) "RAW")
+              (when-not (contains? #{"RAW" "APPLY" "RELEASE"} (.-type data))
                 ;; Log thrown exceptions from comlink
                 ;; https://github.com/GoogleChromeLabs/comlink/blob/dffe9050f63b1b39f30213adeb1dd4b9ed7d2594/src/comlink.ts#L223-L236
                 (if (and (= "HANDLER" (.-type data)) (= "throw" (.-name data)))

--- a/src/main/frontend/persist_db/browser.cljs
+++ b/src/main/frontend/persist_db/browser.cljs
@@ -85,12 +85,24 @@
                  (ldb/write-transit-str context))
       (notification/show! "Latest change was not saved! Please restart the application." :error))))
 
+(defn- with-write-transit-str
+  [p]
+  (p/chain p ldb/write-transit-str))
+
 (deftype Main []
   Object
   (readAsset [_this repo asset-block-id asset-type]
     (assets-handler/<read-asset repo asset-block-id asset-type))
   (writeAsset [_this repo asset-block-id asset-type data]
     (assets-handler/<write-asset repo asset-block-id asset-type data))
+  (rtc-upload-asset [_this repo asset-block-uuid-str asset-type put-url]
+    (with-write-transit-str
+      (js/Promise.
+       (assets-handler/new-task--rtc-upload-asset repo asset-block-uuid-str asset-type put-url))))
+  (rtc-download-asset [_this repo asset-block-uuid-str asset-type get-url]
+    (with-write-transit-str
+      (js/Promise.
+       (assets-handler/new-task--rtc-download-asset repo asset-block-uuid-str asset-type get-url))))
   (testFn [_this]
     (prn :debug :works)))
 

--- a/src/main/frontend/persist_db/browser.cljs
+++ b/src/main/frontend/persist_db/browser.cljs
@@ -98,6 +98,9 @@
   (get-all-asset-file-paths [_this repo]
     (with-write-transit-str
       (assets-handler/<get-all-asset-file-paths repo)))
+  (get-asset-file-metadata [_this repo asset-block-id asset-type]
+    (with-write-transit-str
+      (assets-handler/<get-asset-file-metadata repo asset-block-id asset-type)))
   (rtc-upload-asset [_this repo asset-block-uuid-str asset-type put-url]
     (with-write-transit-str
       (js/Promise.

--- a/src/main/frontend/persist_db/browser.cljs
+++ b/src/main/frontend/persist_db/browser.cljs
@@ -95,6 +95,9 @@
     (assets-handler/<read-asset repo asset-block-id asset-type))
   (writeAsset [_this repo asset-block-id asset-type data]
     (assets-handler/<write-asset repo asset-block-id asset-type data))
+  (get-all-asset-file-paths [_this repo]
+    (with-write-transit-str
+      (assets-handler/<get-all-asset-file-paths repo)))
   (rtc-upload-asset [_this repo asset-block-uuid-str asset-type put-url]
     (with-write-transit-str
       (js/Promise.

--- a/src/main/frontend/persist_db/browser.cljs
+++ b/src/main/frontend/persist_db/browser.cljs
@@ -103,10 +103,10 @@
   (get-asset-file-metadata [_this repo asset-block-id asset-type]
     (with-write-transit-str
       (assets-handler/<get-asset-file-metadata repo asset-block-id asset-type)))
-  (rtc-upload-asset [_this repo asset-block-uuid-str asset-type put-url]
+  (rtc-upload-asset [_this repo asset-block-uuid-str asset-type checksum put-url]
     (with-write-transit-str
       (js/Promise.
-       (assets-handler/new-task--rtc-upload-asset repo asset-block-uuid-str asset-type put-url))))
+       (assets-handler/new-task--rtc-upload-asset repo asset-block-uuid-str asset-type checksum put-url))))
   (rtc-download-asset [_this repo asset-block-uuid-str asset-type get-url]
     (with-write-transit-str
       (js/Promise.

--- a/src/main/frontend/persist_db/browser.cljs
+++ b/src/main/frontend/persist_db/browser.cljs
@@ -95,6 +95,8 @@
     (assets-handler/<read-asset repo asset-block-id asset-type))
   (writeAsset [_this repo asset-block-id asset-type data]
     (assets-handler/<write-asset repo asset-block-id asset-type data))
+  (unlinkAsset [_this repo asset-block-id asset-type]
+    (assets-handler/<unlink-asset repo asset-block-id asset-type))
   (get-all-asset-file-paths [_this repo]
     (with-write-transit-str
       (assets-handler/<get-all-asset-file-paths repo)))

--- a/src/main/frontend/worker/db_worker.cljs
+++ b/src/main/frontend/worker/db_worker.cljs
@@ -31,14 +31,14 @@
             [logseq.common.util :as common-util]
             [logseq.db :as ldb]
             [logseq.db.frontend.order :as db-order]
+            [logseq.db.frontend.schema :as db-schema]
             [logseq.db.sqlite.common-db :as sqlite-common-db]
             [logseq.db.sqlite.create-graph :as sqlite-create-graph]
             [logseq.db.sqlite.util :as sqlite-util]
             [logseq.outliner.op :as outliner-op]
+            [me.tonsky.persistent-sorted-set :as set :refer [BTSet]]
             [promesa.core :as p]
-            [shadow.cljs.modern :refer [defclass]]
-            [logseq.db.frontend.schema :as db-schema]
-            [me.tonsky.persistent-sorted-set :as set :refer [BTSet]]))
+            [shadow.cljs.modern :refer [defclass]]))
 
 (defonce *sqlite worker-state/*sqlite)
 (defonce *sqlite-conns worker-state/*sqlite-conns)
@@ -915,9 +915,7 @@
     (worker-state/set-worker-object! obj)
     (file/<ratelimit-file-writes!)
     (js/setInterval #(.postMessage js/self "keepAliveResponse") (* 1000 25))
-    (Comlink/expose obj)
-    (let [^js main (Comlink/wrap js/self)]
-      (.testFn main))))
+    (Comlink/expose obj)))
 
 (comment
   (defn <remove-all-files!

--- a/src/main/frontend/worker/db_worker.cljs
+++ b/src/main/frontend/worker/db_worker.cljs
@@ -915,7 +915,9 @@
     (worker-state/set-worker-object! obj)
     (file/<ratelimit-file-writes!)
     (js/setInterval #(.postMessage js/self "keepAliveResponse") (* 1000 25))
-    (Comlink/expose obj)))
+    (Comlink/expose obj)
+    (let [^js main (Comlink/wrap js/self)]
+      (.testFn main))))
 
 (comment
   (defn <remove-all-files!

--- a/src/main/frontend/worker/db_worker.cljs
+++ b/src/main/frontend/worker/db_worker.cljs
@@ -915,7 +915,8 @@
     (worker-state/set-worker-object! obj)
     (file/<ratelimit-file-writes!)
     (js/setInterval #(.postMessage js/self "keepAliveResponse") (* 1000 25))
-    (Comlink/expose obj)))
+    (Comlink/expose obj)
+    (reset! worker-state/*main-thread (Comlink/wrap js/self))))
 
 (comment
   (defn <remove-all-files!

--- a/src/main/frontend/worker/rtc/asset.cljs
+++ b/src/main/frontend/worker/rtc/asset.cljs
@@ -115,7 +115,7 @@
 (defn create-assets-sync-loop
   [get-ws-create-task graph-uuid conn]
   (let [started-dfv         (m/dfv)
-        asset-change-event-flow global-asset-change-event-flow
+        asset-change-event-flow m/none
         add-log-fn (fn [type message]
                      (assert (map? message) message)
                      (rtc-log-and-state/rtc-log type (assoc message :graph-uuid graph-uuid)))]

--- a/src/main/frontend/worker/rtc/asset.cljs
+++ b/src/main/frontend/worker/rtc/asset.cljs
@@ -3,12 +3,8 @@
   some notes:
   - has :logseq.property.asset/type
   - block/content, store the asset name
-  - an asset-block not having :file/path indicates need to download asset from server
   - an asset-block not having :logseq.property.asset/remote-metadata
-    indicates need to upload the asset to server
-  - if an asset-block doesn't have both :file/path and :logseq.property.asset/remote-metadata,
-    it means the other client hasn't uploaded the asset to server
-"
+    indicates need to upload the asset to server"
   (:require [clojure.set :as set]
             [datascript.core :as d]
             [frontend.common.missionary-util :as c.m]

--- a/src/main/frontend/worker/rtc/asset.cljs
+++ b/src/main/frontend/worker/rtc/asset.cljs
@@ -1,8 +1,8 @@
 (ns frontend.worker.rtc.asset
   "Fns to sync assets.
   some notes:
-  - has :logseq.property.asset/type
-  - block/content, store the asset name
+  - has :logseq.property.asset/type, :logseq.property.asset/size, :logseq.property.asset/checksum
+  - block/title, store the asset name
   - an asset-block not having :logseq.property.asset/remote-metadata
     indicates need to upload the asset to server"
   (:require [clojure.set :as set]

--- a/src/main/frontend/worker/rtc/asset.cljs
+++ b/src/main/frontend/worker/rtc/asset.cljs
@@ -162,7 +162,6 @@
                                                          [asset-uuid {"checksum" checksum "type" asset-type}]))
                                                   asset-uuid->asset-type+checksum)}))
                    :asset-uuid->url))]
-        (prn :xxx-push-local-asset-updates asset-ops (keys asset-uuid->url))
         (doseq [[asset-uuid put-url] asset-uuid->url]
           (prn :start-upload-asset asset-uuid)
           (let [[asset-type checksum] (get asset-uuid->asset-type+checksum asset-uuid)
@@ -217,7 +216,6 @@
                                             :graph-uuid graph-uuid
                                             :asset-uuids (keys asset-uuid->asset-type)}))
                    :asset-uuid->url))]
-        (prn :xxx-pull-remote-asset-updates asset-uuid->asset-type asset-uuid->url)
         (doseq [[asset-uuid asset-type] remove-asset-uuid->asset-type]
           (c.m/<? (.unlinkAsset ^js @worker-state/*main-thread repo (str asset-uuid) asset-type)))
         (doseq [[asset-uuid get-url] asset-uuid->url]

--- a/src/main/frontend/worker/rtc/asset.cljs
+++ b/src/main/frontend/worker/rtc/asset.cljs
@@ -162,13 +162,13 @@
                                           (into {} (map (fn [asset-uuid] [asset-uuid {"checksum" "TEST-CHECKSUM"}]))
                                                 (keys asset-uuid->asset-type))}))
                  :asset-uuid->url))]
-      (prn :xxx-push-local-asset-updates asset-ops asset-uuid->url)
+      (prn :xxx-push-local-asset-updates asset-ops asset-uuid->url asset-uuid->asset-type)
       (doseq [[asset-uuid put-url] asset-uuid->url]
         (prn :start-upload-asset asset-uuid)
         (let [r (ldb/read-transit-str
                  (c.m/<?
                   (.rtc-upload-asset
-                   @worker-state/*main-thread
+                   ^js @worker-state/*main-thread
                    repo (str asset-uuid) (get asset-uuid->asset-type asset-uuid) put-url)))]
           (when (:ex-data r)
             (throw (ex-info "upload asset failed" r)))
@@ -201,7 +201,7 @@
           (let [r (ldb/read-transit-str
                    (c.m/<?
                     (.rtc-download-asset
-                     @worker-state/*main-thread
+                     ^js @worker-state/*main-thread
                      repo (str asset-uuid) (get asset-uuid->asset-type asset-uuid) get-url)))]
             (when (:ex-data r)
               (throw (ex-info "upload asset failed" r)))))))))

--- a/src/main/frontend/worker/rtc/asset.cljs
+++ b/src/main/frontend/worker/rtc/asset.cljs
@@ -112,22 +112,6 @@
      (finally
        (reset! *assets-sync-lock nil)))))
 
-(def ^:private asset-change-event-schema
-  [:map-of
-   [:enum :download :upload
-    ;; Why don't need :delete event?
-    ;; when remove-block-op sync to server, server will know this asset need to be deleted
-    ;; :delete
-    ]
-   [:set :uuid]])
-
-(def ^:private asset-change-event-validator (ma/validator asset-change-event-schema))
-
-(defonce *global-asset-change-event (atom nil :validator asset-change-event-validator))
-
-(defonce ^:private global-asset-change-event-flow
-  (m/buffer 20 (m/watch *global-asset-change-event)))
-
 (defn create-assets-sync-loop
   [get-ws-create-task graph-uuid conn]
   (let [started-dfv         (m/dfv)

--- a/src/main/frontend/worker/rtc/asset_db_listener.cljs
+++ b/src/main/frontend/worker/rtc/asset_db_listener.cljs
@@ -28,8 +28,6 @@
 (defmethod db-listener/listen-db-changes :gen-asset-change-events
   [_ {:keys [_tx-data tx-meta _db-before db-after
              repo _id->attr->datom _e->a->add?->v->t same-entity-datoms-coll]}]
-  (def xx-db-after db-after)
-  (def xx same-entity-datoms-coll)
   (when (and (client-op/rtc-db-graph? repo)
              (:generate-asset-change-events? tx-meta true))
     (generate-asset-ops repo db-after same-entity-datoms-coll)))

--- a/src/main/frontend/worker/rtc/asset_db_listener.cljs
+++ b/src/main/frontend/worker/rtc/asset_db_listener.cljs
@@ -27,12 +27,9 @@
   (when-let [ops (not-empty (mapcat (partial entity-datoms=>ops db-before db-after) same-entity-datoms-coll))]
     (client-op/add-asset-ops repo ops)))
 
-(sr/defkeyword :generate-asset-change-events?
-  "tx-meta option, generate events to notify asset-sync (default true)")
-
 (defmethod db-listener/listen-db-changes :gen-asset-change-events
   [_ {:keys [_tx-data tx-meta db-before db-after
              repo _id->attr->datom _e->a->add?->v->t same-entity-datoms-coll]}]
   (when (and (client-op/rtc-db-graph? repo)
-             (:generate-asset-change-events? tx-meta true))
+             (:persist-op? tx-meta true))
     (generate-asset-ops repo db-before db-after same-entity-datoms-coll)))

--- a/src/main/frontend/worker/rtc/asset_db_listener.cljs
+++ b/src/main/frontend/worker/rtc/asset_db_listener.cljs
@@ -1,7 +1,6 @@
 (ns frontend.worker.rtc.asset-db-listener
   "Listen asset-block changes in db, generate asset-sync operations"
   (:require [datascript.core :as d]
-            [frontend.common.schema-register :as sr]
             [frontend.worker.db-listener :as db-listener]
             [frontend.worker.rtc.client-op :as client-op]
             [logseq.db :as ldb]))

--- a/src/main/frontend/worker/rtc/asset_db_listener.cljs
+++ b/src/main/frontend/worker/rtc/asset_db_listener.cljs
@@ -3,29 +3,24 @@
   (:require [datascript.core :as d]
             [frontend.common.schema-register :as sr]
             [frontend.worker.db-listener :as db-listener]
-            [frontend.worker.rtc.asset :as r.asset]
             [frontend.worker.rtc.client-op :as client-op]
             [logseq.db :as ldb]))
 
-(defn entity-datoms=>action+asset-uuid
+(defn- max-t
+  [entity-datoms]
+  (apply max (map (fn [[_e _a _v t]] t) entity-datoms)))
+
+(defn- entity-datoms=>ops
   [db-after entity-datoms]
   (when-let [e (ffirst entity-datoms)]
-    (let [ent (d/entity db-after e)
-          block-uuid (:block/uuid ent)]
-      (when (and block-uuid (ldb/asset? ent))
-        (when-let [action (r.asset/asset-block->upload+download-action ent)]
-          [action block-uuid])))))
+    (let [ent (d/entity db-after e)]
+      (when (ldb/asset? ent)
+        [[:update-asset (max-t entity-datoms) {:block-uuid (:block/uuid ent)}]]))))
 
-(defn generate-asset-change-events
-  [db-after same-entity-datoms-coll]
-  (let [action->asset-uuids
-        (->> same-entity-datoms-coll
-             (keep (partial entity-datoms=>action+asset-uuid db-after))
-             (reduce
-              (fn [action->asset-uuids [action asset-uuid]]
-                (update action->asset-uuids action (fnil conj #{}) asset-uuid))
-              {}))]
-    (reset! r.asset/*global-asset-change-event action->asset-uuids)))
+(defn generate-asset-ops
+  [repo db-after same-entity-datoms-coll]
+  (when-let [ops (not-empty (mapcat (partial entity-datoms=>ops db-after) same-entity-datoms-coll))]
+    (client-op/add-asset-ops repo ops)))
 
 (sr/defkeyword :generate-asset-change-events?
   "tx-meta option, generate events to notify asset-sync (default true)")
@@ -33,6 +28,8 @@
 (defmethod db-listener/listen-db-changes :gen-asset-change-events
   [_ {:keys [_tx-data tx-meta _db-before db-after
              repo _id->attr->datom _e->a->add?->v->t same-entity-datoms-coll]}]
+  (def xx-db-after db-after)
+  (def xx same-entity-datoms-coll)
   (when (and (client-op/rtc-db-graph? repo)
              (:generate-asset-change-events? tx-meta true))
-    (generate-asset-change-events db-after same-entity-datoms-coll)))
+    (generate-asset-ops repo db-after same-entity-datoms-coll)))

--- a/src/main/frontend/worker/rtc/client.cljs
+++ b/src/main/frontend/worker/rtc/client.cljs
@@ -320,7 +320,7 @@
   "Return a task: push local updates"
   [repo conn graph-uuid date-formatter get-ws-create-task add-log-fn]
   (m/sp
-    (let [block-ops-map-coll (client-op/get&remove-all-ops repo)]
+    (let [block-ops-map-coll (client-op/get&remove-all-block-ops repo)]
       (when-let [block-uuid->remote-ops (not-empty (gen-block-uuid->remote-ops @conn block-ops-map-coll))]
         (when-let [ops-for-remote (rtc-const/to-ws-ops-decoder
                                    (sort-remote-ops

--- a/src/main/frontend/worker/rtc/client.cljs
+++ b/src/main/frontend/worker/rtc/client.cljs
@@ -95,10 +95,17 @@
               ;; [a v] as key for card-many attr, `a` as key for card-one attr
          ]
     (if-not av
-      (sort-by #(nth % 2) (vals r))
+      (vals r)
       (let [[a v _t _add?] av
             av-key (if (card-many-attr? db a) [a v] a)]
-        (recur others (assoc r av-key av))))))
+        (if-let [old-av (get r av-key)]
+          (recur others
+                 (cond
+                   (< (nth old-av 2) (nth av 2)) (assoc r av-key av)
+                   (> (nth old-av 2) (nth av 2)) r
+                   (true? (nth av 3)) (assoc r av-key av)
+                   :else r))
+          (recur others (assoc r av-key av)))))))
 
 (defn- remove-non-exist-ref-av
   "Remove av if its v is ref(block-uuid) and not exist"

--- a/src/main/frontend/worker/rtc/client_op.cljs
+++ b/src/main/frontend/worker/rtc/client_op.cljs
@@ -40,7 +40,20 @@
      [:t :int]
      [:value [:map
               [:block-uuid :uuid]
-              [:av-coll [:sequential rtc-const/av-schema]]]]]]])
+              [:av-coll [:sequential rtc-const/av-schema]]]]]]
+
+   [:update-asset
+    [:catn
+     [:op :keyword]
+     [:t :int]
+     [:value [:map
+              [:block-uuid :uuid]]]]]
+   [:remove-asset
+    [:catn
+     [:op :keyword]
+     [:t :int]
+     [:value [:map
+              [:block-uuid :uuid]]]]]])
 
 (def ops-schema [:sequential op-schema])
 (def ops-coercer (ma/coercer ops-schema mt/json-transformer nil
@@ -232,3 +245,11 @@
           (emit! (datom-count @conn))
           (fn dtor []
             (d/unlisten! conn :create-pending-ops-count-flow))))))))
+
+;;; asset ops
+(defn add-asset-ops
+  [repo _asset-ops]
+  (let [conn (worker-state/get-client-ops-conn repo)]
+    (assert (some? conn) repo)
+    ;TODO
+    ))

--- a/src/main/frontend/worker/rtc/client_op.cljs
+++ b/src/main/frontend/worker/rtc/client_op.cljs
@@ -310,3 +310,17 @@
                (when (not= :block/uuid k) v))
              m))
      (vals (get-all-asset-ops* @conn)))))
+
+(defn- get&remove-all-asset-ops*
+  [conn]
+  (let [e->op-map (get-all-asset-ops* @conn)
+        retract-all-tx-data (mapcat
+                             (fn [e] (map (fn [a] [:db.fn/retractAttribute e a]) asset-op-types))
+                             (keys e->op-map))]
+    (d/transact! conn retract-all-tx-data)
+    (vals e->op-map)))
+
+(defn get&remove-all-asset-ops
+  [repo]
+  (when-let [conn (worker-state/get-client-ops-conn repo)]
+    (get&remove-all-asset-ops* conn)))

--- a/src/main/frontend/worker/rtc/client_op.cljs
+++ b/src/main/frontend/worker/rtc/client_op.cljs
@@ -220,7 +220,7 @@
   (when-let [conn (worker-state/get-client-ops-conn repo)]
     (get&remove-all-block-ops* conn)))
 
-(defn get-unpushed-ops-count
+(defn get-unpushed-block-ops-count
   [repo]
   (when-let [conn (worker-state/get-client-ops-conn repo)]
     (count (get-all-block-ops* @conn))))
@@ -295,6 +295,11 @@
                             (> (count op-map) 1))
                    [e op-map]))))
        (into {})))
+
+(defn get-unpushed-asset-ops-count
+  [repo]
+  (when-let [conn (worker-state/get-client-ops-conn repo)]
+    (count (get-all-asset-ops* @conn))))
 
 (defn get-all-asset-ops
   [repo]

--- a/src/main/frontend/worker/rtc/client_op.cljs
+++ b/src/main/frontend/worker/rtc/client_op.cljs
@@ -281,7 +281,7 @@
 
 (defn- get-all-asset-ops*
   [db]
-  (->> (d/datoms @conn :eavt)
+  (->> (d/datoms db :eavt)
        (group-by :e)
        (keep (fn [[e datoms]]
                (let [op-map (into {}

--- a/src/main/frontend/worker/rtc/const.cljs
+++ b/src/main/frontend/worker/rtc/const.cljs
@@ -154,6 +154,7 @@
         [:op :keyword]
         [:block-uuid :uuid]]]]]]
    [:asset-uuid->url {:optional true} [:map-of :uuid :string]]
+   [:uploaded-assets {:optional true} [:map-of :uuid :map]]
    [:ex-data {:optional true} [:map [:type :keyword]]]
    [:ex-message {:optional true} :string]])
 

--- a/src/main/frontend/worker/rtc/const.cljs
+++ b/src/main/frontend/worker/rtc/const.cljs
@@ -261,6 +261,12 @@
       [:action :string]
       [:graph-uuid :string]
       [:asset-uuids [:sequential :uuid]]]]
+    ["delete-assets"
+     [:map
+      [:req-id :string]
+      [:action :string]
+      [:graph-uuid :string]
+      [:asset-uuids [:sequential :uuid]]]]
     ["get-user-devices"
      [:map
       [:req-id :string]

--- a/src/main/frontend/worker/rtc/core.cljs
+++ b/src/main/frontend/worker/rtc/core.cljs
@@ -206,9 +206,10 @@
            (m/reduce {} nil)
            (m/?))
           (catch Cancelled e
-            (when @*assets-sync-loop-canceler (@*assets-sync-loop-canceler))
             (add-log-fn :rtc.log/cancelled {})
-            (throw e)))))}))
+            (throw e))
+          (finally
+            (when @*assets-sync-loop-canceler (@*assets-sync-loop-canceler))))))}))
 
 (def ^:private empty-rtc-loop-metadata
   {:graph-uuid nil

--- a/src/main/frontend/worker/rtc/core.cljs
+++ b/src/main/frontend/worker/rtc/core.cljs
@@ -294,27 +294,27 @@
 (def ^:private create-get-state-flow
   (let [rtc-loop-metadata-flow (m/watch *rtc-loop-metadata)]
     (m/ap
-     (let [{rtc-lock :*rtc-lock :keys [repo graph-uuid user-uuid rtc-state-flow *rtc-auto-push? *online-users]}
-           (m/?< rtc-loop-metadata-flow)]
-       (try
-         (when (and repo rtc-state-flow *rtc-auto-push? rtc-lock)
-           (m/?<
-            (m/latest
-             (fn [rtc-state rtc-auto-push? rtc-lock online-users pending-local-ops-count local-tx remote-tx]
-               {:graph-uuid graph-uuid
-                :user-uuid user-uuid
-                :unpushed-block-update-count pending-local-ops-count
-                :local-tx local-tx
-                :remote-tx remote-tx
-                :rtc-state rtc-state
-                :rtc-lock rtc-lock
-                :auto-push? rtc-auto-push?
-                :online-users online-users})
-             rtc-state-flow (m/watch *rtc-auto-push?) (m/watch rtc-lock) (m/watch *online-users)
-             (client-op/create-pending-ops-count-flow repo)
-             (rtc-log-and-state/create-local-t-flow graph-uuid)
-             (rtc-log-and-state/create-remote-t-flow graph-uuid))))
-         (catch Cancelled _))))))
+      (let [{rtc-lock :*rtc-lock :keys [repo graph-uuid user-uuid rtc-state-flow *rtc-auto-push? *online-users]}
+            (m/?< rtc-loop-metadata-flow)]
+        (try
+          (when (and repo rtc-state-flow *rtc-auto-push? rtc-lock)
+            (m/?<
+             (m/latest
+              (fn [rtc-state rtc-auto-push? rtc-lock online-users pending-local-ops-count local-tx remote-tx]
+                {:graph-uuid graph-uuid
+                 :user-uuid user-uuid
+                 :unpushed-block-update-count pending-local-ops-count
+                 :local-tx local-tx
+                 :remote-tx remote-tx
+                 :rtc-state rtc-state
+                 :rtc-lock rtc-lock
+                 :auto-push? rtc-auto-push?
+                 :online-users online-users})
+              rtc-state-flow (m/watch *rtc-auto-push?) (m/watch rtc-lock) (m/watch *online-users)
+              (client-op/create-pending-block-ops-count-flow repo)
+              (rtc-log-and-state/create-local-t-flow graph-uuid)
+              (rtc-log-and-state/create-remote-t-flow graph-uuid))))
+          (catch Cancelled _))))))
 
 (defn new-task--get-debug-state
   []

--- a/src/main/frontend/worker/rtc/core.cljs
+++ b/src/main/frontend/worker/rtc/core.cljs
@@ -50,7 +50,7 @@
         merge-flow (m/latest vector auto-push-flow clock-flow)]
     (m/eduction (filter first)
                 (map second)
-                (filter (fn [v] (when (pos? (client-op/get-unpushed-ops-count repo)) v)))
+                (filter (fn [v] (when (pos? (client-op/get-unpushed-block-ops-count repo)) v)))
                 merge-flow)))
 
 (defn- create-pull-remote-updates-flow

--- a/src/main/frontend/worker/rtc/core.cljs
+++ b/src/main/frontend/worker/rtc/core.cljs
@@ -150,7 +150,7 @@
         get-ws-create-task         (r.client/ensure-register-graph-updates
                                     get-ws-create-task graph-uuid repo conn *last-calibrate-t *online-users)
         {:keys [assets-sync-loop-task]}
-        (r.asset/create-assets-sync-loop get-ws-create-task graph-uuid conn)
+        (r.asset/create-assets-sync-loop repo get-ws-create-task graph-uuid conn *auto-push?)
         mixed-flow                 (create-mixed-flow repo get-ws-create-task *auto-push?)]
     (assert (some? *current-ws))
     {:rtc-state-flow     (create-rtc-state-flow (create-ws-state-flow *current-ws))

--- a/src/main/frontend/worker/rtc/core.cljs
+++ b/src/main/frontend/worker/rtc/core.cljs
@@ -188,7 +188,8 @@
                         (m/? (r.client/new-task--pull-remote-data
                               repo conn graph-uuid date-formatter get-ws-create-task add-log-fn)))))
                :remote-asset-update
-               (r.asset/emit-remote-asset-updates-from-push-asset-upload-updates @conn (:value event))
+               (m/? (r.asset/new-task--emit-remote-asset-updates-from-push-asset-upload-updates
+                     repo @conn (:value event)))
 
                :local-update-check
                (m/? (r.client/new-task--push-local-ops

--- a/src/main/frontend/worker/rtc/db_listener.cljs
+++ b/src/main/frontend/worker/rtc/db_listener.cljs
@@ -5,7 +5,8 @@
             [frontend.common.schema-register :include-macros true :as sr]
             [frontend.worker.db-listener :as db-listener]
             [frontend.worker.rtc.client-op :as client-op]
-            [logseq.db :as ldb]))
+            [logseq.db :as ldb]
+            [logseq.db.frontend.property :as db-property]))
 
 (defn- latest-add?->v->t
   [add?->v->t]
@@ -26,9 +27,7 @@
     :db/index :db/valueType :db/cardinality})
 
 (def ^:private watched-attr-ns
-  #{"logseq.property" "logseq.property.tldraw" "logseq.property.pdf" "logseq.property.fsrs"
-    "logseq.property.linked-references" "logseq.task" "logseq.property.node" "logseq.property.code"
-    "logseq.class" "logseq.kv"})
+  (conj db-property/logseq-property-namespaces "logseq.class" "logseq.kv"))
 
 (defn- watched-attr?
   [attr]

--- a/src/main/frontend/worker/rtc/exception.cljs
+++ b/src/main/frontend/worker/rtc/exception.cljs
@@ -30,6 +30,12 @@ the server will put it to s3 and return its presigned-url to clients.")
 (sr/defkeyword :rtc.exception/different-graph-skeleton
   "remote graph skeleton data is different from local's.")
 
+(sr/defkeyword :rtc.exception/bad-request-body
+  "bad request body, rejected by server-schema")
+
+(sr/defkeyword :rtc.exception/not-allowed
+  "this api-call is not allowed")
+
 (def ex-remote-graph-not-exist
   (ex-info "remote graph not exist" {:type :rtc.exception/remote-graph-not-exist}))
 
@@ -42,6 +48,12 @@ the server will put it to s3 and return its presigned-url to clients.")
 
 (def ex-local-not-rtc-graph
   (ex-info "RTC is not supported for this local-graph" {:type :rtc.exception/not-rtc-graph}))
+
+(def ex-bad-request-body
+  (ex-info "bad request body" {:type :rtc.exception/bad-request-body}))
+
+(def ex-not-allowed
+  (ex-info "not allowed" {:type :rtc.exception/not-allowed}))
 
 (def ex-unknown-server-error
   (ex-info "Unknown server error" {:type :rtc.exception/unknown-server-error}))

--- a/src/main/frontend/worker/rtc/log_and_state.cljs
+++ b/src/main/frontend/worker/rtc/log_and_state.cljs
@@ -25,7 +25,11 @@
    :rtc.log/apply-remote-update
    :rtc.log/push-local-update
 
-   :rtc.asset.log/cancelled])
+   :rtc.asset.log/cancelled
+   :rtc.asset.log/upload-assets
+   :rtc.asset.log/download-assets
+   :rtc.asset.log/remove-assets
+   :rtc.asset.log/initial-download-missing-assets-count])
 
 (def ^:private rtc-log-type-validator (ma/validator rtc-log-type-schema))
 

--- a/src/main/frontend/worker/rtc/remote_update.cljs
+++ b/src/main/frontend/worker/rtc/remote_update.cljs
@@ -4,7 +4,6 @@
             [clojure.set :as set]
             [clojure.string :as string]
             [datascript.core :as d]
-            [frontend.common.missionary-util :as c.m]
             [frontend.common.schema-register :as sr]
             [frontend.worker.handler.page :as worker-page]
             [frontend.worker.rtc.asset :as r.asset]
@@ -571,10 +570,7 @@
           (worker-util/profile :apply-remote-remove-ops (apply-remote-remove-ops repo conn date-formatter remove-ops))
           ;; wait all remote-ops transacted into db,
           ;; then start to check any asset-updates in remote
-          (c.m/run-task
-           (r.asset/new-task--emit-remote-asset-updates! repo @conn db-before update-ops remove-ops)
-           :emit-remote-asset-updates
-           :succ (constantly nil))
+          (r.asset/emit-remote-asset-updates-from-block-ops db-before remove-ops)
           (js/console.groupEnd)
 
           (client-op/update-local-tx repo remote-t)

--- a/src/main/frontend/worker/rtc/remote_update.cljs
+++ b/src/main/frontend/worker/rtc/remote_update.cljs
@@ -14,6 +14,7 @@
             [logseq.clj-fractional-indexing :as index]
             [logseq.common.util :as common-util]
             [logseq.db :as ldb]
+            [logseq.db.frontend.property :as db-property]
             [logseq.db.frontend.property.util :as db-property-util]
             [logseq.graph-parser.whiteboard :as gp-whiteboard]
             [logseq.outliner.batch-tx :as batch-tx]
@@ -335,12 +336,16 @@
     :property/schema.classes
     :property.value/content})
 
+(def ^:private watched-attr-ns
+  (conj db-property/logseq-property-namespaces "logseq.class" "logseq.kv"))
+
 (defn- update-op-watched-attr?
   [attr]
   (or (contains? update-op-watched-attrs attr)
       (when-let [ns (namespace attr)]
-        (or (= "logseq.task" ns)
-            (string/ends-with? ns ".property")))))
+        (or (contains? watched-attr-ns ns)
+            (string/ends-with? ns ".property")
+            (string/ends-with? ns ".class")))))
 
 (defn- diff-block-kv->tx-data
   [db db-schema e k local-v remote-v]

--- a/src/main/frontend/worker/rtc/remote_update.cljs
+++ b/src/main/frontend/worker/rtc/remote_update.cljs
@@ -365,15 +365,18 @@
       [true false]
       (let [remote-block-uuid (if (coll? remote-v) (first remote-v) remote-v)]
         (when (not= local-v remote-block-uuid)
-          (when-let [db-id (:db/id (d/entity db [:block/uuid remote-block-uuid]))]
-            [[:db/add e k db-id]])))
+          (if (nil? remote-block-uuid)
+            [[:db/retract e k]]
+            (when-let [db-id (:db/id (d/entity db [:block/uuid remote-block-uuid]))]
+              [[:db/add e k db-id]]))))
+
       [false false]
       (let [remote-v* (if (coll? remote-v)
                         (first (map ldb/read-transit-str remote-v))
                         (ldb/read-transit-str remote-v))]
         (when (not= local-v remote-v*)
           (if (nil? remote-v*)
-            [[:db/retract e k local-v]]
+            [[:db/retract e k]]
             [[:db/add e k remote-v*]])))
 
       [false true]

--- a/src/main/frontend/worker/rtc/remote_update.cljs
+++ b/src/main/frontend/worker/rtc/remote_update.cljs
@@ -276,7 +276,7 @@
 
 (defn- affected-blocks->diff-type-ops
   [repo affected-blocks]
-  (let [unpushed-ops (client-op/get-all-ops repo)
+  (let [unpushed-ops (client-op/get-all-block-ops repo)
         affected-blocks-map* (if unpushed-ops
                                (update-remote-data-by-local-unpushed-ops
                                 affected-blocks unpushed-ops)

--- a/src/main/frontend/worker/rtc/ws_util.cljs
+++ b/src/main/frontend/worker/rtc/ws_util.cljs
@@ -60,6 +60,7 @@
 
 (defn get-ws-url
   [token]
+  (assert (some? token))
   (gstring/format @worker-state/*rtc-ws-url token))
 
 (defn- gen-get-ws-create-map

--- a/src/main/frontend/worker/rtc/ws_util.cljs
+++ b/src/main/frontend/worker/rtc/ws_util.cljs
@@ -13,7 +13,9 @@
 (defn- handle-remote-ex
   [resp]
   (if-let [e ({:graph-not-exist r.ex/ex-remote-graph-not-exist
-               :graph-not-ready r.ex/ex-remote-graph-not-ready}
+               :graph-not-ready r.ex/ex-remote-graph-not-ready
+               :bad-request-body r.ex/ex-bad-request-body
+               :not-allowed r.ex/ex-not-allowed}
               (:type (:ex-data resp)))]
     (throw e)
     resp))

--- a/src/main/frontend/worker/state.cljs
+++ b/src/main/frontend/worker/state.cljs
@@ -10,6 +10,9 @@
 (sr/defkeyword :undo/repo->page-block-uuid->redo-ops
   "{repo {<page-block-uuid> [op1 op2 ...]}}")
 
+
+(defonce *main-thread (atom nil))
+
 (defonce *state (atom {:worker/object nil
 
                        :db/latest-transact-time {}

--- a/src/rtc_e2e_test/client_steps.cljs
+++ b/src/rtc_e2e_test/client_steps.cljs
@@ -27,7 +27,7 @@
               [[:block/updated-at "[\"~#'\",1724836490810]" true]
                [:block/created-at "[\"~#'\",1724836490810]" true]
                [:block/title "[\"~#'\",\"block1\"]" true]]]}
-           (set (map helper/simplify-client-op (client-op/get-all-ops const/downloaded-test-repo)))))))
+           (set (map helper/simplify-client-op (client-op/get-all-block-ops const/downloaded-test-repo)))))))
    :client2 nil})
 
 (def ^:private step1

--- a/src/rtc_e2e_test/helper.cljs
+++ b/src/rtc_e2e_test/helper.cljs
@@ -103,7 +103,7 @@
     (let [r (m/? (m/timeout
                   (m/reduce (fn [_ v]
                               (when (and (= :rtc.log/push-local-update (:type v))
-                                         (empty? (client-op/get-all-ops const/downloaded-test-repo)))
+                                         (empty? (client-op/get-all-block-ops const/downloaded-test-repo)))
                                 (is (nil? (:ex-data v)))
                                 (reduced v)))
                             rtc-log-and-state/rtc-log-flow)

--- a/src/test/frontend/worker/rtc/db_listener_test.cljs
+++ b/src/test/frontend/worker/rtc/db_listener_test.cljs
@@ -131,7 +131,7 @@
                               :create-first-block? false})
         (is (some? (d/pull @conn '[*] [:block/uuid page-uuid])))
         (is (= {page-uuid #{:update-page :update}}
-               (ops-coll=>block-uuid->op-types (client-op/get&remove-all-ops repo)))))
+               (ops-coll=>block-uuid->op-types (client-op/get&remove-all-block-ops repo)))))
       (testing "add blocks to this page"
         (let [target-entity (d/entity @conn [:block/uuid page-uuid])]
           (batch-tx/with-batch-tx-mode conn
@@ -147,7 +147,7 @@
           (is (=
                {block-uuid1 #{:move :update}
                 block-uuid2 #{:move :update}}
-               (ops-coll=>block-uuid->op-types (client-op/get&remove-all-ops repo))))))
+               (ops-coll=>block-uuid->op-types (client-op/get&remove-all-block-ops repo))))))
 
       (testing "delete a block"
         (batch-tx/with-batch-tx-mode conn
@@ -156,4 +156,4 @@
 
         (is (=
              {block-uuid1 #{:remove}}
-             (ops-coll=>block-uuid->op-types (client-op/get&remove-all-ops repo))))))))
+             (ops-coll=>block-uuid->op-types (client-op/get&remove-all-block-ops repo))))))))


### PR DESCRIPTION
This PR adds asset synchronization to the rtc implementation.
Briefly describe the implementation:
- `frontend.worker.rtc.asset-db-listener`

  like `frontend.worker.rtc.db-listener`,
  `asset-db-listener` add a new method to `db-listener/listen-db-changes`(`:gen-asset-change-events`),
  it will generate asset-update-ops, then store them into client-ops db
  
- `frontend.worker.rtc.asset`

  main namespace for asset-sync, the main fn is `create-assets-sync-loop`.
  `frontend.worker.rtc.core/create-rtc-loop` is responsible for blocks-sync
  `frontend.worker.rtc.asset/create-assets-sync-loop` is responsible for assets-sync

Some UI components are not reactive when working with asset-sync.
- download-asset-file from s3 won't trigger an ui-refresh.
- adding some highlights in PDF also won't trigger an ui-refresh on other clients.

Because these issues are not closely related to asset-sync itself, this PR does not attempt to modify them.  

![2](https://github.com/user-attachments/assets/1e2e1d3b-c1c0-4bb8-9241-9e3f583779f3)

