### PR TITLE
[codex] fix multi-block selection and delete

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2196,6 +2196,7 @@
 (defn- block-content-on-pointer-down
   [e block block-id edit-input-id content config]
   (when-not @(:ui/scrolling? @state/state)
+    (editor-handler/track-selection-pointer! e)
     (let [target (.-target e)
           selection-blocks (state/get-selection-blocks)
           starting-block (state/get-selection-start-block-or-first)
@@ -3295,7 +3296,8 @@
          :on-mouse-enter (fn [e]
                            (block-mouse-over e block *control-show? block-id doc-mode?))
          :on-mouse-move (fn [e]
-                          (reset! *block-last-mouse-event e))
+                          (reset! *block-last-mouse-event e)
+                          (editor-handler/track-selection-pointer! e))
          :on-mouse-leave (fn [_e]
                            (block-mouse-leave *control-show? block-id doc-mode?))}
 

--- a/src/main/frontend/components/container.cljs
+++ b/src/main/frontend/components/container.cljs
@@ -362,6 +362,9 @@
   (mixins/event-mixin
    (fn [state]
      (mixins/listen state js/window "pointerdown" hide-context-menu-and-clear-selection)
+     (mixins/listen state js/window "pointerup"
+                    (fn [_e]
+                      (editor-handler/clear-selection-pointer!)))
      (mixins/listen state js/window "keydown"
                     (fn [e]
                       (cond

--- a/src/main/frontend/handler/common.cljs
+++ b/src/main/frontend/handler/common.cljs
@@ -38,6 +38,7 @@
                     (when @*scroll-timer
                       (js/clearTimeout @*scroll-timer))
                     (state/set-state! :ui/scrolling? true)
+                    (state/pub-event! [:editor/extend-selection-under-pointer])
                     (state/save-scroll-position! (util/scroll-top))
                     (state/save-main-container-position!
                      (-> (util/app-scroll-container-node)

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -69,9 +69,21 @@
 
 (defonce *asset-uploading? (atom false))
 (defonce *asset-uploading-process (atom 0))
+(defonce ^:private *selection-pointer (atom nil))
 
 (def clear-selection! state/clear-selection!)
 (def edit-block! block-handler/edit-block!)
+
+(defn track-selection-pointer!
+  [^js e]
+  (when e
+    (reset! *selection-pointer {:x (.-clientX e)
+                                :y (.-clientY e)
+                                :buttons (.-buttons e)})))
+
+(defn clear-selection-pointer!
+  []
+  (reset! *selection-pointer nil))
 
 (defn- outliner-save-block!
   [block & {:as opts}]
@@ -1159,6 +1171,23 @@
                     (state/drop-selection-blocks-starts-with! end-block-node)
                     (state/conj-selection-block! blocks direction)))
               (state/exit-editing-and-set-selected-blocks! blocks direction))))))))
+
+(defn extend-selection-under-pointer!
+  []
+  (when-let [{:keys [x y buttons]} @*selection-pointer]
+    (when (and (= buttons 1)
+               (state/get-selection-start-block-or-first))
+      (when-let [target (.elementFromPoint js/document x y)]
+        (when-let [block-dom-element (util/rec-get-node target "ls-block")]
+          (let [selected-blocks (state/get-unsorted-selection-blocks)
+                selection-end (when (seq selected-blocks)
+                                (if (= :up (state/get-selection-direction))
+                                  (first selected-blocks)
+                                  (last selected-blocks)))]
+            (when-not (identical? selection-end block-dom-element)
+              (highlight-selection-area! (.-id block-dom-element)
+                                         block-dom-element
+                                         {:append? true}))))))))
 
 (defonce *action-bar-timeout (atom nil))
 

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -406,6 +406,9 @@
                   (db-async/<get-block (state/get-current-repo) id
                                        {:skip-refresh? false})) ids))))
 
