### PR TITLE
fix: delete block in a container moves cursor to another container

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -4301,9 +4301,12 @@
                                      (when (not (:block-children? config))
                                        {:top? top?
                                         :bottom? bottom?}))
-        (str (:block/uuid item)
-             (when linked-block
-               (str "-" (:block/uuid original-block))))))))
+        (str
+         (:container-id config)
+         "-"
+         (:block/uuid item)
+         (when linked-block
+           (str "-" (:block/uuid original-block))))))))
 
 (rum/defc block-list
   [config blocks]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2588,34 +2588,34 @@
           forbidden-edit? (target-forbidden-edit? target)]
       (when (and (not forbidden-edit?) (contains? #{1 0} button))
         (let [selection-blocks (state/get-selection-blocks)
-              starting-block (state/get-selection-start-block-or-first)]
+              starting-block (state/get-selection-start-block-or-first)
+              block-dom-element (util/rec-get-node target "ls-block")]
           (cond
             (and meta? shift?)
             (when-not (empty? selection-blocks)
               (util/stop e)
-              (editor-handler/highlight-selection-area! block-id {:append? true}))
+              (editor-handler/highlight-selection-area! block-id block-dom-element {:append? true}))
 
             meta?
             (do
               (util/stop e)
-              (let [block-dom-element (gdom/getElement block-id)]
-                (if (some #(= block-dom-element %) selection-blocks)
-                  (state/drop-selection-block! block-dom-element)
-                  (state/conj-selection-block! block-dom-element :down)))
+              (if (some #(= block-dom-element %) selection-blocks)
+                (state/drop-selection-block! block-dom-element)
+                (state/conj-selection-block! block-dom-element :down))
               (if (empty? (state/get-selection-blocks))
                 (state/clear-selection!)
-                (state/set-selection-start-block! block-id)))
+                (state/set-selection-start-block! block-dom-element)))
 
             (and shift? starting-block)
             (do
               (util/stop e)
               (util/clear-selection!)
-              (editor-handler/highlight-selection-area! block-id))
+              (editor-handler/highlight-selection-area! block-id block-dom-element))
 
             shift?
             (do
               (util/clear-selection!)
-              (state/set-selection-start-block! block-id))
+              (state/set-selection-start-block! block-dom-element))
 
             :else
             (let [block (or (db/entity [:block/uuid (:block/uuid block)]) block)]
@@ -2650,7 +2650,7 @@
                  (state/pub-event! [:editor/save-code-editor])
                  (f))
 
-                (state/set-selection-start-block! block-id)))))))))
+                (state/set-selection-start-block! block-dom-element)))))))))
 
 (rum/defc dnd-separator-wrapper < rum/reactive
   [block children block-id top? block-content?]
@@ -3381,7 +3381,8 @@
 
 (defn- block-mouse-over
   [^js e block *control-show? block-id doc-mode?]
-  (let [mouse-moving? (not= (some-> @*block-last-mouse-event (.-clientY)) (.-clientY e))]
+  (let [mouse-moving? (not= (some-> @*block-last-mouse-event (.-clientY)) (.-clientY e))
+        block-dom-node (util/rec-get-node (.-target e) "ls-block")]
     (when (and mouse-moving?
                (not @*dragging?)
                (not= (:block/uuid block) (:block/uuid (state/get-edit-block))))
@@ -3394,7 +3395,7 @@
       (when (non-dragging? e)
         (when-let [container (gdom/getElement "app-container-wrapper")]
           (dom/add-class! container "blocks-selection-mode"))
-        (editor-handler/highlight-selection-area! block-id {:append? true})))))
+        (editor-handler/highlight-selection-area! block-id block-dom-node {:append? true})))))
 
 (defn- block-mouse-leave
   [*control-show? block-id doc-mode?]

--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -481,7 +481,6 @@
                                      (contains? #{:code} (:logseq.property.node/display-type code-block))
                                      (not= (:block/uuid edit-block) (:block/uuid (state/get-edit-block))))
                                 (editor-handler/edit-block! (or code-block edit-block) :max {:container-id (:container-id config)}))
