### PR TITLE
feat: allow changing property type

### DIFF
--- a/clj-e2e/src/logseq/e2e/util.clj
+++ b/clj-e2e/src/logseq/e2e/util.clj
@@ -72,10 +72,10 @@
 (defn double-esc
   "Exits editing mode and ensure there's no action bar"
   []
-  (when (w/visible? "div[data-radix-popper-content-wrapper]")
+  (when (.isVisible (.first (w/-query "div[data-radix-popper-content-wrapper]")))
     (k/esc))
   (exit-edit)
-  (when (w/visible? "div[data-radix-popper-content-wrapper]")
+  (when (.isVisible (.first (w/-query "div[data-radix-popper-content-wrapper]")))
     (k/esc)))
 
 (defn search
@@ -103,6 +103,10 @@
 (defn wait-editor-visible
   []
   (w/wait-for ".editor-wrapper textarea"))
+
+(defn wait-popup-visible
+  []
+  (w/wait-for "div[data-radix-popper-content-wrapper]"))
 
 (defn count-elements
   [q]

--- a/clj-e2e/test/logseq/e2e/property_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/property_basic_test.clj
@@ -6,8 +6,7 @@
             [logseq.e2e.keyboard :as k]
             [logseq.e2e.locator :as loc]
             [logseq.e2e.util :as util]
-            [wally.main :as w]
-            [wally.repl :as repl]))
+            [wally.main :as w]))
 
 (use-fixtures :once fixtures/open-page)
 
@@ -66,12 +65,13 @@
     (w/click (loc/and "span" (util/get-by-text "Text" true)))
     (w/click (format ".property-pair:has-text('%s') > .ls-block" property-name))
     (util/input "Text")
-    (k/esc)
-    (repl/pause)
-    (w/click (format ".property-pair:has-text('%s') .property-k" property-name))
-    (w/click (w/get-by-text "Property type"))
-    (w/click (loc/and "span" (util/get-by-text "Number" true)))
-    (k/esc)
-    (w/click (format ".property-pair:has-text('%s') .property-k" property-name))
-    (assert/assert-is-visible (w/get-by-text "Property type"))
-    (assert/assert-is-visible (w/get-by-text "Number"))))
+    (util/double-esc)
+    (doseq [property-type (rest property-types)]
+      (w/click (format ".property-pair:has-text('%s') .property-k" property-name))
+      (w/click (w/get-by-text "Property type"))
+      (w/click (loc/and "span" (util/get-by-text property-type true)))
+      (k/esc)
+      (w/click (format ".property-pair:has-text('%s') .property-k" property-name))
+      (assert/assert-is-visible (w/get-by-text "Property type"))
+      (assert/assert-is-visible (w/get-by-text property-type))
+      (k/esc))))

--- a/clj-e2e/test/logseq/e2e/property_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/property_basic_test.clj
@@ -51,27 +51,29 @@
   (let [title-prefix "new-property-test"]
     (add-new-properties title-prefix)))
 
+(defn change-property-type
+  [title property-name property-types]
+  (b/new-block title)
+  (w/click (util/get-by-text title true))
+  (k/press "Control+e")
+  (util/input-command "Add new property")
+  (w/click "input[placeholder]")
+  (util/input property-name)
+  (w/click (util/get-by-text "New option:" false))
+  (assert/assert-is-visible (w/get-by-text "Select a property type"))
+  (w/click (loc/and "span" (util/get-by-text (first property-types) true)))
+  (w/click (format ".property-pair:has-text('%s') > .ls-block" property-name))
+  (util/input "Text")
+  (util/double-esc)
+  (doseq [property-type (rest property-types)]
+    (w/click (format ".property-pair:has-text('%s') .property-k" property-name))
+    (w/click (w/get-by-text "Property type"))
+    (w/click (loc/and "span" (util/get-by-text property-type true)))
+    (k/esc)
+    (w/click (format ".property-pair:has-text('%s') .property-k" property-name))
+    (assert/assert-is-visible (w/get-by-text "Property type"))
+    (assert/assert-is-visible (w/get-by-text property-type))
+    (k/esc)))
+
 (deftest change-property-type-test
-  (let [title "change-property-type-test"
-        property-name "p-change-type"]
-    (b/new-block title)
-    (w/click (util/get-by-text title true))
-    (k/press "Control+e")
-    (util/input-command "Add new property")
-    (w/click "input[placeholder]")
-    (util/input property-name)
-    (w/click (util/get-by-text "New option:" false))
-    (assert/assert-is-visible (w/get-by-text "Select a property type"))
-    (w/click (loc/and "span" (util/get-by-text "Text" true)))
-    (w/click (format ".property-pair:has-text('%s') > .ls-block" property-name))
-    (util/input "Text")
-    (util/double-esc)
-    (doseq [property-type (rest property-types)]
-      (w/click (format ".property-pair:has-text('%s') .property-k" property-name))
-      (w/click (w/get-by-text "Property type"))
-      (w/click (loc/and "span" (util/get-by-text property-type true)))
-      (k/esc)
-      (w/click (format ".property-pair:has-text('%s') .property-k" property-name))
-      (assert/assert-is-visible (w/get-by-text "Property type"))
-      (assert/assert-is-visible (w/get-by-text property-type))
-      (k/esc))))
+  (change-property-type "change-property-type-test" "p-change-type" property-types))

