### PR TITLE
enhance: make build-db-initial-data idempotent

### DIFF
--- a/deps/common/src/logseq/common/uuid.cljs
+++ b/deps/common/src/logseq/common/uuid.cljs
@@ -40,11 +40,12 @@ the remaining chars for data of this type"
   - :journal-page-uuid, 00000001
   - :db-ident-block-uuid, 00000002
   - :migrate-new-block-uuid, 00000003
-  - :builtin-page-uuid, 00000004"
+  - :builtin-block-uuid, 00000004"
   ([] (d/squuid))
   ([type' v]
+   (assert (some? v))
    (case type'
      :journal-page-uuid (gen-journal-page-uuid v)
      :db-ident-block-uuid (gen-db-ident-block-uuid v)
      :migrate-new-block-uuid (gen-block-uuid v "00000003")
-     :builtin-page-uuid (gen-block-uuid v "00000004"))))
+     :builtin-block-uuid (gen-block-uuid v "00000004"))))

--- a/deps/common/src/logseq/common/uuid.cljs
+++ b/deps/common/src/logseq/common/uuid.cljs
@@ -19,23 +19,32 @@ the remaining chars for data of this type"
   (let [s-length (count s)]
     (apply str s (repeat (- length s-length) "0"))))
 
-(defn- gen-db-ident-block-uuid
-  "00000002-<hash-of-db-ident>-<padding-with-0>"
-  [db-ident]
-  {:pre [(keyword? db-ident)]}
-  (let [hash-num (str (Math/abs (hash db-ident)))
+(defn- gen-block-uuid
+  "prefix-<hash-of-db-ident>-<padding-with-0>"
+  [k prefix]
+  (let [hash-num (str (Math/abs (hash k)))
         part1 (fill-with-0 (subs hash-num 0 4) 4)
         part2 (fill-with-0 (subs hash-num 4 8) 4)
         part3 (fill-with-0 (subs hash-num 8 12) 4)
         part4 (fill-with-0 (subs hash-num 12) 12)]
-    (uuid (str "00000002-" part1 "-" part2 "-" part3 "-" part4))))
+    (uuid (str prefix "-" part1 "-" part2 "-" part3 "-" part4))))
+
+(defn- gen-db-ident-block-uuid
+  "00000002-<hash-of-db-ident>-<padding-with-0>"
+  [db-ident]
+  {:pre [(keyword? db-ident)]}
+  (gen-block-uuid db-ident "00000002"))
 
 (defn gen-uuid
   "supported type:
-  - :journal-page-uuid
-  - :db-ident-block-uuid"
+  - :journal-page-uuid, 00000001
+  - :db-ident-block-uuid, 00000002
+  - :migrate-new-block-uuid, 00000003
+  - :builtin-page-uuid, 00000004"
   ([] (d/squuid))
   ([type' v]
    (case type'
      :journal-page-uuid (gen-journal-page-uuid v)
-     :db-ident-block-uuid (gen-db-ident-block-uuid v))))
+     :db-ident-block-uuid (gen-db-ident-block-uuid v)
+     :migrate-new-block-uuid (gen-block-uuid v "00000003")
+     :builtin-page-uuid (gen-block-uuid v "00000004"))))

--- a/deps/db/src/logseq/db/sqlite/create_graph.cljs
+++ b/deps/db/src/logseq/db/sqlite/create_graph.cljs
@@ -1,14 +1,13 @@
 (ns logseq.db.sqlite.create-graph
   "Helper fns for creating a DB graph"
   (:require [clojure.string :as string]
-            [datascript.core :as d]
             [logseq.common.config :as common-config]
             [logseq.common.util :as common-util]
             [logseq.common.uuid :as common-uuid]
+            [logseq.db.common.order :as db-order]
             [logseq.db.frontend.class :as db-class]
             [logseq.db.frontend.entity-util :as entity-util]
             [logseq.db.frontend.malli-schema :as db-malli-schema]
-            [logseq.db.common.order :as db-order]
             [logseq.db.frontend.property :as db-property]
             [logseq.db.frontend.property.build :as db-property-build]
             [logseq.db.frontend.property.type :as db-property-type]
@@ -211,17 +210,17 @@
                        {:db/ident :logseq.property/empty-placeholder}]
                        import-type
                        (into (sqlite-util/import-tx import-type)))
