### PR TITLE
fix(translations): "Rectangle" for es in whiteboard

### DIFF
--- a/src/resources/dicts/es.edn
+++ b/src/resources/dicts/es.edn
@@ -672,7 +672,7 @@
  :whiteboard/pan                                    "Mover"
  :whiteboard/paste                                  "Pegar"
  :whiteboard/paste-as-link                          "Pegar como enlace"
- :whiteboard/rectangle                              "Recargar"
+ :whiteboard/rectangle                              "Rectángulo"
  :whiteboard/redo                                   "Rehacer"
  :whiteboard/references                             "Referencias"
  :whiteboard/reload                                 "Recargar"


### PR DESCRIPTION
I've realised that the translation for "Rectangle" in `es` is wrong: it is currently translated as "Recargar", which would be the spanish for "Reload"; the correct translation would be "Rectángulo".

After further inspection, I strongly think that this has just been a copy&paste error from a near line:

```
 :whiteboard/reload                                 "Recargar"
```