### PR TITLE
enhance: search for extensions

### DIFF
--- a/src/main/frontend/components/plugins.cljs
+++ b/src/main/frontend/components/plugins.cljs
@@ -1093,10 +1093,17 @@
                              (if-let [author (and (string/starts-with? @*search-key "@")
                                                   (subs @*search-key 1))]
                                (filter #(= author (:author %)) filtered-pkgs)
-                               (search/fuzzy-search
-                                filtered-pkgs @*search-key
-                                :limit 30
-                                :extract-fn :title))
+                               (let [low-case-search (string/lower-case @*search-key)
+                                     fuzzy-title-matches (search/fuzzy-search
+                                                    filtered-pkgs @*search-key
+                                                    :limit 30
+                                                    :extract-fn :title)
+                                     precise-description-matches (filter #(some-> (:description %)
+                                                                                   string/lower-case
+                                                                                   (string/includes? low-case-search))
+                                                                         filtered-pkgs)]
+                                 (-> (concat fuzzy-title-matches precise-description-matches)
+                                     (distinct))))
                              filtered-pkgs)
         filtered-pkgs      (map #(if-let [stat (get stats (keyword (:id %)))]
                                    (let [downloads (:total_downloads stat)

--- a/src/main/frontend/components/plugins.cljs
+++ b/src/main/frontend/components/plugins.cljs
@@ -1094,14 +1094,19 @@
                                                   (subs @*search-key 1))]
                                (filter #(= author (:author %)) filtered-pkgs)
                                (let [low-case-search (string/lower-case @*search-key)
+                                     min-description-search-length 3
+                                     max-description-matches 30
                                      fuzzy-title-matches (search/fuzzy-search
                                                     filtered-pkgs @*search-key
                                                     :limit 30
                                                     :extract-fn :title)
-                                     precise-description-matches (filter #(some-> (:description %)
-                                                                                   string/lower-case
-                                                                                   (string/includes? low-case-search))
-                                                                         filtered-pkgs)]
+                                     precise-description-matches (if (>= (count low-case-search) min-description-search-length)
+                                                                   (->> filtered-pkgs
+                                                                        (filter #(some-> (:description %)
+                                                                                         string/lower-case
+                                                                                         (string/includes? low-case-search)))
+                                                                        (take max-description-matches))
+                                                                   [])]
                                  (-> (concat fuzzy-title-matches precise-description-matches)
                                      (distinct))))
                              filtered-pkgs)


### PR DESCRIPTION
### Problem: 
While looking for extensions in the shop, I couldn't find one that allows articles to be exported to Hugo (I tried searching with the keywords "Hugo" and "export"). I had to search online and found that the extension is called "logseq-schrodinger". I would never have thought to search for something like that! However, the keywords were present in the description: "An awesome logseq plugin to export to Hugo Static sites and jumpstart your digital garden 🌱!"
Another example would be searching for the word "mind" and not having the most popular mind map extension in Logseq, Markmap, in the results. This wouldn't be the case if this PR is accepted.


I first tried doing a fuzzy search on the title and description, but a fuzzy search on the description field was a bad idea as too many results were returned (which is logical).

### Proposed behavior:
Combined result (without duplicate) of fuzzy search on title (same as current behavior) + precise search on description (if it exists)