### PR TITLE
fix: restore :ref/default-open-blocks-level 0 behavior in DB graphs (re-fix after #12228 regressed)

### DIFF
--- a/deps/db/src/logseq/db/common/initial_data.cljs
+++ b/deps/db/src/logseq/db/common/initial_data.cljs
@@ -262,7 +262,8 @@
                                                       (and children? (empty? properties))
                                                       :children
                                                       :else
-                                                      :self)))]
+                                                      :self)
+                            :block.temp/has-children? (some? (first (d/datoms db :avet :block/parent (:db/id block))))))]
         (cond->
          {:block block'}
           children?

--- a/deps/db/test/logseq/db/common/initial_data_test.cljs
+++ b/deps/db/test/logseq/db/common/initial_data_test.cljs
@@ -60,3 +60,27 @@
         conn (d/conn-from-datoms initial-data schema)]
     (is (some? (db-test/find-page-by-title @conn "page1"))
         "Restores recently updated page")))
+
+(deftest get-block-and-children-has-children-flag
+  (testing "Top-level block with children has :block.temp/has-children? true"
+    (let [conn (db-test/create-conn-with-blocks
+                [{:page {:block/title "test-page"}
+                  :blocks [{:block/title "parent"
+                            :build/children
+                            [{:block/title "child1"}
+                             {:block/title "child2"}]}]}])
+          parent-block (db-test/find-block-by-content @conn "parent")
+          result (common-initial-data/get-block-and-children
+                  @conn (:block/uuid parent-block) {:children? false})]
+      (is (true? (:block.temp/has-children? (:block result)))
+          "Top-level block with children should have :block.temp/has-children? true")))
+
+  (testing "Top-level block without children has :block.temp/has-children? false"
+    (let [conn (db-test/create-conn-with-blocks
+                [{:page {:block/title "test-page2"}
+                  :blocks [{:block/title "leaf-block"}]}])
+          leaf-block (db-test/find-block-by-content @conn "leaf-block")
+          result (common-initial-data/get-block-and-children
+                  @conn (:block/uuid leaf-block) {:children? false})]
+      (is (false? (:block.temp/has-children? (:block result)))
+          "Top-level block without children should have :block.temp/has-children? false"))))

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -3559,7 +3559,9 @@
         page-embed? (:page-embed? config)
         reference? (:reference? config)
         block-id (str "ls-block-" uuid)
-        has-child? (first (:block/_parent (db/entity (:db/id block))))
+        has-child? (let [e (db/entity (:db/id block))]
+                     (or (:block.temp/has-children? e)
+                         (first (:block/_parent e))))
         top? (:top? config)
         original-block (:original-block config)
         attrs (on-drag-and-mouse-attrs block original-block uuid top? block-id *move-to)

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -543,7 +543,8 @@
                  (rum/with-key
                    (reference/references page {:sidebar? sidebar?
                                                :journals? journals?
-                                               :refs-count (:refs-count option)})
+                                               :refs-count (:refs-count option)
+                                               :linked-refs-section? true})
                    (str title "-refs"))])
 
               (when-not (or unlinked-refs?

--- a/src/main/frontend/components/reference.cljs
+++ b/src/main/frontend/components/reference.cljs
@@ -18,6 +18,7 @@
 (rum/defc references-aux
   [page-entity config]
   (let [filters (db-reference/get-filters page-entity)
+        open-blocks-level (state/get-ref-open-blocks-level)
         reference-filter (fn [{:keys [ref-pages-count]}]
                            (shui/button
                             {:title (t :reference/page-filter)
@@ -48,7 +49,10 @@
       :show-items-count? true
       :additional-actions [reference-filter]
       :columns (views/build-columns config [] {})
-      :config config})))
+      :config config
+      :foldable-options (when (and (:linked-refs-section? config)
+                                   (zero? open-blocks-level))
+                          {:default-collapsed? true})})))
 
 (rum/defc references-cp < rum/reactive db-mixins/query
   [entity config]


### PR DESCRIPTION
## Problem

PR #12228 fixed `default-open-blocks-level 0` but subsequent changes to the DB graph codebase (new list-view, lazy child loading) broke it again in three distinct ways.

## Root causes & fixes

### 1. Linked References section not collapsed (`reference.cljs`, `page.cljs`)

The `references-aux` component was not reading `open-blocks-level` at all. Added `:foldable-options {:default-collapsed? true}` when the configured level is `0`, so the "Linked References" section collapses by default — matching the original file-graph behavior where level `0` meant "show no expanded references".

The fold is gated on a new `:linked-refs-section?` config flag set only by the page-bottom call site in `page.cljs`. The same `references-aux` component is also reused by the inline "Open block references" popup rendered next to blocks (`block.cljs:3366`, dispatched via `(state/get-component :block/linked-references)`). That popup passes `{}`, so it never opts in and its references always render uncollapsed at the section level — clicking the count button to view references shouldn't hide them again.

### 2. `block.temp/has-children?` not propagated to top-level blocks (`initial_data.cljs`)

`get-block-and-children` already set `:block.temp/has-children?` on child blocks, but not on the **top-level fetched block** itself. The list-view loads linked-reference blocks with `:children? false`, meaning `(:block/_parent …)` is always `nil` in the client DB for those blocks. Without this flag the `block-default-collapsed?` check could never fire for them.

The flag is set via a lightweight `(d/datoms db :avet :block/parent id)` scan that stops at the first match, rather than `(some? (:block/_parent block))` — the reverse ref materializes the full child entity set in DataScript, while the datoms index lookup is O(1) on hit. Includes a regression test verifying the flag is set on top-level blocks returned by `get-block-and-children`.

### 3. Collapse arrow missing for lazily-loaded blocks (`block.cljs`)

`has-child?` in `block-container-inner-aux` used only `(:block/_parent …)` — which is `nil` for blocks whose children live in the worker DB but haven't been pulled into the client DB yet. Added `:block.temp/has-children?` as a fallback so the collapse arrow renders correctly, and clicking it calls `expand-block!` which loads the children on demand.

## Testing

With `:ref/default-open-blocks-level 0` set in config:

1. **Page-bottom Linked References** — Open a page that has linked references. The "Linked References" section at the bottom should be collapsed by default. Expanding the section, and then individual blocks, should show the collapse arrows and children load on demand.
2. **Inline "Open block references" popup** — Find a block that is referenced by other blocks (the count button renders next to it). The references shown next to / below the block should render uncollapsed at the section level — the section fold from (1) must not apply here.
3. **Per-block collapse still works in both contexts** — Inside both the page-bottom panel and the inline popup, individual reference blocks that have children should still be collapsed per `block-default-collapsed?` (the level threshold), and the collapse arrows render correctly even for lazily-loaded blocks.
4. **Default level (`2`) sanity check** — With the default `:ref/default-open-blocks-level 2`, neither the page-bottom section nor the inline popup is section-folded; behavior matches pre-regression.