### PR TITLE
refactor: remove deftype Main

### DIFF
--- a/src/main/frontend/common/thread_api.cljc
+++ b/src/main/frontend/common/thread_api.cljc
@@ -12,7 +12,7 @@
 
 (defmacro def-thread-api
   "Define a api invokeable by other threads.
-e.g. (def-thread-api :thread-api/a-api [arg1 arg2] body)"
+  e.g. (def-thread-api :thread-api/a-api [arg1 arg2] body)"
   [qualified-keyword-name params & body]
   (assert (= "thread-api" (namespace qualified-keyword-name)) qualified-keyword-name)
   (assert (vector? params) params)

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -46,7 +46,7 @@
   [qkw & args]
   (<invoke-db-worker* qkw false args))
 
-(defn <invoke-db-worker-direct-passthrough-args
+(defn <invoke-db-worker-direct-pass-args
   "invoke db-worker thread api.
   But directly pass args to db-worker(won't do transit-write on them)."
   [qkw & args]

--- a/src/main/frontend/worker/state.cljs
+++ b/src/main/frontend/worker/state.cljs
@@ -10,6 +10,26 @@
 
 (defonce *main-thread (atom nil))
 
+(defn- <invoke-main-thread*
+  [qkw direct-pass-args? args-list]
+  (let [main-thread @*main-thread]
+    (when (nil? main-thread)
+      (prn :<invoke-main-thread-error qkw)
+      (throw (ex-info "main-thread has not been initialized" {})))
+    (apply main-thread qkw direct-pass-args? args-list)))
+
+(defn <invoke-main-thread
+  "invoke main thread api"
+  [qkw & args]
+  (<invoke-main-thread* qkw false args))
+
+(comment
+  (defn <invoke-main-thread-direct-pass-args
+    "invoke main thread api.
+  But directly pass args to main-thread(won't do transit-write on them)"
+    [qkw & args]
+    (<invoke-main-thread* qkw true args)))
+
 (defonce *state (atom {:db/latest-transact-time {}
                        :worker/context {}
 


### PR DESCRIPTION
similar to this PR: https://github.com/logseq/logseq/pull/11790

use `#js{"remoteInvoke" remote-function}` to replace `deftype Main` in main-thread.
