### PR TITLE
Add ability to sort plugins by added date on marketplace

### DIFF
--- a/src/main/frontend/components/plugins.cljs
+++ b/src/main/frontend/components/plugins.cljs
@@ -669,7 +669,11 @@
 
                      {:title (t :plugin/title "A - Z")
                       :options {:on-click #(reset! *sort-by :letters)}
-                      :icon (ui/icon (aim-icon :letters))}]]
+                      :icon (ui/icon (aim-icon :letters))}
+
+                     {:title   (t :plugin/date-added)
+                      :options {:on-click #(reset! *sort-by :date-added)}
+                      :icon    (ui/icon (aim-icon :date-added))}]]
 
           (ui/button
            (ui/icon "arrows-sort")
@@ -814,7 +818,7 @@
   (rum/local false ::fetching)
   (rum/local "" ::search-key)
   (rum/local :plugins ::category)
-  (rum/local :default ::sort-by)        ;; default (weighted) / downloads / stars / letters / updates
+  (rum/local :default ::sort-by)        ;; default (weighted) / downloads / stars / letters / updates / date-added
   (rum/local :default ::filter-by)
   (rum/local nil ::error)
   (rum/local nil ::cached-query-flag)

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -512,6 +512,7 @@
  :plugin/uninstall "Uninstall"
  :plugin/marketplace "Marketplace"
  :plugin/downloads "Downloads"
+ :plugin/date-added "Newly added"
  :plugin/popular "Popular"
  :plugin/stars "Stars"
  :plugin/title "Title ({1})"


### PR DESCRIPTION
Allow to show recently added plugins in the marketplace. This would definitely help discovery of new plugins and I think it was meant to be added at some point (looking at the code), but never materialized.

<img width="1409" height="945" alt="Screenshot_20250713_001527" src="https://github.com/user-attachments/assets/4584dbd5-8ee3-4f02-a67a-7d4b84043e55" />
