### PR TITLE
fix(electron): repair custom URI scheme links

### DIFF
--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -1,7 +1,7 @@
 (ns electron.utils
   (:require ["electron" :refer [app BrowserWindow]]
             ["node-fetch" :default node-fetch]
-            ["open" :default open-external]
+            ["open" :as open-external]
             ["fs-extra" :as fs]
             ["path" :as node-path]
             [cljs-bean.core :as bean]


### PR DESCRIPTION
## Summary

Custom URI scheme links (`freetube://`, `tg://`, `obsidian://`, `vscode://`, etc.) have been broken in Electron since #12460. Clicking such a link shows the "Are you sure you want to open this link?" confirmation, but pressing **OK** does nothing — the main process throws an `uncaughtException` that's never surfaced to the user.

`~/.config/Logseq/logs/main.log`:

```
[info]  new-window tg://resolve?domain=durov
[error] uncaughtException TypeError: $shadow$js$shim$module$0open$$.default is not a function
```

## Cause

`src/electron/electron/utils.cljs` imports the npm `open` package as:

```clojure
["open" :default open-external]
```

But `open` v8.4.2 is a CommonJS module whose only export is `module.exports = open;` — it does not set `exports.default`. Shadow-cljs's `:default` therefore binds `open-external` to `undefined`, and every `(open-external target)` call in `electron.utils/open` throws synchronously. Because the call site in `electron.window/open-default-app!` invokes it as a fire-and-forget `(default-open url)` with no `.catch`, the failure is invisible in the UI.

This regressed in d6403b7746 (#12460), which replaced the previously working `(defonce open (js/require "open"))` with the ESM-style import. Sister import `["node-fetch" :default node-fetch]` happens to work only because node-fetch v2.7.0 explicitly defines `exports.default = exports` for ESM-interop; `open` does not.

## Fix

Switch to `:as open-external` so the symbol binds to `module.exports` itself (which is the function). Single-line change.

```diff
-            ["open" :default open-external]
+            ["open" :as open-external]
```

## Test plan
- [ ] `xdg-mime default freetube.desktop x-scheme-handler/freetube` (or any custom-scheme handler), put `freetube://https://www.youtube.com/watch?v=dQw4w9WgXcQ` in a block, click → confirm dialog → OK → external app launches.
- [ ] Repeat with `tg://resolve?domain=telegram`, `obsidian://open?vault=foo`, etc.
- [ ] `~/.config/Logseq/logs/main.log` no longer shows `TypeError: ...default is not a function` after clicking such links.
- [ ] Standard `https://` links continue to open via `shell.openExternal` (different code path; should be untouched).