### PR TITLE
feat: send migrate-data when rtc start

### DIFF
--- a/src/main/frontend/worker/db_worker.cljs
+++ b/src/main/frontend/worker/db_worker.cljs
@@ -344,6 +344,8 @@
                                         (= "db" (:kv/value (d/entity @conn :logseq.kv/db-type)))))]
         (swap! *datascript-conns assoc repo conn)
         (swap! *client-ops-conns assoc repo client-ops-conn)
+        (when (not= client-op/schema-in-db (d/schema client-ops-conn))
+          (d/reset-schema! client-ops-conn client-op/schema-in-db))
         (when (and db-based? (not initial-data-exists?) (not datoms))
           (let [config (or config "")
                 initial-data (sqlite-create-graph/build-db-initial-data config

--- a/src/main/frontend/worker/db_worker.cljs
+++ b/src/main/frontend/worker/db_worker.cljs
@@ -344,7 +344,7 @@
                                         (= "db" (:kv/value (d/entity @conn :logseq.kv/db-type)))))]
         (swap! *datascript-conns assoc repo conn)
         (swap! *client-ops-conns assoc repo client-ops-conn)
-        (when (not= client-op/schema-in-db (d/schema client-ops-conn))
+        (when (not= client-op/schema-in-db (d/schema @client-ops-conn))
           (d/reset-schema! client-ops-conn client-op/schema-in-db))
         (when (and db-based? (not initial-data-exists?) (not datoms))
           (let [config (or config "")

--- a/src/main/frontend/worker/rtc/client.cljs
+++ b/src/main/frontend/worker/rtc/client.cljs
@@ -93,6 +93,10 @@
 
 (defmulti ^:private local-block-ops->remote-ops-aux (fn [tp & _] tp))
 
+(defmethod local-block-ops->remote-ops-aux :update-kv-value-op
+  [_ & {:keys [db-ident value *remote-ops]}]
+  (swap! *remote-ops conj [:update-kv-value {:db-ident db-ident :value value}]))
+
 (defmethod local-block-ops->remote-ops-aux :move-op
   [_ & {:keys [parent-uuid block-order block-uuid *remote-ops *depend-on-block-uuid-set]}]
   (when parent-uuid

--- a/src/main/frontend/worker/rtc/client.cljs
+++ b/src/main/frontend/worker/rtc/client.cljs
@@ -93,10 +93,6 @@
 
 (defmulti ^:private local-block-ops->remote-ops-aux (fn [tp & _] tp))
 
-(defmethod local-block-ops->remote-ops-aux :update-kv-value-op
-  [_ & {:keys [db-ident value *remote-ops]}]
-  (swap! *remote-ops conj [:update-kv-value {:db-ident db-ident :value value}]))
-
 (defmethod local-block-ops->remote-ops-aux :move-op
   [_ & {:keys [parent-uuid block-order block-uuid *remote-ops *depend-on-block-uuid-set]}]
   (when parent-uuid
@@ -274,6 +270,30 @@
             (:remote-ops (local-block-ops->remote-ops db block-ops-map))]))
         block-ops-map-coll))
 
+(defmulti ^:private local-db-ident-kv-ops->remote-ops-aux (fn [op-type & _] op-type))
+(defmethod local-db-ident-kv-ops->remote-ops-aux :update-kv-value
+  [_ op]
+  (let [op-value (last op)
+        db-ident (:db-ident op-value)
+        value (:value op-value)]
+    [:update-kv-value {:db-ident db-ident :value (ldb/write-transit-str value)}]))
+
+(defmethod local-db-ident-kv-ops->remote-ops-aux :db-ident
+  [_ _op]
+  ;; ignore
+  )
+
+(defn- local-db-ident-kv-ops->remote-ops
+  [db-ident-kv-ops-map]
+  (keep
+   (fn [[op-type op]]
+     (local-db-ident-kv-ops->remote-ops-aux op-type op))
+   db-ident-kv-ops-map))
+
+(defn- gen-db-ident-kv-remote-ops
+  [db-ident-kv-ops-map-coll]
+  (mapcat local-db-ident-kv-ops->remote-ops db-ident-kv-ops-map-coll))
+
 (defn- merge-remove-remove-ops
   [remote-remove-ops]
   (when-let [block-uuids (->> remote-remove-ops
@@ -332,61 +352,73 @@
     (concat update-schema-ops update-page-ops remove-ops sorted-move-ops update-ops remove-page-ops)))
 
 (defn- rollback
-  [repo block-ops-map-coll]
-  (let [ops (mapcat
-             (fn [m]
-               (keep (fn [[k op]]
-                       (when (not= :block/uuid k)
-                         op))
-                     m))
-             block-ops-map-coll)]
-    (client-op/add-ops repo ops)
+  [repo block-ops-map-coll db-ident-kv-ops-map-coll]
+  (let [block-ops
+        (mapcat
+         (fn [m]
+           (keep (fn [[k op]]
+                   (when-not (keyword-identical? :block/uuid k)
+                     op))
+                 m))
+         block-ops-map-coll)
+        db-ident-kv-ops
+        (mapcat
+         (fn [m]
+           (keep (fn [[k op]]
+                   (when-not (keyword-identical? :db-ident k)
+                     op))
+                 m))
+         db-ident-kv-ops-map-coll)]
+    (client-op/add-ops! repo block-ops)
+    (client-op/add-ops! repo db-ident-kv-ops)
     nil))
 
 (defn new-task--push-local-ops
   "Return a task: push local updates"
   [repo conn graph-uuid major-schema-version date-formatter get-ws-create-task *remote-profile? add-log-fn]
   (m/sp
-    (let [block-ops-map-coll (client-op/get&remove-all-block-ops repo)]
-      (when-let [block-uuid->remote-ops (not-empty (gen-block-uuid->remote-ops @conn block-ops-map-coll))]
-        (when-let [ops-for-remote (rtc-schema/to-ws-ops-decoder
-                                   (sort-remote-ops
-                                    block-uuid->remote-ops))]
-          (let [local-tx (client-op/get-local-tx repo)
-                r (try
-                    (m/? (ws-util/send&recv get-ws-create-task
-                                            (cond-> {:action "apply-ops"
-                                                     :graph-uuid graph-uuid :schema-version (str major-schema-version)
-                                                     :ops ops-for-remote :t-before (or local-tx 1)}
-                                              (true? @*remote-profile?) (assoc :profile true))))
-                    (catch :default e
-                      (rollback repo block-ops-map-coll)
-                      (throw e)))]
-            (if-let [remote-ex (:ex-data r)]
-              (do (add-log-fn :rtc.log/push-local-update remote-ex)
-                  (case (:type remote-ex)
-                    ;; - :graph-lock-failed
-                    ;;   conflict-update remote-graph, keep these local-pending-ops
-                    ;;   and try to send ops later
-                    :graph-lock-failed
-                    (rollback repo block-ops-map-coll)
-                    ;; - :graph-lock-missing
-                    ;;   this case means something wrong in remote-graph data,
-                    ;;   nothing to do at client-side
-                    :graph-lock-missing
-                    (do (rollback repo block-ops-map-coll)
-                        (throw r.ex/ex-remote-graph-lock-missing))
+    (let [block-ops-map-coll (client-op/get&remove-all-block-ops repo)
+          db-ident-kv-ops-map-coll (client-op/get&remove-all-db-ident-kv-ops repo)
+          block-uuid->remote-ops (not-empty (gen-block-uuid->remote-ops @conn block-ops-map-coll))
+          other-remote-ops (gen-db-ident-kv-remote-ops db-ident-kv-ops-map-coll)
+          remote-ops (concat (when block-uuid->remote-ops (sort-remote-ops block-uuid->remote-ops))
+                             other-remote-ops)]
+      (when-let [ops-for-remote (rtc-schema/to-ws-ops-decoder remote-ops)]
+        (let [local-tx (client-op/get-local-tx repo)
+              r (try
+                  (m/? (ws-util/send&recv get-ws-create-task
+                                          (cond-> {:action "apply-ops"
+                                                   :graph-uuid graph-uuid :schema-version (str major-schema-version)
+                                                   :ops ops-for-remote :t-before (or local-tx 1)}
+                                            (true? @*remote-profile?) (assoc :profile true))))
+                  (catch :default e
+                    (rollback repo block-ops-map-coll db-ident-kv-ops-map-coll)
+                    (throw e)))]
+          (if-let [remote-ex (:ex-data r)]
+            (do (add-log-fn :rtc.log/push-local-update remote-ex)
+                (case (:type remote-ex)
+                  ;; - :graph-lock-failed
+                  ;;   conflict-update remote-graph, keep these local-pending-ops
+                  ;;   and try to send ops later
+                  :graph-lock-failed
+                  (rollback repo block-ops-map-coll db-ident-kv-ops-map-coll)
+                  ;; - :graph-lock-missing
+                  ;;   this case means something wrong in remote-graph data,
+                  ;;   nothing to do at client-side
+                  :graph-lock-missing
+                  (do (rollback repo block-ops-map-coll db-ident-kv-ops-map-coll)
+                      (throw r.ex/ex-remote-graph-lock-missing))
 
-                    :rtc.exception/get-s3-object-failed
-                    (rollback repo block-ops-map-coll)
-                    ;; else
-                    (do (rollback repo block-ops-map-coll)
-                        (throw (ex-info "Unavailable1" {:remote-ex remote-ex})))))
+                  :rtc.exception/get-s3-object-failed
+                  (rollback repo block-ops-map-coll db-ident-kv-ops-map-coll)
+                  ;; else
+                  (do (rollback repo block-ops-map-coll db-ident-kv-ops-map-coll)
+                      (throw (ex-info "Unavailable1" {:remote-ex remote-ex})))))
 
-              (do (assert (pos? (:t r)) r)
-                  (r.remote-update/apply-remote-update
-                   graph-uuid repo conn date-formatter {:type :remote-update :value r} add-log-fn)
-                  (add-log-fn :rtc.log/push-local-update {:remote-t (:t r)})))))))))
+            (do (assert (pos? (:t r)) r)
+                (r.remote-update/apply-remote-update
+                 graph-uuid repo conn date-formatter {:type :remote-update :value r} add-log-fn)
+                (add-log-fn :rtc.log/push-local-update {:remote-t (:t r)}))))))))
 
 (defn new-task--pull-remote-data
   [repo conn graph-uuid major-schema-version date-formatter get-ws-create-task add-log-fn]

--- a/src/main/frontend/worker/rtc/client_op.cljs
+++ b/src/main/frontend/worker/rtc/client_op.cljs
@@ -1,12 +1,10 @@
 (ns frontend.worker.rtc.client-op
   "Store client-ops in a persisted datascript"
   (:require [datascript.core :as d]
-            [datascript.impl.entity :as de]
             [frontend.common.missionary :as c.m]
             [frontend.worker.rtc.malli-schema :as rtc-schema]
             [frontend.worker.state :as worker-state]
             [lambdaisland.glogi :as log]
-            [logseq.db :as ldb]
             [logseq.db.sqlite.util :as sqlite-util]
             [malli.core :as ma]
             [malli.transform :as mt]
@@ -364,18 +362,3 @@
                                (d/datoms @conn :avet :block/uuid))
                        (map (fn [datom] [:db/retractEntity (:e datom)])))]
       (d/transact! conn tx-data))))
-
-(defn property-entity->ops
-  [property-entity]
-  (assert (and (de/entity? property-entity) (ldb/property? property-entity)))
-  [[:update-schema
-    (cond-> {:block-uuid (:block/uuid property-entity)
-             :db/ident (:db/ident property-entity)
-             :db/valueType (or (:db/valueType property-entity) :db.type/string)}
-      (:db/cardinality property-entity) (assoc :db/cardinality (:db/cardinality property-entity))
-      (:db/index property-entity) (assoc :db/index (:db/index property-entity)))]
-
-   [:update
-    ;; todo
-    ]
-   ])

--- a/src/main/frontend/worker/rtc/core.cljs
+++ b/src/main/frontend/worker/rtc/core.cljs
@@ -188,15 +188,16 @@
         *last-calibrate-t          (atom nil)
         *online-users              (atom nil)
         *assets-sync-loop-canceler (atom nil)
+        *server-schema-version     (atom nil)
         started-dfv                (m/dfv)
         add-log-fn                 (fn [type message]
                                      (assert (map? message) message)
                                      (rtc-log-and-state/rtc-log type (assoc message :graph-uuid graph-uuid)))
         {:keys [*current-ws get-ws-create-task]}
         (gen-get-ws-create-map--memoized ws-url)
-        get-ws-create-task         (r.client/ensure-register-graph-updates
-                                    get-ws-create-task graph-uuid major-schema-version
-                                    repo conn *last-calibrate-t *online-users add-log-fn)
+        get-ws-create-task (r.client/ensure-register-graph-updates
+                            get-ws-create-task graph-uuid major-schema-version
+                            repo conn *last-calibrate-t *online-users *server-schema-version add-log-fn)
         {:keys [assets-sync-loop-task]}
         (r.asset/create-assets-sync-loop repo get-ws-create-task graph-uuid major-schema-version conn *auto-push?)
         mixed-flow                 (create-mixed-flow repo get-ws-create-task *auto-push? *online-users)]

--- a/src/main/frontend/worker/rtc/core.cljs
+++ b/src/main/frontend/worker/rtc/core.cljs
@@ -11,6 +11,7 @@
             [frontend.worker.rtc.exception :as r.ex]
             [frontend.worker.rtc.full-upload-download-graph :as r.upload-download]
             [frontend.worker.rtc.log-and-state :as rtc-log-and-state]
+            [frontend.worker.rtc.migrate :as r.migrate]
             [frontend.worker.rtc.remote-update :as r.remote-update]
             [frontend.worker.rtc.skeleton]
             [frontend.worker.rtc.ws :as ws]
@@ -215,6 +216,13 @@
           ;; init run to open a ws
           (m/? get-ws-create-task)
           (started-dfv true)
+          (when @*server-schema-version
+            (let [client-schema-version (ldb/get-graph-schema-version @conn)]
+              (log/info :add-migration-client-ops
+                        {:repo repo
+                         :server-schema-version @*server-schema-version
+                         :client-schema-version client-schema-version})
+              (r.migrate/add-migration-client-ops! repo @conn @*server-schema-version client-schema-version)))
           (reset! *assets-sync-loop-canceler
                   (c.m/run-task assets-sync-loop-task :assets-sync-loop-task))
           (->>

--- a/src/main/frontend/worker/rtc/db_listener.cljs
+++ b/src/main/frontend/worker/rtc/db_listener.cljs
@@ -1,147 +1,13 @@
 (ns frontend.worker.rtc.db-listener
   "listen datascript changes, infer operations from the db tx-report"
-  (:require [clojure.string :as string]
-            [datascript.core :as d]
-            [frontend.worker.db-listener :as db-listener]
+  (:require [frontend.worker.db-listener :as db-listener]
             [frontend.worker.rtc.client-op :as client-op]
-            [frontend.worker.rtc.const :as rtc-const]
-            [logseq.db :as ldb]
-            [logseq.db.frontend.property :as db-property]))
-
-(defn- latest-add?->v->t
-  [add?->v->t]
-  (let [latest-add     (first (sort-by second > (seq (add?->v->t true))))
-        latest-retract (first (sort-by second > (seq (add?->v->t false))))]
-    (cond
-      (nil? latest-add)                               {false (conj {} latest-retract)}
-      (nil? latest-retract)                           {true (conj {} latest-add)}
-      (= (second latest-add) (second latest-retract)) {true (conj {} latest-add)
-                                                       false (conj {} latest-retract)}
-      (> (second latest-add) (second latest-retract)) {true (conj {} latest-add)}
-      :else                                           {false (conj {} latest-retract)})))
-
-(def ^:private watched-attrs
-  #{:block/title :block/created-at :block/updated-at :block/alias
-    :block/tags :block/link :block/journal-day
-    :logseq.property/classes :logseq.property/value
-    :db/index :db/valueType :db/cardinality})
-
-(def ^:private watched-attr-ns
-  (conj db-property/logseq-property-namespaces "logseq.class"))
-
-(defn- watched-attr?
-  [attr]
-  (or (contains? watched-attrs attr)
-      (let [ns (namespace attr)]
-        (or (contains? watched-attr-ns ns)
-            (string/ends-with? ns ".property")
-            (string/ends-with? ns ".class")))))
-
-(defn- ref-attr?
-  [db attr]
-  (= :db.type/ref (get-in (d/schema db) [attr :db/valueType])))
-
-(defn- update-op-av-coll
-  [db-before db-after a->add?->v->t]
-  (mapcat
-   (fn [[a add?->v->t]]
-     (mapcat
-      (fn [[add? v->t]]
-        (keep
-         (fn [[v t]]
-           (let [ref? (ref-attr? db-after a)]
-             (case [add? ref?]
-               [true true]
-               (when-let [v-uuid (:block/uuid (d/entity db-after v))]
-                 [a v-uuid t add?])
-               [false true]
-               (when-let [v-uuid (:block/uuid
-                                  (or (d/entity db-after v)
-                                      (d/entity db-before v)))]
-                 [a v-uuid t add?])
-               ([true false] [false false]) [a (ldb/write-transit-str v) t add?])))
-         v->t))
-      add?->v->t))
-   a->add?->v->t))
-
-(defn- redundant-update-op-av-coll?
-  [av-coll]
-  (every? (fn [av] (keyword-identical? :block/updated-at (first av))) av-coll))
-
-(defn- max-t
-  [a->add?->v->t]
-  (apply max (mapcat vals (mapcat vals (vals a->add?->v->t)))))
-
-(defn- get-first-vt
-  [add?->v->t k]
-  (some-> add?->v->t (get k) first))
-
-(defn- entity-datoms=>ops
-  [db-before db-after e->a->add?->v->t ignore-attr-set entity-datoms]
-  (let [e                        (ffirst entity-datoms)
-        entity                   (d/entity db-after e)
-        {block-uuid :block/uuid} entity
-        a->add?->v->t            (e->a->add?->v->t e)
-        {add?->block-name->t   :block/name
-         add?->block-title->t  :block/title
-         add?->block-uuid->t   :block/uuid
-         add?->block-parent->t :block/parent
-         add?->block-order->t  :block/order}
-        a->add?->v->t
-        [retract-block-uuid t1]  (some-> add?->block-uuid->t (get false) first)
-        [retract-block-name _]   (some-> add?->block-name->t (get false) first)
-        [add-block-name t2]      (some-> add?->block-name->t latest-add?->v->t (get-first-vt true))
-        [add-block-title t3]     (some-> add?->block-title->t latest-add?->v->t (get-first-vt true))
-        [add-block-parent t4]    (some-> add?->block-parent->t latest-add?->v->t (get-first-vt true))
-        [add-block-order t5]     (some-> add?->block-order->t latest-add?->v->t (get-first-vt true))
-        a->add?->v->t*           (into {}
-                                       (filter
-                                        (fn [[a _]]
-                                          (and (watched-attr? a)
-                                               (not (contains? ignore-attr-set a)))))
-                                       a->add?->v->t)]
-    (cond
-      (and retract-block-uuid retract-block-name)
-      [[:remove-page t1 {:block-uuid retract-block-uuid}]]
-
-      retract-block-uuid
-      [[:remove t1 {:block-uuid retract-block-uuid}]]
-
-      :else
-      (let [ops (cond-> []
-                  (or add-block-parent add-block-order)
-                  (conj [:move (or t4 t5) {:block-uuid block-uuid}])
-
-                  (or add-block-name
-                      (and (ldb/page? entity) add-block-title))
-                  (conj [:update-page (or t2 t3) {:block-uuid block-uuid}]))
-            update-op (when-let [av-coll (not-empty (update-op-av-coll db-before db-after a->add?->v->t*))]
-                        (when-not (redundant-update-op-av-coll? av-coll)
-                          (let [t (max-t a->add?->v->t*)]
-                            [:update t {:block-uuid block-uuid :av-coll av-coll}])))]
-        (cond-> ops update-op (conj update-op))))))
-
-(defn- generate-rtc-ops
-  [repo db-before db-after same-entity-datoms-coll e->a->v->add?->t]
-  (let [ops (mapcat
-             (partial entity-datoms=>ops
-                      db-before db-after e->a->v->add?->t rtc-const/ignore-attrs-when-syncing)
-             same-entity-datoms-coll)]
-    (when (seq ops)
-      (client-op/add-ops repo ops))))
+            [frontend.worker.rtc.gen-client-op :as gen-client-op]))
 
 (comment
   ;; TODO: make it a qualified-keyword
   (defkeywords
     :persist-op? {:doc "tx-meta option, generate rtc ops when not nil (default true)"}))
