### PR TITLE
fix: snapshot upload stuck when graph has large blocks

### DIFF
--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -125,7 +125,7 @@
 (defn- ws-open? [ws]
   (sync-transport/ws-open? ws))
 
-(defn- upload-large-title! [repo graph-id title aes-key]
+(defn upload-large-title! [repo graph-id title aes-key]
   (sync-large-title/upload-large-title!
    {:repo repo
     :graph-id graph-id

--- a/src/main/frontend/worker/sync/upload.cljs
+++ b/src/main/frontend/worker/sync/upload.cljs
@@ -125,7 +125,7 @@
               :process-batch-f
               (fn [batch]
                 (p/let [datoms* (sync-large-title/offload-large-titles-in-datoms-batch
-                                 repo graph-id batch aes-key sync-large-title/upload-large-title!)
+                                 repo graph-id batch aes-key sync-apply/upload-large-title!)
                         encrypted-datoms (if aes-key
                                            (sync-crypt/<encrypt-datoms aes-key datoms*)
                                            datoms*)


### PR DESCRIPTION
When uploading a graph that was imported via "File to DB graph", the sync could get stuck at "Encrypting...". `upload.cljs` passed `sync-large-title/upload-large-title!` directly as the upload callback, but that function expects a single map argument while the caller provides 4 positional args causing a silent crash in the web worker. The existing 4-arg wrapper in `apply_txs.cljs` already handled this correctly, so the fix makes it public and reuses it.