### PR TITLE
fix: match paste of x.com links for twitter

### DIFF
--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -52,7 +52,8 @@
     (boolean (text-util/get-matched-video url))
     (util/format "{{video %s}}" url)
 
-    (or (string/includes? url "twitter.com") (string/includes? url "x.com"))
+    (or (re-matches #"^https://twitter\.com.*?$" url)
+        (re-matches #"^https://x\.com.*?$" url))
     (util/format "{{twitter %s}}" url)))
 
 (defn- try-parse-as-json


### PR DESCRIPTION
* Problem described in #11942 
* Problem fixed on master with commit 0feb634198
* Should fix #12041 on version/file branch for 0.10.x

I just cherry picked the commit.