-
-(defn- entity-datoms=>a->add?->v->t
-  [entity-datoms]
-  (reduce
-   (fn [m datom]
-     (let [[_e a v t add?] datom]
-       (assoc-in m [a add? v] t)))
-   {} entity-datoms))
 
 (defmethod db-listener/listen-db-changes :gen-rtc-ops
   [_
@@ -151,5 +17,7 @@
              (:persist-op? tx-meta true))
     (let [e->a->add?->v->t (update-vals
                             id->same-entity-datoms
-                            entity-datoms=>a->add?->v->t)]
-      (generate-rtc-ops repo db-before db-after same-entity-datoms-coll e->a->add?->v->t))))
+                            gen-client-op/entity-datoms=>a->add?->v->t)
+          ops (gen-client-op/generate-rtc-ops db-before db-after same-entity-datoms-coll e->a->add?->v->t)]
+      (when (seq ops)
+        (client-op/add-ops repo ops)))))

--- a/src/main/frontend/worker/rtc/db_listener.cljs
+++ b/src/main/frontend/worker/rtc/db_listener.cljs
@@ -20,4 +20,4 @@
                             gen-client-op/entity-datoms=>a->add?->v->t)
           ops (gen-client-op/generate-rtc-ops db-before db-after same-entity-datoms-coll e->a->add?->v->t)]
       (when (seq ops)
-        (client-op/add-ops repo ops)))))
+        (client-op/add-ops! repo ops)))))

