### PR TITLE
fix(sync): resume bootstrap uploads and seed empty downloads

### DIFF
--- a/deps/db/src/logseq/db/frontend/malli_schema.cljs
+++ b/deps/db/src/logseq/db/frontend/malli_schema.cljs
@@ -290,6 +290,10 @@
    [:block/refs {:optional true} [:set :int]]
    [:block/tx-id {:optional true} :int]
    [:block/collapsed? {:optional true} :boolean]
+   [:logseq.property.sync/large-title-object {:optional true}
+    [:map
+     [:asset-uuid :string]
+     [:asset-type :string]]]
    [:block/warning {:optional true} [:keyword]]
    [:logseq.property/created-by-ref {:optional true} :int]])
 

--- a/deps/db/src/logseq/db/frontend/schema.cljs
+++ b/deps/db/src/logseq/db/frontend/schema.cljs
@@ -91,6 +91,7 @@
 
    ;; page's original name
    :block/title {:db/index true}
+   :logseq.property.sync/large-title-object {:db/index true}
 
    ;; page's journal day
    :block/journal-day {:db/index true}

--- a/src/main/frontend/handler/db_based/sync.cljs
+++ b/src/main/frontend/handler/db_based/sync.cljs
@@ -45,6 +45,7 @@
 
 (declare coerce-http-response)
 (declare <sync-auth-state-to-db-worker!)
+(declare <get-remote-graphs)
 
 (defn fetch-json
   [url opts {:keys [response-schema error-schema] :or {error-schema :error}}]
@@ -99,10 +100,15 @@
   [repo]
   (some #(when (= repo (:url %)) %) (state/get-rtc-graphs)))
 
+(defn- local-graph-id
+  [repo]
+  (some-> (db/get-db repo)
+          ldb/get-graph-rtc-uuid
+          str))
+
 (defn- graph-has-local-rtc-id?
   [repo]
-  (boolean (some-> (db/get-db repo)
-                   ldb/get-graph-rtc-uuid)))
+  (boolean (local-graph-id repo)))
 
 (defn- should-start-rtc?
   [repo]
@@ -110,6 +116,16 @@
        (let [graph (remote-graph repo)]
          (and (some? graph)
               (not= false (:graph-ready-for-use? graph))))))
+
+(defn- should-resume-graph-upload?
+  [repo]
+  (let [graph (remote-graph repo)
+        local-graph-uuid (local-graph-id repo)]
+    (and (not (true? (:rtc/uploading? @state/state)))
+         (some? graph)
+         (= false (:graph-ready-for-use? graph))
+         (string? local-graph-uuid)
+         (= local-graph-uuid (:GraphUUID graph)))))
 
 (defn- normalize-graph-e2ee?
   [graph-e2ee?]
@@ -185,16 +201,51 @@
           payload (sync-app-state-payload)]
     (state/<invoke-db-worker :thread-api/sync-app-state payload)))
 
