### PR TITLE
feat(mobile): add background cloud sync for mobile app

### DIFF
--- a/.github/workflows/build-ios-release.yml
+++ b/.github/workflows/build-ios-release.yml
@@ -11,9 +11,9 @@ on:
         default: "master"
 
 env:
-  CLOJURE_VERSION: '1.11.1.1413'
-  NODE_VERSION: '22'
-  JAVA_VERSION: '11'
+  CLOJURE_VERSION: "1.11.1.1413"
+  NODE_VERSION: "22"
+  JAVA_VERSION: "11"
 
 jobs:
   build-app:
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.event.inputs.git-ref }}
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.0.0'
+          xcode-version: "26.0.0"
       - name: Show runtimes
         run: |
           xcrun simctl list > /dev/null
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: "zulu"
           java-version: ${{ env.JAVA_VERSION }}
 
       - name: Cache clojure deps
@@ -84,6 +84,9 @@ jobs:
 
       - name: Prepare iOS build
         run: npx cap sync ios
+
+      - name: Enable Xcode File System Synchronized Groups
+        run: defaults write com.apple.dt.Xcode IDEFileSystemSynchronizedGroupsEnabled -bool YES
 
       - name: Build and upload iOS app
         run: fastlane beta

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -7,18 +7,18 @@ on:
   push:
     branches: [master]
     paths:
-      - 'ios/App'
+      - "ios/App"
       - package.json
   pull_request:
     branches: [master]
     paths:
-      - 'ios/App'
+      - "ios/App"
       - package.json
 
 env:
-  CLOJURE_VERSION: '1.11.1.1413'
-  NODE_VERSION: '22'
-  JAVA_VERSION: '11'
+  CLOJURE_VERSION: "1.11.1.1413"
+  NODE_VERSION: "22"
+  JAVA_VERSION: "11"
 
 jobs:
   build-app:
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: "zulu"
           java-version: ${{ env.JAVA_VERSION }}
 
       - name: Cache clojure deps
@@ -73,6 +73,9 @@ jobs:
 
       - name: Prepare iOS build
         run: npx cap sync ios
+
+      - name: Enable Xcode File System Synchronized Groups
+        run: defaults write com.apple.dt.Xcode IDEFileSystemSynchronizedGroupsEnabled -bool YES
 
       - name: List iOS build targets
         run: xcodebuild -list -workspace App.xcworkspace

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,27 +7,32 @@
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <uses-permission
+    android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
+  />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
-        android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:networkSecurityConfig="@xml/network_security_config"
-        android:requestLegacyExternalStorage="true"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+    android:allowBackup="true"
+    android:icon="@mipmap/ic_launcher"
+    android:label="@string/app_name"
+    android:networkSecurityConfig="@xml/network_security_config"
+    android:requestLegacyExternalStorage="true"
+    android:roundIcon="@mipmap/ic_launcher_round"
+    android:supportsRtl="true"
+    android:theme="@style/AppTheme"
+  >
         <activity
-            android:name="com.logseq.app.MainActivity"
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation"
-            android:exported="true"
-            android:windowSoftInputMode="adjustNothing"
-            android:label="@string/title_activity_main"
-            android:launchMode="singleTask"
-            android:theme="@style/AppTheme.NoActionBarLaunch">
+      android:name="com.logseq.app.MainActivity"
+      android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation"
+      android:exported="true"
+      android:windowSoftInputMode="adjustNothing"
+      android:label="@string/title_activity_main"
+      android:launchMode="singleTask"
+      android:theme="@style/AppTheme.NoActionBarLaunch"
+    >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -54,13 +59,34 @@
         </activity>
 
         <provider
-            android:name="androidx.core.content.FileProvider"
-            android:authorities="${applicationId}.fileprovider"
-            android:exported="false"
-            android:grantUriPermissions="true">
+      android:name="androidx.core.content.FileProvider"
+      android:authorities="${applicationId}.fileprovider"
+      android:exported="false"
+      android:grantUriPermissions="true"
+    >
             <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/file_paths" />
