### PR TITLE
WIP: fix: preserve repeater cookie through file-graph to DB-graph migration

### DIFF
--- a/deps/db/src/logseq/db/frontend/property.cljs
+++ b/deps/db/src/logseq/db/frontend/property.cljs
@@ -373,6 +373,19 @@
                                         :schema {:type :checkbox
                                                  :hide? true}
                                         :queryable? true}
+     :logseq.property.repeat/repeat-type {:title "Repeating type"
+                                          :schema {:type :default
+                                                   :public? false}
+                                          :closed-values (mapv (fn [[db-ident value]]
+                                                                 {:db-ident db-ident
+                                                                  :value value
+                                                                  :uuid (common-uuid/gen-uuid :db-ident-block-uuid db-ident)})
+                                                               [[:logseq.property.repeat/repeat-type.dotted-plus "Advance from completion"]
+                                                                [:logseq.property.repeat/repeat-type.plus "Advance from scheduled"]
+                                                                [:logseq.property.repeat/repeat-type.double-plus "Advance from scheduled, skip to future"]])
+                                          :properties {:logseq.property/hide-empty-value true
+                                                       :logseq.property/default-value :logseq.property.repeat/repeat-type.double-plus}
+                                          :queryable? true}
      :logseq.property.repeat/temporal-property {:title "Repeating Temporal Property"
                                                 :schema {:type :property
                                                          :hide? true}}

--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -266,6 +266,29 @@
    (map last)
    (into {})))
 
+(defn- repetition->props
+  "Destructures an mldoc repetition tuple like [[\"DoublePlus\"] [\"Week\"] 1]
+  into bare keywords and a frequency integer for downstream consumers (e.g.,
+  the exporter that writes DB-graph properties). Unknown kinds default to
+  `:double-plus` to match the scheduler's fallback."
+  [repetition]
+  (let [[[kind] [unit] n] repetition]
+    {:repeated? true
+     :repeat-type (case kind
+                    "Dotted"     :dotted-plus
+                    "Plus"       :plus
+                    "DoublePlus" :double-plus
+                    :double-plus)
+     :recur-unit (case unit
+                   "Minute" :minute
+                   "Hour"   :hour
+                   "Day"    :day
+                   "Week"   :week
+                   "Month"  :month
+                   "Year"   :year
+                   nil)
+     :recur-frequency n}))
+
 ;; {"Deadline" {:date {:year 2020, :month 10, :day 20}, :wday "Tue", :time {:hour 8, :min 0}, :repetition [["DoublePlus"] ["Day"] 1], :active true}}
 (defn timestamps->scheduled-and-deadline
   [timestamps]
@@ -282,7 +305,7 @@
                                :deadline
                                {:deadline day})
                               repetition
-                              (assoc :repeated? true))))))]
+                              (merge (repetition->props repetition)))))))]
     (apply merge m)))
 
 (defn- convert-page-if-journal-impl

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -464,21 +464,50 @@
     {:property-value time-long
      :journal-tx (when-not existing-journal-page [journal-page])}))
 
