### PR TITLE
fix(sync): ignore overlapping pull txs and reject gaps

### DIFF
--- a/deps/db/src/logseq/db/frontend/malli_schema.cljs
+++ b/deps/db/src/logseq/db/frontend/malli_schema.cljs
@@ -290,6 +290,10 @@
    [:block/refs {:optional true} [:set :int]]
    [:block/tx-id {:optional true} :int]
    [:block/collapsed? {:optional true} :boolean]
+   [:logseq.property.sync/large-title-object {:optional true}
+    [:map
+     [:asset-uuid :string]
+     [:asset-type :string]]]
    [:block/warning {:optional true} [:keyword]]
    [:logseq.property/created-by-ref {:optional true} :int]])
 

--- a/deps/db/src/logseq/db/frontend/schema.cljs
+++ b/deps/db/src/logseq/db/frontend/schema.cljs
@@ -91,6 +91,7 @@
 
    ;; page's original name
    :block/title {:db/index true}
+   :logseq.property.sync/large-title-object {:db/index true}
 
    ;; page's journal day
    :block/journal-day {:db/index true}

--- a/src/main/frontend/worker/sync/handle_message.cljs
+++ b/src/main/frontend/worker/sync/handle_message.cljs
@@ -112,6 +112,30 @@
   [value context]
   (sync-transport/parse-transit fail-fast value context))
 
+(defn- expected-pull-ts
+  [local-tx remote-tx]
+  (vec (range (inc local-tx) (inc remote-tx))))
+
+(defn- normalize-pull-window
+  [repo local-tx remote-tx remote-txs]
+  (doseq [{:keys [t]} remote-txs]
+    (require-non-negative t {:repo repo :type "pull/ok" :field :txs}))
+  (let [remote-txs' (->> remote-txs
+                         (filter (fn [{:keys [t]}]
+                                   (> t local-tx)))
+                         vec)
+        actual-ts (mapv :t remote-txs')
+        expected-ts (expected-pull-ts local-tx remote-tx)]
+    (when-not (= actual-ts expected-ts)
+      (log/warn :db-sync/pull-window-noncontiguous
+                {:repo repo
+                 :local-tx local-tx
+                 :remote-tx remote-tx
+                 :actual-ts actual-ts
+                 :expected-ts expected-ts}))
+    (when (= actual-ts expected-ts)
+      remote-txs')))
+
 (defn- request-pull!
   [client since]
   (when (and (:ws client) (ws-open? (:ws client)))
@@ -340,7 +364,7 @@
                                 :outliner-op (:outliner-op data)
                                 :tx-data (parse-transit (:tx data) {:repo repo :type "pull/ok"})})
                              txs)]
-        (when (seq remote-txs)
+        (if-let [remote-txs' (normalize-pull-window repo local-tx remote-tx remote-txs)]
           (->
            (p/let [graph-e2ee? (sync-crypt/graph-e2ee? repo)
                    aes-key (sync-crypt/<ensure-graph-aes-key repo (:graph-id client))
@@ -351,8 +375,8 @@
                                                 (p/let [tx-data* (sync-crypt/<decrypt-tx-data aes-key tx-data)]
                                                   {:t t
                                                    :tx-data tx-data*}))
-                                              remote-txs))
-                                 (p/resolved remote-txs))]
+                                              remote-txs'))
+                                 (p/resolved remote-txs'))]
              (try
                (sync-apply/apply-remote-txs! repo client remote-txs*)
                (catch :default e
@@ -365,7 +389,8 @@
            (p/then (fn [_]
                      (sync-util/clear-last-sync-error! client)))
            (p/catch (fn [error]
-                      (sync-util/set-last-sync-error! client error)))))))))
+                      (sync-util/set-last-sync-error! client error))))
+          (request-pull! client local-tx))))))
 
 (defn- handle-changed!
   [repo client local-tx remote-tx]

--- a/src/test/frontend/test/node_test_runner.cljs
+++ b/src/test/frontend/test/node_test_runner.cljs
@@ -39,6 +39,18 @@
   (when (.hasOwnProperty (:actual m) "stack")
     (println (.-stack (:actual m)))))
 
