### PR TITLE
fix: gh workflows missing deps

### DIFF
--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -8,12 +8,16 @@ on:
       - 'deps/db/**'
       - '.github/workflows/db.yml'
       - '!deps/db/**.md'
+      # Deps that logseq/db depends on should trigger this workflow
+      - 'deps/common/**'
   pull_request:
     branches: [master]
     paths:
       - 'deps/db/**'
       - '.github/workflows/db.yml'
       - '!deps/db/**.md'
+      # Deps that logseq/db depends on should trigger this workflow
+      - 'deps/common/**'
 
 defaults:
   run:

--- a/.github/workflows/graph-parser.yml
+++ b/.github/workflows/graph-parser.yml
@@ -7,17 +7,20 @@ on:
     branches: [master]
     paths:
       - 'deps/graph-parser/**'
-      # db is a local dep that could break functionality in this lib and should trigger this
-      - 'deps/db/**'
       - '.github/workflows/graph-parser.yml'
       - '!deps/graph-parser/**.md'
+      # Deps that logseq/graph-parser depends on should trigger this workflow
+      - 'deps/db/**'
+      - 'deps/common/**'
   pull_request:
     branches: [master]
     paths:
       - 'deps/graph-parser/**'
-      - 'deps/db/**'
       - '.github/workflows/graph-parser.yml'
       - '!deps/graph-parser/**.md'
+      # Deps that logseq/graph-parser depends on should trigger this workflow
+      - 'deps/db/**'
+      - 'deps/common/**'
 
 defaults:
   run:

--- a/.github/workflows/outliner.yml
+++ b/.github/workflows/outliner.yml
@@ -7,17 +7,22 @@ on:
     branches: [master]
     paths:
       - 'deps/outliner/**'
-      # db is a local dep that could break functionality in this lib and should trigger this
-      - 'deps/db/**'
       - '.github/workflows/outliner.yml'
       - '!deps/outliner/**.md'
+      # Deps that logseq/outliner depends on should trigger this workflow
+      - 'deps/graph-parser/**'
+      - 'deps/db/**'
+      - 'deps/common/**'
   pull_request:
     branches: [master]
     paths:
       - 'deps/outliner/**'
-      - 'deps/db/**'
       - '.github/workflows/outliner.yml'
       - '!deps/outliner/**.md'
+      # Deps that logseq/outliner depends on should trigger this workflow
+      - 'deps/graph-parser/**'
+      - 'deps/db/**'
+      - 'deps/common/**'
 
 defaults:
   run:

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -7,17 +7,20 @@ on:
     branches: [master]
     paths:
       - 'deps/publishing/**'
-      # db is a local dep that could break functionality in this lib and should trigger this
-      - 'deps/db/**'
       - '.github/workflows/publishing.yml'
       - '!deps/publishing/**.md'
+      # Deps that logseq/publishing depends on should trigger this workflow
+      - 'deps/db/**'
+      - 'deps/common/**'
   pull_request:
     branches: [master]
     paths:
       - 'deps/publishing/**'
-      - 'deps/db/**'
       - '.github/workflows/publishing.yml'
       - '!deps/publishing/**.md'
+      # Deps that logseq/publishing depends on should trigger this workflow
+      - 'deps/db/**'
+      - 'deps/common/**'
 
 defaults:
   run:


### PR DESCRIPTION
Deps changes could break downstream dependents since their workflows aren't run. outliner was missing graph-parser and all deps were missing common