### PR TITLE
fix(rtc): persist remote-t to prevent full re-sync on restart

### DIFF
--- a/src/main/frontend/worker/rtc/full_upload_download_graph.cljs
+++ b/src/main/frontend/worker/rtc/full_upload_download_graph.cljs
@@ -427,7 +427,7 @@
     (m/sp
       (rtc-log-and-state/clean-cached-graph-local-and-remote-t graph-uuid)
       (rtc-log-and-state/update-local-t graph-uuid remote-t)
-      (rtc-log-and-state/update-remote-t graph-uuid remote-t)
+      (rtc-log-and-state/update-remote-t graph-uuid remote-t repo)
       (c.m/<?
        (p/do!
         ((@thread-api/*thread-apis :thread-api/create-or-open-db) repo {:close-other-db? false})

--- a/src/main/frontend/worker/rtc/remote_update.cljs
+++ b/src/main/frontend/worker/rtc/remote_update.cljs
@@ -659,7 +659,7 @@
             tx-meta {:rtc-tx? true
                      :persist-op? false
                      :gen-undo-ops? false}]
-        (rtc-log-and-state/update-remote-t graph-uuid remote-t)
+        (rtc-log-and-state/update-remote-t graph-uuid remote-t repo)
         (js/console.groupCollapsed "rtc/apply-remote-ops-log")
         (ldb/transact-with-temp-conn!
          conn tx-meta


### PR DESCRIPTION
## Summary
- Adds `remote-t` persistence to the client-ops database (similar to `local-tx`)
- Restores `remote-t` from database during RTC initialization to prevent unnecessary full re-syncs
- Updates all three call sites where `update-remote-t` is invoked

## Problem
Previously, `remote-t` was only stored in memory via `*graph-uuid->remote-t` atom. On app restart, this value was lost, causing the sync system to think it needed to re-sync all files from the remote.

This issue primarily affected Mac users with large graphs, while Windows users didn't experience it due to different state management.

## Test plan
- [ ] Restart Logseq with RTC sync enabled
- [ ] Verify that files are not fully re-synced after restart
- [ ] Check logs for `rtc/restore-remote-t` message confirming restoration

Fixes: https://github.com/logseq/logseq/issues/12333

🤖 Generated with [Claude Code](https://claude.com/claude-code)