### PR TITLE
refactor: store all node references using `[[uuid]]`

### DIFF
--- a/deps/db/src/logseq/db.cljs
+++ b/deps/db/src/logseq/db.cljs
@@ -15,9 +15,9 @@
             [logseq.db.frontend.rules :as rules]
             [logseq.db.sqlite.common-db :as sqlite-common-db]
             [logseq.db.sqlite.util :as sqlite-util]
-            [logseq.db.frontend.content :as db-content]
             [logseq.db.frontend.property :as db-property]
-            [logseq.common.util.namespace :as ns-util])
+            [logseq.common.util.namespace :as ns-util]
+            [logseq.common.util.page-ref :as page-ref])
   (:refer-clojure :exclude [object?]))
 
 (defonce *transact-fn (atom nil))
@@ -588,8 +588,7 @@
 (defn inline-tag?
   [block-raw-title tag]
   (assert (string? block-raw-title) "block-raw-title should be a string")
-  (or (string/includes? block-raw-title (str "#" (db-content/block-id->special-id-ref (:block/uuid tag))))
-      (string/includes? block-raw-title (str "#" db-content/page-ref-special-chars (:block/uuid tag)))))
+  (string/includes? block-raw-title (str "#" (page-ref/->page-ref (:block/uuid tag)))))
 
 (defonce node-display-type-classes
   #{:logseq.class/Code-block :logseq.class/Math-block :logseq.class/Quote-block})

--- a/deps/db/src/logseq/db/frontend/content.cljs
+++ b/deps/db/src/logseq/db/frontend/content.cljs
@@ -27,7 +27,9 @@
   [refs]
   (sort-by
    (fn [ref]
-     (not (boolean (re-find page-ref/page-ref-without-nested-re (:block/title ref)))))
+     [(boolean (re-find page-ref/page-ref-without-nested-re (:block/title ref)))
+      (:block/title ref)])
+   >
    refs))
 
 (defn id-ref->title-ref

--- a/deps/db/src/logseq/db/frontend/content.cljs
+++ b/deps/db/src/logseq/db/frontend/content.cljs
@@ -6,10 +6,15 @@
             [logseq.common.util :as common-util]
             [logseq.db.frontend.entity-util :as entity-util]))
 
-#_(defonce page-ref-special-chars "~^")
-
-(defonce id-ref-pattern
-  #"\[\[([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\]\]")
+;; [[uuid]]
+(def id-ref-pattern
+  (re-pattern
+   (str
+    "\\[\\["
+    "("
+    common-util/uuid-pattern
+    ")"
+    "\\]\\]")))
 
 (defn content-id-ref->page
   "Convert id ref backs to page name using refs."

--- a/deps/db/src/logseq/db/frontend/delete_blocks.cljs
+++ b/deps/db/src/logseq/db/frontend/delete_blocks.cljs
@@ -5,8 +5,7 @@
             [logseq.common.util.page-ref :as page-ref]
             [datascript.core :as d]
             [clojure.string :as string]
-            [logseq.db.frontend.entity-util :as entity-util]
-            [logseq.db.frontend.content :as db-content]))
+            [logseq.db.frontend.entity-util :as entity-util]))
 
 (defn- replace-ref-with-deleted-block-title
   [block ref-raw-title]
@@ -19,11 +18,6 @@
 
             (string/replace (block-ref/->block-ref (str (:block/uuid block)))
                             block-content)
-
-                                               ;; Replace object
-            (string/replace (db-content/block-id->special-id-ref (:block/uuid block))
-                            block-content)
-                                               ;; Replace non-object
             (string/replace (page-ref/->page-ref (str (:block/uuid block)))
                             block-content))))
 