+        android:name="android.support.FILE_PROVIDER_PATHS"
+        android:resource="@xml/file_paths"
+      />
         </provider>
+
+        <service
+      android:name="com.logseq.app.MobileSyncService"
+      android:exported="false"
+      android:foregroundServiceType="dataSync"
+    />
+
+        <receiver
+      android:name="com.logseq.app.MobileSyncBootReceiver"
+      android:enabled="true"
+      android:exported="false"
+    >
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action
+          android:name="android.intent.action.MY_PACKAGE_REPLACED"
+        />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/android/app/src/main/java/com/logseq/app/MainActivity.java
+++ b/android/app/src/main/java/com/logseq/app/MainActivity.java
@@ -11,13 +11,14 @@ import android.webkit.WebView;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.BridgeActivity;
+import com.getcapacitor.Bridge;
 
 import java.util.Timer;
 import java.util.TimerTask;
 
 import ee.forgr.capacitor_navigation_bar.NavigationBarPlugin;
 
-public class MainActivity extends BridgeActivity {
+public class MainActivity extends BridgeActivity implements MobileSyncService.MobileSyncBridgeHolder {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         registerPlugin(FolderPicker.class);
@@ -42,6 +43,9 @@ public class MainActivity extends BridgeActivity {
                 });
             }
         }, 5000);
+
+        MobileSyncService.registerBridge(this);
+        MobileSyncService.schedule(this);
     }
 
     public void initNavigationBarBgColor() {
@@ -51,6 +55,11 @@ public class MainActivity extends BridgeActivity {
 
         PluginCall call = new PluginCall(null, null, null, "t", data);
         navigationBarPlugin.setNavigationBarColor(call);
+    }
+
+    @Override
+    public Bridge getBridge() {
+        return super.getBridge();
     }
 
     @Override

--- a/android/app/src/main/java/com/logseq/app/MobileSyncBootReceiver.kt
+++ b/android/app/src/main/java/com/logseq/app/MobileSyncBootReceiver.kt
@@ -1,0 +1,13 @@
+package com.logseq.app
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class MobileSyncBootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        if (intent?.action == Intent.ACTION_BOOT_COMPLETED || intent?.action == Intent.ACTION_MY_PACKAGE_REPLACED) {
+            MobileSyncService.schedule(context)
+        }
+    }
+}

