### PR TITLE
enhance: improve RTL/BiDi row direction for mixed block content

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -72,6 +72,7 @@
             [frontend.state :as state]
             [frontend.ui :as ui]
             [frontend.util :as util]
+            [frontend.util.bidi :as bidi-util]
             [frontend.util.clock :as clock]
             [frontend.util.ref :as ref]
             [frontend.util.text :as text-util]
@@ -1255,7 +1256,7 @@
                            (:logseq.property/status block)
                            (:logseq.property/priority block))
                    [:div.inline-block
-                    {:style {:margin-right 1
+                    {:style {:margin-inline-end 1
                              :margin-top -2
                              :vertical-align "middle"}
                      :on-pointer-down (fn [e]
@@ -2396,7 +2397,7 @@
 (defn list-checkbox
   [config checked?]
   (ui/checkbox
-   {:style {:margin-right 6}
+   {:style {:margin-inline-end 6}
     :value checked?
     :checked checked?
     :on-change (fn [event]
@@ -4249,17 +4250,32 @@
                  (on-error error)))}
    view))
 
+(defn- get-cached-bidi-dir!
+  [*bidi-dir-state block-id text]
+  (let [{cached-block-id :block-id
+         cached-text :text
+         cached-dir :dir} @*bidi-dir-state]
+    (if (and (= cached-block-id block-id)
+             (= cached-text text))
+      cached-dir
+      (let [dir (bidi-util/infer-text-dir text)]
+        (reset! *bidi-dir-state {:block-id block-id
+                                 :text text
+                                 :dir dir})
+        dir))))
+
 (hsx/defc ^:large-vars/cleanup-todo block-container-inner-aux
   [container-state repo config* block {:keys [navigating-block navigated? editing? selected?] :as opts}]
   (let [current-block-page? (= (str (:block/uuid block)) (state/get-current-page))
            embed-self? (and (:embed? config*)
                             (= (:block/uuid block) (:block/uuid (:block config*))))
-           default-hide? (or (not (and current-block-page? (not embed-self?) (state/auto-expand-block-refs?)))
-                             (= (str (:id config*)) (str (:block/uuid block))))
-           *ref (hooks/use-memo #(atom nil) [])
-           *hide-block-refs? (hooks/use-memo #(atom default-hide?) [])
-           *show-query? (hooks/use-memo #(atom false) [])
-           *plugin-renderer-error? (hooks/use-memo #(atom false) [])
+	           default-hide? (or (not (and current-block-page? (not embed-self?) (state/auto-expand-block-refs?)))
+	                             (= (str (:id config*)) (str (:block/uuid block))))
+	           *ref (hooks/use-memo #(atom nil) [])
+           *bidi-dir-state (hooks/use-memo #(atom {:block-id nil :text nil :dir "auto"}) [])
+	           *hide-block-refs? (hooks/use-memo #(atom default-hide?) [])
+	           *show-query? (hooks/use-memo #(atom false) [])
+	           *plugin-renderer-error? (hooks/use-memo #(atom false) [])
            *use-plugin-renderer? (hooks/use-memo #(atom true) [])
            *hydrated-comment-thread (hooks/use-memo #(atom nil) [])
            *comment-thread-present? (hooks/use-memo #(atom nil) [])
@@ -4284,11 +4300,11 @@
               (fn []
                 ;; Mobile swipe handling calls preventDefault, so avoid registering
                 ;; the active touchmove listener on desktop blocks.
-                (when (or (util/mobile?) (mobile-util/native-platform?))
-                  (when-let [node @*ref]
-                    (.addEventListener node "touchmove" block-handler/on-touch-move)
-                    #(.removeEventListener node "touchmove" block-handler/on-touch-move))))
-              [])
+	                (when (or (util/mobile?) (mobile-util/native-platform?))
+	                  (when-let [node @*ref]
+	                    (.addEventListener node "touchmove" block-handler/on-touch-move)
+	                    #(.removeEventListener node "touchmove" block-handler/on-touch-move))))
+	              [])
         switch-to-plugin-renderer! (fn []
                                      (reset! *plugin-renderer-error? false)
                                      (reset! *use-plugin-renderer? true))
@@ -4309,6 +4325,15 @@
         ref-or-custom-query? (or ref? custom-query?)
         *navigating-block (get container-state ::navigating-block)
         {:block/keys [uuid title]} block
+        edit-content (when editing? (state/sub-edit-content uuid))
+        bidi-text (bidi-util/row-dir-source-text
+                   {:editing? editing?
+                    :edit-content edit-content
+                    :title title
+                    :original-name (:block/original-name block)
+                    :name (:block/name block)
+                    :raw-title (:block/raw-title block)})
+        bidi-dir (get-cached-bidi-dir! *bidi-dir-state uuid bidi-text)
         config (build-config config* block {:navigated? navigated? :navigating-block navigating-block})
         level (:level config)
         *control-show? (get container-state ::control-show?)
@@ -4509,10 +4534,11 @@
      (when (and top? (not (or table? property?)))
        (dnd-separator-wrapper block block-id true))
 
-     (when-not (:hide-title? config)
-       [:div.block-main-container.flex.flex-row.gap-1
-        {:class (when (:page-title? config) "is-page-title-row")
-         :style (when (:page-title? config)
+    (when-not (:hide-title? config)
+      [:div.block-main-container.flex.gap-1
+       {:class (when (:page-title? config) "is-page-title-row")
+        :data-row-dir bidi-dir
+        :style (when (:page-title? config)
                   {:margin-left (cond
                                   (util/capacitor?) 0
                                   page-icon -36
@@ -4526,18 +4552,19 @@
          :on-mouse-leave (fn [_e]
                            (block-mouse-leave *control-show? block-id doc-mode?))}
 
-        (when (and (not property?) (not (:table-block-title? config)) (not (:hide-block-control? config)))
-          (let [edit? (or editing?
-                        (= uuid (:block/uuid (state/get-edit-block))))]
+	        (when (and (not property?) (not (:table-block-title? config)) (not (:hide-block-control? config)))
+	          (let [edit? (or editing?
+	                        (= uuid (:block/uuid (state/get-edit-block))))]
             (block-control (assoc config :hide-bullet? (:page-title? config))
               block
               (merge opts
                 {:uuid uuid
-                 :block-id block-id
-                 :collapsed? collapsed?
-                 :*control-show? *control-show?
-                 :edit? edit?}))))
+	                 :block-id block-id
+	                 :collapsed? collapsed?
+	                 :*control-show? *control-show?
+	                 :edit? edit?}))))
 
+	       [:div.block-main-content-wrap.flex.flex-col.w-full
         (if (= :plugin renderer-display-mode)
           ;; --- Plugin renderer: full-block replacement ---
           [:div.block-renderer-container.flex.flex-col.w-full
@@ -4563,7 +4590,7 @@
                (js/React.createElement renderer block-renderer-props-js))]]]
 
           ;; --- Original outline ---
-          outline-view-cp)
+          outline-view-cp)]
 
         (when (and has-comment-thread? (not table?) (not property?))
           (shui/button

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -600,7 +600,8 @@ html.is-mobile .ls-block-content-indent {
     @apply py-[1px] m-0;
 
     .ui__checkbox {
-      @apply mr-1.5 overflow-hidden relative top-0.5;
+      @apply overflow-hidden relative top-0.5;
+      margin-inline-end: 0.375rem;
     }
   }
 }
@@ -663,10 +664,12 @@ html.is-mobile .ls-block-content-indent {
   @apply relative;
 
   &.is-order-list {
-    @apply mr-0 pr-0;
+    margin-inline-end: 0;
+    padding-inline-end: 0;
 
     .bullet-link-wrap {
-      @apply relative left-[-3px];
+      @apply relative;
+      inset-inline-start: -3px;
     }
   }
 
@@ -690,13 +693,13 @@ html.is-mobile .ls-block-content-indent {
   }
 
   &.bullet-hidden {
-    padding-right: 2px;
+    padding-inline-end: 2px;
   }
 }
 
 .block-editing-avatar-wrap {
   @apply absolute top-1/2 -translate-y-1/2 pointer-events-none;
-  left: 6px;
+  inset-inline-start: 6px;
   z-index: 2;
   opacity: 0;
   animation: block-editing-avatar-fade-in 160ms ease-out forwards;
@@ -960,6 +963,19 @@ html.is-mobile .ls-block-content-indent {
 
 .block-main-container {
   @apply min-h-[24px];
+  --ls-heading-control-icon-size: 14px;
+  direction: ltr;
+  flex-direction: row;
+  unicode-bidi: isolate;
+
+  > .block-control-wrap {
+    order: 1;
+  }
+
+  > .block-main-content-wrap {
+    order: 2;
+    min-width: 0;
+  }
 
   > .block-control-wrap.is-with-icon {
     .icon-cp-container,
@@ -975,6 +991,38 @@ html.is-mobile .ls-block-content-indent {
     .ui__icon em-emoji {
       display: block;
       line-height: 1;
+    }
+  }
+
+  &[data-row-dir="rtl"] {
+    /* In RTL rows, keep controls at logical end and content at logical start. */
+    > .block-control-wrap {
+      order: 2;
+      padding-inline: 0;
+      flex-direction: row-reverse;
+    }
+
+    > .block-main-content-wrap {
+      order: 1;
+    }
+
+    > .block-main-content-wrap .block-content-wrapper {
+      justify-content: flex-end;
+    }
+
+    > .block-main-content-wrap .block-content,
+    > .block-main-content-wrap .block-content-inner,
+    > .block-main-content-wrap .block-head-wrap {
+      direction: rtl;
+    }
+
+    > .block-main-content-wrap .block-head-wrap {
+      justify-content: flex-end;
+    }
+
+    /* Keep "block-left" positioned properties at logical start in RTL rows. */
+    > .block-main-content-wrap .block-content-or-editor-wrap {
+      flex-direction: row-reverse;
     }
   }
 
@@ -1004,10 +1052,14 @@ html.is-mobile .ls-block-content-indent {
 
 }
 
+.block-main-content-wrap {
+  direction: ltr;
+}
+
 .ls-page-title-container .block-content-wrapper {
   .ls-page-title-actions {
     @apply absolute -top-5 opacity-0;
-    left: -2px;
+    inset-inline-start: -2px;
   }
 
   &:hover {
@@ -1890,6 +1942,10 @@ html.is-mac {
 .ls-page-title .positioned-properties.block-right svg {
   width: 24px;
   height: 24px;
+}
+
+.ls-page-title .positioned-properties.block-below {
+  margin-inline-start: 7px;
 }
 
 .ls-page-title .ls-properties-area .positioned-properties.block-left svg,

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -571,7 +571,8 @@
               nil)))
      (state/set-state! :editor/on-paste? false)))
   [:div#mock-text
-   {:style {:width "100%"
+   {:dir "auto"
+    :style {:width "100%"
             :height "100%"
             :position "absolute"
             :visibility "hidden"

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -177,6 +177,7 @@
         props (assoc props
                      :ref *el
                      "data-testid" "block editor"
+                     :dir "auto"
                      :on-change (fn [e] (when-not (state/editor-in-composition?)
                                           (on-change e)))
                      :on-composition-start on-composition

--- a/src/main/frontend/util/bidi.cljs
+++ b/src/main/frontend/util/bidi.cljs
@@ -1,0 +1,202 @@
+(ns frontend.util.bidi
+  (:require [cljs.cache :as cache]
+            [clojure.string :as string]
+            [frontend.common.cache :as common.cache]
+            [goog.i18n.bidi :as bidi]
+            [logseq.graph-parser.mldoc :as gp-mldoc]))
+
+(defn- estimated-dir->text-dir
+  [estimated-dir]
+  (cond
+    (number? estimated-dir)
+    (cond
+      (neg? estimated-dir) "rtl"
+      (pos? estimated-dir) "ltr"
+      :else "auto")
+
+    :else "auto"))
+
+(defn- non-blank-string?
+  [value]
+  (and (string? value)
+       (not (string/blank? value))))
+
+(defn- first-non-blank-string
+  [values]
+  (some (fn [value]
+          (when (non-blank-string? value)
+            value))
+        values))
+
+(def ^:private checkbox-prefix-regex
+  #"^\[(?: |x|X|-)\]\s*")
+
+(def ^:private ordered-list-prefix-regex
+  #"^\d+[.)]\s+")
+
+(def ^:private task-marker-prefix-regex
+  #"(?i)^(?:TODO|NOW|LATER|DOING|DONE|WAITING|CANCELED|CANCELLED)\b[:：]?\s*")
+
+(def ^:private property-prefix-regex
+  #"^[^:\n]{1,80}::\s*")
+
+(def ^:private page-ref-wrapper-regex
+  #"^\[\[([^\]]+)\]\]$")
+
+(def ^:private markdown-link-wrapper-regex
+  #"^\[([^\]]+)\]\((.+)\)$")
+
+(def ^:private leading-neutral-prefix-regex
+  #"^[\s\u2022>*-]+")
+
+(def ^:private maybe-inline-markup-regex
+  #"[()\[\]]")
+
+(def ^:private max-dir-sample-length 512)
+(def ^:private max-first-strong-scan-length 256)
+
+(defonce ^:private markdown-inline-parse-config
+  (gp-mldoc/default-config :markdown))
+
+(defonce ^:private *text-dir-cache
+  (volatile! (cache/lru-cache-factory {} :threshold 2000)))
+
+(defn- sample-dir-text
+  [text]
+  (let [text (or text "")]
+    (if (> (count text) max-dir-sample-length)
+      (subs text 0 max-dir-sample-length)
+      text)))
+
+(defn- unwrap-dir-text-once
+  [text]
+  (or (second (re-matches page-ref-wrapper-regex text))
+      (second (re-matches markdown-link-wrapper-regex text))
+      text))
+
+(defn- strip-dir-prefixes-once
+  [text]
+  (-> text
+      string/triml
+      (string/replace leading-neutral-prefix-regex "")
+      (string/replace checkbox-prefix-regex "")
+      (string/replace ordered-list-prefix-regex "")
+      (string/replace task-marker-prefix-regex "")
+      (string/replace property-prefix-regex "")))
+
+(defn- normalize-text-for-dir
+  [sampled-text]
+  (let [stripped (strip-dir-prefixes-once sampled-text)
+        unwrapped (-> stripped unwrap-dir-text-once string/trim)]
+    (if (= stripped unwrapped)
+      unwrapped
+      (-> unwrapped strip-dir-prefixes-once string/trim))))
+
+(defn- infer-text-dir-helper
+  [sampled-text]
+  (let [text (normalize-text-for-dir sampled-text)
+        starts-rtl? (try
+                      (bidi/startsWithRtl text false)
+                      (catch :default _ false))
+        starts-ltr? (try
+                      (bidi/startsWithLtr text false)
+                      (catch :default _ false))]
+    (cond
+      starts-rtl? "rtl"
+      starts-ltr? "ltr"
+      :else (let [estimated-dir (try
+                                   (bidi/estimateDirection text false)
+                                   (catch :default _ nil))]
+              (estimated-dir->text-dir estimated-dir)))))
+
+(defn- first-strong-char-dir
+  [text]
+  (let [length (min (count text) max-first-strong-scan-length)]
+    (loop [idx 0]
+      (if (>= idx length)
+        nil
+        (let [ch (subs text idx (inc idx))
+              rtl? (try
+                     (bidi/startsWithRtl ch false)
+                     (catch :default _ false))
+              ltr? (try
+                     (bidi/startsWithLtr ch false)
+                     (catch :default _ false))]
+          (cond
+            rtl? "rtl"
+            ltr? "ltr"
+            :else (recur (inc idx))))))))
+
+(defn- unwrap-page-ref-content
+  [content]
+  (if-let [match (and (string? content)
+                      (re-matches page-ref-wrapper-regex content))]
+    (second match)
+    content))
+
+(defn- extract-visible-inline-text
+  [inline-ast]
+  (if-not (coll? inline-ast)
+    ""
+    (let [parts (reduce
+                 (fn [result node]
+                   (if-not (vector? node)
+                     result
+                     (let [typ (first node)
+                           payload (second node)]
+                       (case typ
+                         "Plain"
+                         (if (non-blank-string? payload)
+                           (conj result payload)
+                           result)
+
+                         "Nested_link"
+                         (let [content (some-> payload :content unwrap-page-ref-content)]
+                           (if (non-blank-string? content)
+                             (conj result content)
+                             result))
+
+                         result))))
+                 []
+                 (tree-seq coll? seq inline-ast))]
+      (string/trim (string/join " " parts)))))
+
+(defn- infer-text-dir-with-fallback
+  [sampled-text]
+  (let [text (normalize-text-for-dir sampled-text)
+        first-strong-dir (first-strong-char-dir text)
+        inferred-dir (or first-strong-dir
+                         (infer-text-dir-helper text))
+        should-parse? (and (= inferred-dir "auto")
+                           (re-find maybe-inline-markup-regex text))]
+    (cond
+      (not should-parse?)
+      inferred-dir
+
+      :else
+      (let [inline-ast (gp-mldoc/inline->edn text markdown-inline-parse-config)
+            visible-text (-> inline-ast
+                             extract-visible-inline-text
+                             normalize-text-for-dir)
+            fallback-first-strong-dir (first-strong-char-dir visible-text)]
+        (or fallback-first-strong-dir
+            (infer-text-dir-helper visible-text))))))
+
+(def ^:private infer-text-dir-cached
+  (common.cache/cache-fn
+   *text-dir-cache
+   (fn [text]
+     (let [sampled-text (sample-dir-text text)]
+       [[sampled-text] [sampled-text]]))
+   infer-text-dir-with-fallback))
+
+(defn row-dir-source-text
+  [{:keys [editing? edit-content title original-name name raw-title]}]
+  (if (and editing? (non-blank-string? edit-content))
+    edit-content
+    (or (first-non-blank-string [title original-name name raw-title])
+        "")))
+
+(defn infer-text-dir
+  [text]
+  (infer-text-dir-cached text))

--- a/src/test/frontend/util/bidi_test.cljs
+++ b/src/test/frontend/util/bidi_test.cljs
@@ -1,0 +1,123 @@
+(ns frontend.util.bidi-test
+  (:require [cljs.test :refer [are deftest is]]
+            [frontend.util.bidi :as bidi-util]))
+
+(deftest infer-text-dir-basic
+  (are [text expected] (= expected (bidi-util/infer-text-dir text))
+    "الحمد لله" "rtl"
+    "hello world" "ltr"
+    "كلام more english" "rtl"
+    "more english عربي كلام" "ltr"
+    "" "auto"
+    "   " "auto"
+    "... ---" "auto"))
+
+(deftest infer-text-dir-strips-prefixes
+  (are [text expected] (= expected (bidi-util/infer-text-dir text))
+    "[ ] مهمة" "rtl"
+    "[x] مهمة" "rtl"
+    "1. مهمة" "rtl"
+    "TODO: مهمة" "rtl"
+    "status:: مهمة" "rtl"
+    "[ ] task" "ltr"
+    "1. task" "ltr"
+    "NOW: task" "ltr"
+    "status:: task" "ltr"))
+
+(deftest infer-text-dir-unwraps-wrappers
+  (are [text expected] (= expected (bidi-util/infer-text-dir text))
+    "[[اختبار]]" "rtl"
+    "[اختبار](https://example.com)" "rtl"
+    "[[test]]" "ltr"
+    "[test](https://example.com)" "ltr"))
+
+(deftest infer-text-dir-handles-namespace-page-refs
+  (are [text expected] (= expected (bidi-util/infer-text-dir text))
+    "[[x/ع]]" "ltr"
+    "[[ع/x]]" "rtl"
+    "alias:: [[x/ع]]" "ltr"
+    "alias:: [[ع/x]]" "rtl"))
+
+(deftest infer-text-dir-handles-complex-markdown-links
+  (are [text expected] (= expected (bidi-util/infer-text-dir text))
+    "[اختبار [فرعي]](https://example.com/a(b)c)" "rtl"
+    "[test [nested]](https://example.com/a(b)c)" "ltr"))
+
+(deftest infer-text-dir-prefers-content-over-leading-neutrals
+  (is (= "rtl" (bidi-util/infer-text-dir " - *   اختبار")))
+  (is (= "ltr" (bidi-util/infer-text-dir " - *   test"))))
+
+(deftest row-dir-source-text-prefers-edit-content-while-editing
+  (is (= "نص التحرير"
+         (bidi-util/row-dir-source-text
+          {:editing? true
+           :edit-content "نص التحرير"
+           :title "title"
+           :original-name "original"
+           :name "name"
+           :raw-title "raw"}))))
+
+(deftest row-dir-source-text-falls-back-when-edit-content-is-blank
+  (is (= "عنوان"
+         (bidi-util/row-dir-source-text
+          {:editing? true
+           :edit-content "   "
+           :title "عنوان"
+           :original-name "original"
+           :name "name"
+           :raw-title "raw"}))))
+
+(deftest row-dir-source-text-ignores-edit-content-when-not-editing
+  (is (= "title"
+         (bidi-util/row-dir-source-text
+          {:editing? false
+           :edit-content "edited"
+           :title "title"
+           :original-name "original"
+           :name "name"
+           :raw-title "raw"}))))
+
+(deftest row-dir-source-text-priority-order
+  (is (= "original"
+         (bidi-util/row-dir-source-text
+          {:editing? false
+           :edit-content nil
+           :title "  "
+           :original-name "original"
+           :name "name"
+           :raw-title "raw"})))
+  (is (= "name"
+         (bidi-util/row-dir-source-text
+          {:editing? false
+           :edit-content nil
+           :title nil
+           :original-name ""
+           :name "name"
+           :raw-title "raw"})))
+  (is (= "raw"
+         (bidi-util/row-dir-source-text
+          {:editing? false
+           :edit-content nil
+           :title nil
+           :original-name nil
+           :name "  "
+           :raw-title "raw"})))
+  (is (= ""
+         (bidi-util/row-dir-source-text
+          {:editing? false
+           :edit-content nil
+           :title nil
+           :original-name nil
+           :name nil
+           :raw-title nil}))))
+
+(deftest row-dir-source-text-regression-chain
+  (let [source (bidi-util/row-dir-source-text
+                {:editing? false
+                 :edit-content nil
+                 :title "الحمد لله"
+                 :original-name nil
+                 :name nil
+                 :raw-title nil})]
+    (is (= "الحمد لله" source))
+    (is (= "rtl" (bidi-util/infer-text-dir source)))))


### PR DESCRIPTION
## Summary
This PR adds core RTL/BiDi behavior for mixed-content blocks (Arabic/English, tasks, wrappers) by making row direction inference robuster and by applying direction consistently in row/editor layout.

Closes [#12525.](https://github.com/logseq/db-test/issues/811)

## What Changed
- Added `frontend.util.bidi` with cached direction inference helpers
- Added normalization for common prefixes/wrappers before direction detection:
  - task prefixes (`TODO`, `DOING`, etc.)
  - ordered list/checkbox prefixes
  - property prefixes (`key::`)
  - page-ref/markdown link wrappers
- Added fallback inline parsing path for ambiguous markup-heavy text
- Prefer edit-content while editing (`row-dir-source-text`) so row dir updates from current editor text
- Wired direction attributes/classes in block/editor UI to keep control/content alignment consistent for LTR/RTL
- Added regression tests in `src/test/frontend/util/bidi_test.cljs`

## User impact
- Mixed Arabic/English blocks choose direction more consistently
- RTL rows keep controls on the correct side
- Edit mode follows current typed text direction more reliably

<img width="1321" height="393" alt="image" src="https://github.com/user-attachments/assets/da98cbd5-8182-4171-97b3-d10ea1763181" />

## Validation
- Manual UI pass on mixed-content blocks (Arabic/English, task markers, page refs, markdown links)
- Added unit tests for bidi utility behavior and wrappers
