### PR TITLE
enhance(ux): use select component for setting tag properties

### DIFF
--- a/deps/db/src/logseq/db/frontend/db.cljs
+++ b/deps/db/src/logseq/db/frontend/db.cljs
@@ -40,8 +40,7 @@
 (defn get-all-properties
   [db]
   (->> (d/datoms db :avet :block/tags :logseq.class/Property)
-       (map (fn [d]
-              (d/entity db (:e d))))))
+       (map (fn [d] (d/entity db (:e d))))))
 
 (defn get-page-parents
   [node & {:keys [node-class?]}]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2131,8 +2131,9 @@
         own-number-list?   (:own-order-number-list? config)
         order-list?        (boolean own-number-list?)
         order-list-idx     (:own-order-list-index config)
+        page-title?        (:page-title? config)
         collapsable?       (editor-handler/collapsable? uuid {:semantic? true
-                                                              :ignore-children? (:page-title? config)})
+                                                              :ignore-children? page-title?})
         link?              (boolean (:original-block config))
         icon-size          (if collapsed? 12 14)
         icon               (icon-component/get-node-icon-cp block {:size icon-size :color? true})
@@ -2147,7 +2148,8 @@
                                 :is-with-icon  with-icon?
                                 :bullet-closed collapsed?
                                 :bullet-hidden (:hide-bullet? config)}])}
-     (when (and (or (not fold-button-right?) collapsable?) (not (:table? config)))
+     (when (and (or (not fold-button-right?) collapsable?)
+                (not (:table? config)))
        [:a.block-control
         {:id       (str "control-" uuid)
          :on-click (fn [event]
@@ -2162,7 +2164,7 @@
                      (when (and (state/developer-mode?) (.-metaKey event))
                        (js/console.debug "[block config]==" config)))}
         [:span {:class (if (or (and control-show? (or collapsed? collapsable?))
-                               (and collapsed? (or order-list? config/publishing?)))
+                               (and collapsed? (or page-title? order-list? config/publishing?)))
                          "control-show cursor-pointer"
                          "control-hide")}
          (ui/rotating-arrow collapsed?)]])

--- a/src/main/frontend/components/objects.cljs
+++ b/src/main/frontend/components/objects.cljs
@@ -94,9 +94,10 @@
                   :add-new-object! add-new-object!
                   :show-add-property? true
                   :show-items-count? true
-                  :add-property! (fn []
+                  :add-property! (fn [e]
                                    (state/pub-event! [:editor/new-property {:block class
-                                                                            :class-schema? true}]))})]))
+                                                                            :class-schema? true
+                                                                            :target (.-target e)}]))})]))
 
 (rum/defcs class-objects < rum/reactive db-mixins/query mixins/container-id
   [state class {:keys [current-page? sidebar?]}]

--- a/src/main/frontend/components/property.cljs
+++ b/src/main/frontend/components/property.cljs
@@ -361,7 +361,6 @@
                    state)}
   [state block *property-key {:keys [class-schema?]
                               :as opts}]
