### PR TITLE
refactor: remove defclass DBWorker

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -217,7 +217,8 @@
                         rum.core/defcs hooks.rum/defcs
                         clojure.string/join hooks.path-invalid-construct/string-join
                         clojure.string/replace hooks.regex-checks/double-escaped-regex
-                        logseq.common.defkeywords/defkeywords hooks.defkeywords/defkeywords}}
+                        logseq.common.defkeywords/defkeywords hooks.defkeywords/defkeywords
+                        frontend.common.thread-api/def-thread-api hooks.def-thread-api/def-thread-api}}
  :lint-as {promesa.core/let clojure.core/let
            promesa.core/loop clojure.core/loop
            promesa.core/recur clojure.core/recur
@@ -233,7 +234,8 @@
            frontend.test.helper/deftest-async clojure.test/deftest
            frontend.worker.rtc.idb-keyval-mock/with-reset-idb-keyval-mock cljs.test/async
            frontend.react/defc clojure.core/defn
-           logseq.common.defkeywords/defkeyword cljs.spec.alpha/def}
+           logseq.common.defkeywords/defkeyword cljs.spec.alpha/def
+           frontend.common.thread-api/defkeyword cljs.spec.alpha/def}
  :skip-comments true
  :output {:progress true
           :exclude-files ["src/test/docs-0.10.9/"]}}

