### PR TITLE
fix(editor): Korean IME auto-pair behavior

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1580,6 +1580,12 @@
   (zipmap (vals autopair-map)
           (keys autopair-map)))
 
+(def autopair-openers
+  (set (keys autopair-map)))
+
+(def autopair-closers
+  (set (keys reversed-autopair-map)))
+
 (def autopair-when-selected
   #{"*" "^" "_" "=" "+" "/"})
 
@@ -1587,6 +1593,24 @@
   (assoc autopair-map
          "$" "$"
          ":" ":"))
+
+(defn- run-autopair-search-actions!
+  [input prefix selected]
+  (cond
+    (= prefix page-ref/left-brackets)
+    (do
+      (commands/handle-step [:editor/search-page])
+      (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)
+                                      :selected selected}))
+
+    (= prefix block-ref/left-parens)
+    (do
+      (commands/handle-step [:editor/search-block :reference])
+      (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)
+                                      :selected selected}))
+
+    :else
+    nil))
 
 (defn- autopair
   [input-id prefix _format _option]
@@ -1602,18 +1626,349 @@
                                                                  (when (>= prefix-pos 0)
                                                                    [(subs new-value prefix-pos (+ prefix-pos 2))
                                                                     (+ prefix-pos 2)]))})]
-        (cond
-          (= prefix page-ref/left-brackets)
-          (do
-            (commands/handle-step [:editor/search-page])
-            (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)
-                                            :selected selected}))
+        (run-autopair-search-actions! input prefix selected)))))
 
