### PR TITLE
Refactor: mv file handlers

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -97,7 +97,6 @@
              frontend.fs.nfs nfs
              frontend.handler.common common-handler
              frontend.handler.common.developer dev-common-handler
-             frontend.handler.common.file file-common-handler
              frontend.handler.common.page page-common-handler
              frontend.handler.common.plugin plugin-common-handler
              frontend.handler.config config-handler
@@ -114,6 +113,7 @@
              frontend.handler.file-based.property file-property-handler
              frontend.handler.file-based.property.util property-util
              frontend.handler.file-based.recent file-recent-handler
+             frontend.handler.file-based.reset-file reset-file-handler
              frontend.handler.file-based.repo file-repo-handler
              frontend.handler.global-config global-config-handler
              frontend.handler.notification notification

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -108,6 +108,7 @@
              frontend.handler.editor.property editor-property
              frontend.handler.events events
              frontend.handler.extract extract
+             frontend.handler.file-based.file file-handler
              frontend.handler.file-based.page file-page-handler
              frontend.handler.file-based.page-property file-page-property
              frontend.handler.file-based.property file-property-handler

--- a/deps/graph-parser/src/logseq/graph_parser.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser.cljs
@@ -1,6 +1,6 @@
 (ns logseq.graph-parser
-  "Main ns used by logseq app to parse graph from source files and then save to
-  the given database connection"
+  "For file graphs, provides main ns to parse graph from source files.
+   Used by logseq app to parse graph and then save to the given database connection"
   (:require [clojure.set :as set]
             [clojure.string :as string]
             [datascript.core :as d]

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -1,5 +1,6 @@
 (ns logseq.graph-parser.block
-  "Given mldoc ast, prepares block data in preparation for db transaction"
+  "Given mldoc ast, prepares block data in preparation for db transaction.
+   Used by file and DB graphs"
   (:require [clojure.set :as set]
             [clojure.string :as string]
             [clojure.walk :as walk]

--- a/deps/graph-parser/src/logseq/graph_parser/cli.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/cli.cljs
@@ -1,5 +1,5 @@
 (ns ^:node-only logseq.graph-parser.cli
-  "Primary ns to parse graphs with node.js based CLIs"
+  "For file graphs, primary ns to parse graphs with node.js based CLIs"
   (:require ["fs" :as fs]
             ["path" :as path]
             [clojure.edn :as edn]

--- a/deps/graph-parser/src/logseq/graph_parser/extract.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/extract.cljc
@@ -1,6 +1,6 @@
 (ns logseq.graph-parser.extract
-  "Handles extraction of blocks, pages and mldoc ast in preparation for db
-  transaction"
+  "For file graphs, handles extraction of blocks, pages and mldoc ast in
+  preparation for db transaction"
   ;; Disable clj linters since we don't support clj
   #?(:clj {:clj-kondo/config {:linters {:unresolved-namespace {:level :off}
                                         :unresolved-symbol {:level :off}}}})
@@ -226,7 +226,7 @@
      :resolve-uuid-fn - Optional fn which is called to resolve uuids of each block. Enables diff-merge
        (2 ways diff) based uuid resolution upon external editing.
        returns a list of the uuids, given the receiving ast, or nil if not able to resolve.
-       Implemented in file-common-handler/diff-merge-uuids for IoC
+       Implemented in reset-file-handler/diff-merge-uuids-2ways for IoC
        Called in gp-extract/extract as AST is being parsed and properties are extracted there"
   [format ast properties file content {:keys [date-formatter db filename-format extracted-block-ids resolve-uuid-fn]
                                        :or {extracted-block-ids (atom #{})

--- a/deps/graph-parser/src/logseq/graph_parser/property.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/property.cljs
@@ -1,5 +1,5 @@
 (ns logseq.graph-parser.property
-  "Core vars and util fns for properties and file based graphs"
+  "For file graphs, core vars and util fns for properties"
   (:require [logseq.common.util :as common-util]
             [clojure.string :as string]
             [clojure.set :as set]

--- a/deps/graph-parser/src/logseq/graph_parser/text.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/text.cljs
@@ -1,5 +1,5 @@
 (ns logseq.graph-parser.text
-  "Miscellaneous text util fns for the parser"
+  "Miscellaneous text util fns for the parser. Used by file and DB graphs"
   (:require [goog.string :as gstring]
             [clojure.string :as string]
             [clojure.set :as set]

--- a/src/main/frontend/common/file/core.cljs
+++ b/src/main/frontend/common/file/core.cljs
@@ -2,33 +2,12 @@
   "Save file to disk. Used by both file and DB graphs and shared
    by worker and frontend namespaces"
   (:require [clojure.string :as string]
-            [frontend.common.file.util :as wfu]
             [logseq.graph-parser.property :as gp-property]
-            [logseq.common.path :as path]
             [datascript.core :as d]
             [logseq.db :as ldb]
-            [logseq.common.date :as common-date]
             [logseq.db.frontend.content :as db-content]
             [logseq.db.sqlite.util :as sqlite-util]
             [logseq.outliner.tree :as otree]))
-
-(defonce *writes (atom {}))
-(defonce *request-id (atom 0))
-
-(defn conj-page-write!
-  [page-id]
-  (let [request-id (swap! *request-id inc)]
-    (swap! *writes assoc request-id page-id)
-    request-id))
-
-(defn dissoc-request!
-  [request-id]
-  (when-let [page-id (get @*writes request-id)]
-    (let [old-page-request-ids (keep (fn [[r p]]
-                                       (when (and (= p page-id) (<= r request-id))
-                                         r)) @*writes)]
-      (when (seq old-page-request-ids)
-        (swap! *writes (fn [x] (apply dissoc x old-page-request-ids)))))))
 
 (defn- indented-block-content
   [content spaces-tabs]
@@ -128,74 +107,6 @@
   [repo db tree opts context]
   (->> (tree->file-content-aux repo db tree opts context) (string/join "\n")))
 
-(defn- transact-file-tx-if-not-exists!
-  [conn page-block ok-handler context]
-  (when (:block/name page-block)
-    (let [format (name (get page-block :block/format (:preferred-format context)))
-          date-formatter (:date-formatter context)
-          title (string/capitalize (:block/name page-block))
-          whiteboard-page? (ldb/whiteboard? page-block)
-          format (if whiteboard-page? "edn" format)
-          journal-page? (common-date/valid-journal-title? title date-formatter)
-          journal-title (common-date/normalize-journal-title title date-formatter)
-          journal-page? (and journal-page? (not (string/blank? journal-title)))
-          filename (if journal-page?
-                     (common-date/date->file-name journal-title (:journal-file-name-format context))
-                     (-> (or (:block/title page-block) (:block/name page-block))
-                         wfu/file-name-sanity))
-          sub-dir (cond
-                    journal-page?    (:journals-directory context)
-                    whiteboard-page? (:whiteboards-directory context)
-                    :else            (:pages-directory context))
-          ext (if (= format "markdown") "md" format)
-          file-rpath (path/path-join sub-dir (str filename "." ext))
-          file {:file/path file-rpath}
-          tx [{:file/path file-rpath}
-              {:block/name (:block/name page-block)
-               :block/file file}]]
-      (ldb/transact! conn tx)
-      (when ok-handler (ok-handler)))))
-
-(defn- remove-transit-ids [block] (dissoc block :db/id :block/file))
-
-(defn- save-tree-aux!
-  [repo db page-block tree blocks-just-deleted? context request-id]
-  (let [page-block (d/pull db '[*] (:db/id page-block))
-        init-level 1
-        file-db-id (-> page-block :block/file :db/id)
-        file-path (-> (d/entity db file-db-id) :file/path)
-        result (if (and (string? file-path) (not-empty file-path))
-                 (let [new-content (if (ldb/whiteboard? page-block)
-                                     (->
-                                      (wfu/ugly-pr-str {:blocks tree
-                                                        :pages (list (remove-transit-ids page-block))})
-                                      (string/triml))
-                                     (tree->file-content repo db tree {:init-level init-level} context))]
-                   (when-not (and (string/blank? new-content) (not blocks-just-deleted?))
-                     (let [files [[file-path new-content]]]
-                       (when (seq files)
-                         (let [page-id (:db/id page-block)]
-                           (wfu/post-message :write-files {:request-id request-id
-                                                           :page-id page-id
-                                                           :repo repo
-                                                           :files files})
-                           :sent)))))
-                 ;; In e2e tests, "card" page in db has no :file/path
-                 (js/console.error "File path from page-block is not valid" page-block tree))]
-    (when-not (= :sent result)          ; page may not exists now
-      (dissoc-request! request-id))))
-
-(defn save-tree!
-  [repo conn page-block tree blocks-just-deleted? context request-id]
-  {:pre [(map? page-block)]}
-  (when repo
-    (let [ok-handler #(save-tree-aux! repo @conn page-block tree blocks-just-deleted? context request-id)
-          file (or (:block/file page-block)
-                   (when-let [page-id (:db/id (:block/page page-block))]
-                     (:block/file (d/entity @conn page-id))))]
-      (if file
-        (ok-handler)
-        (transact-file-tx-if-not-exists! conn page-block ok-handler context)))))
 
 (defn block->content
   "Converts a block including its children (recursively) to plain-text."

--- a/src/main/frontend/components/diff.cljs
+++ b/src/main/frontend/components/diff.cljs
@@ -1,7 +1,7 @@
 (ns frontend.components.diff
   (:require [clojure.string :as string]
             [frontend.diff :as diff]
-            [frontend.handler.file :as file]
+            [frontend.handler.file-based.file :as file-handler]
             [frontend.ui :as ui]
             [frontend.util :as util]
             [logseq.shui.ui :as shui]
@@ -70,7 +70,7 @@
                  :on-click
                  (fn []
                    (when-let [value @disk-value]
-                     (file/alter-file repo path value
+                     (file-handler/alter-file repo path value
                                       {:re-render-root? true
                                        :skip-compare? true}))
                    (shui/dialog-close!)))]
@@ -87,7 +87,7 @@
                  :on-click
                  (fn []
                    (when-let [value @db-value]
-                     (file/alter-file repo path value
+                     (file-handler/alter-file repo path value
                                       {:re-render-root? true
                                        :skip-compare? true}))
                    (shui/dialog-close!)))]]]])

--- a/src/main/frontend/components/file_based/git.cljs
+++ b/src/main/frontend/components/file_based/git.cljs
@@ -1,4 +1,4 @@
-(ns frontend.components.git
+(ns frontend.components.file-based.git
   (:require [clojure.string :as string]
             [frontend.handler.file-based.file :as file-handler]
             [frontend.handler.shell :as shell]

--- a/src/main/frontend/components/git.cljs
+++ b/src/main/frontend/components/git.cljs
@@ -1,6 +1,6 @@
 (ns frontend.components.git
   (:require [clojure.string :as string]
-            [frontend.handler.file :as file]
+            [frontend.handler.file-based.file :as file-handler]
             [frontend.handler.shell :as shell]
             [frontend.hooks :as hooks]
             [frontend.state :as state]
@@ -72,7 +72,7 @@
        [:pre content]
        (ui/button "Revert"
                   :on-click (fn []
-                              (file/alter-file (state/get-current-repo)
+                              (file-handler/alter-file (state/get-current-repo)
                                                path
                                                content
                                                {:re-render-root? true

--- a/src/main/frontend/components/imports.cljs
+++ b/src/main/frontend/components/imports.cljs
@@ -10,6 +10,7 @@
             [frontend.context.i18n :refer [t]]
             [frontend.db :as db]
             [frontend.fs :as fs]
+            [frontend.handler.file-based.import :as file-import-handler]
             [frontend.handler.db-based.editor :as db-editor-handler]
             [frontend.handler.import :as import-handler]
             [frontend.handler.notification :as notification]
@@ -59,7 +60,7 @@
           (set! (.-onload reader)
                 (fn [e]
                   (let [text (.. e -target -result)]
-                    (import-handler/import-from-roam-json!
+                    (file-import-handler/import-from-roam-json!
                      text
                      #(do
                         (state/set-state! :graph/importing nil)

--- a/src/main/frontend/fs/sync.cljs
+++ b/src/main/frontend/fs/sync.cljs
@@ -25,7 +25,7 @@
             [frontend.fs :as fs]
             [frontend.fs.capacitor-fs :as capacitor-fs]
             [frontend.fs.diff-merge :as diff-merge]
-            [frontend.handler.file :as file-handler]
+            [frontend.handler.file-based.file :as file-handler]
             [frontend.handler.notification :as notification]
             [frontend.handler.user :as user]
             [frontend.mobile.util :as mobile-util]

--- a/src/main/frontend/fs/watcher_handler.cljs
+++ b/src/main/frontend/fs/watcher_handler.cljs
@@ -7,7 +7,7 @@
             [frontend.db.model :as model]
             [frontend.fs :as fs]
             [logseq.common.path :as path]
-            [frontend.handler.file :as file-handler]
+            [frontend.handler.file-based.file :as file-handler]
             [frontend.handler.file-based.property :as file-property-handler]
             [frontend.handler.global-config :as global-config-handler]
             [frontend.handler.notification :as notification]

--- a/src/main/frontend/handler.cljs
+++ b/src/main/frontend/handler.cljs
@@ -16,7 +16,7 @@
             [frontend.error :as error]
             [frontend.handler.command-palette :as command-palette]
             [frontend.handler.events :as events]
-            [frontend.handler.file :as file-handler]
+            [frontend.handler.file-based.file :as file-handler]
             [frontend.handler.file-based.events]
             [frontend.handler.global-config :as global-config-handler]
             [frontend.handler.notification :as notification]
@@ -95,7 +95,8 @@
            (page-handler/init-commands!)
 
            (watch-for-date!)
-           (when (util/electron?) (file-handler/watch-for-current-graph-dir!))))
+           (when (and (not (config/db-based-graph? repo)) (util/electron?))
+             (file-handler/watch-for-current-graph-dir!))))
         (p/catch (fn [error]
                    (log/error :exception error))))))
 

--- a/src/main/frontend/handler/code.cljs
+++ b/src/main/frontend/handler/code.cljs
@@ -49,7 +49,8 @@
                  (config/db-based-graph? repo))
             (db-editor-handler/save-file! (:file-path config) value)
 
-            (not-empty (:file-path config))
+            (and (not-empty (:file-path config))
+                 (not (config/db-based-graph? repo)))
             (let [path (:file-path config)
                   repo-dir (config/get-repo-dir repo)
                   rpath (when (string/starts-with? path repo-dir)

--- a/src/main/frontend/handler/code.cljs
+++ b/src/main/frontend/handler/code.cljs
@@ -4,7 +4,7 @@
             [frontend.config :as config]
             [frontend.db :as db]
             [frontend.handler.editor :as editor-handler]
-            [frontend.handler.file :as file-handler]
+            [frontend.handler.file-based.file :as file-handler]
             [frontend.state :as state]
             [goog.object :as gobj]
             [logseq.graph-parser.utf8 :as utf8]

--- a/src/main/frontend/handler/config.cljs
+++ b/src/main/frontend/handler/config.cljs
@@ -5,7 +5,7 @@
             [frontend.config :as config]
             [frontend.db :as db]
             [frontend.handler.db-based.editor :as db-editor-handler]
-            [frontend.handler.file :as file-handler]
+            [frontend.handler.file-based.file :as file-handler]
             [frontend.handler.repo-config :as repo-config-handler]
             [frontend.state :as state]))
 

--- a/src/main/frontend/handler/draw.cljs
+++ b/src/main/frontend/handler/draw.cljs
@@ -5,7 +5,7 @@
             [frontend.date :as date]
             [frontend.db :as db]
             [frontend.fs :as fs]
-            [frontend.handler.file :as file-handler]
+            [frontend.handler.file-based.file :as file-handler]
             [frontend.state :as state]
             [frontend.util :as util]
             [logseq.common.config :as common-config]

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -46,7 +46,7 @@
             [frontend.handler.db-based.rtc :as rtc-handler]
             [frontend.handler.editor :as editor-handler]
             [frontend.handler.export :as export]
-            [frontend.handler.file :as file-handler]
+            [frontend.handler.file-based.file :as file-handler]
             [frontend.handler.file-based.nfs :as nfs-handler]
             [frontend.handler.file-sync :as file-sync-handler]
             [frontend.handler.graph :as graph-handler]

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -15,7 +15,7 @@
             [frontend.components.diff :as diff]
             [frontend.components.encryption :as encryption]
             [frontend.components.file-sync :as file-sync]
-            [frontend.components.git :as git-component]
+            [frontend.components.file-based.git :as git-component]
             [frontend.components.plugins :as plugin]
             [frontend.components.property.dialog :as property-dialog]
             [frontend.components.repo :as repo]

--- a/src/main/frontend/handler/file_based/file.cljs
+++ b/src/main/frontend/handler/file_based/file.cljs
@@ -6,7 +6,7 @@
             [frontend.fs :as fs]
             [frontend.fs.nfs :as nfs]
             [frontend.fs.capacitor-fs :as capacitor-fs]
-            [frontend.handler.common.file :as file-common-handler]
+            [frontend.handler.file-based.reset-file :as reset-file-handler]
             [frontend.handler.common.config-edn :as config-edn-common-handler]
             [frontend.handler.repo-config :as repo-config-handler]
             [frontend.handler.global-config :as global-config-handler]
@@ -168,7 +168,7 @@
                                          [[:db/retract page-id :block/alias]
                                           [:db/retract page-id :block/tags]]
                                          opts)))
-                       (file-common-handler/reset-file!
+                       (reset-file-handler/reset-file!
                         repo path content (merge opts
                                                  ;; To avoid skipping the `:or` bounds for keyword destructuring
                                                  (when (some? extracted-block-ids) {:extracted-block-ids extracted-block-ids})
@@ -248,7 +248,7 @@
     (when update-db?
       (doseq [[path content] files]
         (if reset?
-          (file-common-handler/reset-file! repo path content)
+          (reset-file-handler/reset-file! repo path content)
           (db/set-file-content! repo path content))))
     (alter-files-handler! repo files opts file->content)))
 

--- a/src/main/frontend/handler/file_based/file.cljs
+++ b/src/main/frontend/handler/file_based/file.cljs
@@ -1,5 +1,5 @@
-(ns frontend.handler.file
-  "Provides util handler fns for files"
+(ns frontend.handler.file-based.file
+  "Provides util handler fns for file graph files"
   (:refer-clojure :exclude [load-file])
   (:require [frontend.config :as config]
             [frontend.db :as db]
@@ -35,7 +35,7 @@
          (println "Load file failed: " path)
          (js/console.error e)))))
 
-(defn load-multiple-files
+(defn- load-multiple-files
   [repo-url paths]
   (doall
    (mapv #(load-file repo-url %) paths)))
@@ -92,7 +92,7 @@
   [path content]
   (when (or (= path "logseq/config.edn")
             (= (path/dirname path) (global-config-handler/safe-global-config-dir)))
-    (config-edn-common-handler/detect-deprecations path content {:db-graph? (config/db-based-graph? (state/get-current-repo))})))
+    (config-edn-common-handler/detect-deprecations path content {:db-graph? false})))
 
 (defn- validate-file
   "Returns true if valid and if false validator displays error message. Files
@@ -202,7 +202,7 @@
   (alter-file repo path new-content {:reset? false
                                      :re-render-root? false}))
 
-(defn alter-files-handler!
+(defn- alter-files-handler!
   [repo files {:keys [finish-handler]} file->content]
   (let [write-file-f (fn [[path content]]
                        (when path
@@ -255,7 +255,7 @@
 (defn watch-for-current-graph-dir!
   []
   (when-let [repo (state/get-current-repo)]
-    (when-let [dir (and (not (config/db-based-graph? repo)) (config/get-repo-dir repo))]
+    (when-let [dir (config/get-repo-dir repo)]
       ;; An unwatch shouldn't be needed on startup. However not having this
       ;; after an app refresh can cause stale page data to load
       (fs/unwatch-dir! dir)

--- a/src/main/frontend/handler/file_based/import.cljs
+++ b/src/main/frontend/handler/file_based/import.cljs
@@ -1,0 +1,70 @@
+(ns frontend.handler.file-based.import
+  "Handles file-graph specific imports"
+  (:require [clojure.string :as string]
+            [frontend.config :as config]
+            [frontend.db :as db]
+            [frontend.date :as date]
+            [frontend.external :as external]
+            [frontend.handler.file-based.file :as file-handler]
+            [frontend.handler.file-based.repo :as file-repo-handler]
+            [frontend.state :as state]
+            [frontend.util :as util]
+            [logseq.common.util :as common-util]
+            [logseq.common.util.date-time :as date-time-util]))
+
+
+(defn index-files!
+  "Create file structure, then parse into DB (client only)"
+  [repo files finish-handler]
+  (let [titles (->> files
+                    (map :title)
+                    (remove nil?))
+        files (map (fn [file]
+                     (let [title (:title file)
+                           journal? (date/valid-journal-title? title)]
+                       (when-let [text (:text file)]
+                         (let [title (or
+                                      (when journal?
+                                        (date/journal-title->default title))
+                                      (string/replace title "/" "-"))
+                               title (-> (common-util/page-name-sanity title)
+                                         (string/replace "\n" " "))
+                               path (str (if journal?
+                                           (config/get-journals-directory)
+                                           (config/get-pages-directory))
+                                         "/"
+                                         title
+                                         ".md")]
+                           {:file/path path
+                            :file/content text}))))
+                   files)
+        files (remove nil? files)]
+    (file-repo-handler/parse-files-and-load-to-db! repo files nil)
+    (let [files (->> (map (fn [{:file/keys [path content]}] (when path [path content])) files)
+                     (remove nil?))]
+      (file-handler/alter-files repo files {:add-history? false
+                                            :update-db? false
+                                            :update-status? false
+                                            :finish-handler finish-handler}))
+    (let [journal-pages-tx (let [titles (filter date/normalize-journal-title titles)]
+                             (map
+                              (fn [title]
+                                (let [day (date/journal-title->int title)
+                                      journal-title (date-time-util/int->journal-title day (state/get-date-formatter))]
+                                  (when journal-title
+                                    (let [page-name (util/page-name-sanity-lc journal-title)]
+                                      {:block/name page-name
+                                       :block/type "journal"
+                                       :block/journal-day day}))))
+                              titles))]
+      (when (seq journal-pages-tx)
+        (db/transact! repo journal-pages-tx)))))
+
+;; TODO: replace files with page blocks transaction
+(defn import-from-roam-json!
+  [data finished-ok-handler]
+  (when-let [repo (state/get-current-repo)]
+    (let [files (external/to-markdown-files :roam data {})]
+      (index-files! repo files
+                    (fn []
+                      (finished-ok-handler))))))

--- a/src/main/frontend/handler/file_based/repo.cljs
+++ b/src/main/frontend/handler/file_based/repo.cljs
@@ -5,7 +5,7 @@
             [frontend.fs :as fs]
             [frontend.handler.file-based.file :as file-handler]
             [frontend.handler.repo-config :as repo-config-handler]
-            [frontend.handler.common.file :as file-common-handler]
+            [frontend.handler.file-based.reset-file :as reset-file-handler]
             [frontend.handler.route :as route-handler]
             [frontend.handler.ui :as ui-handler]
             [frontend.spec :as spec]
@@ -37,7 +37,7 @@
         (p/let [_ (fs/mkdir-if-not-exists (path/path-join repo-dir pages-dir))
                 file-exists? (fs/create-if-not-exists repo-url repo-dir file-rpath default-content)]
           (when-not file-exists?
-            (file-common-handler/reset-file! repo-url file-rpath default-content)))))))
+            (reset-file-handler/reset-file! repo-url file-rpath default-content)))))))
 
 (defn- create-custom-theme
   [repo-url]
@@ -49,7 +49,7 @@
     (p/let [_ (fs/mkdir-if-not-exists (path/path-join repo-dir config/app-name))
             file-exists? (fs/create-if-not-exists repo-url repo-dir file-rpath default-content)]
       (when-not file-exists?
-        (file-common-handler/reset-file! repo-url path default-content)))))
+        (reset-file-handler/reset-file! repo-url path default-content)))))
 
 (comment
   (defn- create-dummy-notes-page
@@ -59,7 +59,7 @@
          file-rpath (str (config/get-pages-directory) "/how_to_make_dummy_notes.md")]
      (p/let [_ (fs/mkdir-if-not-exists (path/path-join repo-dir (config/get-pages-directory)))
              _file-exists? (fs/create-if-not-exists repo-url repo-dir file-rpath content)]
-       (file-common-handler/reset-file! repo-url file-rpath content)))))
+       (reset-file-handler/reset-file! repo-url file-rpath content)))))
 
 (comment
   (defn- create-today-journal-if-not-exists
@@ -93,7 +93,7 @@
                  _ (fs/mkdir-if-not-exists (path/path-join repo-dir (config/get-journals-directory)))
                  file-exists? (fs/file-exists? repo-dir file-rpath)]
            (when-not file-exists?
-             (p/let [_ (file-common-handler/reset-file! repo-url file-rpath content)]
+             (p/let [_ (reset-file-handler/reset-file! repo-url file-rpath content)]
                (fs/create-if-not-exists repo-url repo-dir file-rpath content)))))))))
 
 
