### PR TITLE
fix: gc unused addresses in SQLite kvs table

### DIFF
--- a/deps/db/.carve/ignore
+++ b/deps/db/.carve/ignore
@@ -34,3 +34,11 @@ logseq.db.common.initial-data/with-parent
 logseq.db.common.initial-data/get-block-and-children
 ;; API
 logseq.db.common.initial-data/get-initial-data
+;; API
+logseq.db.sqlite.debug/find-missing-addresses
+;; API
+logseq.db.sqlite.debug/find-missing-addresses-node-version
+;; API
+logseq.db.sqlite.gc/gc-kvs-table!
+;; API
+logseq.db.sqlite.gc/gc-kvs-table-node-version!

--- a/deps/db/.carve/ignore
+++ b/deps/db/.carve/ignore
@@ -42,3 +42,5 @@ logseq.db.sqlite.debug/find-missing-addresses-node-version
 logseq.db.sqlite.gc/gc-kvs-table!
 ;; API
 logseq.db.sqlite.gc/gc-kvs-table-node-version!
+;; API
+logseq.db.sqlite.gc/ensure-no-garbage

--- a/deps/db/src/logseq/db/common/sqlite_cli.cljs
+++ b/deps/db/src/logseq/db/common/sqlite_cli.cljs
@@ -32,16 +32,12 @@
 
 (defn- upsert-addr-content!
   "Upsert addr+data-seq. Should be functionally equivalent to db-worker/upsert-addr-content!"
-  [db data delete-addrs]
+  [db data]
   (let [insert (.prepare db "INSERT INTO kvs (addr, content, addresses) values ($addr, $content, $addresses) on conflict(addr) do update set content = $content, addresses = $addresses")
-        delete (.prepare db "Delete from kvs WHERE addr = ? AND NOT EXISTS (SELECT 1 FROM json_each(addresses) WHERE value = ?);")
         insert-many (.transaction ^object db
                                   (fn [data]
                                     (doseq [item data]
-                                      (.run ^object insert item))
-                                    (doseq [addr delete-addrs]
-                                      (when addr
-                                        (.run ^object delete addr)))))]
+                                      (.run ^object insert item))))]
     (insert-many data)))
 
 (defn- restore-data-from-addr
@@ -61,16 +57,9 @@
   "Creates a datascript storage for sqlite. Should be functionally equivalent to db-worker/new-sqlite-storage"
   [db]
   (reify IStorage
-    (-store [_ addr+data-seq delete-addrs]
-            ;; Only difference from db-worker impl is that js data maps don't start with '$' e.g. :$addr -> :addr
-      (let [used-addrs (set (mapcat
-                             (fn [[addr data]]
-                               (cons addr
-                                     (when (map? data)
-                                       (:addresses data))))
-                             addr+data-seq))
-            delete-addrs (remove used-addrs delete-addrs)
-            data (map
+    (-store [_ addr+data-seq _delete-addrs]
+      ;; Only difference from db-worker impl is that js data maps don't start with '$' e.g. :$addr -> :addr
+      (let [data (map
                   (fn [[addr data]]
                     (let [data' (if (map? data) (dissoc data :addresses) data)
                           addresses (when (map? data)
@@ -80,7 +69,7 @@
                            :content (sqlite-util/transit-write data')
                            :addresses addresses}))
                   addr+data-seq)]
-        (upsert-addr-content! db data delete-addrs)))
+        (upsert-addr-content! db data)))
     (-restore [_ addr]
       (restore-data-from-addr db addr))))
 

--- a/deps/db/src/logseq/db/common/sqlite_cli.cljs
+++ b/deps/db/src/logseq/db/common/sqlite_cli.cljs
@@ -74,7 +74,7 @@
       (restore-data-from-addr db addr))))
 
 (defn open-sqlite-datascript!
-  "Returns `conn` for datascript connection and `db` for sqlite connection"
+  "Returns a map including `conn` for datascript connection and `sqlite` for sqlite connection"
   ([db-full-path]
    (open-sqlite-datascript! nil db-full-path))
   ([graphs-dir db-name]

--- a/deps/db/src/logseq/db/common/sqlite_cli.cljs
+++ b/deps/db/src/logseq/db/common/sqlite_cli.cljs
@@ -57,7 +57,7 @@
   "Creates a datascript storage for sqlite. Should be functionally equivalent to db-worker/new-sqlite-storage"
   [db]
   (reify IStorage
-    (-store [_ addr+data-seq delete-addrs]
+    (-store [_ addr+data-seq _delete-addrs]
       ;; Only difference from db-worker impl is that js data maps don't start with '$' e.g. :$addr -> :addr
       (let [data (map
                   (fn [[addr data]]

--- a/deps/db/src/logseq/db/frontend/kv_entity.cljs
+++ b/deps/db/src/logseq/db/frontend/kv_entity.cljs
@@ -25,4 +25,7 @@ RTC won't start when major-schema-versions don't match"
   :logseq.kv/graph-backup-folder          {:doc "Backup folder for automated backup feature"
                                            :rtc {:rtc/ignore-entity-when-init-upload true
                                                  :rtc/ignore-entity-when-init-download true}}
-  :logseq.kv/graph-initial-schema-version {:doc "Graph's schema version when created"})
+  :logseq.kv/graph-initial-schema-version {:doc "Graph's schema version when created"}
+  :logseq.kv/graph-last-gc-at             {:doc "Last time graph gc at"
+                                           :rtc {:rtc/ignore-entity-when-init-upload true
+                                                 :rtc/ignore-entity-when-init-download true}})

--- a/deps/db/src/logseq/db/sqlite/debug.cljs
+++ b/deps/db/src/logseq/db/sqlite/debug.cljs
@@ -1,0 +1,22 @@
+(ns logseq.db.sqlite.debug
+  "SQLite debug fns"
+  (:require [cljs-bean.core :as bean]
+            [clojure.set]
+            [logseq.db.sqlite.util :as sqlite-util]))
+
+(defn find-missing-addresses
+  "Find missing addresses from the kvs table"
+  [^Object db]
+  (let [schema (some->> (.exec db #js {:sql "select content from kvs where addr = 0"
+                                       :rowMode "array"})
+                        bean/->clj
+                        ffirst
+                        sqlite-util/transit-read)
+        result (->> (.exec db #js {:sql "select addr, addresses from kvs"
+                                   :rowMode "array"})
+                    bean/->clj
+                    (keep (fn [[addr addresses]]
+                            [addr (bean/->clj (js/JSON.parse addresses))])))
+        used-addresses (set (concat (mapcat second result)
+                                    [0 1 (:eavt schema) (:avet schema) (:aevt schema)]))]
+    (clojure.set/difference used-addresses (set (map first result)))))

--- a/deps/db/src/logseq/db/sqlite/debug.cljs
+++ b/deps/db/src/logseq/db/sqlite/debug.cljs
@@ -5,7 +5,7 @@
             [logseq.db.sqlite.util :as sqlite-util]))
 
 (defn find-missing-addresses
-  "Find missing addresses from the kvs table"
+  "WASM version to find missing addresses from the kvs table"
   [^Object db]
   (let [schema (some->> (.exec db #js {:sql "select content from kvs where addr = 0"
                                        :rowMode "array"})
@@ -16,6 +16,21 @@
                                    :rowMode "array"})
                     bean/->clj
                     (keep (fn [[addr addresses]]
+                            [addr (bean/->clj (js/JSON.parse addresses))])))
+        used-addresses (set (concat (mapcat second result)
+                                    [0 1 (:eavt schema) (:avet schema) (:aevt schema)]))]
+    (clojure.set/difference used-addresses (set (map first result)))))
+
+(defn find-missing-addresses-node-version
+  "Node version to find missing addresses from the kvs table"
+  [^Object db]
+  (let [schema (let [stmt (.prepare db "select content from kvs where addr = ?")
+                     content (.-content (.get stmt 0))]
+                 (sqlite-util/transit-read content))
+        stmt (.prepare db "select addr, addresses from kvs")
+        result (->> (.all ^Object stmt)
+                    bean/->clj
+                    (keep (fn [{:keys [addr addresses]}]
                             [addr (bean/->clj (js/JSON.parse addresses))])))
         used-addresses (set (concat (mapcat second result)
                                     [0 1 (:eavt schema) (:avet schema) (:aevt schema)]))]

--- a/deps/db/src/logseq/db/sqlite/debug.cljs
+++ b/deps/db/src/logseq/db/sqlite/debug.cljs
@@ -34,4 +34,4 @@
                             [addr (bean/->clj (js/JSON.parse addresses))])))
         used-addresses (set (concat (mapcat second result)
                                     [0 1 (:eavt schema) (:avet schema) (:aevt schema)]))]