--- a/clj-e2e/test/logseq/e2e/property_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/property_basic_test.clj
@@ -6,7 +6,8 @@
             [logseq.e2e.keyboard :as k]
             [logseq.e2e.locator :as loc]
             [logseq.e2e.util :as util]
-            [wally.main :as w]))
+            [wally.main :as w]
+            [wally.repl :as repl]))
 
 (use-fixtures :once fixtures/open-page)
 
@@ -50,3 +51,27 @@
 (deftest new-property-test
   (let [title-prefix "new-property-test"]
     (add-new-properties title-prefix)))
+
+(deftest change-property-type-test
+  (let [title "change-property-type-test"
+        property-name "p-change-type"]
+    (b/new-block title)
+    (w/click (util/get-by-text title true))
+    (k/press "Control+e")
+    (util/input-command "Add new property")
+    (w/click "input[placeholder]")
+    (util/input property-name)
+    (w/click (util/get-by-text "New option:" false))
+    (assert/assert-is-visible (w/get-by-text "Select a property type"))
+    (w/click (loc/and "span" (util/get-by-text "Text" true)))
+    (w/click (format ".property-pair:has-text('%s') > .ls-block" property-name))
+    (util/input "Text")
+    (k/esc)
+    (repl/pause)
+    (w/click (format ".property-pair:has-text('%s') .property-k" property-name))
+    (w/click (w/get-by-text "Property type"))
+    (w/click (loc/and "span" (util/get-by-text "Number" true)))
+    (k/esc)
+    (w/click (format ".property-pair:has-text('%s') .property-k" property-name))
+    (assert/assert-is-visible (w/get-by-text "Property type"))
+    (assert/assert-is-visible (w/get-by-text "Number"))))

--- a/clj-e2e/test/logseq/e2e/rtc_extra_test.clj
+++ b/clj-e2e/test/logseq/e2e/rtc_extra_test.clj
@@ -187,6 +187,14 @@
             (let [{:keys [_local-tx remote-tx]}
                   (rtc/with-wait-tx-updated
                     (property-basic-test/add-new-properties title-prefix))]
+              (reset! *latest-remote-tx remote-tx))))
+        change-prop-type-in-page2
+        (fn [*latest-remote-tx]
+          (w/with-page @*page2
+            (let [{:keys [_local-tx remote-tx]}
+                  (rtc/with-wait-tx-updated
+                    (property-basic-test/change-property-type
+                     "change-property-type-test" "p-change-type" ["Text" "Checkbox"]))]
               (reset! *latest-remote-tx remote-tx))))]
     (testing "add different types user properties on page2 while keeping rtc connected on page1"
       (let [*latest-remote-tx (atom nil)]
@@ -201,6 +209,15 @@
     (testing "perform same operations on page2 while keeping rtc connected on page1"
       (let [*latest-remote-tx (atom nil)]
         (insert-new-property-blocks-in-page2 *latest-remote-tx "rtc-property-test-2")
+        (w/with-page @*page1
+          (rtc/wait-tx-update-to @*latest-remote-tx))
+        (validate-2-graphs)))
+
+    (new-logseq-page)
+
+    (testing "change property type"
+      (let [*latest-remote-tx (atom nil)]
+        (change-prop-type-in-page2 *latest-remote-tx)
         (w/with-page @*page1
           (rtc/wait-tx-update-to @*latest-remote-tx))
         (validate-2-graphs)))))

--- a/deps/db/src/logseq/db/common/initial_data.cljs
+++ b/deps/db/src/logseq/db/common/initial_data.cljs
@@ -316,7 +316,8 @@
              (let [e (d/entity db (:e datom))]
                (when (and (common-entity-util/page? e)
                           (not (entity-util/hidden? e))
-                          (not (string/blank? (:block/title e))))
+                          (not (string/blank? (:block/title e)))
+                          (not (:logseq.property/deprecated? e)))
                  e))))
      (take 30))))
 