--- a/src/main/frontend/worker/rtc/gen_client_op.cljs
+++ b/src/main/frontend/worker/rtc/gen_client_op.cljs
@@ -134,12 +134,17 @@
             db-before db-after e->a->v->add?->t rtc-const/ignore-attrs-when-syncing)
    same-entity-datoms-coll))
 
-(defn generate-rtc-ops-from-property-entity
-  [property-entity]
-  (assert (ldb/property? property-entity))
-  (let [db (d/entity-db property-entity)
-        e (:db/id property-entity)
-        datoms (d/datoms db :eavt e)
-        id->same-entity-datoms {e datoms}
-        e->a->v->add?->t (update-vals id->same-entity-datoms entity-datoms=>a->add?->v->t)]
-    (generate-rtc-ops db db [datoms] e->a->v->add?->t)))
+(defn generate-rtc-ops-from-property-entities
+  [property-entities]
+  (when (seq property-entities)
+    (assert (every? ldb/property? property-entities))
+    (let [db (d/entity-db (first property-entities))
+          id->same-entity-datoms
+          (into {}
+                (map (fn [prop-ent]
+                       (let [e (:db/id prop-ent)
+                             datoms (d/datoms db :eavt e)]
+                         [e datoms])))
+                property-entities)
+          e->a->v->add?->t (update-vals id->same-entity-datoms entity-datoms=>a->add?->v->t)]
+      (generate-rtc-ops db db (vals id->same-entity-datoms) e->a->v->add?->t))))

