### PR TITLE
fix: preserve dark theme when installing non-theme plugins on Linux

### DIFF
--- a/src/main/frontend/handler/plugin.cljs
+++ b/src/main/frontend/handler/plugin.cljs
@@ -916,7 +916,10 @@
                   (.on "reset-custom-theme" (fn [^js themes]
                                               (let [themes (bean/->clj themes)
                                                     custom-theme (dissoc themes :mode)
-                                                    mode (:mode themes)]
+                                                    ;; Fall back to the user's current theme so that
+                                                    ;; installing a non-theme plugin does not flash
+                                                    ;; the UI back to light mode (#12434).
+                                                    mode (or (:mode themes) (:ui/theme @state/state))]
                                                 (state/set-custom-theme! {:light (if (nil? (:light custom-theme)) {:mode "light"} (:light custom-theme))
                                                                           :dark (if (nil? (:dark custom-theme)) {:mode "dark"} (:dark custom-theme))})
                                                 (state/set-theme-mode! mode))))


### PR DESCRIPTION
Fixes #12434

## Problem

On Linux (and other platforms), installing any plugin causes a brief switch from dark mode to light mode — a jarring "flashbang" effect. The theme returns to dark after the plugin loads, but the flash is clearly visible.

## Root Cause

In `src/main/frontend/handler/plugin.cljs`, the `"reset-custom-theme"` event fired by `LSPluginCore` during plugin registration is handled for **all** plugins, not just theme plugins. The handler extracts `(:mode themes)` from the event payload. When the installing plugin is not a theme plugin, `:mode` is absent, so `mode` is `nil`. Calling `state/set-theme-mode!` with `nil` resolves to `"light"` (the default), momentarily switching the UI to light mode.

```clojure
;; Before — nil mode → flashes light
(let [mode (:mode themes)]
  ...
  (state/set-theme-mode! mode))
```

## Fix

Fall back to the user's current `(:ui/theme @state/state)` when the event payload does not include an explicit `:mode`:

```clojure
;; After — preserves current theme when event carries no mode
(let [mode (or (:mode themes) (:ui/theme @state/state))]
  ...
  (state/set-theme-mode! mode))
```

Theme plugins that intentionally send a `:mode` are unaffected — `or` short-circuits on their value.

## Test Plan

- Set Logseq to **dark mode**
- Open the Plugin Marketplace and install any **non-theme** plugin
- Verify the UI stays dark throughout installation — no white flash
- Install a **theme plugin** and verify it still switches the theme correctly
- Reproduces most reliably on Linux; also verifiable on macOS/Windows