--- a/deps/db/src/logseq/db/frontend/entity_plus.cljc
+++ b/deps/db/src/logseq/db/frontend/entity_plus.cljc
@@ -34,7 +34,7 @@
        (let [result (lookup-entity e k default-value)
              refs (:block/refs e)
              result' (if (and (string? result) refs)
-                       (db-content/special-id-ref->page-ref result refs)
+                       (db-content/id-ref->title-ref result refs)
                        result)]
          (or result' default-value))))))
 
@@ -104,7 +104,7 @@
   [^js this]
   (let [v @(.-cache this)
         v' (if (:block/title v)
-             (assoc v :block/title (db-content/special-id-ref->page-ref (:block/title v) (:block/refs this)))
+             (assoc v :block/title (db-content/id-ref->title-ref (:block/title v) (:block/refs this)))
              v)]
     (concat (seq v')
             (seq (.-kv this)))))

--- a/deps/db/src/logseq/db/frontend/schema.cljs
+++ b/deps/db/src/logseq/db/frontend/schema.cljs
@@ -2,7 +2,7 @@
   "Main datascript schemas for the Logseq app"
   (:require [clojure.set :as set]))
 
-(def version 48)
+(def version 49)
 
 ;; A page is a special block, a page can corresponds to multiple files with the same ":block/name".
 (def ^:large-vars/data-var schema

--- a/deps/db/src/logseq/db/sqlite/build.cljs
+++ b/deps/db/src/logseq/db/sqlite/build.cljs
@@ -138,7 +138,7 @@
                                                            (throw (ex-info (str "No uuid for page ref name" (pr-str %)) {})))
                                                        :block/title %)
                                             ref-names)]
-                       {:block/title (db-content/refs->special-id-ref (:block/title m) block-refs {:replace-tag? false})
+                       {:block/title (db-content/title-ref->id-ref (:block/title m) block-refs {:replace-tag? false})
                         :block/refs block-refs})))))))
 
 (defn- build-properties-tx [properties page-uuids all-idents]

--- a/deps/db/test/logseq/db/frontend/content_test.cljs
+++ b/deps/db/test/logseq/db/frontend/content_test.cljs
@@ -4,7 +4,7 @@
 
 (deftest replace-tags-with-page-refs
   (testing "tags with overlapping names get replaced correctly"
-    (is (= "string [[~^foo]] string2 [[~^foo-bar]]"
+    (is (= "string [[foo]] string2 [[foo-bar]]"
            (db-content/replace-tags-with-page-refs
             "string #foo string2 #foo-bar"
             [{:block/title "foo" :block/uuid "foo"}

--- a/deps/db/test/logseq/db/frontend/content_test.cljs
+++ b/deps/db/test/logseq/db/frontend/content_test.cljs
@@ -5,7 +5,7 @@
 (deftest replace-tags-with-page-refs
   (testing "tags with overlapping names get replaced correctly"
     (is (= "string [[foo]] string2 [[foo-bar]]"
-           (db-content/replace-tags-with-page-refs
+           (db-content/replace-tags-with-id-refs
             "string #foo string2 #foo-bar"
             [{:block/title "foo" :block/uuid "foo"}
              {:block/title "foo-bar" :block/uuid "foo-bar"}])))))

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -825,7 +825,7 @@
                                   ;; ignore deadline related refs that don't affect content
                                             (and (keyword? %) (db-malli-schema/internal-ident? %))))
                                (map #(add-uuid-to-page-map % page-names-to-uuids)))]
-                 (db-content/refs->special-id-ref (:block/title block) refs {:replace-tag? false}))))
+                 (db-content/title-ref->id-ref (:block/title block) refs {:replace-tag? false}))))
       block)))
 
 (defn- fix-pre-block-references

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -228,7 +228,7 @@
                            (map :block/title)))
               true
               (update :block/title
-                      db-content/replace-tags-with-page-refs
+                      db-content/replace-tags-with-id-refs
                       (->> original-tags
                            (remove convert-tag?')
                            (map #(add-uuid-to-page-map % (:page-names-to-uuids per-file-state)))))

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -20,7 +20,8 @@
             [logseq.db.test.helper :as db-test]
             [logseq.db.frontend.rules :as rules]
             [logseq.common.util.date-time :as date-time-util]
-            [logseq.graph-parser.block :as gp-block]))
+            [logseq.graph-parser.block :as gp-block]
+            [logseq.db.frontend.content :as db-content]))
 
 ;; Helpers
 ;; =======
