### PR TITLE
feat: add embedded ClojureScript REPL for interactive graph querying

### DIFF
--- a/src/main/frontend/components/repl.cljs
+++ b/src/main/frontend/components/repl.cljs
@@ -1,0 +1,142 @@
+(ns frontend.components.repl
+  "Notebook-style ClojureScript REPL UI.
+  Renders in both the right sidebar (compact) and a dedicated /repl route."
+  (:require [clojure.string :as string]
+            [frontend.extensions.repl :as repl]
+            [frontend.state :as state]
+            [frontend.ui :as ui]
+            [rum.core :as rum]))
+
+;; Helpers
+;; =======
+
+(defn- get-cm-theme
+  "Returns the CodeMirror theme string matching the current Logseq theme."
+  []
+  (if (state/sub :ui/radix-color)
+    (str "lsradix " (state/sub :ui/theme))
+    (str "solarized " (state/sub :ui/theme))))
+
+;; Result rendering
+;; ================
+
+(rum/defc repl-result
+  "Renders a cell result — hiccup if tagged, otherwise pre-formatted text."
+  [result error?]
+  (when (some? result)
+    (if error?
+      [:pre.code.text-red-500.mt-1.mb-0.p-2.text-sm {:style {:white-space "pre-wrap"}}
+       (str result)]
+      (if (and (vector? result) (:hiccup (meta result)))
+        [:div.mt-1.mb-0.p-2 result]
+        [:pre.code.mt-1.mb-0.p-2.text-sm {:style {:white-space "pre-wrap"}}
+         (str result)]))))
+
+;; Autocomplete
+;; ============
+
+(defn- repl-hint
+  "CodeMirror hint function that completes from the SCI context's bindings."
+  [cm _options]
+  (let [cur (.getCursor cm)
+        token (.getTokenAt cm cur)
+        token-string (.-string token)
+        start (.-start token)
+        end (.-end token)
+        all-syms (or (repl/completions) [])
+        matches (if (string/blank? token-string)
+                  []
+                  (filterv #(string/starts-with? % token-string) all-syms))]
+    (when (seq matches)
+      (clj->js {:list matches
+                :from (.Pos js/window.CodeMirror (.-line cur) start)
+                :to (.Pos js/window.CodeMirror (.-line cur) end)}))))
+
+;; Cell
+;; ====
+
+(rum/defcs repl-cell < rum/reactive
+  {:did-mount
+   (fn [state]
+     (let [[cell _] (:rum/args state)
+           node (rum/dom-node state)
+           textarea (.querySelector node "textarea")
+           theme (get-cm-theme)
+           cm (js/window.CodeMirror.fromTextArea
+               textarea
+               (clj->js {:mode "clojure"
+                         :theme theme
+                         :matchBrackets true
+                         :autoCloseBrackets true
+                         :smartIndent true
+                         :lineNumbers false
+                         :viewportMargin js/Infinity
+                         :hintOptions {:hint repl-hint
+                                       :completeSingle false}
+                         :extraKeys {"Shift-Enter"
+                                     (fn [editor]
+                                       (repl/update-cell-code! (:id cell) (.getValue editor))
+                                       (repl/run-cell! (:id cell)))
+                                     "Ctrl-Space" "autocomplete"}}))]
+       (.setValue cm (:code cell))
+       (.on cm "blur" (fn [editor _]
+                        (repl/update-cell-code! (:id cell) (.getValue editor))))
+       (assoc state ::cm cm)))
+   :will-unmount
+   (fn [state]
+     (when-let [cm (::cm state)]
+       (.toTextArea cm))
+     state)}
+  [state cell on-remove]
+  (let [cells (rum/react repl/*repl-cells)
+        cell' (some #(when (= (:id %) (:id cell)) %) cells)]
+    [:div.repl-cell.mb-2.rounded-md.border {:style {:border-color "var(--ls-border-color)"}}
+     [:div.repl-cell-input.p-1
+      [:textarea {:default-value (:code cell)}]]
+     (when cell'
+       (repl-result (:result cell') (:error? cell')))
+     [:div.flex.justify-end.p-1
+      [:button.text-xs.opacity-50.hover:opacity-100.px-2
+       {:on-click (fn [_] (on-remove (:id cell)))}
+       (ui/icon "trash" {:size 14})]]]))
+
+;; Notebook (shared core)
+;; ======================
+
+(rum/defc repl-notebook < rum/reactive
+  "Toolbar + ordered list of cells. Used by both sidebar and page views."
+  []
+  (let [cells (rum/react repl/*repl-cells)]
+    ;; Ensure at least one cell exists
+    (when (empty? cells)
+      (repl/add-cell!))
+    [:div.repl-notebook.flex.flex-col.gap-2.p-2
+     ;; Toolbar
+     [:div.flex.gap-2.items-center.mb-2
+      [:button.button.text-sm {:on-click (fn [_] (repl/run-all-cells!))}
+       "Run All"]
+      [:button.button.text-sm {:on-click (fn [_] (repl/clear-all!))}
+       "Clear"]
+      [:button.button.text-sm {:on-click (fn [_] (repl/add-cell!))}
+       "Add Cell"]]
+     ;; Cells
+     (for [cell cells]
+       (rum/with-key
+         (repl-cell cell repl/remove-cell!)
+         (:id cell)))]))
+
+;; Wrappers
+;; ========
+
+(rum/defc repl-sidebar
+  "Compact wrapper for the right sidebar panel."
+  []
+  [:div.repl-sidebar.p-1
+   (repl-notebook)])
+
+(defn repl-page
+  "Full-page wrapper for the /repl route."
+  [_route-match]
+  [:div.repl-page.mx-auto.p-4 {:style {:max-width "960px"}}
+   [:h1.text-2xl.font-bold.mb-4 "ClojureScript REPL"]
+   (repl-notebook)])

--- a/src/main/frontend/components/right_sidebar.cljs
+++ b/src/main/frontend/components/right_sidebar.cljs
@@ -7,6 +7,7 @@
             [frontend.components.onboarding :as onboarding]
             [frontend.components.page :as page]
             [frontend.components.profiler :as profiler]
+            [frontend.components.repl :as repl-ui]
             [frontend.components.shortcut-help :as shortcut-help]
             [frontend.components.vector-search.sidebar :as vector-search]
             [frontend.config :as config]
@@ -93,7 +94,7 @@
   [repo idx db-id block-type *db-id init-key]
   (->
    (p/do!
-    (when-not (contains? #{:contents :search} block-type)
+    (when-not (contains? #{:contents :search :repl} block-type)
       (db-async/<get-block repo db-id))
     (let [lookup (cond
                    (integer? db-id) db-id
@@ -154,6 +155,10 @@
         :vector-search
         [[:.flex.items-center (ui/icon "file-search" {:class "text-md mr-2"}) "(Dev) VectorSearch"]
          (vector-search/vector-search-sidebar)]
+
+        :repl
+        [[:.flex.items-center (ui/icon "terminal-2" {:class "text-md mr-2"}) "REPL"]
+         (repl-ui/repl-sidebar)]
 
         ["" [:span]])))
    (p/catch (fn [error]
@@ -458,7 +463,12 @@
           [:div.text-sm
            [:button.button.cp__right-sidebar-settings-btn {:on-click (fn [_e]
                                                                        (state/sidebar-add-block! repo "profiler" :profiler))}
-            "(Dev) Profiler"]])]]
+            "(Dev) Profiler"]])
+        (when (state/sub [:ui/developer-mode?])
+          [:div.text-sm
+           [:button.button.cp__right-sidebar-settings-btn {:on-click (fn [_e]
+                                                                       (state/sidebar-add-block! repo "repl" :repl))}
+            "(Dev) REPL"]])]]
 
       [:.sidebar-item-list.flex-1.scrollbar-spacing.px-2
        (if @*anim-finished?

--- a/src/main/frontend/extensions/repl.cljs
+++ b/src/main/frontend/extensions/repl.cljs
@@ -1,0 +1,142 @@
+(ns frontend.extensions.repl
+  "Persistent notebook-style REPL engine.
+  Maintains a SCI context across evaluations so that defs accumulate,
+  and exposes the current graph's DataScript database for interactive querying."
+  (:require [sci.core :as sci]
+            [datascript.core :as d]
+            [frontend.db.conn :as db-conn]
+            [frontend.util :as util]))
+
+;; Persistent state — survives hot-reload and navigation
+;; =====================================================
+
+(defonce *repl-sci-ctx (atom nil))
+(defonce *repl-cells (atom []))
+
+;; SCI context
+;; ===========
+
+(defn- current-db
+  "Returns the current graph's DataScript db value."
+  []
+  (db-conn/get-db))
+
+(defn- make-sci-ctx
+  "Builds a SCI context with DataScript and utility bindings."
+  []
+  (sci/init
+   {:bindings {'q       (fn [& args] (apply d/q (first args) (current-db) (rest args)))
+               'pull    (fn [& args] (apply d/pull (current-db) args))
+               'entity  (fn [eid] (d/entity (current-db) eid))
+               'db      current-db
+               'sum     (partial apply +)
+               'average (fn [coll] (/ (reduce + coll) (count coll)))
+               'pprint  util/pp-str
+               'log     js/console.log}
+    :namespaces {'d {'q        d/q
+                     'pull     d/pull
+                     'pull-many d/pull-many
+                     'entity   d/entity
+                     'datoms   d/datoms}}}))
+
+(defn get-ctx!
+  "Returns the persistent SCI context, creating it lazily."
+  []
+  (or @*repl-sci-ctx
+      (let [ctx (make-sci-ctx)]
+        (reset! *repl-sci-ctx ctx)
+        ctx)))
+
+;; Completions
+;; ===========
+
+(defn completions
+  "Returns a sorted vector of all available symbol names (strings) in the
+  SCI context, including user defs and namespace-qualified symbols.
+  Safe to call before any evaluation — returns initial bindings."
+  []
+  (when-let [ctx @*repl-sci-ctx]
+    (try
+      (let [nss (sci/eval-string* ctx "(mapv ns-name (all-ns))")
+            syms (sci/eval-string* ctx
+                   "(vec (mapcat (fn [ns]
+                                  (let [ns-str (str (ns-name ns))
+                                        qualify? (not= ns-str \"user\")]
+                                    (map (fn [sym]
+                                           (if qualify?
+                                             (str ns-str \"/\" sym)
+                                             (str sym)))
+                                         (keys (ns-publics ns)))))
+                                (all-ns)))")]
+        (vec (sort (distinct syms))))
+      (catch :default _
+        []))))
+
+;; Evaluation
+;; ==========
+
+(defn eval-cell!
+  "Evaluates `code` in the persistent SCI context.
+  Returns {:result ... :error? bool}."
+  [code]
+  (try
+    {:result (sci/eval-string* (get-ctx!) code)
+     :error? false}
+    (catch :default e
+      {:result (ex-message e)
+       :error? true})))
+
+;; Cell CRUD
+;; =========
+
+(defn- make-cell
+  ([] (make-cell ""))
+  ([code]
+   {:id (str (random-uuid))
+    :code code
+    :result nil
+    :error? false
+    :running? false}))
+
+(defn add-cell!
+  "Appends a new empty cell."
+  []
+  (let [cell (make-cell)]
+    (swap! *repl-cells conj cell)
+    (:id cell)))
+
+(defn remove-cell!
+  "Removes the cell with the given id."
+  [id]
+  (swap! *repl-cells (fn [cells] (vec (remove #(= (:id %) id) cells)))))
+
+(defn update-cell-code!
+  "Updates the code of the cell with the given id."
+  [id code]
+  (swap! *repl-cells
+         (fn [cells]
+           (mapv #(if (= (:id %) id) (assoc % :code code) %) cells))))
+
+(defn run-cell!
+  "Evaluates the cell with the given id and stores the result."
+  [id]
+  (swap! *repl-cells
+         (fn [cells]
+           (mapv (fn [cell]
+                   (if (= (:id cell) id)
+                     (let [{:keys [result error?]} (eval-cell! (:code cell))]
+                       (assoc cell :result result :error? error? :running? false))
+                     cell))
+                 cells))))
+
+(defn run-all-cells!
+  "Evaluates all cells in order."
+  []
+  (doseq [{:keys [id]} @*repl-cells]
+    (run-cell! id)))
+
+(defn clear-all!
+  "Resets the SCI context and removes all cells."
+  []
+  (reset! *repl-sci-ctx nil)
+  (reset! *repl-cells []))

--- a/src/main/frontend/routes.cljs
+++ b/src/main/frontend/routes.cljs
@@ -11,6 +11,7 @@
             [frontend.components.repo :as repo]
             [frontend.components.settings :as settings]
             [frontend.components.user.login :as login]
+            [frontend.components.repl :as repl]
             [frontend.config :as config]
             [logseq.shui.demo :as shui]))
 
@@ -80,4 +81,9 @@
    (when config/dev?
      ["/ui"
       {:name :ui
-       :view shui/page}])])
+       :view shui/page}])
+
+   (when config/dev?
+     ["/repl"
+      {:name :repl
+       :view repl/repl-page}])])


### PR DESCRIPTION
The existing code block evaluation creates a fresh SCI context each time, so defs don't accumulate and exploratory work is lost. This adds a persistent, notebook-style REPL that maintains state across cells and navigation, and exposes the graph's DataScript database for interactive querying.

Accessible from the right sidebar (developer mode) and a dedicated /repl route (dev builds only). Cells use CodeMirror with Clojure mode and Shift+Enter to evaluate. Top-level convenience bindings (q, pull, entity, db) and namespaced DataScript access (d/q, d/pull, etc.) are provided.

Ctrl+Space triggers autocomplete from the SCI context — includes initial bindings, namespace-qualified symbols, and any user-defined vars. Clojure-aware auto-indentation is enabled via smartIndent.