### PR TITLE
fix(sync): retract skeleton entities after remote tx rebase

### DIFF
--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -1000,6 +1000,29 @@
                                                         cycle-tx-report])
                                       tx-meta)))
 
+(defn- retract-skeleton-entities!
+  "After batch processing, some entities may end up with only partial attributes
+   (e.g., only created-by-ref) that don't form a valid entity type. Retract them
+   from the temp conn so they won't pollute the main conn with unclassifiable data."
+  [temp-conn *batch-tx-data]
+  (let [db @temp-conn
+        changed-eids (->> @*batch-tx-data
+                          (keep (fn [d] (when (:added d) (:e d))))
+                          distinct)
+        skeleton-eids (filterv
+                       (fn [eid]
+                         (when-let [entity (d/entity db eid)]
+                           (and (not (:block/uuid entity))
+                                (not (:db/ident entity))
+                                (not (:logseq.property.reaction/target entity)))))
+                       changed-eids)]
+    (when (seq skeleton-eids)
+      (log/info :db-sync/retract-skeleton-entities {:eids skeleton-eids})
+      (ldb/transact! temp-conn
+                     (mapv (fn [eid] [:db/retractEntity eid]) skeleton-eids)
+                     {:op :retract-skeleton-entities
+                      :skip-validate-db? true}))))
+
 (defn- apply-remote-tx-with-local-changes!
   [{:keys [conn local-txs remote-txs temp-tx-meta *remote-tx-report *reversed-tx-report *rebased-pending-txs *temp-after-db]}]
   (let [batch-tx-meta {:rtc-tx? true
@@ -1007,7 +1030,7 @@
     (ldb/transact-with-temp-conn!
      conn
      batch-tx-meta
-     (fn [temp-conn _*batch-tx-data]
+     (fn [temp-conn *batch-tx-data]
        (let [tx-meta temp-tx-meta
              reversed-tx-reports (reverse-local-txs! temp-conn local-txs tx-meta)
              reversed-tx-report (combine-tx-reports reversed-tx-reports)
@@ -1024,9 +1047,10 @@
                                         rebase-state
                                         {:temp-conn temp-conn
                                          :tx-meta tx-meta
-                                         :*temp-after-db *temp-after-db}))))
+                                         :*temp-after-db *temp-after-db}))
+         (retract-skeleton-entities! temp-conn *batch-tx-data)))
      {:listen-db (fn [{:keys [tx-meta tx-data db-before db-after]}]
-                   (when-not (contains? #{:reverse :transact-remote-tx-data} (:op tx-meta))
+                   (when-not (contains? #{:reverse :transact-remote-tx-data :retract-skeleton-entities} (:op tx-meta))
                      (swap! *rebased-pending-txs conj {:tx-data tx-data
                                                        :tx-meta tx-meta
                                                        :db-before db-before
@@ -1038,8 +1062,9 @@
    conn
    {:rtc-tx? true
     :without-local-changes? true}
-   (fn [temp-conn]
+   (fn [temp-conn *batch-tx-data]
      (let [remote-results (transact-remote-txs! temp-conn remote-txs temp-tx-meta)]
+       (retract-skeleton-entities! temp-conn *batch-tx-data)
        (combine-tx-reports (map :report remote-results))))))
 
 (defn apply-remote-txs!


### PR DESCRIPTION
## Problem

During `apply-remote-tx-with-local-changes!`, the rebase pipeline (reverse local txs → apply remote txs → rebase local txs) can leave an entity in a broken state: all structural attributes (`block/uuid`, `block/parent`, `block/page`) stripped away, with only a non-structural property like `logseq.property/created-by-ref` remaining.

When the accumulated temp-conn datoms are committed atomically to the main conn, DB validation fails:

```
DB write failed with invalid data
  entity-map: {block/properties: [[:logseq.property/created-by-ref 184]], db/id: 39663}
  errors: [["invalid dispatch value"]]
```

`entity-dispatch-key` in `malli_schema.cljs` returns `nil` for entities lacking `block/uuid`, `db/ident`, and `logseq.property.reaction/target`, causing the `:multi` schema to reject them with "invalid dispatch value".

## Root cause

The entity is valid at the time each individual remote tx is applied to the temp conn, so the existing per-tx `sanitize-tx-data` does not catch it. The corruption only becomes visible in the final aggregated datom state:

1. Reversing a pending local tx retracts the entity's structural attributes (uuid, parent, page).
2. A separate remote tx in the same batch adds only a ref attribute (e.g. `created-by-ref`) to that entity.
3. The accumulated datom sequence, replayed atomically on the main conn, recreates the entity from just that one attribute.

## Fix

Add `retract-skeleton-entities!`, called at the end of both batch paths (`apply-remote-tx-with-local-changes!` and `apply-remote-tx-without-local-changes!`). It scans entities that received adds during the batch and retracts any whose final state in the temp conn has no `block/uuid`, `db/ident`, or `logseq.property.reaction/target`. The retraction datoms flow through the temp-conn listener into the same atomic commit to the main conn.

The `:retract-skeleton-entities` op is excluded from `*rebased-pending-txs` so the cleanup is not re-queued as a local tx to push to the server.

## Safety

A skeleton entity by definition carries no user content (no title, no parent, no page). The full entity exists on the server with all its attributes; only the desktop's corrupted fragment is retracted. The condition (`not block/uuid AND not db/ident AND not reaction/target`) matches no valid Logseq entity type, so no real entity is ever incorrectly retracted.