### PR TITLE
fix(assets): preserve asset titles and render fallback labels

### DIFF
--- a/deps/db/src/logseq/db/frontend/malli_schema.cljs
+++ b/deps/db/src/logseq/db/frontend/malli_schema.cljs
@@ -290,6 +290,10 @@
    [:block/refs {:optional true} [:set :int]]
    [:block/tx-id {:optional true} :int]
    [:block/collapsed? {:optional true} :boolean]
+   [:logseq.property.sync/large-title-object {:optional true}
+    [:map
+     [:asset-uuid :string]
+     [:asset-type :string]]]
    [:block/warning {:optional true} [:keyword]]
    [:logseq.property/created-by-ref {:optional true} :int]])
 

--- a/deps/db/src/logseq/db/frontend/schema.cljs
+++ b/deps/db/src/logseq/db/frontend/schema.cljs
@@ -91,6 +91,7 @@
 
    ;; page's original name
    :block/title {:db/index true}
+   :logseq.property.sync/large-title-object {:db/index true}
 
    ;; page's journal day
    :block/journal-day {:db/index true}

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -489,10 +489,21 @@
                          (p/then load$)))))
                (js/console.error _e))))))))
 
+(defn- asset-title-or-fallback
+  [asset-block]
+  (let [title (:block/title asset-block)
+        title (some-> title util/trim-safe not-empty)
+        asset-uuid (some-> (:block/uuid asset-block) str)]
+    (or title asset-uuid (t :class.built-in/asset))))
+
 (rum/defcs asset-link < rum/reactive
   (rum/local nil ::src)
   [state config title href metadata full_text]
   (let [src (::src state)
+        asset-block (:asset-block config)
+        title (if asset-block
+                (asset-title-or-fallback asset-block)
+                title)
         ^js js-url (:link-js-url config)
         href (cond-> href
                (nil? js-url)
@@ -547,7 +558,7 @@
            title]
 
           util/web-platform?
-          (let [file-name (str (:block/title (:asset-block config)) "." (name ext))]
+          (let [file-name (str title "." (name ext))]
             [:a.asset-ref
              {:href @src
               :download file-name}
@@ -555,7 +566,7 @@
 
           (and (util/electron?) (:asset-block config))
           (let [asset-block (:asset-block config)
-                file-name (str (:block/title asset-block) "." (name ext))]
+                file-name (str title "." (name ext))]
             [:a.asset-ref
              {:on-click (fn [e]
                           (util/stop e)
@@ -1086,7 +1097,7 @@
                   (asset-link (assoc config
                                      :asset-block block
                                      :image-placeholder img-placeholder)
-                              (:block/title block)
+                              (asset-title-or-fallback block)
                               (path/path-join (str "../" common-config/local-assets-dir) file)
                               img-metadata
                               nil)
@@ -1098,13 +1109,6 @@
            [:div.asset-transfer-placeholder (t :asset/transfer-placeholder label)])
        progress-view]
       content)))
-
-(defn- img-audio-video?
-  [block]
-  (let [asset-type (some-> (:logseq.property.asset/type block) keyword)]
-    (or (contains? (common-config/img-formats) asset-type)
-        (contains? config/audio-formats asset-type)
-        (contains? config/video-formats asset-type))))
 
 (declare block-positioned-properties)
 
@@ -1141,7 +1145,7 @@
                              (not contents-page?))]
           (when-not (and (:db/id block) (= (:db/id block) (:db/id (:block config))))
             (cond
-              (and asset? (img-audio-video? block))
+              asset?
               (asset-cp config block)
 
               (and (string? uuid-or-title) (string/ends-with? uuid-or-title ".excalidraw"))
@@ -3025,7 +3029,7 @@
                                      config))]
              show-editor? (and editor-box edit? (not type-block-editor?))]
          (cond
-           (and (ldb/asset? block) (img-audio-video? block))
+           (ldb/asset? block)
            [:div.flex.flex-col.asset-block-wrap.w-full
             (block-content-f {:custom-block-content
                               [:div.flex.flex-1

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1241,7 +1241,8 @@
       (let [value (string/trim value)]
         ;; FIXME: somehow frontend.components.editor's will-unmount event will loop forever
         ;; maybe we shouldn't save in "will-unmount" event?
-        (save-block-if-changed! block value opts)))))
+        (when-not (and (ldb/asset? entity) (string/blank? value))
+          (save-block-if-changed! block value opts))))))
 
 (defn save-block!
   ([repo block-or-uuid content]
@@ -1324,7 +1325,8 @@
           [file external-url] (if (string? file) [nil file] [file external-url])
           file-name (node-path/basename (or (some-> file (.-name)) (str external-url)))
           file-name-without-ext* (db-asset/asset-name->title file-name)
-          file-name-without-ext (if (= file-name-without-ext* "image")
+          file-name-without-ext (if (or (= file-name-without-ext* "image")
+                                        (string/blank? file-name-without-ext*))
                                   (date/get-date-time-string-2)
                                   file-name-without-ext*)
           checksum (some-> (or file external-url) (assets-handler/get-file-checksum))
@@ -1351,7 +1353,8 @@
          (when file
            (let [file-path (str block-id "." ext)]
              (db-based-write-asset! repo file-path file)))
-         {:block/title (or title file-name-without-ext)
+         {:block/title (or (some-> title util/trim-safe not-empty)
+                           file-name-without-ext)
           :block/uuid block-id
           :logseq.property.asset/type ext
           :logseq.property.asset/external-url external-url


### PR DESCRIPTION
## Summary

Preserve asset block titles and render fallback labels for all asset block types.

Synced or imported asset blocks can have blank titles, and non-image/audio/video assets were not rendered through the asset component path. That left some asset blocks with missing labels or no visible asset affordance.

## Changes

- Trim explicit asset titles and keep them when present.
- Fall back to asset UUID, then the translated built-in Asset label, when title is blank.
- Render all DB asset blocks through the asset component instead of only image/audio/video assets.
- Avoid saving a blank editor value over an existing asset title.
- Treat blank uploaded file stems like generic `image` stems and replace them with a timestamp title.

## Validation

- `git diff --check origin/master..HEAD`
- `bb lang:lint-hardcoded --git-changed`
- `clojure -M:clj-kondo --lint src/main/frontend/components/block.cljs src/main/frontend/handler/editor.cljs --cache false`