--- a/deps/db/src/logseq/db/frontend/db.cljs
+++ b/deps/db/src/logseq/db/frontend/db.cljs
@@ -42,7 +42,10 @@
 (defn get-all-properties
   [db]
   (->> (d/datoms db :avet :block/tags :logseq.class/Property)
-       (map (fn [d] (d/entity db (:e d))))))
+       (keep (fn [d]
+               (let [e (d/entity db (:e d))]
+                 (when-not (:logseq.property/deprecated? e)
+                   e))))))
 
 (defn get-page-parents
   [node]

--- a/deps/db/src/logseq/db/frontend/entity_util.cljs
+++ b/deps/db/src/logseq/db/frontend/entity_util.cljs
@@ -68,7 +68,8 @@
      (if (string? page)
        (string/starts-with? page "$$$")
        (when (or (map? page) (de/entity? page))
-         (:logseq.property/hide? page))))))
+         (or (:logseq.property/hide? page)
+             (:logseq.property/deprecated? page)))))))
 
 (defn object?
   [node]

--- a/deps/db/src/logseq/db/frontend/malli_schema.cljs
+++ b/deps/db/src/logseq/db/frontend/malli_schema.cljs
@@ -105,11 +105,12 @@
                                (contains? (set (map :db/id (:property/closed-values property))) val)))
                         validate-fn')]
     (if (db-property/many? property)
-      (or (every? validate-fn'' property-val)
-          (empty-placeholder-value? db property (first property-val)))
-      (or (validate-fn'' property-val)
-          ;; also valid if value is empty-placeholder
-          (empty-placeholder-value? db property property-val)))))
+      (or (empty-placeholder-value? db property (first property-val))
+          (every? validate-fn'' property-val))
+      (or
+       ;; also valid if value is empty-placeholder
+       (empty-placeholder-value? db property property-val)
+       (validate-fn'' property-val)))))
 
 (def required-properties
   "Set of properties required by a schema and that are validated directly in a schema instead

--- a/deps/db/src/logseq/db/frontend/property.cljs
+++ b/deps/db/src/logseq/db/frontend/property.cljs
@@ -44,6 +44,9 @@
      :logseq.property/public? {:title "Property public?"
                                :schema {:type :checkbox
                                         :hide? true}}
+     :logseq.property/deprecated? {:title "Property already deprecated?"
+                                   :schema {:type :checkbox
+                                            :hide? true}}
      :logseq.property/view-context {:title "Property view context"
                                     :schema {:type :keyword
                                              :hide? true}}

--- a/deps/db/src/logseq/db/frontend/property.cljs
+++ b/deps/db/src/logseq/db/frontend/property.cljs
@@ -741,3 +741,8 @@
   [db-ident]
   (contains? db-property-type/value-ref-property-types
              (get-in built-in-properties [db-ident :schema :type])))
+
+(defn deprecated?
+  "Whether the property has been deprecated"
+  [property]
+  (:logseq.property/deprecated? property))

--- a/deps/db/src/logseq/db/frontend/schema.cljs
+++ b/deps/db/src/logseq/db/frontend/schema.cljs
@@ -37,7 +37,7 @@
          (map (juxt :major :minor)
               [(parse-schema-version x) (parse-schema-version y)])))
 
