### PR TITLE
enhance: query ux

### DIFF
--- a/src/main/frontend/commands.cljs
+++ b/src/main/frontend/commands.cljs
@@ -198,7 +198,8 @@
      [:editor/set-property :block/tags :logseq.class/Query]
      [:editor/set-property :logseq.property/query ""]
      [:editor/set-property-on-block-property :logseq.property/query :logseq.property.node/display-type :code]
-     [:editor/set-property-on-block-property :logseq.property/query :logseq.property.code/lang "clojure"]]
+     [:editor/set-property-on-block-property :logseq.property/query :logseq.property.code/lang "clojure"]
+     [:editor/exit]]
     (->block "query")))
 
 (defn db-based-code-block

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2367,7 +2367,7 @@
       :on-mouse-out #(set-hover? false)}
      [:span.w-full
       (cond
-        (not blank?)
+        (or (not blank?) (not query?))
         (text-block-title config block)
         advanced-query?
         [:span.opacity-75.hover:opacity-100 "Untitled query"]

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -1008,10 +1008,12 @@ html.is-mac {
   height: 18px;
 }
 
+.ls-small-icon svg {
+    width: 12px;
+    height: 12px;
+}
 .ls-type-warning svg {
   color: var(--rx-gray-09);
-  width: 12px;
-  height: 12px;
 }
 
 .ls-page-title .ls-page-icon svg, .ls-page-title .ls-page-icon button {

--- a/src/main/frontend/components/views.cljs
+++ b/src/main/frontend/components/views.cljs
@@ -1793,8 +1793,12 @@
                          (c.m/run-task*
                           (m/sp
                             (let [need-query? (and query? (seq query-entity-ids) (or sorting filters (not (string/blank? input))))]
-                              (if (and query? (not (or sorting filters)) (string/blank? input))
+                              (cond
+                                (and query? (empty? query-entity-ids))
+                                (set-data! nil)
+                                (and query? (not (or sorting filters)) (string/blank? input))
                                 (set-data! query-entity-ids)
+                                :else
                                 (when (or (not query?) need-query?)
                                   (try
                                     (let [{:keys [data ref-pages-count]}

--- a/src/main/frontend/db/query_dsl.cljs
+++ b/src/main/frontend/db/query_dsl.cljs
@@ -732,10 +732,7 @@ Some bindings in this fn:
 
 (def db-block-attrs
   "Block attributes for db graph queries"
-  ;; '*' needed as we need to pull user properties and don't know their names in advance
-  '[*
-    {:block/page [:db/id :block/name :block/title :block/journal-day]}
-    {:block/_parent ...}])
+  '[:db/id])
 
 (defn query
   "Runs a dsl query with query as a string. Primary use is from '/query' or '{{query }}'"

--- a/src/main/frontend/db/query_dsl.cljs
+++ b/src/main/frontend/db/query_dsl.cljs
@@ -732,13 +732,8 @@ Some bindings in this fn:
 
 (def db-block-attrs
   "Block attributes for db graph queries"
-  ;; '*' needed as we need to pull user properties and don't know their names in advance
-  (if util/node-test?
-    '[*
-      {:block/page [:db/id :block/name :block/title :block/journal-day]}
-      {:block/_parent ...}]
-    ;; db graphs needs :db/id only for query view
-    [:db/id]))
+  ;; only needs :db/id for query/view
+  [:db/id])
 
 (defn query
   "Runs a dsl query with query as a string. Primary use is from '/query' or '{{query }}'"

--- a/src/main/frontend/db/query_dsl.cljs
+++ b/src/main/frontend/db/query_dsl.cljs
@@ -765,8 +765,7 @@ Some bindings in this fn:
                                      :query-string query-string
                                      :rules rules}
                                     (merge
-                                     {:use-cache? false
-                                      :transform-fn transform-fn}
+                                     {:transform-fn transform-fn}
                                      query-opts))))))))
 
 (defn custom-query

--- a/src/main/frontend/db/query_dsl.cljs
+++ b/src/main/frontend/db/query_dsl.cljs
@@ -732,7 +732,13 @@ Some bindings in this fn:
 
 (def db-block-attrs
   "Block attributes for db graph queries"
-  '[:db/id])
+  ;; '*' needed as we need to pull user properties and don't know their names in advance
+  (if util/node-test?
+    '[*
+      {:block/page [:db/id :block/name :block/title :block/journal-day]}
+      {:block/_parent ...}]
+    ;; db graphs needs :db/id only for query view
+    [:db/id]))
 
 (defn query
   "Runs a dsl query with query as a string. Primary use is from '/query' or '{{query }}'"

--- a/src/main/frontend/db/react.cljs
+++ b/src/main/frontend/db/react.cljs
@@ -198,7 +198,8 @@
            (when (or query query-fn)
              (try
                (let [f #(execute-query! repo-url db (vec (cons repo-url k)) cache)]
-                 (when-not custom?
+                 (if custom?
+                   (async/put! (state/get-reactive-custom-queries-chan) [f query])
                    (f)))
                (catch :default e
                  (js/console.error e)


### PR DESCRIPTION
1. able to collapse editing either simple or advanced query by clicking the settings icon.
2. more compact view, it shows the block title if it's not empty, or `Untitled query` for advanced query and query builder for simple query.
3. fixes https://github.com/logseq/db-test/issues/237
4. perf: query `:db/id` only because db views don't rely on other properties
<img width="568" alt="image" src="https://github.com/user-attachments/assets/ba67f8ef-1bbe-45a4-b6cf-039962a29fe4" />
