### PR TITLE
Chore: Update actions to use Node 20

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -42,7 +42,7 @@ on:
 
 env:
   CLOJURE_VERSION: '1.11.1.1413'
-  NODE_VERSION: '18'
+  NODE_VERSION: '20'
   JAVA_VERSION: '17'
 
 jobs:

--- a/.github/workflows/build-demo.yml
+++ b/.github/workflows/build-demo.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   CLOJURE_VERSION: '1.11.1.1413'
-  NODE_VERSION: '18'
+  NODE_VERSION: '20'
   JAVA_VERSION: '17'
 
 jobs:

--- a/.github/workflows/build-desktop-release.yml
+++ b/.github/workflows/build-desktop-release.yml
@@ -48,7 +48,7 @@ on:
 
 env:
   CLOJURE_VERSION: '1.11.1.1413'
-  NODE_VERSION: '18'
+  NODE_VERSION: '20'
   JAVA_VERSION: '11'
 
 jobs:

--- a/.github/workflows/build-ios-release.yml
+++ b/.github/workflows/build-ios-release.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   CLOJURE_VERSION: '1.11.1.1413'
-  NODE_VERSION: '18'
+  NODE_VERSION: '20'
   JAVA_VERSION: '11'
 
 jobs:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   CLOJURE_VERSION: '1.11.1.1413'
-  NODE_VERSION: '18'
+  NODE_VERSION: '20'
   JAVA_VERSION: '11'
 
 jobs:

--- a/.github/workflows/build-stage.yml
+++ b/.github/workflows/build-stage.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   CLOJURE_VERSION: '1.11.1.1413'
-  NODE_VERSION: '18'
+  NODE_VERSION: '20'
   JAVA_VERSION: '17'
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ env:
   CLOJURE_VERSION: '1.11.1.1413'
   JAVA_VERSION: '11'
   # This is the latest node version we can run.
-  NODE_VERSION: '18'
+  NODE_VERSION: '20'
   BABASHKA_VERSION: '1.0.168'
 
 jobs:

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -23,7 +23,7 @@ env:
   CLOJURE_VERSION: '1.11.1.1413'
   JAVA_VERSION: '11'
   # This is the latest node version we can run.
-  NODE_VERSION: '18'
+  NODE_VERSION: '20'
   BABASHKA_VERSION: '1.0.168'
 
 jobs:

--- a/.github/workflows/deploy-db-pages.yml
+++ b/.github/workflows/deploy-db-pages.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   CLOJURE_VERSION: "1.11.1.1413"
-  NODE_VERSION: "18"
+  NODE_VERSION: '20'
   JAVA_VERSION: "11"
 
 jobs:

--- a/.github/workflows/deploy-db-test-pages.yml
+++ b/.github/workflows/deploy-db-test-pages.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   CLOJURE_VERSION: "1.11.1.1413"
-  NODE_VERSION: "18"
+  NODE_VERSION: '20'
   JAVA_VERSION: "11"
 
 jobs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ env:
   CLOJURE_VERSION: '1.11.1.1413'
   JAVA_VERSION: '11'
   # This is the latest node version we can run.
-  NODE_VERSION: '18'
+  NODE_VERSION: '20'
   BABASHKA_VERSION: '1.0.168'
 
 jobs:

--- a/.github/workflows/graph-parser.yml
+++ b/.github/workflows/graph-parser.yml
@@ -28,7 +28,7 @@ env:
   # This is the same as 1.8.
   JAVA_VERSION: '11'
   # This is the latest node version we can run.
-  NODE_VERSION: '18'
+  NODE_VERSION: '20'
   BABASHKA_VERSION: '1.0.168'
 
 jobs:

--- a/.github/workflows/logseq-common.yml
+++ b/.github/workflows/logseq-common.yml
@@ -23,7 +23,7 @@ env:
   CLOJURE_VERSION: '1.11.1.1413'
   JAVA_VERSION: '11'
   # This is the latest node version we can run.
-  NODE_VERSION: '18'
+  NODE_VERSION: '20'
   BABASHKA_VERSION: '1.0.168'
 
 jobs:

--- a/.github/workflows/outliner.yml
+++ b/.github/workflows/outliner.yml
@@ -28,7 +28,7 @@ env:
   # This is the same as 1.8.
   JAVA_VERSION: '11'
   # This is the latest node version we can run.
-  NODE_VERSION: '18'
+  NODE_VERSION: '20'
   BABASHKA_VERSION: '1.0.168'
 
 jobs:

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -28,7 +28,7 @@ env:
   # This is the same as 1.8.
   JAVA_VERSION: '11'
   # This is the latest node version we can run.
-  NODE_VERSION: '18'
+  NODE_VERSION: '20'
   BABASHKA_VERSION: '1.0.168'
 
 jobs:


### PR DESCRIPTION
We should be doing this since we upgraded electron in #11620 - https://github.com/electron/electron/blob/main/docs/tutorial/electron-timelines.md