-                              (state/set-editing-block-dom-id! (:block-parent-id config))
                               (state/set-block-component-editing-mode! true)
                               (state/set-state! :editor/code-block-context
                                                 {:editor editor

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2589,7 +2589,8 @@
                (save-block! repo uuid value))
 
              (cond
-               (dom/has-class? sibling-block "block-add-button")
+               (and (dom/has-class? sibling-block "block-add-button")
+                    (util/rec-get-node current-block "ls-page-title"))
                (.click sibling-block)
 
                property-value-container?
@@ -2665,7 +2666,8 @@
           (property-value-node? sibling-block)
           (focus-trigger editing-block sibling-block)
 
-          (dom/has-class? sibling-block "block-add-button")
+          (and (dom/has-class? sibling-block "block-add-button")
+               (util/rec-get-node editing-block "ls-page-title"))
           (.click sibling-block)
 
           :else

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1210,26 +1210,24 @@
       (delete-block-aux! block))))
 
 (defn highlight-selection-area!
-  [end-block-id & {:keys [append?]}]
-  (when-let [start-block (state/get-selection-start-block-or-first)]
-    (let [end-block-node (gdom/getElement end-block-id)
-          start-node (gdom/getElement start-block)
+  [end-block-id block-dom-element & {:keys [append?]}]
+  (when-let [start-node (state/get-selection-start-block-or-first)]
+    (let [end-block-node block-dom-element
           select-direction (state/get-selection-direction)
           selected-blocks (state/get-unsorted-selection-blocks)
-          last-node (when-let [node (last selected-blocks)]
-                      (gdom/getElement (.-id ^js node)))
+          last-node (last selected-blocks)
           latest-visible-block (or last-node start-node)
           latest-block-id (when latest-visible-block (.-id latest-visible-block))]
       (if (and start-node end-block-node)
-        (let [blocks (util/get-nodes-between-two-nodes start-block end-block-id "ls-block")
-              direction (util/get-direction-between-two-nodes start-block end-block-id "ls-block")
+        (let [blocks (util/get-nodes-between-two-nodes start-node end-block-node "ls-block")
+              direction (util/get-direction-between-two-nodes start-node end-block-node "ls-block")
               blocks (if (= direction :up) (reverse blocks) blocks)]
           (state/exit-editing-and-set-selected-blocks! blocks direction))
         (when latest-visible-block
-          (let [blocks (util/get-nodes-between-two-nodes latest-block-id end-block-id "ls-block")
+          (let [blocks (util/get-nodes-between-two-nodes latest-visible-block end-block-node "ls-block")
                 direction (if (= latest-block-id end-block-id)
                             select-direction
-                            (util/get-direction-between-two-nodes latest-block-id end-block-id "ls-block"))
+                            (util/get-direction-between-two-nodes latest-visible-block end-block-node "ls-block"))
                 blocks (if (= direction :up) (reverse (util/sort-by-height blocks)) (util/sort-by-height blocks))]
             (if append?
               (do (state/clear-edit!)

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1260,7 +1260,7 @@
   (cond
     ;; when editing, quit editing and select current block
     (state/editing?)
-    (let [element (gdom/getElement (state/get-editing-block-dom-id))]
+    (when-let [element (state/get-editor-block-container)]
       (when element
         (p/do!
          (save-current-block!)
@@ -2641,7 +2641,7 @@
         {:block/keys [format uuid] :as block} (or block (state/get-edit-block))
         format (or format :markdown)
         repo (state/get-current-repo)
-        editing-block (gdom/getElement (state/get-editing-block-dom-id))
+        editing-block (state/get-editor-block-container)
         f (if up? util/get-prev-block-non-collapsed util/get-next-block-non-collapsed)
         sibling-block (f editing-block)
         sibling-block (or (when (and sibling-block (property-value-node? sibling-block))

--- a/src/main/frontend/handler/editor/lifecycle.cljs
+++ b/src/main/frontend/handler/editor/lifecycle.cljs
@@ -9,7 +9,7 @@
 
 (defn did-mount!
   [state]
-  (let [[{:keys [block-parent-id]} id] (:rum/args state)
+  (let [[_ id] (:rum/args state)
         content (state/get-edit-content)
         input (state/get-input)
         node (util/rec-get-node input "ls-block")
@@ -19,9 +19,6 @@
     (.focus input)
     (when container-id
       (state/set-state! :editor/container-id container-id))
-
-    (when block-parent-id
-      (state/set-editing-block-dom-id! block-parent-id))
 
     (when content
       (editor-handler/restore-cursor-pos! id content))

--- a/src/main/frontend/handler/jump.cljs
+++ b/src/main/frontend/handler/jump.cljs
@@ -99,9 +99,7 @@
         (editor-handler/expand-block! current-block-id))
       (let [f #(let [selected-block-or-editing-block (or (first (state/get-selection-blocks))
                                                          ;; current editing block
-                                                         (some-> (state/get-editing-block-dom-id)
-                                                                 js/document.getElementById
-                                                                 (util/rec-get-node ".ls-block")))
+                                                         (state/get-editor-block-container))
                      triggers (->> (if selected-block-or-editing-block
                                      (d/sel selected-block-or-editing-block ".jtrigger")
                                      (d/sel ".jtrigger"))

--- a/src/main/frontend/mixins.cljs
+++ b/src/main/frontend/mixins.cljs
@@ -133,7 +133,7 @@
   "Notice: the first parameter needs to be a `config` with `id`, optional `sidebar?`, `whiteboard?`"
   {:init (fn [state]
            (let [config (first (:rum/args state))
-                 key (select-keys config [:id :sidebar? :whiteboard? :embed? :custom-query? :query :current-block :table?])
+                 key (select-keys config [:id :sidebar? :whiteboard? :embed? :custom-query? :query :current-block :table? :block? :db/id :page-name])
                  container-id (or (:container-id config) (state/get-container-id key))]
              (assoc state :container-id container-id)))})
 

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -154,7 +154,6 @@
       :editor/in-composition?                false
       :editor/content                        (atom {})
       :editor/block                          (atom nil)
-      :editor/block-dom-id                   (atom nil)
       :editor/set-timestamp-block            (atom nil) ;; click rendered block timestamp-cp to set timestamp
       :editor/last-input-time                (atom {})
       :editor/document-mode?                 document-mode?
@@ -1463,14 +1462,6 @@ Similar to re-frame subscriptions"
         (util/set-theme-light)
         (util/set-theme-dark)))))
 
-(defn set-editing-block-dom-id!
-  [block-dom-id]
-  (set-state! :editor/block-dom-id block-dom-id))
-
-(defn get-editing-block-dom-id
-  []
-  @(:editor/block-dom-id @state))
-
 (defn set-root-component!
   [component]
   (set-state! :ui/root-component component))
@@ -1929,6 +1920,12 @@ Similar to re-frame subscriptions"
 (defn get-editor-args
   []
   @(:editor/args @state))
+
+(defn get-editor-block-container
+  []
+  (some-> (get-edit-input-id)
+          (gdom/getElement)
+          (util/rec-get-node "ls-block")))
 
 (defn set-page-blocks-cp!
   [value]

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1072,9 +1072,9 @@ Similar to re-frame subscriptions"
   []
   (or @(get @state :selection/start-block)
       (when-let [edit-block (get-edit-block)]
-        (let [id (str "ls-block-" (:block/uuid edit-block))]
-          (set-selection-start-block! id)
-          id))))
+        (let [node (util/rec-get-node edit-block "ls-block")]
+          (set-selection-start-block! node)
+          node))))
 
 (defn get-cursor-range
   []

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -736,11 +736,9 @@
 
 #?(:cljs
    (defn get-nodes-between-two-nodes
-     [id1 id2 class]
+     [node-1 node-2 class]
      (when-let [nodes (array-seq (js/document.getElementsByClassName class))]
-       (let [node-1 (gdom/getElement id1)
-             node-2 (gdom/getElement id2)
-             idx-1 (.indexOf nodes node-1)
+       (let [idx-1 (.indexOf nodes node-1)
              idx-2 (.indexOf nodes node-2)
              start (min idx-1 idx-2)
              end (inc (max idx-1 idx-2))]
@@ -748,11 +746,9 @@
 
 #?(:cljs
    (defn get-direction-between-two-nodes
-     [id1 id2 class]
+     [node-1 node-2 class]
      (when-let [nodes (array-seq (js/document.getElementsByClassName class))]
-       (let [node-1 (gdom/getElement id1)
-             node-2 (gdom/getElement id2)
-             idx-1 (.indexOf nodes node-1)
+       (let [idx-1 (.indexOf nodes node-1)
              idx-2 (.indexOf nodes node-2)]
          (if (>= idx-1 idx-2)
            :up

--- a/src/main/logseq/api.cljs
+++ b/src/main/logseq/api.cljs
@@ -844,7 +844,7 @@
     (let [block (state/get-edit-block)
           block (or block
                     (some-> (or (first (state/get-selection-blocks))
-                                (gdom/getElement (state/get-editing-block-dom-id)))
+                                (state/get-editor-block-container))
                             (.getAttribute "blockid")
                             (db-model/get-block-by-uuid)))]
       (get_block (:block/uuid block) opts))))


### PR DESCRIPTION
Fixes https://github.com/logseq/db-test/issues/284.

This PR uses the exact dom nodes for selected blocks instead of using their blockid because blockid will find the first block in the dom tree that have this id.

This PR also fixes another bug that pressing `arrow down` in the editor can keep creating new blocks.
To reproduce:
1. create a new page `test page`
2. keep pressing `arrow down`