@@ -495,7 +496,7 @@
       (is (= 2
              (->> (find-block-by-content @conn #"replace with same start string")
                   :block/title
-                  (re-seq #"\[\[~\^\S+\]\]")
+                  (re-seq db-content/id-ref-pattern)
                   distinct
                   count))
           "A block with ref names that start with same string has 2 distinct refs")
@@ -503,7 +504,7 @@
       (is (= 1
              (->> (find-block-by-content @conn #"replace case insensitive")
                   :block/title
-                  (re-seq #"\[\[~\^\S+\]\]")
+                  (re-seq db-content/id-ref-pattern)
                   distinct
                   count))
           "A block with different case of same ref names has 1 distinct ref"))

--- a/deps/outliner/src/logseq/outliner/pipeline.cljs
+++ b/deps/outliner/src/logseq/outliner/pipeline.cljs
@@ -136,7 +136,7 @@
   (let [content (or (:block/raw-title block)
                     (:block/title block))]
     (when (string? content)
-      (->> (db-content/get-matched-special-ids content)
+      (->> (db-content/get-matched-ids content)
            (map (fn [id]
                   (when-let [e (d/entity db [:block/uuid id])]
                     (:db/id e))))))))

--- a/deps/outliner/test/logseq/outliner/pipeline_test.cljs
+++ b/deps/outliner/test/logseq/outliner/pipeline_test.cljs
@@ -8,7 +8,7 @@
             [logseq.outliner.pipeline :as outliner-pipeline]
             [clojure.string :as string]
             [logseq.db.test.helper :as db-test]
-            [logseq.db.frontend.content :as db-content]))
+            [logseq.common.util.page-ref :as page-ref]))
 
 (defn- get-blocks [db]
   (->> (d/q '[:find (pull ?b [* {:block/path-refs [:block/name :db/id]}])
@@ -64,4 +64,4 @@
     (assert block)
     (is (= [(:db/id block)]
            (outliner-pipeline/block-content-refs @conn
-                                                 {:block/title (str "ref to " (db-content/block-id->special-id-ref (:block/uuid block)))})))))
+                                                 {:block/title (str "ref to " (page-ref/->page-ref (:block/uuid block)))})))))

--- a/docs/dev-practices.md
+++ b/docs/dev-practices.md
@@ -377,7 +377,7 @@ These tasks are specific to database graphs. For these tasks there is a one time
   ```sh
   $ bb dev:db-query woot '[:find (pull ?b [*]) :where (block-content ?b "Dogma")]'
   DB contains 833 datoms
-  [{:block/tx-id 536870923, :block/link #:db{:id 100065}, :block/uuid #uuid "65565c26-f972-4400-bce4-a15df488784d", :block/updated-at 1700158508564, :block/order "a0", :block/refs [#:db{:id 100064}], :block/created-at 1700158502056, :block/format :markdown, :block/tags [#:db{:id 100064}], :block/title "Dogma #~^65565c2a-b1c5-4dc8-a0f0-81b786bc5c6d", :db/id 100090, :block/path-refs [#:db{:id 100051} #:db{:id 100064}], :block/parent #:db{:id 100051}, :block/page #:db{:id 100051}}]
+  [{:block/tx-id 536870923, :block/link #:db{:id 100065}, :block/uuid #uuid "65565c26-f972-4400-bce4-a15df488784d", :block/updated-at 1700158508564, :block/order "a0", :block/refs [#:db{:id 100064}], :block/created-at 1700158502056, :block/format :markdown, :block/tags [#:db{:id 100064}], :block/title "Dogma #[[65565c2a-b1c5-4dc8-a0f0-81b786bc5c6d]]", :db/id 100090, :block/path-refs [#:db{:id 100051} #:db{:id 100064}], :block/parent #:db{:id 100051}, :block/page #:db{:id 100051}}]
   ```
 
 * `dev:db-transact` - Run a `d/transact!` against the queried results of a DB graph

