### PR TITLE
Fix node version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
 # install NodeJS & yarn
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_22.x | bash -
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | \
     tee /etc/apt/trusted.gpg.d/yarn.gpg && \


### PR DESCRIPTION
1.018 error logseq@0.0.1: The engine "node" is incompatible with this module. Expected version ">=22.20.0". Got "18.20.8"
1.031 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
1.031 error Found incompatible module.
------
Dockerfile:33

--------------------

  31 |     RUN git clone -b master https://github.com/logseq/logseq.git .

  32 |

  33 | >>> RUN yarn config set network-timeout 240000 -g && yarn install

  34 |

  35 |     RUN  yarn release

--------------------

failed to solve: process "/bin/sh -c yarn config set network-timeout 240000 -g && yarn install" did not complete successfully: exit code: 1