### PR TITLE
Update dompurify dependency version from version 2.5.4 to 3.2.4

### DIFF
--- a/libs/package.json
+++ b/libs/package.json
@@ -20,7 +20,7 @@
     "csstype": "3.1.0",
     "debug": "4.3.4",
     "deepmerge": "4.3.1",
-    "dompurify": "2.5.4",
+    "dompurify": "3.2.4",
     "eventemitter3": "4.0.7",
     "fast-deep-equal": "3.1.3",
     "lodash-es": "4.17.21",


### PR DESCRIPTION
Updated dompurify dependency from version 2.5.4 to 3.2.4.

DOMPurify before 3.2.4 has an incorrect template literal regular expression when SAFE_FOR_TEMPLATES is set to true, sometimes leading to mutation cross-site scripting (mXSS).