### PR TITLE
refactor: rename repeat properties to reflect use outside of tasks

### DIFF
--- a/deps/db/src/logseq/db/frontend/property.cljs
+++ b/deps/db/src/logseq/db/frontend/property.cljs
@@ -335,42 +335,42 @@
       :properties {:logseq.property/hide-empty-value true
                    :logseq.property/description "Use it to plan something to start at a specific date(time)."}
       :queryable? true}
-     :logseq.task/recur-frequency
+     :logseq.property.repeat/recur-frequency
      (let [schema {:type :number
                    :public? false}]
-       {:title "Recur frequency"
+       {:title "Repeating recur frequency"
         :schema schema
         :properties {:logseq.property/hide-empty-value true
                      :logseq.property/default-value 1}
         :queryable? true})
-     :logseq.task/recur-unit
-     {:title "Recur unit"
+     :logseq.property.repeat/recur-unit
+     {:title "Repeating recur unit"
       :schema {:type :default
                :public? false}
       :closed-values (mapv (fn [[db-ident value]]
                              {:db-ident db-ident
                               :value value
                               :uuid (common-uuid/gen-uuid :db-ident-block-uuid db-ident)})
-                           [[:logseq.task/recur-unit.minute "Minute"]
-                            [:logseq.task/recur-unit.hour "Hour"]
-                            [:logseq.task/recur-unit.day "Day"]
-                            [:logseq.task/recur-unit.week "Week"]
-                            [:logseq.task/recur-unit.month "Month"]
-                            [:logseq.task/recur-unit.year "Year"]])
+                           [[:logseq.property.repeat/recur-unit.minute "Minute"]
+                            [:logseq.property.repeat/recur-unit.hour "Hour"]
+                            [:logseq.property.repeat/recur-unit.day "Day"]
+                            [:logseq.property.repeat/recur-unit.week "Week"]
+                            [:logseq.property.repeat/recur-unit.month "Month"]
+                            [:logseq.property.repeat/recur-unit.year "Year"]])
       :properties {:logseq.property/hide-empty-value true
-                   :logseq.property/default-value :logseq.task/recur-unit.day}
+                   :logseq.property/default-value :logseq.property.repeat/recur-unit.day}
       :queryable? true}
-     :logseq.task/repeated?
-     {:title "Repeated task?"
+     :logseq.property.repeat/repeated?
+     {:title "Node Repeats?"
       :schema {:type :checkbox
                :hide? true}
       :queryable? true}
-     :logseq.task/scheduled-on-property
-     {:title "Scheduled on property"
+     :logseq.property.repeat/temporal-property
+     {:title "Repeating Temporal Property"
       :schema {:type :property
                :hide? true}}
-     :logseq.task/recur-status-property
-     {:title "Recur status property"
+     :logseq.property.repeat/checked-property
+     {:title "Repeating Checked Property"
       :schema {:type :property
                :hide? true}}
 
@@ -625,7 +625,7 @@
 (def logseq-property-namespaces
   #{"logseq.property" "logseq.property.tldraw" "logseq.property.pdf" "logseq.property.fsrs" "logseq.task"
     "logseq.property.linked-references" "logseq.property.asset" "logseq.property.table" "logseq.property.node"
-    "logseq.property.code"
+    "logseq.property.code" "logseq.property.repeat"
     "logseq.property.journal" "logseq.property.class" "logseq.property.view"
     "logseq.property.user" "logseq.property.history"})
 

--- a/deps/db/src/logseq/db/frontend/schema.cljs
+++ b/deps/db/src/logseq/db/frontend/schema.cljs
@@ -37,7 +37,7 @@
          (map (juxt :major :minor)
               [(parse-schema-version x) (parse-schema-version y)])))
 
-(def version (parse-schema-version "64.6"))
+(def version (parse-schema-version "64.7"))
 
 (defn major-version
   "Return a number.

--- a/deps/db/test/logseq/db/sqlite/create_graph_test.cljs
+++ b/deps/db/test/logseq/db/sqlite/create_graph_test.cljs
@@ -120,7 +120,7 @@
                  :logseq.property/enable-history?))
           "A :checkbox property is created correctly")
       (is (= 1
-             (-> (d/entity @conn :logseq.task/recur-frequency)
+             (-> (d/entity @conn :logseq.property.repeat/recur-frequency)
                  :logseq.property/default-value
                  db-property/property-value-content))
           "A numeric property is created correctly"))))

