### PR TITLE
Use `capacitor-dark-mode` plugin

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -9,6 +9,7 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
+    implementation project(':aparajita-capacitor-dark-mode')
     implementation project(':capacitor-action-sheet')
     implementation project(':capacitor-app')
     implementation project(':capacitor-camera')

--- a/android/app/src/main/assets/capacitor.plugins.json
+++ b/android/app/src/main/assets/capacitor.plugins.json
@@ -1,5 +1,9 @@
 [
 	{
+		"pkg": "@aparajita/capacitor-dark-mode",
+		"classpath": "com.aparajita.capacitor.darkmode.DarkModeNative"
+	},
+	{
 		"pkg": "@capacitor/action-sheet",
 		"classpath": "com.capacitorjs.plugins.actionsheet.ActionSheetPlugin"
 	},

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -2,6 +2,9 @@
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/android/capacitor')
 
+include ':aparajita-capacitor-dark-mode'
+project(':aparajita-capacitor-dark-mode').projectDir = new File('../node_modules/@aparajita/capacitor-dark-mode/android')
+
 include ':capacitor-action-sheet'
 project(':capacitor-action-sheet').projectDir = new File('../node_modules/@capacitor/action-sheet/android')
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
         "postinstall": "yarn tldraw:build && yarn amplify:build "
     },
     "dependencies": {
+        "@aparajita/capacitor-dark-mode": "^4.0.1",
         "@capacitor/action-sheet": "^5.0.7",
         "@capacitor/android": "^5.0.0",
         "@capacitor/app": "^5.0.0",

--- a/src/main/frontend/core.cljs
+++ b/src/main/frontend/core.cljs
@@ -14,7 +14,9 @@
             [logseq.api]
             [frontend.fs.sync :as sync]
             [frontend.config :as config]
-            [malli.dev.cljs :as md]))
+            [malli.dev.cljs :as md]
+            [promesa.core :as p]
+            ["@aparajita/capacitor-dark-mode" :refer [DarkMode]]))
 
 (defn set-router!
   []
@@ -59,8 +61,11 @@
   ;; this is called in the index.html and must be exported
   ;; so it is available even in :advanced release builds
 
-  (plugin-handler/setup!
-   #(handler/start! start)))
+  (p/do!
+   (.init DarkMode #js {:cssClass "dark"})
+   (plugin-handler/setup!
+    #(handler/start! start)))
+)
 
 (defn stop []
   ;; stop is called before any code is reloaded

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -18,6 +18,7 @@
             [malli.core :as m]
             [medley.core :as medley]
             [promesa.core :as p]
+            ["@aparajita/capacitor-dark-mode" :refer [DarkMode]]
             [rum.core :as rum]))
 
 ;; Stores main application state
@@ -1247,7 +1248,8 @@ Similar to re-frame subscriptions"
 
 (defn sync-system-theme!
   []
-  (let [system-dark? (.-matches (js/window.matchMedia "(prefers-color-scheme: dark)"))]
+  (p/let [system-dark? (-> (.isDarkMode DarkMode)
+                           (.then #(.-dark %)))]
     (set-theme-mode! (if system-dark? "dark" "light"))
     (set-state! :ui/system-theme? true)
     (storage/set :ui/system-theme? true)))

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -1,6 +1,7 @@
 (ns frontend.ui
   "Main ns for reusable components"
   (:require ["@logseq/react-tweet-embed" :as react-tweet-embed]
+            ["@aparajita/capacitor-dark-mode" :refer [DarkMode]]
             ["react-intersection-observer" :as react-intersection-observer]
             ["react-resize-context" :as Resize]
             ["react-textarea-autosize" :as TextareaAutosize]
@@ -417,14 +418,10 @@
 
 (defn setup-system-theme-effect!
   []
-  (let [^js schemaMedia (js/window.matchMedia "(prefers-color-scheme: dark)")]
-    (try (.addEventListener schemaMedia "change" state/sync-system-theme!)
-         (catch :default _error
-           (.addListener schemaMedia state/sync-system-theme!)))
-    (state/sync-system-theme!)
-    #(try (.removeEventListener schemaMedia "change" state/sync-system-theme!)
-          (catch :default _error
-            (.removeListener schemaMedia state/sync-system-theme!)))))
+  (let [handle (atom nil)]
+    (-> (.addAppearanceListener DarkMode #(state/sync-system-theme!))
+        (p/then #(reset! handle %)))
+    #(.remove @handle)))
 
 (defn set-global-active-keystroke [val]
   (.setAttribute js/document.body "data-active-keystroke" val))

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,16 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@aparajita/capacitor-dark-mode@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@aparajita/capacitor-dark-mode/-/capacitor-dark-mode-4.0.1.tgz#b4350ec280ba1c61eb3220b7147c88eb1f1325a2"
+  integrity sha512-6FLL3tVHjejGlSvBOZGL5Igh9X3rQTU/goRXAEPG8Rxs6BSy4bmKq9yiRn3YKAKUVRh1H4TYqTOK66WdvbNZvg==
+  dependencies:
+    "@capacitor/android" "^5.5.0"
+    "@capacitor/core" "^5.5.0"
+    "@capacitor/ios" "^5.5.0"
+    "@capacitor/status-bar" "^5.0.6"
+
 "@axe-core/playwright@=4.4.4":
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/@axe-core/playwright/-/playwright-4.4.4.tgz#3786c5f6bba38d1991b608584b00ae2744544573"
@@ -250,6 +260,11 @@
   resolved "https://registry.yarnpkg.com/@capacitor/android/-/android-5.4.1.tgz#5b0445202ca5e48fcb79d0c88e4403acc32504bc"
   integrity sha512-25k/GyIly/8xKQo0EO6eIvJStpVWsBPyYh9Eiv+Or9DCz9iuVlGZY3vui+zjFhfHQ5f9Uwywa8B+thOGWU8f6g==
 
+"@capacitor/android@^5.5.0":
+  version "5.7.8"
+  resolved "https://registry.yarnpkg.com/@capacitor/android/-/android-5.7.8.tgz#9c18fec3ea6ebba5b34fa48cc7a01dc6aa46e312"
+  integrity sha512-ooWclwcuW0dy3YfqgoozkHkjatX8H2fb2/RwRsJa3cew1P1lUXIXri3Dquuy4LdqFAJA7UHcJ19Bl/6UKdsZYA==
+
 "@capacitor/app@^5.0.0":
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/@capacitor/app/-/app-5.0.6.tgz#2ee02551115fd2e92dc7e81bc30a6c6fa78efa66"
@@ -295,6 +310,13 @@
   dependencies:
     tslib "^2.1.0"
 
+"@capacitor/core@^5.5.0":
+  version "5.7.8"
+  resolved "https://registry.yarnpkg.com/@capacitor/core/-/core-5.7.8.tgz#584d5ac2754501ef1443ab4bf182d8f5be16f65e"
+  integrity sha512-rrZcm/2vJM0WdWRQup1TUidbjQV9PfIadSkV4rAGLD7R6PuzZSMPGT0gmoZzCRlXkqrazrWWDkurei3ozU02FA==
+  dependencies:
+    tslib "^2.1.0"
+
 "@capacitor/filesystem@^5.0.0":
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/@capacitor/filesystem/-/filesystem-5.1.4.tgz#6e3278f4c47c72416d586367889736b576113ef5"
@@ -309,6 +331,11 @@
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@capacitor/ios/-/ios-5.4.1.tgz#79c1620ac7b57dc1ea85653ad1e5a32e8ec7dbea"
   integrity sha512-s5djQEX1HFM6u4gQlWz7DUWG7ma0d3AwwnjbSbCh25aYEt40Dbei0TjzlKrfU6b3nUbyVVAZJBJgMuk7Bq59qA==
+
+"@capacitor/ios@^5.5.0":
+  version "5.7.8"
+  resolved "https://registry.yarnpkg.com/@capacitor/ios/-/ios-5.7.8.tgz#cbed9afa58bc49e8edcf4dfbef130903ad686e39"
+  integrity sha512-XhGrziBnlRmCJ97LdPXOJquHPpYTwSJZIxYSXuPl7SDDuAEve8vs2wY76gLdaaFH2Z6ctdugUX+jR6VNu+ds+w==
 
 "@capacitor/keyboard@^5.0.0":
   version "5.0.6"
@@ -329,6 +356,11 @@
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/@capacitor/status-bar/-/status-bar-5.0.6.tgz#281568a7f7aeacf80777702cb9947c29dc32685c"
   integrity sha512-7od8CxsBnot1XMK3IeOkproFL4hgoKoWAc3pwUvmDOkQsXoxwQm4SR9mLwQavv1XfxtHbFV9Ukd7FwMxOPSViw==
+
+"@capacitor/status-bar@^5.0.6":
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/@capacitor/status-bar/-/status-bar-5.0.8.tgz#f00e21a99f79b06c36d61ad35ba78675fdefda54"
+  integrity sha512-ES/4ik3/6SV6RVXVVoMm5i7zanwZ+CBtNX6glhBHDHS0nR2m3Dmdxuk/BaFEZWT5bDn4xzg0LlnMsS8mlbUf+A==
 
 "@capawesome/capacitor-background-task@^5.0.0":
   version "5.0.0"


### PR DESCRIPTION
On Android `prefers-color-scheme` is well and truly broken. With this plugin `logseq` can achieve reliable light/dark theme switching depending on the system theme across all platforms.

Fixes #11314