### PR TITLE
fix(sync): drop missing large-title objects on 404

### DIFF
--- a/deps/db/src/logseq/db/frontend/malli_schema.cljs
+++ b/deps/db/src/logseq/db/frontend/malli_schema.cljs
@@ -290,6 +290,10 @@
    [:block/refs {:optional true} [:set :int]]
    [:block/tx-id {:optional true} :int]
    [:block/collapsed? {:optional true} :boolean]
+   [:logseq.property.sync/large-title-object {:optional true}
+    [:map
+     [:asset-uuid :string]
+     [:asset-type :string]]]
    [:block/warning {:optional true} [:keyword]]
    [:logseq.property/created-by-ref {:optional true} :int]])
 

--- a/deps/db/src/logseq/db/frontend/schema.cljs
+++ b/deps/db/src/logseq/db/frontend/schema.cljs
@@ -91,6 +91,7 @@
 
    ;; page's original name
    :block/title {:db/index true}
+   :logseq.property.sync/large-title-object {:db/index true}
 
    ;; page's journal day
    :block/journal-day {:db/index true}

--- a/src/main/frontend/worker/sync/large_title.cljs
+++ b/src/main/frontend/worker/sync/large_title.cljs
@@ -1,6 +1,7 @@
 (ns frontend.worker.sync.large-title
   "Large title offload and rehydration helpers for db sync."
   (:require [datascript.core :as d]
+            [lambdaisland.glogi :as log]
             [logseq.db :as ldb]
             [promesa.core :as p]
             [frontend.worker.sync.util :refer [get-graph-id]]))
@@ -90,7 +91,12 @@
                                     :headers (clj->js auth-headers)})]
       (when-not (.-ok resp)
         (fail-fast-f :db-sync/large-title-download-failed
-                     {:repo repo :status (.-status resp)}))
+                     {:type :db-sync/large-title-download-failed
+                      :repo repo
+                      :graph-id graph-id
+                      :status (.-status resp)
+                      :url url
+                      :object obj}))
       (p/let [buf (.arrayBuffer resp)
               payload (js/Uint8Array. buf)
               payload-str (.decode text-decoder payload)
@@ -99,6 +105,12 @@
                          (p/catch (fn [_] payload-str)))
                      (p/resolved payload-str))]
         data))))
+
+(defn missing-large-title-error?
+  [error]
+  (let [{:keys [type status]} (ex-data error)]
+    (and (= :db-sync/large-title-download-failed type)
+         (= 404 status))))
 
 (defn offload-large-titles
   [tx-data {:keys [repo graph-id upload-fn aes-key]}]
@@ -160,12 +172,28 @@
                     (fail-fast-f :db-sync/missing-field {:repo repo :field :aes-key}))]
           (p/all
            (mapv (fn [{:keys [e obj]}]
-                   (p/let [title (download-fn repo graph-id* obj aes-key*)]
-                     (ldb/transact! conn*
-                                    [[:db/add e :block/title title]]
-                                    {:rtc-tx? true
-                                     :persist-op? false
-                                     :op :large-title-rehydrate})))
+                   (-> (p/let [title (download-fn repo graph-id* obj aes-key*)]
+                         (ldb/transact! conn*
+                                        [[:db/add e :block/title title]]
+                                        {:rtc-tx? true
+                                         :persist-op? false
+                                         :op :large-title-rehydrate}))
+                       (p/catch
+                        (fn [error]
+                          (if (missing-large-title-error? error)
+                            (do
+                              (log/warn :db-sync/large-title-missing
+                                        {:repo repo
+                                         :graph-id graph-id*
+                                         :entity e
+                                         :object obj
+                                         :error error})
+                              (ldb/transact! conn*
+                                             [[:db/retract e large-title-object-attr obj]]
+                                             {:rtc-tx? true
+                                              :persist-op? false
+                                              :op :large-title-missing-cleanup}))
+                            (p/rejected error))))))
                  items)))))))
 
 (defn offload-large-titles-in-datoms-batch

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -4843,6 +4843,48 @@
                        (is (= "rehydrated-title" (:block/title block))))
                      (p/finally done))))))))
 