+(defmethod handle :editor/extend-selection-under-pointer [_]
+  (editor-handler/extend-selection-under-pointer!))
+
 (defn run!
   []
   (let [chan (state/get-events-chan)]

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -980,6 +980,27 @@ Similar to re-frame subscriptions"
 (def ^:private block-selected-flow
   (m/watch (:selection/blocks @state)))
 
+(defonce ^:private *selection-load-timeout (atom nil))
+(def ^:private selection-load-delay-ms 100)
+
+(defn- cancel-selection-load!
+  []
+  (when-let [timeout @*selection-load-timeout]
+    (js/clearTimeout timeout)
+    (reset! *selection-load-timeout nil)))
+
+(defn- schedule-selection-load!
+  [ids]
+  (cancel-selection-load!)
+  (when (seq ids)
+    (let [ids (vec ids)]
+      (reset! *selection-load-timeout
+              (js/setTimeout
+               (fn []
+                 (reset! *selection-load-timeout nil)
+                 (pub-event! [:editor/load-blocks ids]))
+               selection-load-delay-ms)))))
+
 (defn sub-block-selected?
   [block-id]
   (assert (uuid? block-id))
@@ -1021,6 +1042,8 @@ Similar to re-frame subscriptions"
 
 (defn- set-selection-blocks-aux!
   [blocks]
+  (when-not (seq blocks)
+    (cancel-selection-load!))
   (set-state! :view/selected-blocks nil)
   (let [selected-blocks @(:selection/blocks @state)
         selected-ids (set (get-selected-block-ids selected-blocks))
@@ -1048,10 +1071,11 @@ Similar to re-frame subscriptions"
        (set-selection-blocks-aux! blocks)
        (when direction (set-state! :selection/direction direction))
        (let [ids (get-selection-block-ids)]
-         (when (seq ids) (pub-event! [:editor/load-blocks ids])))))))
+         (schedule-selection-load! ids))))))
 
 (defn state-clear-selection!
   []
+  (cancel-selection-load!)
   (set-state! :selection/blocks nil)
   (set-state! :selection/direction nil)
   (set-state! :selection/start-block nil)

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -662,24 +662,54 @@
     (subvec xs start end)))
 
 #?(:cljs
