### PR TITLE
feat: graph runtime cache + node-position persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,14 @@
 - `bb dev:lint-and-test` runs linters and unit tests.
 - `bb dev:test -v <namespace/testcase-name>` runs a single unit test (example: `bb dev:test -v logseq.some-test/foo`).
 - E2E tests live in `clj-e2e/`; run them from that directory if needed.
+- Do not use `npx shadow-cljs compile test` — it does not activate the
+  `:test` alias from `deps.edn`, so `src/test/` is not on the source path
+  and compilation fails. Use the `bb` commands above instead.
+- `pixi-graph-fork` and its `@pixi/*` dependencies crash at module load in
+  Node.js (`self is not defined` in `@pixi/settings`). Any namespace that
+  requires it — including `frontend.extensions.graph.pixi` — is untestable
+  in the unit-test environment. Extract testable logic into a separate
+  namespace with no browser-only dependencies before writing tests.
 
 ## Coding Style & Naming Conventions
 - ClojureScript keywords are defined via `logseq.common.defkeywords/defkeyword`; use existing keywords and add new ones in the shared definitions.

--- a/src/main/frontend/extensions/graph.cljs
+++ b/src/main/frontend/extensions/graph.cljs
@@ -1,6 +1,7 @@
 (ns frontend.extensions.graph
   (:require [cljs-bean.core :as bean]
             [frontend.extensions.graph.pixi :as pixi]
+            [frontend.extensions.graph.position-cache :as position-cache]
             [frontend.handler.route :as route-handler]
             [frontend.colors :as colors]
             [frontend.db :as db]
@@ -56,6 +57,7 @@
                           (select-keys (first (:rum/args new-state))
                                        [:nodes :links :dark? :link-dist :charge-strength :charge-range])))
    :will-unmount (fn [state]
+                   (position-cache/capture-positions! (:nodes @pixi/*graph-instance))
                    (reset! pixi/*graph-instance nil)
                    state)}
   [state _opts]

--- a/src/main/frontend/extensions/graph/position_cache.cljs
+++ b/src/main/frontend/extensions/graph/position_cache.cljs
@@ -1,0 +1,50 @@
+(ns frontend.extensions.graph.position-cache
+  (:require [goog.object :as gobj]))
+
+;; -- node-position cache (keyed by page title, survives restarts) -----------
+(def ^:private POSITIONS-KEY "logseq-global-graph-node-positions")
+
+(defn- load-positions-from-storage
+  []
+  (try
+    (when-let [^js raw (.getItem js/localStorage POSITIONS-KEY)]
+      (let [^js parsed (js/JSON.parse raw)]
+        (->> (js/Object.keys parsed)
+             (reduce (fn [acc ^js label]
+                       (let [^js pos (gobj/get parsed label)]
+                         (if (and (number? (.-x pos)) (number? (.-y pos)))
+                           (assoc acc label {:x (.-x pos) :y (.-y pos)})
+                           acc)))
+                     {}))))
+    (catch :default _e {})))
+
+(defn- save-positions-to-storage
+  [positions]
+  (try
+    (.setItem js/localStorage POSITIONS-KEY
+              (js/JSON.stringify (clj->js positions)))
+    (catch :default _e nil)))
+
+(defonce *cached-node-positions
+  (atom (load-positions-from-storage)))
+;; ---------------------------------------------------------------------------
+
+(defn capture-positions!
+  "Snapshot live node x/y into the position cache and persist.
+  Merges into existing cache so positions for pages not in the current
+  (possibly filtered) view are preserved.
+  nodes — a JS array of d3 node objects, or nil (no-op)."
+  [nodes]
+  (when nodes
+    (let [new-positions
+          (reduce (fn [acc ^js node]
+                    (let [label (.-label node)
+                          x     (.-x node)
+                          y     (.-y node)]
+                      (if (and label (number? x) (number? y))
+                        (assoc acc label {:x x :y y})
+                        acc)))
+                  {}
+                  nodes)]
+      (swap! *cached-node-positions merge new-positions)
+      (save-positions-to-storage @*cached-node-positions))))

--- a/src/test/frontend/extensions/graph/pixi_test.cljs
+++ b/src/test/frontend/extensions/graph/pixi_test.cljs
@@ -1,0 +1,69 @@
+(ns frontend.extensions.graph.pixi-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [frontend.extensions.graph.position-cache :as pc]))
+
+(deftest capture-positions-extracts-node-positions
+  (testing "captures x/y from nodes keyed by label"
+    (reset! pc/*cached-node-positions {})
+    (pc/capture-positions! #js [#js {:label "Page A" :x 10 :y 20}
+                                #js {:label "Page B" :x 30 :y 40}])
+    (is (= {"Page A" {:x 10 :y 20}
+            "Page B" {:x 30 :y 40}}
+           @pc/*cached-node-positions))))
+
+(deftest capture-positions-merges-with-existing
+  (testing "preserves positions for pages not in the current view"
+    (reset! pc/*cached-node-positions {"Page C" {:x 100 :y 200}})
+    (pc/capture-positions! #js [#js {:label "Page A" :x 50 :y 60}])
+    (is (= {"Page A" {:x 50 :y 60}
+            "Page C" {:x 100 :y 200}}
+           @pc/*cached-node-positions)))
+
+  (testing "overwrites position for a page already in cache"
+    (reset! pc/*cached-node-positions {"Page A" {:x 1 :y 2}})
+    (pc/capture-positions! #js [#js {:label "Page A" :x 99 :y 88}])
+    (is (= {"Page A" {:x 99 :y 88}}
+           @pc/*cached-node-positions))))
+
+(deftest capture-positions-noop-when-nil
+  (testing "does nothing when nodes is nil"
+    (reset! pc/*cached-node-positions {"Page A" {:x 1 :y 2}})
+    (pc/capture-positions! nil)
+    (is (= {"Page A" {:x 1 :y 2}}
+           @pc/*cached-node-positions))))
+
+(deftest capture-positions-skips-invalid-nodes
+  (testing "skips nodes with no label"
+    (reset! pc/*cached-node-positions {})
+    (pc/capture-positions! #js [#js {:x 10 :y 20}
+                                #js {:label "Valid" :x 5 :y 15}])
+    (is (= {"Valid" {:x 5 :y 15}}
+           @pc/*cached-node-positions)))
+
+  (testing "skips nodes with non-numeric x"
+    (reset! pc/*cached-node-positions {})
+    (pc/capture-positions! #js [#js {:label "Bad" :x "nope" :y 20}
+                                #js {:label "Good" :x 10 :y 20}])
+    (is (= {"Good" {:x 10 :y 20}}
+           @pc/*cached-node-positions)))
+
+  (testing "skips nodes with null y"
+    (reset! pc/*cached-node-positions {})
+    (pc/capture-positions! #js [#js {:label "Bad" :x 10 :y nil}
+                                #js {:label "Good" :x 10 :y 20}])
+    (is (= {"Good" {:x 10 :y 20}}
+           @pc/*cached-node-positions)))
+
+  (testing "skips nodes with undefined x and y (keys absent)"
+    (reset! pc/*cached-node-positions {})
+    (pc/capture-positions! #js [#js {:label "NoCoords"}
+                                #js {:label "HasCoords" :x 7 :y 8}])
+    (is (= {"HasCoords" {:x 7 :y 8}}
+           @pc/*cached-node-positions))))
+
+(deftest capture-positions-empty-nodes-array
+  (testing "no-op with an empty nodes array"
+    (reset! pc/*cached-node-positions {"Existing" {:x 1 :y 2}})
+    (pc/capture-positions! #js [])
+    (is (= {"Existing" {:x 1 :y 2}}
+           @pc/*cached-node-positions))))


### PR DESCRIPTION
Two problems with the global graph page, solved together:

1. Navigating away from /graph and back forced a full worker round-trip before anything rendered. A module-level atom (*cached-graph-data in page.cljs) now caches the last worker result keyed by [theme settings]. On remount graph-aux seeds React state from it, so the graph renders immediately. The worker still fires in the background; when its result arrives, graph-2d's existing should-update predicate suppresses the pixi re-render if the data hasn't changed — the refresh is free.

2. The d3 force simulation started from random positions every time, causing the layout to re-settle on every visit or hard refresh. Node x/y coordinates are now captured into an in-memory map keyed by page title (the only stable cross-session identifier — db/ids are ephemeral). The map is persisted to localStorage under the key logseq-global-graph-node-positions. layout! seeds nodes with cached positions before forceSimulation is constructed; d3 respects pre-existing .x/.y and starts from those positions.

Position capture runs on two paths:
- Unmount (user navigates away): graph-2d's :will-unmount
- Re-render (new data arrives while graph is mounted): top of destroy-instance! Both are idempotent — whichever fires second is a no-op.

The cache logic lives in its own namespace
(frontend.extensions.graph.position-cache) with no browser-only dependencies, so it can be unit-tested under Node.js. pixi-graph-fork crashes at module load in Node (self is not defined), which is why the extraction was necessary rather than testing pixi.cljs directly.

Testing:
- 5 unit tests (9 assertions) covering extraction, merge-without-clobber, no-op on nil, skipping of invalid nodes, and empty-array handling. Picked up by CI automatically (no :fix-me metadata, runs under `node static/tests.js -e fix-me`).
- Manually validated: positions survive navigation, hard refresh, and settings changes. localStorage key verified in DevTools.

Disclosure:
My Clojure knowledge is minimal, I used Claude Code to author these changes.  I have manually validated the feature and have reviewed the code, and I believe the PR is in a suitable state for me to submit it for review.