### PR TITLE
chore: bump nbb-logseq to feat-db-v34

### DIFF
--- a/deps/cli/package.json
+++ b/deps/cli/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@logseq/nbb-logseq": "github:logseq/nbb-logseq#feat-db-v33",
+    "@logseq/nbb-logseq": "github:logseq/nbb-logseq#feat-db-v34",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "better-sqlite3": "^12.8.0",
     "fastify": "5.8.2",

--- a/deps/cli/yarn.lock
+++ b/deps/cli/yarn.lock
@@ -48,9 +48,9 @@
   resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.11.tgz#dc419f0826dd2504e9fc86ad289d5636a0444e2f"
   integrity sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==
 
-"@logseq/nbb-logseq@github:logseq/nbb-logseq#feat-db-v33":
-  version "1.2.173-feat-db-v33"
-  resolved "https://codeload.github.com/logseq/nbb-logseq/tar.gz/cfe10d5ad2c3960ce9fd6540dc2f490080c81897"
+"@logseq/nbb-logseq@github:logseq/nbb-logseq#feat-db-v34":
+  version "1.2.173-feat-db-v34"
+  resolved "https://codeload.github.com/logseq/nbb-logseq/tar.gz/4d9f1382ce2cec6f39bf12df49ba425f1bd5f3fb"
   dependencies:
     import-meta-resolve "^4.1.0"
 