--- a/src/main/frontend/worker/rtc/gen_client_op.cljs
+++ b/src/main/frontend/worker/rtc/gen_client_op.cljs
@@ -1,0 +1,145 @@
+(ns frontend.worker.rtc.gen-client-op
+  "Generate client-ops from entities/datoms"
+  (:require [clojure.string :as string]
+            [datascript.core :as d]
+            [frontend.worker.rtc.const :as rtc-const]
+            [logseq.db :as ldb]
+            [logseq.db.frontend.property :as db-property]))
+
+(defn- latest-add?->v->t
+  [add?->v->t]
+  (let [latest-add     (first (sort-by second > (seq (add?->v->t true))))
+        latest-retract (first (sort-by second > (seq (add?->v->t false))))]
+    (cond
+      (nil? latest-add)                               {false (conj {} latest-retract)}
+      (nil? latest-retract)                           {true (conj {} latest-add)}
+      (= (second latest-add) (second latest-retract)) {true (conj {} latest-add)
+                                                       false (conj {} latest-retract)}
+      (> (second latest-add) (second latest-retract)) {true (conj {} latest-add)}
+      :else                                           {false (conj {} latest-retract)})))
+
+(def ^:private watched-attrs
+  #{:block/title :block/created-at :block/updated-at :block/alias
+    :block/tags :block/link :block/journal-day
+    :logseq.property/classes :logseq.property/value
+    :db/index :db/valueType :db/cardinality})
+
+(def ^:private watched-attr-ns
+  (conj db-property/logseq-property-namespaces "logseq.class"))
+
+(defn- watched-attr?
+  [attr]
+  (or (contains? watched-attrs attr)
+      (let [ns (namespace attr)]
+        (or (contains? watched-attr-ns ns)
+            (string/ends-with? ns ".property")
+            (string/ends-with? ns ".class")))))
+
+(defn- ref-attr?
+  [db attr]
+  (= :db.type/ref (get-in (d/schema db) [attr :db/valueType])))
+
+(defn- update-op-av-coll
+  [db-before db-after a->add?->v->t]
+  (mapcat
+   (fn [[a add?->v->t]]
+     (mapcat
+      (fn [[add? v->t]]
+        (keep
+         (fn [[v t]]
+           (let [ref? (ref-attr? db-after a)]
+             (case [add? ref?]
+               [true true]
+               (when-let [v-uuid (:block/uuid (d/entity db-after v))]
+                 [a v-uuid t add?])
+               [false true]
+               (when-let [v-uuid (:block/uuid
+                                  (or (d/entity db-after v)
+                                      (d/entity db-before v)))]
+                 [a v-uuid t add?])
+               ([true false] [false false]) [a (ldb/write-transit-str v) t add?])))
+         v->t))
+      add?->v->t))
+   a->add?->v->t))
+
+(defn- redundant-update-op-av-coll?
+  [av-coll]
+  (every? (fn [av] (keyword-identical? :block/updated-at (first av))) av-coll))
+
+(defn- max-t
+  [a->add?->v->t]
+  (apply max (mapcat vals (mapcat vals (vals a->add?->v->t)))))
+
+(defn- get-first-vt
+  [add?->v->t k]
+  (some-> add?->v->t (get k) first))
+
+(defn- entity-datoms=>ops
+  [db-before db-after e->a->add?->v->t ignore-attr-set entity-datoms]
+  (let [e                        (ffirst entity-datoms)
+        entity                   (d/entity db-after e)
+        {block-uuid :block/uuid} entity
+        a->add?->v->t            (e->a->add?->v->t e)
+        {add?->block-name->t   :block/name
+         add?->block-title->t  :block/title
+         add?->block-uuid->t   :block/uuid
+         add?->block-parent->t :block/parent
+         add?->block-order->t  :block/order}
+        a->add?->v->t
+        [retract-block-uuid t1]  (some-> add?->block-uuid->t (get false) first)
+        [retract-block-name _]   (some-> add?->block-name->t (get false) first)
+        [add-block-name t2]      (some-> add?->block-name->t latest-add?->v->t (get-first-vt true))
+        [add-block-title t3]     (some-> add?->block-title->t latest-add?->v->t (get-first-vt true))
+        [add-block-parent t4]    (some-> add?->block-parent->t latest-add?->v->t (get-first-vt true))
+        [add-block-order t5]     (some-> add?->block-order->t latest-add?->v->t (get-first-vt true))
+        a->add?->v->t*           (into {}
+                                       (filter
+                                        (fn [[a _]]
+                                          (and (watched-attr? a)
+                                               (not (contains? ignore-attr-set a)))))
+                                       a->add?->v->t)]
+    (cond
+      (and retract-block-uuid retract-block-name)
+      [[:remove-page t1 {:block-uuid retract-block-uuid}]]
+
+      retract-block-uuid
+      [[:remove t1 {:block-uuid retract-block-uuid}]]
+
+      :else
+      (let [ops (cond-> []
+                  (or add-block-parent add-block-order)
+                  (conj [:move (or t4 t5) {:block-uuid block-uuid}])
+
+                  (or add-block-name
+                      (and (ldb/page? entity) add-block-title))
+                  (conj [:update-page (or t2 t3) {:block-uuid block-uuid}]))
+            update-op (when-let [av-coll (not-empty (update-op-av-coll db-before db-after a->add?->v->t*))]
+                        (when-not (redundant-update-op-av-coll? av-coll)
+                          (let [t (max-t a->add?->v->t*)]
+                            [:update t {:block-uuid block-uuid :av-coll av-coll}])))]
+        (cond-> ops update-op (conj update-op))))))
+
+(defn entity-datoms=>a->add?->v->t
+  [entity-datoms]
+  (reduce
+   (fn [m datom]
+     (let [[_e a v t add?] datom]
+       (assoc-in m [a add? v] t)))
+   {} entity-datoms))
+
+(defn generate-rtc-ops
+  [db-before db-after same-entity-datoms-coll e->a->v->add?->t]
+  (mapcat
+   (partial entity-datoms=>ops
+            db-before db-after e->a->v->add?->t rtc-const/ignore-attrs-when-syncing)
+   same-entity-datoms-coll))
+
+(defn generate-rtc-ops-from-property-entity
+  [property-entity]
+  (assert (ldb/property? property-entity))
+  (let [db (d/entity-db property-entity)
+        e (:db/id property-entity)
+        datoms (d/datoms db :eavt e)
+        id->same-entity-datoms {e datoms}
+        e->a->v->add?->t (update-vals id->same-entity-datoms entity-datoms=>a->add?->v->t)]
+    (generate-rtc-ops db db [datoms] e->a->v->add?->t)))

