### PR TITLE
Controlling graph node colors from tags

### DIFF
--- a/deps/graph-parser/test/resources/exporter-test-graph/logseq/config.edn
+++ b/deps/graph-parser/test/resources/exporter-test-graph/logseq/config.edn
@@ -283,6 +283,18 @@
  ;;  :excluded-pages? false  ; Default value: false
  ;;  :journal?        false} ; Default value: false
 
+ ;; Graph view configuration.
+ ;; Example usage:
+ ;; :graph/forcesettings
+ ;; {:link-dist       180    ; Default value: 180
+ ;;  :charge-strength -600   ; Default value: -600
+ ;;  :charge-range    600}   ; Default value: 600
+
+ ;; :graph/color-property :type ; use the type property to set the graph node colors
+ ;; :graph/color-settings
+ ;; {<property value> <color code>
+ ;;   article #ff0000 }
+ 
  ;; Favorites to list on the left sidebar
    :favorites ["Interstellar" "some page"]
 

--- a/src/main/frontend/common/graph_view.cljs
+++ b/src/main/frontend/common/graph_view.cljs
@@ -18,7 +18,7 @@
         links))
 
 (defn- build-nodes
-  [dark? current-page page-links tags nodes namespaces color-property color-settings]
+  [dark? current-page page-links nodes namespaces color-property color-settings]
   (let [page-parents (set (map last namespaces))
         current-page (or current-page "")
         pages (common-util/distinct-by :db/id nodes)]
@@ -110,7 +110,7 @@
         page-links (reduce (fn [m [k v]] (-> (update m k inc)
                                              (update v inc))) {} links)
         links (build-links links)
-        nodes (build-nodes dark? nil page-links tags nodes namespaces color-property color-settings)]
+        nodes (build-nodes dark? nil page-links nodes namespaces color-property color-settings)]
     (-> {:nodes nodes
          :links links}
         normalize-page-name
@@ -202,7 +202,7 @@
                    (remove nil?)
                    (map #(d/entity db %))
                    (common-util/distinct-by :db/id))
-        nodes (build-nodes dark? (:block/title page-entity) links tags nodes namespaces color-property color-settings)]
+        nodes (build-nodes dark? (:block/title page-entity) links nodes namespaces color-property color-settings)]
     (normalize-page-name
      {:nodes nodes
       :links links})))
@@ -228,7 +228,7 @@
                      distinct
                        ;; FIXME: get block tags
                      )
-          nodes (build-nodes dark? block links #{} nodes namespaces color-property color-settings)]
+          nodes (build-nodes dark? block links nodes namespaces color-property color-settings)]
       (normalize-page-name
        {:nodes nodes
         :links links}))))

--- a/src/main/frontend/common/graph_view.cljs
+++ b/src/main/frontend/common/graph_view.cljs
@@ -79,7 +79,6 @@
         relation (ldb/get-pages-relation db journal?)
         tagged-pages (ldb/get-all-tagged-pages db)
         namespaces (gp-db/get-all-namespace-relation db)
