### PR TITLE
fix: remove OG block reference code from Cmd K component

### DIFF
--- a/src/main/frontend/components/cmdk/core.cljs
+++ b/src/main/frontend/components/cmdk/core.cljs
@@ -26,11 +26,11 @@
             [frontend.util :as util]
             [frontend.util.page :as page-util]
             [frontend.util.text :as text-util]
+            [frontend.util.ref :as ref]
             [goog.functions :as gfun]
             [goog.object :as gobj]
             [goog.userAgent]
             [logseq.common.util :as common-util]
-            [logseq.common.util.block-ref :as block-ref]
             [logseq.db :as ldb]
             [logseq.shui.hooks :as hooks]
             [logseq.shui.ui :as shui]
@@ -427,7 +427,7 @@
 
 (defn- copy-block-ref [state]
   (when-let [block-uuid (some-> state state->highlighted-item :source-block :block/uuid)]
-    (editor-handler/copy-block-ref! block-uuid block-ref/->block-ref)
+    (editor-handler/copy-block-ref! block-uuid ref/->block-ref)
     (shui/dialog-close! :ls-dialog-cmdk)))
 
 (defmulti handle-action (fn [action _state _event] action))


### PR DESCRIPTION
The old code for the "Copy ref" functionality inside Cmd K would copy ((block-uuid)) to the clipboard instead of [[block-uuid]], since it was using the OG block-reference code instead of frontend.util.ref