### PR TITLE
fix: improve numbered list alignment for multi-digit numbers

### DIFF
--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -792,9 +792,9 @@
   }
 
   &.as-order-list {
-    width: 1.4em;
+    width: auto;
     min-width: 1.4em;
-    @apply whitespace-nowrap justify-center pl-[3px];
+    @apply whitespace-nowrap justify-end pl-[3px] pr-[2px];
   }
 
   .bullet {


### PR DESCRIPTION
Fixes #9515

## Problem

Numbered list items with 2+ digit numbers (10, 100, etc.) have their numbers overlapping with the block content. This happens because the `.bullet-container.as-order-list` uses a fixed width of `1.4em`, which is only wide enough for single-digit numbers.

## Fix

In `src/main/frontend/components/block.css`:
- Changed `width: 1.4em` → `width: auto` so the container grows with the number length
- Kept `min-width: 1.4em` to maintain consistent sizing for single-digit numbers
- Changed `justify-center` → `justify-end` to right-align numbers (so the dots align vertically)
- Added `pr-[2px]` for spacing between the number and block content

### Before
```
1. Content
2. Content
10. Content   ← overlaps
100. Content  ← worse
```

### After
```
  1. Content
  2. Content
 10. Content
100. Content
```