-          (= prefix block-ref/left-parens)
-          (do
-            (commands/handle-step [:editor/search-block :reference])
-            (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)
-                                            :selected selected})))))))
+(defonce ime-snapshots
+  (atom {}))
+
+(defonce ime-skip-next-keyup-fallbacks
+  (atom {}))
+
+(defonce ime-keyup-during-composition-keys
+  (atom {}))
+
+(def ime-snapshot-prop
+  "__logseqImeSnapshot")
+
+(def ime-process-keyup-marker
+  :ime/process-keyup)
+
+(defn- mark-ime-skip-next-keyup-fallback!
+  [input-id key]
+  (when (and input-id
+             (or (contains? keycode/left-square-brackets-keys key)
+                 (contains? keycode/left-paren-keys key)))
+    (swap! ime-skip-next-keyup-fallbacks
+           update
+           input-id
+           (fnil conj #{})
+           key)))
+
+(defn- consume-ime-skip-next-keyup-fallback?
+  [input-id key]
+  (let [skip? (contains? (get @ime-skip-next-keyup-fallbacks input-id #{}) key)]
+    (when skip?
+      (swap! ime-skip-next-keyup-fallbacks
+             (fn [m]
+               (let [ks (disj (get m input-id #{}) key)]
+                 (if (empty? ks)
+                   (dissoc m input-id)
+                   (assoc m input-id ks))))))
+    skip?))
+
+(defn- mark-ime-keyup-during-composition!
+  [input-id key]
+  (let [marker-key (cond
+                     (or (contains? keycode/left-square-brackets-keys key)
+                         (contains? keycode/left-paren-keys key))
+                     key
+
+                     (= key "Process")
+                     ime-process-keyup-marker
+
+                     :else
+                     nil)]
+    (when (and input-id marker-key)
+      (swap! ime-keyup-during-composition-keys
+             update
+             input-id
+             (fnil conj #{})
+             marker-key))))
+
+(defn- consume-ime-keyup-during-composition?
+  [input-id key]
+  (let [keys (get @ime-keyup-during-composition-keys input-id #{})
+        seen-keys (cond-> #{}
+                    (contains? keys key)
+                    (conj key)
+                    (contains? keys ime-process-keyup-marker)
+                    (conj ime-process-keyup-marker))
+        seen? (seq seen-keys)]
+    (when seen?
+      (swap! ime-keyup-during-composition-keys
+             (fn [m]
+               (let [ks (apply disj (get m input-id #{}) seen-keys)]
+                 (if (empty? ks)
+                   (dissoc m input-id)
+                   (assoc m input-id ks))))))
+    (boolean seen?)))
+
+(defn- clear-ime-keyup-during-composition!
+  [input-id]
+  (swap! ime-keyup-during-composition-keys dissoc input-id))
+
+(defn- infer-ime-keyup-key
+  [raw-key key-code committed-char]
+  (let [committed-key (some-> committed-char str)]
+    (cond
+      ;; Some IMEs expose keyup as key=nil/Process + keyCode=229.
+      ;; If a committed opener is visible at caret, recover it for skip-token consumption.
+      (and (= key-code 229)
+           (or (nil? raw-key)
+               (= raw-key "Process"))
+           (or (contains? keycode/left-square-brackets-keys committed-key)
+               (contains? keycode/left-paren-keys committed-key)))
+      committed-key
+
+      (and (nil? raw-key)
+           (= key-code 229))
+      "Process"
+
+      :else
+      raw-key)))
+
+(defn- capture-ime-snapshot!
+  [input-id input]
+  ;; Capture the pre-commit input state for IME autopair.
+  ;; Scenario:
+  ;; 1) User starts typing with IME.
+  ;; 2) Selection may collapse before compositionend.
+  ;; 3) We still need original value/selection to restore wrapping behavior.
+  (let [value (or (gobj/get input "value") "")
+        selection-start (util/get-selection-start input)
+        selection-end (util/get-selection-end input)
+        selected (when (and (number? selection-start)
+                            (number? selection-end)
+                            (not= selection-start selection-end))
+                   (subs value selection-start selection-end))
+        snapshot {:value value
+                  :pos (cursor/pos input)
+                  :selection-start selection-start
+                  :selection-end selection-end
+                  :selected selected}]
+    (gobj/set input ime-snapshot-prop (clj->js snapshot))
+    (swap! ime-snapshots assoc input-id snapshot)))
+
+(defn- consume-ime-snapshot!
+  [input-id input]
+  ;; Consume one-shot snapshot captured before IME commit.
+  (let [snapshot (or (get @ime-snapshots input-id)
+                     (some-> (gobj/get input ime-snapshot-prop)
+                             (js->clj :keywordize-keys true)))]
+    (swap! ime-snapshots dissoc input-id)
+    (gobj/remove input ime-snapshot-prop)
+    snapshot))
+
+(defn- refresh-ime-snapshot-on-keydown!
+  [input-id input]
+  ;; Keep snapshot in sync while keydown is still in IME mode.
+  (if (state/get-editor-action)
+    (do
+      (swap! ime-snapshots dissoc input-id)
+      (gobj/remove input ime-snapshot-prop))
+    (capture-ime-snapshot! input-id input)))
+
+(defn- get-ime-before-commit-context
+  [input key]
+  ;; Some IMEs may materialize opener before/after compositionend.
+  ;; Normalize view so '(' policy uses comparable context.
+  (let [value (gobj/get input "value")
+        pos (cursor/pos input)
+        prev-pos (dec pos)]
+    (if (and (>= prev-pos 0)
+             (= (util/nth-safe value prev-pos) key))
+      {:value (str (subs value 0 prev-pos)
+                   (subs value pos))
+       :pos prev-pos}
+      {:value value
+       :pos pos})))
+
+(defn- autopair-left-paren-at?
+  [value pos]
+  ;; Match the same '(' guard used by non-IME keydown autopair.
+  (or (text-util/surround-by? value pos :start "")
+      (text-util/surround-by? value pos "\n" "")
+      (text-util/surround-by? value pos " " "")
+      (text-util/surround-by? value pos "]" "")
+      (text-util/surround-by? value pos "(" "")))
+
+(defn- autopair-allowed?
+  [input key selected]
+  ;; Share opener eligibility with non-IME path:
+  ;; opener key, selection policy, and '(' position guard.
+  (let [selected? (not (string/blank? selected))]
+    (and (contains? autopair-openers key)
+         (or (not (contains? autopair-when-selected key))
+             selected?)
+         (if (= key "(")
+           (let [{:keys [value pos]} (get-ime-before-commit-context input key)]
+             (autopair-left-paren-at? value pos))
+           true))))
+
+(defn- get-autopair-trigger-prefix
+  [value prefix-pos]
+  ;; Compute the two-char opener token around caret to trigger search actions.
+  (when (and (string? value)
+             (>= prefix-pos 0)
+             (<= (+ prefix-pos 2) (count value)))
+    (subs value prefix-pos (+ prefix-pos 2))))
+
+(defn- should-autopair-move-forward-at?
+  [value pos key]
+  ;; Keep close-char forward behavior aligned with keydown:
+  ;; if closer already exists at caret, move forward instead of inserting.
+  (let [curr (util/nth-safe value pos)
+        prev (util/nth-safe value (dec pos))]
+    (and (> pos 0)
+         (= curr key)
+         (contains? autopair-closers key)
+         (or (not= key "`")
+             (not= prev "`")))))
+
+(defn- get-ime-composition-input-char
+  [^js e input]
+  ;; Prefer compositionend `data`; fallback to char before caret if unavailable.
+  (let [data (gobj/get e "data")]
+    (if (and (string? data) (= 1 (count data)))
+      data
+      (let [value (gobj/get input "value")
+            pos (cursor/pos input)
+            prev (util/nth-safe value (dec pos))]
+        (when prev
+          (str prev))))))
+
+(defn- ime-opener-committed?
+  [value pos key ime-snapshot]
+  ;; Detect whether IME has already committed current input char before compositionend logic.
+  (let [prev (util/nth-safe value (dec pos))]
+    (and (= prev key)
+         (if (map? ime-snapshot)
+           (let [start-value (or (:value ime-snapshot) "")
+                 start-pos (or (:pos ime-snapshot) 0)]
+             (or (> (count value) (count start-value))
+                 (> pos start-pos)))
+           true))))
+
+(defn- ime-handle-existing-closer!
+  [input-id input key ime-snapshot]
+  ;; IME parity with keydown closer behavior:
+  ;; when closer already exists at caret, move forward instead of inserting another one.
+  (when (string/blank? (util/get-selected-text))
+    (let [pos (cursor/pos input)
+          value (gobj/get input "value")
+          key-committed? (ime-opener-committed? value pos key ime-snapshot)
+          snapshot-value (or (:value ime-snapshot) value)
+          snapshot-pos (or (:pos ime-snapshot) pos)
+          move-forward? (or (should-autopair-move-forward-at? snapshot-value snapshot-pos key)
+                            (should-autopair-move-forward-at? value pos key))]
+      (when move-forward?
+        (if (and key-committed?
+                 (> pos 0)
+                 (= (util/nth-safe value (dec pos)) key))
+          (let [value' (str (subs value 0 (dec pos))
+                            (subs value pos))]
+            (state/set-block-content-and-last-pos! input-id value' pos)
+            (cursor/move-cursor-to input pos))
+          (cursor/move-cursor-forward input))
+        true))))
+
+(defn- ime-composition-autopair!
+  [^js e input-id]
+  ;; IME autopair flow:
+  ;; 1) Capture pre-commit snapshot at compositionstart.
+  ;; 2) At compositionend, branch by "had selection at start?".
+  ;; 3) For caret path, preserve keydown parity (forward vs insert).
+  (when-let [input (gdom/getElement input-id)]
+    (let [event-type (gobj/get e "type")
+          key (get-ime-composition-input-char e input)]
+      (cond
+        (= event-type "compositionstart")
+        (do
+          (clear-ime-keyup-during-composition! input-id)
+          (capture-ime-snapshot! input-id input)
+          false)
+
+        (= event-type "compositionend")
+        (let [selected (util/get-selected-text)
+              close-char (get autopair-map key)
+              ime-snapshot (consume-ime-snapshot! input-id input)
+              snapshot-selected (or (:selected ime-snapshot) "")
+              selected* (if (string/blank? selected) snapshot-selected selected)
+              keyup-already-seen? (consume-ime-keyup-during-composition? input-id key)
+              selected-from-snapshot? (and (not (string/blank? snapshot-selected))
+                                           (number? (:selection-start ime-snapshot))
+                                           (number? (:selection-end ime-snapshot)))
+              opener-handled?
+              (when (and (contains? autopair-openers key)
+                         close-char
+                         (or selected-from-snapshot?
+                             (autopair-allowed? input key selected*)))
+                (if selected-from-snapshot?
+                  (let [value (or (:value ime-snapshot) "")
+                        start (:selection-start ime-snapshot)
+                        end (:selection-end ime-snapshot)
+                        before (subs value 0 start)
+                        after (subs value end)
+                        new-value (str before key snapshot-selected close-char after)
+                        new-pos (inc start)
+                        selected-end (+ new-pos (count snapshot-selected))
+                        prefix (get-autopair-trigger-prefix new-value (dec start))]
+                    (state/set-block-content-and-last-pos! input-id new-value new-pos)
+                    (cursor/move-cursor-to input new-pos)
+                    (.setSelectionRange input new-pos selected-end)
+                    (run-autopair-search-actions! input prefix selected*))
+                  (when (string/blank? (util/get-selected-text))
+                    (if (ime-handle-existing-closer! input-id input key ime-snapshot)
+                      nil
+                      (let [pos (cursor/pos input)
+                            value (gobj/get input "value")
+                            key-committed? (ime-opener-committed? value pos key ime-snapshot)]
+                        (commands/simple-insert! input-id
+                                                 (if key-committed?
+                                                   close-char
+                                                   (str key close-char))
+                                                 {:backward-pos 1})
+                        (let [value (gobj/get input "value")
+                              pos (cursor/pos input)
+                              prefix (get-autopair-trigger-prefix value (- pos 2))]
+                          (run-autopair-search-actions! input prefix selected*))))))
+                true)
+              closer-handled?
+              (when (and (contains? autopair-closers key)
+                         (not opener-handled?))
+                (ime-handle-existing-closer! input-id input key ime-snapshot))
+              handled? (or opener-handled? closer-handled?)
+              ;; Keep dedup for ASCII autopair chars even when opener handling is skipped
+              ;; (e.g. first IME "(" after text), but don't suppress full-width fallback.
+              skip-keyup-fallback? (or handled?
+                                      (contains? autopair-openers key)
+                                      (contains? autopair-closers key))
+              _ (when (and skip-keyup-fallback?
+                           (not keyup-already-seen?))
+                  (mark-ime-skip-next-keyup-fallback! input-id key))]
+          (clear-ime-keyup-during-composition! input-id)
+          (boolean handled?))
+
+        :else
+        false))))
+
+(defn- ime-process-key?
+  [key]
+  (= key "Process"))
+
+(defn- ime-process-keycode?
+  [key-code]
+  (= key-code 229))
+
+(defn- ime-composing-keydown?
+  [e key key-code]
+  ;; For native keydown listeners, prefer `isComposing` first.
+  ;; Keep Process/229 fallbacks for IMEs that don't expose it consistently.
+  (or (state/editor-in-composition?)
+      (util/native-event-is-composing? e)
+      (util/goog-event-is-composing? e true)
+      (ime-process-key? key)
+      (ime-process-keycode? key-code)))
 
 (defn surround-by?
   [input before end]
@@ -2849,7 +3204,7 @@
 (defn ^:large-vars/cleanup-todo keydown-not-matched-handler
   "NOTE: Keydown cannot be used on Android platform"
   [format]
-  (fn [e _key-code]
+  (fn [e key-code]
     (let [input-id (state/get-edit-input-id)
           input (state/get-input)
           key (gobj/get e "key")
@@ -2860,15 +3215,19 @@
           hashtag? (or (surround-by? input "#" " ")
                        (surround-by? input "#" :end)
                        (= key "#"))]
+      (when (ime-process-key? key)
+        (refresh-ime-snapshot-on-keydown! input-id input))
       (cond
         (and (contains? #{"ArrowLeft" "ArrowRight"} key)
              (contains? #{:property-search :property-value-search} (state/get-editor-action)))
         (state/clear-editor-action!)
 
-        (and (util/goog-event-is-composing? e true) ;; #3218
+        (and (ime-composing-keydown? e key key-code)
              (not hashtag?) ;; #3283 @Rime
              (not (state/get-editor-show-page-search-hashtag?))) ;; #3283 @MacOS pinyin
-        nil
+        (do
+          (refresh-ime-snapshot-on-keydown! input-id input)
+          nil)
 
         (or ctrlKey metaKey)
         nil
@@ -2887,7 +3246,7 @@
                   (= "#" (util/nth-safe value (dec pos)))))
         (state/clear-editor-action!)
 
-        (and (contains? (set/difference (set (keys reversed-autopair-map))
+        (and (contains? (set/difference autopair-closers
                                         #{"`"})
                         key)
              (= (get-current-input-char input) key))
@@ -2912,8 +3271,7 @@
 
         ;; If you type `xyz`, the last backtick should close the first and not add another autopair
         ;; If you type several backticks in a row, each one should autopair to accommodate multiline code (```)
-        (-> (keys autopair-map)
-            set
+        (-> autopair-openers
             (disj "(")
             (contains? key)
             (or (autopair-left-paren? input key)))
@@ -2957,6 +3315,10 @@
 (defn- default-case-for-keyup-handler
   [input current-pos k code is-processed? c]
   (let [last-key-code (state/get-last-key-code)
+        skip-ime-fallbacks? (consume-ime-skip-next-keyup-fallback?
+                             (state/get-edit-input-id)
+                             k)
+        ime-composing? (state/editor-in-composition?)
         blank-selected? (string/blank? (util/get-selected-text))
         non-enter-processed? (and is-processed? ;; #3251
                                   (not= code keycode/enter-code))  ;; #3459
@@ -2970,6 +3332,13 @@
         (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)}))
       (when (and (not editor-action) (not non-enter-processed?))
         (cond
+         ;; IME composition can report keyup before compositionend in some engines.
+         ;; Skip keyup fallbacks while composition is active to avoid duplicate pairing.
+          ime-composing?
+          (do
+            (mark-ime-keyup-during-composition! (state/get-edit-input-id) k)
+            nil)
+
          ;; When you type text inside square brackets
           (and (not (contains? #{"ArrowDown" "ArrowLeft" "ArrowRight" "ArrowUp" "Escape"} k))
                (wrapped-by? input page-ref/left-brackets page-ref/right-brackets))
@@ -2986,7 +3355,8 @@
             (state/set-editor-action-data! {:pos pos}))
 
          ;; Handle non-ascii square brackets
-          (and (input-page-ref? k current-pos blank-selected? last-key-code)
+          (and (not skip-ime-fallbacks?)
+               (input-page-ref? k current-pos blank-selected? last-key-code)
                (not (wrapped-by? input page-ref/left-brackets page-ref/right-brackets)))
           (do
             (commands/handle-step [:editor/input page-ref/left-and-right-brackets {:backward-truncate-number 2
@@ -2994,8 +3364,9 @@
             (commands/handle-step [:editor/search-page])
             (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)}))
 
-         ;; Handle non-ascii parentheses
-          (and blank-selected?
+          ;; Handle non-ascii parentheses
+          (and (not skip-ime-fallbacks?)
+               blank-selected?
                (contains? keycode/left-paren-keys k)
                (= (:key last-key-code) k)
                (> current-pos 0)
@@ -3022,35 +3393,44 @@
 (defn keyup-handler
   [_state input input-id]
   (fn [e key-code]
-    (when-not (util/goog-event-is-composing? e)
-      (let [current-pos (cursor/pos input)
-            value (gobj/get input "value")
-            c (util/nth-safe value (dec current-pos))
-            [key-code k code is-processed?]
-            (if (and c
-                     (mobile-util/native-android?)
-                     (or (= key-code 229)
-                         (= key-code 0)))
-              [(.charCodeAt value (dec current-pos))
-               c
-               (cond
-                 (= c " ")
-                 "Space"
+    (let [goog-composing? (util/goog-event-is-composing? e)
+          raw-key (gobj/get e "key")
+          key (infer-ime-keyup-key raw-key key-code nil)]
+      ;; Some engines emit keyup before compositionend but keep `isComposing=true`.
+      ;; Record it before the composing guard returns.
+      (when (and goog-composing?
+                 (state/editor-in-composition?))
+        (mark-ime-keyup-during-composition! (state/get-edit-input-id) key))
+      (when-not goog-composing?
+        (let [current-pos (cursor/pos input)
+              value (gobj/get input "value")
+              c (util/nth-safe value (dec current-pos))
+              key (infer-ime-keyup-key raw-key key-code c)
+              [key-code k code is-processed?]
+              (if (and c
+                       (mobile-util/native-android?)
+                       (or (= key-code 229)
+                           (= key-code 0)))
+                [(.charCodeAt value (dec current-pos))
+                 c
+                 (cond
+                   (= c " ")
+                   "Space"
 
-                 (parse-long c)
-                 (str "Digit" c)
+                   (parse-long c)
+                   (str "Digit" c)
 
-                 :else
-                 (str "Key" (string/upper-case c)))
-               false]
-              [key-code
-               (gobj/get e "key")
-               (if (mobile-util/native-android?)
-                 (gobj/get e "key")
-                 (gobj/getValueByKeys e "event_" "code"))
-                ;; #3440
-               (util/goog-event-is-composing? e true)])]
-        (cond
+                   :else
+                   (str "Key" (string/upper-case c)))
+                 false]
+                [key-code
+                 key
+                 (if (mobile-util/native-android?)
+                   key
+                   (gobj/getValueByKeys e "event_" "code"))
+                 ;; #3440
+                 (util/goog-event-is-composing? e true)])]
+          (cond
           ;; When you type something after /
           (and (= :commands (state/get-editor-action)) (not= k commands/command-trigger))
           (if (= commands/command-trigger (second (re-find #"(\S+)\s+$" value)))
@@ -3092,13 +3472,13 @@
           :else
           (default-case-for-keyup-handler input current-pos k code is-processed? c))
 
-        (close-autocomplete-if-outside input)
+          (close-autocomplete-if-outside input)
 
-        (when-not (or (= k "Shift") is-processed?)
-          (state/set-last-key-code! {:key-code key-code
-                                     :code code
-                                     :key k
-                                     :shift? (.-shiftKey e)}))))))
+          (when-not (or (= k "Shift") is-processed?)
+            (state/set-last-key-code! {:key-code key-code
+                                       :code code
+                                       :key k
+                                       :shift? (.-shiftKey e)})))))))
 
 (defn editor-on-click!
   [id]
@@ -3110,7 +3490,8 @@
 (defn editor-on-change!
   [block id search-timeout]
   (fn [e]
-    (if (= :block-search (state/sub :editor/action))
+    (let [editor-action (state/get-editor-action)]
+      (if (= :block-search editor-action)
       (let [timeout 300]
         (when @search-timeout
           (js/clearTimeout @search-timeout))
@@ -3120,7 +3501,9 @@
                  timeout)))
       (let [input (gdom/getElement id)]
         (edit-box-on-change! e block id)
-        (util/scroll-editor-cursor input)))))
+        (when-not editor-action
+          (ime-composition-autopair! e id))
+        (util/scroll-editor-cursor input))))))
 
 (defn- cut-blocks-and-clear-selections!
   [copy?]

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -1,16 +1,700 @@
 (ns frontend.handler.editor-test
-  (:require [frontend.handler.editor :as editor]
+  ;; namespace local config for private function tests
+  {:clj-kondo/config {:linters {:private-call {:level :off}}}}
+  (:require [frontend.commands :as commands]
+            [frontend.handler.editor :as editor]
             [frontend.db :as db]
             [clojure.test :refer [deftest is testing are use-fixtures]]
             [datascript.core :as d]
             [frontend.test.helper :as test-helper :refer [load-test-files]]
             [frontend.db.model :as model]
+            [frontend.mobile.util :as mobile-util]
             [frontend.state :as state]
             [frontend.util.cursor :as cursor]
             [goog.dom :as gdom]
+            [goog.object :as gobj]
             [frontend.util :as util]))
 
 (use-fixtures :each test-helper/start-and-destroy-db)
+
+(defn- set-selection!
+  [input start end]
+  (set! (.-selectionStart input) start)
+  (set! (.-selectionEnd input) end))
+
+(defn- replace-selection-with-text!
+  [value* input text]
+  (let [start (.-selectionStart input)
+        end (.-selectionEnd input)
+        before (subs @value* 0 start)
+        after (subs @value* end)
+        next-value (str before text after)
+        next-pos (+ start (count text))]
+    (reset! value* next-value)
+    (set! (.-value input) next-value)
+    (set-selection! input next-pos next-pos)))
+
+(defn- reset-ime-autopair-state!
+  []
+  (reset! editor/ime-snapshots {})
+  (reset! editor/ime-skip-next-keyup-fallbacks {})
+  (reset! editor/ime-keyup-during-composition-keys {}))
+
+(defn- ime-autopair-on-change-handler
+  [{:keys [value input-char selection-start selection-end repeat-count pre-commit?]
+    :or {value ""
+         selection-start 0
+         selection-end 0
+         repeat-count 1
+         pre-commit? true}}]
+  (let [value* (atom value)
+        search-actions* (atom [])
+        action-data* (atom nil)
+        input (js-obj "value" value
+                      "selectionStart" selection-start
+                      "selectionEnd" selection-end)]
+    (gobj/set input "setSelectionRange"
+              (fn [start end]
+                (set-selection! input start end)))
+    (with-redefs [state/sub (constantly nil)
+                  state/get-editor-action (constantly nil)
+                  state/get-edit-input-id (constantly "id")
+                  state/get-input (constantly input)
+                  gdom/getElement (constantly input)
+                  editor/edit-box-on-change! (fn [_e _block _id] nil)
+                  util/scroll-editor-cursor (fn [_] nil)
+                  cursor/pos (fn [_] (.-selectionStart input))
+                  cursor/get-caret-pos (fn [_] {:pos (.-selectionStart input)})
+                  cursor/move-cursor-forward (fn [_]
+                                               (let [next-pos (inc (.-selectionStart input))]
+                                                 (set-selection! input next-pos next-pos)))
+                  cursor/move-cursor-to (fn
+                                          ([_ n]
+                                           (set-selection! input n n))
+                                          ([_ n _delay?]
+                                           (set-selection! input n n)))
+                  util/get-selection-start (fn [_] (.-selectionStart input))
+                  util/get-selection-end (fn [_] (.-selectionEnd input))
+                  util/get-selected-text
+                  (fn []
+                    (let [start (.-selectionStart input)
+                          end (.-selectionEnd input)]
+                      (if (and (number? start)
+                               (number? end)
+                               (< start end))
+                        (subs @value* start end)
+                        "")))
+                  state/set-block-content-and-last-pos!
+                  (fn [_id next-value next-pos]
+                    (reset! value* next-value)
+                    (set! (.-value input) next-value)
+                    (set-selection! input next-pos next-pos))
+                  commands/simple-insert!
+                  (fn [_id text {:keys [backward-pos]}]
+                    (let [start (.-selectionStart input)
+                          end (.-selectionEnd input)
+                          before (subs @value* 0 start)
+                          after (subs @value* end)
+                          next-value (str before text after)
+                          next-pos (- (+ start (count text))
+                                      (or backward-pos 0))]
+                      (reset! value* next-value)
+                      (set! (.-value input) next-value)
+                      (set-selection! input next-pos next-pos)))
+                  commands/handle-step (fn [step] (swap! search-actions* conj step))
+                  state/set-editor-action-data! (fn [m] (reset! action-data* m))]
+      (let [search-timeout (atom nil)
+            handler (editor/editor-on-change! nil "id" search-timeout)]
+        (dotimes [_ repeat-count]
+          (handler #js {:type "compositionstart" :data ""})
+          (when pre-commit?
+            (replace-selection-with-text! value* input input-char))
+          (handler #js {:type "compositionend" :data input-char})))
+      {:value @value*
+       :pos (.-selectionStart input)
+       :selection-start (.-selectionStart input)
+       :selection-end (.-selectionEnd input)
+       :search-actions @search-actions*
+       :action-data @action-data*})))
+
+(defn- keydown-autopair-replace-call-count
+  [{:keys [value key key-code is-composing? editor-in-composition?]
+    :or {value "test("
+         key "("
+         key-code 57
+         is-composing? false
+         editor-in-composition? false}}]
+  (let [replace-count* (atom 0)
+        pos (count value)
+        input (js-obj "value" value
+                      "selectionStart" pos
+                      "selectionEnd" pos)
+        event (js-obj "key" key
+                      "ctrlKey" false
+                      "metaKey" false
+                      "isComposing" is-composing?)]
+    (with-redefs [state/get-edit-input-id (constantly "id")
+                  state/get-input (constantly input)
+                  state/get-editor-action (constantly nil)
+                  state/get-editor-show-page-search-hashtag? (constantly false)
+                  state/editor-in-composition? (constantly editor-in-composition?)
+                  mobile-util/native-platform? (constantly false)
+                  cursor/pos (fn [_] (.-selectionStart input))
+                  gdom/getElement (constantly input)
+                  util/get-selected-text (constantly "")
+                  util/stop (fn [_e] nil)
+                  commands/simple-replace! (fn [& _]
+                                             (swap! replace-count* inc)
+                                             nil)]
+      ((editor/keydown-not-matched-handler nil) event key-code)
+      @replace-count*)))
+
+(defn- ime-fallback-parenthesis-steps-after-composition
+  []
+  (let [value* (atom "test(")
+        input (js-obj "value" @value*
+                      "selectionStart" (count @value*)
+                      "selectionEnd" (count @value*))
+        fallback-steps* (atom [])]
+    (gobj/set input "setSelectionRange"
+              (fn [start end]
+                (set-selection! input start end)))
+    (with-redefs [state/sub (constantly nil)
+                  state/get-editor-action (constantly nil)
+                  state/get-last-key-code (constantly {:key "("})
+                  state/get-edit-input-id (constantly "id")
+                  state/get-input (constantly input)
+                  gdom/getElement (constantly input)
+                  editor/edit-box-on-change! (fn [_e _block _id] nil)
+                  util/scroll-editor-cursor (fn [_] nil)
+                  cursor/pos (fn [_] (.-selectionStart input))
+                  cursor/get-caret-pos (fn [_] {:pos (.-selectionStart input)})
+                  cursor/move-cursor-forward (fn [_]
+                                               (let [next-pos (inc (.-selectionStart input))]
+                                                 (set-selection! input next-pos next-pos)))
+                  cursor/move-cursor-to (fn
+                                          ([_ n]
+                                           (set-selection! input n n))
+                                          ([_ n _delay?]
+                                           (set-selection! input n n)))
+                  util/get-selection-start (fn [_] (.-selectionStart input))
+                  util/get-selection-end (fn [_] (.-selectionEnd input))
+                  util/get-selected-text (constantly "")
+                  util/stop (fn [_] nil)
+                  state/set-block-content-and-last-pos!
+                  (fn [_id next-value next-pos]
+                    (reset! value* next-value)
+                    (set! (.-value input) next-value)
+                    (set-selection! input next-pos next-pos))
+                  commands/simple-insert!
+                  (fn [_id text {:keys [backward-pos]}]
+                    (let [start (.-selectionStart input)
+                          end (.-selectionEnd input)
+                          before (subs @value* 0 start)
+                          after (subs @value* end)
+                          next-value (str before text after)
+                          next-pos (- (+ start (count text))
+                                      (or backward-pos 0))]
+                      (reset! value* next-value)
+                      (set! (.-value input) next-value)
+                      (set-selection! input next-pos next-pos)))
+                  commands/handle-step
+                  (fn [step]
+                    (when (and (= :editor/input (first step))
+                               (= "(())" (second step)))
+                      (swap! fallback-steps* conj step)))
+                  state/set-editor-action-data! (fn [_] nil)]
+      (let [search-timeout (atom nil)
+            on-change (editor/editor-on-change! nil "id" search-timeout)]
+        (on-change #js {:type "compositionstart" :data ""})
+        (replace-selection-with-text! value* input "(")
+        (on-change #js {:type "compositionend" :data "("}))
+      (editor/default-case-for-keyup-handler input
+                                             (.-selectionStart input)
+                                             "("
+                                             nil
+                                             false
+                                             "(")
+      @fallback-steps*)))
+
+(defn- ime-keyup-before-compositionend-result
+  []
+  (let [value* (atom "test(")
+        composing?* (atom false)
+        input (js-obj "value" @value*
+                      "selectionStart" (count @value*)
+                      "selectionEnd" (count @value*))
+        fallback-steps* (atom [])]
+    (gobj/set input "setSelectionRange"
+              (fn [start end]
+                (set-selection! input start end)))
+    (with-redefs [state/sub (constantly nil)
+                  state/get-editor-action (constantly nil)
+                  state/get-last-key-code (constantly {:key "("})
+                  state/get-edit-input-id (constantly "id")
+                  state/get-input (constantly input)
+                  state/editor-in-composition? (fn [] @composing?*)
+                  gdom/getElement (constantly input)
+                  editor/edit-box-on-change! (fn [_e _block _id] nil)
+                  util/scroll-editor-cursor (fn [_] nil)
+                  cursor/pos (fn [_] (.-selectionStart input))
+                  cursor/get-caret-pos (fn [_] {:pos (.-selectionStart input)})
+                  cursor/move-cursor-forward (fn [_]
+                                               (let [next-pos (inc (.-selectionStart input))]
+                                                 (set-selection! input next-pos next-pos)))
+                  cursor/move-cursor-to (fn
+                                          ([_ n]
+                                           (set-selection! input n n))
+                                          ([_ n _delay?]
+                                           (set-selection! input n n)))
+                  util/get-selection-start (fn [_] (.-selectionStart input))
+                  util/get-selection-end (fn [_] (.-selectionEnd input))
+                  util/get-selected-text (constantly "")
+                  util/stop (fn [_] nil)
+                  state/set-block-content-and-last-pos!
+                  (fn [_id next-value next-pos]
+                    (reset! value* next-value)
+                    (set! (.-value input) next-value)
+                    (set-selection! input next-pos next-pos))
+                  commands/simple-insert!
+                  (fn [_id text {:keys [backward-pos]}]
+                    (let [start (.-selectionStart input)
+                          end (.-selectionEnd input)
+                          before (subs @value* 0 start)
+                          after (subs @value* end)
+                          next-value (str before text after)
+                          next-pos (- (+ start (count text))
+                                      (or backward-pos 0))]
+                      (reset! value* next-value)
+                      (set! (.-value input) next-value)
+                      (set-selection! input next-pos next-pos)))
+                  commands/handle-step
+                  (fn [step]
+                    (when (and (= :editor/input (first step))
+                               (= "(())" (second step)))
+                      (swap! fallback-steps* conj step)))
+                  state/set-editor-action-data! (fn [_] nil)]
+      (let [search-timeout (atom nil)
+            on-change (editor/editor-on-change! nil "id" search-timeout)]
+        (reset! composing?* true)
+        (on-change #js {:type "compositionstart" :data ""})
+        (replace-selection-with-text! value* input "(")
+        ;; Simulate engines where keyup happens before compositionend.
+        (editor/default-case-for-keyup-handler input
+                                               (.-selectionStart input)
+                                               "("
+                                               nil
+                                               false
+                                               "(")
+        (reset! composing?* false)
+        (on-change #js {:type "compositionend" :data "("}))
+      {:value @value*
+       :fallback-steps @fallback-steps*})))
+
+(defn- ime-fallback-after-first-left-paren-composition
+  []
+  (let [value* (atom "test")
+        input (js-obj "value" @value*
+                      "selectionStart" (count @value*)
+                      "selectionEnd" (count @value*))
+        fallback-steps* (atom [])]
+    (gobj/set input "setSelectionRange"
+              (fn [start end]
+                (set-selection! input start end)))
+    (with-redefs [state/sub (constantly nil)
+                  state/get-editor-action (constantly nil)
+                  state/get-last-key-code (constantly {:key "("})
+                  state/get-edit-input-id (constantly "id")
+                  state/get-input (constantly input)
+                  state/editor-in-composition? (constantly false)
+                  gdom/getElement (constantly input)
+                  editor/edit-box-on-change! (fn [_e _block _id] nil)
+                  util/scroll-editor-cursor (fn [_] nil)
+                  cursor/pos (fn [_] (.-selectionStart input))
+                  cursor/get-caret-pos (fn [_] {:pos (.-selectionStart input)})
+                  cursor/move-cursor-forward (fn [_]
+                                               (let [next-pos (inc (.-selectionStart input))]
+                                                 (set-selection! input next-pos next-pos)))
+                  cursor/move-cursor-to (fn
+                                          ([_ n]
+                                           (set-selection! input n n))
+                                          ([_ n _delay?]
+                                           (set-selection! input n n)))
+                  util/get-selection-start (fn [_] (.-selectionStart input))
+                  util/get-selection-end (fn [_] (.-selectionEnd input))
+                  util/get-selected-text (constantly "")
+                  util/stop (fn [_] nil)
+                  state/set-block-content-and-last-pos!
+                  (fn [_id next-value next-pos]
+                    (reset! value* next-value)
+                    (set! (.-value input) next-value)
+                    (set-selection! input next-pos next-pos))
+                  commands/simple-insert!
+                  (fn [_id text {:keys [backward-pos]}]
+                    (let [start (.-selectionStart input)
+                          end (.-selectionEnd input)
+                          before (subs @value* 0 start)
+                          after (subs @value* end)
+                          next-value (str before text after)
+                          next-pos (- (+ start (count text))
+                                      (or backward-pos 0))]
+                      (reset! value* next-value)
+                      (set! (.-value input) next-value)
+                      (set-selection! input next-pos next-pos)))
+                  commands/handle-step
+                  (fn [step]
+                    (when (and (= :editor/input (first step))
+                               (= "(())" (second step)))
+                      (swap! fallback-steps* conj step)))
+                  state/set-editor-action-data! (fn [_] nil)]
+      (let [search-timeout (atom nil)
+            on-change (editor/editor-on-change! nil "id" search-timeout)]
+        (on-change #js {:type "compositionstart" :data ""})
+        (replace-selection-with-text! value* input "(")
+        (on-change #js {:type "compositionend" :data "("}))
+      (editor/default-case-for-keyup-handler input
+                                             (.-selectionStart input)
+                                             "("
+                                             nil
+                                             false
+                                             "(")
+      {:value @value*
+       :fallback-steps @fallback-steps*})))
+
+(defn- ime-stale-skip-steps-on-next-fallback
+  [{:keys [before-compositionend after-compositionend ime-key fallback-value fallback-char tracked-fallback-step]
+    :or {before-compositionend (fn [_] nil)
+         after-compositionend (fn [_] nil)
+         ime-key "("
+         fallback-value "hello("
+         fallback-char "("
+         tracked-fallback-step "(())"}}]
+  (reset-ime-autopair-state!)
+  (let [value* (atom "test(")
+        composing?* (atom false)
+        input (js-obj "value" @value*
+                      "selectionStart" (count @value*)
+                      "selectionEnd" (count @value*))
+        fallback-steps* (atom [])]
+    (gobj/set input "setSelectionRange"
+              (fn [start end]
+                (set-selection! input start end)))
+    (with-redefs [state/sub (constantly nil)
+                  state/get-editor-action (constantly nil)
+                  state/get-last-key-code (constantly {:key ime-key})
+                  state/get-edit-input-id (constantly "id")
+                  state/get-input (constantly input)
+                  state/editor-in-composition? (fn [] @composing?*)
+                  gdom/getElement (constantly input)
+                  editor/edit-box-on-change! (fn [_e _block _id] nil)
+                  util/scroll-editor-cursor (fn [_] nil)
+                  cursor/pos (fn [_] (.-selectionStart input))
+                  cursor/get-caret-pos (fn [_] {:pos (.-selectionStart input)})
+                  cursor/move-cursor-forward (fn [_]
+                                               (let [next-pos (inc (.-selectionStart input))]
+                                                 (set-selection! input next-pos next-pos)))
+                  cursor/move-cursor-to (fn
+                                          ([_ n]
+                                           (set-selection! input n n))
+                                          ([_ n _delay?]
+                                           (set-selection! input n n)))
+                  util/get-selection-start (fn [_] (.-selectionStart input))
+                  util/get-selection-end (fn [_] (.-selectionEnd input))
+                  util/get-selected-text (constantly "")
+                  util/stop (fn [_] nil)
+                  state/set-block-content-and-last-pos!
+                  (fn [_id next-value next-pos]
+                    (reset! value* next-value)
+                    (set! (.-value input) next-value)
+                    (set-selection! input next-pos next-pos))
+                  commands/simple-insert!
+                  (fn [_id text {:keys [backward-pos]}]
+                    (let [start (.-selectionStart input)
+                          end (.-selectionEnd input)
+                          before (subs @value* 0 start)
+                          after (subs @value* end)
+                          next-value (str before text after)
+                          next-pos (- (+ start (count text))
+                                      (or backward-pos 0))]
+                      (reset! value* next-value)
+                      (set! (.-value input) next-value)
+                      (set-selection! input next-pos next-pos)))
+                  commands/handle-step
+                  (fn [step]
+                    (when (and (= :editor/input (first step))
+                               (= tracked-fallback-step (second step)))
+                      (swap! fallback-steps* conj step)))
+                  state/set-editor-action-data! (fn [_] nil)]
+      (let [search-timeout (atom nil)
+            on-change (editor/editor-on-change! nil "id" search-timeout)
+            on-keyup (editor/keyup-handler nil input "id")
+            run-fallback-keyup! (fn [k]
+                                  (editor/default-case-for-keyup-handler input
+                                                                         (.-selectionStart input)
+                                                                         k
+                                                                         nil
+                                                                         false
+                                                                         fallback-char))]
+        (reset! composing?* true)
+        (on-change #js {:type "compositionstart" :data ""})
+        (replace-selection-with-text! value* input ime-key)
+        (before-compositionend {:on-change on-change
+                                :on-keyup on-keyup
+                                :run-fallback-keyup! run-fallback-keyup!})
+        (reset! composing?* false)
+        (on-change #js {:type "compositionend" :data ime-key})
+        (after-compositionend {:on-change on-change
+                               :on-keyup on-keyup
+                               :run-fallback-keyup! run-fallback-keyup!})
+        ;; Simulate next non-IME keyup fallback opportunity on the same input.
+        (reset! value* fallback-value)
+        (set! (.-value input) @value*)
+        (set-selection! input (count @value*) (count @value*))
+        (run-fallback-keyup! ime-key))
+      @fallback-steps*)))
+
+(defn- ime-stale-keyup-skip-steps-on-next-fallback
+  []
+  (ime-stale-skip-steps-on-next-fallback
+   {:before-compositionend
+    (fn [{:keys [run-fallback-keyup!]}]
+      ;; Create an IME sequence where keyup arrives before compositionend.
+      (run-fallback-keyup! "("))}))
+
+(defn- ime-process-keyup-stale-skip-steps-on-next-fallback
+  []
+  (ime-stale-skip-steps-on-next-fallback
+   {:before-compositionend
+    (fn [{:keys [run-fallback-keyup!]}]
+      ;; Simulate IME engines that emit keyup as Process/229 during composition.
+      (run-fallback-keyup! "Process"))}))
+
+(defn- ime-filtered-composing-keyup-stale-skip-steps-on-next-fallback
+  []
+  (ime-stale-skip-steps-on-next-fallback
+   {:before-compositionend
+    (fn [{:keys [on-keyup]}]
+      ;; Simulate engines where keyup happens before compositionend,
+      ;; but keyup is filtered by goog-event-is-composing?.
+      (let [filtered-keyup-event (js-obj "key" "Process"
+                                         "event_" (js-obj "code" "Digit9")
+                                         "shiftKey" true
+                                         "getBrowserEvent" (fn [] (js-obj "isComposing" true)))]
+        (on-keyup filtered-keyup-event 229)))}))
+
+(defn- ime-post-composition-nil-key229-keyup-consumes-skip-token
+  []
+  (ime-stale-skip-steps-on-next-fallback
+   {:after-compositionend
+    (fn [{:keys [on-keyup]}]
+      ;; Post-composition keyup without `key` should still consume IME skip token.
+      (let [post-keyup-event (js-obj "key" nil
+                                     "keyCode" 229
+                                     "event_" (js-obj "code" "Digit9")
+                                     "shiftKey" true
+                                     "getBrowserEvent" (fn [] (js-obj "isComposing" false)))]
+        (on-keyup post-keyup-event 229)))}))
+
+(defn- ime-full-width-paren-stale-skip-steps-on-next-fallback
+  []
+  (ime-stale-skip-steps-on-next-fallback
+   {:ime-key "（"
+    :fallback-value "hello（"
+    :fallback-char "（"}))
+
+(defn- ime-stale-snapshot-clear-path-result
+  []
+  (let [value* (atom "AB")
+        action* (atom nil)
+        input (js-obj "value" @value*
+                      "selectionStart" 0
+                      "selectionEnd" 1)]
+    (gobj/set input "setSelectionRange"
+              (fn [start end]
+                (set-selection! input start end)))
+    (with-redefs [state/sub (constantly nil)
+                  state/get-editor-action (fn [] @action*)
+                  state/get-editor-show-page-search-hashtag? (constantly false)
+                  state/get-last-key-code (constantly {:key "("})
+                  state/get-edit-input-id (constantly "id")
+                  state/get-input (constantly input)
+                  state/editor-in-composition? (constantly true)
+                  mobile-util/native-platform? (constantly false)
+                  gdom/getElement (constantly input)
+                  editor/edit-box-on-change! (fn [_e _block _id] nil)
+                  util/scroll-editor-cursor (fn [_] nil)
+                  cursor/pos (fn [_] (.-selectionStart input))
+                  cursor/get-caret-pos (fn [_] {:pos (.-selectionStart input)})
+                  cursor/move-cursor-forward (fn [_]
+                                               (let [next-pos (inc (.-selectionStart input))]
+                                                 (set-selection! input next-pos next-pos)))
+                  cursor/move-cursor-to (fn
+                                          ([_ n]
+                                           (set-selection! input n n))
+                                          ([_ n _delay?]
+                                           (set-selection! input n n)))
+                  util/get-selection-start (fn [_] (.-selectionStart input))
+                  util/get-selection-end (fn [_] (.-selectionEnd input))
+                  util/get-selected-text
+                  (fn []
+                    (let [start (.-selectionStart input)
+                          end (.-selectionEnd input)]
+                      (if (and (number? start)
+                               (number? end)
+                               (< start end))
+                        (subs @value* start end)
+                        "")))
+                  util/stop (fn [_] nil)
+                  state/set-block-content-and-last-pos!
+                  (fn [_id next-value next-pos]
+                    (reset! value* next-value)
+                    (set! (.-value input) next-value)
+                    (set-selection! input next-pos next-pos))
+                  commands/simple-insert!
+                  (fn [_id text {:keys [backward-pos]}]
+                    (let [start (.-selectionStart input)
+                          end (.-selectionEnd input)
+                          before (subs @value* 0 start)
+                          after (subs @value* end)
+                          next-value (str before text after)
+                          next-pos (- (+ start (count text))
+                                      (or backward-pos 0))]
+                      (reset! value* next-value)
+                      (set! (.-value input) next-value)
+                      (set-selection! input next-pos next-pos)))
+                  commands/simple-replace! (fn [& _] nil)
+                  commands/handle-step (fn [_] nil)
+                  state/set-editor-action-data! (fn [_] nil)]
+      (let [search-timeout (atom nil)
+            on-change (editor/editor-on-change! nil "id" search-timeout)
+            on-keydown (editor/keydown-not-matched-handler nil)]
+        (on-change #js {:type "compositionstart" :data ""})
+        ;; Trigger clear branch in refresh-ime-snapshot-on-keydown!
+        (reset! action* :commands)
+        (on-keydown (js-obj "key" "Process"
+                            "ctrlKey" false
+                            "metaKey" false
+                            "isComposing" true)
+                    229)
+        ;; Commit a caret insertion after the clear branch.
+        (set-selection! input 2 2)
+        (replace-selection-with-text! value* input "(")
+        (reset! action* nil)
+        (on-change #js {:type "compositionend" :data "("}))
+      @value*)))
+
+(deftest ime-keydown-autopair-composing-detection-test
+  (testing "native keydown with isComposing should not run keydown autopair"
+    (is (= 0 (keydown-autopair-replace-call-count {:is-composing? true}))))
+
+  (testing "editor composition state should suppress keydown autopair even without event composing flag"
+    (is (= 0 (keydown-autopair-replace-call-count {:is-composing? false
+                                                   :editor-in-composition? true}))))
+
+  (testing "non-composing keydown should keep existing autopair behavior"
+    (is (= 1 (keydown-autopair-replace-call-count {:is-composing? false})))))
+
+(deftest ime-keyup-fallback-dedup-test
+  (testing "IME composition should not trigger keyup non-ascii parenthesis fallback"
+    (is (empty? (ime-fallback-parenthesis-steps-after-composition))))
+
+  (testing "IME composition state should suppress keyup fallback before compositionend"
+    (let [result (ime-keyup-before-compositionend-result)]
+      (is (empty? (:fallback-steps result)))
+      (is (= "test(()" (:value result)))))
+
+  (testing "first IME '(' after text should not trigger keyup fallback"
+    (let [result (ime-fallback-after-first-left-paren-composition)]
+      (is (empty? (:fallback-steps result)))
+      (is (= "test(" (:value result))))))
+
+(deftest ime-stale-keyup-skip-token-should-not-suppress-next-fallback-test
+  (testing "stale skip token from previous IME cycle should not suppress next fallback"
+    (is (= [[:editor/input "(())" {:backward-truncate-number 2
+                                   :backward-pos 2}]]
+           (ime-stale-keyup-skip-steps-on-next-fallback)))))
+
+(deftest ime-process-keyup-stale-skip-token-should-not-suppress-next-fallback-test
+  (testing "Process keyup during composition should not create stale skip token"
+    (is (= [[:editor/input "(())" {:backward-truncate-number 2
+                                   :backward-pos 2}]]
+           (ime-process-keyup-stale-skip-steps-on-next-fallback)))))
+
+(deftest ime-filtered-composing-keyup-stale-skip-token-should-not-suppress-next-fallback-test
+  (testing "filtered composing keyup should not create stale skip token"
+    (is (= [[:editor/input "(())" {:backward-truncate-number 2
+                                   :backward-pos 2}]]
+           (ime-filtered-composing-keyup-stale-skip-steps-on-next-fallback)))))
+
+(deftest ime-post-composition-nil-key229-keyup-should-consume-skip-token-test
+  (testing "post-composition keyup without key string should consume skip token"
+    (is (= [[:editor/input "(())" {:backward-truncate-number 2
+                                   :backward-pos 2}]]
+           (ime-post-composition-nil-key229-keyup-consumes-skip-token)))))
+
+(deftest ime-full-width-paren-skip-token-should-not-suppress-next-fallback-test
+  (testing "full-width IME '(' should not suppress next non-ascii fallback"
+    (is (= [[:editor/input "(())" {:backward-truncate-number 2
+                                   :backward-pos 2}]]
+           (ime-full-width-paren-stale-skip-steps-on-next-fallback)))))
+
+(deftest ime-snapshot-clear-path-should-not-reuse-dom-snapshot-test
+  (testing "cleared snapshot state should not be consumed from stale DOM snapshot property"
+    (is (= "AB(" (ime-stale-snapshot-clear-path-result)))))
+
+(deftest ime-composition-should-not-disable-next-non-ime-keydown-autopair-test
+  ;; A completed IME composition must not disable the next regular keydown autopair.
+  (ime-autopair-on-change-handler {:value "test("
+                                   :selection-start 5
+                                   :selection-end 5
+                                   :input-char "("})
+  (is (= 1 (keydown-autopair-replace-call-count {:value "test("
+                                                 :is-composing? false}))))
+
+(deftest ime-composition-autopair-basic-test
+  (testing "IME composition should insert pair"
+    (let [result (ime-autopair-on-change-handler {:input-char "("})]
+      (is (= "()" (:value result)))
+      (is (= 1 (:pos result)))))
+
+  (testing "IME composition should move cursor over existing closer"
+    (let [result (ime-autopair-on-change-handler {:value "~~"
+                                                  :selection-start 1
+                                                  :selection-end 1
+                                                  :input-char "~"
+                                                  :pre-commit? false})]
+      (is (= "~~" (:value result)))
+      (is (= 2 (:pos result)))))
+
+  (testing "IME composition should move cursor over existing closer for parentheses"
+    (let [result (ime-autopair-on-change-handler {:value "test()"
+                                                  :selection-start 5
+                                                  :selection-end 5
+                                                  :input-char ")"})]
+      (is (= "test()" (:value result)))
+      (is (= 6 (:pos result))))))
+
+(deftest ime-composition-selected-text-wrapping-test
+  (let [result (ime-autopair-on-change-handler {:value "Test"
+                                                :selection-start 0
+                                                :selection-end 4
+                                                :input-char "("})]
+    (is (= "(Test)" (:value result)))
+    (is (= 1 (:selection-start result)))
+    (is (= 5 (:selection-end result)))))
+
+(deftest ime-composition-search-actions-test
+  (testing "[[ should trigger page search"
+    (let [result (ime-autopair-on-change-handler {:input-char "["
+                                                  :repeat-count 2})]
+      (is (= [[:editor/search-page]] (:search-actions result)))
+      (is (map? (:action-data result)))))
+
+  (testing "(( should trigger block search"
+    (let [result (ime-autopair-on-change-handler {:input-char "("
+                                                  :repeat-count 2})]
+      (is (= [[:editor/search-block :reference]] (:search-actions result)))
+      (is (map? (:action-data result))))))
 
 (deftest extract-nearest-link-from-text-test
   (testing "Page, block and tag links"


### PR DESCRIPTION
# Summary
This pr fixes #12418 in file version.

# Changes
`editor.cljs` : Add IME status snapshot.
`editor_test.cljs` : Add IME related tests.

# Why bunch of codes
This fix became larger because the bug was caused by IME event ordering, not by a single missing condition.

With Korean IME, `compositionend`, `keyup`, and DOM updates do not arrive in the same order as normal keydown-based input, and some engines expose the key as `Process` / `229` or omit it. That means the existing autopair logic cannot infer enough from the current DOM alone.

The snapshot and IME-specific state were added to recover the pre-commit editor state and keep IME behavior aligned with the existing non-IME autopair behavior, instead of introducing a separate autopair implementation.

# Tested Env
Windows 11, Edge & Firefox browser
* Microsoft Korean IME
* Microsoft Korean IME legacy (before Windows 10)
* NGS IME (include TSF based impl)

![logseq_fileversion_kor_ime](https://github.com/user-attachments/assets/4def5797-ba84-4b48-9dc2-b5abd24515a1)