+(defn- <upload-graph-and-refresh!
+  [repo]
+  (-> (p/let [_ (state/set-state! :rtc/uploading? true)
+              _ (state/<invoke-db-worker :thread-api/db-sync-upload-graph repo)
+              graphs (<get-remote-graphs)]
+        graphs)
+      (p/finally
+        (fn []
+          (state/set-state! :rtc/uploading? false)))))
+
 (defn <rtc-start!
   [repo & {:keys [_stop-before-start?] :as _opts}]
   (p/let [_ (<wait-for-db-worker-ready!)]
-    (if (should-start-rtc? repo)
+    (cond
+      (should-start-rtc? repo)
       (do
         (log/info :db-sync/start {:repo repo})
         (p/let [_ (<sync-auth-state-to-db-worker!)]
           (state/<invoke-db-worker :thread-api/db-sync-start repo)))
+
+      (should-resume-graph-upload? repo)
+      (let [graph (remote-graph repo)]
+        (log/info :db-sync/resume-upload
+                  {:repo repo
+                   :graph-id (:GraphUUID graph)})
+        (p/let [_ (<upload-graph-and-refresh! repo)]
+          (if (should-start-rtc? repo)
+            (do
+              (log/info :db-sync/start {:repo repo :reason :bootstrap-upload-finished})
+              (p/let [_ (<sync-auth-state-to-db-worker!)]
+                (state/<invoke-db-worker :thread-api/db-sync-start repo)))
+            (do
+              (log/info :db-sync/skip-start
+                        {:repo repo
+                         :reason :graph-not-ready-for-use
+                         :remote-graphs-loading? (:rtc/loading-graphs? @state/state)
+                         :has-local-rtc-id? (graph-has-local-rtc-id? repo)})
+              (<rtc-stop!)))))
+
+      :else
       (do
-        (log/info :db-sync/skip-start {:repo repo :reason :graph-not-in-remote-list
+        (log/info :db-sync/skip-start {:repo repo
+                                       :reason (if (some? (remote-graph repo))
+                                                 :graph-not-ready-for-use
+                                                 :graph-not-in-remote-list)
                                        :remote-graphs-loading? (:rtc/loading-graphs? @state/state)
                                        :has-local-rtc-id? (graph-has-local-rtc-id? repo)})
         (<rtc-stop!)))))
@@ -384,11 +435,13 @@
                           :graph-uuid graph-uuid}))))
 
 (defn <rtc-upload-graph!
-  [repo _graph-e2ee?]
-  (p/do!
-   (state/<invoke-db-worker :thread-api/db-sync-upload-graph repo)
-   (<get-remote-graphs)
-   (<rtc-start! repo)))
+  [repo graph-e2ee?]
+  (p/let [graph-id (<rtc-create-graph! repo graph-e2ee? false)]
+    (when (nil? graph-id)
+      (throw (ex-info "graph id doesn't exist when uploading to server" {:repo repo})))
+    (p/do!
+     (<upload-graph-and-refresh! repo)
+     (<rtc-start! repo))))
 
 (defn <rtc-create-graph-and-start-sync!
   [repo graph-e2ee?]

--- a/src/main/frontend/worker/sync/download.cljs
+++ b/src/main/frontend/worker/sync/download.cljs
@@ -15,11 +15,13 @@
    [frontend.worker.sync.temp-sqlite :as sync-temp-sqlite]
    [frontend.worker.sync.util :refer [fail-fast] :as sync-util]
    [lambdaisland.glogi :as log]
+   [logseq.db :as ldb]
    [logseq.db-sync.snapshot :as snapshot]
    [logseq.db.common.sqlite :as common-sqlite]
    [logseq.db.frontend.schema :as db-schema]
-   [promesa.core :as p]
-   [logseq.db :as ldb]))
+   [logseq.db.sqlite.create-graph :as sqlite-create-graph]
+   [logseq.db.sqlite.util :as sqlite-util]
+   [promesa.core :as p]))
 
 (defn- ->uint8 [data]
   (cond
@@ -446,6 +448,13 @@
   (-> (p/let [state (require-import-state! repo graph-id import-id)
               _ (when (:rows-imported? state)
                   (<replay-imported-rows! state))
+              {:keys [conn graph-e2ee? imported-datoms]} (require-import-state! repo graph-id import-id)
+              _ (when (zero? imported-datoms)
+                  (ldb/transact! conn
+                                 (into (sqlite-create-graph/build-db-initial-data "" :remote-graph? true)
+                                       [(sqlite-util/kv :logseq.kv/graph-uuid (uuid graph-id))
+                                        (sqlite-util/kv :logseq.kv/graph-rtc-e2ee? graph-e2ee?)])
+                                 {:initial-db? true}))
               result (complete-datoms-import! repo graph-id remote-tx)
               _ (clear-import-state! import-id)]
         result)
@@ -503,14 +512,16 @@
                                                {:keys [import-id]} (prepare-import! repo true graph-id graph-e2ee?)]
                                          (reset! import-id* import-id)
                                          import-id)))]