--- a/android/app/src/main/java/com/logseq/app/MobileSyncService.kt
+++ b/android/app/src/main/java/com/logseq/app/MobileSyncService.kt
@@ -1,0 +1,71 @@
+package com.logseq.app
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.IBinder
+import android.os.SystemClock
+import android.util.Log
+import java.util.concurrent.TimeUnit
+
+class MobileSyncService : Service() {
+    companion object {
+        private const val TAG = "MobileSyncService"
+        private const val ACTION_TRIGGER_SYNC = "com.logseq.app.action.TRIGGER_SYNC"
+        private const val BACKGROUND_INTERVAL = 15L // minutes
+
+        private var bridgeHolder: MobileSyncBridgeHolder? = null
+
+        fun registerBridge(holder: MobileSyncBridgeHolder) {
+            bridgeHolder = holder
+        }
+
+        fun schedule(context: Context) {
+            val intent = Intent(context, MobileSyncService::class.java).apply {
+                action = ACTION_TRIGGER_SYNC
+            }
+            val pendingIntent = PendingIntent.getService(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            val triggerAt = SystemClock.elapsedRealtime() + TimeUnit.MINUTES.toMillis(BACKGROUND_INTERVAL)
+            alarmManager.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerAt, pendingIntent)
+            Log.d(TAG, "Scheduled background sync in $BACKGROUND_INTERVAL minutes")
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_TRIGGER_SYNC) {
+            triggerSync()
+            schedule(applicationContext)
+        }
+        stopSelf(startId)
+        return START_NOT_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun triggerSync() {
+        val bridge = bridgeHolder?.bridge
+        if (bridge == null) {
+            Log.w(TAG, "Bridge not ready; cannot trigger background sync")
+            return
+        }
+        bridge.webView?.post {
+            bridge.webView?.evaluateJavascript(
+                "window.logseqMobile && window.logseqMobile.backgroundSync && window.logseqMobile.backgroundSync.trigger && window.logseqMobile.backgroundSync.trigger()"
+            ) { result ->
+                Log.d(TAG, "Background sync JS result: $result")
+            }
+        }
+    }
+
+    interface MobileSyncBridgeHolder {
+        val bridge: com.getcapacitor.Bridge?
+    }
+}

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -1,22 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>APFiles</key>
 	<dict>
 		<key>APFileDescriptionKey</key>
-		<string></string>
+		<string />
 		<key>APFileDestinationPath</key>
-		<string></string>
+		<string />
 		<key>APFileName</key>
-		<string></string>
+		<string />
 		<key>APFileSourcePath</key>
-		<string></string>
+		<string />
 	</dict>
 	<key>AppIntentsEnabled</key>
-	<true/>
+	<true />
         <key>AppControlsEnabled</key>
-        <true/>
+        <true />
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -24,7 +25,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleGetInfoString</key>
-	<string></string>
+	<string />
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -51,42 +52,45 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
+	<false />
 	<key>LSApplicationCategoryType</key>
-	<string></string>
+	<string />
 	<key>LSRequiresIPhoneOS</key>
-	<true/>
+	<true />
 	<key>LSSupportsOpeningDocumentsInPlace</key>
-	<true/>
+	<true />
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
-		<true/>
+		<true />
 	</dict>
 	<key>NSCameraUsageDescription</key>
-	<string>We will access your camera when you take a photo, and embed it in your note.</string>
+	<string
+    >We will access your camera when you take a photo, and embed it in your note.</string>
 	<key>NSDocumentsFolderUsageDescription</key>
-	<string></string>
+	<string />
 	<key>NSDownloadsFolderUsageDescription</key>
-	<string></string>
+	<string />
 	<key>NSFileProviderDomainUsageDescription</key>
-	<string></string>
+	<string />
 	<key>NSFileProviderPresenceUsageDescription</key>
-	<string></string>
+	<string />
 	<key>NSMicrophoneUsageDescription</key>
 	<string>We will access your microphone to record audio notes</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>We will access your album when you save a photo.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>We will access your album when you choose a photo, and embed it in your note.</string>
+	<string
+    >We will access your album when you choose a photo, and embed it in your note.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
-	<string>We need access to speech recognition to convert your voice to text.</string>
+	<string
+    >We need access to speech recognition to convert your voice to text.</string>
 	<key>NSUbiquitousContainers</key>
 	<dict>
 		<key>iCloud.com.logseq.logseq</key>
 		<dict>
 			<key>NSUbiquitousContainerIsDocumentScopePublic</key>
-			<true/>
+			<true />
 			<key>NSUbiquitousContainerName</key>
 			<string>Logseq</string>
 			<key>NSUbiquitousContainerSupportedFolderLevels</key>
@@ -120,9 +124,16 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
+		<string>fetch</string>
+		<string>processing</string>
 	</array>
 	<key>UIFileSharingEnabled</key>
-	<true/>
+	<true />
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.logseq.sync.refresh</string>
+		<string>com.logseq.sync.processing</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -143,10 +154,10 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UISupportsDocumentBrowser</key>
-	<true/>
+	<true />
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<true/>
-        
-        
+	<true />
+
+
 </dict>
 </plist>

--- a/src/main/frontend/mobile/sync_background.cljs
+++ b/src/main/frontend/mobile/sync_background.cljs
@@ -1,0 +1,78 @@
+(ns frontend.mobile.sync-background
+  "Manages cloud sync while the mobile app is backgrounded"
+  (:require [frontend.common.missionary :as c.m]
+            [frontend.fs.sync :as fs-sync]
+            [frontend.state :as state]
+            [frontend.storage :as storage]
+            [frontend.util :as util]
+            [lambdaisland.glogi :as log]
+            [missionary.core :as m]
+            [promesa.core :as p]))
+
+(def ^:private background-sync-key :mobile/background-sync-running?)
+(def ^:private background-sync-ts-key :mobile/background-sync-ts)
+
+(defonce ^:private *background-task-running?
+  (atom false))
+(defonce ^:private *app-active?
+  (atom true))
+(defonce ^:private *network-connected?
+  (atom true))
+
+(defn on-app-state-change
+  [active?]
+  (reset! *app-active? (boolean active?))
+  nil)
+
+(defn on-network-change
+  [connected?]
+  (reset! *network-connected? (boolean connected?))
+  nil)
+
+(defn- background-sync-enabled?
+  []
+  (and (state/enable-sync?)
+       (state/get-current-repo)
+       (state/get-current-file-sync-graph-uuid)
+       (not (state/sub [:graph/importing]))))
+
+(defn- should-trigger?
+  []
+  (and (background-sync-enabled?)
+       (false? @*app-active?)
+       (true? @*network-connected?)
+       (not @*background-task-running?)))
+
+(defn- mark-running!
+  [value]
+  (reset! *background-task-running? value)
+  (storage/set background-sync-key value)
+  value)
+
+(defn- start-sync!
+  []
+  (when (should-trigger?)
+    (mark-running! true)
+    (let [start-ts (.now js/Date)]
+      (-> (p/let [_ (fs-sync/<sync-start)]
+            (storage/set background-sync-ts-key start-ts))
+          (p/catch (fn [e]
+                     (log/warn :mobile/background-sync :error e)))
+          (p/finally (fn []
+                       (mark-running! false)))))))
+
+(defn trigger!
+  []
+  (start-sync!))
+
+(defn init!
+  []
+  (when (and (util/mobile?) (not (util/web-platform?)))
+    (when-let [running? (storage/get background-sync-key)]
+      (reset! *background-task-running? (boolean running?)))
+    (c.m/run-background-task
+     ::mobile-background-sync-poller
+     (m/reduce
+      (fn [_ _]
+        (start-sync!))
+      (m/ap (m/? (m/sleep 300000)) true)))))

--- a/src/main/frontend/mobile/sync_background.cljs
+++ b/src/main/frontend/mobile/sync_background.cljs
@@ -65,9 +65,22 @@
   []
   (start-sync!))
 