--- a/src/main/frontend/common_keywords.cljs
+++ b/src/main/frontend/common_keywords.cljs
@@ -25,7 +25,7 @@
 
 (sr/defkeyword :block/title
   "Title or content string of the blocks.
-in db-version, page-references(e.g. [[page-name]]) are stored as [[~^uuid]]."
+in db-version, page-references(e.g. [[page-name]]) are stored as [[uuid]]."
   :string)
 
 (sr/defkeyword :block/raw-title

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -751,8 +751,8 @@
                                                            :block/title "FIX unknown page"
                                                            :block/name "fix unknown page"}])
                                            "Unknown title")
-                                         (re-find db-content/special-id-ref-pattern s)
-                                         (db-content/special-id-ref->page s (:block/refs page-entity))
+                                         (re-find db-content/id-ref-pattern s)
+                                         (db-content/content-id-ref->page s (:block/refs page-entity))
                                          :else
                                          s)
                                      s (if tag? (str "#" s) s)]
@@ -904,11 +904,7 @@
                  *result (atom nil)
                  page-name (or (:block/uuid page)
                                (when-let [s (:block/name page)]
-                                 (let [s (string/trim s)
-                                       s (if (string/starts-with? s db-content/page-ref-special-chars)
-                                           (common-util/safe-subs s 2)
-                                           s)]
-                                   s)))
+                                 (string/trim s)))
                  page-entity (if (e/entity? page) page (db/get-page page-name))]
              (if page-entity
                (reset! *result page-entity)
@@ -1060,10 +1056,7 @@
   [html-export? uuid-or-title* {:keys [nested-link? show-brackets? id] :as config} label]
   (when uuid-or-title*
     (let [uuid-or-title (if (string? uuid-or-title*)
-                          (as-> (string/trim uuid-or-title*) s
-                            (if (string/starts-with? s db-content/page-ref-special-chars)
-                              (common-util/safe-subs s 2)
-                              s))
+                          (string/trim uuid-or-title*)
                           uuid-or-title*)
           show-brackets? (if (some? show-brackets?) show-brackets? (state/show-brackets?))
           contents-page? (= "contents" (string/lower-case (str id)))

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -171,7 +171,7 @@ independent of format as format specific heading characters are stripped"
                   (let [block (db-utils/entity repo block-id)
                         ref-tags (distinct (concat (:block/tags block) (:block/refs block)))]
                     (= (-> block-content
-                           (db-content/id-ref->title-ref ref-tags)
+                           (db-content/id-ref->title-ref ref-tags true)
                            (db-content/content-id-ref->page ref-tags)
                            heading-content->route-name)
                        (string/lower-case external-content))))

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -171,8 +171,8 @@ independent of format as format specific heading characters are stripped"
                   (let [block (db-utils/entity repo block-id)
                         ref-tags (distinct (concat (:block/tags block) (:block/refs block)))]
                     (= (-> block-content
-                           (db-content/special-id-ref->page-ref ref-tags)
-                           (db-content/special-id-ref->page ref-tags)
+                           (db-content/id-ref->title-ref ref-tags)
+                           (db-content/content-id-ref->page ref-tags)
                            heading-content->route-name)
                        (string/lower-case external-content))))
                 (rules/extract-rules rules/db-query-dsl-rules [:has-property]))

--- a/src/main/frontend/handler/common/page.cljs
+++ b/src/main/frontend/handler/common/page.cljs
@@ -20,7 +20,6 @@
             [frontend.modules.outliner.ui :as ui-outliner-tx]
             [frontend.modules.outliner.op :as outliner-op]
             [frontend.handler.db-based.editor :as db-editor-handler]
-            [logseq.db.frontend.content :as db-content]
             [logseq.common.util.page-ref :as page-ref]
             [frontend.handler.notification :as notification]))
 