-                (p/let [_ (do
-                            (reset! stage* :stream-snapshot)
-                            (<stream-snapshot-row-batches!
-                             resp
-                             25000
-                             (fn [rows]
-                               (p/let [import-id (ensure-import!)]
-                                 (import-rows-chunk! rows graph-id import-id)))))
+                (p/let [{:keys [chunk-count]} (do
+                                                (reset! stage* :stream-snapshot)
+                                                (<stream-snapshot-row-batches!
+                                                 resp
+                                                 25000
+                                                 (fn [rows]
+                                                   (p/let [import-id (ensure-import!)]
+                                                     (import-rows-chunk! rows graph-id import-id)))))
+                        _ (when (zero? chunk-count)
+                            (ensure-import!))
                         _ (log-f {:sub-type :download-completed
                                   :graph-uuid graph-id
                                   :message "Graph snapshot downloaded"})

--- a/src/test/frontend/handler/db_based/sync_test.cljs
+++ b/src/test/frontend/handler/db_based/sync_test.cljs
@@ -2,12 +2,14 @@
   (:require [cljs.test :refer [deftest is async]]
             [clojure.string :as string]
             [frontend.config :as config]
+            [frontend.db :as db]
             [frontend.handler.db-based.sync :as db-sync]
             [frontend.persist-db :as persist-db]
             [frontend.handler.repo :as repo-handler]
             [frontend.handler.user :as user-handler]
             [frontend.state :as state]
             [frontend.util :as util]
+            [logseq.db :as ldb]
             [promesa.core :as p]))
 
 (deftest remove-member-request-test
@@ -110,12 +112,13 @@
 
 (deftest rtc-upload-graph-creates-remote-graph-as-not-ready-test
   (async done
-         (let [upload-calls (atom [])
+         (let [create-calls (atom [])
+               upload-calls (atom [])
                refresh-calls (atom 0)
                start-calls (atom [])]
-           (-> (p/with-redefs [db-sync/http-base (fn [] "http://base")
-                               user-handler/task--ensure-id&access-token (fn [resolve _reject]
-                                                                           (resolve true))
+           (-> (p/with-redefs [db-sync/<rtc-create-graph! (fn [repo graph-e2ee? & [graph-ready-for-use?]]
+                                                            (swap! create-calls conj [repo graph-e2ee? graph-ready-for-use?])
+                                                            (p/resolved "graph-3"))
                                state/<invoke-db-worker (fn [& args]
                                                          (swap! upload-calls conj args)
                                                          (p/resolved :ok))
@@ -127,6 +130,8 @@
                                                      (p/resolved :ok))]
                  (db-sync/<rtc-upload-graph! "logseq_db_demo" false))
                (p/then (fn [_]
+                         (is (= [["logseq_db_demo" false false]]
+                                @create-calls))
                          (is (= [[:thread-api/db-sync-upload-graph "logseq_db_demo"]]
                                 @upload-calls))
                          (is (= 1 @refresh-calls))
@@ -201,6 +206,8 @@
                   :rtc/loading-graphs? false)
            (-> (p/with-redefs [state/get-rtc-graphs (fn [] [{:url "demo-graph"
                                                              :graph-ready-for-use? false}])
+                               db/get-db (fn [_repo] :db)
+                               ldb/get-graph-rtc-uuid (fn [_db] nil)
                                state/<invoke-db-worker (fn [& args]
                                                          (swap! calls conj args)
                                                          (p/resolved :ok))]
@@ -208,6 +215,51 @@
                (p/then (fn [_]
                          (is (not-any? #(= :thread-api/db-sync-start (first %)) @calls))
                          (is (some #(= :thread-api/db-sync-stop (first %)) @calls))
+                         (done)))
+               (p/catch (fn [error]
+                          (is false (str error))
+                          (done)))
+               (p/finally (fn []
+                            (reset! state/*db-worker worker-prev)
+                            (reset! state/state state-prev)))))))
+
+(deftest rtc-start-resumes-upload-when-remote-graph-is-not-ready-for-use-test
+  (async done
+         (let [worker-prev @state/*db-worker
+               state-prev @state/state
+               calls (atom [])
+               upload-state-changes (atom [])
+               remote-graphs (atom [{:url "demo-graph"
+                                     :GraphUUID "11111111-1111-1111-1111-111111111111"
+                                     :graph-ready-for-use? false}])]
+           (reset! state/*db-worker :worker)
+           (swap! state/state assoc
+                  :rtc/uploading? false
+                  :rtc/loading-graphs? false)
+           (-> (p/with-redefs [state/get-rtc-graphs (fn [] @remote-graphs)
+                               user-handler/task--ensure-id&access-token (fn [resolve _reject]
+                                                                           (resolve true))
+                               db/get-db (fn [_repo] :db)
+                               ldb/get-graph-rtc-uuid (fn [_db] (uuid "11111111-1111-1111-1111-111111111111"))
+                               state/set-state! (fn [k v]
+                                                  (when (= k :rtc/uploading?)
+                                                    (swap! upload-state-changes conj v))
+                                                  (swap! state/state assoc k v)
+                                                  nil)
+                               state/<invoke-db-worker (fn [& args]
+                                                         (swap! calls conj args)
+                                                         (p/resolved :ok))
+                               db-sync/<get-remote-graphs (fn []
+                                                            (reset! remote-graphs
+                                                                    [{:url "demo-graph"
+                                                                      :GraphUUID "11111111-1111-1111-1111-111111111111"
+                                                                      :graph-ready-for-use? true}])
+                                                            (p/resolved @remote-graphs))]
+                 (db-sync/<rtc-start! "demo-graph"))
+               (p/then (fn [_]
+                         (is (some #(= [:thread-api/db-sync-upload-graph "demo-graph"] %) @calls))
+                         (is (some #(= [:thread-api/db-sync-start "demo-graph"] %) @calls))
+                         (is (= [true false] @upload-state-changes))
                          (done)))
                (p/catch (fn [error]
                           (is false (str error))

--- a/src/test/frontend/handler/worker_test.cljs
+++ b/src/test/frontend/handler/worker_test.cljs
@@ -50,7 +50,7 @@
           wrapped-worker (fn [qkw & args]
                            (swap! calls conj [qkw args])
                            (p/resolved {:ok true}))]
-      (with-redefs [frontend.handler.worker/<db-worker-ui-action
+      (with-redefs [worker-handler/<db-worker-ui-action
                     (fn [_action _payload]
                       (p/resolved {:password "pw"}))]
         (-> (worker-handler/handle :db-worker/ui-request
@@ -72,7 +72,7 @@
           wrapped-worker (fn [qkw & args]
                            (swap! calls conj [qkw args])
                            (p/resolved {:ok true}))]
-      (with-redefs [frontend.handler.worker/<db-worker-ui-action
+      (with-redefs [worker-handler/<db-worker-ui-action
                     (fn [_action _payload]
                       (p/rejected (ex-info "boom" {:code :boom :x 1})))]
         (-> (worker-handler/handle :db-worker/ui-request

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -5,6 +5,7 @@
    [clojure.string :as string]
    [datascript.core :as d]
    [frontend.common.crypt :as crypt]
+   [frontend.common.thread-api :as thread-api]
    [frontend.worker-common.util :as worker-util]
    [frontend.worker.handler.page :as worker-page]
    [frontend.worker.pipeline :as worker-pipeline]
@@ -17,6 +18,7 @@
    [frontend.worker.sync.auth :as sync-auth]
    [frontend.worker.sync.client-op :as client-op]
    [frontend.worker.sync.crypt :as sync-crypt]
+   [frontend.worker.sync.download :as sync-download]
    [frontend.worker.sync.handle-message :as sync-handle-message]
    [frontend.worker.sync.large-title :as sync-large-title]
    [frontend.worker.sync.log-and-state :as sync-log-state]
@@ -4671,6 +4673,50 @@
                    (is (= [[1 2] [3 4] [5]] @seen-batches))
                    (is (= [[2 5] [4 5] [5 5]] @progress-calls)))
                  (p/finally done))))))
+
+(deftest finalize-import-seeds-empty-graph-test
+  (testing "empty snapshot imports seed the built-in graph structure before finalization"
+    (async done
+           (let [conn (db-test/create-conn)
+                 client-ops-conn (new-client-ops-db)
+                 import-id "import-1"
+                 graph-id "11111111-1111-1111-1111-111111111111"]
+             (with-datascript-conns
+               conn
+               client-ops-conn
+               (fn []
+                 (reset! @#'sync-download/*import-state
+                         {:repo test-repo
+                          :graph-id graph-id
+                          :import-id import-id
+                          :conn conn
+                          :graph-e2ee? true
+                          :imported-datoms 0
+                          :rows-db nil
+                          :rows-imported? false
+                          :rows-path nil
+                          :rows-pool nil})
+                 (with-redefs [thread-api/*thread-apis (atom {:thread-api/db-sync-rehydrate-large-titles
+                                                              (fn [_repo _graph-id] nil)})
+                               worker-state/get-sqlite-conn (fn [& _] nil)
+                               shared-service/broadcast-to-clients! (fn [& _] nil)]
+                   (let [result (sync-download/finalize-import! test-repo graph-id 7 import-id)]
+                     (-> result
+                         (p/then
+                          (fn [value]
+                            (is (nil? value))
+                            (is (= 7 (client-op/get-local-tx test-repo)))
+                            (is (= (uuid graph-id) (ldb/get-graph-rtc-uuid @conn)))
+                            (is (= true (:kv/value (d/entity @conn :logseq.kv/graph-rtc-e2ee?))))
+                            (is (some? (d/entity @conn :logseq.kv/schema-version)))
+                            (is (nil? @(deref #'sync-download/*import-state)))))
+                         (p/catch
+                          (fn [error]
+                            (is false (str error))))
+                         (p/finally
+                          (fn []
+                            (reset! @#'sync-download/*import-state nil)
+                            (done))))))))))))
 
 (deftest create-temp-sqlite-db-uses-opfs-pool-test
   (testing "temp upload db should use an OPFS-backed sqlite db instead of :memory:"


### PR DESCRIPTION
## Summary
- create upload bootstrap graphs as not-ready, then mark them through the existing db-worker upload path
- resume a not-ready remote graph upload on sync startup when the local graph UUID matches
- initialize the built-in DB graph structure when a snapshot download contains zero rows

## Tests
- `git diff --check`
- `bb dev:test-no-worker -v frontend.handler.db-based.sync-test/rtc-upload-graph-creates-remote-graph-as-not-ready-test -v frontend.handler.db-based.sync-test/rtc-start-resumes-upload-when-remote-graph-is-not-ready-for-use-test -v frontend.handler.db-based.sync-test/rtc-start-skips-when-remote-graph-is-not-ready-for-use-test`
- `bb dev:test -v frontend.worker.db-sync-test/finalize-import-seeds-empty-graph-test`
- `clojure -M:clj-kondo --lint src/main/frontend/handler/db_based/sync.cljs src/main/frontend/worker/sync/download.cljs src/test/frontend/handler/db_based/sync_test.cljs src/test/frontend/worker/db_sync_test.cljs --cache false`