-  (prn :debug :key *property-key)
   (let [*property (::property state)
         *show-new-property-config? (::show-new-property-config? state)
         *show-class-select? (::show-class-select? state)
@@ -388,7 +387,7 @@
         [:div.flex.flex-row {:on-pointer-down (fn [e] (util/stop-propagation e))}
          (when (not= @*show-new-property-config? :adding-property)
            (cond
-             @*show-new-property-config?
+             (or (nil? property) @*show-new-property-config?)
              (property-type-select property (merge opts
                                                    {:*property *property
                                                     :*property-name *property-key

--- a/src/main/frontend/components/property.cljs
+++ b/src/main/frontend/components/property.cljs
@@ -638,9 +638,12 @@
                                         (into result cur-properties)
                                         result)))
                              result))
-        full-properties (->> (concat block-own-properties'
-                                     (map (fn [p] [p (get block p)]) class-properties))
-                             remove-built-in-or-other-position-properties)]
+        full-properties (cond->
+                         (->> (concat block-own-properties'
+                                      (map (fn [p] [p (get block p)]) class-properties))
+                              remove-built-in-or-other-position-properties)
+                          (and (ldb/class? block) (empty? (:logseq.property.class/properties block)))
+                          (concat [[:logseq.property.class/properties nil]]))]
     (cond
       (empty? full-properties)
       (when sidebar-properties?

--- a/src/main/frontend/components/property.cljs
+++ b/src/main/frontend/components/property.cljs
@@ -148,22 +148,19 @@
                    [:span "Changing the property type clears some property configurations."]))]))
 
 (rum/defc property-select
-  [exclude-properties select-opts]
+  [select-opts]
   (let [[properties set-properties!] (rum/use-state nil)
-        [classes set-classes!] (rum/use-state nil)
-        [excluded-properties set-excluded-properties!] (rum/use-state nil)]
+        [classes set-classes!] (rum/use-state nil)]
     (hooks/use-effect!
      (fn []
        (p/let [repo (state/get-current-repo)
-               properties (db-async/db-based-get-all-properties repo)
+               properties (if (:class-schema? select-opts)
+                            (property-handler/get-class-property-choices)
+                            (db-model/get-all-properties repo {:remove-ui-non-suitable-properties? true}))
                classes (->> (db-model/get-all-classes repo)
                             (remove ldb/built-in?))]
          (set-classes! classes)
-         (set-properties! (remove exclude-properties properties))
-         (set-excluded-properties! (->> properties
-                                        (filter exclude-properties)
-                                        (map :block/title)
-                                        set))))
+         (set-properties! properties)))
      [])
     (let [items (->>
                  (concat
@@ -186,7 +183,7 @@
                          :close-modal? false
                          :new-case-sensitive? true
                          :show-new-when-not-exact-match? true
-                         :exact-match-exclude-items (fn [s] (contains? excluded-properties s))
+                         ;; :exact-match-exclude-items (fn [s] (contains? excluded-properties s))
                          :input-default-placeholder "Add or change property"}
                         select-opts))]])))
 