+   (defn- node-index
+     [nodes target]
+     (first (keep-indexed (fn [idx node]
+                            (when (identical? node target)
+                              idx))
+                          nodes))))
+
+#?(:cljs
+   (defn- selection-scope-nodes
+     [node-1 node-2 class]
+     (let [container-1 (some-> node-1 rec-get-blocks-container)
+           container-2 (some-> node-2 rec-get-blocks-container)]
+       (cond
+         (and container-1 container-2)
+         (if (identical? container-1 container-2)
+           (->> (get-blocks-noncollapse container-1)
+                (filter #(d/has-class? % class))
+                vec)
+           [])
+
+         :else
+         (->> (array-seq (js/document.getElementsByClassName class))
+              (filter #(some? (gobj/get % "offsetParent")))
+              vec)))))
+
+#?(:cljs
    (defn get-nodes-between-two-nodes
      [node-1 node-2 class]
-     (when-let [nodes (array-seq (js/document.getElementsByClassName class))]
-       (let [idx-1 (.indexOf nodes node-1)
-             idx-2 (.indexOf nodes node-2)
-             start (min idx-1 idx-2)
-             end (inc (max idx-1 idx-2))]
-         (safe-subvec (vec nodes) start end)))))
+     (let [nodes (selection-scope-nodes node-1 node-2 class)
+           idx-1 (node-index nodes node-1)
+           idx-2 (node-index nodes node-2)]
+       (if (and (some? idx-1) (some? idx-2))
+         (let [start (min idx-1 idx-2)
+               end (inc (max idx-1 idx-2))]
+           (safe-subvec nodes start end))
+         (cond-> []
+           node-2
+           (conj node-2))))))
 
 #?(:cljs
    (defn get-direction-between-two-nodes
      [node-1 node-2 class]
-     (when-let [nodes (array-seq (js/document.getElementsByClassName class))]
-       (let [idx-1 (.indexOf nodes node-1)
-             idx-2 (.indexOf nodes node-2)]
-         (if (>= idx-1 idx-2)
-           :up
-           :down)))))
+     (let [nodes (selection-scope-nodes node-1 node-2 class)
+           idx-1 (node-index nodes node-1)
+           idx-2 (node-index nodes node-2)]
+       (if (and (some? idx-1) (some? idx-2) (>= idx-1 idx-2))
+         :up
+         :down))))
 
 #?(:cljs
    (defn rec-get-node

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -231,3 +231,27 @@
       (is (nil? (:logseq.property/deleted-at source')))
       (is (nil? (:logseq.property.recycle/original-page source')))
       (is (not= (:db/id recycle-page) (:db/id (:block/page source')))))))
+
+(deftest extend-selection-under-pointer-test
+  (let [calls (atom [])
+        block-dom-element #js {:id "ls-block-target"}
+        original-element-from-point (.-elementFromPoint js/document)]
+    (try
+      (set! (.-elementFromPoint js/document) (fn [_x _y] #js {:tagName "DIV"}))
+      (with-redefs [state/get-selection-start-block-or-first (constantly #js {:id "ls-block-start"})
+                    state/get-unsorted-selection-blocks (constantly [])
+                    state/get-selection-direction (constantly :down)
+                    util/rec-get-node (fn [_node class]
+                                        (when (= class "ls-block")
+                                          block-dom-element))
+                    editor/highlight-selection-area! (fn [block-id dom-block & {:keys [append?]}]
+                                                       (swap! calls conj [block-id dom-block append?]))]
+        (editor/track-selection-pointer! #js {:clientX 12
+                                              :clientY 34
+                                              :buttons 1})
+        (editor/extend-selection-under-pointer!)
+        (is (= [["ls-block-target" block-dom-element true]]
+               @calls)))
+      (finally
+        (set! (.-elementFromPoint js/document) original-element-from-point)
+        (editor/clear-selection-pointer!)))))

--- a/src/test/frontend/util_test.cljs
+++ b/src/test/frontend/util_test.cljs
@@ -71,3 +71,30 @@
       (is (= @actual-ops 4))
       (is (= (m+ 3 5) 8))
       (is (= @actual-ops 4)))))
+
+(deftest test-get-nodes-between-two-nodes-scopes-to-container
+  (let [container-1 (.createElement js/document "div")
+        container-2 (.createElement js/document "div")
+        block-1 (.createElement js/document "div")
+        block-2 (.createElement js/document "div")
+        block-3 (.createElement js/document "div")
+        other-block (.createElement js/document "div")]
+    (doseq [node [block-1 block-2 block-3 other-block]]
+      (.add (.-classList node) "ls-block"))
+    (with-redefs [util/rec-get-blocks-container (fn [node]
+                                                  (cond
+                                                    (identical? node other-block) container-2
+                                                    (some #(identical? node %) [block-1 block-2 block-3]) container-1
+                                                    :else nil))
+                  util/get-blocks-noncollapse (fn [container]
+                                                (if (identical? container container-1)
+                                                  [block-1 block-2 block-3]
+                                                  [other-block]))]
+      (is (= [block-1 block-2 block-3]
+             (util/get-nodes-between-two-nodes block-1 block-3 "ls-block")))
+      (is (= [other-block]
+             (util/get-nodes-between-two-nodes block-1 other-block "ls-block")))
+      (is (= :up
+             (util/get-direction-between-two-nodes block-3 block-1 "ls-block")))
+      (is (= :down
+             (util/get-direction-between-two-nodes block-1 other-block "ls-block"))))))


### PR DESCRIPTION
## Summary

This fixes several related frontend block selection regressions:

- scope shift-range selection to the current blocks container instead of the whole document
- keep extending block selection while scrolling by tracking the pointer and resolving the block under it
- debounce selection-triggered block preloads so delete and range selection do not pay repeated eager loading costs

## Root Cause

Block range selection was computed from the document-wide `.ls-block` list, so selection could cross the wrong DOM scope when multiple block containers were present. The drag-selection flow also relied on mouse enter behavior, which does not reliably advance selection when the viewport scrolls under a stationary pointer. On top of that, every intermediate selection update eagerly triggered nested block loads, making frontend editing operations feel heavier than they needed to.

## Impact

This makes multi-block delete, `shift+click` range selection, and click-then-scroll range selection behave consistently, and reduces the amount of work done before selection-driven actions take effect.

## Validation

- `git diff --check`
- attempted `bb dev:test -v frontend.util-test`
- attempted `bb dev:test -v frontend.handler.editor-test`

The two targeted cljs test commands were stopped after spending more than 5 minutes in the shared compile phase.