-    (clojure.set/difference used-addresses (set (map first result)))))
+    (clojure.set/difference used-addresses  (set (map first result)))))

--- a/deps/db/src/logseq/db/sqlite/gc.cljs
+++ b/deps/db/src/logseq/db/sqlite/gc.cljs
@@ -22,6 +22,8 @@
                           bean/->clj
                           ffirst
                           sqlite-util/transit-read)
+          ;; 0: Datascript sets 0 as the address to store the db's meta, including addresses for :eavt, :avet, and aevt index.
+          ;; 1: Datascript sets 1 for tail, to improve the performance
           internal-addrs (set [0 1 (:eavt schema) (:avet schema) (:aevt schema)])
           non-refed-addrs (->> (.exec db #js {:sql get-non-refed-addrs-sql
                                               :rowMode "array"})

--- a/deps/db/src/logseq/db/sqlite/gc.cljs
+++ b/deps/db/src/logseq/db/sqlite/gc.cljs
@@ -13,23 +13,27 @@
   FROM kvs
   WHERE kvs.addr NOT IN (SELECT addr FROM all_referenced)")
 
+(defn- get-unused-addresses
+  [db]
+  (let [schema (some->> (.exec db #js {:sql "select content from kvs where addr = 0"
+                                       :rowMode "array"})
+                        bean/->clj
+                        ffirst
+                        sqlite-util/transit-read)
+          ;; 0: Datascript sets 0 as the address to store the db's meta, including addresses for :eavt, :avet, and aevt index.
+          ;; 1: Datascript sets 1 for tail, to improve the performance
+        internal-addrs (set [0 1 (:eavt schema) (:avet schema) (:aevt schema)])
+        non-refed-addrs (->> (.exec db #js {:sql get-non-refed-addrs-sql
+                                            :rowMode "array"})
+                             (map first)
+                             set)]
+    (clojure.set/difference non-refed-addrs internal-addrs)))
+
 (defn gc-kvs-table!
   "WASM version to GC kvs table to remove unused addresses"
   [^Object db]
   (when db
-    (let [schema (some->> (.exec db #js {:sql "select content from kvs where addr = 0"
-                                         :rowMode "array"})
-                          bean/->clj
-                          ffirst
-                          sqlite-util/transit-read)
-          ;; 0: Datascript sets 0 as the address to store the db's meta, including addresses for :eavt, :avet, and aevt index.
-          ;; 1: Datascript sets 1 for tail, to improve the performance
-          internal-addrs (set [0 1 (:eavt schema) (:avet schema) (:aevt schema)])
-          non-refed-addrs (->> (.exec db #js {:sql get-non-refed-addrs-sql
-                                              :rowMode "array"})
-                               (map first)
-                               set)
-          unused-addresses (clojure.set/difference non-refed-addrs internal-addrs)]
+    (let [unused-addresses (get-unused-addresses db)]
       (if (seq unused-addresses)
         (do
           (println :debug :db-gc :unused-addresses unused-addresses)
@@ -39,32 +43,42 @@
                                               :bind #js [addr]})))))
         (println :debug :db-gc "There's no garbage data that's need to be collected.")))))
 