--- a/src/main/frontend/components/property/value.cljs
+++ b/src/main/frontend/components/property/value.cljs
@@ -274,15 +274,15 @@
      [:div.mb-4
       [:div.flex.flex-row.items-center.gap-1
        [:div.w-4
-        (property-value block (db/entity :logseq.task/repeated?)
+        (property-value block (db/entity :logseq.property.repeat/repeated?)
                         (assoc opts
                                :on-checked-change (fn [value]
                                                     (if value
                                                       (db-property-handler/set-block-property! (:db/id block)
-                                                                                               :logseq.task/scheduled-on-property
+                                                                                               :logseq.property.repeat/temporal-property
                                                                                                (:db/id property))
                                                       (db-property-handler/remove-block-property! (:db/id block)
-                                                                                                  :logseq.task/scheduled-on-property)))))]
+                                                                                                  :logseq.property.repeat/temporal-property)))))]
        (if (#{:logseq.task/deadline :logseq.task/scheduled} (:db/ident property))
          [:div "Repeat task"]
          [:div "Repeat " (if (= :date (:logseq.property/type property)) "date" "datetime")])]]
@@ -292,11 +292,11 @@
 
       ;; recur frequency
       [:div.w-6
-       (property-value block (db/entity :logseq.task/recur-frequency) opts)]
+       (property-value block (db/entity :logseq.property.repeat/recur-frequency) opts)]
 
       ;; recur unit
       [:div.w-20
-       (property-value block (db/entity :logseq.task/recur-unit) (assoc opts :property property))]]
+       (property-value block (db/entity :logseq.property.repeat/recur-unit) (assoc opts :property property))]]
      (let [properties (->>
                        (outliner-property/get-block-full-properties (db/get-db) (:db/id block))
                        (filter (fn [property]
@@ -304,7 +304,7 @@
                                       (>= (count (:property/closed-values property)) 2))))
                        (concat [(db/entity :logseq.task/status)])
                        (util/distinct-by :db/id))
-           status-property (or (:logseq.task/recur-status-property block)
+           status-property (or (:logseq.property.repeat/checked-property block)
                                (db/entity :logseq.task/status))
            property-id (:db/id status-property)
            done-choice (or
@@ -317,7 +317,7 @@
          (cond->
           {:on-value-change (fn [v]
                               (db-property-handler/set-block-property! (:db/id block)
-                                                                       :logseq.task/recur-status-property
+                                                                       :logseq.property.repeat/checked-property
                                                                        v))}
            property-id
            (assoc :default-value property-id))
@@ -482,7 +482,7 @@
                         (when-not config/publishing?
                           (shui/popup-show! (.-target e) content-fn
                                             {:align "start" :auto-focus? true}))))
-        repeated-task? (:logseq.task/repeated? block)]
+        repeated-task? (:logseq.property.repeat/repeated? block)]
     (if editing?
       (content-fn {:id :date-picker})
       (if multiple-values?
@@ -911,11 +911,11 @@
             closed-values? (seq (:property/closed-values property))
             items (if closed-values?
                     (let [date? (and
-                                 (= (:db/ident property) :logseq.task/recur-unit)
+                                 (= (:db/ident property) :logseq.property.repeat/recur-unit)
                                  (= :date (:logseq.property/type (:property opts))))
                           values (cond->> (:property/closed-values property)
                                    date?
-                                   (remove (fn [b] (contains? #{:logseq.task/recur-unit.minute :logseq.task/recur-unit.hour} (:db/ident b)))))]
+                                   (remove (fn [b] (contains? #{:logseq.property.repeat/recur-unit.minute :logseq.property.repeat/recur-unit.hour} (:db/ident b)))))]
                       (keep (fn [block]
                               (let [icon (pu/get-block-property-value block :logseq.property/icon)
                                     value (db-property/closed-value-content block)]

--- a/src/main/frontend/worker/commands.cljs
+++ b/src/main/frontend/worker/commands.cljs
@@ -15,7 +15,7 @@
   (atom
    [[:repeated-task
      {:title "Repeated task"
-      :entity-conditions [{:property :logseq.task/repeated?
+      :entity-conditions [{:property :logseq.property.repeat/repeated?
                            :value true}]
       :tx-conditions [{:property :status
                        :value :done}]
@@ -32,7 +32,7 @@
   [entity property]
   (if (= property :status)
     (or
-     (:db/ident (:logseq.task/recur-status-property entity))
+     (:db/ident (:logseq.property.repeat/checked-property entity))
      :logseq.task/status)
     property))
 
@@ -41,7 +41,7 @@
   (cond
     (and (= property :status) (= value :done))
     (or
-     (let [p (:logseq.task/recur-status-property entity)
+     (let [p (:logseq.property.repeat/checked-property entity)
            choices (:property/closed-values p)
            checkbox? (= :checkbox (:logseq.property/type p))]
        (if checkbox?
@@ -52,7 +52,7 @@
      :logseq.task/status.done)
     (and (= property :status) (= value :todo))
     (or
-     (let [p (:logseq.task/recur-status-property entity)
+     (let [p (:logseq.property.repeat/checked-property entity)
            choices (:property/closed-values p)
            checkbox? (= :checkbox (:logseq.property/type p))]
        (if checkbox?
@@ -130,30 +130,30 @@
   (let [current-date-time (tc/to-date-time current-value)
         default-timezone-time (t/to-default-time-zone current-date-time)
         [recur-unit period-f] (case (:db/ident unit)
-                                :logseq.task/recur-unit.minute [t/minutes t/in-minutes]
-                                :logseq.task/recur-unit.hour [t/hours t/in-hours]
-                                :logseq.task/recur-unit.day [t/days t/in-days]
-                                :logseq.task/recur-unit.week [t/weeks t/in-weeks]
-                                :logseq.task/recur-unit.month [t/months t/in-months]
-                                :logseq.task/recur-unit.year [t/years t/in-years]
+                                :logseq.property.repeat/recur-unit.minute [t/minutes t/in-minutes]
+                                :logseq.property.repeat/recur-unit.hour [t/hours t/in-hours]
+                                :logseq.property.repeat/recur-unit.day [t/days t/in-days]
+                                :logseq.property.repeat/recur-unit.week [t/weeks t/in-weeks]
+                                :logseq.property.repeat/recur-unit.month [t/months t/in-months]
+                                :logseq.property.repeat/recur-unit.year [t/years t/in-years]
                                 nil)]
     (when recur-unit
       (let [delta (recur-unit frequency)
             next-time (case (:db/ident unit)
-                        :logseq.task/recur-unit.year
+                        :logseq.property.repeat/recur-unit.year
                         (repeat-until-future-timestamp default-timezone-time recur-unit frequency period-f false)
-                        :logseq.task/recur-unit.month
+                        :logseq.property.repeat/recur-unit.month
                         (repeat-until-future-timestamp default-timezone-time recur-unit frequency period-f false)
-                        :logseq.task/recur-unit.week
+                        :logseq.property.repeat/recur-unit.week
                         (repeat-until-future-timestamp default-timezone-time recur-unit frequency period-f true)
                         (t/plus (t/now) delta))]
         (tc/to-long next-time)))))
 
 (defmethod handle-command :reschedule [_ db entity _datoms]
-  (let [property-ident (or (:db/ident (:logseq.task/scheduled-on-property entity))
+  (let [property-ident (or (:db/ident (:logseq.property.repeat/temporal-property entity))
                            :logseq.task/scheduled)
-        frequency (db-property/property-value-content (:logseq.task/recur-frequency entity))
-        unit (:logseq.task/recur-unit entity)
+        frequency (db-property/property-value-content (:logseq.property.repeat/recur-frequency entity))
+        unit (:logseq.property.repeat/recur-unit entity)
         property (d/entity db property-ident)
         date? (= :date (:logseq.property/type property))
         current-value (cond->


### PR DESCRIPTION
This PR addresses some [cleanup we'd talked about](https://logseq.slack.com/archives/C04ENNDPDFB/p1736252801748289?thread_ts=1735200320.849879&cid=C04ENNDPDFB). Better to do this before the merge to master. I QAed the migration works for affected properties with deadline, scheduled and custom user repeat use cases