### PR TITLE
fix: Show #Page tag immediately on 'add tag to node' popup, but hide it on node

### DIFF
--- a/deps/db/src/logseq/db/frontend/class.cljs
+++ b/deps/db/src/logseq/db/frontend/class.cljs
@@ -24,7 +24,9 @@
 
      :logseq.class/Property {:title "Property"}
 
-     :logseq.class/Page {:title "Page"}
+     :logseq.class/Page
+     {:title "Page"
+      :properties {:logseq.property.class/hide-from-node true}}
 
      :logseq.class/Journal
      {:title "Journal"
@@ -106,7 +108,7 @@
 
 (def internal-tags
   "Built-in classes that are hidden on a node and all pages view"
-  #{:logseq.class/Page :logseq.class/Property :logseq.class/Tag :logseq.class/Root
+  #{:logseq.class/Property :logseq.class/Tag :logseq.class/Root
     :logseq.class/Asset})
 
 (def private-tags


### PR DESCRIPTION
Currently, if you type '#' to tag a node, the #Page tag doesnt show up immediately on the list of Tags, you need to type 'P' first:

https://github.com/user-attachments/assets/fbae33a3-3a4b-4524-882b-fc1ea65920ef

I believe it should show up alongside the rest of the Tags as soon as that popup appears, which is what this PR does:

https://github.com/user-attachments/assets/afd9de34-c9ff-493f-93ce-6390ff395e39

The #Page tag is no longer a 'private-tag', and therefore shouldnt be treated as such