@@ -109,7 +109,7 @@
             path (str app-dir "/" config/config-file)]
         (p/let [file-exists? (fs/create-if-not-exists repo-url repo-dir "logseq/config.edn" default-content)]
           (when-not file-exists?
-            (file-common-handler/reset-file! repo-url path default-content)
+            (reset-file-handler/reset-file! repo-url path default-content)
             (repo-config-handler/set-repo-config-state! repo-url default-content)))))))
 
 (defn- create-default-files!

--- a/src/main/frontend/handler/file_based/repo.cljs
+++ b/src/main/frontend/handler/file_based/repo.cljs
@@ -3,7 +3,7 @@
   (:require [frontend.config :as config]
             [frontend.db :as db]
             [frontend.fs :as fs]
-            [frontend.handler.file :as file-handler]
+            [frontend.handler.file-based.file :as file-handler]
             [frontend.handler.repo-config :as repo-config-handler]
             [frontend.handler.common.file :as file-common-handler]
             [frontend.handler.route :as route-handler]

--- a/src/main/frontend/handler/file_based/reset_file.cljs
+++ b/src/main/frontend/handler/file_based/reset_file.cljs
@@ -1,5 +1,5 @@
-(ns frontend.handler.common.file
-  "Common file related fns for handlers"
+(ns frontend.handler.file-based.reset-file
+  "Fns for resetting a db file with parsed file content"
   (:require [frontend.config :as config]
             [frontend.state :as state]
             [frontend.db :as db]

--- a/src/main/frontend/handler/import.cljs
+++ b/src/main/frontend/handler/import.cljs
@@ -13,7 +13,7 @@
             [frontend.format.block :as block]
             [frontend.format.mldoc :as mldoc]
             [frontend.handler.editor :as editor]
-            [frontend.handler.file :as file-handler]
+            [frontend.handler.file-based.file :as file-handler]
             [frontend.handler.file-based.repo :as file-repo-handler]
             [frontend.handler.notification :as notification]
             [frontend.handler.page :as page-handler]

--- a/src/main/frontend/handler/import.cljs
+++ b/src/main/frontend/handler/import.cljs
@@ -6,85 +6,23 @@
             [clojure.string :as string]
             [clojure.walk :as walk]
             [frontend.config :as config]
-            [frontend.date :as date]
             [frontend.db :as db]
             [frontend.db.async :as db-async]
-            [frontend.external :as external]
             [frontend.format.block :as block]
             [frontend.format.mldoc :as mldoc]
             [frontend.handler.editor :as editor]
-            [frontend.handler.file-based.file :as file-handler]
-            [frontend.handler.file-based.repo :as file-repo-handler]
             [frontend.handler.notification :as notification]
             [frontend.handler.page :as page-handler]
             [frontend.handler.repo :as repo-handler]
             [frontend.persist-db :as persist-db]
             [frontend.state :as state]
             [frontend.util :as util]
-            [logseq.common.util :as common-util]
-            [logseq.common.util.date-time :as date-time-util]
             [logseq.db :as ldb]
             [logseq.db.sqlite.util :as sqlite-util]
             [logseq.graph-parser.mldoc :as gp-mldoc]
             [logseq.graph-parser.whiteboard :as gp-whiteboard]
             [medley.core :as medley]
             [promesa.core :as p]))
-
-(defn index-files!
-  "Create file structure, then parse into DB (client only)"
-  [repo files finish-handler]
-  (let [titles (->> files
-                    (map :title)
-                    (remove nil?))
-        files (map (fn [file]
-                     (let [title (:title file)
-                           journal? (date/valid-journal-title? title)]
-                       (when-let [text (:text file)]
-                         (let [title (or
-                                      (when journal?
-                                        (date/journal-title->default title))
-                                      (string/replace title "/" "-"))
-                               title (-> (common-util/page-name-sanity title)
-                                         (string/replace "\n" " "))
-                               path (str (if journal?
-                                           (config/get-journals-directory)
-                                           (config/get-pages-directory))
-                                         "/"
-                                         title
-                                         ".md")]
-                           {:file/path path
-                            :file/content text}))))
-                   files)
-        files (remove nil? files)]
-    (file-repo-handler/parse-files-and-load-to-db! repo files nil)
-    (let [files (->> (map (fn [{:file/keys [path content]}] (when path [path content])) files)
-                     (remove nil?))]
-      (file-handler/alter-files repo files {:add-history? false
-                                            :update-db? false
-                                            :update-status? false
-                                            :finish-handler finish-handler}))
-    (let [journal-pages-tx (let [titles (filter date/normalize-journal-title titles)]
-                             (map
-                              (fn [title]
-                                (let [day (date/journal-title->int title)
-                                      journal-title (date-time-util/int->journal-title day (state/get-date-formatter))]
-                                  (when journal-title
-                                    (let [page-name (util/page-name-sanity-lc journal-title)]
-                                      {:block/name page-name
-                                       :block/type "journal"
-                                       :block/journal-day day}))))
-                              titles))]
-      (when (seq journal-pages-tx)
-        (db/transact! repo journal-pages-tx)))))
-
-;; TODO: replace files with page blocks transaction
-(defn import-from-roam-json!
-  [data finished-ok-handler]
-  (when-let [repo (state/get-current-repo)]
-    (let [files (external/to-markdown-files :roam data {})]
-      (index-files! repo files
-                    (fn []
-                      (finished-ok-handler))))))
 
 ;;; import OPML files
 (defn import-from-opml!

--- a/src/main/frontend/handler/worker.cljs
+++ b/src/main/frontend/handler/worker.cljs
@@ -1,7 +1,7 @@
 (ns frontend.handler.worker
   "Handle messages received from the db worker"
   (:require [cljs-bean.core :as bean]
-            [frontend.handler.file :as file-handler]
+            [frontend.handler.file-based.file :as file-handler]
             [frontend.handler.notification :as notification]
             [frontend.state :as state]
             [lambdaisland.glogi :as log]

--- a/src/test/frontend/fs/diff_merge_test.cljs
+++ b/src/test/frontend/fs/diff_merge_test.cljs
@@ -3,7 +3,7 @@
             [cljs.test :refer [are deftest is]]
             [frontend.db.conn :as conn]
             [frontend.fs.diff-merge :as fs-diff]
-            [frontend.handler.common.file :as file-common-handler]
+            [frontend.handler.file-based.reset-file :as reset-file-handler]
             [logseq.graph-parser :as graph-parser]
             [logseq.graph-parser.db :as gp-db]
             [logseq.graph-parser.mldoc :as gp-mldoc]
@@ -377,7 +377,7 @@
     (graph-parser/parse-file conn "bar.md" bar-content {})
     (are [ast content page-name uuids]
          (= (with-redefs [conn/get-db (constantly @conn)]
-              (#'file-common-handler/diff-merge-uuids-2ways :markdown ast content {:page-name page-name
+              (#'reset-file-handler/diff-merge-uuids-2ways :markdown ast content {:page-name page-name
                                                                              :block-pattern "-"}))
             uuids)
 
@@ -409,7 +409,7 @@
     ;; Compare if the uuids are the same as those inside DB when the modified content (adding new line) is parsed
     (are [ast content page-name DB-uuids->new-uuids-fn]
          (= (with-redefs [conn/get-db (constantly @conn)]
-              (#'file-common-handler/diff-merge-uuids-2ways :markdown ast content {:page-name page-name
+              (#'reset-file-handler/diff-merge-uuids-2ways :markdown ast content {:page-name page-name
                                                                              :block-pattern "-"}))
             ;; Get all uuids under the page
             (->> page-name
@@ -441,7 +441,7 @@
          (= (with-redefs [conn/get-db (constantly @conn)
                                 ;; Hijack the function to throw an exception
                           fs-diff/db->diff-blocks #(throw (js/Error. "intentional exception for testing diff-merge-uuids-2ways error capture"))]
-              (#'file-common-handler/diff-merge-uuids-2ways :markdown ast content {:page-name page-name
+              (#'reset-file-handler/diff-merge-uuids-2ways :markdown ast content {:page-name page-name
                                                                                    :block-pattern "-"}))
             nil)
 


### PR DESCRIPTION
Moves a handler namespace and its dependent namespaces to file-based as they are only used by file graphs. Makes maintenance easier as another 1k+ lines are explicitly file based. Merging once green