### PR TITLE
feat: add "Always on Top" in electron window menu.

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -206,11 +206,19 @@
                        {:role "editMenu"}
                        {:role "viewMenu"}
                        {:role "windowMenu"
-                        :submenu (when-not mac? [{:role "minimize"}
-                                                 {:role "zoom"}
-                                                 ;; Disable Control+W shortcut
-                                                 {:role "close"
-                                                  :accelerator false}])})
+                        :submenu
+                        (concat
+                          (when-not mac?
+                            [{:role "minimize"}
+                             {:role "zoom"}
+                             ;; Disable Control+W shortcut
+                             {:role "close"
+                              :accelerator false}])
+                          [{:label "Always on Top"
+                            :type "checkbox"
+                            :click (fn [menuItem browserWindow]
+                                     ;; switch alwaysOnTop state
+                                     (.setAlwaysOnTop browserWindow (.-checked menuItem)))}])})
         ;; Windows has no about role
         template (conj template
                        (if mac?


### PR DESCRIPTION
Pin Electron windows top on any other apps.

<img width="550" height="532" alt="image" src="https://github.com/user-attachments/assets/904106f9-d560-4d24-b01c-9d14c4b64260" />
