### PR TITLE
(temporarily) disable stale issues policy

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -7,8 +7,8 @@
 ---
 name: 'Stale Issues Policy'
 on:  # yamllint disable-line rule:truthy
-  schedule:
-    - cron: '0 0 * * *'  # Run at 00:00 UTC every day
+#  schedule:
+#    - cron: '0 0 * * *'  # Run at 00:00 UTC every day
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Issues which have not been tagged are liable to be marked as stale and closed (issues which have been tagged with certain tags [are exempted](https://github.com/logseq/logseq/blob/2d8e80954e5de53d62ff4713de0289e9a21c039d/.github/stale-issues.yml#L33)). Issues appear to have not been being regularly triaged and tagged for about a year now (presumably resources are being prioritised for the db version).
Having one's issue marked as stale and closed disincentivizes contributors, and means that potential bugs remain, despite someone having put in the effort to report them.

This PR turns off the `stale-issues` action, by commenting out the schedule.

A preferred method might be to exempt issues which are unlabelled (on the assumption that triage results in labels being added), but this appears to not currently be an option - see https://github.com/actions/stale/issues/1236