### PR TITLE
enhance:  / command input tolerance

### DIFF
--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -241,19 +241,16 @@
                 (if db-based?
                   (db-based-statuses)
                   (file-based-statuses))
-                (mapv (fn [m]
-                        (let [command (if db-based?
-                                        [:div.flex.flex-row.items-center.gap-2 m [:div.text-xs.opacity-50 "Status"]]
-                                        m)
-                              icon (if db-based?
-                                     (case m
+                (mapv (fn [command]
+                        (let [icon (if db-based?
+                                     (case command
                                        "Canceled" "Cancelled"
                                        "Doing" "InProgress50"
-                                       m)
+                                       command)
                                      "square-asterisk")]
-                          [command (->marker m) (str "Set status to " m) icon]))))]
+                          [command (->marker command) (str "Set status to " command) icon]))))]
     (when (seq result)
-      (map (fn [v] (conj v "TASK")) result))))
+      (map (fn [v] (conj v "TASK STATUS")) result))))
 
 (defn file-based-priorities
   []
@@ -273,17 +270,17 @@
                   (db-based-priorities)
                   (file-based-priorities))
                 (mapv (fn [item]
-                        (let [command (if db-based?
-                                        [:div.flex.flex-row.items-center.gap-2 item [:div.text-xs.opacity-50 "Priority"]]
-                                        item)]
-                          [command (->priority item) (str "Set priority to " item)
+                        (let [command item]
+                          [command
+                           (->priority item)
+                           (str "Set priority to " item)
                            (if db-based?
                              (str "priorityLvl" item)
                              (str "circle-letter-" (util/safe-lower-case item)))])))
                 (with-no-priority)
                 (vec))]
     (when (seq result)
-      (map (fn [v] (conj v "PRIORITY")) result))))
+      (map (fn [v] (into v ["PRIORITY"])) result))))
 
 ;; Credits to roamresearch.com
 
@@ -297,7 +294,7 @@
   []
   (mapv (fn [level]
           (let [heading (str "Heading " level)]
-            [heading (->heading level) heading (str "h-" level)])) (range 1 7)))
+            [heading (->heading level) heading (str "h-" level) "Heading"])) (range 1 7)))
 
 (defonce *latest-matched-command (atom ""))
 (defonce *matched-commands (atom nil))

--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -299,6 +299,7 @@
           (let [heading (str "Heading " level)]
             [heading (->heading level) heading (str "h-" level)])) (range 1 7)))
 
+(defonce *latest-matched-command (atom ""))
 (defonce *matched-commands (atom nil))
 (defonce *initial-commands (atom nil))
 
@@ -474,12 +475,18 @@
 (defn init-commands!
   [get-page-ref-text]
   (let [commands (commands-map get-page-ref-text)]
+    (reset! *latest-matched-command "")
     (reset! *initial-commands commands)
     (reset! *matched-commands commands)))
 
+(defn set-matched-commands!
+  [command matched-commands]
+  (reset! *latest-matched-command command)
+  (reset! *matched-commands matched-commands))
+
 (defn reinit-matched-commands!
   []
-  (reset! *matched-commands @*initial-commands))
+  (set-matched-commands! "" @*initial-commands))
 
 (defn restore-state
   []

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1068,7 +1068,7 @@
         (contains? config/video-formats asset-type))))
 
 (declare block-positioned-properties)