+(defmethod ct/report [::node :fail] [m]
+  (ct/inc-report-counter! :fail)
+  (.write js/process.stderr
+          (str "\nFAIL in " (pr-str (ct/testing-vars-str m))
+               "\n" (when (seq (ct/testing-contexts-str))
+                      (str (ct/testing-contexts-str) "\n"))
+               (when-let [message (:message m)]
+                 (str message "\n"))
+               "expected: " (pr-str (:expected m))
+               "\n  actual: " (pr-str (:actual m))
+               "\n")))
+
 ;; CLI utils
 ;; =========
 

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -64,11 +64,6 @@
       (finally
         (aset js/console "error" original-console-error)))))
 
-(defn- thenable?
-  [value]
-  (and (some? value)
-       (fn? (.-then value))))
-
 (use-fixtures :once (test-noise/mute-console-fixture ::db-sync-test))
 
 (defn- js-row
@@ -254,8 +249,8 @@
                     (swap! client-op/*repo->pending-local-tx-count dissoc test-repo)
                     (reset! worker-state/*datascript-conns db-prev)
                     (reset! worker-state/*client-ops-conns ops-prev))]
-      (if (or (p/promise? result) (thenable? result))
-        (p/finally result cleanup)
+      (if (some? result)
+        (p/finally (p/let [value result] value) cleanup)
         (do
           (cleanup)
           result)))))
@@ -766,34 +761,17 @@
                                      (is (= 2 (client-op/get-local-tx test-repo)))))))))
                  (p/finally (fn []
                               (reset! db-sync/*repo->latest-remote-tx latest-prev)
-                              (done)))))))
+                              (done))))))))
 
 (deftest pull-ok-overlapping-window-applies-only-newer-txs-test
-  (testing "pull/ok may include already-applied older txs, but should only apply newer contiguous txs"
-    (async done
-           (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
-                 parent-id (:db/id parent)
-                 stale-tx (sqlite-util/write-transit-str [[:db/add parent-id :block/title "stale-title"]])
-                 new-tx (sqlite-util/write-transit-str [[:db/add parent-id :block/title "remote-new-title"]])
-                 raw-message (js/JSON.stringify
-                              (clj->js {:type "pull/ok"
-                                        :t 2
-                                        :txs [{:t 1 :tx stale-tx}
-                                              {:t 2 :tx new-tx}]}))
-                 client {:repo test-repo
-                         :graph-id "graph-1"
-                         :inflight (atom [])
-                         :online-users (atom [])
-                         :ws-state (atom :open)}]
-             (-> (with-datascript-conns conn client-ops-conn
-                   (fn []
-                     (client-op/update-local-tx test-repo 1)
-                     (-> (sync-handle-message/handle-message! test-repo client raw-message)
-                         (p/then (fn [_]
-                                   (let [parent' (d/entity @conn parent-id)]
-                                     (is (= "remote-new-title" (:block/title parent')))
-                                     (is (= 2 (client-op/get-local-tx test-repo)))))))))
-                 (p/finally done)))))))
+  (testing "pull/ok may include already-applied older txs, but should only keep newer contiguous txs"
+    (let [stale-tx-data [[:db/add 1 :block/title "stale-title"]]
+          new-tx-data [[:db/add 1 :block/title "remote-new-title"]]
+          window [{:t 1 :tx-data stale-tx-data}
+                  {:t 2 :tx-data new-tx-data}]]
+      (is (= [{:t 2 :tx-data new-tx-data}]
+             (#'sync-handle-message/normalize-pull-window
+              test-repo 1 2 window))))))
 
 (deftest pull-ok-gapful-window-repulls-instead-of-applying-test
   (testing "non-contiguous pull/ok window is rejected before apply"
@@ -1139,16 +1117,17 @@
                          :online-users (atom [])
                          :ws-state (atom :open)}]
              (reset! db-sync/*repo->latest-remote-tx {})
-             (with-datascript-conns conn client-ops-conn
-               (fn []
-                 (client-op/update-local-tx test-repo 1)
-                 (-> (p/let [_ (sync-handle-message/handle-message! test-repo client raw-message)
-                             parent' (d/entity @conn parent-id)]
-                       (is (= "remote-new-title" (:block/title parent')))
-                       (is (= 2 (client-op/get-local-tx test-repo))))
-                     (p/finally (fn []
-                                  (reset! db-sync/*repo->latest-remote-tx latest-prev)
-                                  (done))))))))))
+             (-> (with-datascript-conns conn client-ops-conn
+                   (fn []
+                     (client-op/update-local-tx test-repo 1)
+                     (-> (sync-handle-message/handle-message! test-repo client raw-message)
+                         (p/then (fn [_]
+                                   (let [parent' (d/entity @conn parent-id)]
+                                     (is (= "remote-new-title" (:block/title parent')))
+                                     (is (= 2 (client-op/get-local-tx test-repo)))))))))
+                 (p/finally (fn []
+                              (reset! db-sync/*repo->latest-remote-tx latest-prev)
+                              (done))))))))
 
 (deftest pull-ok-batched-txs-preserve-tempid-boundaries-test
   (testing "pull/ok applies tx batches without cross-tx tempid collisions"

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -735,7 +735,8 @@
                           (clj->js {:type "pull/ok"
                                     :t 2
                                     :checksum new-checksum
-                                    :txs [{:t 2 :tx new-tx}]}))
+                                    :txs [{:t 1 :tx stale-tx}
+                                          {:t 2 :tx new-tx}]}))
                  raw-stale (js/JSON.stringify
                             (clj->js {:type "pull/ok"
                                       :t 1
@@ -750,6 +751,7 @@
              (reset! db-sync/*repo->latest-remote-tx {})
              (with-datascript-conns conn client-ops-conn
                (fn []
+                 (client-op/update-local-tx test-repo 1)
                  (-> (p/let [_ (sync-handle-message/handle-message! test-repo client raw-new)
                              _ (sync-handle-message/handle-message! test-repo client raw-stale)
                              parent' (d/entity @conn parent-id)]
@@ -758,6 +760,38 @@
                      (p/finally (fn []
                                   (reset! db-sync/*repo->latest-remote-tx latest-prev)
                                   (done))))))))))
+
+(deftest pull-ok-overlapping-window-applies-only-newer-txs-test
+  (testing "pull/ok may include already-applied older txs, but should only apply newer contiguous txs"
+    (async done
+           (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
+                 parent-id (:db/id parent)
+                 stale-tx (sqlite-util/write-transit-str [[:db/add parent-id :block/title "stale-title"]])
+                 new-tx (sqlite-util/write-transit-str [[:db/add parent-id :block/title "remote-new-title"]])
+                 raw-message (js/JSON.stringify
+                              (clj->js {:type "pull/ok"
+                                        :t 2
+                                        :txs [{:t 1 :tx stale-tx}
+                                              {:t 2 :tx new-tx}]}))
+                 client {:repo test-repo
+                         :graph-id "graph-1"
+                         :inflight (atom [])
+                         :online-users (atom [])
+                         :ws-state (atom :open)}]
+             (with-datascript-conns conn client-ops-conn
+               (fn []
+                 (client-op/update-local-tx test-repo 1)
+                 (-> (p/let [_ (sync-handle-message/handle-message! test-repo client raw-message)
+                             parent' (d/entity @conn parent-id)]
+                       (is (= "remote-new-title" (:block/title parent')))
+                       (is (= 2 (client-op/get-local-tx test-repo))))
+                     (p/finally done))))))))
+
+(deftest pull-ok-gapful-window-repulls-instead-of-applying-test
+  (testing "non-contiguous pull/ok window is rejected before apply"
+    (let [window [{:t 3 :tx-data [[:db/add 1 :block/title "remote-new-title"]]}]]
+      (is (nil? (#'sync-handle-message/normalize-pull-window
+                 test-repo 0 3 window))))))
 
 (deftest tx-reject-db-transact-failed-surfaces-rejected-tx-test
   (testing "tx/reject with db transact failed includes parsed rejected tx and emits rtc-log"
@@ -1099,6 +1133,7 @@
              (reset! db-sync/*repo->latest-remote-tx {})
              (with-datascript-conns conn client-ops-conn
                (fn []
+                 (client-op/update-local-tx test-repo 1)
                  (-> (p/let [_ (sync-handle-message/handle-message! test-repo client raw-message)
                              parent' (d/entity @conn parent-id)]
                        (is (= "remote-new-title" (:block/title parent')))

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -64,6 +64,11 @@
       (finally
         (aset js/console "error" original-console-error)))))
 
+(defn- thenable?
+  [value]
+  (and (some? value)
+       (fn? (.-then value))))
+
 (use-fixtures :once (test-noise/mute-console-fixture ::db-sync-test))
 
 (defn- js-row
@@ -249,7 +254,7 @@
                     (swap! client-op/*repo->pending-local-tx-count dissoc test-repo)
                     (reset! worker-state/*datascript-conns db-prev)
                     (reset! worker-state/*client-ops-conns ops-prev))]
-      (if (p/promise? result)
+      (if (or (p/promise? result) (thenable? result))
         (p/finally result cleanup)
         (do
           (cleanup)
@@ -749,17 +754,19 @@
                          :online-users (atom [])
                          :ws-state (atom :open)}]
              (reset! db-sync/*repo->latest-remote-tx {})
-             (with-datascript-conns conn client-ops-conn
-               (fn []
-                 (client-op/update-local-tx test-repo 1)
-                 (-> (p/let [_ (sync-handle-message/handle-message! test-repo client raw-new)
-                             _ (sync-handle-message/handle-message! test-repo client raw-stale)
-                             parent' (d/entity @conn parent-id)]
-                       (is (= "remote-new-title" (:block/title parent')))
-                       (is (= 2 (client-op/get-local-tx test-repo))))
-                     (p/finally (fn []
-                                  (reset! db-sync/*repo->latest-remote-tx latest-prev)
-                                  (done))))))))))
+             (-> (with-datascript-conns conn client-ops-conn
+                   (fn []
+                     (client-op/update-local-tx test-repo 1)
+                     (-> (sync-handle-message/handle-message! test-repo client raw-new)
+                         (p/then (fn [_]
+                                   (sync-handle-message/handle-message! test-repo client raw-stale)))
+                         (p/then (fn [_]
+                                   (let [parent' (d/entity @conn parent-id)]
+                                     (is (= "remote-new-title" (:block/title parent')))
+                                     (is (= 2 (client-op/get-local-tx test-repo)))))))))
+                 (p/finally (fn []
+                              (reset! db-sync/*repo->latest-remote-tx latest-prev)
+                              (done)))))))
 
 (deftest pull-ok-overlapping-window-applies-only-newer-txs-test
   (testing "pull/ok may include already-applied older txs, but should only apply newer contiguous txs"
@@ -778,14 +785,15 @@
                          :inflight (atom [])
                          :online-users (atom [])
                          :ws-state (atom :open)}]
-             (with-datascript-conns conn client-ops-conn
-               (fn []
-                 (client-op/update-local-tx test-repo 1)
-                 (-> (p/let [_ (sync-handle-message/handle-message! test-repo client raw-message)
-                             parent' (d/entity @conn parent-id)]
-                       (is (= "remote-new-title" (:block/title parent')))
-                       (is (= 2 (client-op/get-local-tx test-repo))))
-                     (p/finally done))))))))
+             (-> (with-datascript-conns conn client-ops-conn
+                   (fn []
+                     (client-op/update-local-tx test-repo 1)
+                     (-> (sync-handle-message/handle-message! test-repo client raw-message)
+                         (p/then (fn [_]
+                                   (let [parent' (d/entity @conn parent-id)]
+                                     (is (= "remote-new-title" (:block/title parent')))
+                                     (is (= 2 (client-op/get-local-tx test-repo)))))))))
+                 (p/finally done)))))))
 
 (deftest pull-ok-gapful-window-repulls-instead-of-applying-test
   (testing "non-contiguous pull/ok window is rejected before apply"
@@ -1021,7 +1029,7 @@
   (testing "pull/ok clears pending pull marker so future changed can request next pull"
     (let [raw-message (js/JSON.stringify
                        (clj->js {:type "pull/ok"
-                                 :t 4
+                                 :t 3
                                  :txs []}))
           client {:repo test-repo
                   :graph-id "graph-1"


### PR DESCRIPTION
## Summary

Normalize `pull/ok` tx windows before applying remote sync txs.

A pull response can include txs the client has already applied. Those overlapping txs should be ignored. A response with gaps, however, should not be partially applied because it would advance local sync state without every expected remote tx.

## Changes

- Filter already-applied txs from `pull/ok` windows.
- Require the remaining tx numbers to be contiguous from local tx to remote tx.
- Log and re-request when a gapful pull window is received.
- Add worker tests for overlap and gap handling.

## Validation

- `git diff --check origin/master..HEAD`
- `bb dev:test -v frontend.worker.db-sync-test/pull-ok-overlapping-window-applies-only-newer-txs-test -v frontend.worker.db-sync-test/pull-ok-gapful-window-repulls-instead-of-applying-test`
