### PR TITLE
fix: render images as <img> tags in HTML export

### DIFF
--- a/src/main/frontend/handler/export/html.cljs
+++ b/src/main/frontend/handler/export/html.cljs
@@ -93,11 +93,15 @@
   (let [href (case (first url)
                "Search" (second url)
                "Complex" (str (:protocol (second url)) "://" (:link (second url)))
-               nil)]
-    (cond-> [:a]
-      href (conj {:href href})
-      href (concatv (mapv inline-ast->hiccup label))
-      (not href) (conj full_text))))
+               nil)
+        image? (and (string? full_text) (string/starts-with? full_text "!"))
+        alt-text (string/join (keep #(when (= "Plain" (first %)) (second %)) label))]
+    (if (and image? href)
+      [:img {:src href :alt alt-text}]
+      (cond-> [:a]
+        href (conj {:href href})
+        href (concatv (mapv inline-ast->hiccup label))
+        (not href) (conj full_text)))))
 
 (defn- inline-nested-link
   [{:keys [content]}]

--- a/src/main/frontend/handler/export/html.cljs
+++ b/src/main/frontend/handler/export/html.cljs
@@ -91,10 +91,11 @@
 (defn- inline-link
   [{:keys [url label full_text]}]
   (let [href (case (first url)
-               "Search" (second url)
+               "Search"  (second url)
                "Complex" (str (:protocol (second url)) "://" (:link (second url)))
+               "File"    (second url)
                nil)
-        image? (and (string? full_text) (string/starts-with? full_text "!"))
+        image? (and (string? full_text) (string/starts-with? (string/triml full_text) "!"))
         alt-text (string/join (keep #(when (= "Plain" (first %)) (second %)) label))]
     (if (and image? href)
       [:img {:src href :alt alt-text}]


### PR DESCRIPTION
Fixes #9765

## Problem

When exporting a page to HTML, embedded images (`![alt](url)`) were rendered as `<a>` anchor tags instead of `<img>` elements. The exported HTML showed a clickable link instead of the image.

## Root Cause

In `src/main/frontend/handler/export/html.cljs`, the `inline-link` function handles the `"Link"` AST node emitted by mldoc. Both regular hyperlinks and image links map to the same AST type. The function had no branch to distinguish them and unconditionally emitted `[:a {:href ...}]`.

The distinguishing signal is `full_text`: for image links it always starts with `!`.

## Fix

Added an `image?` predicate in `inline-link` that checks whether `full_text` starts with `"!"` (after trimming leading whitespace, consistent with `block.cljs`'s `show-link?`). When true and a resolved `href` is present, emits `[:img {:src href :alt alt-text}]` using the label's plain-text content as `alt`. Handles both HTTP (`"Complex"`) and local asset (`"File"`) URL types. All other link cases are unchanged.

```clojure
;; Before
(cond-> [:a]
  href (conj {:href href})
  href (concatv (mapv inline-ast->hiccup label))
  (not href) (conj full_text))

;; After
(let [image? (and (string? full_text) (string/starts-with? (string/triml full_text) "!"))
      alt-text (string/join (keep #(when (= "Plain" (first %)) (second %)) label))]
  (if (and image? href)
    [:img {:src href :alt alt-text}]
    (cond-> [:a]
      href (conj {:href href})
      href (concatv (mapv inline-ast->hiccup label))
      (not href) (conj full_text))))
```

## Test Plan

- Insert a local asset image on a Logseq page
- Insert an external image link (e.g. `![logo](https://example.com/logo.png)`)
- Export the page as HTML (via `…` → Export → HTML)
- Open the exported HTML in a browser — images should display, not links
- Verify regular hyperlinks `[text](url)` still render as `<a>` tags