@@ -270,7 +267,8 @@
   (shui/trigger-as
    :a
    {:tabIndex 0
-    :title (:block/title property)
+    :title (or (:block/title (:logseq.property/description property))
+               (:block/title property))
     :class "property-k flex select-none jtrigger w-full"
     :on-pointer-down (fn [^js e]
                        (when (util/meta-key? e)
@@ -363,26 +361,11 @@
                    state)}
   [state block *property-key {:keys [class-schema?]
                               :as opts}]
+  (prn :debug :key *property-key)
   (let [*property (::property state)
         *show-new-property-config? (::show-new-property-config? state)
         *show-class-select? (::show-class-select? state)
         *property-schema (::property-schema state)
-        page? (entity-util/page? block)
-        block-types (let [types (ldb/get-entity-types block)]
-                      (cond-> types
-                        (and page? (not (contains? types :page)))
-                        (conj :page)
-                        (empty? types)
-                        (conj :block)))
-        exclude-properties (fn [m]
-                             (let [view-context (get m :logseq.property/view-context :all)]
-                               (or (contains? #{:logseq.property/query} (:db/ident m))
-                                   (and (not page?) (contains? #{:block/alias} (:db/ident m)))
-                                   ;; Filters out properties from being in wrong :view-context and :never view-contexts
-                                   (and (not= view-context :all) (not (contains? block-types view-context)))
-                                   (and (ldb/built-in? block) (contains? #{:logseq.property/parent} (:db/ident m)))
-                                   ;; Filters out adding buggy class properties e.g. Alias and Parent
-                                   (and class-schema? (ldb/public-built-in-property? m) (:logseq.property/view-context m)))))
         property (rum/react *property)
         property-key (rum/react *property-key)
         batch? (pv/batch-operation?)
@@ -434,9 +417,9 @@
                                       (= "" (.-value (.-target e))))
                              (util/stop e)
                              (shui/popup-hide!)))}]
-         (property-select exclude-properties
-                          (merge (:select-opts opts) {:on-chosen on-chosen
-                                                      :input-opts input-opts}))))]))
+         (property-select (merge (:select-opts opts) {:on-chosen on-chosen
+                                                      :input-opts input-opts
+                                                      :class-schema? class-schema?}))))]))
 
 (rum/defcs new-property < rum/reactive
   [state block opts]
@@ -491,8 +474,6 @@
                                                                     :page-cp page-cp))]
         [:div {:key (str "property-pair-" (:db/id block) "-" (:db/id property))
                :class (cond
-                        (= (:db/ident property) :logseq.property.class/properties)
-                        "property-pair !flex !flex-col"
                         (or date? datetime? checkbox?)
                         "property-pair items-center"
                         :else
@@ -501,21 +482,14 @@
            (dnd/sortable-item (assoc sortable-opts :class "property-key") property-key-cp')
            [:div.property-key property-key-cp'])
 
-         (let [class-properties? (= (:db/ident property) :logseq.property.class/properties)
-               property-desc (when-not (= (:db/ident property) :logseq.property/description)
+         (let [property-desc (when-not (= (:db/ident property) :logseq.property/description)
                                (:logseq.property/description property))]
            [:div.ls-block.property-value-container.flex.flex-row.gap-1.items-center
-            (cond-> {}
-              class-properties? (assoc :class (if (:logseq.property.class/properties block)
-                                                "ml-2 -mt-1"
-                                                "-ml-1")))
-            (when-not (or block? class-properties? (and property-desc (:class-schema? opts)))
+            (when-not (or block? (and property-desc (:class-schema? opts)))
               [:div {:class "pl-1.5 -mr-[3px] opacity-60"}
                [:span.bullet-container [:span.bullet]]])
             [:div.flex.flex-1
              [:div.property-value.flex.flex-1
-              (cond-> {}
-                class-properties? (assoc :class :opacity-90))
               (if (:class-schema? opts)
                 (pv/property-value property (db/entity :logseq.property/description) opts)
                 (pv/property-value block property opts))]]])]))))
@@ -592,7 +566,6 @@
                                             (and show?
                                                  (or (= mode :global)
                                                      (and (set? ids) (contains? ids (:block/uuid block))))))
-        class? (ldb/class? block)
         properties (:block/properties block)
         remove-built-in-or-other-position-properties
         (fn [properties]
@@ -667,9 +640,7 @@
                                         result)))
                              result))
         full-properties (->> (concat block-own-properties'
-                                     (map (fn [p] [p (get block p)]) class-properties)
-                                     (when (and class? (nil? (:logseq.property.class/properties block)))
-                                       [[:logseq.property.class/properties nil]]))
+                                     (map (fn [p] [p (get block p)]) class-properties))
                              remove-built-in-or-other-position-properties)]
     (cond
       (empty? full-properties)
@@ -678,28 +649,15 @@
 
       :else
       (let [remove-properties #{:logseq.property/icon :logseq.property/query}
-            properties' (remove (fn [[k _v]] (contains? remove-properties k)) full-properties)
-            properties'' (->> properties'
-                              (remove (fn [[k _v]] (= k :logseq.property.class/properties))))
+            properties' (remove (fn [[k _v]] (contains? remove-properties k))
+                                full-properties)
             page? (entity-util/page? block)]
         [:div.ls-properties-area
          {:id id
           :class (util/classnames [{:ls-page-properties page?}])
           :tab-index 0}
          [:<>
-          (properties-section block properties'' opts)
+          (properties-section block properties' opts)
 
-          (when (and page? (not class?))
-            (rum/with-key (new-property block opts) (str id "-add-property")))]
-
-         (when class?
-           (let [properties (->> (:logseq.property.class/properties block)
-                                 (map (fn [e] [(:db/ident e)])))
-                 opts' (assoc opts :class-schema? true)]
-             [:<>
-              [:div.mt-2
-               [:div.text-sm.text-muted-foreground.mb-2 {:style {:margin-left 10}}
-                "Tag Properties:"]
-               [:div
-                (properties-section block properties opts')
-                (rum/with-key (new-property block opts') (str id "-class-add-property"))]]]))]))))
+          (when page?
+            (rum/with-key (new-property block opts) (str id "-add-property")))]]))))

--- a/src/main/frontend/components/property/value.cljs
+++ b/src/main/frontend/components/property/value.cljs
@@ -679,7 +679,7 @@
 
 (rum/defc ^:large-vars/cleanup-todo select-node < rum/static
   [property
-   {:keys [block multiple-choices? dropdown? input-opts on-input add-new-choice!] :as opts}
+   {:keys [block multiple-choices? dropdown? input-opts on-input add-new-choice! target] :as opts}
    result]
   (let [repo (state/get-current-repo)
         classes (:logseq.property/classes property)
@@ -695,9 +695,6 @@
         parent-property? (= (:db/ident property) :logseq.property/parent)
         children-pages (when parent-property? (model/get-structured-children repo (:db/id block)))
         property-type (:logseq.property/type property)
-        get-all-classes-f (fn []
-                            (model/get-all-classes repo {:except-root-class? true
-                                                         :except-private-tags? (not (contains? #{:logseq.property/template-applied-to} (:db/ident property)))}))
         nodes (cond
                 parent-property?
                 (let [;; Disallows cyclic hierarchies
@@ -709,8 +706,14 @@
                       excluded-options (remove (fn [e] (contains? exclude-ids (:block/uuid e))) options)]
                   excluded-options)
 
-                (= property-type :class)
-                (get-all-classes-f)
+                (contains? #{:class :property} property-type)
+                (let [classes (model/get-all-classes
+                               repo
+                               {:except-root-class? true
+                                :except-private-tags? (not (contains? #{:logseq.property/template-applied-to} (:db/ident property)))})]
+                  (if (= property-type :class)
+                    classes
+                    (property-handler/get-class-property-choices)))
 
                 (seq classes)
                 (->>
@@ -766,7 +769,7 @@
                                                                 (breadcrumb {:search? true} (state/get-current-repo) (:block/uuid node) {})]))
                                                     label [:div.flex.flex-row.items-center.gap-1
                                                            (when-not (or (:logseq.property/classes property)
-                                                                         (= (:db/ident property) :block/tags))
+                                                                         (contains? #{:class :property} (:logseq.property/type property)))
                                                              (ui/icon icon {:size 14}))
                                                            [:div title]]]
                                                 [header label])
@@ -806,10 +809,18 @@
                  :input-opts input-opts
                  :on-input (debounce on-input 50)
                  :on-chosen (fn [chosen selected?]
-                              (p/let [id (if (integer? chosen)
+                              (p/let [add-tag-property? (and (= (:db/ident property) :logseq.property.class/properties) (not (integer? chosen)))
+                                      id (if (integer? chosen)
                                            chosen
                                            (when-not (string/blank? (string/trim chosen))
-                                             (<create-page-if-not-exists! block property classes' chosen)))
+                                             (if (= (:db/ident property) :logseq.property.class/properties)
+                                               (do
+                                                 (shui/popup-hide!)
+                                                 (state/pub-event! [:editor/new-property {:block block
+                                                                                          :class-schema? true
+                                                                                          :property-key chosen
+                                                                                          :target target}]))
+                                               (<create-page-if-not-exists! block property classes' chosen))))
                                       _ (when (and (integer? id) (not (entity-util/page? (db/entity id))))
                                           (db-async/<get-block repo id))]
                                 (if id
@@ -820,7 +831,8 @@
                                       (let [e (db/entity id)]
                                         {:value (select-keys e [:db/id :block/uuid])
                                          :label (:block/title e)}))))
-                                  (log/error :msg "No :db/id found or created for chosen" :chosen chosen))))})
+                                  (when-not add-tag-property?
+                                    (log/error :msg "No :db/id found or created for chosen" :chosen chosen)))))})
 
                 (and (seq classes') (not tags-or-alias?))
                 (assoc
@@ -1144,17 +1156,17 @@
         editing? (:editing? opts)
         type (:logseq.property/type property)
         select-opts' (assoc select-opts :multiple-choices? false)
-        popup-content (fn content-fn [_]
+        popup-content (fn content-fn [target]
                         [:div.property-select
                          (case type
                            (:entity :number :default :url)
                            (select block property select-opts' opts)
 
                            (:node :class :property :page :date)
-                           (property-value-select-node block property select-opts' opts))])
+                           (property-value-select-node block property select-opts' (assoc opts :target target)))])
         trigger-id (str "trigger-" (:container-id opts) "-" (:db/id block) "-" (:db/id property))
         show-popup! (fn [target]
-                      (shui/popup-show! target popup-content
+                      (shui/popup-show! target (fn [] (popup-content target))
                                         {:align "start"
                                          :as-dropdown? true
                                          :auto-focus? true
@@ -1368,7 +1380,7 @@
         items (cond->> (if (entity-map? v) #{v} v)
                 (= (:db/ident property) :block/tags)
                 (remove (fn [v] (contains? ldb/hidden-tags (:db/ident v)))))
-        select-cp (fn [select-opts]
+        select-cp (fn [select-opts target]
                     (let [select-opts (merge {:multiple-choices? true
                                               :on-chosen (fn []
                                                            (when on-chosen (on-chosen)))}
@@ -1378,18 +1390,20 @@
                       [:div.property-select
                        (if (contains? #{:node :page :class :property} type)
                          (property-value-select-node block property
-                                                     select-opts
+                                                     (assoc select-opts :target target)
                                                      opts)
                          (select block property select-opts opts))]))]
     (if editing?
-      (select-cp {})
+      (select-cp {} nil)
       (let [toggle-fn shui/popup-hide!
-            content-fn (fn [{:keys [_id content-props]}]
-                         (select-cp {:content-props content-props}))
+            content-fn (fn [{:keys [_id content-props]} target]
+                         (select-cp {:content-props content-props} target))
             show-popup! (fn [^js e]
                           (let [target (.-target e)]
                             (when-not (or (util/link? target) (.closest target "a") config/publishing?)
-                              (shui/popup-show! (rum/deref *el) content-fn
+                              (shui/popup-show! (rum/deref *el)
+                                                (fn [opts]
+                                                  (content-fn opts target))
                                                 {:as-dropdown? true :as-content? false
                                                  :align "start" :auto-focus? true}))))]
         [:div.multi-values.jtrigger
@@ -1432,7 +1446,6 @@
   (ui/catch-error
    (ui/block-error "Something wrong" {})
    (let [block-cp (state/get-component :block/blocks-container)
-         properties-cp (state/get-component :block/properties-cp)
          opts (merge opts
                      {:page-cp (state/get-component :block/page-cp)
                       :inline-text (state/get-component :block/inline-text)
@@ -1486,10 +1499,6 @@
                         :class (str (when empty-value? "empty-value")
                                     (when-not (:other-position? opts) " w-full"))}
                        (cond
-                         (= property-ident :logseq.property.class/properties)
-                         (properties-cp {} block {:selected? false
-                                                  :class-schema? true})
-
                          (and multiple-values? (contains? #{:default :url} type) (not closed-values?) (not editing?))
                          (property-normal-block-value block property v opts)
 

--- a/src/main/frontend/components/views.cljs
+++ b/src/main/frontend/components/views.cljs
@@ -695,7 +695,7 @@
                                {:id "add property"
                                 :prop {:style {:width "-webkit-fill-available"
                                                :min-width 160}
-                                       :on-click (fn [] (when (fn? add-property!) (add-property!)))}
+                                       :on-click (fn [e] (when (fn? add-property!) (add-property! e)))}
                                 :value :add-new-property
                                 :content (add-property-button)
                                 :disabled? true})

--- a/src/main/frontend/db/model.cljs
+++ b/src/main/frontend/db/model.cljs
@@ -17,6 +17,7 @@
             [logseq.db :as ldb]
             [logseq.db.frontend.class :as db-class]
             [logseq.db.frontend.content :as db-content]
+            [logseq.db.frontend.property :as db-property]
             [logseq.db.frontend.rules :as rules]))
 
 ;; TODO: extract to specific models and move data transform logic to the
@@ -528,6 +529,52 @@ independent of format as format specific heading characters are stripped"
     (if except-root-class?
       (keep (fn [e] (when-not (= :logseq.class/Root (:db/ident e)) e)) classes)
       classes)))
+
+(defn ui-non-suitable-property?
+  [block m {:keys [class-schema?]}]
+  (when block
+    (let [block-page? (ldb/page? block)
+          block-types (let [types (ldb/get-entity-types block)]
+                        (cond-> types
+                          (and block-page? (not (contains? types :page)))
+                          (conj :page)
+                          (empty? types)
+                          (conj :block)))
+          view-context (get m :logseq.property/view-context :all)]
+      (or (contains? #{:logseq.property/query} (:db/ident m))
+          (and (not block-page?) (contains? #{:block/alias} (:db/ident m)))
+        ;; Filters out properties from being in wrong :view-context and :never view-contexts
+          (and (not= view-context :all) (not (contains? block-types view-context)))
+          (and (ldb/built-in? block) (contains? #{:logseq.property/parent} (:db/ident m)))
+        ;; Filters out adding buggy class properties e.g. Alias and Parent
+          (and class-schema? (ldb/public-built-in-property? m) (:logseq.property/view-context m))))))
+
+(defn get-all-properties
+  "Return seq of all property names except for private built-in properties."
+  [graph & {:keys [remove-built-in-property? remove-non-queryable-built-in-property? remove-ui-non-suitable-properties?
+                   class-schema? block]
+            :or {remove-built-in-property? true
+                 remove-non-queryable-built-in-property? false
+                 remove-ui-non-suitable-properties? false}}]
+  (let [db (conn/get-db graph)
+        result (sort-by (juxt ldb/built-in? :block/title)
+                        (ldb/get-all-properties db))]
+    (cond->> result
+      remove-built-in-property?
+      ;; remove private built-in properties
+      (remove (fn [p]
+                (let [ident (:db/ident p)]
+                  (and (ldb/built-in? p)
+                       (not (ldb/public-built-in-property? p))
+                       (not= ident :logseq.property/icon)))))
+      remove-non-queryable-built-in-property?
+      (remove (fn [p]
+                (let [ident (:db/ident p)]
+                  (and (ldb/built-in? p)
+                       (not (:queryable? (db-property/built-in-properties ident)))))))
+      remove-ui-non-suitable-properties?
+      (remove (fn [p]
+                (ui-non-suitable-property? block p {:class-schema? class-schema?}))))))
 
 (defn get-all-readable-classes
   "Gets all classes that are used in a read only context e.g. querying or used

--- a/src/main/frontend/handler/property.cljs
+++ b/src/main/frontend/handler/property.cljs
@@ -1,6 +1,7 @@
 (ns frontend.handler.property
   "Property fns for both file and DB graphs"
   (:require [frontend.config :as config]
+            [frontend.db.model :as db-model]
             [frontend.handler.db-based.property :as db-property-handler]
             [frontend.handler.file-based.page-property :as file-page-property]
             [frontend.handler.file-based.property :as file-property-handler]
@@ -66,3 +67,20 @@
   (assert (uuid? block-id))
   (when (config/db-based-graph? repo)
     (db-property-handler/set-block-properties! block-id properties)))
+
+(defonce class-property-excludes
+  #{:logseq.property.class/properties :block/tags
+    :logseq.property/icon :block/alias :logseq.property/enable-history?
+    :logseq.property/exclude-from-graph-view :logseq.property/template-applied-to
+    :logseq.property/hide-empty-value :logseq.property.class/hide-from-node
+    :logseq.property/page-tags :logseq.property/parent
+    :logseq.property/publishing-public? :logseq.property.user/avatar
+    :logseq.property.user/email :logseq.property.user/name})
+
+(defn get-class-property-choices
+  []
+  (->>
+   (db-model/get-all-properties (state/get-current-repo)
+                                {:remove-ui-non-suitable-properties? true})
+   (remove (fn [p]
+             (contains? class-property-excludes (:db/ident p))))))


### PR DESCRIPTION
This PR uses the default `select` component for setting tag properties, this makes the properties UX more consistent, efficient, and it includes some other enhancements:
1. Display `Set icon | Configure` for property page, `Set icon | Add tag property` for tag page
2. Display a collapsed triangle on the left of page title when it's collapsed.


Demo:
https://www.loom.com/share/8005608eb5bd47af83d8781ba3185bb1