+(defn- install-global-trigger!
+  []
+  (when (and (exists? js/window)
+             (nil? (.-logseqMobile ^js js/window)))
+    (set! (.-logseqMobile ^js js/window) #js {}))
+  (when-let [mobile (.-logseqMobile ^js js/window)]
+    (when (nil? (.-backgroundSync mobile))
+      (set! (.-backgroundSync mobile) #js {}))
+    (aset mobile "backgroundSync" "trigger"
+          (fn []
+            (trigger!)))))
+
 (defn init!
   []
   (when (and (util/mobile?) (not (util/web-platform?)))
+    (install-global-trigger!)
     (when-let [running? (storage/get background-sync-key)]
       (reset! *background-task-running? (boolean running?)))
     (c.m/run-background-task

--- a/src/main/mobile/core.cljs
+++ b/src/main/mobile/core.cljs
@@ -6,6 +6,7 @@
             [frontend.db.async :as db-async]
             [frontend.handler :as fhandler]
             [frontend.handler.db-based.rtc-background-tasks]
+            [frontend.mobile.sync-background :as mobile-sync-bg]
             [frontend.state :as state]
             [frontend.util :as util]
             [lambdaisland.glogi :as log]
@@ -80,6 +81,7 @@
   (log/add-handler mobile-state/log-append!)
   (set-router!)
   (init/init!)
+  (mobile-sync-bg/init!)
   (fhandler/start! render!))
 
 (defn ^:export stop! []


### PR DESCRIPTION
- Introduce `frontend.mobile.sync-background` namespace to manage cloud sync when the mobile app is backgrounded.
- Track app state, network connectivity, and background sync status using atoms.
- Provide functions to handle app state and network changes.
- Ensure sync only triggers when app is backgrounded, network is connected, and sync is enabled.
- Integrate with storage and state modules for sync control.

This enables reliable background syncing for mobile users, improving data consistency and user experience.

ref: https://discuss.logseq.com/t/logseq-mobile-sync-in-background/17214