### PR TITLE
Enhance: add configurable keyboard shortcut :go/today

### DIFF
--- a/libs/src/LSPlugin.ts
+++ b/libs/src/LSPlugin.ts
@@ -299,6 +299,7 @@ export type ExternalCommandType =
   | 'logseq.go/next-journal'
   | 'logseq.go/prev-journal'
   | 'logseq.go/search'
+  | 'logseq.go/today'
   | 'logseq.go/tomorrow'
   | 'logseq.go/backward'
   | 'logseq.go/forward'

--- a/src/main/frontend/handler/journal.cljs
+++ b/src/main/frontend/handler/journal.cljs
@@ -20,6 +20,10 @@
                                  :path-params {:name page}})
        (page-handler/<create! page)))))
 
+(defn go-to-today!
+  []
+  (redirect-to-journal! (date/today)))
+
 (defn go-to-tomorrow!
   []
   (redirect-to-journal! (date/tomorrow)))

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -510,6 +510,9 @@
    :go/keyboard-shortcuts                   {:binding "g s"
                                              :fn      #(state/pub-event! [:modal/keymap])}
 
+   :go/today                                {:binding []
+                                             :fn      journal-handler/go-to-today!}
+
    :go/tomorrow                             {:binding "g t"
                                              :fn      journal-handler/go-to-tomorrow!}
 
@@ -855,6 +858,7 @@
           :go/all-graphs
           :go/whiteboards
           :go/keyboard-shortcuts
+          :go/today
           :go/tomorrow
           :go/next-journal
           :go/prev-journal
@@ -959,6 +963,7 @@
      :go/all-graphs
      :go/whiteboards
      :go/flashcards
+     :go/today
      :go/tomorrow
      :go/next-journal
      :go/prev-journal

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -757,6 +757,7 @@
   :go/all-pages                   "Go to all pages"
   :go/graph-view                  "Go to graph view"
   :go/keyboard-shortcuts          "Go to keyboard shortcuts"
+  :go/today                       "Go to today"
   :go/tomorrow                    "Go to tomorrow"
   :go/next-journal                "Go to next journal"
   :go/prev-journal                "Go to previous journal"


### PR DESCRIPTION
This PR adds a new (unbound) keyboard config option to go to today's journal.

This allows quick, focused, main page access to today.

For folks distracted by previous days when using "g j", and preferring "g t" to take them to today, not tomorrow.

This PR gives folks that ability _without_ disturbing any current keyboard shortcut defaults.