### PR TITLE
feat(markdown): add support for image captions from title attribute

### DIFF
--- a/resources/css/ui.css
+++ b/resources/css/ui.css
@@ -2153,3 +2153,25 @@
   line-height: 1.625;
 }
 
+/* Image caption styles */
+figure.asset-container-with-caption {
+  display: inline-block;
+  max-width: 100%;
+  margin: 0.5em 0;
+}
+
+.asset-caption {
+  display: block;
+  text-align: center;
+  font-size: 0.9em;
+  color: hsl(var(--ls-secondary-text-color, var(--muted-foreground)));
+  font-style: italic;
+  margin-top: 0.5em;
+  padding: 0 0.5em;
+  line-height: 1.4;
+}
+
+/* Dark mode support */
+.dark .asset-caption {
+  color: hsl(var(--ls-secondary-text-color, var(--muted-foreground)));
+}

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -312,8 +312,9 @@
                      (string/starts-with? src "~"))
                (str "file://" src)
                src)
-        get-blockid #(some-> (rum/deref *el-ref) (.closest "[blockid]") (.getAttribute "blockid") (uuid))]
-    [:div.asset-container
+        get-blockid #(some-> (rum/deref *el-ref) (.closest "[blockid]") (.getAttribute "blockid") (uuid))
+        has-caption? (and title (not (string/blank? title)))]
+    [(if has-caption? :figure.asset-container-with-caption :div.asset-container)
      {:key "resize-asset-container"
       :on-pointer-down util/stop
       :on-click (fn [e]
@@ -400,7 +401,9 @@
                                                     (ui/icon "trash") (t :asset/delete)])])])
                                             {:align :start
                                              :dropdown-menu? true}))}