+(defn- get-unused-addresses-node-version
+  [db]
+  (let [schema (let [stmt (.prepare db "select content from kvs where addr = ?")
+                     content (.-content (.get stmt 0))]
+                 (sqlite-util/transit-read content))
+        internal-addrs (set [0 1 (:eavt schema) (:avet schema) (:aevt schema)])
+        non-refed-addrs (let [stmt (.prepare db get-non-refed-addrs-sql)]
+                          (->> (.all ^object stmt)
+                               bean/->clj
+                               (map :addr)
+                               (set)))]
+    (clojure.set/difference non-refed-addrs internal-addrs)))
+
 (defn gc-kvs-table-node-version!
   "Node version to GC kvs table to remove unused addresses"
   [^Object db]
-  (when db
-    (let [schema (let [stmt (.prepare db "select content from kvs where addr = ?")
-                       content (.-content (.get stmt 0))]
-                   (sqlite-util/transit-read content))
-          internal-addrs (set [0 1 (:eavt schema) (:avet schema) (:aevt schema)])
-          result (let [stmt (.prepare db "select addr, addresses from kvs")]
-                   (->> (.all ^object stmt)
-                        bean/->clj
-                        (map (fn [{:keys [addr addresses]}]
-                               [addr (bean/->clj (js/JSON.parse addresses))]))))
-          used-addresses (set (concat (mapcat second result) internal-addrs))
-          unused-addresses (clojure.set/difference (set (map first result)) used-addresses)
-          addrs-count (let [stmt (.prepare db "select count(*) as c from kvs")]
-                        (.-c (.get stmt)))]
-      (println :debug "addrs total count: " addrs-count)
-      (if (seq unused-addresses)
-        (do
-          (println :debug :db-gc :unused-addresses-count (count unused-addresses))
-          (let [stmt (.prepare db "Delete from kvs where addr = ?")
-                delete (.transaction
-                        db
-                        (fn [addrs]
-                          (doseq [addr addrs]
-                            (.run stmt addr))))]
-            (delete (bean/->js unused-addresses))))
-        (println :debug :db-gc "There's no garbage data that's need to be collected.")))))
+  (let [unused-addresses (get-unused-addresses-node-version db)
+        addrs-count (let [stmt (.prepare db "select count(*) as c from kvs")]
+                      (.-c (.get stmt)))]
+    (println :debug "addrs total count: " addrs-count)
+    (if (seq unused-addresses)
+      (do
+        (println :debug :db-gc :unused-addresses-count (count unused-addresses))
+        (let [stmt (.prepare db "Delete from kvs where addr = ?")
+              delete (.transaction
+                      db
+                      (fn [addrs]
+                        (doseq [addr addrs]
+                          (.run stmt addr))))]
+          (delete (bean/->js unused-addresses))
+          (gc-kvs-table-node-version! db)))
+      (println :debug :db-gc "There's no garbage data that's need to be collected."))))
+
+(defn ensure-no-garbage
+  [^Object db]
+  (let [unused-addresses (get-unused-addresses-node-version db)]
+    ;; (println :debug :db-gc :unused-addresses-count (count unused-addresses))
+    ;; (println :debug :unused-addresses unused-addresses)
+    (empty? unused-addresses)))

