### PR TITLE
fix(UI): cmdk shows Mac icon on Windows

### DIFF
--- a/src/main/frontend/components/cmdk/core.cljs
+++ b/src/main/frontend/components/cmdk/core.cljs
@@ -29,7 +29,6 @@
             [frontend.util.ref :as ref]
             [goog.functions :as gfun]
             [goog.object :as gobj]
-            [goog.userAgent]
             [logseq.common.util :as common-util]
             [logseq.db :as ldb]
             [logseq.shui.hooks :as hooks]
@@ -916,7 +915,7 @@
       (for [key shortcut]
         [:div.ui__button-shortcut-key
          (case key
-           "cmd" [:div (if goog.userAgent/MAC "⌘" "Ctrl")]
+           "cmd" [:div (if util/mac? "⌘" "Ctrl")]
            "shift" [:div "⇧"]
            "return" [:div "⏎"]
            "esc" [:div.tracking-tightest {:style {:transform   "scaleX(0.8) scaleY(1.2) "


### PR DESCRIPTION
There is a section of code in the Cmd K component that matches the name of keyboard keys to their UI equivalent, and it correctly translates "cmd" to be either "⌘" on Mac or "Ctrl" on Windows, but someone forgot to use the "cmd" key and instead just hardwaired the Mac value

Before
<img width="1123" height="724" alt="chrome_HDi5ssmvsS" src="https://github.com/user-attachments/assets/23cf3883-0bf0-4f3b-9169-da108a4e5291" />

After
<img width="1121" height="719" alt="Fh5ypcR9tJ" src="https://github.com/user-attachments/assets/a1f42600-3c7c-4d80-ba09-0eb55b2788b0" />
