### PR TITLE
[codex] Preserve desktop release artifacts during clean

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,6 +22,7 @@ const outputFilePath = path.join(outputPath, '**')
 const rawCopySrc = (globs, options = {}) =>
   gulp.src(globs, { encoding: false, ...options })
 const staticCleanKeep = new Set([
+  'dist',
   'entitlements.plist',
   'node_modules',
   'package.json',


### PR DESCRIPTION
## Summary
- Keep `static/dist` when `gulp clean` removes generated static assets.

## Why
Desktop release workflows collect Electron artifacts from `static/dist`. Cleaning `static` should not delete that release output directory between build steps.

## Validation
- `git diff --check`
- `node --check gulpfile.js`
