### PR TITLE
fix(plugin): ignore missing plugin storage reads

### DIFF
--- a/src/main/logseq/api/plugin.cljs
+++ b/src/main/logseq/api/plugin.cljs
@@ -138,10 +138,16 @@
 (def read_plugin_storage_file
   (fn [plugin-id file assets?]
     (let [plugin-id (util/node-path.basename plugin-id)
-          sub-root  (util/node-path.join "storages" plugin-id)]
-      (if (true? assets?)
-        (read_assetsdir_file file sub-root)
-        (read_dotdir_file file sub-root)))))
+          sub-root  (util/node-path.join "storages" plugin-id)
+          task      (if (true? assets?)
+                      (read_assetsdir_file file sub-root)
+                      (read_dotdir_file file sub-root))]
+      (-> task
+          (p/catch
+           (fn [error]
+             (if (= "file not existed" (ex-message error))
+               nil
+               (p/rejected error))))))))
 
 (def unlink_plugin_storage_file
   (fn [plugin-id file assets?]

--- a/src/test/logseq/api/plugin_test.cljs
+++ b/src/test/logseq/api/plugin_test.cljs
@@ -1,0 +1,29 @@
+(ns logseq.api.plugin-test
+  (:require [cljs.test :refer [async deftest is testing]]
+            [logseq.api.plugin :as plugin]
+            [promesa.core :as p]))
+
+(deftest read-plugin-storage-file-missing-file-test
+  (testing "missing plugin storage files read as nil"
+    (async done
+           (p/with-redefs [plugin/read_dotdir_file
+                           (fn [_file _sub-root]
+                             (p/rejected (js/Error. "file not existed")))]
+             (-> (plugin/read_plugin_storage_file "test-plugin" "missing.edn" false)
+                 (p/then (fn [result]
+                           (is (nil? result))))
+                 (p/finally done)))))))
+
+(deftest read-plugin-storage-file-keeps-non-missing-errors-test
+  (testing "non-missing storage errors still reject"
+    (async done
+           (let [error (js/Error. "read file denied")]
+             (p/with-redefs [plugin/read_dotdir_file
+                             (fn [_file _sub-root]
+                               (p/rejected error))]
+               (-> (plugin/read_plugin_storage_file "test-plugin" "secrets.edn" false)
+                   (p/then (fn [_]
+                             (is false "read should reject")))
+                   (p/catch (fn [result]
+                              (is (identical? error result))))
+                   (p/finally done)))))))


### PR DESCRIPTION
## Summary

Make plugin storage reads tolerant of missing files while preserving fail-fast behavior for other storage errors.

Plugin callers can probe storage before a file exists. Previously `read_plugin_storage_file` rejected with `file not existed`, which forced callers to treat normal absent storage as an exceptional path.

## Changes

- Return `nil` when plugin storage read fails specifically because the file does not exist.
- Continue rejecting denied paths and other storage errors.
- Add focused CLJS unit coverage for the missing-file and non-missing-error paths.

## Validation

- `git diff --check origin/master..HEAD`
- Attempted: `bb dev:test -v logseq.api.plugin-test/read-plugin-storage-file-missing-file-test -v logseq.api.plugin-test/read-plugin-storage-file-keeps-non-missing-errors-test`; initial fresh worktree failed before compile because `node_modules` was absent.
- Retried after linking existing repo `node_modules`; both `bb dev:test ...` and `bb dev:test-no-worker ...` reached the repo test compile, then failed before running this test with the current `frontend.components.lazy_editor` `shadow.lazy/loadable` error: `Could not find module for ns: frontend.extensions.code`.
