### PR TITLE
Fix: auto-pair for Korean input

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2547,7 +2547,8 @@
 
         (and (util/goog-event-is-composing? e true) ;; #3218
              (not hashtag?) ;; #3283 @Rime
-             (not (state/get-editor-show-page-search-hashtag?))) ;; #3283 @MacOS pinyin
+             (not (state/get-editor-show-page-search-hashtag?)) ;; #3283 @MacOS pinyin
+             (not (contains? (set (keys autopair-map)) key))) ;; allow autopair chars through during IME
         nil
 
         (or ctrlKey metaKey)


### PR DESCRIPTION
resolves #12418 

**Problem**
--
When keyboard language is switched to Korean, auto pairing for characters such as '{', '[', and '(' does not work, and does not generate the closing bracket.

**Steps to reproduce**
--
clone repository
yarn install
yarn watch
switch keyboard language to Korean, and attempt to write brackets in a note

**changes**
--
This PR changes the autopair-eligible characters to fall through to the autopair logic when typing in Korean since the previous logic swallowed ALL keydown events by returning nil. This mean that when IME languages were used, pressing brackets were silently ignored. 