### PR TITLE
fix(shortcut): limit prefix-conflict detection to same-handler only

### DIFF
--- a/src/main/frontend/modules/shortcut/data_helper.cljs
+++ b/src/main/frontend/modules/shortcut/data_helper.cljs
@@ -243,7 +243,7 @@
                                                                           (every? #(handlers-co-active? % handler-id') handler-ids)))))
                                                         binding-match?
                                                         (or (= input-binding k)
-                                                            (and handler-match?
+                                                            (and same-handler?
                                                                  (binding-prefix-overlap? input-binding k)))]
                                                     (if (and (not (contains? exclude-ids id))
                                                              handler-match?

--- a/src/test/frontend/modules/shortcut/core_test.cljs
+++ b/src/test/frontend/modules/shortcut/core_test.cljs
@@ -114,22 +114,24 @@
                      {:exclude-ids #{} :group-global? false})]
       (is (false? (dh/conflict-has-exact? conflicts "t"))))))
 
-(deftest test-cross-handler-prefix-detection
-  (testing "t on global-prevent-default detects cross-handler chord prefix conflicts"
-    ;; With group-global? true, "t" should detect chord conflicts from co-active
-    ;; handlers like global-non-editing-only (which has t d, t t, t r, etc.)
+(deftest test-same-handler-prefix-detection
+  (testing "prefix conflicts are only detected within the same handler"
+    ;; Prefix overlaps only cause chord dormancy on the SAME Closure handler
+    ;; instance. Cross-handler prefixes work fine because each handler has
+    ;; its own independent key tree and state machine.
     (let [conflicts (dh/get-conflicts-by-keys
                      "t" :shortcut.handler/global-prevent-default
                      {:exclude-ids #{} :group-global? true})
           all-keys (->> (vals conflicts) (mapcat vals) (map first) (set))]
-      ;; Same-handler chords (global-prevent-default has t n, t b)
+      ;; Same-handler chords (global-prevent-default has t n, t b) — detected
       (is (contains? all-keys "t n"))
       (is (contains? all-keys "t b"))
-      ;; Cross-handler chords from co-active global-non-editing-only
-      (is (contains? all-keys "t d")
-          "t d from global-non-editing-only should be detected as cross-handler prefix conflict")
-      (is (contains? all-keys "t r")
-          "t r from global-non-editing-only should be detected as cross-handler prefix conflict"))))
+      ;; Cross-handler chords from global-non-editing-only — NOT detected
+      ;; because they're on a different handler and still work at runtime
+      (is (not (contains? all-keys "t d"))
+          "t d from global-non-editing-only should NOT be detected (cross-handler)")
+      (is (not (contains? all-keys "t r"))
+          "t r from global-non-editing-only should NOT be detected (cross-handler)"))))
 
 (deftest test-add-reaction-shortcut
   (testing "add reaction shortcut is configured with p r"


### PR DESCRIPTION
## Summary
- Cross-handler prefix overlaps don't cause chord dormancy because each Closure `KeyboardShortcutHandler` instance has its own independent key tree and state machine
- Only same-handler prefix conflicts (where Closure's tree can't have a node be both leaf and branch) cause actual chord dormancy
- Changes `binding-match?` to use `same-handler?` instead of `handler-match?` for prefix overlaps (exact matches still use `handler-match?`)
- Updates test to verify cross-handler prefixes are correctly excluded

## Test plan
- [ ] Assign ⌘C to another action via Reassign — amber banner should show only same-handler chords (⌘C ⌘C, ⌘C ⌘S) not cross-handler ones (⌘C ⌘R)
- [ ] Verify chords on other handlers still work after reassignment
- [ ] Verify undo restores previous state correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)