### PR TITLE
Fix: replace 'mv' with cross-platform compatible file move in gulpfil…

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -171,16 +171,15 @@ const common = {
   },
 
   switchReactDevelopmentMode (cb) {
-    const reactFrom = path.join(outputPath, 'js', 'react.development.js')
-    const reactTo = path.join(outputPath, 'js', 'react.production.min.js')
-    cp.execSync(`mv ${reactFrom} ${reactTo}`, { stdio: 'inherit' })
+    const reactFrom = path.join(outputPath, 'js', 'react.development.js');
+    const reactTo = path.join(outputPath, 'js', 'react.production.min.js');
+    fs.renameSync(reactFrom, reactTo);
 
-    const reactDomFrom = path.join(outputPath, 'js', 'react-dom.development.js')
-    const reactDomTo = path.join(outputPath, 'js',
-      'react-dom.production.min.js')
-    cp.execSync(`mv ${reactDomFrom} ${reactDomTo}`, { stdio: 'inherit' })
+    const reactDomFrom = path.join(outputPath, 'js', 'react-dom.development.js');
+    const reactDomTo = path.join(outputPath, 'js', 'react-dom.production.min.js');
+    fs.renameSync(reactDomFrom, reactDomTo);
 
-    cb()
+    cb();
   },
 }
 


### PR DESCRIPTION
...GitHub\logseq\gulpfile.js

Replaced 'mv' command with platform check to support both Windows and Unix-like systems in the switchReactDevelopmentMode task.