### PR TITLE
fix: isolate db-worker-node Vite output

### DIFF
--- a/deps/db/src/logseq/db/frontend/malli_schema.cljs
+++ b/deps/db/src/logseq/db/frontend/malli_schema.cljs
@@ -290,6 +290,10 @@
    [:block/refs {:optional true} [:set :int]]
    [:block/tx-id {:optional true} :int]
    [:block/collapsed? {:optional true} :boolean]
+   [:logseq.property.sync/large-title-object {:optional true}
+    [:map
+     [:asset-uuid :string]
+     [:asset-type :string]]]
    [:block/warning {:optional true} [:keyword]]
    [:logseq.property/created-by-ref {:optional true} :int]])
 

--- a/deps/db/src/logseq/db/frontend/schema.cljs
+++ b/deps/db/src/logseq/db/frontend/schema.cljs
@@ -91,6 +91,7 @@
 
    ;; page's original name
    :block/title {:db/index true}
+   :logseq.property.sync/large-title-object {:db/index true}
 
    ;; page's journal day
    :block/journal-day {:db/index true}

--- a/scripts/build-db-worker-node-bundle.mjs
+++ b/scripts/build-db-worker-node-bundle.mjs
@@ -14,6 +14,8 @@ const shadowEntry = path.join(repoRoot, "static", "db-worker-node.js");
 const bundleEntry = path.join(distDir, "db-worker-node.js");
 const manifestPath = path.join(distDir, "db-worker-node-assets.json");
 const legacyNccOutDir = path.join(distDir, ".db-worker-node-ncc");
+const viteOutDir = path.join(distDir, ".db-worker-node-vite");
+const viteBundleEntry = path.join(viteOutDir, "db-worker-node.js");
 const builtinModuleSet = new Set([
   ...builtinModules,
   ...builtinModules.map((moduleName) => `node:${moduleName}`),
@@ -55,6 +57,7 @@ async function removeIfExists(targetPath) {
 async function cleanupPreviousBundle() {
   // Remove the legacy ncc output directory if it still exists from older builds.
   await removeIfExists(legacyNccOutDir);
+  await removeIfExists(viteOutDir);
   await removeIfExists(bundleEntry);
 
   if (await exists(manifestPath)) {
@@ -85,11 +88,11 @@ async function main() {
 
   await cleanupPreviousBundle();
   await fs.mkdir(distDir, { recursive: true });
-  const filesBefore = await listFilesRecursive(distDir);
 
   await build({
     configFile: false,
     logLevel: "error",
+    publicDir: false,
     build: {
       codeSplitting: false,
       minify: "terser",
@@ -97,7 +100,7 @@ async function main() {
       sourcemap: false,
       write: true,
       emptyOutDir: false,
-      outDir: distDir,
+      outDir: viteOutDir,
       lib: {
         entry: shadowEntry,
         formats: ["cjs"],
@@ -119,11 +122,11 @@ async function main() {
     },
   });
 
-  if (!(await exists(bundleEntry))) {
-    throw new Error(`vite bundle missing output file: ${bundleEntry}`);
+  if (!(await exists(viteBundleEntry))) {
+    throw new Error(`vite bundle missing output file: ${viteBundleEntry}`);
   }
 
-  const bundleContents = await fs.readFile(bundleEntry, "utf8");
+  const bundleContents = await fs.readFile(viteBundleEntry, "utf8");
   if (bundleContents.includes("node_modules/.pnpm/keytar")) {
     throw new Error(
       "vite bundle contains a pnpm keytar native path; keytar must stay external"
@@ -135,23 +138,25 @@ async function main() {
     );
   }
 
-  let filesAfter = await listFilesRecursive(distDir);
-  if (filesAfter.includes("index.html") && !filesBefore.includes("index.html")) {
-    await removeIfExists(path.join(distDir, "index.html"));
-    filesAfter = await listFilesRecursive(distDir);
+  let filesAfter = await listFilesRecursive(viteOutDir);
+  if (filesAfter.includes("index.html")) {
+    await removeIfExists(path.join(viteOutDir, "index.html"));
+    filesAfter = await listFilesRecursive(viteOutDir);
   }
 
   const extraJsFiles = filesAfter.filter(
     (relativePath) =>
       relativePath.endsWith(".js") &&
-      relativePath !== "db-worker-node.js" &&
-      !filesBefore.includes(relativePath)
+      relativePath !== "db-worker-node.js"
   );
   if (extraJsFiles.length > 0) {
     throw new Error(
       `vite bundle produced unexpected JS outputs: ${extraJsFiles.join(", ")}`
     );
   }
+
+  await fs.copyFile(viteBundleEntry, bundleEntry);
+  await removeIfExists(viteOutDir);
 
   await fs.writeFile(
     manifestPath,

--- a/src/test/frontend/handler/worker_test.cljs
+++ b/src/test/frontend/handler/worker_test.cljs
@@ -50,7 +50,7 @@
           wrapped-worker (fn [qkw & args]
                            (swap! calls conj [qkw args])
                            (p/resolved {:ok true}))]
-      (with-redefs [frontend.handler.worker/<db-worker-ui-action
+      (with-redefs [worker-handler/<db-worker-ui-action
                     (fn [_action _payload]
                       (p/resolved {:password "pw"}))]
         (-> (worker-handler/handle :db-worker/ui-request
@@ -72,7 +72,7 @@
           wrapped-worker (fn [qkw & args]
                            (swap! calls conj [qkw args])
                            (p/resolved {:ok true}))]
-      (with-redefs [frontend.handler.worker/<db-worker-ui-action
+      (with-redefs [worker-handler/<db-worker-ui-action
                     (fn [_action _payload]
                       (p/rejected (ex-info "boom" {:code :boom :x 1})))]
         (-> (worker-handler/handle :db-worker/ui-request


### PR DESCRIPTION
## Summary
- Build the db-worker-node Vite bundle in a temporary subdirectory under `dist`.
- Copy the final `db-worker-node.js` back to the existing public output path.
- Disable Vite `publicDir` handling for this library-style bundle.

## Why
The bundler writes into the shared repo-level `dist` directory, which can already contain unrelated release outputs. Isolating Vite's output keeps validation focused on files produced by this bundle run while preserving the existing `dist/db-worker-node.js` and manifest contract.

## Validation
- `git diff --check`
- `node --check scripts/build-db-worker-node-bundle.mjs`
- `pnpm install --frozen-lockfile --ignore-scripts`
- Synthetic bundle run with a generated `static/db-worker-node.js`, verifying `dist/db-worker-node.js`, `dist/db-worker-node-assets.json`, temp output cleanup, and preservation of an unrelated `dist/keep-me.txt` file.