--- a/src/main/frontend/worker/rtc/gen_client_op.cljs
+++ b/src/main/frontend/worker/rtc/gen_client_op.cljs
@@ -134,17 +134,27 @@
             db-before db-after e->a->v->add?->t rtc-const/ignore-attrs-when-syncing)
    same-entity-datoms-coll))
 
+(defn- generate-rtc-ops-from-entities
+  [ents]
+  (let [db (d/entity-db (first ents))
+        id->same-entity-datoms
+        (into {}
+              (map (fn [ent]
+                     (let [e (:db/id ent)
+                           datoms (d/datoms db :eavt e)]
+                       [e datoms])))
+              ents)
+        e->a->v->add?->t (update-vals id->same-entity-datoms entity-datoms=>a->add?->v->t)]
+    (generate-rtc-ops db db (vals id->same-entity-datoms) e->a->v->add?->t)))
+
 (defn generate-rtc-ops-from-property-entities
-  [property-entities]
-  (when (seq property-entities)
-    (assert (every? ldb/property? property-entities))
-    (let [db (d/entity-db (first property-entities))
-          id->same-entity-datoms
-          (into {}
-                (map (fn [prop-ent]
-                       (let [e (:db/id prop-ent)
-                             datoms (d/datoms db :eavt e)]
-                         [e datoms])))
-                property-entities)
-          e->a->v->add?->t (update-vals id->same-entity-datoms entity-datoms=>a->add?->v->t)]
-      (generate-rtc-ops db db (vals id->same-entity-datoms) e->a->v->add?->t))))
+  [property-ents]
+  (when (seq property-ents)
+    (assert (every? ldb/property? property-ents))
+    (generate-rtc-ops-from-entities property-ents)))
+
+(defn generate-rtc-ops-from-class-entities
+  [class-ents]
+  (when (seq class-ents)
+    (assert (every? ldb/class? class-ents))
+    (generate-rtc-ops-from-entities class-ents)))

