### PR TITLE
fix(publish): set dir auto for mixed rtl/ltr content

### DIFF
--- a/deps/publish/src/logseq/publish/render.cljs
+++ b/deps/publish/src/logseq/publish/render.cljs
@@ -383,7 +383,7 @@
                           props)]
        [:div.property
         [:dt.property-name (property-title k (:property-title-by-ident ctx))]
-        [:dd.property-value
+        [:dd.property-value {:dir "auto"}
          (into [:span] (normalize-nodes (property-value->nodes v k ctx entities)))]])]))
 
 (defn- property-ui-position
@@ -455,7 +455,7 @@
        (for [[k v] (sorted-properties props ctx)]
          [:div.positioned-property
           [:span.property-name (property-title k (:property-title-by-ident ctx))]
-          [:span.property-value
+          [:span.property-value {:dir "auto"}
            (into [:span.inline-flex] (positioned-value-nodes v k ctx entities))]])]
 
       [:div {:class (str "positioned-properties " (name position))}
@@ -835,7 +835,7 @@
                     block-level? :div.block-text
                     (some macro-embed-node? content) :div.block-text
                     :else :span.block-text)]
-    (into [container] content)))
+    (into [container {:dir "auto"}] content)))
 
 (defn block-raw-content [block]
   (or (:block/content block)
@@ -947,7 +947,7 @@
                     (if (seq ast)
                       (mapcat #(inline->nodes ctx %) ast)
                       (content->nodes raw (:uuid->title ctx) (:graph-uuid ctx)))))]
-    (into [(if block-level? :div.block-text :span.block-text)] content)))
+    (into [(if block-level? :div.block-text :span.block-text) {:dir "auto"}] content)))
 
 (comment
   (def ^:private void-tags

--- a/deps/publish/test/logseq/publish/render_test.cljs
+++ b/deps/publish/test/logseq/publish/render_test.cljs
@@ -25,3 +25,26 @@
                     2 {:db/ident :user.property/custom}}
           result (render/filter-tags [1 2] entities)]
       (is (= [2] result)))))
+
+(deftest block-content-nodes-use-auto-dir
+  (let [node (render/block-content-nodes
+              {:block/content "english then عربي"}
+              {:uuid->title {} :graph-uuid "g"}
+              1)]
+    (is (= "auto" (get-in node [1 :dir])))))
+
+(deftest block-content-from-ref-uses-auto-dir
+  (let [node (render/block-content-from-ref
+              {"source_block_content" "كلام عربي then english"}
+              {:uuid->title {} :graph-uuid "g"})]
+    (is (= "auto" (get-in node [1 :dir])))))
+
+(deftest render-properties-use-auto-dir
+  (let [props {:user.property/sample "english then عربي"}
+        ctx {:property-title-by-ident {}
+             :property-type-by-ident {}}
+        rendered (render/render-properties props ctx {})
+        entry (first (second rendered))
+        dd-node (nth entry 2)]
+    (is (= :dd.property-value (first dd-node)))
+    (is (= "auto" (get-in dd-node [1 :dir])))))


### PR DESCRIPTION
## Summary
This patch fixes mixed RTL/LTR rendering issues in Logseq publish output by adding semantic direction hints at render time instead of relying on CSS-only bidi workarounds.

## Changes
- Add `dir="auto"` to rendered publish block text containers in:
  - `block-content-nodes`
  - `block-content-from-ref`
- Add `dir="auto"` to property value renderers in:
  - `render-properties`
  - `render-positioned-properties`

## Why
Mixed Arabic/English content was rendering inconsistently (line order/alignment issues), especially in block text and property values.  
Using `dir="auto"` lets the browser choose direction based on first strong character, which is more robust and standards-based for multilingual content.

## Tests
- Added/updated tests in `deps/publish/test/logseq/publish/render_test.cljs` to verify `dir="auto"` is emitted.
- Manual build verification. URL [here](https://lsp.yshalsager.com/p/bQmdIfvr-N).

<details>
<summary>Screenshot</summary>

<img width="1405" height="713" alt="image" src="https://github.com/user-attachments/assets/fdf2aeb3-fcc2-4433-91ee-ddacb7ae17bc" />


</details>
