### PR TITLE
fix: ghost sidebar resizer bar

### DIFF
--- a/src/main/frontend/components/container.css
+++ b/src/main/frontend/components/container.css
@@ -364,6 +364,12 @@
     }
   }
 
+  &:not(.is-open) {
+      .left-sidebar-resizer {
+          @apply hidden;
+      }
+  }
+
   &.is-closing {
     .left-sidebar-inner {
       transition: transform .3s;


### PR DESCRIPTION
Fixes #11085

Problem: When the left sidebar is closed, the sidebar resizer turns into a malevolent ghost. On desktop, it can be selected, but not moved. On Android, it can *technically* be used to open the sidebar, but there are crucial issues. First, it is in fact not the intended behaviour of the code and is more a strange side-effect. Second, it is in practice unusable because swiping from the left instead triggers the Back gesture on Adnroid. Most importantly, this ghost sidebar resizer takes up click space on the left edge of the screen and blocks the left portion of the hamburger menu from being activated, as can be seen in the issue linked above.

Solution: Don't activate the sidebar resizer when the sidebar is closed.