### PR TITLE
enhance(ux): table row/cell navigation

### DIFF
--- a/deps/shui/src/logseq/shui/table/core.cljc
+++ b/deps/shui/src/logseq/shui/table/core.cljc
@@ -276,7 +276,7 @@
 (rum/defc table-row < rum/static
   [& prop-and-children]
   (let [[prop children] (get-prop-and-children prop-and-children)]
-    [:div.ls-table-row.flex.flex-row.items-center
+    [:div.ls-table-row.ls-block.flex.flex-row.items-center
      (merge {:class "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted bg-gray-01 items-stretch"}
             prop)
      children]))

--- a/src/main/frontend/common.css
+++ b/src/main/frontend/common.css
@@ -327,7 +327,7 @@ h1.title, h1.title input, .ls-page-title-container {
 .block-highlight,
 .ls-block.selected,
 .ls-dummy-block.selected,
-.ls-table-cell:focus
+.ls-table-cell.selected
 {
   transition: background-color 0.2s cubic-bezier(0, 1, 0, 1);
   background-color: var(--ls-block-highlight-color, var(--rx-gray-04));

--- a/src/main/frontend/common.css
+++ b/src/main/frontend/common.css
@@ -326,7 +326,9 @@ h1.title, h1.title input, .ls-page-title-container {
 
 .block-highlight,
 .ls-block.selected,
-.ls-dummy-block.selected {
+.ls-dummy-block.selected,
+.ls-table-cell:focus
+{
   transition: background-color 0.2s cubic-bezier(0, 1, 0, 1);
   background-color: var(--ls-block-highlight-color, var(--rx-gray-04));
 }

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -3534,8 +3534,7 @@
        :data-is-property (ldb/property? block)
        :ref #(when (nil? @*ref) (reset! *ref %))
        :data-collapsed (and collapsed? has-child?)
-       :class (str "id" uuid " "
-                   (when selected? " selected")
+       :class (str (when selected? "selected")
                    (when pre-block? " pre-block")
                    (when order-list? " is-order-list")
                    (when (string/blank? title) " is-blank")

--- a/src/main/frontend/components/table.css
+++ b/src/main/frontend/components/table.css
@@ -29,6 +29,10 @@
     }
   }
 
+  .ls-table-row, .ls-table-cell, .ls-table-cell .jtrigger {
+    @apply focus:ring-0 focus:ring-offset-0 focus-visible:outline-none;
+  }
+
   .ls-table-row {
     @apply h-[33px] min-h-[33px] max-h-[33px];
     div, span, a {

--- a/src/main/frontend/components/table.css
+++ b/src/main/frontend/components/table.css
@@ -35,6 +35,10 @@
       @apply whitespace-nowrap;
     }
 
+    :focus {
+        @apply bg-gray-03;
+    }
+
     .table-block-title, .block-head-wrap a {
       @apply text-ellipsis overflow-hidden;
     }

--- a/src/main/frontend/components/table.css
+++ b/src/main/frontend/components/table.css
@@ -35,10 +35,6 @@
       @apply whitespace-nowrap;
     }
 
-    :focus {
-        @apply bg-gray-03;
-    }
-
     .table-block-title, .block-head-wrap a {
       @apply text-ellipsis overflow-hidden;
     }

--- a/src/main/frontend/components/views.cljs
+++ b/src/main/frontend/components/views.cljs
@@ -211,36 +211,36 @@
                         :else
                         (p/do!
                          (shui/popup-show!
-                           (.closest (.-target e) ".ls-table-cell")
-                           (fn []
-                             (let [width (-> (max 160 width)
-                                           (- 18))]
-                               [:div.ls-table-block.flex.flex-row.items-start
-                                {:style {:width width :max-width width :margin-right "6px"}
-                                 :on-click util/stop-propagation}
-                                (block-container {:popup? true
-                                                  :view? true
-                                                  :table-block-title? true} block)
-                                (shui/button
-                                  {:variant :ghost
-                                   :title "Open node"
-                                   :on-click (fn [e]
-                                               (util/stop-propagation e)
-                                               (shui/popup-hide!)
-                                               (redirect!))
-                                   :class (str "h-6 w-6 !p-0 text-muted-foreground transition-opacity duration-100 ease-in bg-gray-01 "
-                                            "opacity-" opacity)}
-                                  (ui/icon "arrow-right"))]))
-                           {:id :ls-table-block-editor
-                            :as-mask? true})
-                          (editor-handler/edit-block! block :max {:container-id :unknown-container}))))))}
+                          (.closest (.-target e) ".ls-table-cell")
+                          (fn []
+                            (let [width (-> (max 160 width)
+                                            (- 18))]
+                              [:div.ls-table-block.flex.flex-row.items-start
+                               {:style {:width width :max-width width :margin-right "6px"}
+                                :on-click util/stop-propagation}
+                               (block-container {:popup? true
+                                                 :view? true
+                                                 :table-block-title? true} block)
+                               (shui/button
+                                {:variant :ghost
+                                 :title "Open node"
+                                 :on-click (fn [e]
+                                             (util/stop-propagation e)
+                                             (shui/popup-hide!)
+                                             (redirect!))
+                                 :class (str "h-6 w-6 !p-0 text-muted-foreground transition-opacity duration-100 ease-in bg-gray-01 "
+                                             "opacity-" opacity)}
+                                (ui/icon "arrow-right"))]))
+                          {:id :ls-table-block-editor
+                           :as-mask? true})
+                         (editor-handler/edit-block! block :max {:container-id :unknown-container}))))))}
      (if block
        [:div
         (inline-title
-          (some->> (:block/title block)
-            string/trim
-            string/split-lines
-            first))]
+         (some->> (:block/title block)
+                  string/trim
+                  string/split-lines
+                  first))]
        [:div])
 
      [:div.absolute.right-0.p-1
@@ -249,11 +249,11 @@
                    (add-to-sidebar!))}
       [:div.flex.items-center
        (shui/button
-         {:variant :ghost
-          :title "Open in sidebar"
-          :class (str "h-5 w-5 !p-0 text-muted-foreground transition-opacity duration-100 ease-in bg-gray-01 "
-                   "opacity-" opacity)}
-         (ui/icon "layout-sidebar-right"))]]]))
+        {:variant :ghost
+         :title "Open in sidebar"
+         :class (str "h-5 w-5 !p-0 text-muted-foreground transition-opacity duration-100 ease-in bg-gray-01 "
+                     "opacity-" opacity)}
+        (ui/icon "layout-sidebar-right"))]]]))
 
 (defn build-columns
   [config properties & {:keys [with-object-name? with-id? add-tags-column?]
@@ -263,30 +263,30 @@
   (let [;; FIXME: Shouldn't file graphs have :block/tags?
         add-tags-column?' (and (config/db-based-graph? (state/get-current-repo)) add-tags-column?)
         properties' (->>
-                      (if (or (some #(= (:db/ident %) :block/tags) properties) (not add-tags-column?'))
-                        properties
-                        (conj properties (db/entity :block/tags)))
-                      (remove nil?))]
+                     (if (or (some #(= (:db/ident %) :block/tags) properties) (not add-tags-column?'))
+                       properties
+                       (conj properties (db/entity :block/tags)))
+                     (remove nil?))]
     (->> (concat
-           [{:id :select
-             :name "Select"
-             :header (fn [table _column] (header-checkbox table))
-             :cell (fn [table row column]
-                     (row-checkbox table row column))
-             :column-list? false
-             :resizable? false}
-            (when with-id?
-              {:id :id
-               :name "ID"
-               :header (fn [_table _column] (header-index))
-               :cell (fn [table row _column]
-                       (inc (.indexOf (:rows table) (:db/id row))))
-               :resizable? false})
-            (when with-object-name?
-              {:id :block/title
-               :name "Name"
-               :type :string
-               :header header-cp
+          [{:id :select
+            :name "Select"
+            :header (fn [table _column] (header-checkbox table))
+            :cell (fn [table row column]
+                    (row-checkbox table row column))
+            :column-list? false
+            :resizable? false}
+           (when with-id?
+             {:id :id
+              :name "ID"
+              :header (fn [_table _column] (header-index))
+              :cell (fn [table row _column]
+                      (inc (.indexOf (:rows table) (:db/id row))))
+              :resizable? false})
+           (when with-object-name?
+             {:id :block/title
+              :name "Name"
+              :type :string
+              :header header-cp
               :cell (fn [_table row _column style]
                       (block-title row {:property-ident :block/title
                                         :sidebar? (:sidebar? config)
@@ -690,6 +690,7 @@
       props
       {:key (str (:db/id row))
        :data-state (when (row-selected? row) "selected")
+       :data-id (:db/id row)
        :on-pointer-down (fn [_e] (db-async/<get-block (state/get-current-repo) (:db/id row) {:children? false}))})
      (when (seq pinned-columns)
        [:div.sticky-columns.flex.flex-row

--- a/src/main/frontend/components/views.cljs
+++ b/src/main/frontend/components/views.cljs
@@ -1435,6 +1435,7 @@
     (when (seq rows)
       (ui/virtualized-list
        {:ref #(reset! *scroller-ref %)
+        :increase-viewport-by {:top 300 :bottom 300}
         :custom-scroll-parent (if sidebar?
                                 (first (dom/by-class "sidebar-item-list"))
                                 (gdom/getElement "main-content-container"))

--- a/src/main/frontend/components/views.cljs
+++ b/src/main/frontend/components/views.cljs
@@ -243,8 +243,10 @@
                            :on-after-hide (fn []
                                             (let [node (rum/deref *ref)
                                                   cell (util/rec-get-node node "ls-table-cell")]
-                                              (state/exit-editing-and-set-selected-blocks! [cell])
-                                              (set-focus-timeout! (js/setTimeout #(.focus cell) 100))))})
+                                              (p/do!
+                                               (editor-handler/save-current-block!)
+                                               (state/exit-editing-and-set-selected-blocks! [cell])
+                                               (set-focus-timeout! (js/setTimeout #(.focus cell) 100)))))})
                          (editor-handler/edit-block! block :max {:container-id :unknown-container}))))))}
      (if block
        [:div
@@ -810,8 +812,8 @@
                           (case (util/ekey e)
                             "Enter"
                             (do
-                              (state/exit-editing-and-set-selected-blocks! [])
                               (state/sidebar-add-block! (state/get-current-repo) (:db/id row) :block)
+                              (state/clear-selection!)
                               (util/stop e))
                             "ArrowLeft"
                             (do

--- a/src/main/frontend/components/views.cljs
+++ b/src/main/frontend/components/views.cljs
@@ -672,7 +672,29 @@
      (assoc cell-opts
             :tabIndex 0
             :ref *ref
-            :on-click (fn [] (click-cell (rum/deref *ref))))
+            :on-click (fn [] (click-cell (rum/deref *ref)))
+            :on-key-down (fn [e]
+                           (let [container (rum/deref *ref)]
+                             (case (util/ekey e)
+                               "Escape"
+                               (do
+                                 (dom/remove-class! container "selected")
+                                 (let [row (util/rec-get-node container "ls-table-row")]
+                                   (state/exit-editing-and-set-selected-blocks! [row]))
+                                 (util/stop e))
+                               "Enter"
+                               (do
+                                 (click-cell container)
+                                 (util/stop e))
+                               "ArrowUp"
+                               nil
+                               "ArrowDown"
+                               nil
+                               "ArrowLeft"
+                               nil
+                               "ArrowRight"
+                               nil
+                               nil))))
      body)))
 
 (rum/defc table-row-inner < rum/static
@@ -727,22 +749,25 @@
                               (util/stop e))
                             "ArrowLeft"
                             (do
-
-                              (when-let [first-cell (->> (dom/sel container ".ls-table-cell")
-                                                         (remove (fn [node]
-                                                                   (some? (dom/sel1 node ".ui__checkbox"))))
-                                                         first)]
+                              (when-let [cell (->> (dom/sel container ".ls-table-cell")
+                                                   (remove (fn [node]
+                                                             (some? (dom/sel1 node ".ui__checkbox"))))
+                                                   first)]
                                 (state/clear-selection!)
                                 (dom/remove-class! container "selected")
-                                (dom/add-class! first-cell "selected"))
+                                (dom/add-class! cell "selected")
+                                (.focus cell))
                               (util/stop e))
                             "ArrowRight"
                             (do
-                              (state/clear-selection!)
-                              (.blur container)
-                              (dom/remove-class! container "selected")
-                              (when-let [last-cell (last (dom/sel container ".ls-table-cell"))]
-                                (.focus last-cell))
+                              (when-let [cell (->> (dom/sel container ".ls-table-cell")
+                                                   (remove (fn [node]
+                                                             (some? (dom/sel1 node ".ui__checkbox"))))
+                                                   last)]
+                                (state/clear-selection!)
+                                (dom/remove-class! container "selected")
+                                (dom/add-class! cell "selected")
+                                (.focus cell))
                               (util/stop e))
                             nil))))})
      (when (seq pinned-columns)

--- a/src/main/frontend/components/views.cljs
+++ b/src/main/frontend/components/views.cljs
@@ -691,6 +691,7 @@
       {:key (str (:db/id row))
        :data-state (when (row-selected? row) "selected")
        :data-id (:db/id row)
+       :blockid (str (:block/uuid row))
        :on-pointer-down (fn [_e] (db-async/<get-block (state/get-current-repo) (:db/id row) {:children? false}))})
      (when (seq pinned-columns)
        [:div.sticky-columns.flex.flex-row

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -66,7 +66,7 @@
 
 (defn select-block!
   [block-uuid]
-  (let [blocks (js/document.getElementsByClassName (str "id" block-uuid))]
+  (let [blocks (util/get-blocks-by-id block-uuid)]
     (when (seq blocks)
       (state/exit-editing-and-set-selected-blocks! blocks))))
 

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3450,7 +3450,6 @@
                (not (slide-focused?))
                (not (state/get-timestamp-block)))
       (util/stop e)
-
       (cond
         (or (state/editing?) (active-jtrigger?))
         (keydown-up-down-handler direction {})

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2768,9 +2768,10 @@
       (move-cross-boundary-up-down direction move-opts)
 
       :else
-      (if up?
-        (cursor/move-cursor-up input)
-        (cursor/move-cursor-down input)))))
+      (when input
+        (if up?
+          (cursor/move-cursor-up input)
+          (cursor/move-cursor-down input))))))
 
 (defn move-to-block-when-cross-boundary
   [direction {:keys [block]}]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2672,10 +2672,6 @@
       (util/scroll-to-block block)
       (state/exit-editing-and-set-selected-blocks! [block]))))
 
-(defn- table-row-container?
-  [node]
-  (when node (dom/has-class? node "ls-table-row")))
-
 (defn- select-up-down [direction]
   (let [selected-blocks (state/get-selection-blocks)
         selected (case direction

--- a/src/main/frontend/handler/ui.cljs
+++ b/src/main/frontend/handler/ui.cljs
@@ -98,7 +98,7 @@
             (> (count fragment) 36)
             (subs fragment (- (count fragment) 36)))]
     (if (and id (util/uuid-string? id))
-      (let [elements (array-seq (js/document.getElementsByClassName (str "id" id)))]
+      (let [elements (util/get-blocks-by-id id)]
         (when (first elements)
           (util/scroll-to-element (gobj/get (first elements) "id")))
         (state/exit-editing-and-set-selected-blocks! elements))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1230,7 +1230,7 @@ Similar to re-frame subscriptions"
         removed (set/difference selected-ids new-ids)]
     (mark-dom-blocks-as-selected blocks)
     (doseq [id removed]
-      (doseq [node (array-seq (gdom/getElementsByClass (str "id" id)))]
+      (doseq [node (dom/sel (util/format "[blockid='%s']" id))]
         (dom/remove-class! node "selected")))))
 
 (defn set-selection-blocks!

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1201,13 +1201,15 @@ Similar to re-frame subscriptions"
 
 (defn dom-clear-selection!
   []
-  (doseq [node (dom/by-class "ls-block selected")]
+  (doseq [node (dom/by-class "selected")]
     (dom/remove-class! node "selected")))
 
 (defn mark-dom-blocks-as-selected
   [nodes]
   (doseq [node nodes]
-    (dom/add-class! node "selected")))
+    (dom/add-class! node "selected")
+    (when (dom/has-class? node "ls-table-row")
+      (.focus node))))
 
 (defn get-events-chan
   []
@@ -1231,7 +1233,9 @@ Similar to re-frame subscriptions"
     (mark-dom-blocks-as-selected blocks)
     (doseq [id removed]
       (doseq [node (dom/sel (util/format "[blockid='%s']" id))]
-        (dom/remove-class! node "selected")))))
+        (dom/remove-class! node "selected")
+        (when (dom/has-class? node "ls-table-row")
+          (.blur node))))))
 
 (defn set-selection-blocks!
   ([blocks]

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -993,12 +993,15 @@
                    :clj nil))
 
 #?(:cljs
+   (defn get-blocks-by-id
+     [block-id]
+     (when (uuid-string? (str block-id))
+       (d/sel (format "[blockid='%s']" (str block-id))))))
+
+#?(:cljs
    (defn get-first-block-by-id
      [block-id]
-     (when block-id
-       (let [block-id (str block-id)]
-         (when (uuid-string? block-id)
-           (first (array-seq (js/document.getElementsByClassName (str "id" block-id)))))))))
+     (first (get-blocks-by-id block-id))))
 
 #?(:cljs
    (defn url-encode


### PR DESCRIPTION
Some enhancement:
1. up/down to focus on any table row or outliner block (non-editing mode)
2. `left` to focus on the first cell when a table row has been focused, `right` to choose the last cell for this row
3. up/down/left/right to navigate between cells
4. Enter to edit a cell
5. ESC to quit editing the cell and focus on it, another ESC to focus on the table row

https://www.loom.com/share/e29191b6d7ed4fb2902edbf333e9bc3b