--- a/deps/db/src/logseq/db/sqlite/gc.cljs
+++ b/deps/db/src/logseq/db/sqlite/gc.cljs
@@ -14,7 +14,7 @@
   WHERE kvs.addr NOT IN (SELECT addr FROM all_referenced)")
 
 (defn gc-kvs-table!
-  "GC kvs table to remove unused addresses"
+  "WASM version to GC kvs table to remove unused addresses"
   [^Object db]
   (when db
     (let [schema (some->> (.exec db #js {:sql "select content from kvs where addr = 0"
@@ -30,9 +30,39 @@
           unused-addresses (clojure.set/difference non-refed-addrs internal-addrs)]
       (if (seq unused-addresses)
         (do
-          (prn :debug :db-gc :unused-addresses unused-addresses)
+          (println :debug :db-gc :unused-addresses unused-addresses)
           (.transaction db (fn [tx]
                              (doseq [addr unused-addresses]
                                (.exec tx #js {:sql "Delete from kvs where addr = ?"
                                               :bind #js [addr]})))))
-        (prn :debug :db-gc "There's no garbage data that needs to be collected.")))))
+        (println :debug :db-gc "There's no garbage data that's need to be collected.")))))
+
+(defn gc-kvs-table-node-version!
+  "Node version to GC kvs table to remove unused addresses"
+  [^Object db]
+  (when db
+    (let [schema (let [stmt (.prepare db "select content from kvs where addr = ?")
+                       content (.-content (.get stmt 0))]
+                   (sqlite-util/transit-read content))
+          internal-addrs (set [0 1 (:eavt schema) (:avet schema) (:aevt schema)])
+          result (let [stmt (.prepare db "select addr, addresses from kvs")]
+                   (->> (.all ^object stmt)
+                        bean/->clj
+                        (map (fn [{:keys [addr addresses]}]
+                               [addr (bean/->clj (js/JSON.parse addresses))]))))
+          used-addresses (set (concat (mapcat second result) internal-addrs))
+          unused-addresses (clojure.set/difference (set (map first result)) used-addresses)
+          addrs-count (let [stmt (.prepare db "select count(*) as c from kvs")]
+                        (.-c (.get stmt)))]
+      (println :debug "addrs total count: " addrs-count)
+      (if (seq unused-addresses)
+        (do
+          (println :debug :db-gc :unused-addresses-count (count unused-addresses))
+          (let [stmt (.prepare db "Delete from kvs where addr = ?")
+                delete (.transaction
+                        db
+                        (fn [addrs]
+                          (doseq [addr addrs]
+                            (.run stmt addr))))]
+            (delete (bean/->js unused-addresses))))
+        (println :debug :db-gc "There's no garbage data that's need to be collected.")))))

--- a/deps/db/src/logseq/db/sqlite/gc.cljs
+++ b/deps/db/src/logseq/db/sqlite/gc.cljs
@@ -1,8 +1,19 @@
 (ns logseq.db.sqlite.gc
   "GC unused addresses from `kvs` table"
   (:require [cljs-bean.core :as bean]
-            [clojure.set]
+            [clojure.set :as set]
             [logseq.db.sqlite.util :as sqlite-util]))
+
+(defn walk-addresses
+  "Given a map of parent address to children addresses and a root address,
+   returns a set of all used addresses including the root and its descendants."
+  [root addr->children]
+  (println :debug :walk-addresses :root root)
+  (time
+   (letfn [(collect-addresses [addr]
+             (let [children (addr->children addr)]
+               (into #{addr} (mapcat collect-addresses children))))]
+     (collect-addresses root))))
 
 (defonce get-non-refed-addrs-sql
   "WITH all_referenced AS (
@@ -27,7 +38,7 @@
                                             :rowMode "array"})
                              (map first)
                              set)]
-    (clojure.set/difference non-refed-addrs internal-addrs)))
+    (set/difference non-refed-addrs internal-addrs)))
 
 (defn gc-kvs-table!
   "WASM version to GC kvs table to remove unused addresses"
@@ -54,12 +65,34 @@
                                bean/->clj
                                (map :addr)
                                (set)))]
