### PR TITLE
fix: snapshot download fails with 401 on selfhosted sync server behind TLS proxy

### DIFF
--- a/deps/db-sync/src/logseq/db_sync/node/server.cljs
+++ b/deps/db-sync/src/logseq/db_sync/node/server.cljs
@@ -2,6 +2,7 @@
   (:require ["http" :as http]
             ["path" :as node-path]
             ["ws" :as ws]
+            [clojure.string :as string]
             [lambdaisland.glogi :as log]
             [logseq.db-sync.index :as index]
             [logseq.db-sync.logging :as logging]
@@ -93,6 +94,9 @@
 (defn start!
   [overrides]
   (let [cfg (config/normalize-config overrides)
+        scheme (if (and (:base-url cfg) (string/starts-with? (:base-url cfg) "https"))
+                 "https"
+                 "http")
         index-db (storage/open-index-db (:data-dir cfg))
         assets-bucket (assets/make-bucket (node-path/join (:data-dir cfg) "assets"))
         registry (atom {})
@@ -105,7 +109,7 @@
                       (graph/delete-graph! registry deps graph-id))))
         server (.createServer http
                               (fn [req res]
-                                (-> (p/let [request (platform-node/request-from-node req {:scheme "http"})
+                                (-> (p/let [request (platform-node/request-from-node req {:scheme scheme})
                                             response (dispatch/handle-node-fetch {:request request
                                                                                   :env env
                                                                                   :registry registry
@@ -123,7 +127,7 @@
     (p/let [_ (index/<index-init! index-db)]
       (.on server "upgrade"
            (fn [req ^js socket head]
-             (let [request (platform-node/request-from-node req {:scheme "http"})
+             (let [request (platform-node/request-from-node req {:scheme scheme})
                    url (platform/request-url request)
                    path (.-pathname url)
                    parsed (node-routes/parse-sync-path path)


### PR DESCRIPTION
When using HTTPS with a reverse proxy in front of the sync server, streaming the snapshot results in an 401 error.
The `/snapshot/download` endpoint returns a JSON containing the stream URL. 
```
{
    "ok": true,
    "key": "stream/fa2ac49b-fe47-454f-8b47-6ab775dc6979.snapshot",
    "url": "http://sync_url/sync/fa2ac49b-fe47-454f-8b47-6ab775dc6979/snapshot/stream"
}
```
This URL was constructed from the incoming request's origin, which always used `http://` because `request-from-node` hardcodes the scheme. 
When the client followed that `http://` URL, the reverse proxy redirected to HTTPS (307), and the browser stripped the `Authorization` header on the redirect, resulting in a 401.

The fix derives the scheme from `DB_SYNC_BASE_URL` instead of hardcoding `http`.
