### PR TITLE
fix: db graph import fails from UI

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -1813,7 +1813,7 @@
         ;; uuids to be valid. Also upstream-properties-tx comes after blocks-tx to possibly override blocks
         tx (concat whiteboard-pages pages-index page-properties-tx property-page-properties-tx pages-tx'' classes-tx' blocks-index blocks-tx)
         tx' (common-util/fast-remove-nils tx)
-        ;; (prn :tx-counts (map #(vector %1 (count %2))
+        ;; _ (prn :tx-counts (map #(vector %1 (count %2))
         ;;                        [:whiteboard-pages :pages-index :page-properties-tx :property-page-properties-tx :pages-tx' :classes-tx :blocks-index :blocks-tx]
         ;;                        [whiteboard-pages pages-index page-properties-tx property-page-properties-tx pages-tx' classes-tx blocks-index blocks-tx]))
         ;; _ (when (not (seq whiteboard-pages)) (cljs.pprint/pprint {#_:property-pages-tx #_property-pages-tx :pages-tx pages-tx :tx tx'}))


### PR DESCRIPTION
with errors `RangeError: Maximum call stack size exceeded`. This seems to be affecting all imported graphs. Fixes https://github.com/logseq/db-test/issues/525 and may fix https://github.com/logseq/db-test/issues/537 and https://github.com/logseq/db-test/issues/539. After #12130, invoke-hooks-for-imported-graph no longer works because :pipeline-replace? is no longer handled 

Remaining tasks
* [ ] Fix bug(s) with importing exporter-test-graph and docs from UI
* [ ] Update CLI to use transact-pipeline