-        initial-files [{:block/uuid (d/squuid)
+        initial-files [{:block/uuid (common-uuid/gen-uuid :builtin-page-uuid "logseq/config.edn")
                         :file/path (str "logseq/" "config.edn")
                         :file/content config-content
                         :file/created-at (js/Date.)
                         :file/last-modified-at (js/Date.)}
-                       {:block/uuid (d/squuid)
+                       {:block/uuid (common-uuid/gen-uuid :builtin-page-uuid "logseq/custom.css")
                         :file/path (str "logseq/" "custom.css")
                         :file/content ""
                         :file/created-at (js/Date.)
                         :file/last-modified-at (js/Date.)}
-                       {:block/uuid (d/squuid)
+                       {:block/uuid (common-uuid/gen-uuid :builtin-page-uuid "logseq/custom.js")
                         :file/path (str "logseq/" "custom.js")
                         :file/content ""
                         :file/created-at (js/Date.)

--- a/deps/db/src/logseq/db/sqlite/create_graph.cljs
+++ b/deps/db/src/logseq/db/sqlite/create_graph.cljs
@@ -31,20 +31,22 @@
   "Given a new block and its properties, creates a map of properties which have values of property value tx.
    This map is used for both creating the new property values and then adding them to a block"
   [new-block properties]
-  (->> properties
-       (keep (fn [[k v]]
-               (when-let [built-in-type (get-in db-property/built-in-properties [k :schema :type])]
-                 (if (and (db-property-type/value-ref-property-types built-in-type)
-                          ;; closed values are referenced by their :db/ident so no need to create values
-                          (not (get-in db-property/built-in-properties [k :closed-values])))
-                   (let [property-map {:db/ident k
-                                       :logseq.property/type built-in-type}]
-                     [property-map v])
-                   (when-let [built-in-type' (get (:build/properties-ref-types new-block) built-in-type)]
-                     (let [property-map {:db/ident k
-                                         :logseq.property/type built-in-type'}]
-                       [property-map v]))))))
-       (db-property-build/build-property-values-tx-m new-block)))
+  (db-property-build/build-property-values-tx-m
+   new-block
+   (->> properties
+        (keep (fn [[k v]]
+                (when-let [built-in-type (get-in db-property/built-in-properties [k :schema :type])]
+                  (if (and (db-property-type/value-ref-property-types built-in-type)
+                           ;; closed values are referenced by their :db/ident so no need to create values
+                           (not (get-in db-property/built-in-properties [k :closed-values])))
+                    (let [property-map {:db/ident k
+                                        :logseq.property/type built-in-type}]
+                      [property-map v])
+                    (when-let [built-in-type' (get (:build/properties-ref-types new-block) built-in-type)]
+                      (let [property-map {:db/ident k
+                                          :logseq.property/type built-in-type'}]
+                        [property-map v])))))))
+   :pure? true))
 
 (defn build-properties
   "Given a properties map in the format of db-property/built-in-properties, builds their properties tx"

--- a/deps/db/src/logseq/db/sqlite/create_graph.cljs
+++ b/deps/db/src/logseq/db/sqlite/create_graph.cljs
@@ -169,7 +169,7 @@
 (defn build-initial-views
   "Builds initial blocks used for storing views. Used by db and file graphs"
   []
-  (let [page-id (common-uuid/gen-uuid)]
+  (let [page-id (common-uuid/gen-uuid :builtin-block-uuid common-config/views-page-name)]
     [(sqlite-util/block-with-timestamps
       {:block/uuid page-id
        :block/name common-config/views-page-name
@@ -178,7 +178,7 @@
        :logseq.property/hide? true
        :logseq.property/built-in? true})
      (sqlite-util/block-with-timestamps
-      {:block/uuid (common-uuid/gen-uuid)
+      {:block/uuid (common-uuid/gen-uuid :builtin-block-uuid "All Pages Default View")
        :block/title "All Pages Default View"
        :block/parent [:block/uuid page-id]
        :block/order (db-order/gen-key nil)
@@ -189,7 +189,7 @@
 (defn- build-favorites-page
   []
   [(sqlite-util/block-with-timestamps
-    {:block/uuid (common-uuid/gen-uuid)
+    {:block/uuid (common-uuid/gen-uuid :builtin-block-uuid common-config/favorites-page-name)
      :block/name common-config/favorites-page-name
      :block/title common-config/favorites-page-name
      :block/tags [:logseq.class/Page]
@@ -210,17 +210,17 @@
                        {:db/ident :logseq.property/empty-placeholder}]
                        import-type
                        (into (sqlite-util/import-tx import-type)))
-        initial-files [{:block/uuid (common-uuid/gen-uuid :builtin-page-uuid "logseq/config.edn")
+        initial-files [{:block/uuid (common-uuid/gen-uuid :builtin-block-uuid "logseq/config.edn")
                         :file/path (str "logseq/" "config.edn")
                         :file/content config-content
                         :file/created-at (js/Date.)
                         :file/last-modified-at (js/Date.)}
-                       {:block/uuid (common-uuid/gen-uuid :builtin-page-uuid "logseq/custom.css")
+                       {:block/uuid (common-uuid/gen-uuid :builtin-block-uuid "logseq/custom.css")
                         :file/path (str "logseq/" "custom.css")
                         :file/content ""
                         :file/created-at (js/Date.)
                         :file/last-modified-at (js/Date.)}
-                       {:block/uuid (common-uuid/gen-uuid :builtin-page-uuid "logseq/custom.js")
+                       {:block/uuid (common-uuid/gen-uuid :builtin-block-uuid "logseq/custom.js")
                         :file/path (str "logseq/" "custom.js")
                         :file/content ""
                         :file/created-at (js/Date.)

--- a/deps/db/src/logseq/db/sqlite/util.cljs
+++ b/deps/db/src/logseq/db/sqlite/util.cljs
@@ -3,6 +3,7 @@
   (:require [cljs-bean.transit]
             [clojure.string :as string]
             [cognitect.transit :as transit]
+            [datascript.core]
             [datascript.impl.entity :as de]
             [datascript.transit :as dt]
             [logseq.common.util :as common-util]

--- a/deps/db/src/logseq/db/sqlite/util.cljs
+++ b/deps/db/src/logseq/db/sqlite/util.cljs
@@ -3,16 +3,15 @@
   (:require [cljs-bean.transit]
             [clojure.string :as string]
             [cognitect.transit :as transit]
-            [datascript.core :as d]
             [datascript.impl.entity :as de]
             [datascript.transit :as dt]
             [logseq.common.util :as common-util]
             [logseq.common.uuid :as common-uuid]
             [logseq.db.common.order :as db-order]
+            [logseq.db.file-based.schema :as file-schema]
             [logseq.db.frontend.property :as db-property]
             [logseq.db.frontend.property.type :as db-property-type]
-            [logseq.db.frontend.schema :as db-schema]
-            [logseq.db.file-based.schema :as file-schema]))
+            [logseq.db.frontend.schema :as db-schema]))
 
 (defonce db-version-prefix "logseq_db_")
 (defonce file-version-prefix "logseq_local_")

--- a/deps/db/src/logseq/db/sqlite/util.cljs
+++ b/deps/db/src/logseq/db/sqlite/util.cljs
@@ -121,7 +121,7 @@
   (block-with-timestamps
    {:block/name (common-util/page-name-sanity-lc page-name)
     :block/title page-name
-    :block/uuid (d/squuid)
+    :block/uuid (common-uuid/gen-uuid :builtin-block-uuid page-name)
     :block/tags #{:logseq.class/Page}}))
 
 (defn kv

--- a/deps/db/test/logseq/db/sqlite/create_graph_test.cljs
+++ b/deps/db/test/logseq/db/sqlite/create_graph_test.cljs
@@ -157,12 +157,15 @@
     (letfn [(remove-ignored-attrs&entities [init-data]
               (let [[before after] (split-with #(not= :logseq.kv/graph-created-at (:db/ident %)) init-data)
                     init-data* (concat before (rest after))]
-                (map (fn [ent] (dissoc ent :block/created-at :block/updated-at
+                (map (fn [ent] (dissoc ent
+                                       :block/created-at :block/updated-at
+                                       :file/last-modified-at :file/created-at
                                        :block/order ;; TODO: block/order should be same as well
                                        ))
                      init-data*)))]
-      (let [[first-only second-only _common]
+      (let [[first-only second-only common]
             (data/diff (remove-ignored-attrs&entities (sqlite-create-graph/build-db-initial-data ""))
                        (remove-ignored-attrs&entities (sqlite-create-graph/build-db-initial-data "")))]
         (is (and (every? nil? first-only)
-                 (every? nil? second-only)))))))
+                 (every? nil? second-only))
+            (pr-str [first-only second-only common]))))))

--- a/deps/db/test/logseq/db/sqlite/create_graph_test.cljs
+++ b/deps/db/test/logseq/db/sqlite/create_graph_test.cljs
@@ -1,5 +1,6 @@
 (ns logseq.db.sqlite.create-graph-test
   (:require [cljs.test :refer [deftest is testing]]
+            [clojure.data :as data]
             [clojure.set :as set]
             [clojure.string :as string]
             [datascript.core :as d]
@@ -150,3 +151,18 @@
 
       (is (empty? (map :entity (:errors (db-validate/validate-db! @conn))))
           "Graph with different :url blocks has no validation errors"))))
+
+(deftest build-db-initial-data-test
+  (testing "idempotent initial-data"
+    (letfn [(remove-ignored-attrs&entities [init-data]
+              (let [[before after] (split-with #(not= :logseq.kv/graph-created-at (:db/ident %)) init-data)
+                    init-data* (concat before (rest after))]
+                (map (fn [ent] (dissoc ent :block/created-at :block/updated-at
+                                       :block/order ;; TODO: block/order should be same as well
+                                       ))
+                     init-data*)))]
+      (let [[first-only second-only _common]
+            (data/diff (remove-ignored-attrs&entities (sqlite-create-graph/build-db-initial-data ""))
+                       (remove-ignored-attrs&entities (sqlite-create-graph/build-db-initial-data "")))]
+        (is (and (every? nil? first-only)
+                 (every? nil? second-only)))))))

--- a/src/main/frontend/components/plugins.cljs
+++ b/src/main/frontend/components/plugins.cljs
@@ -847,7 +847,6 @@
                                        :latestAt latest-at
                                        :downloads downloads))
                                    %) filtered-pkgs)
-        _ (def debug-pkgs filtered-pkgs)
         sorted-plugins     (weighted-sort-by @*sort-by filtered-pkgs)
 
         fn-query-flag      (fn [] (string/join "_" (map #(str @%) [*filter-by *sort-by *search-key *category])))


### PR DESCRIPTION
Ensure that the `tx-data` returned by `build-db-initial-data` is idempotent (except for certain attributes such as `:block/created-at`).

This approach can resolve potential issues of multiple duplicate blocks when RTC is enabled. 
For instance, currently, `$$$favorites` and `$$$views` may generate multiple duplicates because their `block/uuid` is randomly assigned (`d/squuid`).

testcase: build-db-initial-data-test
run `build-db-initial-data` 2 times, and compare their result