### PR TITLE
fix: Cross-graph linking freeze issue

### DIFF
--- a/src/electron/electron/url.cljs
+++ b/src/electron/electron/url.cljs
@@ -41,7 +41,7 @@
       (p/let [window-on-graph (first (win/get-graph-all-windows (utils/get-graph-dir graph-name)))
               open-new-window? (or force-new-window? (not window-on-graph))
               _ (when (and force-new-window? window-on-graph)
-                  (handler/broadcast-persist-graph! graph-name))]
+                  (p/timeout (handler/broadcast-persist-graph! graph-name) 3500))]
           ;; TODO: call open new window on new graph without renderer (remove the reliance on local storage)
           ;; TODO: allow open new window on specific page, without waiting for `graph ready` ipc then redirect to that page
         (when (or page-name block-id file)


### PR DESCRIPTION
## Summary

Fixes the window freeze issue when clicking cross-graph links.

Closes #12132

## Root Cause

The freeze was caused by two problems in the cross-graph navigation flow:

1. **Database persistence deadlock**: `broadcast-persist-graph!` waited indefinitely for a renderer response that could never come
2. **File system watcher race condition**: File watchers were closed prematurely due to timing issues in window registration

## Changes Made

### 1. Fixed Database Persistence Deadlock
- Added 3-second timeout protection to `broadcast-persist-graph!` function
- Prevents indefinite waiting for renderer response
- Includes proper cleanup of timeout handlers
- Added warning logging for timeout cases

### 2. Fixed File Watcher Race Condition  
- Reordered operations in `set-current-graph!` to update window mapping first
- Added 100ms delay before checking for orphaned watchers
- Ensures new windows are properly registered before cleanup decisions

### 3. Added Extra Safety
- Added additional timeout protection in URL handler with 3.5s timeout
- Double-layer protection against persistence blocking

## Testing

- [x] Reproduced original freeze issue on development build
- [x] Applied fixes and verified cross-graph linking works without freezing
- [x] Original window remains responsive after cross-graph navigation
- [x] New window opens correctly and is functional

## Files Changed

- `src/electron/electron/handler.cljs`: Fixed persistence deadlock and watcher race condition
- `src/electron/electron/url.cljs`: Added additional timeout protection

This fix resolves a timing-sensitive race condition that particularly affected Linux users with multiple graph workflows.