-(def version (parse-schema-version "65.9"))
+(def version (parse-schema-version "65.10"))
 
 (defn major-version
   "Return a number.

--- a/deps/db/src/logseq/db/sqlite/util.cljs
+++ b/deps/db/src/logseq/db/sqlite/util.cljs
@@ -82,9 +82,11 @@
          :block/uuid (or block-uuid (common-uuid/gen-uuid :db-ident-block-uuid db-ident'))
          :block/title (name prop-name)
          :db/index true
-         :db/cardinality (if (#{:many :db.cardinality/many} (:db/cardinality prop-schema))
-                           :db.cardinality/many
-                           :db.cardinality/one)
+         :db/cardinality (if (= :checkbox prop-type)
+                           :db.cardinality/one
+                           (if (#{:many :db.cardinality/many} (:db/cardinality prop-schema))
+                             :db.cardinality/many
+                             :db.cardinality/one))
          :block/order (db-order/gen-key)}
          (or ref-type? (contains? db-property-type/all-ref-property-types prop-type))
          (assoc :db/valueType :db.type/ref)

--- a/deps/outliner/test/logseq/outliner/property_test.cljs
+++ b/deps/outliner/test/logseq/outliner/property_test.cljs
@@ -24,10 +24,12 @@
         (is (> (:block/updated-at (d/entity @conn :user.property/num))
                old-updated-at)))
 
-      (testing "and change its type from a ref to a non-ref type"
-        (outliner-property/upsert-property! conn :user.property/num {:logseq.property/type :checkbox} {})
-        (is (= :checkbox (:logseq.property/type (d/entity @conn :user.property/num))))
-        (is (= nil (:db/valueType (d/entity @conn :user.property/num)))))))
+      (testing "and change its type from a ref to a non-ref type, this should create a new property"
+        (let [new-property (outliner-property/upsert-property! conn :user.property/num {:logseq.property/type :checkbox} {})]
+          (is (= :checkbox (:logseq.property/type new-property)))
+          (is (not= (:db/ident new-property) :user.property/num))
+          (is (= :number (:logseq.property/type (d/entity @conn :user.property/num))))
+          (is (nil? (:db/valueType new-property)))))))
 
   (testing "Multiple properties that generate the same initial :db/ident"
     (let [conn (db-test/create-conn-with-blocks [])]

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -451,7 +451,10 @@
         :container-id container-id
         :show-tag-and-property-classes? true
         :from-journals? (contains? #{:home :all-journals} (get-in (state/get-route-match) [:data :name]))}
-       page)]]))
+       page)
+      (when (:logseq.property/deprecated? page)
+        [:span.warning.text-sm
+         "Deprecated"])]]))
 
 (defn- page-mouse-over
   [e *control-show? *all-collapsed?]

--- a/src/main/frontend/components/property.cljs
+++ b/src/main/frontend/components/property.cljs
@@ -581,6 +581,8 @@
                        (= id :block/tags)
                        (when-let [ent (db/entity id)]
                          (or
+                          ;; deprecated?
+                          (db-property/deprecated? ent)
                           ;; built-in
                           (and (not (ldb/public-built-in-property? ent))
                                (ldb/built-in? ent))
@@ -677,6 +679,7 @@
 
           (when class?
             (let [properties (->> (:logseq.property.class/properties block)
+                                  (remove db-property/deprecated?)
                                   (map (fn [e] [(:db/ident e)])))
                   opts' (assoc opts :class-schema? true)]
               [:div.flex.flex-col.gap-1

--- a/src/main/frontend/components/property.css
+++ b/src/main/frontend/components/property.css
@@ -196,6 +196,7 @@
 }
 
 .property-value-inner {
+  min-height: 28px;
   .select-item {
     @apply flex items-center shrink whitespace-nowrap;
   }

--- a/src/main/frontend/components/property/config.cljs
+++ b/src/main/frontend/components/property/config.cljs
@@ -556,7 +556,8 @@
                                (db-property-handler/set-block-property! (:db/id owner-block) (:db/ident new-property)
                                                                         (if (= (keyword v) :checkbox)
                                                                           false
-                                                                          :logseq.property/empty-placeholder))))))
+                                                                          :logseq.property/empty-placeholder)))
+                             (shui/popup-hide-all!))))
         item-props {:on-select handle-select!}
         schema-types (->> db-property-type/user-built-in-property-types
                           (map (fn [type]

--- a/src/main/frontend/worker/db/migrate.cljs
+++ b/src/main/frontend/worker/db/migrate.cljs
@@ -367,7 +367,8 @@
    ["65.6" {:fix update-extends-to-cardinality-many}]
    ["65.7" {:fix add-quick-add-page}]
    ["65.8" {:fix add-missing-page-name}]
-   ["65.9" {:properties [:logseq.property.embedding/hnsw-label-updated-at]}]])
+   ["65.9" {:properties [:logseq.property.embedding/hnsw-label-updated-at]}]
+   ["65.10" {:properties [:logseq.property/deprecated?]}]])
 
 (let [[major minor] (last (sort (map (comp (juxt :major :minor) db-schema/parse-schema-version first)
                                      schema-version->updates)))]

--- a/src/main/frontend/worker/embedding.cljs
+++ b/src/main/frontend/worker/embedding.cljs
@@ -53,7 +53,8 @@
   (or (ldb/hidden? entity)
       (let [page (:block/page entity)]
         (and (ldb/hidden? page)
-             (not= (:block/title page) common-config/quick-add-page-name)))))
+             (not= (:block/title page) common-config/quick-add-page-name)))
+      (:logseq.property/deprecated? entity)))
 
 (defn- stale-block-filter-preds
   "When `reset?`, ignore :logseq.property.embedding/hnsw-label-updated-at in block"

--- a/src/main/frontend/worker/handler/page.cljs
+++ b/src/main/frontend/worker/handler/page.cljs
@@ -49,14 +49,15 @@
       (when (seq refs)
         (let [tx-data (mapcat (fn [{:block/keys [raw-title] :as ref}]
                                 ;; block content
-                                (let [content' (id-ref->page raw-title)
-                                      content-tx (when (not= raw-title content')
-                                                   {:db/id (:db/id ref)
-                                                    :block/title content'})
-                                      tx content-tx]
-                                  (concat
-                                   [[:db/retract (:db/id ref) :block/refs (:db/id page-entity)]]
-                                   (when tx [tx])))) refs)]
+                                (when raw-title
+                                  (let [content' (id-ref->page raw-title)
+                                        content-tx (when (not= raw-title content')
+                                                     {:db/id (:db/id ref)
+                                                      :block/title content'})
+                                        tx content-tx]
+                                    (concat
+                                     [[:db/retract (:db/id ref) :block/refs (:db/id page-entity)]]
+                                     (when tx [tx]))))) refs)]
           tx-data)))))
 
 (defn delete!

--- a/src/main/frontend/worker/search.cljs
+++ b/src/main/frontend/worker/search.cljs
@@ -224,7 +224,8 @@ DROP TRIGGER IF EXISTS blocks_au;
   (or (ldb/hidden? entity)
       (let [page (:block/page entity)]
         (and (ldb/hidden? page)
-             (not= (:block/title page) common-config/quick-add-page-name)))))
+             (not= (:block/title page) common-config/quick-add-page-name)))
+      (:logseq.property/deprecated? entity)))
 
 (defn- page-or-object?
   [entity]
@@ -460,10 +461,14 @@ DROP TRIGGER IF EXISTS blocks_au;
     (let [blocks-to-add-set (->> (filter :added datoms)
                                  (map :e)
                                  (set))
-          blocks-to-remove-set (->> (remove :added datoms)
-                                    (filter #(= :block/uuid (:a %)))
-                                    (map :e)
-                                    (set))
+          blocks-to-remove-set (set/union
+                                (->> (remove :added datoms)
+                                     (filter #(= :block/uuid (:a %)))
+                                     (map :e)
+                                     (set))
+                                (->> (filter (fn [d] (and (= :logseq.property/deprecated? (:a d)) (false? (:added d)))) datoms)
+                                     (map :e)
+                                     (set)))
           blocks-to-add-set' (if (and (sqlite-util/db-based-graph? repo) (seq blocks-to-add-set))
                                (->> blocks-to-add-set
                                     (mapcat (fn [id] (map :db/id (:block/_refs (d/entity db-after id)))))
@@ -482,7 +487,7 @@ DROP TRIGGER IF EXISTS blocks_au;
         datoms (filter
                 (fn [datom]
                   ;; Capture any direct change on page display title, page ref or block content
-                  (contains? #{:block/uuid :block/name :block/title :block/properties} (:a datom)))
+                  (contains? #{:block/uuid :block/name :block/title :block/properties :logseq.property/deprecated?} (:a datom)))
                 data)]
     (when (seq datoms)
       (get-blocks-from-datoms-impl repo tx-report datoms))))

--- a/src/main/frontend/worker/search.cljs
+++ b/src/main/frontend/worker/search.cljs
@@ -466,7 +466,7 @@ DROP TRIGGER IF EXISTS blocks_au;
                                      (filter #(= :block/uuid (:a %)))
                                      (map :e)
                                      (set))
-                                (->> (filter (fn [d] (and (= :logseq.property/deprecated? (:a d)) (false? (:added d)))) datoms)
+                                (->> (filter (fn [d] (and (= :logseq.property/deprecated? (:a d)) (true? (:added d)))) datoms)
                                      (map :e)
                                      (set)))
           blocks-to-add-set' (if (and (sqlite-util/db-based-graph? repo) (seq blocks-to-add-set))


### PR DESCRIPTION
This PR allows to change user property's type to any other type.

How it works:
Changing property type will create a new property and mark the old one as `deprecated`. 
It also remove old property kvs, history blocks and value blocks that're not pages or closed values.

New property:
`:logseq.property/deprecated?` 

- [x] add unit tests
- [x] add e2e tests
- [x] test with rtc
- [x] add rtc e2e test @RCmerci 

Screenshot:
<img width="671" height="561" alt="image" src="https://github.com/user-attachments/assets/8903a7f2-6907-4333-a8a3-6f48b15f1465" />
