### PR TITLE
fix: error if user uses an outdated frontend version

### DIFF
--- a/src/main/frontend/worker/db/migrate.cljs
+++ b/src/main/frontend/worker/db/migrate.cljs
@@ -7,6 +7,7 @@
             [datascript.core :as d]
             [datascript.impl.entity :as de]
             [frontend.worker.search :as search]
+            [frontend.worker.util :as worker-util]
             [logseq.common.config :as common-config]
             [logseq.common.util :as common-util]
             [logseq.common.util.date-time :as date-time-util]
@@ -1154,8 +1155,7 @@
         nil
 
         (neg? compare-result) ; outdated client, db version could be synced from server
-        ;; FIXME: notify users to upgrade to the latest version asap
-        nil
+        (worker-util/post-message :notification ["Your app is using an outdated version that is incompatible with your current graph. Please update your app before editing this graph." :error false])
 
         (pos? compare-result)
         (try


### PR DESCRIPTION
Now that users are using different desktop versions we should guard against the incompatible version case. More motivation at https://logseq.slack.com/archives/C04ENNDPDFB/p1748443014151109 . For now I just displayed an error but feel free to change this e.g. if it should disallow editing altogether . To QA, change `db-schema/version` to an older version and switch to a DB graph