### PR TITLE
chore(deps): add deepmerge to @tldraw/core

### DIFF
--- a/tldraw/packages/core/package.json
+++ b/tldraw/packages/core/package.json
@@ -38,6 +38,7 @@
     "@tldraw/intersect": "2.0.0-alpha.1",
     "@tldraw/vec": "2.0.0-alpha.1",
     "@use-gesture/react": "^10.2.22",
+    "deepmerge": "^4.2.2",
     "fast-copy": "^3.0.0",
     "fast-deep-equal": "^3.1.3",
     "hotkeys-js": "^3.10.0",

--- a/tldraw/yarn.lock
+++ b/tldraw/yarn.lock
@@ -2152,6 +2152,11 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+deepmerge@^4.2.2:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
+  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
+
 defined@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"


### PR DESCRIPTION
Hey! I'm working on a [Nix package](https://kirarin.hootr.club/git/steinuil/flakes/src/branch/master/packages/logseq) that builds Logseq from source rather than relying on the AppImage like the nixpkgs version.

In the Nix expression I'm building several components in isolation from one another, and I noticed that `@tldraw/core` is missing a dependency on `deepmerge`. This PR just adds the dependency and updates the lockfile in `tldraw`.