### PR TITLE
[WIP] enhance(ux): add dot indicator if a table row has children

### DIFF
--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -799,8 +799,8 @@
                                       (when (= (util/ekey e) "Escape")
                                         (editor-on-hide state :esc e))))
                :auto-focus true
-               :autocapitalize "off"
-               :autocorrect "off"
+               :autoCapitalize "off"
+               :autoCorrect "off"
                :class heading-class}
                (some? parent-block)
                (assoc :parentblockid (str (:block/uuid parent-block)))

--- a/src/main/frontend/components/views.cljs
+++ b/src/main/frontend/components/views.cljs
@@ -288,7 +288,7 @@
                                               (save-block-and-focus *ref set-focus-timeout! false))})
                            (editor-handler/edit-block! block :max {:container-id :unknown-container})))))))}
      (if block
-       [:div.flex.flex-row
+       [:div.flex.flex-row.relative
         (let [render (fn [block]
                        [:div
                         (inline-title
@@ -302,26 +302,35 @@
             (render block*)))]
        [:div])
 
-     (let [class (str "h-6 w-6 !p-1 text-muted-foreground transition-opacity duration-100 ease-in bg-gray-01 "
+     (let [class (str "h-5 w-5 !p-1 text-muted-foreground transition-opacity duration-100 ease-in bg-gray-01 "
                       "opacity-" opacity)]
-       [:div.absolute.-right-1
-        [:div.flex.flex-row.items-center
+       [:div.absolute.right-0
+        [:div.flex.flex-row.items-center.gap-1
+         (when (and (or (:block.temp/has-children? block*)
+                        (some? (:block/_parent block*)))
+                    (not (ldb/page? block*)))
+           [:span.absolute.-top-3.right-8.transition-opacity.duration-100.ease-in
+            {:title "This block has children"
+             :class (str "opacity-" (if (zero? opacity) opacity 50))}
+            "·"])
          (shui/button
           {:variant :ghost
+           :size :sm
            :title "Open"
            :on-click (fn [e]
                        (util/stop-propagation e)
                        (redirect!))
            :class class}
-          (ui/icon "arrow-right"))
+          (ui/icon "arrow-right" {:size 14}))
          (shui/button
           {:variant :ghost
+           :size :sm
            :title "Open in sidebar"
            :class class
            :on-click (fn [e]
                        (util/stop-propagation e)
                        (add-to-sidebar!))}
-          (ui/icon "layout-sidebar-right"))]])]))
+          (ui/icon "layout-sidebar-right" {:size 14}))]])]))
 
 (defn build-columns
   [config properties & {:keys [with-object-name? with-id? add-tags-column?]

--- a/src/main/frontend/components/views.cljs
+++ b/src/main/frontend/components/views.cljs
@@ -226,6 +226,38 @@
      (state/exit-editing-and-set-selected-blocks! [cell])
      (set-focus-timeout! (js/setTimeout #(.focus cell) 100)))))
 
+(rum/defc block-open-buttons
+  [block* opacity redirect! add-to-sidebar!]
+  (let [class (str "h-5 w-5 !p-1 text-muted-foreground transition-opacity duration-100 ease-in bg-gray-01 "
+                   "opacity-" opacity)]
+    [:div.absolute.right-0
+     [:div.flex.flex-row.items-center.gap-1
+      (when (and (or (:block.temp/has-children? block*)
+                     (some? (:block/_parent block*)))
+                 (not (ldb/page? block*)))
+        [:span.absolute.-top-3.right-8.transition-opacity.duration-100.ease-in
+         {:title "This block has children"
+          :class (str "opacity-" (if (zero? opacity) opacity 50))}
+         "·"])
+      (shui/button
+       {:variant :ghost
+        :size :sm
+        :title "Open"
+        :on-click (fn [e]
+                    (util/stop-propagation e)
+                    (redirect!))
+        :class class}
+       (ui/icon "arrow-right" {:size 14}))
+      (shui/button
+       {:variant :ghost
+        :size :sm
+        :title "Open in sidebar"
+        :class class
+        :on-click (fn [e]
+                    (util/stop-propagation e)
+                    (add-to-sidebar!))}
+       (ui/icon "layout-sidebar-right" {:size 14}))]]))
+
 (rum/defc block-title
   "Used on table view"
   [block* {:keys [create-new-block width row property]}]
@@ -302,35 +334,7 @@
             (render block*)))]
        [:div])
 
-     (let [class (str "h-5 w-5 !p-1 text-muted-foreground transition-opacity duration-100 ease-in bg-gray-01 "
-                      "opacity-" opacity)]
-       [:div.absolute.right-0
-        [:div.flex.flex-row.items-center.gap-1
-         (when (and (or (:block.temp/has-children? block*)
-                        (some? (:block/_parent block*)))
-                    (not (ldb/page? block*)))
-           [:span.absolute.-top-3.right-8.transition-opacity.duration-100.ease-in
-            {:title "This block has children"
-             :class (str "opacity-" (if (zero? opacity) opacity 50))}
-            "·"])
-         (shui/button
-          {:variant :ghost
-           :size :sm
-           :title "Open"
-           :on-click (fn [e]
-                       (util/stop-propagation e)
-                       (redirect!))
-           :class class}
-          (ui/icon "arrow-right" {:size 14}))
-         (shui/button
-          {:variant :ghost
-           :size :sm
-           :title "Open in sidebar"
-           :class class
-           :on-click (fn [e]
-                       (util/stop-propagation e)
-                       (add-to-sidebar!))}
-          (ui/icon "layout-sidebar-right" {:size 14}))]])]))
+     (block-open-buttons block* opacity redirect! add-to-sidebar!)]))
 
 (defn build-columns
   [config properties & {:keys [with-object-name? with-id? add-tags-column?]


### PR DESCRIPTION
This PR adds a little dot above the `open` icon when hovering a table row if it has children blocks, so we don't have to click a row to check whether there are more children blocks.

<img width="1052" alt="image" src="https://github.com/user-attachments/assets/067f3e3e-6269-42d6-ac9a-606eb1c91157" />

Notice: this is not going to be merged soon, we still want to experiment with the best ux.