-    (clojure.set/difference non-refed-addrs internal-addrs)))
+    (set/difference non-refed-addrs internal-addrs)))
+
+(defn- get-unused-addresses-node-walk-version
+  [db]
+  (let [schema (let [stmt (.prepare db "select content from kvs where addr = ?")
+                     content (.-content (.get stmt 0))]
+                 (sqlite-util/transit-read content))
+        set-addresses #{(:eavt schema) (:avet schema) (:aevt schema)}
+        internal-addresses (conj set-addresses 0 1)
+        parent->children (let [stmt (.prepare db "select addr, addresses from kvs")]
+                           (->> (.all ^object stmt)
+                                bean/->clj
+                                (map (fn [{:keys [addr addresses]}]
+                                       [addr (bean/->clj (js/JSON.parse addresses))]))
+                                (into {})))
+        used-addresses (->> (mapcat (fn [set-root-addr]
+                                      (walk-addresses set-root-addr parent->children)) set-addresses)
+                            set
+                            (set/union internal-addresses))]
+    (set/difference (set (keys parent->children)) used-addresses)))
 
 (defn gc-kvs-table-node-version!
-  "Node version to GC kvs table to remove unused addresses"
-  [^Object db]
-  (let [unused-addresses (get-unused-addresses-node-version db)
+  "Node version to GC kvs table to remove unused addresses
+  `walk?` - `true`: walk all used addresses, `false`: gc recursively"
+  [^Object db walk?]
+  (let [unused-addresses (if walk?
+                           (get-unused-addresses-node-walk-version db)
+                           (get-unused-addresses-node-version db))
         addrs-count (let [stmt (.prepare db "select count(*) as c from kvs")]
                       (.-c (.get stmt)))]
     (println :debug "addrs total count: " addrs-count)
@@ -73,7 +106,8 @@
                         (doseq [addr addrs]
                           (.run stmt addr))))]
           (delete (bean/->js unused-addresses))
-          (gc-kvs-table-node-version! db)))
+          (when-not walk?
+            (gc-kvs-table-node-version! db false))))
       (println :debug :db-gc "There's no garbage data that's need to be collected."))))
 
 (defn ensure-no-garbage

--- a/deps/db/src/logseq/db/sqlite/gc.cljs
+++ b/deps/db/src/logseq/db/sqlite/gc.cljs
@@ -1,0 +1,38 @@
+(ns logseq.db.sqlite.gc
+  "GC unused addresses from `kvs` table"
+  (:require [cljs-bean.core :as bean]
+            [clojure.set]
+            [logseq.db.sqlite.util :as sqlite-util]))
+
+(defonce get-non-refed-addrs-sql
+  "WITH all_referenced AS (
+     SELECT CAST(value AS INTEGER) AS addr
+     FROM kvs, json_each(kvs.addresses)
+  )
+  SELECT kvs.addr
+  FROM kvs
+  WHERE kvs.addr NOT IN (SELECT addr FROM all_referenced)")
+
+(defn gc-kvs-table!
+  "GC kvs table to remove unused addresses"
+  [^Object db]
+  (when db
+    (let [schema (some->> (.exec db #js {:sql "select content from kvs where addr = 0"
+                                         :rowMode "array"})
+                          bean/->clj
+                          ffirst
+                          sqlite-util/transit-read)
+          internal-addrs (set [0 1 (:eavt schema) (:avet schema) (:aevt schema)])
+          non-refed-addrs (->> (.exec db #js {:sql get-non-refed-addrs-sql
+                                              :rowMode "array"})
+                               (map first)
+                               set)
+          unused-addresses (clojure.set/difference non-refed-addrs internal-addrs)]
+      (if (seq unused-addresses)
+        (do
+          (prn :debug :db-gc :unused-addresses unused-addresses)
+          (.transaction db (fn [tx]
+                             (doseq [addr unused-addresses]
+                               (.exec tx #js {:sql "Delete from kvs where addr = ?"
+                                              :bind #js [addr]})))))
+        (prn :debug :db-gc "There's no garbage data that needs to be collected.")))))

--- a/deps/db/test/logseq/db/sqlite/gc_test.cljs
+++ b/deps/db/test/logseq/db/sqlite/gc_test.cljs
@@ -22,7 +22,7 @@
   [dir db-name]
   (fs/mkdirSync (node-path/join dir db-name) #js {:recursive true}))
 
-(deftest ^:focus gc-kvs-table-test
+(deftest gc-kvs-table-test
   (testing "Create a datascript db, gc it and ensure there's no missing addrs"
     (create-graph-dir "tmp/graphs" "test-db")
 

--- a/deps/db/test/logseq/db/sqlite/gc_test.cljs
+++ b/deps/db/test/logseq/db/sqlite/gc_test.cljs
@@ -29,15 +29,15 @@
     (let [{:keys [conn sqlite]} (sqlite-cli/open-sqlite-datascript! "tmp/graphs" "test-db")
           tx-data (map (fn [i] {:block/uuid (random-uuid)
                                 :block/title (str "title " i)})
-                       (range 0 10000))]
+                       (range 0 500000))]
       (println "DB start transacting")
       (d/transact! conn tx-data)
       (println "DB transacted")
       (let [non-ordered-tx (->> (shuffle tx-data)
-                                (take 10000)
+                                (take 100000)
                                 (map (fn [block] [:db/retractEntity [:block/uuid (:block/uuid block)]])))]
         (d/transact! conn non-ordered-tx))
-      (sqlite-gc/gc-kvs-table-node-version! sqlite)
+      (time (sqlite-gc/gc-kvs-table-node-version! sqlite))
 
       ;; ensure there's no missing address (broken db)
       (is (empty? (sqlite-debug/find-missing-addresses-node-version sqlite))

--- a/deps/db/test/logseq/db/sqlite/gc_test.cljs
+++ b/deps/db/test/logseq/db/sqlite/gc_test.cljs
@@ -37,7 +37,9 @@
                                 (take 100000)
                                 (map (fn [block] [:db/retractEntity [:block/uuid (:block/uuid block)]])))]
         (d/transact! conn non-ordered-tx))
-      (time (sqlite-gc/gc-kvs-table-node-version! sqlite))
+      (println "gc time")
+      ;; `true` to walk addresses and `false` to recursively run gc
+      (time (sqlite-gc/gc-kvs-table-node-version! sqlite false))
 
       ;; ensure there's no missing address (broken db)
       (is (empty? (sqlite-debug/find-missing-addresses-node-version sqlite))

--- a/deps/db/test/logseq/db/sqlite/gc_test.cljs
+++ b/deps/db/test/logseq/db/sqlite/gc_test.cljs
@@ -1,0 +1,42 @@
+(ns logseq.db.sqlite.gc-test
+  (:require ["fs" :as fs]
+            ["path" :as node-path]
+            [cljs.test :refer [deftest async use-fixtures is testing]]
+            [datascript.core :as d]
+            [logseq.db.common.sqlite-cli :as sqlite-cli]
+            [logseq.db.sqlite.debug :as sqlite-debug]
+            [logseq.db.sqlite.gc :as sqlite-gc]))
+
+(use-fixtures
+  :each
+ ;; Cleaning tmp/ before leaves last tmp/ after a test run for dev and debugging
+  {:before
+   #(async done
+           (if (fs/existsSync "tmp")
+             (fs/rm "tmp" #js {:recursive true} (fn [err]
+                                                  (when err (js/console.log err))
+                                                  (done)))
+             (done)))})
+
+(defn- create-graph-dir
+  [dir db-name]
+  (fs/mkdirSync (node-path/join dir db-name) #js {:recursive true}))
+
+(deftest ^:focus gc-kvs-table-test
+  (testing "Create a datascript db, gc it and ensure there's no missing addrs"
+    (create-graph-dir "tmp/graphs" "test-db")
+
+    (let [{:keys [conn sqlite]} (sqlite-cli/open-sqlite-datascript! "tmp/graphs" "test-db")
+          tx-data (map (fn [i] {:block/uuid (random-uuid)
+                                :block/title (str "title " i)})
+                       (range 0 100000))]
+      (println "DB start transacting")
+      (d/transact! conn tx-data)
+      (println "DB transacted")
+      (let [non-ordered-tx (->> (shuffle tx-data)
+                                (take 10000)
+                                (map (fn [block] [:db/retractEntity [:block/uuid (:block/uuid block)]])))]
+        (d/transact! conn non-ordered-tx))
+      (sqlite-gc/gc-kvs-table-node-version! sqlite)
+      (is (empty? (sqlite-debug/find-missing-addresses-node-version sqlite))
+          "Found missing addresses!"))))

--- a/deps/db/test/logseq/db/sqlite/gc_test.cljs
+++ b/deps/db/test/logseq/db/sqlite/gc_test.cljs
@@ -22,7 +22,7 @@
   [dir db-name]
   (fs/mkdirSync (node-path/join dir db-name) #js {:recursive true}))
 
-(deftest ^:focus gc-kvs-table-test
+(deftest ^:long gc-kvs-table-test
   (testing "Create a datascript db, gc it and ensure there's no missing addrs and garbage addrs"
     (create-graph-dir "tmp/graphs" "test-db")
 

--- a/src/main/frontend/handler/repo.cljs
+++ b/src/main/frontend/handler/repo.cljs
@@ -216,3 +216,11 @@
 (defn fix-broken-graph!
   [graph]
   (state/<invoke-db-worker :thread-api/fix-broken-graph graph))
+
+(defn gc-graph!
+  [graph]
+  (p/do!
+   (state/<invoke-db-worker :thread-api/gc-graph graph)
+   (state/pub-event! [:notification/show
+                      {:content "Graph gc successfully!"
+                       :status :success}])))

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -600,7 +600,7 @@
                           :fn #(repo-handler/fix-broken-graph! (state/get-current-repo))}
 
    :dev/gc-graph {:binding []
-                  :db-graph? true
+                  :inactive (not (state/developer-mode?))
                   :fn #(repo-handler/gc-graph! (state/get-current-repo))}
 
    :dev/replace-graph-with-db-file {:binding []

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -599,6 +599,10 @@
                           :db-graph? true
                           :fn #(repo-handler/fix-broken-graph! (state/get-current-repo))}
 
+   :dev/gc-graph {:binding []
+                  :db-graph? true
+                  :fn #(repo-handler/gc-graph! (state/get-current-repo))}
+
    :dev/replace-graph-with-db-file {:binding []
                                     :inactive (or (not (util/electron?)) (not (state/developer-mode?)))
                                     :fn :frontend.handler.common.developer/replace-graph-with-db-file}
@@ -876,6 +880,7 @@
           :dev/replace-graph-with-db-file
           :dev/validate-db
           :dev/fix-broken-graph
+          :dev/gc-graph
           :dev/rtc-stop
           :dev/rtc-start
           :ui/customize-appearance])
@@ -1072,6 +1077,7 @@
      :dev/replace-graph-with-db-file
      :dev/validate-db
      :dev/fix-broken-graph
+     :dev/gc-graph
      :dev/rtc-stop
      :dev/rtc-start
      :ui/clear-all-notifications]

--- a/src/main/frontend/worker/db_worker.cljs
+++ b/src/main/frontend/worker/db_worker.cljs
@@ -251,10 +251,10 @@
               (not (number? last-gc-at))
               (> (- (common-util/time-ms) last-gc-at) (* 7 24 3600 1000))) ; 1 week ago
       (prn :debug "gc current graph")
-      (sqlite-gc/gc-kvs-table! sqlite-db)
+      (doseq [db [sqlite-db client-ops-db]]
+        (sqlite-gc/gc-kvs-table! db))
       (d/transact! datascript-conn [{:db/ident :logseq.kv/graph-last-gc-at
-                                     :kv/value (common-util/time-ms)}])))
-  (sqlite-gc/gc-kvs-table! client-ops-db))
+                                     :kv/value (common-util/time-ms)}]))))
 
 (defn- create-or-open-db!
   [repo {:keys [config import-type datoms] :as opts}]
@@ -734,7 +734,8 @@
   (let [{:keys [db client-ops]} (get @*sqlite-conns repo)
         conn (get @*datascript-conns repo)]
     (when (and db conn)
-      (gc-sqlite-dbs! db client-ops conn {:from-user? true}))))
+      (gc-sqlite-dbs! db client-ops conn {:from-user? true})
+      nil)))
 
 (comment
   (def-thread-api :general/dangerousRemoveAllDbs

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -788,7 +788,7 @@
   :dev/replace-graph-with-db-file "(Dev) Replace graph with its db.sqlite file"
   :dev/validate-db "(Dev) Validate current graph"
   :dev/fix-broken-graph "Fix current broken graph"
-  :dev/gc-graph "Garbage collect graph (remove unused data in SQLite)"
+  :dev/gc-graph "(Dev) Garbage collect graph (remove unused data in SQLite)"
   :dev/rtc-stop "(Dev) RTC Stop"
   :dev/rtc-start "(Dev) RTC Start"
   :window/close "Close window"}}

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -788,6 +788,7 @@
   :dev/replace-graph-with-db-file "(Dev) Replace graph with its db.sqlite file"
   :dev/validate-db "(Dev) Validate current graph"
   :dev/fix-broken-graph "Fix current broken graph"
+  :dev/gc-graph "Garbage collect graph (remove unused data in SQLite)"
   :dev/rtc-stop "(Dev) RTC Stop"
   :dev/rtc-start "(Dev) RTC Start"
   :window/close "Close window"}}


### PR DESCRIPTION
This PR introduces gc to remove unused addresses from the `kvs` table, to reduce disk usage.
Previously, 6051be610f disabled deleting addresses from our forked [persistent-sorted-set](https://github.com/logseq/persistent-sorted-set) [pss] because the nodes using those addresses may still be shared by other nodes. This introduced errors, including missing addresses and invalidated blocks.

Using gc is safer than deleting kvs from pss because we're sure that those deleting addresses are no longer used by other nodes. 

By default, gc will run if the db hasn't been GCed before or the last time was 3 days ago, I also added a command `Garbage collect graph` so that users can run without waiting. 

Other notes:
`gc` takes about 650ms on [4k movies](https://github.com/logseq/db-benchmark-graphs/blob/master/sqlite/logseq_db_4k%20movies_1744119718.sqlite) so that it's a bit slow, that's why it's not enabled when opening the db, we can adjust the default window to maybe 1 day if it increases disk usage a lot. 