### PR TITLE
fix: run webpack after cljs in electron release flow

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -259,6 +259,10 @@ exports.electronMaker = async () => {
     stdio: 'inherit',
   })
 
+  cp.execSync('yarn webpack-app-build', {
+    stdio: 'inherit',
+  })
+
   const pkgPath = path.join(outputPath, 'package.json')
   const pkg = require(pkgPath)
   const version = fs.readFileSync(

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "release-mobile": "run-s gulp:buildMobile cljs:release-mobile webpack-mobile-build",
         "dev-release-app": "run-s gulp:build cljs:dev-release-app webpack-app-build",
         "dev-electron-app": "gulp electron",
-        "release-electron": "run-s gulp:build && yarn webpack-app-build && gulp electronMaker",
+        "release-electron": "run-s gulp:build && gulp electronMaker",
         "debug-electron": "cd static/ && yarn electron:debug",
         "webpack-watch": "webpack --watch",
         "webpack-app-watch": "npx webpack --watch --config-name app",


### PR DESCRIPTION
## Problem

After a clean clone of the repository, running `yarn release-electron` fails because ./target/db-worker.js and ./target/inference-worker.js cannot be found.

The root cause is that webpack is invoked before cljs:release-electron generates the required target/*.js artifacts, while the webpack entry configuration expects those files to already exist.

As a result, the build process fails in a fresh environment.

## Steps to Reproduce

1. Clone the repository
2. `yarn install`
3. `yarn release-electron`

## Changes

This PR modifies the release-electron script to:
- Execute cljs:release-electron first
- Run webpack only after the required target/*.js artifacts have been generated