-             (shui/tabler-icon "dots-vertical")))])])]))
+             (shui/tabler-icon "dots-vertical")))])])]
+     (when has-caption?
+       [:figcaption.asset-caption title])])
 
 ;; TODO: store image height and width for better ux
 (rum/defcs ^:large-vars/cleanup-todo resizable-image <
@@ -595,11 +598,10 @@
 
 ;; TODO: safe encoding asciis
 ;; TODO: image link to another link
-(defn image-link [config url href label metadata full_text]
+(defn image-link [config url href label title metadata full_text]
   (let [metadata (if (string/blank? metadata)
                    nil
                    (common-util/safe-read-map-string metadata))
-        title (second (first label))
         repo (state/get-current-repo)]
     (ui/catch-error
      [:span.warning full_text]
@@ -1481,7 +1483,7 @@
               (config/get-local-asset-absolute-path path)))))
 
 (rum/defc audio-link
-  [config url href _label metadata full_text]
+  [config url href _label _title metadata full_text]
   (if (and (common-config/local-asset? href)
            (or (config/local-file-based-graph? (state/get-current-repo))
                (config/db-based-graph? (state/get-current-repo))))
@@ -1503,18 +1505,18 @@
       (audio-cp href))))
 
 (defn- media-link
-  [config url s label metadata full_text]
+  [config url s label title metadata full_text]
   (let [ext (keyword (util/get-file-ext s))
         label-text (get-label-text label)]
     (cond
       (contains? config/audio-formats ext)
-      (audio-link config url s label metadata full_text)
+      (audio-link config url s label title metadata full_text)
 
       (contains? config/doc-formats ext)
       (asset-link config label-text s metadata full_text)
 
       (not (contains? #{:mp4 :webm :mov} ext))
-      (image-link config url s label metadata full_text)
+      (image-link config url s label title metadata full_text)
 
       :else
       (asset-reference config label s))))
@@ -1547,7 +1549,7 @@
             (map-inline config label))
 
     (show-link? config metadata s full_text)
-    (media-link config url s label metadata full_text)
+    (media-link config url s label title metadata full_text)
 
     (util/electron?)
     (let [path (cond
@@ -1593,14 +1595,14 @@
         (if (and (= format :org)
                  (show-link? config nil page page)
                  (not (contains? #{"pdf" "mp4" "ogg" "webm"} (util/get-file-ext page))))
-          (image-link config url page nil metadata full_text)
+          (image-link config url page nil title metadata full_text)
           (let [label* (if (seq (mldoc/plain->text label)) label nil)]
             (if (and (string? page) (string/blank? page))
               [:span (ref/->page-ref page)]
               (page-reference config page label*)))))
 
       ["Embed_data" src]
-      (image-link config url src nil metadata full_text)
+      (image-link config url src nil title metadata full_text)
 
       ["Search" s]
       (search-link-cp config url s label title metadata full_text)
@@ -1624,7 +1626,7 @@
 
           (= protocol "file")
           (if (show-link? config metadata href full_text)
-            (media-link config url href label metadata full_text)
+            (media-link config url href label title metadata full_text)
             (let [href* (if (util/electron?)
                           (relative-assets-path->absolute-path href)
                           href)]
@@ -1644,7 +1646,7 @@
                 (map-inline config label))]))
 
           (show-link? config metadata href full_text)
-          (media-link config url href label metadata full_text)
+          (media-link config url href label title metadata full_text)
 
           :else
           (->elem

--- a/src/test/frontend/components/image_caption_test.cljs
+++ b/src/test/frontend/components/image_caption_test.cljs
@@ -1,0 +1,53 @@
+(ns frontend.components.image-caption-test
+  (:require [cljs.test :refer [deftest testing is]]
+            [frontend.format.mldoc :as mldoc]
+            [frontend.components.block :as block]))
+
+(deftest test-image-markdown-with-caption
+  (testing "Markdown image with title attribute is parsed"
+    (let [markdown "![alt text](image.png \"my caption\")"
+          parsed (mldoc/->edn markdown (mldoc/default-config :markdown))]
+      ;; The mldoc parser should extract the title
+      (is (some? parsed) "Markdown should be parsed successfully")))
+
+  (testing "Image without caption is parsed"
+    (let [markdown "![alt text](image.png)"
+          parsed (mldoc/->edn markdown (mldoc/default-config :markdown))]
+      (is (some? parsed) "Markdown without caption should be parsed successfully")))
+
+  (testing "Image with metadata and caption"
+    (let [markdown "![alt text](image.png \"my caption\"){:width 200 :height 100}"
+          parsed (mldoc/->edn markdown (mldoc/default-config :markdown))]
+      (is (some? parsed) "Markdown with both caption and metadata should be parsed"))))
+
+(deftest test-asset-container-caption-rendering
+  (testing "asset-container renders figcaption when title is present"
+    ;; This tests the has-caption? logic
+    (let [title "My image caption"
+          has-caption? (and title (not (clojure.string/blank? title)))]
+      (is (true? has-caption?) "Non-blank title should result in has-caption? being true")))
+
+  (testing "asset-container does not render figcaption for blank title"
+    (let [title ""
+          has-caption? (and title (not (clojure.string/blank? title)))]
+      (is (false? has-caption?) "Blank title should result in has-caption? being false")))
+
+  (testing "asset-container does not render figcaption for nil title"
+    (let [title nil
+          has-caption? (and title (not (clojure.string/blank? title)))]
+      (is (false? has-caption?) "Nil title should result in has-caption? being false")))
+
+  (testing "asset-container does not render figcaption for whitespace-only title"
+    (let [title "   "
+          has-caption? (and title (not (clojure.string/blank? title)))]
+      (is (false? has-caption?) "Whitespace-only title should result in has-caption? being false"))))
+
+(comment
+  ;; Manual testing notes:
+  ;; To test manually in Logseq:
+  ;; 1. Create a markdown block with: ![test](image.png "my caption")
+  ;; 2. Verify a caption appears below the image
+  ;; 3. Verify the caption is styled correctly (centered, italic, etc.)
+  ;; 4. Test with long captions to ensure wrapping works
+  ;; 5. Test in dark mode to ensure caption color is visible
+  )


### PR DESCRIPTION
Implement rendering of markdown image captions using the standard title attribute syntax: `![alt](image.png "caption text")`

<!--
Thank you for the pull request. Please provide a description. Screenshots and gifs are appreciated for UX enhancements, new features and bug fixes!

For bug fixes and new features, please include tests and possibly benchmarks.
-->