--- a/.clj-kondo/hooks/def_thread_api.clj
+++ b/.clj-kondo/hooks/def_thread_api.clj
@@ -1,0 +1,13 @@
+(ns hooks.def-thread-api
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn def-thread-api
+  [{:keys [node]}]
+  (let [[_ kw & others] (:children node)
+        new-node (api/list-node
+                  [(api/token-node 'do)
+                   (api/list-node [(api/token-node 'frontend.common.thread-api/defkeyword) kw])
+                   (api/list-node
+                    (cons (api/token-node 'fn) others))])
+        new-node* (with-meta new-node (meta node))]
+    {:node new-node*}))

--- a/deps/db/src/logseq/db/sqlite/util.cljs
+++ b/deps/db/src/logseq/db/sqlite/util.cljs
@@ -6,7 +6,6 @@
             [datascript.core]
             [datascript.impl.entity :as de]
             [datascript.transit :as dt]
-            [lambdaisland.glogi :as log]
             [logseq.common.util :as common-util]
             [logseq.common.uuid :as common-uuid]
             [logseq.db.common.order :as db-order]
@@ -54,7 +53,7 @@
     (fn read-transit-str* [s]
       (if (and (string? s) (identical? "[" (first s)))
         (transit/read reader s)
-        (do (log/error :invalid-transit-string s)
+        (do (prn :invalid-transit-string s)
             s)))))
 
 (defn db-based-graph?

--- a/deps/db/src/logseq/db/sqlite/util.cljs
+++ b/deps/db/src/logseq/db/sqlite/util.cljs
@@ -6,6 +6,7 @@
             [datascript.core]
             [datascript.impl.entity :as de]
             [datascript.transit :as dt]
+            [lambdaisland.glogi :as log]
             [logseq.common.util :as common-util]
             [logseq.common.uuid :as common-uuid]
             [logseq.db.common.order :as db-order]
@@ -50,7 +51,11 @@
                                    "datascript/Entity" identity)
                             (merge read-handlers))
         reader (transit/reader :json {:handlers read-handlers*})]
-    (fn read-transit-str* [s] (transit/read reader s))))
+    (fn read-transit-str* [s]
+      (if (and (string? s) (identical? "[" (first s)))
+        (transit/read reader s)
+        (do (log/error :invalid-transit-string s)
+            s)))))
 
 (defn db-based-graph?
   [graph-name]

--- a/deps/db/src/logseq/db/sqlite/util.cljs
+++ b/deps/db/src/logseq/db/sqlite/util.cljs
@@ -51,6 +51,8 @@
                             (merge read-handlers))
         reader (transit/reader :json {:handlers read-handlers*})]
     (fn read-transit-str* [s]
+      ;; TODO: delete the following pred later
+      ;; https://github.com/logseq/logseq/pull/11790#discussion_r2014120469
       (if (and (string? s) (identical? "[" (first s)))
         (transit/read reader s)
         (do (prn :invalid-transit-string s)

--- a/src/main/frontend/common/thread_api.cljc
+++ b/src/main/frontend/common/thread_api.cljc
@@ -12,9 +12,9 @@
 
 (defmacro def-thread-api
   "Define a api invokeable by other threads.
-e.g. (def-thread-api :rtc/a-api [arg1 arg2] body)"
+e.g. (def-thread-api :thread-api/a-api [arg1 arg2] body)"
   [qualified-keyword-name params & body]
-  (assert (qualified-keyword? qualified-keyword-name) qualified-keyword-name)
+  (assert (= "thread-api" (namespace qualified-keyword-name)) qualified-keyword-name)
   (assert (vector? params) params)
   `(vswap! *thread-apis assoc
            ~qualified-keyword-name

--- a/src/main/frontend/common/thread_api.cljc
+++ b/src/main/frontend/common/thread_api.cljc
@@ -1,0 +1,19 @@
+(ns frontend.common.thread-api
+  "Macro for defining thread apis, which is invokeable by other threads"
+  #?(:cljs (:require-macros [frontend.common.thread-api])))
+
+#?(:cljs
+   (def *thread-apis (volatile! {})))
+
+#_:clj-kondo/ignore
+(defmacro defkeyword [& _args])
+
+(defmacro def-thread-api
+  "Define a api invokeable by other threads.
+e.g. (def-thread-api :rtc/a-api [arg1 arg2] body)"
+  [qualified-keyword-name params & body]
+  (assert (qualified-keyword? qualified-keyword-name) qualified-keyword-name)
+  (assert (vector? params) params)
+  `(vswap! *thread-apis assoc
+           ~qualified-keyword-name
+           (fn ~params ~@body)))

--- a/src/main/frontend/components/all_pages.cljs
+++ b/src/main/frontend/components/all_pages.cljs
@@ -10,7 +10,6 @@
             [frontend.hooks :as hooks]
             [frontend.state :as state]
             [logseq.common.config :as common-config]
-            [logseq.db :as ldb]
             [logseq.shui.ui :as shui]
             [promesa.core :as p]
             [rum.core :as rum]))

--- a/src/main/frontend/components/all_pages.cljs
+++ b/src/main/frontend/components/all_pages.cljs
@@ -51,8 +51,7 @@
     (hooks/use-effect!
      (fn []
        (when-let [worker @state/*db-worker]
-         (p/let [result-str (worker :general/get-page-refs-count (state/get-current-repo))
-                 result (ldb/read-transit-str result-str)
+         (p/let [result (worker :general/get-page-refs-count (state/get-current-repo))
                  data (get-all-pages)
                  data (map (fn [row] (assoc row :block.temp/refs-count (get result (:db/id row) 0))) data)]
            (set-data! data))))

--- a/src/main/frontend/components/all_pages.cljs
+++ b/src/main/frontend/components/all_pages.cljs
@@ -50,8 +50,8 @@
                                        :with-id? false})]
     (hooks/use-effect!
      (fn []
-       (when-let [^js worker @state/*db-worker]
-         (p/let [result-str (.get-page-refs-count worker (state/get-current-repo))
+       (when-let [worker @state/*db-worker]
+         (p/let [result-str (worker :general/get-page-refs-count (state/get-current-repo))
                  result (ldb/read-transit-str result-str)
                  data (get-all-pages)
                  data (map (fn [row] (assoc row :block.temp/refs-count (get result (:db/id row) 0))) data)]

--- a/src/main/frontend/components/all_pages.cljs
+++ b/src/main/frontend/components/all_pages.cljs
@@ -50,7 +50,7 @@
     (hooks/use-effect!
      (fn []
        (when-let [worker @state/*db-worker]
-         (p/let [result (worker :general/get-page-refs-count (state/get-current-repo))
+         (p/let [result (worker :thread-api/get-page-refs-count (state/get-current-repo))
                  data (get-all-pages)
                  data (map (fn [row] (assoc row :block.temp/refs-count (get result (:db/id row) 0))) data)]
            (set-data! data))))

--- a/src/main/frontend/components/all_pages.cljs
+++ b/src/main/frontend/components/all_pages.cljs
@@ -49,11 +49,10 @@
                                        :with-id? false})]
     (hooks/use-effect!
      (fn []
-       (when-let [worker @state/*db-worker]
-         (p/let [result (worker :thread-api/get-page-refs-count (state/get-current-repo))
-                 data (get-all-pages)
-                 data (map (fn [row] (assoc row :block.temp/refs-count (get result (:db/id row) 0))) data)]
-           (set-data! data))))
+       (p/let [result (state/<invoke-db-worker :thread-api/get-page-refs-count (state/get-current-repo))
+               data (get-all-pages)
+               data (map (fn [row] (assoc row :block.temp/refs-count (get result (:db/id row) 0))) data)]
+         (set-data! data)))
      [])
     [:div.ls-all-pages.w-full.mx-auto
      (views/view {:data data

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -357,8 +357,7 @@
                   (let [worker @db-browser/*worker
                         token (state/get-auth-id-token)
                         graph-uuid (ldb/get-graph-rtc-uuid (db/get-db))]
-                    (p/let [result (worker :rtc/get-block-content-versions token graph-uuid (str block-id))
-                            blocks-versions (ldb/read-transit-str result)]
+                    (p/let [blocks-versions (worker :rtc/get-block-content-versions token graph-uuid (str block-id))]
                       (prn :Dev-show-block-content-history)
                       (doseq [[block-uuid versions] blocks-versions]
                         (prn :block-uuid block-uuid)

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -357,7 +357,7 @@
                   (let [worker @db-browser/*worker
                         token (state/get-auth-id-token)
                         graph-uuid (ldb/get-graph-rtc-uuid (db/get-db))]
-                    (p/let [blocks-versions (worker :rtc/get-block-content-versions token graph-uuid (str block-id))]
+                    (p/let [blocks-versions (worker :rtc/get-block-content-versions token graph-uuid block-id)]
                       (prn :Dev-show-block-content-history)
                       (doseq [[block-uuid versions] blocks-versions]
                         (prn :block-uuid block-uuid)

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -354,10 +354,10 @@
                {:key "(Dev) Show block content history"
                 :on-click
                 (fn []
-                  (let [^object worker @db-browser/*worker
+                  (let [worker @db-browser/*worker
                         token (state/get-auth-id-token)
                         graph-uuid (ldb/get-graph-rtc-uuid (db/get-db))]
-                    (p/let [result (.rtc-get-block-content-versions worker token graph-uuid (str block-id))
+                    (p/let [result (worker :rtc/get-block-content-versions token graph-uuid (str block-id))
                             blocks-versions (ldb/read-transit-str result)]
                       (prn :Dev-show-block-content-history)
                       (doseq [[block-uuid versions] blocks-versions]

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -357,7 +357,7 @@
                   (let [worker @db-browser/*worker
                         token (state/get-auth-id-token)
                         graph-uuid (ldb/get-graph-rtc-uuid (db/get-db))]
-                    (p/let [blocks-versions (worker :rtc/get-block-content-versions token graph-uuid block-id)]
+                    (p/let [blocks-versions (worker :thread-api/rtc-get-block-content-versions token graph-uuid block-id)]
                       (prn :Dev-show-block-content-history)
                       (doseq [[block-uuid versions] blocks-versions]
                         (prn :block-uuid block-uuid)

--- a/src/main/frontend/components/content.cljs
+++ b/src/main/frontend/components/content.cljs
@@ -19,7 +19,6 @@
             [frontend.handler.property :as property-handler]
             [frontend.handler.property.util :as pu]
             [frontend.modules.shortcut.core :as shortcut]
-            [frontend.persist-db.browser :as db-browser]
             [frontend.state :as state]
             [frontend.ui :as ui]
             [frontend.util :as util]
@@ -354,10 +353,9 @@
                {:key "(Dev) Show block content history"
                 :on-click
                 (fn []
-                  (let [worker @db-browser/*worker
-                        token (state/get-auth-id-token)
+                  (let [token (state/get-auth-id-token)
                         graph-uuid (ldb/get-graph-rtc-uuid (db/get-db))]
-                    (p/let [blocks-versions (worker :thread-api/rtc-get-block-content-versions token graph-uuid block-id)]
+                    (p/let [blocks-versions (state/<invoke-db-worker :thread-api/rtc-get-block-content-versions token graph-uuid block-id)]
                       (prn :Dev-show-block-content-history)
                       (doseq [[block-uuid versions] blocks-versions]
                         (prn :block-uuid block-uuid)

--- a/src/main/frontend/components/imports.cljs
+++ b/src/main/frontend/components/imports.cljs
@@ -383,7 +383,7 @@
                                   (let [tx-reports
                                         (gp-exporter/add-file-to-db-graph conn (:file/path m) (:file/content m) opts)]
                                     (doseq [tx-report tx-reports]
-                                      (db-browser/transact! @db-browser/*worker repo (:tx-data tx-report) (:tx-meta tx-report)))))}
+                                      (db-browser/transact! @state/*db-worker repo (:tx-data tx-report) (:tx-meta tx-report)))))}
           {:keys [files import-state]} (gp-exporter/export-file-graph repo db-conn config-file *files options)]
     (log/info :import-file-graph {:msg (str "Import finished in " (/ (t/in-millis (t/interval start-time (t/now))) 1000) " seconds")})
     (state/set-state! :graph/importing nil)

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -117,7 +117,7 @@
     (let [[hover set-hover!] (rum/use-state false)
           click-handler-fn (fn []
                              (p/let [result (editor-handler/insert-first-page-block-if-not-exists! (:block/uuid page))
-                                     result (when (string? result) (:tx-data (ldb/read-transit-str result)))
+                                     result (:tx-data result)
                                      first-child-id (first (map :block/uuid result))
                                      first-child (when first-child-id (db/entity [:block/uuid first-child-id]))]
                                (when first-child

--- a/src/main/frontend/db/async.cljs
+++ b/src/main/frontend/db/async.cljs
@@ -151,9 +151,8 @@
         (swap! *async-queries assoc [name' opts] true)
         (state/update-state! :db/async-query-loading (fn [s] (conj s name')))
         (p/let [{:keys [properties block children] :as result'}
-                (worker :general/get-block-and-children graph id (ldb/write-transit-str
-                                                                  {:children? children?
-                                                                   :nested-children? nested-children?}))
+                (worker :general/get-block-and-children graph id {:children? children?
+                                                                  :nested-children? nested-children?})
                 conn (db/get-db graph false)
                 block-and-children (concat properties [block] children)
                 _ (d/transact! conn block-and-children)
@@ -183,10 +182,9 @@
     (when-let [^Object worker @db-browser/*worker]
       (p/let [result (worker :general/get-block-and-children
                              (state/get-current-repo)
-                             (str (:block/uuid page))
-                             (ldb/write-transit-str
-                              {:children? true
-                               :nested-children? false}))]
+                             (:block/uuid page)
+                             {:children? true
+                              :nested-children? false})]
         (:children result)))))
 
 (defn <get-block-refs

--- a/src/main/frontend/db/async.cljs
+++ b/src/main/frontend/db/async.cljs
@@ -151,7 +151,7 @@
         (swap! *async-queries assoc [name' opts] true)
         (state/update-state! :db/async-query-loading (fn [s] (conj s name')))
         (p/let [{:keys [properties block children] :as result'}
-                (worker :general/get-block-and-children graph id {:children? children?
+                (worker :thread-api/get-block-and-children graph id {:children? children?
                                                                   :nested-children? nested-children?})
                 conn (db/get-db graph false)
                 block-and-children (concat properties [block] children)
@@ -170,7 +170,7 @@
   (when-let [worker @db-browser/*worker]
     (when-let [block-id (:block/uuid (db/entity graph id))]
       (state/update-state! :db/async-query-loading (fn [s] (conj s (str block-id "-parents"))))
-      (p/let [result (worker :general/get-block-parents graph id depth)
+      (p/let [result (worker :thread-api/get-block-parents graph id depth)
               conn (db/get-db graph false)
               _ (d/transact! conn result)]
         (state/update-state! :db/async-query-loading (fn [s] (disj s (str block-id "-parents"))))
@@ -180,7 +180,7 @@
   [page-name]
   (when-let [page (some-> page-name (db-model/get-page))]
     (when-let [^Object worker @db-browser/*worker]
-      (p/let [result (worker :general/get-block-and-children
+      (p/let [result (worker :thread-api/get-block-and-children
                              (state/get-current-repo)
                              (:block/uuid page)
                              {:children? true
@@ -192,7 +192,7 @@
   (assert (integer? eid))
   (when-let [worker @db-browser/*worker]
     (state/update-state! :db/async-query-loading (fn [s] (conj s (str eid "-refs"))))
-    (p/let [result (worker :general/get-block-refs graph eid)
+    (p/let [result (worker :thread-api/get-block-refs graph eid)
             conn (db/get-db graph false)
             _ (d/transact! conn result)]
       (state/update-state! :db/async-query-loading (fn [s] (disj s (str eid "-refs"))))
@@ -202,7 +202,7 @@
   [graph eid]
   (assert (integer? eid))
   (when-let [worker @db-browser/*worker]
-    (worker :general/get-block-refs-count graph eid)))
+    (worker :thread-api/get-block-refs-count graph eid)))
 
 (defn <get-all-referenced-blocks-uuid
   "Get all uuids of blocks with any back link exists."

--- a/src/main/frontend/db/async/util.cljs
+++ b/src/main/frontend/db/async/util.cljs
@@ -3,7 +3,6 @@
   (:require [datascript.core :as d]
             [frontend.db.conn :as db-conn]
             [frontend.state :as state]
-            [logseq.db :as ldb]
             [promesa.core :as p]))
 
 (defn <q
@@ -17,7 +16,7 @@
       (if async-requested?
         (let [db (db-conn/get-db graph)]
           (apply d/q (first inputs) db (rest inputs)))
-        (p/let [result (worker :general/q graph (ldb/write-transit-str inputs))]
+        (p/let [result (worker :general/q graph inputs)]
           (swap! *async-queries assoc [inputs opts] true)
           (when result
             (when (and transact-db? (seq result) (coll? result))
@@ -42,7 +41,7 @@
    (<pull graph '[*] id))
   ([graph selector id]
    (when-let [worker @state/*db-worker]
-     (p/let [result' (worker :general/pull graph (ldb/write-transit-str selector) (ldb/write-transit-str id))]
+     (p/let [result' (worker :general/pull graph selector id)]
        (when result'
          (when-let [conn (db-conn/get-db graph false)]
            (d/transact! conn [result']))

--- a/src/main/frontend/db/async/util.cljs
+++ b/src/main/frontend/db/async/util.cljs
@@ -16,7 +16,7 @@
       (if async-requested?
         (let [db (db-conn/get-db graph)]
           (apply d/q (first inputs) db (rest inputs)))
-        (p/let [result (worker :general/q graph inputs)]
+        (p/let [result (worker :thread-api/q graph inputs)]
           (swap! *async-queries assoc [inputs opts] true)
           (when result
             (when (and transact-db? (seq result) (coll? result))
@@ -41,7 +41,7 @@
    (<pull graph '[*] id))
   ([graph selector id]
    (when-let [worker @state/*db-worker]
-     (p/let [result' (worker :general/pull graph selector id)]
+     (p/let [result' (worker :thread-api/pull graph selector id)]
        (when result'
          (when-let [conn (db-conn/get-db graph false)]
            (d/transact! conn [result']))

--- a/src/main/frontend/db/async/util.cljs
+++ b/src/main/frontend/db/async/util.cljs
@@ -10,39 +10,37 @@
           :or {transact-db? true}
           :as opts} & inputs]
   (assert (not-any? fn? inputs) "Async query inputs can't include fns because fn can't be serialized")
-  (when-let [worker @state/*db-worker]
-    (let [*async-queries (:db/async-queries @state/state)
-          async-requested? (get @*async-queries [inputs opts])]
-      (if async-requested?
-        (let [db (db-conn/get-db graph)]
-          (apply d/q (first inputs) db (rest inputs)))
-        (p/let [result (worker :thread-api/q graph inputs)]
-          (swap! *async-queries assoc [inputs opts] true)
-          (when result
-            (when (and transact-db? (seq result) (coll? result))
-              (when-let [conn (db-conn/get-db graph false)]
-                (let [tx-data (->>
-                               (if (and (coll? (first result))
-                                        (not (map? (first result))))
-                                 (apply concat result)
-                                 result)
-                               (remove nil?))]
-                  (if (every? map? tx-data)
-                    (try
-                      (d/transact! conn tx-data)
-                      (catch :default e
-                        (js/console.error "<q failed with:" e)
-                        nil))
-                    (js/console.log "<q skipped tx for inputs:" inputs)))))
-            result))))))
+  (let [*async-queries (:db/async-queries @state/state)
+        async-requested? (get @*async-queries [inputs opts])]
+    (if async-requested?
+      (let [db (db-conn/get-db graph)]
+        (apply d/q (first inputs) db (rest inputs)))
+      (p/let [result (state/<invoke-db-worker :thread-api/q graph inputs)]
+        (swap! *async-queries assoc [inputs opts] true)
+        (when result
+          (when (and transact-db? (seq result) (coll? result))
+            (when-let [conn (db-conn/get-db graph false)]
+              (let [tx-data (->>
+                             (if (and (coll? (first result))
+                                      (not (map? (first result))))
+                               (apply concat result)
+                               result)
+                             (remove nil?))]
+                (if (every? map? tx-data)
+                  (try
+                    (d/transact! conn tx-data)
+                    (catch :default e
+                      (js/console.error "<q failed with:" e)
+                      nil))
+                  (js/console.log "<q skipped tx for inputs:" inputs)))))
+          result)))))
 
 (defn <pull
   ([graph id]
    (<pull graph '[*] id))
   ([graph selector id]
-   (when-let [worker @state/*db-worker]
-     (p/let [result' (worker :thread-api/pull graph selector id)]
-       (when result'
-         (when-let [conn (db-conn/get-db graph false)]
-           (d/transact! conn [result']))
-         result')))))
+   (p/let [result' (state/<invoke-db-worker :thread-api/pull graph selector id)]
+     (when result'
+       (when-let [conn (db-conn/get-db graph false)]
+         (d/transact! conn [result']))
+       result'))))

--- a/src/main/frontend/db/restore.cljs
+++ b/src/main/frontend/db/restore.cljs
@@ -1,7 +1,6 @@
 (ns frontend.db.restore
   "Fns for DB restore(from text or sqlite)"
   (:require [cljs-time.core :as t]
-            [datascript.transit :as dt]
             [frontend.db.conn :as db-conn]
             [frontend.persist-db :as persist-db]
             [frontend.state :as state]
@@ -13,9 +12,8 @@
   [repo & {:as opts}]
   (state/set-state! :graph/loading? true)
   (p/let [start-time (t/now)
-          data (persist-db/<fetch-init-data repo opts)
+          {:keys [schema initial-data] :as data} (persist-db/<fetch-init-data repo opts)
           _ (assert (some? data) "No data found when reloading db")
-          {:keys [schema initial-data]} (dt/read-transit-str data)
           conn (try
                  (sqlite-common-db/restore-initial-data initial-data schema)
                  (catch :default e

--- a/src/main/frontend/db/rtc/debug_ui.cljs
+++ b/src/main/frontend/db/rtc/debug_ui.cljs
@@ -61,8 +61,7 @@
        {:size :sm
         :on-click (fn [_]
                     (let [worker @db-browser/*worker]
-                      (p/let [result (worker :rtc/get-debug-state)
-                              new-state (ldb/read-transit-str result)]
+                      (p/let [new-state (worker :rtc/get-debug-state)]
                         (swap! debug-state (fn [old] (merge old new-state))))))}
        (shui/tabler-icon "refresh") "state")
 
@@ -72,8 +71,7 @@
         (fn [_]
           (let [token (state/get-auth-id-token)
                 worker @db-browser/*worker]
-            (p/let [result (worker :rtc/get-graphs token)
-                    graph-list (ldb/read-transit-str result)]
+            (p/let [graph-list (worker :rtc/get-graphs token)]
               (swap! debug-state assoc
                      :remote-graphs
                      (map
@@ -188,15 +186,14 @@
                                     (p/let [token (state/get-auth-id-token)
                                             download-info-uuid (worker :rtc/request-download-graph
                                                                        token graph-uuid graph-schema-version)
-                                            download-info-uuid (ldb/read-transit-str download-info-uuid)
-                                            result (worker :rtc/wait-download-graph-info-ready
-                                                           token download-info-uuid graph-uuid graph-schema-version 60000)
                                             {:keys [_download-info-uuid
                                                     download-info-s3-url
                                                     _download-info-tx-instant
                                                     _download-info-t
                                                     _download-info-created-at]
-                                             :as result} (ldb/read-transit-str result)]
+                                             :as result}
+                                            (worker :rtc/wait-download-graph-info-ready
+                                                    token download-info-uuid graph-uuid graph-schema-version 60000)]
                                       (when (not= result :timeout)
                                         (assert (some? download-info-s3-url) result)
                                         (worker :rtc/download-graph-from-s3
@@ -281,10 +278,8 @@
           {:size :sm
            :on-click (fn [_]
                        (let [worker @db-browser/*worker]
-                         (p/let [result1 (worker :rtc/get-graph-keys (state/get-current-repo))
-                                 graph-keys (ldb/read-transit-str result1)
-                                 result2 (some->> (state/get-auth-id-token) (worker :device/list-devices))
-                                 devices (ldb/read-transit-str result2)]
+                         (p/let [graph-keys (worker :rtc/get-graph-keys (state/get-current-repo))
+                                 devices (some->> (state/get-auth-id-token) (worker :device/list-devices))]
                            (swap! (get state ::keys-state) #(merge % graph-keys {:devices devices})))))}
           (shui/tabler-icon "refresh") "keys-state")]
         [:div.pb-4

--- a/src/main/frontend/db/rtc/debug_ui.cljs
+++ b/src/main/frontend/db/rtc/debug_ui.cljs
@@ -9,7 +9,6 @@
             [frontend.state :as state]
             [frontend.ui :as ui]
             [frontend.util :as util]
-            [logseq.db :as ldb]
             [logseq.db.frontend.schema :as db-schema]
             [logseq.shui.ui :as shui]
             [missionary.core :as m]
@@ -160,8 +159,8 @@
                                     (let [worker @db-browser/*worker]
                                       (worker :rtc/grant-graph-access
                                               token graph-uuid
-                                              (some-> user-uuid vector ldb/write-transit-str)
-                                              (some-> user-email vector ldb/write-transit-str))))))})
+                                              (some-> user-uuid vector)
+                                              (some-> user-email vector))))))})
 
         [:b "➡️"]
         [:input.form-input.my-2.py-1
@@ -330,7 +329,7 @@
                         (when-let [token (state/get-auth-id-token)]
                           (when-let [device-uuid (not-empty (:sync-private-key-device-uuid keys-state))]
                             (worker :rtc/sync-current-graph-encrypted-aes-key
-                                    token (ldb/write-transit-str [(parse-uuid device-uuid)]))))))}
+                                    token [(parse-uuid device-uuid)])))))}
          "Sync CurrentGraph EncryptedAesKey")
         [:input.form-input.my-2.py-1.w-32
          {:on-change (fn [e] (swap! *keys-state assoc :sync-private-key-device-uuid (util/evalue e)))

--- a/src/main/frontend/handler/common/developer.cljs
+++ b/src/main/frontend/handler/common/developer.cljs
@@ -91,7 +91,7 @@
 
 (defn ^:export validate-db []
   (when-let [worker @state/*db-worker]
-    (worker :general/validate-db (state/get-current-repo))))
+    (worker :thread-api/validate-db (state/get-current-repo))))
 
 (defn import-chosen-graph
   [repo]

--- a/src/main/frontend/handler/common/developer.cljs
+++ b/src/main/frontend/handler/common/developer.cljs
@@ -90,8 +90,8 @@
         (notification/show! "No page found" :warning)))))
 
 (defn ^:export validate-db []
-  (when-let [^Object worker @state/*db-worker]
-    (.validate-db worker (state/get-current-repo))))
+  (when-let [worker @state/*db-worker]
+    (worker :general/validate-db (state/get-current-repo))))
 
 (defn import-chosen-graph
   [repo]

--- a/src/main/frontend/handler/common/developer.cljs
+++ b/src/main/frontend/handler/common/developer.cljs
@@ -90,8 +90,7 @@
         (notification/show! "No page found" :warning)))))
 
 (defn ^:export validate-db []
-  (when-let [worker @state/*db-worker]
-    (worker :thread-api/validate-db (state/get-current-repo))))
+  (state/<invoke-db-worker :thread-api/validate-db (state/get-current-repo)))
 
 (defn import-chosen-graph
   [repo]

--- a/src/main/frontend/handler/common/page.cljs
+++ b/src/main/frontend/handler/common/page.cljs
@@ -68,10 +68,9 @@
                                 current-user-id
                                 (assoc :created-by current-user-id))
                               options)
-                   result (ui-outliner-tx/transact!
-                           {:outliner-op :create-page}
-                           (outliner-op/create-page! title' options'))
-                   [_page-name page-uuid] (ldb/read-transit-str result)
+                   [_page-name page-uuid] (ui-outliner-tx/transact!
+                                           {:outliner-op :create-page}
+                                           (outliner-op/create-page! title' options'))
                    page (db/get-page (or page-uuid title'))]
              (when redirect?
                (route-handler/redirect-to-page! page-uuid)
@@ -168,9 +167,8 @@
               (notification/show! "Journals enabled" :success)))
            (-> (p/let [res (ui-outliner-tx/transact!
                             {:outliner-op :delete-page}
-                            (outliner-op/delete-page! page-uuid))
-                       res' (ldb/read-transit-str res)]
-                 (if res'
+                            (outliner-op/delete-page! page-uuid))]
+                 (if res
                    (when ok-handler (ok-handler))
                    (when error-handler (error-handler))))
                (p/catch (fn [error]

--- a/src/main/frontend/handler/db_based/export.cljs
+++ b/src/main/frontend/handler/db_based/export.cljs
@@ -14,10 +14,10 @@
 (defn ^:export export-block-data []
   ;; Use editor state to locate most recent block
   (if-let [block-uuid (:block-id (first (state/get-editor-args)))]
-    (when-let [^Object worker @state/*db-worker]
-      (p/let [result* (.export-edn worker
-                                   (state/get-current-repo)
-                                   (ldb/write-transit-str {:export-type :block :block-id [:block/uuid block-uuid]}))
+    (when-let [worker @state/*db-worker]
+      (p/let [result* (worker :general/export-edn
+                              (state/get-current-repo)
+                              (ldb/write-transit-str {:export-type :block :block-id [:block/uuid block-uuid]}))
               result (ldb/read-transit-str result*)
               pull-data (with-out-str (pprint/pprint result))]
         (.writeText js/navigator.clipboard pull-data)
@@ -27,10 +27,10 @@
 
 (defn export-view-nodes-data [nodes]
   (let [block-uuids (mapv #(vector :block/uuid (:block/uuid %)) nodes)]
-    (when-let [^Object worker @state/*db-worker]
-      (p/let [result* (.export-edn worker
-                                   (state/get-current-repo)
-                                   (ldb/write-transit-str {:export-type :view-nodes :node-ids block-uuids}))
+    (when-let [worker @state/*db-worker]
+      (p/let [result* (worker :general/export-edn
+                              (state/get-current-repo)
+                              (ldb/write-transit-str {:export-type :view-nodes :node-ids block-uuids}))
               result (ldb/read-transit-str result*)
               pull-data (with-out-str (pprint/pprint result))]
         (.writeText js/navigator.clipboard pull-data)
@@ -39,8 +39,9 @@
 
 (defn ^:export export-page-data []
   (if-let [page-id (page-util/get-current-page-id)]
-    (when-let [^Object worker @state/*db-worker]
-      (p/let [result* (.export-edn worker (state/get-current-repo) (ldb/write-transit-str {:export-type :page :page-id page-id}))
+    (when-let [worker @state/*db-worker]
+      (p/let [result* (worker :general/export-edn
+                              (state/get-current-repo) (ldb/write-transit-str {:export-type :page :page-id page-id}))
               result (ldb/read-transit-str result*)
               pull-data (with-out-str (pprint/pprint result))]
         (.writeText js/navigator.clipboard pull-data)
@@ -49,8 +50,9 @@
     (notification/show! "No page found" :warning)))
 
 (defn ^:export export-graph-ontology-data []
-  (when-let [^Object worker @state/*db-worker]
-    (p/let [result* (.export-edn worker (state/get-current-repo) (ldb/write-transit-str {:export-type :graph-ontology}))
+  (when-let [worker @state/*db-worker]
+    (p/let [result* (worker :general/export-edn
+                            (state/get-current-repo) (ldb/write-transit-str {:export-type :graph-ontology}))
             result (ldb/read-transit-str result*)
             pull-data (with-out-str (pprint/pprint result))]
       (.writeText js/navigator.clipboard pull-data)
@@ -60,11 +62,11 @@
       (notification/show! "Copied graphs's ontology data!" :success))))
 
 (defn- export-graph-edn-data []
-  (when-let [^Object worker @state/*db-worker]
-    (p/let [result* (.export-edn worker
-                                 (state/get-current-repo)
-                                 (ldb/write-transit-str {:export-type :graph
-                                                         :graph-options {:include-timestamps? true}}))
+  (when-let [worker @state/*db-worker]
+    (p/let [result* (worker :general/export-edn
+                            (state/get-current-repo)
+                            (ldb/write-transit-str {:export-type :graph
+                                                    :graph-options {:include-timestamps? true}}))
             result (ldb/read-transit-str result*)
             pull-data (with-out-str (pprint/pprint result))]
       pull-data)))

--- a/src/main/frontend/handler/db_based/export.cljs
+++ b/src/main/frontend/handler/db_based/export.cljs
@@ -15,10 +15,9 @@
   ;; Use editor state to locate most recent block
   (if-let [block-uuid (:block-id (first (state/get-editor-args)))]
     (when-let [worker @state/*db-worker]
-      (p/let [result* (worker :general/export-edn
-                              (state/get-current-repo)
-                              (ldb/write-transit-str {:export-type :block :block-id [:block/uuid block-uuid]}))
-              result (ldb/read-transit-str result*)
+      (p/let [result (worker :general/export-edn
+                             (state/get-current-repo)
+                             (ldb/write-transit-str {:export-type :block :block-id [:block/uuid block-uuid]}))
               pull-data (with-out-str (pprint/pprint result))]
         (.writeText js/navigator.clipboard pull-data)
         (println pull-data)
@@ -28,10 +27,9 @@
 (defn export-view-nodes-data [nodes]
   (let [block-uuids (mapv #(vector :block/uuid (:block/uuid %)) nodes)]
     (when-let [worker @state/*db-worker]
-      (p/let [result* (worker :general/export-edn
-                              (state/get-current-repo)
-                              (ldb/write-transit-str {:export-type :view-nodes :node-ids block-uuids}))
-              result (ldb/read-transit-str result*)
+      (p/let [result (worker :general/export-edn
+                             (state/get-current-repo)
+                             (ldb/write-transit-str {:export-type :view-nodes :node-ids block-uuids}))
               pull-data (with-out-str (pprint/pprint result))]
         (.writeText js/navigator.clipboard pull-data)
         (println pull-data)
@@ -40,9 +38,8 @@
 (defn ^:export export-page-data []
   (if-let [page-id (page-util/get-current-page-id)]
     (when-let [worker @state/*db-worker]
-      (p/let [result* (worker :general/export-edn
-                              (state/get-current-repo) (ldb/write-transit-str {:export-type :page :page-id page-id}))
-              result (ldb/read-transit-str result*)
+      (p/let [result (worker :general/export-edn
+                             (state/get-current-repo) (ldb/write-transit-str {:export-type :page :page-id page-id}))
               pull-data (with-out-str (pprint/pprint result))]
         (.writeText js/navigator.clipboard pull-data)
         (println pull-data)
@@ -51,9 +48,8 @@
 
 (defn ^:export export-graph-ontology-data []
   (when-let [worker @state/*db-worker]
-    (p/let [result* (worker :general/export-edn
-                            (state/get-current-repo) (ldb/write-transit-str {:export-type :graph-ontology}))
-            result (ldb/read-transit-str result*)
+    (p/let [result (worker :general/export-edn
+                           (state/get-current-repo) (ldb/write-transit-str {:export-type :graph-ontology}))
             pull-data (with-out-str (pprint/pprint result))]
       (.writeText js/navigator.clipboard pull-data)
       (println pull-data)
@@ -63,11 +59,10 @@
 
 (defn- export-graph-edn-data []
   (when-let [worker @state/*db-worker]
-    (p/let [result* (worker :general/export-edn
-                            (state/get-current-repo)
-                            (ldb/write-transit-str {:export-type :graph
-                                                    :graph-options {:include-timestamps? true}}))
-            result (ldb/read-transit-str result*)
+    (p/let [result (worker :general/export-edn
+                           (state/get-current-repo)
+                           (ldb/write-transit-str {:export-type :graph
+                                                   :graph-options {:include-timestamps? true}}))
             pull-data (with-out-str (pprint/pprint result))]
       pull-data)))
 

--- a/src/main/frontend/handler/db_based/export.cljs
+++ b/src/main/frontend/handler/db_based/export.cljs
@@ -8,7 +8,6 @@
             [frontend.util :as util]
             [frontend.util.page :as page-util]
             [goog.dom :as gdom]
-            [logseq.db :as ldb]
             [promesa.core :as p]))
 
 (defn ^:export export-block-data []
@@ -17,7 +16,7 @@
     (when-let [worker @state/*db-worker]
       (p/let [result (worker :general/export-edn
                              (state/get-current-repo)
-                             (ldb/write-transit-str {:export-type :block :block-id [:block/uuid block-uuid]}))
+                             {:export-type :block :block-id [:block/uuid block-uuid]})
               pull-data (with-out-str (pprint/pprint result))]
         (.writeText js/navigator.clipboard pull-data)
         (println pull-data)
@@ -29,7 +28,7 @@
     (when-let [worker @state/*db-worker]
       (p/let [result (worker :general/export-edn
                              (state/get-current-repo)
-                             (ldb/write-transit-str {:export-type :view-nodes :node-ids block-uuids}))
+                             {:export-type :view-nodes :node-ids block-uuids})
               pull-data (with-out-str (pprint/pprint result))]
         (.writeText js/navigator.clipboard pull-data)
         (println pull-data)
@@ -39,7 +38,8 @@
   (if-let [page-id (page-util/get-current-page-id)]
     (when-let [worker @state/*db-worker]
       (p/let [result (worker :general/export-edn
-                             (state/get-current-repo) (ldb/write-transit-str {:export-type :page :page-id page-id}))
+                             (state/get-current-repo)
+                             {:export-type :page :page-id page-id})
               pull-data (with-out-str (pprint/pprint result))]
         (.writeText js/navigator.clipboard pull-data)
         (println pull-data)
@@ -49,7 +49,8 @@
 (defn ^:export export-graph-ontology-data []
   (when-let [worker @state/*db-worker]
     (p/let [result (worker :general/export-edn
-                           (state/get-current-repo) (ldb/write-transit-str {:export-type :graph-ontology}))
+                           (state/get-current-repo)
+                           {:export-type :graph-ontology})
             pull-data (with-out-str (pprint/pprint result))]
       (.writeText js/navigator.clipboard pull-data)
       (println pull-data)
@@ -61,8 +62,8 @@
   (when-let [worker @state/*db-worker]
     (p/let [result (worker :general/export-edn
                            (state/get-current-repo)
-                           (ldb/write-transit-str {:export-type :graph
-                                                   :graph-options {:include-timestamps? true}}))
+                           {:export-type :graph
+                            :graph-options {:include-timestamps? true}})
             pull-data (with-out-str (pprint/pprint result))]
       pull-data)))
 

--- a/src/main/frontend/handler/db_based/export.cljs
+++ b/src/main/frontend/handler/db_based/export.cljs
@@ -14,7 +14,7 @@
   ;; Use editor state to locate most recent block
   (if-let [block-uuid (:block-id (first (state/get-editor-args)))]
     (when-let [worker @state/*db-worker]
-      (p/let [result (worker :general/export-edn
+      (p/let [result (worker :thread-api/export-edn
                              (state/get-current-repo)
                              {:export-type :block :block-id [:block/uuid block-uuid]})
               pull-data (with-out-str (pprint/pprint result))]
@@ -26,7 +26,7 @@
 (defn export-view-nodes-data [nodes]
   (let [block-uuids (mapv #(vector :block/uuid (:block/uuid %)) nodes)]
     (when-let [worker @state/*db-worker]
-      (p/let [result (worker :general/export-edn
+      (p/let [result (worker :thread-api/export-edn
                              (state/get-current-repo)
                              {:export-type :view-nodes :node-ids block-uuids})
               pull-data (with-out-str (pprint/pprint result))]
@@ -37,7 +37,7 @@
 (defn ^:export export-page-data []
   (if-let [page-id (page-util/get-current-page-id)]
     (when-let [worker @state/*db-worker]
-      (p/let [result (worker :general/export-edn
+      (p/let [result (worker :thread-api/export-edn
                              (state/get-current-repo)
                              {:export-type :page :page-id page-id})
               pull-data (with-out-str (pprint/pprint result))]
@@ -48,7 +48,7 @@
 
 (defn ^:export export-graph-ontology-data []
   (when-let [worker @state/*db-worker]
-    (p/let [result (worker :general/export-edn
+    (p/let [result (worker :thread-api/export-edn
                            (state/get-current-repo)
                            {:export-type :graph-ontology})
             pull-data (with-out-str (pprint/pprint result))]
@@ -60,7 +60,7 @@
 
 (defn- export-graph-edn-data []
   (when-let [worker @state/*db-worker]
-    (p/let [result (worker :general/export-edn
+    (p/let [result (worker :thread-api/export-edn
                            (state/get-current-repo)
                            {:export-type :graph
                             :graph-options {:include-timestamps? true}})

--- a/src/main/frontend/handler/db_based/property.cljs
+++ b/src/main/frontend/handler/db_based/property.cljs
@@ -1,21 +1,16 @@
 (ns frontend.handler.db-based.property
   "db based property handler"
-  (:require [frontend.modules.outliner.ui :as ui-outliner-tx]
+  (:require [frontend.db :as db]
             [frontend.modules.outliner.op :as outliner-op]
-            [logseq.outliner.op]
+            [frontend.modules.outliner.ui :as ui-outliner-tx]
             [logseq.db.frontend.property :as db-property]
-            [frontend.db :as db]
-            #_:clj-kondo/ignore
-            [frontend.state :as state]
-            [promesa.core :as p]
-            [logseq.db :as ldb]))
+            [logseq.outliner.op]))
 
 (defn upsert-property!
   [property-id schema property-opts]
-  (p/let [result (ui-outliner-tx/transact!
-                  {:outliner-op :upsert-property}
-                  (outliner-op/upsert-property! property-id schema property-opts))]
-    (ldb/read-transit-str result)))
+  (ui-outliner-tx/transact!
+   {:outliner-op :upsert-property}
+   (outliner-op/upsert-property! property-id schema property-opts)))
 
 (defn set-block-property!
   [block-id property-id value]
@@ -40,37 +35,37 @@
   [block-id property-id property-value]
   (ui-outliner-tx/transact!
    {:outliner-op :delete-property-value}
-    (outliner-op/delete-property-value! block-id property-id property-value)))
+   (outliner-op/delete-property-value! block-id property-id property-value)))
 
 (defn create-property-text-block!
   [block-id property-id value opts]
   (ui-outliner-tx/transact!
    {:outliner-op :create-property-text-block}
-    (outliner-op/create-property-text-block! block-id property-id value opts)))
+   (outliner-op/create-property-text-block! block-id property-id value opts)))
 
 (defn batch-set-property!
   [block-ids property-id value]
   (ui-outliner-tx/transact!
    {:outliner-op :batch-set-property}
-    (outliner-op/batch-set-property! block-ids property-id value)))
+   (outliner-op/batch-set-property! block-ids property-id value)))
 
 (defn batch-remove-property!
   [block-ids property-id]
   (ui-outliner-tx/transact!
    {:outliner-op :batch-remove-property}
-    (outliner-op/batch-remove-property! block-ids property-id)))
+   (outliner-op/batch-remove-property! block-ids property-id)))
 
 (defn class-add-property!
   [class-id property-id]
   (ui-outliner-tx/transact!
    {:outliner-op :class-add-property}
-    (outliner-op/class-add-property! class-id property-id)))
+   (outliner-op/class-add-property! class-id property-id)))
 
 (defn class-remove-property!
   [class-id property-id]
   (ui-outliner-tx/transact!
    {:outliner-op :class-remove-property}
-    (outliner-op/class-remove-property! class-id property-id)))
+   (outliner-op/class-remove-property! class-id property-id)))
 
 (defn batch-set-property-closed-value!
   [block-ids db-ident closed-value]
@@ -91,10 +86,10 @@
   [property-id value]
   (ui-outliner-tx/transact!
    {:outliner-op :delete-closed-value}
-    (outliner-op/delete-closed-value! property-id value)))
+   (outliner-op/delete-closed-value! property-id value)))
 
 (defn add-existing-values-to-closed-values!
   [property-id values]
   (ui-outliner-tx/transact!
    {:outliner-op :add-existing-values-to-closed-values}
-    (outliner-op/add-existing-values-to-closed-values! property-id values)))
+   (outliner-op/add-existing-values-to-closed-values! property-id values)))

--- a/src/main/frontend/handler/db_based/rtc.cljs
+++ b/src/main/frontend/handler/db_based/rtc.cljs
@@ -158,7 +158,7 @@
     (when-let [worker @state/*db-worker]
       (p/let [token (state/get-auth-id-token)
               repo (state/get-current-repo)
-              result (worker :rtc/get-users-info token (str graph-uuid))]
+              result (worker :rtc/get-users-info token graph-uuid)]
         (state/set-state! :rtc/users-info {repo result})))))
 
 (defn <rtc-invite-email
@@ -168,9 +168,7 @@
       (->
        (p/do!
         (worker :rtc/grant-graph-access
-                token (str graph-uuid)
-                (ldb/write-transit-str [])
-                (ldb/write-transit-str [email]))
+                token (str graph-uuid) [] [email])
         (notification/show! "Invitation sent!" :success))
        (p/catch (fn [e]
                   (notification/show! "Something wrong, please try again." :error)

--- a/src/main/frontend/handler/db_based/rtc.cljs
+++ b/src/main/frontend/handler/db_based/rtc.cljs
@@ -16,32 +16,32 @@
 
 (defn <rtc-create-graph!
   [repo]
-  (when-let [^js worker @state/*db-worker]
+  (when-let [worker @state/*db-worker]
     (p/do!
      (js/Promise. user-handler/task--ensure-id&access-token)
      (let [token (state/get-auth-id-token)
            repo-name (sqlite-common-db/sanitize-db-name repo)]
-       (.rtc-async-upload-graph worker repo token repo-name)))))
+       (worker :rtc/async-upload-graph repo token repo-name)))))
 
 (defn <rtc-delete-graph!
   [graph-uuid schema-version]
-  (when-let [^js worker @state/*db-worker]
+  (when-let [worker @state/*db-worker]
     (p/do!
      (js/Promise. user-handler/task--ensure-id&access-token)
      (let [token (state/get-auth-id-token)]
-       (.rtc-delete-graph worker token graph-uuid schema-version)))))
+       (worker :rtc/delete-graph token graph-uuid schema-version)))))
 
 (defn <rtc-download-graph!
   [graph-name graph-uuid graph-schema-version timeout-ms]
   (assert (some? graph-schema-version))
-  (when-let [^js worker @state/*db-worker]
+  (when-let [worker @state/*db-worker]
     (state/set-state! :rtc/downloading-graph-uuid graph-uuid)
     (p/let [_ (js/Promise. user-handler/task--ensure-id&access-token)
             token (state/get-auth-id-token)
-            download-info-uuid* (.rtc-request-download-graph worker token graph-uuid graph-schema-version)
+            download-info-uuid* (worker :rtc/request-download-graph token graph-uuid graph-schema-version)
             download-info-uuid (ldb/read-transit-str download-info-uuid*)
-            result (.rtc-wait-download-graph-info-ready
-                    worker token download-info-uuid graph-uuid graph-schema-version timeout-ms)
+            result (worker :rtc/wait-download-graph-info-ready
+                           token download-info-uuid graph-uuid graph-schema-version timeout-ms)
             {:keys [_download-info-uuid
                     download-info-s3-url
                     _download-info-tx-instant
@@ -51,21 +51,21 @@
       (->
        (when (not= result :timeout)
          (assert (some? download-info-s3-url) result)
-         (.rtc-download-graph-from-s3 worker graph-uuid graph-name download-info-s3-url))
+         (worker :rtc/download-graph-from-s3 graph-uuid graph-name download-info-s3-url))
        (p/finally
          #(state/set-state! :rtc/downloading-graph-uuid nil))))))
 
 (defn <rtc-stop!
   []
-  (when-let [^js worker @state/*db-worker]
-    (.rtc-stop worker)))
+  (when-let [worker @state/*db-worker]
+    (worker :rtc/stop)))
 
 (defn <rtc-branch-graph!
   [repo]
-  (when-let [^js worker @state/*db-worker]
+  (when-let [worker @state/*db-worker]
     (p/let [_ (js/Promise. user-handler/task--ensure-id&access-token)
             token (state/get-auth-id-token)
-            result (.rtc-async-branch-graph worker repo token)
+            result (worker :rtc/async-branch-graph repo token)
             start-ex (ldb/read-transit-str result)]
       (when-let [ex-data* (:ex-data start-ex)]
         (throw (ex-info (:ex-message start-ex) ex-data*))))))
@@ -99,13 +99,13 @@
 
 (defn <rtc-start!
   [repo & {:keys [stop-before-start?] :or {stop-before-start? true}}]
-  (when-let [^js worker @state/*db-worker]
+  (when-let [worker @state/*db-worker]
     (when-let [graph-uuid (ldb/get-graph-rtc-uuid (db/get-db repo))]
       (p/do!
        (js/Promise. user-handler/task--ensure-id&access-token)
        (when stop-before-start? (<rtc-stop!))
        (let [token (state/get-auth-id-token)]
-         (p/let [result (.rtc-start worker repo token)
+         (p/let [result (worker :rtc/start repo token)
                  start-ex (ldb/read-transit-str result)
                  ex-data* (:ex-data start-ex)
                  _ (case (:type ex-data*)
@@ -138,10 +138,10 @@
 
 (defn <get-remote-graphs
   []
-  (when-let [^js worker @state/*db-worker]
+  (when-let [worker @state/*db-worker]
     (p/let [_ (js/Promise. user-handler/task--ensure-id&access-token)
             token (state/get-auth-id-token)
-            result (.rtc-get-graphs worker token)
+            result (worker :rtc/get-graphs token)
             graphs (ldb/read-transit-str result)
             result (->> graphs
                         (remove (fn [graph] (= (:graph-status graph) "deleting")))
@@ -159,10 +159,10 @@
 (defn <rtc-get-users-info
   []
   (when-let [graph-uuid (ldb/get-graph-rtc-uuid (db/get-db))]
-    (when-let [^js worker @state/*db-worker]
+    (when-let [worker @state/*db-worker]
       (p/let [token (state/get-auth-id-token)
               repo (state/get-current-repo)
-              result (.rtc-get-users-info worker token (str graph-uuid))
+              result (worker :rtc/get-users-info token (str graph-uuid))
               result (ldb/read-transit-str result)]
         (state/set-state! :rtc/users-info {repo result})))))
 
@@ -172,9 +172,10 @@
     (let [token (state/get-auth-id-token)]
       (->
        (p/do!
-        (.rtc-grant-graph-access worker token (str graph-uuid)
-                                 (ldb/write-transit-str [])
-                                 (ldb/write-transit-str [email]))
+        (worker :rtc/grant-graph-access
+                token (str graph-uuid)
+                (ldb/write-transit-str [])
+                (ldb/write-transit-str [email]))
         (notification/show! "Invitation sent!" :success))
        (p/catch (fn [e]
                   (notification/show! "Something wrong, please try again." :error)

--- a/src/main/frontend/handler/db_based/rtc.cljs
+++ b/src/main/frontend/handler/db_based/rtc.cljs
@@ -16,57 +16,53 @@
 
 (defn <rtc-create-graph!
   [repo]
-  (when-let [worker @state/*db-worker]
-    (p/do!
-     (js/Promise. user-handler/task--ensure-id&access-token)
-     (let [token (state/get-auth-id-token)
-           repo-name (sqlite-common-db/sanitize-db-name repo)]
-       (worker :thread-api/rtc-async-upload-graph repo token repo-name)))))
+  (p/do!
+   (js/Promise. user-handler/task--ensure-id&access-token)
+   (let [token (state/get-auth-id-token)
+         repo-name (sqlite-common-db/sanitize-db-name repo)]
+     (state/<invoke-db-worker :thread-api/rtc-async-upload-graph repo token repo-name))))
 
 (defn <rtc-delete-graph!
   [graph-uuid schema-version]
-  (when-let [worker @state/*db-worker]
-    (p/do!
-     (js/Promise. user-handler/task--ensure-id&access-token)
-     (let [token (state/get-auth-id-token)]
-       (worker :thread-api/rtc-delete-graph token graph-uuid schema-version)))))
+  (p/do!
+   (js/Promise. user-handler/task--ensure-id&access-token)
+   (let [token (state/get-auth-id-token)]
+     (state/<invoke-db-worker :thread-api/rtc-delete-graph token graph-uuid schema-version))))
 
 (defn <rtc-download-graph!
   [graph-name graph-uuid graph-schema-version timeout-ms]
   (assert (some? graph-schema-version))
-  (when-let [worker @state/*db-worker]
-    (state/set-state! :rtc/downloading-graph-uuid graph-uuid)
-    (p/let [_ (js/Promise. user-handler/task--ensure-id&access-token)
-            token (state/get-auth-id-token)
-            download-info-uuid (worker :thread-api/rtc-request-download-graph token graph-uuid graph-schema-version)
-            {:keys [_download-info-uuid
-                    download-info-s3-url
-                    _download-info-tx-instant
-                    _download-info-t
-                    _download-info-created-at]
-             :as result}
-            (worker :thread-api/rtc-wait-download-graph-info-ready
-                    token download-info-uuid graph-uuid graph-schema-version timeout-ms)]
-      (->
-       (when (not= result :timeout)
-         (assert (some? download-info-s3-url) result)
-         (worker :thread-api/rtc-download-graph-from-s3 graph-uuid graph-name download-info-s3-url))
-       (p/finally
-         #(state/set-state! :rtc/downloading-graph-uuid nil))))))
+  (state/set-state! :rtc/downloading-graph-uuid graph-uuid)
+  (p/let [_ (js/Promise. user-handler/task--ensure-id&access-token)
+          token (state/get-auth-id-token)
+          download-info-uuid (state/<invoke-db-worker
+                              :thread-api/rtc-request-download-graph token graph-uuid graph-schema-version)
+          {:keys [_download-info-uuid
+                  download-info-s3-url
+                  _download-info-tx-instant
+                  _download-info-t
+                  _download-info-created-at]
+           :as result}
+          (state/<invoke-db-worker :thread-api/rtc-wait-download-graph-info-ready
+                                   token download-info-uuid graph-uuid graph-schema-version timeout-ms)]
+    (->
+     (when (not= result :timeout)
+       (assert (some? download-info-s3-url) result)
+       (state/<invoke-db-worker :thread-api/rtc-download-graph-from-s3 graph-uuid graph-name download-info-s3-url))
+     (p/finally
+       #(state/set-state! :rtc/downloading-graph-uuid nil)))))
 
 (defn <rtc-stop!
   []
-  (when-let [worker @state/*db-worker]
-    (worker :thread-api/rtc-stop)))
+  (state/<invoke-db-worker :thread-api/rtc-stop))
 
 (defn <rtc-branch-graph!
   [repo]
-  (when-let [worker @state/*db-worker]
-    (p/let [_ (js/Promise. user-handler/task--ensure-id&access-token)
-            token (state/get-auth-id-token)
-            start-ex (worker :thread-api/rtc-async-branch-graph repo token)]
-      (when-let [ex-data* (:ex-data start-ex)]
-        (throw (ex-info (:ex-message start-ex) ex-data*))))))
+  (p/let [_ (js/Promise. user-handler/task--ensure-id&access-token)
+          token (state/get-auth-id-token)
+          start-ex (state/<invoke-db-worker :thread-api/rtc-async-branch-graph repo token)]
+    (when-let [ex-data* (:ex-data start-ex)]
+      (throw (ex-info (:ex-message start-ex) ex-data*)))))
 
 (defn notification-download-higher-schema-graph!
   [graph-name graph-uuid schema-version]
@@ -97,79 +93,75 @@
 
 (defn <rtc-start!
   [repo & {:keys [stop-before-start?] :or {stop-before-start? true}}]
-  (when-let [worker @state/*db-worker]
-    (when-let [graph-uuid (ldb/get-graph-rtc-uuid (db/get-db repo))]
-      (p/do!
-       (js/Promise. user-handler/task--ensure-id&access-token)
-       (when stop-before-start? (<rtc-stop!))
-       (let [token (state/get-auth-id-token)]
-         (p/let [start-ex (worker :thread-api/rtc-start repo token)
-                 ex-data* (:ex-data start-ex)
-                 _ (case (:type ex-data*)
-                     (:rtc.exception/not-rtc-graph
-                      :rtc.exception/not-found-db-conn)
-                     (notification/show! (:ex-message start-ex) :error)
+  (when-let [graph-uuid (ldb/get-graph-rtc-uuid (db/get-db repo))]
+    (p/do!
+     (js/Promise. user-handler/task--ensure-id&access-token)
+     (when stop-before-start? (<rtc-stop!))
+     (let [token (state/get-auth-id-token)]
+       (p/let [start-ex (state/<invoke-db-worker :thread-api/rtc-start repo token)
+               ex-data* (:ex-data start-ex)
+               _ (case (:type ex-data*)
+                   (:rtc.exception/not-rtc-graph
+                    :rtc.exception/not-found-db-conn)
+                   (notification/show! (:ex-message start-ex) :error)
 
-                     :rtc.exception/major-schema-version-mismatched
-                     (case (:sub-type ex-data*)
-                       :download
-                       (notification-download-higher-schema-graph! repo graph-uuid (:remote ex-data*))
-                       :create-branch
-                       (notification-upload-higher-schema-graph! repo)
+                   :rtc.exception/major-schema-version-mismatched
+                   (case (:sub-type ex-data*)
+                     :download
+                     (notification-download-higher-schema-graph! repo graph-uuid (:remote ex-data*))
+                     :create-branch
+                     (notification-upload-higher-schema-graph! repo)
                         ;; else
-                       (do (log/info :start-ex start-ex)
-                           (notification/show! [:div
-                                                [:div (:ex-message start-ex)]
-                                                [:div (-> ex-data*
-                                                          (select-keys [:app :local :remote])
-                                                          pp/pprint
-                                                          with-out-str)]]
-                                               :error)))
+                     (do (log/info :start-ex start-ex)
+                         (notification/show! [:div
+                                              [:div (:ex-message start-ex)]
+                                              [:div (-> ex-data*
+                                                        (select-keys [:app :local :remote])
+                                                        pp/pprint
+                                                        with-out-str)]]
+                                             :error)))
 
-                     :rtc.exception/lock-failed
-                     (js/setTimeout #(<rtc-start! repo) 1000)
+                   :rtc.exception/lock-failed
+                   (js/setTimeout #(<rtc-start! repo) 1000)
 
                       ;; else
-                     nil)]
-           nil))))))
+                   nil)]
+         nil)))))
 
 (defn <get-remote-graphs
   []
-  (when-let [worker @state/*db-worker]
-    (p/let [_ (js/Promise. user-handler/task--ensure-id&access-token)
-            token (state/get-auth-id-token)
-            graphs (worker :thread-api/rtc-get-graphs token)
-            result (->> graphs
-                        (remove (fn [graph] (= (:graph-status graph) "deleting")))
-                        (mapv (fn [graph]
-                                (merge
-                                 (let [url (str config/db-version-prefix (:graph-name graph))]
-                                   {:url url
-                                    :GraphName (:graph-name graph)
-                                    :GraphSchemaVersion (:graph-schema-version graph)
-                                    :GraphUUID (:graph-uuid graph)
-                                    :rtc-graph? true})
-                                 (dissoc graph :graph-uuid :graph-name)))))]
-      (state/set-state! :rtc/graphs result))))
+  (p/let [_ (js/Promise. user-handler/task--ensure-id&access-token)
+          token (state/get-auth-id-token)
+          graphs (state/<invoke-db-worker :thread-api/rtc-get-graphs token)
+          result (->> graphs
+                      (remove (fn [graph] (= (:graph-status graph) "deleting")))
+                      (mapv (fn [graph]
+                              (merge
+                               (let [url (str config/db-version-prefix (:graph-name graph))]
+                                 {:url url
+                                  :GraphName (:graph-name graph)
+                                  :GraphSchemaVersion (:graph-schema-version graph)
+                                  :GraphUUID (:graph-uuid graph)
+                                  :rtc-graph? true})
+                               (dissoc graph :graph-uuid :graph-name)))))]
+    (state/set-state! :rtc/graphs result)))
 
 (defn <rtc-get-users-info
   []
   (when-let [graph-uuid (ldb/get-graph-rtc-uuid (db/get-db))]
-    (when-let [worker @state/*db-worker]
-      (p/let [token (state/get-auth-id-token)
-              repo (state/get-current-repo)
-              result (worker :thread-api/rtc-get-users-info token graph-uuid)]
-        (state/set-state! :rtc/users-info {repo result})))))
+    (p/let [token (state/get-auth-id-token)
+            repo (state/get-current-repo)
+            result (state/<invoke-db-worker :thread-api/rtc-get-users-info token graph-uuid)]
+      (state/set-state! :rtc/users-info {repo result}))))
 
 (defn <rtc-invite-email
   [graph-uuid email]
-  (when-let [^js worker @state/*db-worker]
-    (let [token (state/get-auth-id-token)]
-      (->
-       (p/do!
-        (worker :thread-api/rtc-grant-graph-access
-                token (str graph-uuid) [] [email])
-        (notification/show! "Invitation sent!" :success))
-       (p/catch (fn [e]
-                  (notification/show! "Something wrong, please try again." :error)
-                  (js/console.error e)))))))
+  (let [token (state/get-auth-id-token)]
+    (->
+     (p/do!
+      (state/<invoke-db-worker :thread-api/rtc-grant-graph-access
+                               token (str graph-uuid) [] [email])
+      (notification/show! "Invitation sent!" :success))
+     (p/catch (fn [e]
+                (notification/show! "Something wrong, please try again." :error)
+                (js/console.error e))))))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2185,8 +2185,9 @@
                    (outliner-save-block! editing-block)))
               result (transact-blocks!)]
         (state/set-block-op-type! nil)
-        (when-let [result (some-> result (ldb/read-transit-str))]
-          (edit-last-block-after-inserted! result) result)))))
+        (when result
+          (edit-last-block-after-inserted! result)
+          result)))))
 
 (defn- block-tree->blocks
   "keep-uuid? - maintain the existing :uuid in tree vec"
@@ -2310,7 +2311,7 @@
                                                              (assoc opts
                                                                     :sibling? sibling?'
                                                                     :insert-template? true)))]
-                   (when result (edit-last-block-after-inserted! (ldb/read-transit-str result))))
+                   (when result (edit-last-block-after-inserted! result)))
 
                  (catch :default ^js/Error e
                    (notification/show!
@@ -3037,8 +3038,8 @@
         (keydown-backspace-handler false e)
 
         (and (= key "#")
-             (and (> pos 0)
-                  (= "#" (util/nth-safe value (dec pos)))))
+             (> pos 0)
+             (= "#" (util/nth-safe value (dec pos))))
         (state/clear-editor-action!)
 
         (and (contains? (set/difference (set (keys reversed-autopair-map))

--- a/src/main/frontend/handler/editor/lifecycle.cljs
+++ b/src/main/frontend/handler/editor/lifecycle.cljs
@@ -4,7 +4,6 @@
             [frontend.util :as util]
             [goog.dom :as gdom]
             [frontend.db :as db]
-            [logseq.db :as ldb]
             [dommy.core :as dom]
             ;; [clojure.string :as string]
             ;; [frontend.handler.block :as block-handler]
@@ -38,7 +37,7 @@
             page-id (:block/uuid (:block/page (db/entity (:db/id (state/get-edit-block)))))
             repo (state/get-current-repo)]
         (when page-id
-          (worker :undo-redo/record-editor-info repo (str page-id) (ldb/write-transit-str (state/get-editor-info))))))
+          (worker :undo-redo/record-editor-info repo (str page-id) (state/get-editor-info)))))
 
     (state/set-state! :editor/op nil))
   state)

--- a/src/main/frontend/handler/editor/lifecycle.cljs
+++ b/src/main/frontend/handler/editor/lifecycle.cljs
@@ -37,7 +37,7 @@
             page-id (:block/uuid (:block/page (db/entity (:db/id (state/get-edit-block)))))
             repo (state/get-current-repo)]
         (when page-id
-          (worker :undo-redo/record-editor-info repo (str page-id) (state/get-editor-info)))))
+          (worker :thread-api/record-editor-info repo (str page-id) (state/get-editor-info)))))
 
     (state/set-state! :editor/op nil))
   state)

--- a/src/main/frontend/handler/editor/lifecycle.cljs
+++ b/src/main/frontend/handler/editor/lifecycle.cljs
@@ -34,11 +34,11 @@
 
     ;; skip recording editor info when undo or redo is still running
     (when-not (contains? #{:undo :redo} @(:editor/op @state/state))
-      (let [^js worker @state/*db-worker
+      (let [worker @state/*db-worker
             page-id (:block/uuid (:block/page (db/entity (:db/id (state/get-edit-block)))))
             repo (state/get-current-repo)]
         (when page-id
-          (.record-editor-info worker repo (str page-id) (ldb/write-transit-str (state/get-editor-info))))))
+          (worker :undo-redo/record-editor-info repo (str page-id) (ldb/write-transit-str (state/get-editor-info))))))
 
     (state/set-state! :editor/op nil))
   state)

--- a/src/main/frontend/handler/editor/lifecycle.cljs
+++ b/src/main/frontend/handler/editor/lifecycle.cljs
@@ -33,11 +33,10 @@
 
     ;; skip recording editor info when undo or redo is still running
     (when-not (contains? #{:undo :redo} @(:editor/op @state/state))
-      (let [worker @state/*db-worker
-            page-id (:block/uuid (:block/page (db/entity (:db/id (state/get-edit-block)))))
+      (let [page-id (:block/uuid (:block/page (db/entity (:db/id (state/get-edit-block)))))
             repo (state/get-current-repo)]
         (when page-id
-          (worker :thread-api/record-editor-info repo (str page-id) (state/get-editor-info)))))
+          (state/<invoke-db-worker :thread-api/record-editor-info repo (str page-id) (state/get-editor-info)))))
 
     (state/set-state! :editor/op nil))
   state)

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -206,7 +206,7 @@
   (reset! r/*key->atom {})
 
   (let [worker @db-browser/*worker]
-    (p/let [writes-finished? (when worker (worker :general/file-writes-finished? (state/get-current-repo)))
+    (p/let [writes-finished? (when worker (worker :thread-api/file-writes-finished? (state/get-current-repo)))
             request-finished? (db-transact/request-finished?)]
       (if (not writes-finished?) ; TODO: test (:sync-graph/init? @state/state)
         (do
@@ -367,7 +367,7 @@
                  :pages-directory (config/get-pages-directory)}
         worker @state/*db-worker]
     (when worker
-      (worker :general/set-context context))))
+      (worker :thread-api/set-context context))))
 
 ;; Hook on a graph is ready to be shown to the user.
 ;; It's different from :graph/restored, as :graph/restored is for window reloaded

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -367,7 +367,7 @@
                  :pages-directory (config/get-pages-directory)}
         worker @state/*db-worker]
     (when worker
-      (worker :general/set-context (ldb/write-transit-str context)))))
+      (worker :general/set-context context))))
 
 ;; Hook on a graph is ready to be shown to the user.
 ;; It's different from :graph/restored, as :graph/restored is for window reloaded

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -205,8 +205,8 @@
   (st/refresh!)
   (reset! r/*key->atom {})
 
-  (let [^js sqlite @db-browser/*worker]
-    (p/let [writes-finished? (when sqlite (.file-writes-finished? sqlite (state/get-current-repo)))
+  (let [worker @db-browser/*worker]
+    (p/let [writes-finished? (when worker (worker :general/file-writes-finished? (state/get-current-repo)))
             request-finished? (db-transact/request-finished?)]
       (if (not writes-finished?) ; TODO: test (:sync-graph/init? @state/state)
         (do
@@ -365,8 +365,9 @@
                  :journals-directory (config/get-journals-directory)
                  :whiteboards-directory (config/get-whiteboards-directory)
                  :pages-directory (config/get-pages-directory)}
-        worker ^Object @state/*db-worker]
-    (when worker (.set-context worker (ldb/write-transit-str context)))))
+        worker @state/*db-worker]
+    (when worker
+      (worker :general/set-context (ldb/write-transit-str context)))))
 
 ;; Hook on a graph is ready to be shown to the user.
 ;; It's different from :graph/restored, as :graph/restored is for window reloaded

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -71,7 +71,6 @@
             [frontend.modules.outliner.ui :as ui-outliner-tx]
             [frontend.modules.shortcut.core :as st]
             [frontend.persist-db :as persist-db]
-            [frontend.persist-db.browser :as db-browser]
             [frontend.quick-capture :as quick-capture]
             [frontend.rum :as r]
             [frontend.search :as search]
@@ -203,21 +202,19 @@
   (state/set-state! :db/async-queries {})
   (st/refresh!)
   (reset! r/*key->atom {})
-
-  (let [worker @db-browser/*worker]
-    (p/let [writes-finished? (when worker (worker :thread-api/file-writes-finished? (state/get-current-repo)))
-            request-finished? (db-transact/request-finished?)]
-      (if (not writes-finished?) ; TODO: test (:sync-graph/init? @state/state)
-        (do
-          (log/info :graph/switch (cond->
-                                   {:request-finished? request-finished?
-                                    :file-writes-finished? writes-finished?}
-                                    (false? request-finished?)
-                                    (assoc :unfinished-requests? @db-transact/*unfinished-request-ids)))
-          (notification/show!
-           "Please wait seconds until all changes are saved for the current graph."
-           :warning))
-        (graph-switch-on-persisted graph opts)))))
+  (p/let [writes-finished? (state/<invoke-db-worker :thread-api/file-writes-finished? (state/get-current-repo))
+          request-finished? (db-transact/request-finished?)]
+    (if (not writes-finished?) ; TODO: test (:sync-graph/init? @state/state)
+      (do
+        (log/info :graph/switch (cond->
+                                 {:request-finished? request-finished?
+                                  :file-writes-finished? writes-finished?}
+                                  (false? request-finished?)
+                                  (assoc :unfinished-requests? @db-transact/*unfinished-request-ids)))
+        (notification/show!
+         "Please wait seconds until all changes are saved for the current graph."
+         :warning))
+      (graph-switch-on-persisted graph opts))))
 
 (defmethod handle :graph/pull-down-remote-graph [[_ graph dir-name]]
   (if (mobile-util/native-ios?)
@@ -363,10 +360,8 @@
                  :preferred-format (state/get-preferred-format)
                  :journals-directory (config/get-journals-directory)
                  :whiteboards-directory (config/get-whiteboards-directory)
-                 :pages-directory (config/get-pages-directory)}
-        worker @state/*db-worker]
-    (when worker
-      (worker :thread-api/set-context context))))
+                 :pages-directory (config/get-pages-directory)}]
+    (state/<invoke-db-worker :thread-api/set-context context)))
 
 ;; Hook on a graph is ready to be shown to the user.
 ;; It's different from :graph/restored, as :graph/restored is for window reloaded

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -83,7 +83,6 @@
             [lambdaisland.glogi :as log]
             [logseq.common.config :as common-config]
             [logseq.common.util :as common-util]
-            [logseq.db :as ldb]
             [logseq.shui.ui :as shui]
             [promesa.core :as p]
             [rum.core :as rum]))
@@ -1017,9 +1016,8 @@
                                      {:outliner-op :insert-blocks}
                                      ;; insert a new block
                                      (let [[_p _ block'] (editor-handler/insert-new-block-aux! {} block "")]
-                                       (turn-type! block')))
-                             result' (ldb/read-transit-str result)]
-                       (when-let [id (:block/uuid (first (:blocks result')))]
+                                       (turn-type! block')))]
+                       (when-let [id (:block/uuid (first (:blocks result)))]
                          (db/entity [:block/uuid id])))
                      (p/do!
                       (turn-type! block)

--- a/src/main/frontend/handler/export/common.cljs
+++ b/src/main/frontend/handler/export/common.cljs
@@ -13,7 +13,6 @@
             [frontend.persist-db.browser :as db-browser]
             [frontend.state :as state]
             [frontend.util :as util :refer [concatv mapcatv removev]]
-            [logseq.db :as ldb]
             [malli.core :as m]
             [malli.util :as mu]
             [promesa.core :as p]))

--- a/src/main/frontend/handler/export/common.cljs
+++ b/src/main/frontend/handler/export/common.cljs
@@ -190,17 +190,17 @@
 (defn <get-all-pages
   [repo]
   (when-let [worker @db-browser/*worker]
-    (worker :export/get-all-pages repo)))
+    (worker :thread-api/export-get-all-pages repo)))
 
 (defn <get-debug-datoms
   [repo]
   (when-let [worker @db-browser/*worker]
-    (worker :export/get-debug-datoms repo)))
+    (worker :thread-api/export-get-debug-datoms repo)))
 
 (defn <get-all-page->content
   [repo]
   (when-let [worker @db-browser/*worker]
-    (worker :export/get-all-page->content repo)))
+    (worker :thread-api/export-get-all-page->content repo)))
 
 (defn <get-file-contents
   [repo suffix]

--- a/src/main/frontend/handler/export/common.cljs
+++ b/src/main/frontend/handler/export/common.cljs
@@ -191,8 +191,7 @@
 (defn <get-all-pages
   [repo]
   (when-let [worker @db-browser/*worker]
-    (p/let [result (worker :export/get-all-pages repo)]
-      (ldb/read-transit-str result))))
+    (worker :export/get-all-pages repo)))
 
 (defn <get-debug-datoms
   [repo]
@@ -202,8 +201,7 @@
 (defn <get-all-page->content
   [repo]
   (when-let [worker @db-browser/*worker]
-    (p/let [result (worker :export/get-all-page->content repo)]
-      (ldb/read-transit-str result))))
+    (worker :export/get-all-page->content repo)))
 
 (defn <get-file-contents
   [repo suffix]

--- a/src/main/frontend/handler/export/common.cljs
+++ b/src/main/frontend/handler/export/common.cljs
@@ -190,19 +190,19 @@
 
 (defn <get-all-pages
   [repo]
-  (when-let [^object worker @db-browser/*worker]
-    (p/let [result (.get-all-pages worker repo)]
+  (when-let [worker @db-browser/*worker]
+    (p/let [result (worker :export/get-all-pages repo)]
       (ldb/read-transit-str result))))
 
 (defn <get-debug-datoms
   [repo]
-  (when-let [^object worker @db-browser/*worker]
-    (.get-debug-datoms worker repo)))
+  (when-let [worker @db-browser/*worker]
+    (worker :export/get-debug-datoms repo)))
 
 (defn <get-all-page->content
   [repo]
-  (when-let [^object worker @db-browser/*worker]
-    (p/let [result (.get-all-page->content worker repo)]
+  (when-let [worker @db-browser/*worker]
+    (p/let [result (worker :export/get-all-page->content repo)]
       (ldb/read-transit-str result))))
 
 (defn <get-file-contents

--- a/src/main/frontend/handler/export/common.cljs
+++ b/src/main/frontend/handler/export/common.cljs
@@ -10,7 +10,6 @@
             [frontend.format.mldoc :as mldoc]
             [frontend.modules.file.core :as outliner-file]
             [frontend.modules.outliner.tree :as outliner-tree]
-            [frontend.persist-db.browser :as db-browser]
             [frontend.state :as state]
             [frontend.util :as util :refer [concatv mapcatv removev]]
             [malli.core :as m]
@@ -189,18 +188,15 @@
 
 (defn <get-all-pages
   [repo]
-  (when-let [worker @db-browser/*worker]
-    (worker :thread-api/export-get-all-pages repo)))
+  (state/<invoke-db-worker :thread-api/export-get-all-pages repo))
 
 (defn <get-debug-datoms
   [repo]
-  (when-let [worker @db-browser/*worker]
-    (worker :thread-api/export-get-debug-datoms repo)))
+  (state/<invoke-db-worker :thread-api/export-get-debug-datoms repo))
 
 (defn <get-all-page->content
   [repo]
-  (when-let [worker @db-browser/*worker]
-    (worker :thread-api/export-get-all-page->content repo)))
+  (state/<invoke-db-worker :thread-api/export-get-all-page->content repo))
 
 (defn <get-file-contents
   [repo suffix]

--- a/src/main/frontend/handler/history.cljs
+++ b/src/main/frontend/handler/history.cljs
@@ -59,7 +59,7 @@
               (editor/save-current-block!)
               (state/clear-editor-action!)
               (let [worker @state/*db-worker]
-                (reset! *last-request (worker :undo-redo/undo repo current-page-uuid-str))
+                (reset! *last-request (worker :thread-api/undo repo current-page-uuid-str))
                 (p/let [result @*last-request]
                   (restore-cursor-and-state! result)))))))))))
 (defonce undo! (debounce undo-aux! 20))
@@ -80,7 +80,7 @@
              (util/stop e)
              (state/clear-editor-action!)
              (let [worker @state/*db-worker]
-               (reset! *last-request (worker :undo-redo/redo repo current-page-uuid-str))
+               (reset! *last-request (worker :thread-api/redo repo current-page-uuid-str))
                (p/let [result @*last-request]
                  (restore-cursor-and-state! result))))))))))
 (defonce redo! (debounce redo-aux! 20))

--- a/src/main/frontend/handler/history.cljs
+++ b/src/main/frontend/handler/history.cljs
@@ -7,9 +7,9 @@
             [frontend.state :as state]
             [frontend.util :as util]
             [frontend.util.page :as page-util]
+            [goog.functions :refer [debounce]]
             [logseq.db :as ldb]
-            [promesa.core :as p]
-            [goog.functions :refer [debounce]]))
+            [promesa.core :as p]))
 
 (defn- restore-cursor!
   [{:keys [editor-cursors block-content undo?]}]
@@ -58,8 +58,8 @@
               (state/set-state! [:editor/last-replace-ref-content-tx repo] nil)
               (editor/save-current-block!)
               (state/clear-editor-action!)
-              (let [^js worker @state/*db-worker]
-                (reset! *last-request (.undo worker repo current-page-uuid-str))
+              (let [worker @state/*db-worker]
+                (reset! *last-request (worker :undo-redo/undo repo current-page-uuid-str))
                 (p/let [result @*last-request]
                   (restore-cursor-and-state! result)))))))))))
 (defonce undo! (debounce undo-aux! 20))
@@ -79,8 +79,8 @@
            (when (db-transact/request-finished?)
              (util/stop e)
              (state/clear-editor-action!)
-             (let [^js worker @state/*db-worker]
-               (reset! *last-request (.redo worker repo current-page-uuid-str))
+             (let [worker @state/*db-worker]
+               (reset! *last-request (worker :undo-redo/redo repo current-page-uuid-str))
                (p/let [result @*last-request]
                  (restore-cursor-and-state! result))))))))))
 (defonce redo! (debounce redo-aux! 20))

--- a/src/main/frontend/handler/history.cljs
+++ b/src/main/frontend/handler/history.cljs
@@ -58,10 +58,9 @@
               (state/set-state! [:editor/last-replace-ref-content-tx repo] nil)
               (editor/save-current-block!)
               (state/clear-editor-action!)
-              (let [worker @state/*db-worker]
-                (reset! *last-request (worker :thread-api/undo repo current-page-uuid-str))
-                (p/let [result @*last-request]
-                  (restore-cursor-and-state! result)))))))))))
+              (reset! *last-request (state/<invoke-db-worker :thread-api/undo repo current-page-uuid-str))
+              (p/let [result @*last-request]
+                (restore-cursor-and-state! result))))))))))
 (defonce undo! (debounce undo-aux! 20))
 
 (let [*last-request (atom nil)]
@@ -79,8 +78,7 @@
            (when (db-transact/request-finished?)
              (util/stop e)
              (state/clear-editor-action!)
-             (let [worker @state/*db-worker]
-               (reset! *last-request (worker :thread-api/redo repo current-page-uuid-str))
-               (p/let [result @*last-request]
-                 (restore-cursor-and-state! result))))))))))
+             (reset! *last-request (state/<invoke-db-worker :thread-api/redo repo current-page-uuid-str))
+             (p/let [result @*last-request]
+               (restore-cursor-and-state! result)))))))))
 (defonce redo! (debounce redo-aux! 20))

--- a/src/main/frontend/handler/history.cljs
+++ b/src/main/frontend/handler/history.cljs
@@ -33,7 +33,7 @@
 (defn- restore-cursor-and-state!
   [result]
   (state/set-state! :history/paused? true)
-  (let [{:keys [ui-state-str undo?] :as data} (ldb/read-transit-str result)]
+  (let [{:keys [ui-state-str undo?] :as data} result]
     (if ui-state-str
       (let [{:keys [old-state new-state]} (ldb/read-transit-str ui-state-str)]
         (if undo? (restore-app-state! old-state) (restore-app-state! new-state)))

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -20,6 +20,7 @@
             [frontend.handler.db-based.property :as db-property-handler]
             [frontend.handler.editor :as editor-handler]
             [frontend.handler.file-based.nfs :as nfs-handler]
+            [frontend.handler.file-based.page-property :as file-page-property]
             [frontend.handler.graph :as graph-handler]
             [frontend.handler.notification :as notification]
             [frontend.handler.plugin :as plugin-handler]
@@ -28,7 +29,6 @@
             [frontend.mobile.util :as mobile-util]
             [frontend.modules.outliner.op :as outliner-op]
             [frontend.modules.outliner.ui :as ui-outliner-tx]
-            [frontend.persist-db.browser :as db-browser]
             [frontend.state :as state]
             [frontend.util :as util]
             [frontend.util.cursor :as cursor]
@@ -44,8 +44,7 @@
             [logseq.db :as ldb]
             [logseq.graph-parser.db :as gp-db]
             [logseq.graph-parser.text :as text]
-            [promesa.core :as p]
-            [frontend.handler.file-based.page-property :as file-page-property]))
+            [promesa.core :as p]))
 
 (def <create! page-common-handler/<create!)
 (def <delete! page-common-handler/<delete!)
@@ -122,23 +121,22 @@
 
 (defn rename!
   [page-uuid-or-old-name new-name & {:as _opts}]
-  (when @db-browser/*worker
-    (p/let [page-uuid (cond
-                        (uuid? page-uuid-or-old-name)
-                        page-uuid-or-old-name
-                        (common-util/uuid-string? page-uuid-or-old-name)
-                        page-uuid-or-old-name
-                        :else
-                        (:block/uuid (db/get-page page-uuid-or-old-name)))
-            result (ui-outliner-tx/transact!
-                    {:outliner-op :rename-page}
-                    (outliner-op/rename-page! page-uuid new-name))]
-      (case (if (string? result) (keyword result) result)
-        :invalid-empty-name
-        (notification/show! "Please use a valid name, empty name is not allowed!" :warning)
-        :rename-page-exists
-        (notification/show! "Another page with the new name exists already" :warning)
-        nil))))
+  (p/let [page-uuid (cond
+                      (uuid? page-uuid-or-old-name)
+                      page-uuid-or-old-name
+                      (common-util/uuid-string? page-uuid-or-old-name)
+                      page-uuid-or-old-name
+                      :else
+                      (:block/uuid (db/get-page page-uuid-or-old-name)))
+          result (ui-outliner-tx/transact!
+                  {:outliner-op :rename-page}
+                  (outliner-op/rename-page! page-uuid new-name))]
+    (case (if (string? result) (keyword result) result)
+      :invalid-empty-name
+      (notification/show! "Please use a valid name, empty name is not allowed!" :warning)
+      :rename-page-exists
+      (notification/show! "Another page with the new name exists already" :warning)
+      nil)))
 
 (defn <reorder-favorites!
   [favorites]

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -132,9 +132,8 @@
                         (:block/uuid (db/get-page page-uuid-or-old-name)))
             result (ui-outliner-tx/transact!
                     {:outliner-op :rename-page}
-                    (outliner-op/rename-page! page-uuid new-name))
-            result' (ldb/read-transit-str result)]
-      (case (if (string? result') (keyword result') result')
+                    (outliner-op/rename-page! page-uuid new-name))]
+      (case (if (string? result) (keyword result) result)
         :invalid-empty-name
         (notification/show! "Please use a valid name, empty name is not allowed!" :warning)
         :rename-page-exists

--- a/src/main/frontend/handler/worker.cljs
+++ b/src/main/frontend/handler/worker.cljs
@@ -14,14 +14,14 @@
   (let [{:keys [request-id page-id repo files]} data]
     (->
      (p/let [_ (file-handler/alter-files repo files {})]
-       (worker :general/page-file-saved request-id page-id))
+       (worker :thread-api/page-file-saved request-id page-id))
      (p/catch (fn [error]
                 (notification/show!
                  [:div
                   [:p "Write file failed, please copy the changes to other editors in case of losing data."]
                   "Error: " (str (.-stack error))]
                  :error)
-                (worker :general/page-file-saved request-id page-id))))))
+                (worker :thread-api/page-file-saved request-id page-id))))))
 
 (defmethod handle :notification [_ _worker data]
   (apply notification/show! data))

--- a/src/main/frontend/handler/worker.cljs
+++ b/src/main/frontend/handler/worker.cljs
@@ -10,18 +10,18 @@
 
 (defmulti handle identity)
 
-(defmethod handle :write-files [_ ^js worker data]
+(defmethod handle :write-files [_ worker data]
   (let [{:keys [request-id page-id repo files]} data]
     (->
      (p/let [_ (file-handler/alter-files repo files {})]
-       (.page-file-saved worker request-id page-id))
+       (worker :general/page-file-saved request-id page-id))
      (p/catch (fn [error]
                 (notification/show!
                  [:div
                   [:p "Write file failed, please copy the changes to other editors in case of losing data."]
                   "Error: " (str (.-stack error))]
                  :error)
-                (.page-file-saved worker request-id page-id))))))
+                (worker :general/page-file-saved request-id page-id))))))
 
 (defmethod handle :notification [_ _worker data]
   (apply notification/show! data))

--- a/src/main/frontend/modules/outliner/ui.cljc
+++ b/src/main/frontend/modules/outliner/ui.cljc
@@ -31,12 +31,13 @@
                                                 ~opts))
                (when (and worker# (seq r#))
                  (let [request-id# (frontend.state/get-worker-next-request-id)
-                       request# #(.apply-outliner-ops ^Object worker# (frontend.state/get-current-repo)
-                                                      (logseq.db/write-transit-str r#)
-                                                      (logseq.db/write-transit-str
-                                                       (assoc ~opts
-                                                              :request-id request-id#
-                                                              :editor-info editor-info#)))
+                       request# #(worker# :general/apply-outliner-ops
+                                          (frontend.state/get-current-repo)
+                                          (logseq.db/write-transit-str r#)
+                                          (logseq.db/write-transit-str
+                                           (assoc ~opts
+                                                  :request-id request-id#
+                                                  :editor-info editor-info#)))
                        response# (frontend.state/add-worker-request! request-id# request#)]
 
                    response#)))))))))

--- a/src/main/frontend/modules/outliner/ui.cljc
+++ b/src/main/frontend/modules/outliner/ui.cljc
@@ -31,7 +31,7 @@
                                                 ~opts))
                (when (and worker# (seq r#))
                  (let [request-id# (frontend.state/get-worker-next-request-id)
-                       request# #(worker# :general/apply-outliner-ops
+                       request# #(worker# :thread-api/apply-outliner-ops
                                           (frontend.state/get-current-repo)
                                           r#
                                           (assoc ~opts

--- a/src/main/frontend/modules/outliner/ui.cljc
+++ b/src/main/frontend/modules/outliner/ui.cljc
@@ -33,11 +33,10 @@
                  (let [request-id# (frontend.state/get-worker-next-request-id)
                        request# #(worker# :general/apply-outliner-ops
                                           (frontend.state/get-current-repo)
-                                          (logseq.db/write-transit-str r#)
-                                          (logseq.db/write-transit-str
-                                           (assoc ~opts
-                                                  :request-id request-id#
-                                                  :editor-info editor-info#)))
+                                          r#
+                                          (assoc ~opts
+                                                 :request-id request-id#
+                                                 :editor-info editor-info#))
                        response# (frontend.state/add-worker-request! request-id# request#)]
 
                    response#)))))))))

--- a/src/main/frontend/modules/outliner/ui.cljc
+++ b/src/main/frontend/modules/outliner/ui.cljc
@@ -16,8 +16,7 @@
          (do ~@body)                    ; nested transact!
          (binding [frontend.modules.outliner.op/*outliner-ops* (transient [])]
            ~@body
-           (let [r# (persistent! frontend.modules.outliner.op/*outliner-ops*)
-                 worker# @frontend.state/*db-worker]
+           (let [r# (persistent! frontend.modules.outliner.op/*outliner-ops*)]
             ;;  (js/console.groupCollapsed "ui/transact!")
             ;;  (prn :ops r#)
             ;;  (js/console.trace)
@@ -29,14 +28,14 @@
                                                 r#
                                                 (frontend.state/get-date-formatter)
                                                 ~opts))
-               (when (and worker# (seq r#))
+               (when (seq r#)
                  (let [request-id# (frontend.state/get-worker-next-request-id)
-                       request# #(worker# :thread-api/apply-outliner-ops
-                                          (frontend.state/get-current-repo)
-                                          r#
-                                          (assoc ~opts
-                                                 :request-id request-id#
-                                                 :editor-info editor-info#))
+                       request# #(frontend.state/<invoke-db-worker
+                                  :thread-api/apply-outliner-ops
+                                  (frontend.state/get-current-repo)
+                                  r#
+                                  (assoc ~opts
+                                         :request-id request-id#
+                                         :editor-info editor-info#))
                        response# (frontend.state/add-worker-request! request-id# request#)]
-
                    response#)))))))))

--- a/src/main/frontend/persist_db/browser.cljs
+++ b/src/main/frontend/persist_db/browser.cljs
@@ -126,7 +126,7 @@
                             ldb/read-transit-str))
           t1 (util/time-ms)]
       (Comlink/expose (Main.) worker)
-      (worker-handler/handle-message! worker wrapped-worker*)
+      (worker-handler/handle-message! worker wrapped-worker)
       (reset! *worker wrapped-worker)
       (-> (p/let [_ (wrapped-worker :thread-api/init config/RTC-WS-URL)
                   _ (js/console.debug (str "debug: init worker spent: " (- (util/time-ms) t1) "ms"))

--- a/src/main/frontend/publishing.cljs
+++ b/src/main/frontend/publishing.cljs
@@ -57,7 +57,7 @@
       (p/let [_ (repo-handler/restore-and-setup-repo! repo)
               _ (let [db-transit-str (unescape-html data)]
                   (when-let [worker @state/*db-worker]
-                    (worker :general/reset-db repo db-transit-str)))
+                    (worker :thread-api/reset-db repo db-transit-str)))
               _ (repo-handler/restore-and-setup-repo! repo)]
         (state/set-db-restoring! false)
         (ui-handler/re-render-root!)))))

--- a/src/main/frontend/publishing.cljs
+++ b/src/main/frontend/publishing.cljs
@@ -56,8 +56,8 @@
       (state/set-current-repo! repo)
       (p/let [_ (repo-handler/restore-and-setup-repo! repo)
               _ (let [db-transit-str (unescape-html data)]
-                  (when-let [^js worker @state/*db-worker]
-                    (.resetDB worker repo db-transit-str)))
+                  (when-let [worker @state/*db-worker]
+                    (worker :general/reset-db repo db-transit-str)))
               _ (repo-handler/restore-and-setup-repo! repo)]
         (state/set-db-restoring! false)
         (ui-handler/re-render-root!)))))

--- a/src/main/frontend/publishing.cljs
+++ b/src/main/frontend/publishing.cljs
@@ -56,8 +56,7 @@
       (state/set-current-repo! repo)
       (p/let [_ (repo-handler/restore-and-setup-repo! repo)
               _ (let [db-transit-str (unescape-html data)]
-                  (when-let [worker @state/*db-worker]
-                    (worker :thread-api/reset-db repo db-transit-str)))
+                  (state/<invoke-db-worker :thread-api/reset-db repo db-transit-str))
               _ (repo-handler/restore-and-setup-repo! repo)]
         (state/set-db-restoring! false)
         (ui-handler/re-render-root!)))))

--- a/src/main/frontend/search.cljs
+++ b/src/main/frontend/search.cljs
@@ -127,7 +127,7 @@
                       (remove (fn [b] (= (:block/uuid b) (:block/uuid entity))))
                       (map (fn [b] [:block/uuid (:block/uuid b)])))
             result (when (seq eids)
-                     (.get-page-unlinked-refs ^Object @state/*db-worker repo (:db/id entity) (ldb/write-transit-str eids)))
+                     (@state/*db-worker :general/get-page-unlinked-refs repo (:db/id entity) (ldb/write-transit-str eids)))
             result' (when result (ldb/read-transit-str result))]
       (when result' (d/transact! (db/get-db repo false) result'))
       (some->> result'

--- a/src/main/frontend/search.cljs
+++ b/src/main/frontend/search.cljs
@@ -127,9 +127,8 @@
                       (remove (fn [b] (= (:block/uuid b) (:block/uuid entity))))
                       (map (fn [b] [:block/uuid (:block/uuid b)])))
             result (when (seq eids)
-                     (@state/*db-worker :general/get-page-unlinked-refs repo (:db/id entity) (ldb/write-transit-str eids)))
-            result' (when result (ldb/read-transit-str result))]
-      (when result' (d/transact! (db/get-db repo false) result'))
-      (some->> result'
+                     (@state/*db-worker :general/get-page-unlinked-refs repo (:db/id entity) (ldb/write-transit-str eids)))]
+      (when result (d/transact! (db/get-db repo false) result))
+      (some->> result
                db-model/sort-by-order-recursive
                db-utils/group-by-page))))

--- a/src/main/frontend/search.cljs
+++ b/src/main/frontend/search.cljs
@@ -126,7 +126,7 @@
                       (remove (fn [b] (= (:block/uuid b) (:block/uuid entity))))
                       (map (fn [b] [:block/uuid (:block/uuid b)])))
             result (when (seq eids)
-                     (@state/*db-worker :general/get-page-unlinked-refs repo (:db/id entity) eids))]
+                     (@state/*db-worker :thread-api/get-page-unlinked-refs repo (:db/id entity) eids))]
       (when result (d/transact! (db/get-db repo false) result))
       (some->> result
                db-model/sort-by-order-recursive

--- a/src/main/frontend/search.cljs
+++ b/src/main/frontend/search.cljs
@@ -14,7 +14,6 @@
             [frontend.state :as state]
             [frontend.util :as util]
             [logseq.common.config :as common-config]
-            [logseq.db :as ldb]
             [promesa.core :as p]))
 
 (def fuzzy-search fuzzy/fuzzy-search)
@@ -127,7 +126,7 @@
                       (remove (fn [b] (= (:block/uuid b) (:block/uuid entity))))
                       (map (fn [b] [:block/uuid (:block/uuid b)])))
             result (when (seq eids)
-                     (@state/*db-worker :general/get-page-unlinked-refs repo (:db/id entity) (ldb/write-transit-str eids)))]
+                     (@state/*db-worker :general/get-page-unlinked-refs repo (:db/id entity) eids))]
       (when result (d/transact! (db/get-db repo false) result))
       (some->> result
                db-model/sort-by-order-recursive

--- a/src/main/frontend/search.cljs
+++ b/src/main/frontend/search.cljs
@@ -126,7 +126,7 @@
                       (remove (fn [b] (= (:block/uuid b) (:block/uuid entity))))
                       (map (fn [b] [:block/uuid (:block/uuid b)])))
             result (when (seq eids)
-                     (@state/*db-worker :thread-api/get-page-unlinked-refs repo (:db/id entity) eids))]
+                     (state/<invoke-db-worker :thread-api/get-page-unlinked-refs repo (:db/id entity) eids))]
       (when result (d/transact! (db/get-db repo false) result))
       (some->> result
                db-model/sort-by-order-recursive

--- a/src/main/frontend/search/browser.cljs
+++ b/src/main/frontend/search/browser.cljs
@@ -13,18 +13,18 @@
   protocol/Engine
   (query [_this q option]
     (if-let [worker @*worker]
-      (worker :search/search-blocks (state/get-current-repo) q option)
+      (worker :thread-api/search-blocks (state/get-current-repo) q option)
       (p/resolved nil)))
   (rebuild-pages-indice! [_this]
     (if-let [worker @*worker]
-      (worker :search/build-pages-indice repo)
+      (worker :thread-api/search-build-pages-indice repo)
       (p/resolved nil)))
   (rebuild-blocks-indice! [this]
     (if-let [worker @*worker]
       (p/let [repo (state/get-current-repo)
               file-based? (config/local-file-based-graph? repo)
               _ (protocol/truncate-blocks! this)
-              result (worker :search/build-blocks-indice repo)
+              result (worker :thread-api/search-build-blocks-indice repo)
               blocks (if file-based?
                        (->> result
                             ;; remove built-in properties from content
@@ -34,20 +34,20 @@
                                         (property-util/remove-built-in-properties (get % :format :markdown) content)))))
                        result)
               _ (when (seq blocks)
-                  (worker :search/upsert-blocks repo blocks))])
+                  (worker :thread-api/search-upsert-blocks repo blocks))])
       (p/resolved nil)))
   (transact-blocks! [_this {:keys [blocks-to-remove-set
                                    blocks-to-add]}]
     (if-let [worker @*worker]
       (let [repo (state/get-current-repo)]
         (p/let [_ (when (seq blocks-to-remove-set)
-                    (worker :search/delete-blocks repo blocks-to-remove-set))]
+                    (worker :thread-api/search-delete-blocks repo blocks-to-remove-set))]
           (when (seq blocks-to-add)
-            (worker :search/upsert-blocks repo blocks-to-add))))
+            (worker :thread-api/search-upsert-blocks repo blocks-to-add))))
       (p/resolved nil)))
   (truncate-blocks! [_this]
     (if-let [worker @*worker]
-      (worker :search/truncate-tables (state/get-current-repo))
+      (worker :thread-api/search-truncate-tables (state/get-current-repo))
       (p/resolved nil)))
   (remove-db! [_this]
     ;; Already removed in OPFS

--- a/src/main/frontend/search/browser.cljs
+++ b/src/main/frontend/search/browser.cljs
@@ -6,7 +6,6 @@
             [frontend.persist-db.browser :as browser]
             [frontend.search.protocol :as protocol]
             [frontend.state :as state]
-            [logseq.db :as ldb]
             [promesa.core :as p]))
 
 (defonce *worker browser/*worker)
@@ -15,8 +14,7 @@
   protocol/Engine
   (query [_this q option]
     (if-let [worker @*worker]
-      (p/let [result (worker :search/search-blocks (state/get-current-repo) q (bean/->js option))]
-        (ldb/read-transit-str result))
+      (worker :search/search-blocks (state/get-current-repo) q (bean/->js option))
       (p/resolved nil)))
   (rebuild-pages-indice! [_this]
     (if-let [worker @*worker]

--- a/src/main/frontend/search/browser.cljs
+++ b/src/main/frontend/search/browser.cljs
@@ -1,7 +1,6 @@
 (ns frontend.search.browser
   "Browser implementation of search protocol"
-  (:require [cljs-bean.core :as bean]
-            [frontend.config :as config]
+  (:require [frontend.config :as config]
             [frontend.handler.file-based.property.util :as property-util]
             [frontend.persist-db.browser :as browser]
             [frontend.search.protocol :as protocol]
@@ -14,7 +13,7 @@
   protocol/Engine
   (query [_this q option]
     (if-let [worker @*worker]
-      (worker :search/search-blocks (state/get-current-repo) q (bean/->js option))
+      (worker :search/search-blocks (state/get-current-repo) q option)
       (p/resolved nil)))
   (rebuild-pages-indice! [_this]
     (if-let [worker @*worker]
@@ -27,12 +26,12 @@
               _ (protocol/truncate-blocks! this)
               result (worker :search/build-blocks-indice repo)
               blocks (if file-based?
-                       (->> (bean/->clj result)
+                       (->> result
                             ;; remove built-in properties from content
-                            (map #(update % :content
-                                          (fn [content]
-                                            (property-util/remove-built-in-properties (get % :format :markdown) content))))
-                            bean/->js)
+                            (map
+                             #(update % :content
+                                      (fn [content]
+                                        (property-util/remove-built-in-properties (get % :format :markdown) content)))))
                        result)
               _ (when (seq blocks)
                   (worker :search/upsert-blocks repo blocks))])
@@ -42,9 +41,9 @@
     (if-let [worker @*worker]
       (let [repo (state/get-current-repo)]
         (p/let [_ (when (seq blocks-to-remove-set)
-                    (worker :search/delete-blocks repo (bean/->js blocks-to-remove-set)))]
+                    (worker :search/delete-blocks repo blocks-to-remove-set))]
           (when (seq blocks-to-add)
-            (worker :search/upsert-blocks repo (bean/->js blocks-to-add)))))
+            (worker :search/upsert-blocks repo blocks-to-add))))
       (p/resolved nil)))
   (truncate-blocks! [_this]
     (if-let [worker @*worker]

--- a/src/main/frontend/search/browser.cljs
+++ b/src/main/frontend/search/browser.cljs
@@ -2,53 +2,40 @@
   "Browser implementation of search protocol"
   (:require [frontend.config :as config]
             [frontend.handler.file-based.property.util :as property-util]
-            [frontend.persist-db.browser :as browser]
             [frontend.search.protocol :as protocol]
             [frontend.state :as state]
             [promesa.core :as p]))
 
-(defonce *worker browser/*worker)
-
 (defrecord Browser [repo]
   protocol/Engine
   (query [_this q option]
-    (if-let [worker @*worker]
-      (worker :thread-api/search-blocks (state/get-current-repo) q option)
-      (p/resolved nil)))
+    (state/<invoke-db-worker :thread-api/search-blocks (state/get-current-repo) q option))
   (rebuild-pages-indice! [_this]
-    (if-let [worker @*worker]
-      (worker :thread-api/search-build-pages-indice repo)
-      (p/resolved nil)))
+    (state/<invoke-db-worker :thread-api/search-build-pages-indice repo))
   (rebuild-blocks-indice! [this]
-    (if-let [worker @*worker]
-      (p/let [repo (state/get-current-repo)
-              file-based? (config/local-file-based-graph? repo)
-              _ (protocol/truncate-blocks! this)
-              result (worker :thread-api/search-build-blocks-indice repo)
-              blocks (if file-based?
-                       (->> result
+    (p/let [repo (state/get-current-repo)
+            file-based? (config/local-file-based-graph? repo)
+            _ (protocol/truncate-blocks! this)
+            result (state/<invoke-db-worker :thread-api/search-build-blocks-indice repo)
+            blocks (if file-based?
+                     (->> result
                             ;; remove built-in properties from content
-                            (map
-                             #(update % :content
-                                      (fn [content]
-                                        (property-util/remove-built-in-properties (get % :format :markdown) content)))))
-                       result)
-              _ (when (seq blocks)
-                  (worker :thread-api/search-upsert-blocks repo blocks))])
-      (p/resolved nil)))
+                          (map
+                           #(update % :content
+                                    (fn [content]
+                                      (property-util/remove-built-in-properties (get % :format :markdown) content)))))
+                     result)
+            _ (when (seq blocks)
+                (state/<invoke-db-worker :thread-api/search-upsert-blocks repo blocks))]))
   (transact-blocks! [_this {:keys [blocks-to-remove-set
                                    blocks-to-add]}]
-    (if-let [worker @*worker]
-      (let [repo (state/get-current-repo)]
-        (p/let [_ (when (seq blocks-to-remove-set)
-                    (worker :thread-api/search-delete-blocks repo blocks-to-remove-set))]
-          (when (seq blocks-to-add)
-            (worker :thread-api/search-upsert-blocks repo blocks-to-add))))
-      (p/resolved nil)))
+    (let [repo (state/get-current-repo)]
+      (p/let [_ (when (seq blocks-to-remove-set)
+                  (state/<invoke-db-worker :thread-api/search-delete-blocks repo blocks-to-remove-set))]
+        (when (seq blocks-to-add)
+          (state/<invoke-db-worker :thread-api/search-upsert-blocks repo blocks-to-add)))))
   (truncate-blocks! [_this]
-    (if-let [worker @*worker]
-      (worker :thread-api/search-truncate-tables (state/get-current-repo))
-      (p/resolved nil)))
+    (state/<invoke-db-worker :thread-api/search-truncate-tables (state/get-current-repo)))
   (remove-db! [_this]
     ;; Already removed in OPFS
     (p/resolved nil)))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -33,6 +33,15 @@
 
 (defonce *db-worker (atom nil))
 
+(defn <invoke-db-worker
+  "invoke db-worker thread api"
+  [qkw & args]
+  (let [worker @*db-worker]
+    (when (nil? worker)
+      (prn :<invoke-db-worker-error qkw)
+      (throw (ex-info "db-worker has not been initialized" {})))
+    (apply worker qkw args)))
+
 ;; Stores main application state
 (defonce ^:large-vars/data-var state
   (let [document-mode? (or (storage/get :document/mode?) false)
@@ -52,7 +61,7 @@
       :nfs/user-granted?                     {}
       :nfs/refreshing?                       nil
       :instrument/disabled?                  (storage/get "instrument-disabled")
-     ;; TODO: how to detect the network reliably?
+      ;; TODO: how to detect the network reliably?
       :network/online?         true
       :indexeddb/support?      true
       :me                      nil
@@ -80,7 +89,7 @@
       :ui/navigation-item-collapsed?         {}
       :ui/recent-pages                       (or (storage/get :ui/recent-pages) {})
 
-     ;; right sidebar
+      ;; right sidebar
       :ui/handbooks-open?                    false
       :ui/help-open?                         false
       :ui/fullscreen?                        false
@@ -142,7 +151,7 @@
       :editor/on-paste?                      (atom false)
       :editor/last-key-code                  (atom nil)
       :ui/global-last-key-code               (atom nil)
-      :editor/block-op-type                  nil             ;; :cut, :copy
+      :editor/block-op-type                  nil ;; :cut, :copy
       :editor/block-refs                     (atom #{})
 
       ;; Stores deleted refed blocks, indexed by repo
@@ -231,7 +240,7 @@
       :plugin/navs-settings?                 true
       :plugin/focused-settings               nil ;; plugin id
 
-     ;; pdf
+      ;; pdf
       :pdf/system-win?                       false
       :pdf/current                           nil
       :pdf/ref-highlight                     nil

--- a/src/main/frontend/worker/crypt.cljs
+++ b/src/main/frontend/worker/crypt.cljs
@@ -3,7 +3,6 @@
   (:require [datascript.core :as d]
             [frontend.common.thread-api :refer [def-thread-api]]
             [frontend.worker.state :as worker-state]
-            [logseq.db :as ldb]
             [promesa.core :as p]))
 
 (defonce ^:private encoder (new js/TextEncoder "utf-8"))

--- a/src/main/frontend/worker/crypt.cljs
+++ b/src/main/frontend/worker/crypt.cljs
@@ -125,13 +125,6 @@
     (let [aes-key-datom (first (d/datoms @conn :avet :aes-key-jwk))]
       {:aes-key-jwk (:v aes-key-datom)})))
 
-(defn- with-write-transit-str
-  [task]
-  (p/chain
-   (js/Promise. task)
-   ldb/write-transit-str))
-
 (def-thread-api :rtc/get-graph-keys
   [repo]
-  (with-write-transit-str
-    (get-graph-keys-jwk repo)))
+  (get-graph-keys-jwk repo))

--- a/src/main/frontend/worker/crypt.cljs
+++ b/src/main/frontend/worker/crypt.cljs
@@ -124,6 +124,6 @@
     (let [aes-key-datom (first (d/datoms @conn :avet :aes-key-jwk))]
       {:aes-key-jwk (:v aes-key-datom)})))
 
-(def-thread-api :rtc/get-graph-keys
+(def-thread-api :thread-api/rtc-get-graph-keys
   [repo]
   (get-graph-keys-jwk repo))

--- a/src/main/frontend/worker/db_listener.cljs
+++ b/src/main/frontend/worker/db_listener.cljs
@@ -32,9 +32,9 @@
         (p/do!
          (let [{:keys [blocks-to-remove-set blocks-to-add]} (search/sync-search-indice repo tx-report')]
            (when (seq blocks-to-remove-set)
-             ((@thread-api/*thread-apis :search/delete-blocks) repo blocks-to-remove-set))
+             ((@thread-api/*thread-apis :thread-api/search-delete-blocks) repo blocks-to-remove-set))
            (when (seq blocks-to-add)
-             ((@thread-api/*thread-apis :search/upsert-blocks) repo blocks-to-add))))))
+             ((@thread-api/*thread-apis :thread-api/search-upsert-blocks) repo blocks-to-add))))))
     tx-report'))
 
 (comment

--- a/src/main/frontend/worker/db_listener.cljs
+++ b/src/main/frontend/worker/db_listener.cljs
@@ -2,6 +2,7 @@
   "Db listeners for worker-db."
   (:require [cljs-bean.core :as bean]
             [datascript.core :as d]
+            [frontend.common.thread-api :as thread-api]
             [frontend.worker.pipeline :as worker-pipeline]
             [frontend.worker.search :as search]
             [frontend.worker.state :as worker-state]
@@ -30,13 +31,11 @@
 
       (when-not from-disk?
         (p/do!
-         (let [{:keys [blocks-to-remove-set blocks-to-add]} (search/sync-search-indice repo tx-report')
-               ^js wo (worker-state/get-worker-object)]
-           (when wo
-             (when (seq blocks-to-remove-set)
-               (.search-delete-blocks wo repo (bean/->js blocks-to-remove-set)))
-             (when (seq blocks-to-add)
-               (.search-upsert-blocks wo repo (bean/->js blocks-to-add))))))))
+         (let [{:keys [blocks-to-remove-set blocks-to-add]} (search/sync-search-indice repo tx-report')]
+           (when (seq blocks-to-remove-set)
+             ((@thread-api/*thread-apis :search/delete-blocks) repo (bean/->js blocks-to-remove-set)))
+           (when (seq blocks-to-add)
+             ((@thread-api/*thread-apis :search/upsert-blocks) repo (bean/->js blocks-to-add)))))))
     tx-report'))
 
 (comment

--- a/src/main/frontend/worker/db_listener.cljs
+++ b/src/main/frontend/worker/db_listener.cljs
@@ -1,7 +1,6 @@
 (ns frontend.worker.db-listener
   "Db listeners for worker-db."
-  (:require [cljs-bean.core :as bean]
-            [datascript.core :as d]
+  (:require [datascript.core :as d]
             [frontend.common.thread-api :as thread-api]
             [frontend.worker.pipeline :as worker-pipeline]
             [frontend.worker.search :as search]
@@ -33,9 +32,9 @@
         (p/do!
          (let [{:keys [blocks-to-remove-set blocks-to-add]} (search/sync-search-indice repo tx-report')]
            (when (seq blocks-to-remove-set)
-             ((@thread-api/*thread-apis :search/delete-blocks) repo (bean/->js blocks-to-remove-set)))
+             ((@thread-api/*thread-apis :search/delete-blocks) repo blocks-to-remove-set))
            (when (seq blocks-to-add)
-             ((@thread-api/*thread-apis :search/upsert-blocks) repo (bean/->js blocks-to-add)))))))
+             ((@thread-api/*thread-apis :search/upsert-blocks) repo blocks-to-add))))))
     tx-report'))
 
 (comment

--- a/src/main/frontend/worker/db_metadata.cljs
+++ b/src/main/frontend/worker/db_metadata.cljs
@@ -1,6 +1,7 @@
 (ns frontend.worker.db-metadata
   "Fns to read/write metadata.edn file for db-based."
-  (:require [frontend.worker.util :as worker-util]
+  (:require [frontend.common.thread-api :refer [def-thread-api]]
+            [frontend.worker.util :as worker-util]
             [promesa.core :as p]))
 
 (defn <store
@@ -11,3 +12,7 @@
           writable (.createWritable file-handle)
           _ (.write writable metadata-str)]
     (.close writable)))
+
+(def-thread-api :db-metadata/store
+  [repo metadata-str]
+  (<store repo metadata-str))

--- a/src/main/frontend/worker/db_metadata.cljs
+++ b/src/main/frontend/worker/db_metadata.cljs
@@ -1,7 +1,6 @@
 (ns frontend.worker.db-metadata
   "Fns to read/write metadata.edn file for db-based."
-  (:require [frontend.common.thread-api :refer [def-thread-api]]
-            [frontend.worker.util :as worker-util]
+  (:require [frontend.worker.util :as worker-util]
             [promesa.core :as p]))
 
 (defn <store
@@ -12,7 +11,3 @@
           writable (.createWritable file-handle)
           _ (.write writable metadata-str)]
     (.close writable)))
-
-(def-thread-api :db-metadata/store
-  [repo metadata-str]
-  (<store repo metadata-str))

--- a/src/main/frontend/worker/db_worker.cljs
+++ b/src/main/frontend/worker/db_worker.cljs
@@ -8,28 +8,22 @@
             [clojure.string :as string]
             [datascript.core :as d]
             [datascript.storage :refer [IStorage] :as storage]
-            [frontend.common.file.core :as common-file]
             [frontend.common.thread-api :as thread-api :refer [def-thread-api]]
-            [frontend.worker.crypt :as worker-crypt]
             [frontend.worker.db-listener :as db-listener]
-            [frontend.worker.db-metadata :as worker-db-metadata]
             [frontend.worker.db.migrate :as db-migrate]
             [frontend.worker.db.validate :as worker-db-validate]
-            [frontend.worker.device :as worker-device]
             [frontend.worker.export :as worker-export]
             [frontend.worker.file :as file]
             [frontend.worker.handler.page :as worker-page]
             [frontend.worker.handler.page.file-based.rename :as file-worker-page-rename]
             [frontend.worker.rtc.asset-db-listener]
             [frontend.worker.rtc.client-op :as client-op]
-            [frontend.worker.rtc.core :as rtc-core]
             [frontend.worker.rtc.db-listener]
             [frontend.worker.search :as search]
             [frontend.worker.state :as worker-state] ;; [frontend.worker.undo-redo :as undo-redo]
             [frontend.worker.undo-redo2 :as undo-redo]
             [frontend.worker.util :as worker-util]
             [goog.object :as gobj]
-            [lambdaisland.glogi :as log]
             [lambdaisland.glogi.console :as glogi-console]
             [logseq.common.config :as common-config]
             [logseq.common.util :as common-util]
@@ -42,8 +36,7 @@
             [logseq.db.sqlite.util :as sqlite-util]
             [logseq.outliner.op :as outliner-op]
             [me.tonsky.persistent-sorted-set :as set :refer [BTSet]]
-            [promesa.core :as p]
-            [shadow.cljs.modern :refer [defclass]]))
+            [promesa.core :as p]))
 
 (defonce *sqlite worker-state/*sqlite)
 (defonce *sqlite-conns worker-state/*sqlite-conns)
@@ -449,14 +442,6 @@
   [repo]
   (worker-state/get-sqlite-conn repo :search))
 
-(defn- with-write-transit-str
-  [task]
-  (p/chain
-   (js/Promise. task)
-   (fn [result]
-     (let [result (when-not (= result @worker-state/*state) result)]
-       (ldb/write-transit-str result)))))
-
 (def-thread-api :general/get-version
   []
   (when-let [sqlite @*sqlite]
@@ -823,7 +808,6 @@
   (glogi-console/install!)
   (check-worker-scope!)
   (outliner-register-op-handlers!)
-  (worker-state/set-worker-object! 11111)
   (<ratelimit-file-writes!)
   (js/setInterval #(.postMessage js/self "keepAliveResponse") (* 1000 25))
     ;; (Comlink/expose obj)

--- a/src/main/frontend/worker/device.cljs
+++ b/src/main/frontend/worker/device.cljs
@@ -4,12 +4,13 @@
             [cljs-time.coerce :as tc]
             [cljs-time.core :as t]
             [clojure.string :as string]
+            [frontend.common.missionary :as c.m]
+            [frontend.common.thread-api :refer [def-thread-api]]
             [frontend.worker.crypt :as crypt]
             [frontend.worker.rtc.client-op :as client-op]
             [frontend.worker.rtc.ws-util :as ws-util]
             [frontend.worker.state :as worker-state]
             [goog.crypt.base64 :as base64]
-            [frontend.common.missionary :as c.m]
             [logseq.db :as ldb]
             [missionary.core :as m]
             [promesa.core :as p]))
@@ -206,3 +207,30 @@
                                  devices*)))]
                 (m/? (new-task--sync-encrypted-aes-key*
                       get-ws-create-task device-uuid->encrypted-aes-key graph-uuid))))))))))
+
+(defn- with-write-transit-str
+  [task]
+  (p/chain
+   (js/Promise. task)
+   ldb/write-transit-str))
+
+(def-thread-api :rtc/sync-current-graph-encrypted-aes-key
+  [token device-uuids-transit-str]
+  (with-write-transit-str
+    (new-task--sync-current-graph-encrypted-aes-key
+     token device-uuids-transit-str)))
+
+(def-thread-api :device/list-devices
+  [token]
+  (with-write-transit-str
+    (new-task--list-devices token)))
+
+(def-thread-api :device/remove-device-public-key
+  [token device-uuid key-name]
+  (with-write-transit-str
+    (new-task--remove-device-public-key token device-uuid key-name)))
+
+(def-thread-api :device/remove-device
+  [token device-uuid]
+  (with-write-transit-str
+    (new-task--remove-device token device-uuid)))

--- a/src/main/frontend/worker/device.cljs
+++ b/src/main/frontend/worker/device.cljs
@@ -207,18 +207,18 @@
                 (m/? (new-task--sync-encrypted-aes-key*
                       get-ws-create-task device-uuid->encrypted-aes-key graph-uuid))))))))))
 
-(def-thread-api :rtc/sync-current-graph-encrypted-aes-key
+(def-thread-api :thread-api/rtc-sync-current-graph-encrypted-aes-key
   [token device-uuids]
   (new-task--sync-current-graph-encrypted-aes-key token device-uuids))
 
-(def-thread-api :device/list-devices
+(def-thread-api :thread-api/list-devices
   [token]
   (new-task--list-devices token))
 
-(def-thread-api :device/remove-device-public-key
+(def-thread-api :thread-api/remove-device-public-key
   [token device-uuid key-name]
   (new-task--remove-device-public-key token device-uuid key-name))
 
-(def-thread-api :device/remove-device
+(def-thread-api :thread-api/remove-device
   [token device-uuid]
   (new-task--remove-device token device-uuid))

--- a/src/main/frontend/worker/device.cljs
+++ b/src/main/frontend/worker/device.cljs
@@ -173,9 +173,8 @@
         (m/? (new-task--remove-user-device* get-ws-create-task device-uuid*))))))
 
 (defn new-task--sync-current-graph-encrypted-aes-key
-  [token device-uuids-transit-str]
-  (let [repo (worker-state/get-current-repo)
-        device-uuids (ldb/read-transit-str device-uuids-transit-str)]
+  [token device-uuids]
+  (let [repo (worker-state/get-current-repo)]
     (assert (and (seq device-uuids) (every? uuid? device-uuids)) device-uuids)
     (m/sp
       (when-let [graph-uuid (client-op/get-graph-uuid repo)]
@@ -209,8 +208,8 @@
                       get-ws-create-task device-uuid->encrypted-aes-key graph-uuid))))))))))
 
 (def-thread-api :rtc/sync-current-graph-encrypted-aes-key
-  [token device-uuids-transit-str]
-  (new-task--sync-current-graph-encrypted-aes-key token device-uuids-transit-str))
+  [token device-uuids]
+  (new-task--sync-current-graph-encrypted-aes-key token device-uuids))
 
 (def-thread-api :device/list-devices
   [token]

--- a/src/main/frontend/worker/device.cljs
+++ b/src/main/frontend/worker/device.cljs
@@ -208,29 +208,18 @@
                 (m/? (new-task--sync-encrypted-aes-key*
                       get-ws-create-task device-uuid->encrypted-aes-key graph-uuid))))))))))
 
-(defn- with-write-transit-str
-  [task]
-  (p/chain
-   (js/Promise. task)
-   ldb/write-transit-str))
-
 (def-thread-api :rtc/sync-current-graph-encrypted-aes-key
   [token device-uuids-transit-str]
-  (with-write-transit-str
-    (new-task--sync-current-graph-encrypted-aes-key
-     token device-uuids-transit-str)))
+  (new-task--sync-current-graph-encrypted-aes-key token device-uuids-transit-str))
 
 (def-thread-api :device/list-devices
   [token]
-  (with-write-transit-str
-    (new-task--list-devices token)))
+  (new-task--list-devices token))
 
 (def-thread-api :device/remove-device-public-key
   [token device-uuid key-name]
-  (with-write-transit-str
-    (new-task--remove-device-public-key token device-uuid key-name)))
+  (new-task--remove-device-public-key token device-uuid key-name))
 
 (def-thread-api :device/remove-device
   [token device-uuid]
-  (with-write-transit-str
-    (new-task--remove-device token device-uuid)))
+  (new-task--remove-device token device-uuid))

--- a/src/main/frontend/worker/file.cljs
+++ b/src/main/frontend/worker/file.cljs
@@ -30,7 +30,7 @@
     (swap! *writes assoc request-id page-id)
     request-id))
 
-(defn- dissoc-request!
+(defn dissoc-request!
   [request-id]
   (when-let [page-id (get @*writes request-id)]
     (let [old-page-request-ids (keep (fn [[r p]]

--- a/src/main/frontend/worker/rtc/core.cljs
+++ b/src/main/frontend/worker/rtc/core.cljs
@@ -548,12 +548,10 @@
   (rtc-toggle-remote-profile))
 
 (def-thread-api :rtc/grant-graph-access
-  [token graph-uuid target-user-uuids-str target-user-emails-str]
-  (let [target-user-uuids (ldb/read-transit-str target-user-uuids-str)
-        target-user-emails (ldb/read-transit-str target-user-emails-str)]
-    (new-task--grant-access-to-others token graph-uuid
-                                      :target-user-uuids target-user-uuids
-                                      :target-user-emails target-user-emails)))
+  [token graph-uuid target-user-uuids target-user-emails]
+  (new-task--grant-access-to-others token graph-uuid
+                                    :target-user-uuids target-user-uuids
+                                    :target-user-emails target-user-emails))
 
 (def-thread-api :rtc/get-graphs
   [token]

--- a/src/main/frontend/worker/rtc/core.cljs
+++ b/src/main/frontend/worker/rtc/core.cljs
@@ -531,69 +531,69 @@
 
 (def new-task--download-graph-from-s3 r.upload-download/new-task--download-graph-from-s3)
 
-(def-thread-api :rtc/start
+(def-thread-api :thread-api/rtc-start
   [repo token]
   (new-task--rtc-start repo token))
 
-(def-thread-api :rtc/stop
+(def-thread-api :thread-api/rtc-stop
   []
   (rtc-stop))
 
-(def-thread-api :rtc/toggle-auto-push
+(def-thread-api :thread-api/rtc-toggle-auto-push
   []
   (rtc-toggle-auto-push))
 
-(def-thread-api :rtc/toggle-remote-profile
+(def-thread-api :thread-api/rtc-toggle-remote-profile
   []
   (rtc-toggle-remote-profile))
 
-(def-thread-api :rtc/grant-graph-access
+(def-thread-api :thread-api/rtc-grant-graph-access
   [token graph-uuid target-user-uuids target-user-emails]
   (new-task--grant-access-to-others token graph-uuid
                                     :target-user-uuids target-user-uuids
                                     :target-user-emails target-user-emails))
 
-(def-thread-api :rtc/get-graphs
+(def-thread-api :thread-api/rtc-get-graphs
   [token]
   (new-task--get-graphs token))
 
-(def-thread-api :rtc/delete-graph
+(def-thread-api :thread-api/rtc-delete-graph
   [token graph-uuid schema-version]
   (new-task--delete-graph token graph-uuid schema-version))
 
-(def-thread-api :rtc/get-users-info
+(def-thread-api :thread-api/rtc-get-users-info
   [token graph-uuid]
   (new-task--get-users-info token graph-uuid))
 
-(def-thread-api :rtc/get-block-content-versions
+(def-thread-api :thread-api/rtc-get-block-content-versions
   [token graph-uuid block-uuid]
   (new-task--get-block-content-versions token graph-uuid block-uuid))
 
-(def-thread-api :rtc/get-debug-state
+(def-thread-api :thread-api/rtc-get-debug-state
   []
   (new-task--get-debug-state))
 
-(def-thread-api :rtc/async-upload-graph
+(def-thread-api :thread-api/rtc-async-upload-graph
   [repo token remote-graph-name]
   (new-task--upload-graph token repo remote-graph-name))
 
-(def-thread-api :rtc/async-branch-graph
+(def-thread-api :thread-api/rtc-async-branch-graph
   [repo token]
   (new-task--branch-graph token repo))
 
-(def-thread-api :rtc/request-download-graph
+(def-thread-api :thread-api/rtc-request-download-graph
   [token graph-uuid schema-version]
   (new-task--request-download-graph token graph-uuid schema-version))
 
-(def-thread-api :rtc/wait-download-graph-info-ready
+(def-thread-api :thread-api/rtc-wait-download-graph-info-ready
   [token download-info-uuid graph-uuid schema-version timeout-ms]
   (new-task--wait-download-info-ready token download-info-uuid graph-uuid schema-version timeout-ms))
 
-(def-thread-api :rtc/download-graph-from-s3
+(def-thread-api :thread-api/rtc-download-graph-from-s3
   [graph-uuid graph-name s3-url]
   (new-task--download-graph-from-s3 graph-uuid graph-name s3-url))
 
-(def-thread-api :rtc/download-info-list
+(def-thread-api :thread-api/rtc-download-info-list
   [token graph-uuid schema-version]
   (new-task--download-info-list token graph-uuid schema-version))
 

--- a/src/main/frontend/worker/rtc/core.cljs
+++ b/src/main/frontend/worker/rtc/core.cljs
@@ -24,8 +24,7 @@
             [logseq.db :as ldb]
             [logseq.db.frontend.schema :as db-schema]
             [malli.core :as ma]
-            [missionary.core :as m]
-            [promesa.core :as p])
+            [missionary.core :as m])
   (:import [missionary Cancelled]))
 
 (def ^:private rtc-state-schema
@@ -532,16 +531,9 @@
 
 (def new-task--download-graph-from-s3 r.upload-download/new-task--download-graph-from-s3)
 
-(defn- with-write-transit-str
-  [task]
-  (p/chain
-   (js/Promise. task)
-   ldb/write-transit-str))
-
 (def-thread-api :rtc/start
   [repo token]
-  (with-write-transit-str
-    (new-task--rtc-start repo token)))
+  (new-task--rtc-start repo token))
 
 (def-thread-api :rtc/stop
   []
@@ -559,65 +551,53 @@
   [token graph-uuid target-user-uuids-str target-user-emails-str]
   (let [target-user-uuids (ldb/read-transit-str target-user-uuids-str)
         target-user-emails (ldb/read-transit-str target-user-emails-str)]
-    (with-write-transit-str
-      (new-task--grant-access-to-others token graph-uuid
-                                        :target-user-uuids target-user-uuids
-                                        :target-user-emails target-user-emails))))
+    (new-task--grant-access-to-others token graph-uuid
+                                      :target-user-uuids target-user-uuids
+                                      :target-user-emails target-user-emails)))
 
 (def-thread-api :rtc/get-graphs
   [token]
-  (with-write-transit-str
-    (new-task--get-graphs token)))
+  (new-task--get-graphs token))
 
 (def-thread-api :rtc/delete-graph
   [token graph-uuid schema-version]
-  (with-write-transit-str
-    (new-task--delete-graph token graph-uuid schema-version)))
+  (new-task--delete-graph token graph-uuid schema-version))
 
 (def-thread-api :rtc/get-users-info
   [token graph-uuid]
-  (with-write-transit-str
-    (new-task--get-users-info token graph-uuid)))
+  (new-task--get-users-info token graph-uuid))
 
 (def-thread-api :rtc/get-block-content-versions
   [token graph-uuid block-uuid]
-  (with-write-transit-str
-    (new-task--get-block-content-versions token graph-uuid block-uuid)))
+  (new-task--get-block-content-versions token graph-uuid block-uuid))
 
 (def-thread-api :rtc/get-debug-state
   []
-  (with-write-transit-str
-    (new-task--get-debug-state)))
+  (new-task--get-debug-state))
 
 (def-thread-api :rtc/async-upload-graph
   [repo token remote-graph-name]
-  (with-write-transit-str
-    (new-task--upload-graph token repo remote-graph-name)))
+  (new-task--upload-graph token repo remote-graph-name))
 
 (def-thread-api :rtc/async-branch-graph
   [repo token]
-  (with-write-transit-str
-    (new-task--branch-graph token repo)))
+  (new-task--branch-graph token repo))
 
 (def-thread-api :rtc/request-download-graph
   [token graph-uuid schema-version]
-  (with-write-transit-str
-    (new-task--request-download-graph token graph-uuid schema-version)))
+  (new-task--request-download-graph token graph-uuid schema-version))
 
 (def-thread-api :rtc/wait-download-graph-info-ready
   [token download-info-uuid graph-uuid schema-version timeout-ms]
-  (with-write-transit-str
-    (new-task--wait-download-info-ready token download-info-uuid graph-uuid schema-version timeout-ms)))
+  (new-task--wait-download-info-ready token download-info-uuid graph-uuid schema-version timeout-ms))
 
 (def-thread-api :rtc/download-graph-from-s3
   [graph-uuid graph-name s3-url]
-  (with-write-transit-str
-    (new-task--download-graph-from-s3 graph-uuid graph-name s3-url)))
+  (new-task--download-graph-from-s3 graph-uuid graph-name s3-url))
 
 (def-thread-api :rtc/download-info-list
-  [ token graph-uuid schema-version]
-   (with-write-transit-str
-     (new-task--download-info-list token graph-uuid schema-version)))
+  [token graph-uuid schema-version]
+  (new-task--download-info-list token graph-uuid schema-version))
 
 ;;; ================ API (ends) ================
 

--- a/src/main/frontend/worker/rtc/core.cljs
+++ b/src/main/frontend/worker/rtc/core.cljs
@@ -3,6 +3,7 @@
   (:require [clojure.data :as data]
             [datascript.core :as d]
             [frontend.common.missionary :as c.m]
+            [frontend.common.thread-api :refer [def-thread-api]]
             [frontend.worker.device :as worker-device]
             [frontend.worker.rtc.asset :as r.asset]
             [frontend.worker.rtc.branch-graph :as r.branch-graph]
@@ -23,7 +24,8 @@
             [logseq.db :as ldb]
             [logseq.db.frontend.schema :as db-schema]
             [malli.core :as ma]
-            [missionary.core :as m])
+            [missionary.core :as m]
+            [promesa.core :as p])
   (:import [missionary Cancelled]))
 
 (def ^:private rtc-state-schema
@@ -529,6 +531,93 @@
      get-ws-create-task download-info-uuid graph-uuid schema-version timeout-ms)))
 
 (def new-task--download-graph-from-s3 r.upload-download/new-task--download-graph-from-s3)
+
+(defn- with-write-transit-str
+  [task]
+  (p/chain
+   (js/Promise. task)
+   ldb/write-transit-str))
+
+(def-thread-api :rtc/start
+  [repo token]
+  (with-write-transit-str
+    (new-task--rtc-start repo token)))
+
+(def-thread-api :rtc/stop
+  []
+  (rtc-stop))
+
+(def-thread-api :rtc/toggle-auto-push
+  []
+  (rtc-toggle-auto-push))
+
+(def-thread-api :rtc/toggle-remote-profile
+  []
+  (rtc-toggle-remote-profile))
+
+(def-thread-api :rtc/grant-graph-access
+  [token graph-uuid target-user-uuids-str target-user-emails-str]
+  (let [target-user-uuids (ldb/read-transit-str target-user-uuids-str)
+        target-user-emails (ldb/read-transit-str target-user-emails-str)]
+    (with-write-transit-str
+      (new-task--grant-access-to-others token graph-uuid
+                                        :target-user-uuids target-user-uuids
+                                        :target-user-emails target-user-emails))))
+
+(def-thread-api :rtc/get-graphs
+  [token]
+  (with-write-transit-str
+    (new-task--get-graphs token)))
+
+(def-thread-api :rtc/delete-graph
+  [token graph-uuid schema-version]
+  (with-write-transit-str
+    (new-task--delete-graph token graph-uuid schema-version)))
+
+(def-thread-api :rtc/get-users-info
+  [token graph-uuid]
+  (with-write-transit-str
+    (new-task--get-users-info token graph-uuid)))
+
+(def-thread-api :rtc/get-block-content-versions
+  [token graph-uuid block-uuid]
+  (with-write-transit-str
+    (new-task--get-block-content-versions token graph-uuid block-uuid)))
+
+(def-thread-api :rtc/get-debug-state
+  []
+  (with-write-transit-str
+    (new-task--get-debug-state)))
+
+(def-thread-api :rtc/async-upload-graph
+  [repo token remote-graph-name]
+  (with-write-transit-str
+    (new-task--upload-graph token repo remote-graph-name)))
+
+(def-thread-api :rtc/async-branch-graph
+  [repo token]
+  (with-write-transit-str
+    (new-task--branch-graph token repo)))
+
+(def-thread-api :rtc/request-download-graph
+  [token graph-uuid schema-version]
+  (with-write-transit-str
+    (new-task--request-download-graph token graph-uuid schema-version)))
+
+(def-thread-api :rtc/wait-download-graph-info-ready
+  [token download-info-uuid graph-uuid schema-version timeout-ms]
+  (with-write-transit-str
+    (new-task--wait-download-info-ready token download-info-uuid graph-uuid schema-version timeout-ms)))
+
+(def-thread-api :rtc/download-graph-from-s3
+  [graph-uuid graph-name s3-url]
+  (with-write-transit-str
+    (new-task--download-graph-from-s3 graph-uuid graph-name s3-url)))
+
+(def-thread-api :rtc/download-info-list
+  [ token graph-uuid schema-version]
+   (with-write-transit-str
+     (new-task--download-info-list token graph-uuid schema-version)))
 
 ;;; ================ API (ends) ================
 

--- a/src/main/frontend/worker/rtc/full_upload_download_graph.cljs
+++ b/src/main/frontend/worker/rtc/full_upload_download_graph.cljs
@@ -357,7 +357,7 @@
         (create-graph-for-rtc-test repo init-tx-data tx-data)
         (c.m/<?
          (p/do!
-          ((@thread-api/*thread-apis :general/create-or-open-db) repo (ldb/write-transit-str {:close-other-db? false}))
+          ((@thread-api/*thread-apis :general/create-or-open-db) repo {:close-other-db? false})
           ((@thread-api/*thread-apis :general/export-db) repo)
           ((@thread-api/*thread-apis :general/transact)
            repo init-tx-data

--- a/src/main/frontend/worker/rtc/full_upload_download_graph.cljs
+++ b/src/main/frontend/worker/rtc/full_upload_download_graph.cljs
@@ -357,9 +357,9 @@
         (create-graph-for-rtc-test repo init-tx-data tx-data)
         (c.m/<?
          (p/do!
-          ((@thread-api/*thread-apis :general/create-or-open-db) repo {:close-other-db? false})
-          ((@thread-api/*thread-apis :general/export-db) repo)
-          ((@thread-api/*thread-apis :general/transact)
+          ((@thread-api/*thread-apis :thread-api/create-or-open-db) repo {:close-other-db? false})
+          ((@thread-api/*thread-apis :thread-api/export-db) repo)
+          ((@thread-api/*thread-apis :thread-api/transact)
            repo init-tx-data
            {:rtc-download-graph? true
             :gen-undo-ops? false
@@ -367,7 +367,7 @@
             :frontend.worker.pipeline/skip-validate-db? true
             :persist-op? false}
            (worker-state/get-context))
-          ((@thread-api/*thread-apis :general/transact)
+          ((@thread-api/*thread-apis :thread-api/transact)
            repo tx-data {:rtc-download-graph? true
                          :gen-undo-ops? false
                          :persist-op? false} (worker-state/get-context))

--- a/src/main/frontend/worker/rtc/full_upload_download_graph.cljs
+++ b/src/main/frontend/worker/rtc/full_upload_download_graph.cljs
@@ -348,8 +348,7 @@
         tx-data (concat
                  (blocks-resolve-temp-id normal-blocks)
                  [(ldb/kv :logseq.kv/graph-uuid graph-uuid)])
-        init-tx-data (cons (ldb/kv :logseq.kv/db-type "db") schema-blocks)
-        worker-obj (:worker/object @worker-state/*state)]
+        init-tx-data (cons (ldb/kv :logseq.kv/db-type "db") schema-blocks)]
     (m/sp
       (client-op/update-local-tx repo t)
       (rtc-log-and-state/update-local-t graph-uuid t)

--- a/src/main/frontend/worker/search.cljs
+++ b/src/main/frontend/worker/search.cljs
@@ -346,8 +346,7 @@ DROP TRIGGER IF EXISTS blocks_au;
   [repo db]
   (build-fuzzy-search-indice repo db)
   (->> (get-all-blocks db)
-       (keep block->index)
-       (bean/->js)))
+       (keep block->index)))
 
 (defn- get-blocks-from-datoms-impl
   [repo {:keys [db-after db-before]} datoms]

--- a/src/main/frontend/worker/state.cljs
+++ b/src/main/frontend/worker/state.cljs
@@ -10,9 +10,7 @@
 
 (defonce *main-thread (atom nil))
 
-(defonce *state (atom {:worker/object nil
-
-                       :db/latest-transact-time {}
+(defonce *state (atom {:db/latest-transact-time {}
                        :worker/context {}
 
                        ;; FIXME: this name :config is too general
@@ -101,14 +99,6 @@
   [new-state]
   (swap! *state (fn [old-state]
                   (merge old-state new-state))))
-
-(defn set-worker-object!
-  [worker]
-  (swap! *state assoc :worker/object worker))
-
-(defn get-worker-object
-  []
-  (:worker/object @*state))
 
 (defn get-date-formatter
   [repo]

--- a/src/main/logseq/api.cljs
+++ b/src/main/logseq/api.cljs
@@ -793,8 +793,7 @@
             (some-> (editor-handler/insert-block-tree-after-target
                      (:db/id block) sibling bb (get block :block/format :markdown) keep-uuid?)
                     (p/then (fn [results]
-                              (some-> results (ldb/read-transit-str)
-                                      :blocks (sdk-utils/normalize-keyword-for-json) (bean/->js)))))))))))
+                              (some-> results :blocks (sdk-utils/normalize-keyword-for-json) (bean/->js)))))))))))
 
 (def ^:export remove_block
   (fn [block-uuid ^js _opts]


### PR DESCRIPTION
- use a simple `#js{"remoteInvoke" remote-function}` to replace the whole `defclass DBWorker`.
   `(Comlink/expose #js{"remoteInvoke" thread-api/remote-function})`
- use `def-thread-api` to define a API to expose to other threads (in this pr, expose APIs from db-worker to ui-thread)
- `(def-thread-api :api-ns/api-name ...)`. I added a clj-kondo hook to this keyword, so it supports jumping and querying references in the editor(with clojure-lsp)
- the transit-read/write for API return values has been unified, so many `ldb/read-transit-str` and `ldb/write-transit-str` have been removed

LATER:
- this pr only handles apis defined by db-worker, there're also apis defined by ui-thread(expose to db-worker).
   I will handle them in another pr