--- a/src/main/frontend/worker/rtc/malli_schema.cljs
+++ b/src/main/frontend/worker/rtc/malli_schema.cljs
@@ -361,4 +361,4 @@
 (def data-to-ws-coercer (m/coercer data-to-ws-schema mt/string-transformer nil
                                    #(do
                                       (log/error ::data-to-ws-schema %)
-                                      (m/-fail! ::data-to-ws-schema %))))
+                                      (m/-fail! ::data-to-ws-schema (select-keys % [:value])))))

--- a/src/main/frontend/worker/rtc/malli_schema.cljs
+++ b/src/main/frontend/worker/rtc/malli_schema.cljs
@@ -25,6 +25,11 @@
 
 (def to-ws-op-schema
   [:multi {:dispatch first :decode/string #(update % 0 keyword)}
+   [:update-kv-value
+    [:cat :keyword
+     [:map
+      [:db-ident :keyword]
+      [:value :string]]]]
    [:move
     [:cat :keyword
      [:map

--- a/src/main/frontend/worker/rtc/migrate.cljs
+++ b/src/main/frontend/worker/rtc/migrate.cljs
@@ -1,0 +1,29 @@
+(ns frontend.worker.rtc.migrate
+  "migrate server data according to schema-version and client's migration-updates"
+  (:require [logseq.db.frontend.schema :as db-schema]
+            [frontend.worker.db.migrate :as db-migrate]
+            [datascript.core :as d]))
+
+(defn- server-client-schema-verion->migrations
+  [server-schema-version client-schema-version]
+  (when (neg? (db-schema/compare-schema-version server-schema-version client-schema-version))
+    (let [sorted-schema-version->updates
+          (->> (map (fn [[schema-version updates]]
+                      [((juxt :major :minor) (db-schema/parse-schema-version schema-version))
+                       updates])
+                    db-migrate/schema-version->updates)
+               (sort-by first))]
+      (->> sorted-schema-version->updates
+           (drop-while (fn [[schema-version _updates]]
+                         (not (neg? (db-schema/compare-schema-version server-schema-version schema-version)))))
+           (take-while (fn [[schema-version _updates]]
+                         (not (neg? (db-schema/compare-schema-version client-schema-version schema-version)))))))))
+
+
+(defn- migration-update->client-ops
+  "TODO: support :classes in migration-updates"
+  [db migrate-update]
+  (let [new-property-entites (keep (fn [k] (d/entity db k)) (:properties migrate-update))]
+
+    )
+  )

--- a/src/main/frontend/worker/rtc/migrate.cljs
+++ b/src/main/frontend/worker/rtc/migrate.cljs
@@ -41,4 +41,4 @@
   (when-let [ops (not-empty
                   (some->> (server-client-schema-verion->migrations server-schema-version client-schema-version)
                            (migration-updates->client-ops db client-schema-version)))]
-    (client-op/add-ops repo ops)))
+    (client-op/add-ops! repo ops)))

--- a/src/main/frontend/worker/rtc/migrate.cljs
+++ b/src/main/frontend/worker/rtc/migrate.cljs
@@ -1,8 +1,10 @@
 (ns frontend.worker.rtc.migrate
   "migrate server data according to schema-version and client's migration-updates"
-  (:require [logseq.db.frontend.schema :as db-schema]
+  (:require [datascript.core :as d]
             [frontend.worker.db.migrate :as db-migrate]
-            [datascript.core :as d]))
+            [frontend.worker.rtc.client-op :as client-op]
+            [frontend.worker.rtc.gen-client-op :as gen-client-op]
+            [logseq.db.frontend.schema :as db-schema]))
 
 (defn- server-client-schema-verion->migrations
   [server-schema-version client-schema-version]
@@ -17,13 +19,26 @@
            (drop-while (fn [[schema-version _updates]]
                          (not (neg? (db-schema/compare-schema-version server-schema-version schema-version)))))
            (take-while (fn [[schema-version _updates]]
-                         (not (neg? (db-schema/compare-schema-version client-schema-version schema-version)))))))))
+                         (not (neg? (db-schema/compare-schema-version client-schema-version schema-version)))))
+           (map second)))))
 