-        tags (set (map second tagged-pages))
         full-pages (ldb/get-all-pages db)
         db-based? (entity-plus/db-based-graph? db)
         created-ats (map :block/created-at full-pages)

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -1108,14 +1108,15 @@
     nodes))
 
 (rum/defc graph-aux
-  [settings forcesettings theme search-graph-filters]
+  [settings forcesettings color-property color-settings theme search-graph-filters]
   (let [[graph set-graph!] (hooks/use-state nil)]
     (hooks/use-effect!
      (fn []
        (p/let [result (state/<invoke-db-worker :thread-api/build-graph (state/get-current-repo)
                                                (assoc settings
                                                       :type :global
-                                                      :theme theme))]
+                                                      :theme theme)
+                                               color-property color-settings)]
          (set-graph! result)))
      [theme settings])
     (when graph
@@ -1136,11 +1137,13 @@
   [state]
   (let [settings (state/graph-settings)
         forcesettings (state/graph-forcesettings)
+        color-property (state/graph-color-property)
+        color-settings (state/graph-color-settings)
         theme (state/sub :ui/theme)
         ;; Needed for query to retrigger after reset
         _reset? (rum/react *graph-reset?)
         search-graph-filters (state/sub :search/graph-filters)]
-    (graph-aux settings forcesettings theme search-graph-filters)))
+    (graph-aux settings forcesettings color-property color-settings theme search-graph-filters)))
 
 (rum/defc page-graph-inner < rum/reactive
   [_page graph dark?]
@@ -1165,12 +1168,12 @@
                         (graph-register-handlers graph (atom nil) (atom nil) dark?))})]))
 
 (rum/defc page-graph-aux
-  [page opts]
+  [page opts color-property color-settings]
   (let [[graph set-graph!] (hooks/use-state nil)
         dark? (= (:theme opts) "dark")]
     (hooks/use-effect!
      (fn []
-       (p/let [result (state/<invoke-db-worker :thread-api/build-graph (state/get-current-repo) opts)]
+       (p/let [result (state/<invoke-db-worker :thread-api/build-graph (state/get-current-repo) opts color-property color-settings)]
          (set-graph! result)))
      [opts])
     (when (seq (:nodes graph))
@@ -1184,12 +1187,16 @@
               (date/today))
         theme (:ui/theme @state/state)
         show-journals-in-page-graph (rum/react *show-journals-in-page-graph?)
-        page-entity (db/get-page page)]
+        page-entity (db/get-page page)
+        color-property (state/graph-color-property)
+        color-settings (state/graph-color-settings)]
     (page-graph-aux page
                     {:type (if (ldb/page? page-entity) :page :block)
                      :block/uuid (:block/uuid page-entity)
                      :theme theme
-                     :show-journals? show-journals-in-page-graph})))
+                     :show-journals? show-journals-in-page-graph}
+                    color-property 
+                    color-settings)))
 
 (defn batch-delete-dialog
   [pages refresh-fn]

--- a/src/main/frontend/extensions/graph/pixi.cljs
+++ b/src/main/frontend/extensions/graph/pixi.cljs
@@ -33,13 +33,7 @@
                     (or (.-size node) 8))
           :border {:width 0}
           :color  (fn [node]
-                    (if-let [parent (gobj/get node "parent")]
-                      (when-let [parent (if (= parent "ls-selected-nodes")
-                                          parent
-                                          (.-id node))]
-                        (let [v (js/Math.abs (hash parent))]
-                          (nth colors (mod v (count colors)))))
-                      (.-color node)))
+                      (.-color node))
           :label  {:content  (fn [node] (.-label node))
                    :type     (.-TEXT (.-TextType Pixi-Graph))
                    :fontSize 12

--- a/src/main/frontend/extensions/graph/pixi.cljs
+++ b/src/main/frontend/extensions/graph/pixi.cljs
@@ -15,18 +15,6 @@
 
 (def Graph (gobj/get graphology "Graph"))
 
-(defonce colors
-  ["#1f77b4"
-   "#ff7f0e"
-   "#2ca02c"
-   "#d62728"
-   "#9467bd"
-   "#8c564b"
-   "#e377c2"
-   "#7f7f7f"
-   "#bcbd22"
-   "#17becf"])
-
 (defn default-style
   [dark?]
   {:node {:size   (fn [node]

--- a/src/main/frontend/schema/handler/common_config.cljc
+++ b/src/main/frontend/schema/handler/common_config.cljc
@@ -63,6 +63,8 @@
     [:ref/linked-references-collapsed-threshold :int]
     [:graph/settings [:map-of :keyword [:or :boolean :int :nil]]]
     [:graph/forcesettings [:map-of :keyword :int]]
+    [:graph/color-property :keyword]
+    [:graph/color-settings [:map-of :string :string]]
     [:favorites [:vector :string]]
     ;; There isn't a :float yet
     [:srs/learning-fraction float?]

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -776,6 +776,14 @@ Similar to re-frame subscriptions"
   []
   (:graph/forcesettings (sub-config)))
 
+(defn graph-color-property
+  []
+  (:graph/color-property (sub-config)))
+
+(defn graph-color-settings
+ []
+ (:graph/color-settings (sub-config)))
+
 ;; Enable by default
 (defn show-brackets?
   []

--- a/src/main/frontend/worker/db_worker.cljs
+++ b/src/main/frontend/worker/db_worker.cljs
@@ -767,9 +767,9 @@
     (db-view/get-property-values @conn property-ident option)))
 
 (def-thread-api :thread-api/build-graph
-  [repo option]
+  [repo option color-property color-settings]
   (let [conn (worker-state/get-datascript-conn repo)]
-    (graph-view/build-graph @conn option)))
+    (graph-view/build-graph @conn option color-property color-settings)))
 
 (def ^:private *get-all-page-titles-cache (volatile! (cache/lru-cache-factory {})))
 (defn- get-all-page-titles


### PR DESCRIPTION
This pull request adds the ability to set the color used for nodes in the graph based on the tag that is applied to them, or in the case of MD graphs the value of a property named in the config.edn file.

Currently the colors are set through a map in the config.edn for both MD and DB graphs, but ideally I think there would be a way to do it through the UI. However, I don't have the knowledge to implement such a thing myself right now (although if I get time I will keep learning and may eventually add this to the PR).

I've seen a number of threads on the Logseq forum and a number of messages in the Discord about being able to control colors of the nodes in the graph view, so I hope this PR will go some way towards implementing this as a feature.