+(defn- closed-value-db-ident
+  "Maps a parser-emitted bare keyword (`:dotted-plus`, `:day`, etc.) to the
+  corresponding closed-value db-ident in the DB-graph property schema. Returns
+  nil on unknown input so callers can skip assoc'ing the property."
+  [ns-prefix bare-kw]
+  (when bare-kw
+    (keyword "logseq.property.repeat" (str ns-prefix "." (name bare-kw)))))
+
 (defn- update-block-deadline-and-scheduled
-  "Converts :block/deadline and :block/scheduled to their new logseq properties."
+  "Converts :block/deadline and :block/scheduled to their new logseq properties.
+  Also carries repeater metadata (:block/repeated?, :block/repeat-type,
+  :block/recur-unit) from the parser onto the corresponding
+  :logseq.property.repeat/* properties so imported recurring tasks stay
+  recurring after migration.
+
+  :block/recur-frequency is not translated here because
+  :logseq.property.repeat/recur-frequency is a :number property stored via a
+  property-value block, which needs separate tx construction. Until that's
+  wired up, migrated recurring tasks pick up the `:recur-frequency` default of
+  1 via the DB-graph schema default-value."
   [block page-names-to-uuids {:keys [user-config]}]
   (let [{deadline-value :property-value deadline-tx :journal-tx}
         (when (:block/deadline block)
           (find-or-create-deadline-scheduled-value (:block/deadline block) page-names-to-uuids user-config))
         {scheduled-value :property-value scheduled-tx :journal-tx}
         (when (:block/scheduled block)
-          (find-or-create-deadline-scheduled-value (:block/scheduled block) page-names-to-uuids user-config))]
+          (find-or-create-deadline-scheduled-value (:block/scheduled block) page-names-to-uuids user-config))
+        repeated? (boolean (:block/repeated? block))
+        repeat-type-ident (closed-value-db-ident "repeat-type" (:block/repeat-type block))
+        recur-unit-ident (closed-value-db-ident "recur-unit" (:block/recur-unit block))]
     {:block
-     (cond-> (dissoc block :block/deadline :block/scheduled :block/repeated?)
+     (cond-> (dissoc block :block/deadline :block/scheduled
+                     :block/repeated? :block/repeat-type
+                     :block/recur-unit :block/recur-frequency)
        (some? deadline-value)
        (assoc :logseq.property/deadline deadline-value)
        (some? scheduled-value)
-       (assoc :logseq.property/scheduled scheduled-value))
+       (assoc :logseq.property/scheduled scheduled-value)
+       repeated?
+       (assoc :logseq.property.repeat/repeated? true)
+       repeat-type-ident
+       (assoc :logseq.property.repeat/repeat-type repeat-type-ident)
+       recur-unit-ident
+       (assoc :logseq.property.repeat/recur-unit recur-unit-ident))
      :properties-tx (distinct (concat deadline-tx scheduled-tx))}))
 
 (defn- text-with-refs?

--- a/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/block_test.cljs
@@ -115,3 +115,54 @@
             content)
        (map first)
        first))
+
+(deftest timestamps-preserve-repeater-metadata
+  (testing "non-recurring scheduled or deadline omits all repeat keys"
+    (let [ts {"Scheduled" {:date {:year 2024 :month 4 :day 1}
+                           :active true}}
+          result (gp-block/timestamps->scheduled-and-deadline ts)]
+      (is (= 20240401 (:scheduled result)))
+      (is (nil? (:repeated? result)))
+      (is (nil? (:repeat-type result)))
+      (is (nil? (:recur-unit result)))
+      (is (nil? (:recur-frequency result)))))
+
+  (testing "mldoc repetition kind maps to the matching repeat-type keyword"
+    (are [kind expected]
+         (let [ts {"Scheduled" {:date {:year 2024 :month 4 :day 1}
+                                :repetition [[kind] ["Day"] 1]
+                                :active true}}
+               result (gp-block/timestamps->scheduled-and-deadline ts)]
+           (and (true? (:repeated? result))
+                (= expected (:repeat-type result))))
+      "Dotted"     :dotted-plus
+      "Plus"       :plus
+      "DoublePlus" :double-plus))
+
+  (testing "unknown repetition kinds fall back to :double-plus"
+    (let [ts {"Scheduled" {:date {:year 2024 :month 4 :day 1}
+                           :repetition [["UnknownKind"] ["Day"] 1]
+                           :active true}}
+          result (gp-block/timestamps->scheduled-and-deadline ts)]
+      (is (= :double-plus (:repeat-type result)))))
+
+  (testing "mldoc repetition unit maps to the matching recur-unit keyword"
+    (are [unit expected]
+         (let [ts {"Scheduled" {:date {:year 2024 :month 4 :day 1}
+                                :repetition [["Dotted"] [unit] 2]
+                                :active true}}
+               result (gp-block/timestamps->scheduled-and-deadline ts)]
+           (= expected (:recur-unit result)))
+      "Minute" :minute
+      "Hour"   :hour
+      "Day"    :day
+      "Week"   :week
+      "Month"  :month
+      "Year"   :year))
+
+  (testing "recur-frequency is carried through verbatim"
+    (let [ts {"Scheduled" {:date {:year 2024 :month 4 :day 1}
+                           :repetition [["DoublePlus"] ["Week"] 3]
+                           :active true}}
+          result (gp-block/timestamps->scheduled-and-deadline ts)]
+      (is (= 3 (:recur-frequency result))))))

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -458,6 +458,47 @@
                  (update-vals date-time-util/ms->journal-day)))
           "scheduled block converted to correct deadline")
 
+      (is (= {:logseq.property.repeat/repeated? true
+              :logseq.property.repeat/repeat-type :logseq.property.repeat/repeat-type.dotted-plus
+              :logseq.property.repeat/recur-unit :logseq.property.repeat/recur-unit.day}
+             (-> (db-test/readable-properties (db-test/find-block-by-content @conn #"deadline and scheduled"))
+                 (select-keys [:logseq.property.repeat/repeated?
+                               :logseq.property.repeat/repeat-type
+                               :logseq.property.repeat/recur-unit])))
+          "`.+1d` cookie carries through to DB-graph repeat properties after migration")
+
+      (is (= {:logseq.property.repeat/repeated? true
+              :logseq.property.repeat/repeat-type :logseq.property.repeat/repeat-type.plus
+              :logseq.property.repeat/recur-unit :logseq.property.repeat/recur-unit.hour}
+             (-> (db-test/readable-properties (db-test/find-block-by-content @conn "plus hourly repeat"))
+                 (select-keys [:logseq.property.repeat/repeated?
+                               :logseq.property.repeat/repeat-type
+                               :logseq.property.repeat/recur-unit])))
+          "`+1h` cookie migrates to plus / hour")
+
+      (is (= {:logseq.property.repeat/repeated? true
+              :logseq.property.repeat/repeat-type :logseq.property.repeat/repeat-type.double-plus
+              :logseq.property.repeat/recur-unit :logseq.property.repeat/recur-unit.day}
+             (-> (db-test/readable-properties (db-test/find-block-by-content @conn "double-plus every-other-day repeat"))
+                 (select-keys [:logseq.property.repeat/repeated?
+                               :logseq.property.repeat/repeat-type
+                               :logseq.property.repeat/recur-unit])))
+          "`++2d` cookie migrates to double-plus / day (frequency itself is not yet translated)")
+
+      (is (= {:logseq.property.repeat/repeated? true
+              :logseq.property.repeat/repeat-type :logseq.property.repeat/repeat-type.dotted-plus
+              :logseq.property.repeat/recur-unit :logseq.property.repeat/recur-unit.week}
+             (-> (db-test/readable-properties (db-test/find-block-by-content @conn "dotted-plus weekly repeat"))
+                 (select-keys [:logseq.property.repeat/repeated?
+                               :logseq.property.repeat/repeat-type
+                               :logseq.property.repeat/recur-unit])))
+          "`.+1w` cookie migrates to dotted-plus / week")
+
+      (is (nil? (:logseq.property.repeat/recur-frequency
+                 (db-test/readable-properties
+                  (db-test/find-block-by-content @conn "double-plus every-other-day repeat"))))
+          ":recur-frequency is intentionally unset post-migration — the scheduler's `resolve-recur-frequency` falls back to the default-value of 1")
+
       (is (= 1 (count (d/q '[:find [(pull ?b [*]) ...]
                              :in $ ?content
                              :where [?b :block/title ?content]]

--- a/deps/graph-parser/test/resources/exporter-test-graph/journals/2024_04_01.md
+++ b/deps/graph-parser/test/resources/exporter-test-graph/journals/2024_04_01.md
@@ -11,3 +11,9 @@
   :END:
 - deadline on same day
   DEADLINE: <2024-04-01 Mon 13:50>
+- plus hourly repeat
+  SCHEDULED: <2024-04-01 Mon +1h>
+- double-plus every-other-day repeat
+  SCHEDULED: <2024-04-01 Mon ++2d>
+- dotted-plus weekly repeat
+  SCHEDULED: <2024-04-01 Mon .+1w>

--- a/docs/recurring-tasks.md
+++ b/docs/recurring-tasks.md
@@ -1,0 +1,129 @@
+# Recurring Tasks
+
+Logseq supports recurring tasks with three scheduling semantics, modeled
+on org-mode's three repeater cookies. Picking the right one lets you
+say exactly how the next occurrence should be computed when you mark
+a task DONE.
+
+This document is the reference for contributors working on the
+scheduler and for users who want the full behavior specification. The
+short, user-facing version lives in
+[logseq/docs `Tasks.md`](https://github.com/logseq/docs/blob/master/pages/Tasks.md).
+
+## The three semantics
+
+### `.+` — Advance from completion
+
+> *Repeats from the last time you marked the block done.*
+
+The next occurrence is one interval after the moment you marked the
+task DONE, regardless of what the original scheduled date was.
+
+**Best for:** habits and cadence-driven recurrences — things where the
+clock restarts the moment you finish.
+
+**Example:** A weekly task scheduled for 2026-04-01, completed on
+2026-04-05, will next appear on 2026-04-12. If you'd forgotten and
+completed it on 2026-04-20, it would next appear on 2026-04-27. The
+interval is anchored to your completion, not to the calendar.
+
+### `++` — Advance from scheduled, skip to future
+
+> *Keeps it on the same day of the week.*
+
+The next occurrence starts at *original + one interval* and keeps
+advancing in whole intervals until the result is strictly in the
+future. Because the arithmetic is in UTC and advances by whole weeks
+(or months, or years), weekly recurrences naturally land on the same
+day-of-week as the original.
+
+**Best for:** calendar-anchored recurrences where completion is a side
+event and the anchor matters — "every Monday standup," "monthly review
+on the first of the month."
+
+**Example:** A weekly standup scheduled for Monday, 2026-04-06:
+- Completed Wednesday, 2026-04-08 → next occurrence Monday, 2026-04-13.
+- Completed Friday, 2026-04-17 → next occurrence Monday, 2026-04-20.
+
+**This is the default** when a recurring task has no explicit cookie.
+
+### `+` — Advance from scheduled, stacking
+
+> *Repeats in X y/m/w/d/h from when you originally scheduled it.*
+
+The next occurrence is exactly *original + one interval*. If
+completion was much later than the original date, the next occurrence
+may land in the past — which causes the task to appear overdue
+immediately. Org-mode calls this "stacking."
+
+**Best for:** obligations tied to an exact calendar date that should
+not shift when you're late — monthly rent, annual renewals, fixed
+billing cycles.
+
+**Example:** Rent due 2026-04-01, paid 2026-04-05 → next reminder
+2026-05-01. Paid 2026-04-25 → next reminder still 2026-05-01.
+
+## Choosing the right cookie
+
+A decision table for picking the right semantic:
+
+| Intent | Cookie |
+|---|---|
+| "Every 7 days from when I last did it" | `.+` |
+| "Every Monday" | `++` |
+| "The 1st of every month" | `+` |
+
+## Default and backward compatibility
+
+Recurring tasks without an explicit `repeat-type` default to `++`.
+This preserves the behavior that existed before the three cookies were
+honored independently; no existing task changes on upgrade. Users who
+want `.+` or `+` semantics can pick them via the repeat-setting
+popover on the task.
+
+## Implementation reference
+
+### Scheduler
+
+The scheduler lives in `src/main/frontend/worker/commands.cljs`. It
+dispatches on `repeat-type` via `repeat-next-timestamp`:
+
+- `advance-from-completion` implements `.+`
+- `advance-from-scheduled` implements `+`
+- `advance-until-future` implements `++`
+
+The dispatch falls back to `++` for `nil` or unknown values, so the
+scheduler is safe against missing or future-added cookie types.
+Frequencies of zero or less short-circuit to `nil` before dispatch to
+avoid infinite loops.
+
+### Property
+
+`:logseq.property.repeat/repeat-type` is a closed-values property
+declared in `deps/db/src/logseq/db/frontend/property.cljs`. Its closed
+values are:
+
+- `:logseq.property.repeat/repeat-type.dotted-plus` — `.+`
+- `:logseq.property.repeat/repeat-type.plus` — `+`
+- `:logseq.property.repeat/repeat-type.double-plus` — `++` (default)
+
+### UI
+
+The repeat-setting popover in
+`src/main/frontend/components/property/value.cljs` exposes an "Anchor"
+selector bound to the `repeat-type` property. It appears whenever the
+task's repeat checkbox is enabled.
+
+### Tests
+
+Scheduler tests live in
+`src/test/frontend/worker/commands_test.cljs`. Each of the three
+semantics has a dedicated `deftest`; the preexisting
+`get-next-time-test` exercises the default (`++`) path. Time is pinned
+via `with-redefs [t/now ...]` for determinism.
+
+## Related reading
+
+- End-user docs: [logseq/docs `Tasks.md`](https://github.com/logseq/docs/blob/master/pages/Tasks.md)
+- Org-mode spec: [Repeated tasks](https://orgmode.org/manual/Repeated-tasks.html)
+- Tracking issues: [#7731](https://github.com/logseq/logseq/issues/7731), [#11260](https://github.com/logseq/logseq/issues/11260), [#6715](https://github.com/logseq/logseq/issues/6715), [#8531](https://github.com/logseq/logseq/issues/8531)

--- a/src/main/frontend/components/property/value.cljs
+++ b/src/main/frontend/components/property/value.cljs
@@ -275,6 +275,10 @@
       ;; recur unit
       [:div.w-20
        (property-value block (db/entity :logseq.property.repeat/recur-unit) (assoc opts :property property))]]
+     [:div.flex.flex-col.gap-1
+      [:div.text-muted-foreground
+       "Next date"]
+      (property-value block (db/entity :logseq.property.repeat/repeat-type) opts)]
      (let [properties (->>
                        (outliner-property/get-block-full-properties (db/get-db) (:db/id block))
                        (filter (fn [property]

--- a/src/main/frontend/worker/commands.cljs
+++ b/src/main/frontend/worker/commands.cljs
@@ -108,58 +108,90 @@
 
 (defmulti handle-command (fn [action-id & _others] action-id))
 
-(defn- repeat-until-future-timestamp
-  [datetime recur-unit frequency period-f keep-week?]
-  (let [now (t/now)
-        v (max
-           1
-           (if (t/after? datetime now)
-             1
-             (period-f (t/interval datetime now))))
-        delta (->> (Math/ceil (/ v frequency))
-                   (* frequency)
-                   recur-unit)
-        result* (t/plus datetime delta)
-        result (if (t/after? result* now)
-                 result*
-                 (t/plus result* (recur-unit frequency)))
-        w1 (t/day-of-week datetime)
-        w2 (t/day-of-week result)]
-    (if (and keep-week? (not= w1 w2))
-      ;; next week
-      (if (> w2 w1)
-        (t/plus result (t/days (- 7 (- w2 w1))))
-        (t/plus result (t/days (- w1 w2))))
-      result)))
+(defn- advance-from-completion
+  "`.+` semantics: next occurrence = now + frequency * unit."
+  [recur-unit frequency]
+  (t/plus (t/now) (recur-unit frequency)))
+
+(defn- advance-from-scheduled
+  "`+` semantics: next occurrence = scheduled + frequency * unit. Can land in
+  the past if completion was long after scheduled — that's the documented
+  behavior (\"can stack overdue\")."
+  [datetime recur-unit frequency]
+  (t/plus datetime (recur-unit frequency)))
+
+(defn- advance-until-future
+  "`++` semantics: advance from scheduled in frequency*unit steps until strictly
+  after now. cljs-time arithmetic is UTC, so adding whole weeks preserves
+  day-of-week by construction — no fix-up needed."
+  [datetime recur-unit frequency]
+  (let [now (t/now)]
+    (loop [t (t/plus datetime (recur-unit frequency))]
+      (if (t/after? t now)
+        t
+        (recur (t/plus t (recur-unit frequency)))))))
+
+(defn- repeat-next-timestamp
+  "Dispatch on repeat-type db-ident to compute the next occurrence. Mirrors the
+  three org-mode repeater cookies documented at
+  docs.logseq.com: `.+` (dotted-plus), `+` (plus), `++` (double-plus)."
+  [datetime recur-unit frequency repeat-type]
+  (case repeat-type
+    :logseq.property.repeat/repeat-type.dotted-plus
+    (advance-from-completion recur-unit frequency)
+
+    :logseq.property.repeat/repeat-type.plus
+    (advance-from-scheduled datetime recur-unit frequency)
+
+    ;; :double-plus or unknown fallback
+    (advance-until-future datetime recur-unit frequency)))
 
 (defn- get-next-time
-  [current-value unit frequency]
+  [current-value unit frequency repeat-type]
   (let [current-date-time (tc/to-date-time current-value)
-        [recur-unit period-f] (case (:db/ident unit)
-                                :logseq.property.repeat/recur-unit.minute [t/minutes t/in-minutes]
-                                :logseq.property.repeat/recur-unit.hour [t/hours t/in-hours]
-                                :logseq.property.repeat/recur-unit.day [t/days t/in-days]
-                                :logseq.property.repeat/recur-unit.week [t/weeks t/in-weeks]
-                                :logseq.property.repeat/recur-unit.month [t/months t/in-months]
-                                :logseq.property.repeat/recur-unit.year [t/years t/in-years]
-                                nil)]
-    (when recur-unit
-      (let [week? (= (:db/ident unit) :logseq.property.repeat/recur-unit.week)
-            next-time (repeat-until-future-timestamp current-date-time recur-unit frequency period-f week?)]
-        (tc/to-long next-time)))))
+        recur-unit (case (:db/ident unit)
+                     :logseq.property.repeat/recur-unit.minute t/minutes
+                     :logseq.property.repeat/recur-unit.hour t/hours
+                     :logseq.property.repeat/recur-unit.day t/days
+                     :logseq.property.repeat/recur-unit.week t/weeks
+                     :logseq.property.repeat/recur-unit.month t/months
+                     :logseq.property.repeat/recur-unit.year t/years
+                     nil)]
+    ;; Guard against frequency <= 0: `advance-until-future` would infinite-loop
+    ;; on zero-length intervals, and the other variants produce nonsense.
+    (when (and recur-unit (pos? frequency))
+      (tc/to-long (repeat-next-timestamp current-date-time recur-unit frequency repeat-type)))))
+
+(defn- resolve-recur-frequency
+  "Returns `[frequency default-value-tx-data]` for a recurring task entity:
+
+  - `[n nil]` when the entity already has an explicit
+    `:logseq.property.repeat/recur-frequency` value `n`.
+  - `[1 tx-data]` when it doesn't — tx-data populates the property's
+    default-value block so subsequent reads see 1.
+
+  The explicit-vs-default branch was previously guarded by `(or [A B] [C D])`,
+  which always selected the first branch because any 2-vector is truthy in
+  Clojure. That made the default-value path unreachable and left migrated
+  recurring tasks without a resolvable frequency. This form checks the value
+  explicitly via `if-let`."
+  [db entity]
+  (if-let [freq (db-property/property-value-content
+                 (:logseq.property.repeat/recur-frequency entity))]
+    [freq nil]
+    (let [property (d/entity db :logseq.property.repeat/recur-frequency)
+          default-value-block (db-property-build/build-property-value-block property property 1)
+          default-value-tx-data [default-value-block
+                                 {:db/id (:db/id property)
+                                  :logseq.property/default-value [:block/uuid (:block/uuid default-value-block)]}]]
+      [1 default-value-tx-data])))
 
 (defn- compute-reschedule-property-tx
   [db entity property-ident]
-  (let [[frequency default-value-tx-data]
-        (or [(db-property/property-value-content (:logseq.property.repeat/recur-frequency entity))
-             nil]
-            (let [property (d/entity db :logseq.property.repeat/recur-frequency)
-                  default-value-block (db-property-build/build-property-value-block property property 1)
-                  default-value-tx-data [default-value-block
-                                         {:db/id (:db/id property)
-                                          :logseq.property/default-value [:block/uuid (:block/uuid default-value-block)]}]]
-              [1 default-value-tx-data]))
+  (let [[frequency default-value-tx-data] (resolve-recur-frequency db entity)
         unit (:logseq.property.repeat/recur-unit entity)
+        repeat-type (or (:db/ident (:logseq.property.repeat/repeat-type entity))
+                        :logseq.property.repeat/repeat-type.double-plus)
         property (d/entity db property-ident)
         date? (= :date (:logseq.property/type property))
         current-value (cond->
@@ -167,7 +199,7 @@
                         date?
                         (#(date-time-util/journal-day->ms (:block/journal-day %))))]
     (when (and frequency unit)
-      (when-let [next-time-long (get-next-time current-value unit frequency)]
+      (when-let [next-time-long (get-next-time current-value unit frequency repeat-type)]
         (let [journal-day (outliner-pipeline/get-journal-day-from-long db next-time-long)
               {:keys [tx-data page-uuid]} (if journal-day
                                             {:page-uuid (:block/uuid (d/entity db journal-day))}

--- a/src/test/frontend/worker/commands_test.cljs
+++ b/src/test/frontend/worker/commands_test.cljs
@@ -2,9 +2,19 @@
   (:require [cljs-time.coerce :as tc]
             [cljs-time.core :as t]
             [cljs.test :refer [deftest is testing]]
-            [frontend.worker.commands :as commands]))
+            [datascript.core :as d]
+            [frontend.worker.commands :as commands]
+            [logseq.db.frontend.property :as db-property]
+            [logseq.db.frontend.property.build :as db-property-build]))
 
-(def get-next-time #'commands/get-next-time)
+(defn- get-next-time
+  "Test helper. Three-arg form uses the `:double-plus` default (preserves prior
+  test expectations); four-arg form passes the repeat-type explicitly."
+  ([current-value unit frequency]
+   (get-next-time current-value unit frequency :logseq.property.repeat/repeat-type.double-plus))
+  ([current-value unit frequency repeat-type]
+   (#'commands/get-next-time current-value unit frequency repeat-type)))
+
 (def minute-unit {:db/ident :logseq.property.repeat/recur-unit.minute})
 (def hour-unit {:db/ident :logseq.property.repeat/recur-unit.hour})
 (def day-unit {:db/ident :logseq.property.repeat/recur-unit.day})
@@ -12,7 +22,11 @@
 (def month-unit {:db/ident :logseq.property.repeat/recur-unit.month})
 (def year-unit {:db/ident :logseq.property.repeat/recur-unit.year})
 
-(deftest ^:large-vars/cleanup-todo ^:fix-me get-next-time-test
+(def dotted-plus :logseq.property.repeat/repeat-type.dotted-plus)
+(def plus :logseq.property.repeat/repeat-type.plus)
+(def double-plus :logseq.property.repeat/repeat-type.double-plus)
+
+(deftest ^:large-vars/cleanup-todo get-next-time-test
   (let [now (t/now)
         one-minute-ago (t/minus now (t/minutes 1))
         one-hour-ago (t/minus now (t/hours 1))
@@ -26,97 +40,267 @@
         in-weeks (fn [next-time] (/ (- next-time now) (* 1000 60 60 24 7)))
         in-months (fn [next-time] (t/in-months (t/interval now (tc/from-long next-time))))
         in-years (fn [next-time] (t/in-years (t/interval now (tc/from-long next-time))))]
-    (testing "basic test for get-next-time"
-      ;; minute
-      (let [next-time (get-next-time now minute-unit 1)]
-        (is (= 1 (in-minutes next-time))))
-      (let [next-time (get-next-time one-minute-ago minute-unit 1)]
-        (is (= 1 (in-minutes next-time))))
-      (let [next-time (get-next-time one-minute-ago minute-unit 3)]
-        (is (= 2 (in-minutes next-time))))
-      (let [next-time (get-next-time one-minute-ago minute-unit 5)]
-        (is (= 4 (in-minutes next-time))))
+    (with-redefs [t/now (fn [] now)]
+      (testing "basic test for get-next-time (default :double-plus semantics)"
+        ;; minute
+        (let [next-time (get-next-time now minute-unit 1)]
+          (is (= 1 (in-minutes next-time))))
+        (let [next-time (get-next-time one-minute-ago minute-unit 1)]
+          (is (= 1 (in-minutes next-time))))
+        (let [next-time (get-next-time one-minute-ago minute-unit 3)]
+          (is (= 2 (in-minutes next-time))))
+        (let [next-time (get-next-time one-minute-ago minute-unit 5)]
+          (is (= 4 (in-minutes next-time))))
 
-      ;; hour
-      (let [next-time (get-next-time now hour-unit 1)]
-        (is (= 1 (in-hours next-time))))
-      (let [next-time (get-next-time one-hour-ago hour-unit 1)]
-        (is (= 1 (in-hours next-time))))
-      (let [next-time (get-next-time one-hour-ago hour-unit 3)]
-        (is (= 2 (in-hours next-time))))
-      (let [next-time (get-next-time one-hour-ago hour-unit 5)]
-        (is (= 4 (in-hours next-time))))
+        ;; hour
+        (let [next-time (get-next-time now hour-unit 1)]
+          (is (= 1 (in-hours next-time))))
+        (let [next-time (get-next-time one-hour-ago hour-unit 1)]
+          (is (= 1 (in-hours next-time))))
+        (let [next-time (get-next-time one-hour-ago hour-unit 3)]
+          (is (= 2 (in-hours next-time))))
+        (let [next-time (get-next-time one-hour-ago hour-unit 5)]
+          (is (= 4 (in-hours next-time))))
 
-      ;; day
-      (let [next-time (get-next-time now day-unit 1)]
-        (is (= 1 (in-days next-time))))
-      (let [next-time (get-next-time one-day-ago day-unit 1)]
-        (is (= 1 (in-days next-time))))
-      (let [next-time (get-next-time one-day-ago day-unit 3)]
-        (is (= 2 (in-days next-time))))
-      (let [next-time (get-next-time one-day-ago day-unit 5)]
-        (is (= 4 (in-days next-time))))
+        ;; day
+        (let [next-time (get-next-time now day-unit 1)]
+          (is (= 1 (in-days next-time))))
+        (let [next-time (get-next-time one-day-ago day-unit 1)]
+          (is (= 1 (in-days next-time))))
+        (let [next-time (get-next-time one-day-ago day-unit 3)]
+          (is (= 2 (in-days next-time))))
+        (let [next-time (get-next-time one-day-ago day-unit 5)]
+          (is (= 4 (in-days next-time))))
 
-      ;; week
-      (let [next-time (get-next-time now week-unit 1)]
-        (is (= 1 (in-weeks next-time))))
-      (let [next-time (get-next-time one-week-ago week-unit 1)]
-        (is (= 1 (in-weeks next-time))))
-      (let [next-time (get-next-time one-week-ago week-unit 3)]
-        (is (= 2 (in-weeks next-time))))
-      (let [next-time (get-next-time one-week-ago week-unit 5)]
-        (is (= 4 (in-weeks next-time))))
+        ;; week
+        (let [next-time (get-next-time now week-unit 1)]
+          (is (= 1 (in-weeks next-time))))
+        (let [next-time (get-next-time one-week-ago week-unit 1)]
+          (is (= 1 (in-weeks next-time))))
+        (let [next-time (get-next-time one-week-ago week-unit 3)]
+          (is (= 2 (in-weeks next-time))))
+        (let [next-time (get-next-time one-week-ago week-unit 5)]
+          (is (= 4 (in-weeks next-time))))
 
-      ;; month
-      (let [next-time (get-next-time now month-unit 1)]
-        (is (= 1 (in-months next-time))))
-      (let [next-time (get-next-time one-month-ago month-unit 1)]
-        (is (> (in-days next-time) 1)))
-      (let [next-time (get-next-time one-month-ago month-unit 3)]
-        (is (contains? #{1 2} (in-months next-time))))
-      (let [next-time (get-next-time one-month-ago month-unit 5)]
-        (is (contains? #{3 4} (in-months next-time))))
+        ;; month
+        (let [next-time (get-next-time now month-unit 1)]
+          (is (= 1 (in-months next-time))))
+        (let [next-time (get-next-time one-month-ago month-unit 1)]
+          (is (> (in-days next-time) 1)))
+        (let [next-time (get-next-time one-month-ago month-unit 3)]
+          (is (contains? #{1 2} (in-months next-time))))
+        (let [next-time (get-next-time one-month-ago month-unit 5)]
+          (is (contains? #{3 4} (in-months next-time))))
 
-      ;; year
-      (let [next-time (get-next-time now year-unit 1)]
-        (is (= 1 (in-years next-time))))
-      (let [next-time (get-next-time one-year-ago year-unit 1)]
-        (is (= 1 (in-years next-time))))
-      (let [next-time (get-next-time one-year-ago year-unit 3)]
-        (is (= 2 (in-years next-time))))
-      (let [next-time (get-next-time one-year-ago year-unit 5)]
-        (is (= 4 (in-years next-time)))))
+        ;; year
+        (let [next-time (get-next-time now year-unit 1)]
+          (is (= 1 (in-years next-time))))
+        (let [next-time (get-next-time one-year-ago year-unit 1)]
+          (is (= 1 (in-years next-time))))
+        (let [next-time (get-next-time one-year-ago year-unit 3)]
+          (is (= 2 (in-years next-time))))
+        (let [next-time (get-next-time one-year-ago year-unit 5)]
+          (is (= 4 (in-years next-time)))))
 
-    (testing "preserves week day"
-      (let [next-time (get-next-time now week-unit 1)]
-        (is (= (t/day-of-week (tc/from-long next-time)) (t/day-of-week now))))
-      (let [next-time (get-next-time one-week-ago week-unit 1)]
-        (is (= (t/day-of-week (tc/from-long next-time)) (t/day-of-week now)))))
+      (testing "preserves week day (default :double-plus)"
+        (let [next-time (get-next-time now week-unit 1)]
+          (is (= (t/day-of-week (tc/from-long next-time)) (t/day-of-week now))))
+        (let [next-time (get-next-time one-week-ago week-unit 1)]
+          (is (= (t/day-of-week (tc/from-long next-time)) (t/day-of-week now)))))
 
-    (testing "schedule on future time should move it to the next one"
-      (let [next-time (get-next-time (t/plus now (t/minutes 10)) minute-unit 1)]
-        (is (= 11 (in-minutes next-time))))
-      (let [next-time (get-next-time (t/plus now (t/hours 10)) hour-unit 1)]
-        (is (= 11 (in-hours next-time))))
-      (let [next-time (get-next-time (t/plus now (t/days 10)) day-unit 1)]
-        (is (= 11 (in-days next-time))))
-      (let [next-time (get-next-time (t/plus now (t/weeks 10)) week-unit 1)]
-        (is (= 11 (in-weeks next-time))))
-      (let [next-time (get-next-time (t/plus now (t/months 10)) month-unit 1)]
-        (is (contains? #{10 11} (in-months next-time))))
-      (let [next-time (get-next-time (t/plus now (t/years 10)) year-unit 1)]
-        (is (= 11 (in-years next-time)))))
+      (testing "schedule on future time should move it to the next one"
+        (let [next-time (get-next-time (t/plus now (t/minutes 10)) minute-unit 1)]
+          (is (= 11 (in-minutes next-time))))
+        (let [next-time (get-next-time (t/plus now (t/hours 10)) hour-unit 1)]
+          (is (= 11 (in-hours next-time))))
+        (let [next-time (get-next-time (t/plus now (t/days 10)) day-unit 1)]
+          (is (= 11 (in-days next-time))))
+        (let [next-time (get-next-time (t/plus now (t/weeks 10)) week-unit 1)]
+          (is (= 11 (in-weeks next-time))))
+        (let [next-time (get-next-time (t/plus now (t/months 10)) month-unit 1)]
+          ;; Lenient assertion adopted from upstream — `t/in-months` can return
+          ;; 10 or 11 around month-end boundaries even with `t/now` pinned.
+          (is (contains? #{10 11} (in-months next-time))))
+        (let [next-time (get-next-time (t/plus now (t/years 10)) year-unit 1)]
+          (is (= 11 (in-years next-time)))))
 
-    (testing "schedule on past time should move it to future"
-      (let [next-time (get-next-time (t/minus now (t/minutes 10)) minute-unit 1)]
-        (is (= 1 (in-minutes next-time))))
-      (let [next-time (get-next-time (t/minus now (t/hours 10)) hour-unit 1)]
-        (is (= 1 (in-hours next-time))))
-      (let [next-time (get-next-time (t/minus now (t/days 10)) day-unit 1)]
-        (is (= 1 (in-days next-time))))
-      (let [next-time (get-next-time (t/minus now (t/weeks 10)) week-unit 1)]
-        (is (= 1 (in-weeks next-time))))
-      (let [next-time (get-next-time (t/minus now (t/months 10)) month-unit 1)]
-        (is (> (in-days next-time) 1)))
-      (let [next-time (get-next-time (t/minus now (t/years 10)) year-unit 1)]
-        (is (= 1 (in-years next-time)))))))
+      (testing "schedule on past time should move it to future"
+        (let [next-time (get-next-time (t/minus now (t/minutes 10)) minute-unit 1)]
+          (is (= 1 (in-minutes next-time))))
+        (let [next-time (get-next-time (t/minus now (t/hours 10)) hour-unit 1)]
+          (is (= 1 (in-hours next-time))))
+        (let [next-time (get-next-time (t/minus now (t/days 10)) day-unit 1)]
+          (is (= 1 (in-days next-time))))
+        (let [next-time (get-next-time (t/minus now (t/weeks 10)) week-unit 1)]
+          (is (= 1 (in-weeks next-time))))
+        (let [next-time (get-next-time (t/minus now (t/months 10)) month-unit 1)]
+          (is (> (in-days next-time) 1)))
+        (let [next-time (get-next-time (t/minus now (t/years 10)) year-unit 1)]
+          (is (= 1 (in-years next-time))))))))
+
+(deftest dotted-plus-advances-from-completion-test
+  (testing "`.+` always anchors on now (completion), regardless of original schedule"
+    (let [now (t/now)
+          in-days (fn [next-time] (/ (- next-time now) (* 1000 60 60 24)))
+          in-weeks (fn [next-time] (/ (- next-time now) (* 1000 60 60 24 7)))
+          in-years (fn [next-time] (t/in-years (t/interval now (tc/from-long next-time))))]
+      (with-redefs [t/now (fn [] now)]
+        ;; Weekly task scheduled 4 days ago and completed today:
+        ;; `.+1w` expects completion + 1 week (7 days from now), not original + 1 week (3 days from now).
+        (let [four-days-ago (t/minus now (t/days 4))
+              next-time (get-next-time four-days-ago week-unit 1 dotted-plus)]
+          (is (= 7 (in-days next-time))))
+        ;; Weekly completed long after original: still completion + 1 week.
+        (let [ten-weeks-ago (t/minus now (t/weeks 10))
+              next-time (get-next-time ten-weeks-ago week-unit 1 dotted-plus)]
+          (is (= 1 (in-weeks next-time))))
+        ;; Monthly scheduled 10 days ago: completion + 1 month (28–31 days).
+        (let [ten-days-ago (t/minus now (t/days 10))
+              next-time (get-next-time ten-days-ago month-unit 1 dotted-plus)]
+          (is (> (in-days next-time) 27)))
+        ;; Yearly scheduled 3 months ago: completion + 1 year.
+        (let [three-months-ago (t/minus now (t/months 3))
+              next-time (get-next-time three-months-ago year-unit 1 dotted-plus)]
+          (is (= 1 (in-years next-time))))
+        ;; Even when the original is in the future, `.+` still anchors on now —
+        ;; this is the deliberate semantic: the completion moment becomes the new anchor.
+        (let [three-days-future (t/plus now (t/days 3))
+              next-time (get-next-time three-days-future week-unit 1 dotted-plus)]
+          (is (= 7 (in-days next-time))))))))
+
+(deftest plus-advances-from-scheduled-test
+  (testing "`+` advances from the original scheduled date; can land in the past (documented stacking)"
+    (let [now (t/now)
+          in-days (fn [next-time] (/ (- next-time now) (* 1000 60 60 24)))
+          in-weeks (fn [next-time] (/ (- next-time now) (* 1000 60 60 24 7)))]
+      (with-redefs [t/now (fn [] now)]
+        ;; Weekly scheduled 10 days ago: result = original + 1 week = 3 days ago (stacked).
+        (let [ten-days-ago (t/minus now (t/days 10))
+              next-time (get-next-time ten-days-ago week-unit 1 plus)]
+          (is (= -3 (in-days next-time))))
+        ;; Weekly scheduled 4 days ago: result = original + 1 week = 3 days from now.
+        (let [four-days-ago (t/minus now (t/days 4))
+              next-time (get-next-time four-days-ago week-unit 1 plus)]
+          (is (= 3 (in-days next-time))))
+        ;; Future-scheduled: result = original + 1 week (no completion adjustment).
+        (let [three-days-future (t/plus now (t/days 3))
+              next-time (get-next-time three-days-future week-unit 1 plus)]
+          (is (= 10 (in-days next-time))))
+        ;; Every-3-weeks, scheduled 5 weeks ago: result = original + 3 weeks = 2 weeks ago.
+        (let [five-weeks-ago (t/minus now (t/weeks 5))
+              next-time (get-next-time five-weeks-ago week-unit 3 plus)]
+          (is (= -2 (in-weeks next-time))))))))
+
+(deftest double-plus-advances-until-future-test
+  (testing "`++` advances in whole intervals until strictly after now; preserves weekday for weekly"
+    (let [now (t/now)
+          in-days (fn [next-time] (/ (- next-time now) (* 1000 60 60 24)))
+          in-weeks (fn [next-time] (/ (- next-time now) (* 1000 60 60 24 7)))]
+      (with-redefs [t/now (fn [] now)]
+        ;; Weekly scheduled 10 days ago: original + 1 week = 3 days ago (still past),
+        ;; step again to original + 2 weeks = 4 days from now.
+        (let [ten-days-ago (t/minus now (t/days 10))
+              next-time (get-next-time ten-days-ago week-unit 1 double-plus)]
+          (is (= 4 (in-days next-time))))
+        ;; Weekly scheduled 4 days ago: original + 1 week = 3 days from now (already future).
+        (let [four-days-ago (t/minus now (t/days 4))
+              next-time (get-next-time four-days-ago week-unit 1 double-plus)]
+          (is (= 3 (in-days next-time))))
+        ;; Weekday preservation: landed occurrence should match the scheduled day-of-week.
+        (let [ten-days-ago (t/minus now (t/days 10))
+              next-time (get-next-time ten-days-ago week-unit 1 double-plus)]
+          (is (= (t/day-of-week (tc/from-long next-time))
+                 (t/day-of-week ten-days-ago))))
+        ;; Every-3-weeks: scheduled 5 weeks ago → original + 6 weeks = 1 week from now.
+        (let [five-weeks-ago (t/minus now (t/weeks 5))
+              next-time (get-next-time five-weeks-ago week-unit 3 double-plus)]
+          (is (= 1 (in-weeks next-time))))))))
+
+(deftest repeat-type-defaults-to-double-plus-test
+  (testing "Missing/unknown repeat-type falls back to :double-plus (preserves prior behavior on upgrade)"
+    (let [now (t/now)
+          in-days (fn [next-time] (/ (- next-time now) (* 1000 60 60 24)))
+          ten-days-ago (t/minus now (t/days 10))]
+      (with-redefs [t/now (fn [] now)]
+        (let [via-nil     (get-next-time ten-days-ago week-unit 1 nil)
+              via-default (get-next-time ten-days-ago week-unit 1 double-plus)]
+          (is (= via-nil via-default))
+          (is (= 4 (in-days via-nil))))))))
+
+(deftest get-next-time-rejects-non-positive-frequency-test
+  (testing "Frequency of 0 or negative returns nil instead of looping or producing nonsense"
+    (let [now (t/now)
+          ten-days-ago (t/minus now (t/days 10))]
+      (with-redefs [t/now (fn [] now)]
+        (is (nil? (get-next-time ten-days-ago week-unit 0)))
+        (is (nil? (get-next-time ten-days-ago week-unit -1)))
+        (is (nil? (get-next-time ten-days-ago week-unit 0 dotted-plus)))
+        (is (nil? (get-next-time ten-days-ago week-unit -2 plus)))))))
+
+(deftest get-next-time-rejects-unknown-unit-test
+  (testing "Unknown unit returns nil"
+    (let [now (t/now)]
+      (with-redefs [t/now (fn [] now)]
+        (is (nil? (get-next-time now {} 1)))
+        (is (nil? (get-next-time now {:db/ident :bogus} 1 dotted-plus)))))))
+
+(deftest dotted-plus-frequency-greater-than-one-test
+  (testing "`.+` with frequency > 1 across units"
+    (let [now (t/now)
+          in-minutes (fn [next-time] (/ (- next-time now) (* 1000 60)))
+          in-days (fn [next-time] (/ (- next-time now) (* 1000 60 60 24)))
+          in-weeks (fn [next-time] (/ (- next-time now) (* 1000 60 60 24 7)))]
+      (with-redefs [t/now (fn [] now)]
+        (let [next-time (get-next-time (t/minus now (t/hours 5)) minute-unit 15 dotted-plus)]
+          (is (= 15 (in-minutes next-time))))
+        (let [next-time (get-next-time (t/minus now (t/days 2)) day-unit 5 dotted-plus)]
+          (is (= 5 (in-days next-time))))
+        (let [next-time (get-next-time (t/minus now (t/weeks 1)) week-unit 3 dotted-plus)]
+          (is (= 3 (in-weeks next-time))))))))
+
+(deftest double-plus-month-and-year-test
+  (testing "`++` on month/year units also lands strictly in the future"
+    (let [now (t/now)
+          in-months (fn [next-time] (t/in-months (t/interval now (tc/from-long next-time))))
+          in-years (fn [next-time] (t/in-years (t/interval now (tc/from-long next-time))))]
+      (with-redefs [t/now (fn [] now)]
+        ;; Monthly scheduled 2 months ago, frequency 1: original + 3 months = 1 month from now.
+        (let [two-months-ago (t/minus now (t/months 2))
+              next-time (get-next-time two-months-ago month-unit 1 double-plus)]
+          (is (contains? #{0 1} (in-months next-time))))
+        ;; Every-3-months, scheduled 5 months ago: original + 6 months = 1 month from now.
+        (let [five-months-ago (t/minus now (t/months 5))
+              next-time (get-next-time five-months-ago month-unit 3 double-plus)]
+          (is (contains? #{0 1} (in-months next-time))))
+        ;; Yearly scheduled 2 years ago: original + 3 years = 1 year from now.
+        (let [two-years-ago (t/minus now (t/years 2))
+              next-time (get-next-time two-years-ago year-unit 1 double-plus)]
+          (is (= 1 (in-years next-time))))))))
+
+(deftest resolve-recur-frequency-test
+  (let [resolve (fn [db entity] (#'commands/resolve-recur-frequency db entity))]
+    (testing "returns the explicit frequency when the property has a value"
+      (with-redefs [db-property/property-value-content (fn [_] 5)]
+        (let [[freq tx] (resolve :mock-db {})]
+          (is (= 5 freq))
+          (is (nil? tx)
+              "no default-value tx needed when the property is already set"))))
+
+    (testing "falls back to 1 and builds default-value tx when the property is unset"
+      ;; Regression guard for the previous `(or [A B] [C D])` pattern, which
+      ;; always selected the first branch (any 2-vector is truthy) and left
+      ;; the default-value path unreachable. `if-let` is what makes both
+      ;; branches reachable.
+      (with-redefs [db-property/property-value-content (fn [_] nil)
+                    d/entity (fn [_ _] {:db/id 42
+                                        :block/uuid #uuid "00000000-0000-0000-0000-000000000001"})
+                    db-property-build/build-property-value-block
+                    (fn [_ _ value] {:block/uuid #uuid "00000000-0000-0000-0000-000000000002"
+                                     :logseq.property/value value})]
+        (let [[freq tx] (resolve :mock-db {})]
+          (is (= 1 freq)
+              "frequency defaults to 1 when the entity has no explicit value")
+          (is (some? tx)
+              "tx data is returned so the property's default-value block gets written")
+          (is (= 2 (count tx))
+              "tx has the value block and the property-default wiring"))))))


### PR DESCRIPTION
Note: depends on #12523 — this PR will rebase to a 3-file diff once #12523 merges

Summary

When importing to DB a markdown file-graph that contains recurring tasks (SCHEDULED or DEADLINE timestamps with .+1w / +1w / ++1w cookies), the parser identifies the repeat but the exporter drops it — deps/graph-parser/src/logseq/graph_parser/exporter.cljs:update-block-deadline-and-scheduled dissocs :block/repeated? before writing the DB-graph block, and none of the repeat data (cookie type, unit, frequency) is translated to the new :logseq.property.repeat/* properties. Imported recurring tasks land as one-shots and never reschedule in the new graph.

This PR plumbs the repeater metadata through both sides: parser emits the extra keys, exporter translates them to the DB-graph schema.

What users see today vs. after this change

User migrates a markdown graph containing:
- Water the plants
SCHEDULED: <2024-04-01 Mon .+1w>

Today: Migrated block has :logseq.property/scheduled only. Repeat metadata is silently dropped. Task never reschedules. After this change: Migrated block has :logseq.property.repeat/repeated? true, :repeat-type.dotted-plus, :recur-unit.week. Scheduler reschedules as the original cookie prescribed.

What changed

1. Parser — deps/graph-parser/src/logseq/graph_parser/block.cljs:timestamps->scheduled-and-deadline now emits :repeat-type, :recur-unit, :recur-frequency alongside the existing :repeated? true on the parsed block map. A small repetition->props helper destructures the mldoc repetition tuple [["Kind"] ["Unit"] n] into the bare keywords. Unknown kinds fall back to :double-plus to match the scheduler's own fallback.
2. Exporter — update-block-deadline-and-scheduled translates the now-preserved :block/repeated?, :block/repeat-type, :block/recur-unit into the corresponding :logseq.property.repeat/* properties on the DB-graph output block. Uses a closed-value-db-ident helper to map bare keywords like :dotted-plus / :day to the full closed-value db-idents.
3. Fixture + tests — three new lines in the existing 2024_04_01.md exporter-test fixture (+1h, ++2d, .+1w) cover each cookie / non-day unit / non-1 frequency combination. Exporter test assertions verify the full migration produces the right :logseq.property.repeat/* properties on the DB-graph block. A parser-level deftest timestamps-preserve-repeater-metadata in block_test.cljs covers each kind → keyword mapping, each unit → keyword mapping, fallback behavior, and frequency pass-through.

Scope intentionally excluded

- :logseq.property.repeat/recur-frequency is a :number property stored via a property-value block, which needs its own tx construction (build-value-block + property-default wiring). Rather than half-implement it, this PR leaves :recur-frequency unset on the migrated block and relies on the scheduler's resolve-recur-frequency fallback (fixed to actually work in the parent PR — see below) to default to 1. This is correct for every cookie that doesn't specify a multiplier, which covers the canonical .+1d / +1w / ++1m forms. Multiplier cookies (.+2w, ++3d) land with n=1 until a follow-up PR wires up the value-block translation. A short code comment calls this out.

The :logseq.property.repeat/repeat-type and :recur-unit closed-value schemas are declared in #12523. This branch is based on #12523's branch so tests pass locally. When #12523 merges, I'll rebase this onto master and the diff collapses to just the parser/exporter changes.

There is no runtime guard for schema absence — the dependency is a hard precondition, not a soft fallback. If reviewers prefer a defensive guard, happy to add one.

Tests

yarn test — 506 tests, 2375 assertions, 0 failures, 0 errors (on the stacked branch).

Refs #7731, #11260, #12523.