-
-(defn- migration-update->client-ops
+(defn- migration-updates->client-ops
   "TODO: support :classes in migration-updates"
-  [db migrate-update]
-  (let [new-property-entites (keep (fn [k] (d/entity db k)) (:properties migrate-update))]
+  [db client-schema-version migrate-updates]
+  (let [property-ks (mapcat :properties migrate-updates)
+        new-property-entites (keep (fn [k] (d/entity db k)) property-ks)
+        client-ops (vec (gen-client-op/generate-rtc-ops-from-property-entities new-property-entites))
+        max-t (apply max (map second client-ops))]
+    (conj client-ops
+          [:update-kv-value
+           max-t
+           {:db-ident :logseq.kv/schema-version
+            :value client-schema-version}])))
 
-    )
-  )
+(defn add-migration-client-ops!
+  [repo db server-schema-version client-schema-version]
+  (assert (and server-schema-version client-schema-version))
+  (when-let [ops (not-empty
+                  (some->> (server-client-schema-verion->migrations server-schema-version client-schema-version)
+                           (migration-updates->client-ops db client-schema-version)))]
+    (client-op/add-ops repo ops)))

--- a/src/main/frontend/worker/rtc/migrate.cljs
+++ b/src/main/frontend/worker/rtc/migrate.cljs
@@ -28,7 +28,7 @@
   (let [property-ks (mapcat :properties migrate-updates)
         new-property-entites (keep (fn [k] (d/entity db k)) property-ks)
         client-ops (vec (gen-client-op/generate-rtc-ops-from-property-entities new-property-entites))
-        max-t (apply max (map second client-ops))]
+        max-t (apply max 0 (map second client-ops))]
     (conj client-ops
           [:update-kv-value
            max-t
@@ -41,4 +41,5 @@
   (when-let [ops (not-empty
                   (some->> (server-client-schema-verion->migrations server-schema-version client-schema-version)
                            (migration-updates->client-ops db client-schema-version)))]
-    (client-op/add-ops! repo ops)))
+    (client-op/add-ops! repo ops)
+    ops))

--- a/src/main/frontend/worker/rtc/migrate.cljs
+++ b/src/main/frontend/worker/rtc/migrate.cljs
@@ -6,7 +6,7 @@
             [frontend.worker.rtc.gen-client-op :as gen-client-op]
             [logseq.db.frontend.schema :as db-schema]))
 