--- a/deps/common/package.json
+++ b/deps/common/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "devDependencies": {
-    "@logseq/nbb-logseq": "github:logseq/nbb-logseq#feat-db-v33"
+    "@logseq/nbb-logseq": "github:logseq/nbb-logseq#feat-db-v34"
   },
   "scripts": {
     "test": "yarn nbb-logseq -cp test -m nextjournal.test-runner"

--- a/deps/common/yarn.lock
+++ b/deps/common/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@logseq/nbb-logseq@github:logseq/nbb-logseq#feat-db-v33":
-  version "1.2.173-feat-db-v33"
-  resolved "https://codeload.github.com/logseq/nbb-logseq/tar.gz/cfe10d5ad2c3960ce9fd6540dc2f490080c81897"
+"@logseq/nbb-logseq@github:logseq/nbb-logseq#feat-db-v34":
+  version "1.2.173-feat-db-v34"
+  resolved "https://codeload.github.com/logseq/nbb-logseq/tar.gz/4d9f1382ce2cec6f39bf12df49ba425f1bd5f3fb"
   dependencies:
     import-meta-resolve "^4.1.0"
 

--- a/deps/db/package.json
+++ b/deps/db/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "devDependencies": {
-    "@logseq/nbb-logseq": "github:logseq/nbb-logseq#feat-db-v33",
+    "@logseq/nbb-logseq": "github:logseq/nbb-logseq#feat-db-v34",
     "fs-extra": "^11.3.4"
   },
   "dependencies": {

--- a/deps/db/yarn.lock
+++ b/deps/db/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@logseq/nbb-logseq@github:logseq/nbb-logseq#feat-db-v33":
-  version "1.2.173-feat-db-v33"
-  resolved "https://codeload.github.com/logseq/nbb-logseq/tar.gz/cfe10d5ad2c3960ce9fd6540dc2f490080c81897"
+"@logseq/nbb-logseq@github:logseq/nbb-logseq#feat-db-v34":
+  version "1.2.173-feat-db-v34"
+  resolved "https://codeload.github.com/logseq/nbb-logseq/tar.gz/4d9f1382ce2cec6f39bf12df49ba425f1bd5f3fb"
   dependencies:
     import-meta-resolve "^4.1.0"
 

--- a/deps/graph-parser/package.json
+++ b/deps/graph-parser/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "devDependencies": {
-    "@logseq/nbb-logseq": "github:logseq/nbb-logseq#feat-db-v33",
+    "@logseq/nbb-logseq": "github:logseq/nbb-logseq#feat-db-v34",
     "better-sqlite3": "^12.8.0"
   },
   "dependencies": {

--- a/deps/graph-parser/yarn.lock
+++ b/deps/graph-parser/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@logseq/nbb-logseq@github:logseq/nbb-logseq#feat-db-v33":
-  version "1.2.173-feat-db-v33"
-  resolved "https://codeload.github.com/logseq/nbb-logseq/tar.gz/cfe10d5ad2c3960ce9fd6540dc2f490080c81897"
+"@logseq/nbb-logseq@github:logseq/nbb-logseq#feat-db-v34":
+  version "1.2.173-feat-db-v34"
+  resolved "https://codeload.github.com/logseq/nbb-logseq/tar.gz/4d9f1382ce2cec6f39bf12df49ba425f1bd5f3fb"
   dependencies:
     import-meta-resolve "^4.1.0"
 

--- a/deps/outliner/package.json
+++ b/deps/outliner/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "devDependencies": {
-    "@logseq/nbb-logseq": "github:logseq/nbb-logseq#feat-db-v33"
+    "@logseq/nbb-logseq": "github:logseq/nbb-logseq#feat-db-v34"
   },
   "dependencies": {
     "better-sqlite3": "^12.8.0",

--- a/deps/outliner/yarn.lock
+++ b/deps/outliner/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@logseq/nbb-logseq@github:logseq/nbb-logseq#feat-db-v33":
-  version "1.2.173-feat-db-v33"
-  resolved "https://codeload.github.com/logseq/nbb-logseq/tar.gz/cfe10d5ad2c3960ce9fd6540dc2f490080c81897"
+"@logseq/nbb-logseq@github:logseq/nbb-logseq#feat-db-v34":
+  version "1.2.173-feat-db-v34"
+  resolved "https://codeload.github.com/logseq/nbb-logseq/tar.gz/4d9f1382ce2cec6f39bf12df49ba425f1bd5f3fb"
   dependencies:
     import-meta-resolve "^4.1.0"
 

--- a/deps/publishing/package.json
+++ b/deps/publishing/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "devDependencies": {
-    "@logseq/nbb-logseq": "github:logseq/nbb-logseq#feat-db-v33",
+    "@logseq/nbb-logseq": "github:logseq/nbb-logseq#feat-db-v34",
     "mldoc": "^1.5.9"
   },
   "dependencies": {

--- a/deps/publishing/yarn.lock
+++ b/deps/publishing/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@logseq/nbb-logseq@github:logseq/nbb-logseq#feat-db-v33":
-  version "1.2.173-feat-db-v33"
-  resolved "https://codeload.github.com/logseq/nbb-logseq/tar.gz/cfe10d5ad2c3960ce9fd6540dc2f490080c81897"
+"@logseq/nbb-logseq@github:logseq/nbb-logseq#feat-db-v34":
+  version "1.2.173-feat-db-v34"
+  resolved "https://codeload.github.com/logseq/nbb-logseq/tar.gz/4d9f1382ce2cec6f39bf12df49ba425f1bd5f3fb"
   dependencies:
     import-meta-resolve "^4.1.0"
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "devDependencies": {
-    "@logseq/nbb-logseq": "github:logseq/nbb-logseq#feat-db-v33"
+    "@logseq/nbb-logseq": "github:logseq/nbb-logseq#feat-db-v34"
   },
   "dependencies": {
     "better-sqlite3": "12.8.0",

--- a/scripts/yarn.lock
+++ b/scripts/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@logseq/nbb-logseq@github:logseq/nbb-logseq#feat-db-v33":
-  version "1.2.173-feat-db-v33"
-  resolved "https://codeload.github.com/logseq/nbb-logseq/tar.gz/cfe10d5ad2c3960ce9fd6540dc2f490080c81897"
+"@logseq/nbb-logseq@github:logseq/nbb-logseq#feat-db-v34":
+  version "1.2.173-feat-db-v34"
+  resolved "https://codeload.github.com/logseq/nbb-logseq/tar.gz/4d9f1382ce2cec6f39bf12df49ba425f1bd5f3fb"
   dependencies:
     import-meta-resolve "^4.1.0"
 


### PR DESCRIPTION
This bumps nbb-logseq to use latest sci which should allow for upgrading to malli 0.20+