-(rum/defc page-reference < rum/reactive
+(rum/defc page-reference < rum/reactive db-mixins/query
   "Component for page reference"
   [html-export? uuid-or-title* {:keys [nested-link? show-brackets? id] :as config} label]
   (when uuid-or-title*
@@ -1077,7 +1077,8 @@
                           uuid-or-title*)
           show-brackets? (if (some? show-brackets?) show-brackets? (state/show-brackets?))
           contents-page? (= "contents" (string/lower-case (str id)))
-          block (db/get-page uuid-or-title)
+          block* (db/get-page uuid-or-title)
+          block (or (some-> (:db/id block*) db/sub-block) block*)
           config' (assoc config
                          :label (mldoc/plain->text label)
                          :contents-page? contents-page?

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -47,7 +47,7 @@
               (or
                (= "Add new property" (first item))
                (when (= (count item) 5)
-                 (contains? #{"TASK" "PRIORITY"} (last item))))) commands)
+                 (contains? #{"TASK STATUS" "PRIORITY"} (last item))))) commands)
     commands))
 
 (rum/defcs commands < rum/reactive

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -38,7 +38,7 @@
             [react-draggable]
             [rum.core :as rum]))
 
-(defonce no-matched-coomands [["No matched commands" [[:editor/move-cursor-to-end]]]])
+(defonce no-matched-commands [["No matched commands" [[:editor/move-cursor-to-end]]]])
 
 (defn filter-commands
   [page? commands]
@@ -58,7 +58,7 @@
         _ (when (state/get-editor-action)
             (reset! *matched matched'))
         page? (db/page? (db/entity (:db/id (state/get-edit-block))))
-        matched (or (filter-commands page? @*matched) no-matched-coomands)
+        matched (or (filter-commands page? @*matched) no-matched-commands)
         filtered? (not= matched @commands/*initial-commands)]
     (ui/auto-complete
      matched

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -58,57 +58,59 @@
         _ (when (state/get-editor-action)
             (reset! *matched matched'))
         page? (db/page? (db/entity (:db/id (state/get-edit-block))))
-        matched (or (filter-commands page? @*matched) no-matched-coomands)]
+        matched (or (filter-commands page? @*matched) no-matched-coomands)
+        filtered? (not= matched @commands/*initial-commands)]
     (ui/auto-complete
      matched
-     {:get-group-name
-      (fn [item]
-        (when (= (count item) 5) (last item)))
+     (cond->
+      {:item-render
+       (fn [item]
+         (let [command-name (first item)
+               command-doc (get item 2)
+               plugin-id (get-in item [1 1 1 :pid])
+               doc (when (state/show-command-doc?) command-doc)
+               options (some-> item (get 3))
+               icon-name (some-> (if (map? options) (:icon options) options) (name))
+               command-name (if icon-name
+                              [:span.flex.items-center.gap-1
+                               (shui/tabler-icon icon-name)
+                               [:strong.font-normal command-name]]
+                              command-name)]
+           (cond
+             (or plugin-id (vector? doc))
+             [:div.has-help
+              {:title plugin-id}
+              command-name
+              (when doc (ui/tooltip [:small (svg/help-circle)] doc))]
 
-      :item-render
-      (fn [item]
-        (let [command-name (first item)
-              command-doc (get item 2)
-              plugin-id (get-in item [1 1 1 :pid])
-              doc (when (state/show-command-doc?) command-doc)
-              options (some-> item (get 3))
-              icon-name (some-> (if (map? options) (:icon options) options) (name))
-              command-name (if icon-name
-                             [:span.flex.items-center.gap-1
-                              (shui/tabler-icon icon-name)
-                              [:strong.font-normal command-name]]
-                             command-name)]
-          (cond
-            (or plugin-id (vector? doc))
-            [:div.has-help
-             {:title plugin-id}
-             command-name
-             (when doc (ui/tooltip [:small (svg/help-circle)] doc))]
+             (string? doc)
+             [:div {:title doc}
+              command-name]
 
-            (string? doc)
-            [:div {:title doc}
-             command-name]
+             :else
+             [:div command-name])))
 
-            :else
-            [:div command-name])))
-
-      :on-chosen
-      (fn [chosen-item]
-        (let [command (first chosen-item)]
-          (reset! commands/*current-command command)
-          (let [command-steps (get (into {} matched) command)
-                restore-slash? (or
-                                (contains? #{"Today" "Yesterday" "Tomorrow" "Current time"} command)
-                                (and
-                                 (not (fn? command-steps))
-                                 (not (contains? (set (map first command-steps)) :editor/input))
-                                 (not (contains? #{"Date picker" "Template" "Deadline" "Scheduled" "Upload an image"} command))))]
-            (editor-handler/insert-command! id command-steps
-                                            format
-                                            {:restore? restore-slash?
-                                             :command command}))))
-      :class
-      "cp__commands-slash"})))
+       :on-chosen
+       (fn [chosen-item]
+         (let [command (first chosen-item)]
+           (reset! commands/*current-command command)
+           (let [command-steps (get (into {} matched) command)
+                 restore-slash? (or
+                                 (contains? #{"Today" "Yesterday" "Tomorrow" "Current time"} command)
+                                 (and
+                                  (not (fn? command-steps))
+                                  (not (contains? (set (map first command-steps)) :editor/input))
+                                  (not (contains? #{"Date picker" "Template" "Deadline" "Scheduled" "Upload an image"} command))))]
+             (editor-handler/insert-command! id command-steps
+                                             format
+                                             {:restore? restore-slash?
+                                              :command command}))))
+       :class
+       "cp__commands-slash"}
+       (not filtered?)
+       (assoc :get-group-name
+              (fn [item]
+                (when (= (count item) 5) (last item))))))))
 
 (defn- page-on-chosen-handler
   [embed? input id q pos format]

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -38,6 +38,8 @@
             [react-draggable]
             [rum.core :as rum]))
 
+(defonce no-matched-coomands [["No matched commands" [[:editor/move-cursor-to-end]]]])
+
 (defn filter-commands
   [page? commands]
   (if page?
@@ -56,7 +58,7 @@
         _ (when (state/get-editor-action)
             (reset! *matched matched'))
         page? (db/page? (db/entity (:db/id (state/get-edit-block))))
-        matched (filter-commands page? @*matched)]
+        matched (or (filter-commands page? @*matched) no-matched-coomands)]
     (ui/auto-complete
      matched
      {:get-group-name

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -818,7 +818,7 @@
                     concat-prev-block?
                     (let [children (:block/_parent (db/entity (:db/id block)))
                           db-based? (config/db-based-graph? repo)
-                          prev-block-is-not-parent? (not= (:block/uuid (:block/parent block)) (:block/uuid prev-block))
+                          prev-block-is-not-parent? (empty? (:block/_parent prev-block))
                           delete-prev-block? (and db-based?
                                                   prev-block-is-not-parent?
                                                   (empty? (:block/tags block))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3212,7 +3212,7 @@
                   matched-commands (get-matched-commands command)]
               (if (seq matched-commands)
                 (commands/set-matched-commands! command matched-commands)
-                (if (> (- (count command) (count @commands/*latest-matched-command)) 1)
+                (if (> (- (count command) (count @commands/*latest-matched-command)) 2)
                   (state/clear-editor-action!)
                   (reset! commands/*matched-commands nil)))))
 

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1773,22 +1773,24 @@
   [property q]
   (search/property-value-search property q))
 
-(defn get-matched-commands
+(defn get-last-command
   [input]
   (try
     (let [edit-content (or (gobj/get input "value") "")
           pos (cursor/pos input)
           last-slash-caret-pos (:pos (:pos (state/get-editor-action-data)))
           last-command (and last-slash-caret-pos (subs edit-content last-slash-caret-pos pos))]
-      (when (> pos 0)
-        (or
-         (and (= commands/command-trigger (util/nth-safe edit-content (dec pos)))
-              @commands/*initial-commands)
-         (and last-command
-              (commands/get-matched-commands last-command)))))
+      (when (> pos 0) last-command))
     (catch :default e
       (js/console.error e)
       nil)))
+
+(defn get-matched-commands
+  [command]
+  (condp = command
+    nil nil
+    "" @commands/*initial-commands
+    (commands/get-matched-commands command)))
 
 (defn auto-complete?
   []
@@ -3206,10 +3208,13 @@
           (and (= :commands (state/get-editor-action)) (not= k commands/command-trigger))
           (if (= commands/command-trigger (second (re-find #"(\S+)\s+$" value)))
             (state/clear-editor-action!)
-            (let [matched-commands (get-matched-commands input)]
+            (let [command (get-last-command input)
+                  matched-commands (get-matched-commands command)]
               (if (seq matched-commands)
-                (reset! commands/*matched-commands matched-commands)
-                (state/clear-editor-action!))))
+                (commands/set-matched-commands! command matched-commands)
+                (if (> (- (count command) (count @commands/*latest-matched-command)) 1)
+                  (state/clear-editor-action!)
+                  (reset! commands/*matched-commands nil)))))
 
           :else
           (default-case-for-keyup-handler input current-pos k code is-processed?))

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -93,20 +93,26 @@
        #js {:key (subs value (dec (count value)))}
        nil))))
 
-(deftest keyup-handler-test
+(deftest ^:focus keyup-handler-test
   (testing "Command autocompletion"
     ;; default last matching command is ""
     (keyup-handler {:value "/z"
                     :action :commands
                     :commands []})
     (is (= :commands (state/get-editor-action))
-        "Completion stays open if no matches but differs by 1 character from last matching command")
+        "Completion stays open if no matches but differs from last success by <= 2 chars")
 
     (keyup-handler {:value "/zz"
                     :action :commands
                     :commands []})
+    (is (= :commands (state/get-editor-action))
+        "Completion stays open if no matches but differs from last success by <= 2 chars")
+
+    (keyup-handler {:value "/zzz"
+                    :action :commands
+                    :commands []})
     (is (= nil (state/get-editor-action))
-        "Completion closed if there no matching commands")
+        "Completion closed if no matches and > 2 chars form last success")
 
     (keyup-handler {:value "/b"
                     :action :commands


### PR DESCRIPTION
- Enhance the `/` input tolerance to allow the current matching content to differ from the most recent successful match by ​up to 1 extra character, if no commands match, display "No matched commands" in the popup. For example:
	- ​Scenario 1
		- User inputs `he` → successfully matches `help`.
		- User adds `x` → input becomes `hex`, which fails to match. Since `hex` is ​1 character longer​ than `he`, the popup remains open.
		- User adds another `x` → input becomes `hexx`, which fails and exceeds the tolerance (2 characters longer than `he`). The popup closes.
	- ​Scenario 2
		- User inputs `he` → successfully matches `help`.
		- User presses the ​left arrow key, moving the cursor between `h` and `e`.
		- User inputs `x` → input becomes `hx`, which fails to match. Since `hx` is ​1 character shorter​ than `he`, the popup remains open.
		- User adds another `x` → input becomes `hxx`, which fails and exceeds the tolerance (now 1 character shorter than `he`). The popup closes.
		- Final input state: `hxxe`, with the cursor between the second `x` and `e`.