-(defn- server-client-schema-verion->migrations
+(defn- server-client-schema-version->migrations
   [server-schema-version client-schema-version]
   (when (neg? (db-schema/compare-schema-version server-schema-version client-schema-version))
     (let [sorted-schema-version->updates
@@ -43,7 +43,7 @@
   [repo db server-schema-version client-schema-version]
   (assert (and server-schema-version client-schema-version))
   (when-let [ops (not-empty
-                  (some->> (server-client-schema-verion->migrations server-schema-version client-schema-version)
+                  (some->> (server-client-schema-version->migrations server-schema-version client-schema-version)
                            (migration-updates->client-ops db client-schema-version)))]
     (client-op/add-ops! repo ops)
     ops))

--- a/src/main/frontend/worker/rtc/remote_update.cljs
+++ b/src/main/frontend/worker/rtc/remote_update.cljs
@@ -317,10 +317,10 @@ so need to pull earlier remote-data from websocket."})
 
 (defn- affected-blocks->diff-type-ops
   [repo affected-blocks]
-  (let [unpushed-ops (client-op/get-all-block-ops repo)
-        affected-blocks-map* (if unpushed-ops
+  (let [unpushed-block-ops (client-op/get-all-block-ops repo)
+        affected-blocks-map* (if unpushed-block-ops
                                (update-remote-data-by-local-unpushed-ops
-                                affected-blocks unpushed-ops)
+                                affected-blocks unpushed-block-ops)
                                affected-blocks)
         {remove-ops-map :remove move-ops-map :move update-ops-map :update-attrs
          move+update-ops-map :move+update-attrs

--- a/src/main/frontend/worker/rtc/skeleton.cljs
+++ b/src/main/frontend/worker/rtc/skeleton.cljs
@@ -51,4 +51,5 @@
                                            (conj [:p (str :client-only-db-idents client-only)])
                                            (seq server-only)
                                            (conj [:p (str :server-only-db-idents server-only)]))
-                                         :error]))))))))
+                                         :error])))
+          r)))))

--- a/src/test/frontend/worker/rtc/client_test.cljs
+++ b/src/test/frontend/worker/rtc/client_test.cljs
@@ -40,7 +40,25 @@
   (testing "user.property/xxx creation"
     (let [block-uuid (random-uuid)
           block-order "b0P"
-          db (d/db-with empty-db [{:db/index true
+          db (d/db-with empty-db [{:block/uuid #uuid "00000002-5389-0208-3000-000000000000",
+                                   :block/updated-at 1741424828774,
+                                   :block/created-at 1741424828774,
+                                   :logseq.property/built-in? true,
+                                   :block/tags [2],
+                                   :block/title "Tag",
+                                   :db/id 2,
+                                   :db/ident :logseq.class/Tag,
+                                   :block/name "tag"}
+                                  {:block/uuid #uuid "00000002-1038-7670-4800-000000000000",
+                                   :block/updated-at 1741424828774,
+                                   :block/created-at 1741424828774,
+                                   :logseq.property/built-in? true,
+                                   :block/tags [2]
+                                   :block/title "Property",
+                                   :db/id 3,
+                                   :db/ident :logseq.class/Property,
+                                   :block/name "property"}
+                                  {:db/index true
                                    :block/uuid block-uuid
                                    :db/valueType :db.type/ref
                                    :block/updated-at 1716880036491
@@ -48,6 +66,7 @@
                                    :logseq.property/type :number
                                    :db/cardinality :db.cardinality/one
                                    :db/ident :user.property/xxx,
+                                   :block/tags [3]
                                    :block/type "property",
                                    :block/order block-order,
                                    :block/name "xxx",

--- a/src/test/frontend/worker/rtc/fixture.cljs
+++ b/src/test/frontend/worker/rtc/fixture.cljs
@@ -4,6 +4,7 @@
             [frontend.test.helper :as test-helper]
             [frontend.worker.db-listener :as worker-db-listener]
             [frontend.worker.rtc.client-op :as client-op]
+            [frontend.worker.rtc.db-listener]
             [frontend.worker.state :as worker-state]))
 
 (def listen-test-db-to-gen-rtc-ops-fixture

--- a/src/test/frontend/worker/rtc/gen_client_op_test.cljs
+++ b/src/test/frontend/worker/rtc/gen_client_op_test.cljs
@@ -161,4 +161,5 @@
   (let [repo (state/get-current-repo)
         db (conn/get-db repo true)
         ent (d/entity db :logseq.property.view/feature-type)]
-    (is (= #{:move :update-page :update} (set (map first (subject/generate-rtc-ops-from-property-entity ent)))))))
+    (is (= #{:move :update-page :update}
+           (set (map first (subject/generate-rtc-ops-from-property-entities [ent])))))))

--- a/src/test/frontend/worker/rtc/gen_client_op_test.cljs
+++ b/src/test/frontend/worker/rtc/gen_client_op_test.cljs
@@ -1,4 +1,4 @@
-(ns frontend.worker.rtc.db-listener-test
+(ns frontend.worker.rtc.gen-client-op-test
   (:require [cljs.test :as t :refer [deftest is testing]]
             [datascript.core :as d]
             [frontend.db.conn :as conn]
@@ -6,8 +6,8 @@
             [frontend.test.helper :as test-helper]
             [frontend.worker.handler.page :as worker-page]
             [frontend.worker.rtc.client-op :as client-op]
-            [frontend.worker.rtc.db-listener :as subject]
             [frontend.worker.rtc.fixture :as r.fixture]
+            [frontend.worker.rtc.gen-client-op :as subject]
             [frontend.worker.state :as worker-state]
             [logseq.db.test.helper :as db-test]
             [logseq.outliner.batch-tx :as batch-tx]
@@ -156,3 +156,9 @@
         (is (=
              {block-uuid1 #{:remove}}
              (ops-coll=>block-uuid->op-types (client-op/get&remove-all-block-ops repo))))))))
+
+(deftest generate-rtc-ops-from-property-entity-test
+  (let [repo (state/get-current-repo)
+        db (conn/get-db repo true)
+        ent (d/entity db :logseq.property.view/feature-type)]
+    (is (= #{:move :update-page :update} (set (map first (subject/generate-rtc-ops-from-property-entity ent)))))))


### PR DESCRIPTION
This PR compares the client-schema-version and server-schema-version, retrieves the migration-data diff from `frontend.worker.db.migrate/schema-version->updates`, and synchronizes them to the server.

Currently, it only supports adding :properties and :classes, while ignoring :fix.