### PR TITLE
Don't auto-export if user is typing

### DIFF
--- a/src/main/frontend/persist_db.cljs
+++ b/src/main/frontend/persist_db.cljs
@@ -55,7 +55,9 @@
   [& {:keys [succ-notification? force-save?]}]
   (when (util/electron?)
     (when-let [repo (state/get-current-repo)]
-      (when (or (graph-has-changed? repo) force-save?)
+      (when (or force-save? 
+                (and (graph-has-changed? repo)
+                     (state/input-idle? repo :diff 5000)))
         (println :debug :save-db-to-disk repo)
         (->
          (p/do!


### PR DESCRIPTION
On a large graph, approximately every 30 seconds input is blocked for about 1 second while the db is automatically exported, even if the user is typing. This can be verified on a large graph by observing the messages output to the dev console while typing. 

https://github.com/logseq/logseq/blob/3d88cd1fd64b819f0fbf626d6ea6cf61caeed21b/src/main/frontend/persist_db.cljs#L75-L79

Blocking keyboard input while typing negatively impacts UX. 

This PR makes the auto-export conditional, so it doesn't export if the user has typed anything in the last 5 seconds, so that the user's flow isn't interrupted. Manual save (`force-save`) should still work.

A better approach might be to do the export in a separate worker that doesn't block the main thread at all, but this change is much easier to make immediately and should be relatively harmless.

Resolves https://github.com/logseq/db-test/issues/755