--- a/src/main/frontend/handler/common/page.cljs
+++ b/src/main/frontend/handler/common/page.cljs
@@ -54,8 +54,7 @@
              has-tags? (and db-based? (seq (:block/tags parsed-result)))
              title' (if has-tags?
                       (some-> (first
-                               (or (common-util/split-first (str "#" db-content/page-ref-special-chars) (:block/title parsed-result))
-                                   (common-util/split-first (str "#" page-ref/left-brackets db-content/page-ref-special-chars) (:block/title parsed-result))))
+                               (common-util/split-first (str "#" page-ref/left-brackets) (:block/title parsed-result)))
                               string/trim)
                       title)]
        (if (and has-tags? (nil? title'))
@@ -77,7 +76,6 @@
                (when-let [first-block (ldb/get-first-child @conn (:db/id page))]
                  (block-handler/edit-block! first-block :max {:container-id :unknown-container}))
                page))))))))
-
 
 ;; favorite fns
 ;; ============
@@ -145,9 +143,7 @@
      {:outliner-op :delete-blocks}
      (outliner-op/delete-blocks! [block] {}))))
 
-
 ;; favorites fns end ================
-
 
 (defn <delete!
   "Deletes a page. If delete is successful calls ok-handler. Otherwise calls error-handler
@@ -180,7 +176,6 @@
 
 ;; other fns
 ;; =========
-
 
 (defn after-page-deleted!
   [repo page-name file-path tx-meta]

--- a/src/main/frontend/handler/db_based/editor.cljs
+++ b/src/main/frontend/handler/db_based/editor.cljs
@@ -66,7 +66,7 @@
         result (-> block
                    (merge (if level {:block/level level} {}))
                    (assoc :block/title
-                          (db-content/refs->special-id-ref (:block/title block) (:block/refs block))))]
+                          (db-content/title-ref->id-ref (:block/title block) (:block/refs block))))]
     result))
 
 (defn save-file!

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -64,7 +64,8 @@
             [logseq.outliner.core :as outliner-core]
             [promesa.core :as p]
             [rum.core :as rum]
-            [logseq.outliner.property :as outliner-property]))
+            [logseq.outliner.property :as outliner-property]
+            [datascript.core :as d]))
 
 ;; FIXME: should support multiple images concurrently uploading
 
@@ -3444,12 +3445,13 @@
 (defn- db-collapsable?
   [block]
   (let [class-properties (:classes-properties (outliner-property/get-block-classes-properties (db/get-db) (:db/id block)))
-        properties (->> (keys (:block/properties block))
+        properties (->> (map :a (d/datoms (db/get-db) :eavt (:db/id block)))
                         (map db/entity)
                         (concat class-properties)
                         (remove (fn [e] (db-property/db-attribute-properties (:db/ident e))))
                         (remove outliner-property/property-with-other-position?)
-                        (remove (fn [e] (:hide? (:block/schema e)))))]
+                        (remove (fn [e] (:hide? (:block/schema e))))
+                        (remove nil?))]
     (or (seq properties)
         (ldb/class-instance? (db/entity :logseq.class/Query) block))))
 

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -41,13 +41,11 @@
             [logseq.common.config :as common-config]
             [logseq.common.path :as path]
             [logseq.common.util :as common-util]
-            [logseq.common.util.block-ref :as block-ref]
             [logseq.common.util.page-ref :as page-ref]
             [logseq.db :as ldb]
             [logseq.graph-parser.db :as gp-db]
             [logseq.graph-parser.text :as text]
-            [promesa.core :as p]
-            [logseq.db.frontend.content :as db-content]))
+            [promesa.core :as p]))
 
 (def <create! page-common-handler/<create!)
 (def <delete! page-common-handler/<delete!)
