### PR TITLE
fix: `default-open-blocks-level 0` no longer working in DB version

### DIFF
--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -623,11 +623,11 @@ should be done through this fn in order to get global config and config defaults
 
 (defn get-ref-open-blocks-level
   []
-  (or
-   (when-let [value (:ref/default-open-blocks-level (get-config))]
-     (when (pos-int? value)
-       (min value 9)))
-   2))
+  (if-let [value (:ref/default-open-blocks-level (get-config))]
+    (if (and (int? value) (>= value 0))
+      (min value 9)
+      2)
+    2))
 
 (defn get-export-bullet-indentation
   []


### PR DESCRIPTION
When migrating my file graph to the DB version I noticed my Linked References section was no longer collapsed by default and the `:ref/default-open-blocks-level 0` config was being ignored. This fix restores that previous functionality.