+(deftest rehydrate-large-title-skips-missing-object-test
+  (testing "rehydrate keeps going when a large-title object is missing remotely"
+    (async done
+           (let [conn (db-test/create-conn-with-blocks
+                       {:pages-and-blocks
+                        [{:page {:block/title "rehydrate-page"}
+                          :blocks [{:block/title "missing-large-title-block"}]}]})
+                 block (db-test/find-block-by-content @conn "missing-large-title-block")
+                 block-id (:db/id block)
+                 obj {:asset-uuid "missing-title-1" :asset-type "txt"}
+                 tx-data [[:db/add block-id :block/title ""]
+                          [:db/add block-id :logseq.property.sync/large-title-object obj]]
+                 download-fn (fn [_repo _graph-id _obj _aes-key]
+                               (p/rejected
+                                (ex-info "missing large title"
+                                         {:type :db-sync/large-title-download-failed
+                                          :status 404})))]
+             (with-datascript-conns conn nil
+               (fn []
+                 (d/transact! conn tx-data)
+                 (-> (p/let [result (sync-large-title/rehydrate-large-titles!
+                                     test-repo
+                                     {:tx-data tx-data
+                                      :conn conn
+                                      :graph-id "graph-1"
+                                      :download-fn download-fn
+                                      :aes-key nil
+                                      :get-conn-f worker-state/get-datascript-conn
+                                      :get-graph-id-f (fn [repo]
+                                                        (sync-large-title/get-graph-id
+                                                         worker-state/get-datascript-conn repo))
+                                      :graph-e2ee?-f sync-crypt/graph-e2ee?
+                                      :ensure-graph-aes-key-f sync-crypt/<ensure-graph-aes-key
+                                      :fail-fast-f db-sync/fail-fast})
+                             _ (is (some? result))
+                             block' (d/entity @conn block-id)
+                             obj-datoms (filter #(= :logseq.property.sync/large-title-object (:a %))
+                                                (d/datoms @conn :eavt))]
+                       (is (= "" (:block/title block')))
+                       (is (empty? obj-datoms)))
+                     (p/finally done))))))))
+
 (defn- apply-template-to-empty-target!
   [conn template-root-uuid empty-target-uuid]
   (let [template-root (d/entity @conn [:block/uuid template-root-uuid])

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -4871,9 +4871,6 @@
                                       :download-fn download-fn
                                       :aes-key nil
                                       :get-conn-f worker-state/get-datascript-conn
-                                      :get-graph-id-f (fn [repo]
-                                                        (sync-large-title/get-graph-id
-                                                         worker-state/get-datascript-conn repo))
                                       :graph-e2ee?-f sync-crypt/graph-e2ee?
                                       :ensure-graph-aes-key-f sync-crypt/<ensure-graph-aes-key
                                       :fail-fast-f db-sync/fail-fast})


### PR DESCRIPTION
## Summary

Do not fail the whole sync rehydrate step when a remote large-title object is already missing.

Large block titles are offloaded to remote objects. If one of those objects returns 404 during rehydrate, the local entity should stop pointing at that missing object so sync can continue instead of repeatedly failing on an unrecoverable reference.

## Changes

- Include typed error data when large-title download fails.
- Detect 404 large-title downloads during rehydrate.
- Retract the missing large-title object reference and continue with the rest of the batch.
- Add a focused worker regression test.

## Validation

- `git diff --check origin/master..HEAD`
- `bb dev:test -v frontend.worker.db-sync-test/rehydrate-large-title-skips-missing-object-test`

The test passed with 3 assertions. The CLJS compile emitted one existing warning in nearby test code about `frontend.worker.sync.large-title/get-graph-id`; it did not fail the test run.