@@ -363,11 +361,7 @@
                                               [page (db/get-page page)])))
                                         [chosen' chosen-result])
             ref-text (if (and (de/entity? chosen-result) (not (ldb/page? chosen-result)))
-                       (cond
-                         db-based?
-                         (db-content/block-id->special-id-ref (:block/uuid chosen-result))
-                         :else
-                         (block-ref/->block-ref (:block/uuid chosen-result)))
+                       (page-ref/->page-ref (:block/uuid chosen-result))
                        (get-page-ref-text chosen'))
             result (when db-based?
                      (when-not (de/entity? chosen-result)

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -37,7 +37,7 @@
                              (-> block
                                  (dissoc :block/tags)
                                  (update :block/title (fn [title]
-                                                        (let [title' (db-content/replace-tags-with-page-refs title refs)]
+                                                        (let [title' (db-content/replace-tags-with-id-refs title refs)]
                                                           (db-content/title-ref->id-ref title' refs)))))))))]
       (editor-handler/paste-blocks blocks' {:keep-uuid? true}))))
 

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -38,7 +38,7 @@
                                  (dissoc :block/tags)
                                  (update :block/title (fn [title]
                                                         (let [title' (db-content/replace-tags-with-page-refs title refs)]
-                                                          (db-content/refs->special-id-ref title' refs)))))))))]
+                                                          (db-content/title-ref->id-ref title' refs)))))))))]
       (editor-handler/paste-blocks blocks' {:keep-uuid? true}))))
 
 (defn- paste-segmented-text

--- a/src/main/frontend/worker/db/migrate.cljs
+++ b/src/main/frontend/worker/db/migrate.cljs
@@ -404,14 +404,14 @@
                   (re-find db-content/id-ref-pattern v))
              [:db/retractEntity e]
 
-             (string/includes? v (str ref-special-chars page-ref/left-brackets))
-             (let [title' (string/replace v (str ref-special-chars page-ref/left-brackets) page-ref/left-brackets)]
+             (string/includes? v (str page-ref/left-brackets ref-special-chars))
+             (let [title' (string/replace v (str page-ref/left-brackets ref-special-chars) page-ref/left-brackets)]
                (prn :debug {:old-title v :new-title title'})
                {:db/id e
                 :block/title title'})
 
              (re-find id-ref-pattern v)
-             (let [title' (string/replace v id-ref-pattern (page-ref/->page-ref "$1"))]
+             (let [title' (string/replace v id-ref-pattern "$1")]
                (prn :debug {:old-title v :new-title title'})
                {:db/id e
                 :block/title title'})))))

--- a/src/main/frontend/worker/handler/page.cljs
+++ b/src/main/frontend/worker/handler/page.cljs
@@ -46,7 +46,7 @@
   [repo page-entity]
   (when (sqlite-util/db-based-graph? repo)
     (let [refs (:block/_refs page-entity)
-          id-ref->page #(db-content/special-id-ref->page % [page-entity])]
+          id-ref->page #(db-content/content-id-ref->page % [page-entity])]
       (when (seq refs)
         (let [tx-data (mapcat (fn [{:block/keys [raw-title] :as ref}]
                                 ;; block content

--- a/src/main/frontend/worker/search.cljs
+++ b/src/main/frontend/worker/search.cljs
@@ -224,7 +224,7 @@ DROP TRIGGER IF EXISTS blocks_au;
       ;; (let [content (if (and db-based? (seq (:block/properties block)))
       ;;                 (str content (when (not= content "") "\n") (get-db-properties-str db properties))
       ;;                 content)])
-    (let [title (ldb/get-title-with-parents block)]
+    (let [title (ldb/get-title-with-parents (assoc block :block.temp/search? true))]
       (when uuid
         {:id (str uuid)
          :page (str (or (:block/uuid page) uuid))


### PR DESCRIPTION
This PR replaces both `~^uuid` and `[[~^uuid]]` with `[[uuid]]` for node references in `:block/title`, to simplify the code and fix the following bugs:

1. [[~^uuid]] is shown when referencing a non-page block
2. [[nested [[page]]]] can't be parsed back after editing the block content
3. wrong page named as `~^uuid` created
4. adding an inline tag still shows the tag at the end of the block
5. non-page blocks are displayed with their names instead of `[[uuid]]` in the editor mode, there're two problems:
    a. references might share the same name in the same block
    b. reference block content might have other references, for example [[this is a block that has other [[reference]]]].

The migration will replace the previous references with the `[[id]]`:
1. `[[~^id]]` -> `[[id]]`
7. `#~^id` -> `#[[id]]`
8. `#[[~^id]]` -> `#[[id]]`