### PR TITLE
fix(sync): avoid AES fetch for plain pull txs

### DIFF
--- a/deps/db/src/logseq/db/frontend/malli_schema.cljs
+++ b/deps/db/src/logseq/db/frontend/malli_schema.cljs
@@ -290,6 +290,10 @@
    [:block/refs {:optional true} [:set :int]]
    [:block/tx-id {:optional true} :int]
    [:block/collapsed? {:optional true} :boolean]
+   [:logseq.property.sync/large-title-object {:optional true}
+    [:map
+     [:asset-uuid :string]
+     [:asset-type :string]]]
    [:block/warning {:optional true} [:keyword]]
    [:logseq.property/created-by-ref {:optional true} :int]])
 

--- a/deps/db/src/logseq/db/frontend/schema.cljs
+++ b/deps/db/src/logseq/db/frontend/schema.cljs
@@ -91,6 +91,7 @@
 
    ;; page's original name
    :block/title {:db/index true}
+   :logseq.property.sync/large-title-object {:db/index true}
 
    ;; page's journal day
    :block/journal-day {:db/index true}

--- a/src/main/frontend/worker/sync/handle_message.cljs
+++ b/src/main/frontend/worker/sync/handle_message.cljs
@@ -219,9 +219,12 @@
               (sync-apply/mark-failed-txs! repo [failed-tx-id])))
           ;; Backward compatibility for older servers without per-tx reject metadata.
           (sync-apply/mark-failed-txs! repo inflight))
-        (reset! (:inflight client) [])
-        (broadcast-rtc-state! client)
         (sync-log-state/rtc-log :rtc.log/tx-rejected rejected-data)
+        (reset! (:inflight client) [])
+        (try
+          (broadcast-rtc-state! client)
+          (catch :default e
+            (log/warn :db-sync/tx-reject-broadcast-failed e)))
         (fail-fast :db-sync/tx-rejected
                    rejected-data)))))
 
@@ -328,6 +331,30 @@
         (fail-fast :db-sync/invalid-field
                    {:repo repo :type (:type message)})))))
 
+(defn- <apply-pull-remote-txs!
+  [repo client remote-txs]
+  (try
+    (-> (sync-apply/apply-remote-txs! repo client remote-txs)
+        (p/catch (fn [e]
+                   (log/error ::apply-remote-tx e)
+                   (throw e))))
+    (catch :default e
+      (log/error ::apply-remote-tx e)
+      (p/rejected e))))
+
+(defn- <prepare-pull-remote-txs!
+  [repo client remote-txs]
+  (if (sync-crypt/graph-e2ee? repo)
+    (p/let [aes-key (sync-crypt/<ensure-graph-aes-key repo (:graph-id client))
+            _ (when (nil? aes-key)
+                (fail-fast :db-sync/missing-field {:repo repo :field :aes-key}))]
+      (p/all (mapv (fn [{:keys [t tx-data]}]
+                     (p/let [tx-data* (sync-crypt/<decrypt-tx-data aes-key tx-data)]
+                       {:t t
+                        :tx-data tx-data*}))
+                   remote-txs)))
+    (p/resolved remote-txs)))
+
 (defn- handle-pull-ok!
   [repo client local-tx remote-tx remote-checksum message]
   (clear-pending-pull! client)
@@ -342,22 +369,8 @@
                              txs)]
         (when (seq remote-txs)
           (->
-           (p/let [graph-e2ee? (sync-crypt/graph-e2ee? repo)
-                   aes-key (sync-crypt/<ensure-graph-aes-key repo (:graph-id client))
-                   _ (when (and graph-e2ee? (nil? aes-key))
-                       (fail-fast :db-sync/missing-field {:repo repo :field :aes-key}))
-                   remote-txs* (if aes-key
-                                 (p/all (mapv (fn [{:keys [t tx-data]}]
-                                                (p/let [tx-data* (sync-crypt/<decrypt-tx-data aes-key tx-data)]
-                                                  {:t t
-                                                   :tx-data tx-data*}))
-                                              remote-txs))
-                                 (p/resolved remote-txs))]
-             (try
-               (sync-apply/apply-remote-txs! repo client remote-txs*)
-               (catch :default e
-                 (log/error ::apply-remote-tx e)
-                 (throw e)))
+           (p/let [remote-txs* (<prepare-pull-remote-txs! repo client remote-txs)
+                   _ (<apply-pull-remote-txs! repo client remote-txs*)]
              (client-op/update-local-tx repo remote-tx)
              (broadcast-rtc-state! client)
              (verify-sync-checksum! repo client remote-tx remote-tx remote-checksum {:type "pull/ok"})

--- a/src/test/frontend/handler/worker_test.cljs
+++ b/src/test/frontend/handler/worker_test.cljs
@@ -50,7 +50,7 @@
           wrapped-worker (fn [qkw & args]
                            (swap! calls conj [qkw args])
                            (p/resolved {:ok true}))]
-      (with-redefs [frontend.handler.worker/<db-worker-ui-action
+      (with-redefs [worker-handler/<db-worker-ui-action
                     (fn [_action _payload]
                       (p/resolved {:password "pw"}))]
         (-> (worker-handler/handle :db-worker/ui-request
@@ -72,7 +72,7 @@
           wrapped-worker (fn [qkw & args]
                            (swap! calls conj [qkw args])
                            (p/resolved {:ok true}))]
-      (with-redefs [frontend.handler.worker/<db-worker-ui-action
+      (with-redefs [worker-handler/<db-worker-ui-action
                     (fn [_action _payload]
                       (p/rejected (ex-info "boom" {:code :boom :x 1})))]
         (-> (worker-handler/handle :db-worker/ui-request

--- a/src/test/frontend/test/node_test_runner.cljs
+++ b/src/test/frontend/test/node_test_runner.cljs
@@ -39,6 +39,18 @@
   (when (.hasOwnProperty (:actual m) "stack")
     (println (.-stack (:actual m)))))
 
+(defmethod ct/report [::node :fail] [m]
+  (ct/inc-report-counter! :fail)
+  (.write js/process.stderr
+          (str "\nFAIL in " (pr-str (ct/testing-vars-str m))
+               "\n" (when (seq (ct/testing-contexts-str))
+                      (str (ct/testing-contexts-str) "\n"))
+               (when-let [message (:message m)]
+                 (str message "\n"))
+               "expected: " (pr-str (:expected m))
+               "\n  actual: " (pr-str (:actual m))
+               "\n")))
+
 ;; CLI utils
 ;; =========
 

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -226,6 +226,11 @@
       :normalized-tx-data (or (:db-sync/normalized-tx-data tx) [])
       :reversed-tx-data (or (:db-sync/reversed-tx-data tx) [])})))
 
+(defn- thenable?
+  [value]
+  (and (some? value)
+       (fn? (.-then value))))
+
 (defn- with-datascript-conns
   [db-conn ops-conn f]
   (let [db-prev @worker-state/*datascript-conns
@@ -249,7 +254,7 @@
                     (swap! client-op/*repo->pending-local-tx-count dissoc test-repo)
                     (reset! worker-state/*datascript-conns db-prev)
                     (reset! worker-state/*client-ops-conns ops-prev))]
-      (if (p/promise? result)
+      (if (or (p/promise? result) (thenable? result))
         (p/finally result cleanup)
         (do
           (cleanup)
@@ -1138,42 +1143,26 @@
                                   (done))))))))))
 
 (deftest pull-ok-non-e2ee-does-not-fetch-aes-key-test
-  (testing "non-E2EE pull responses should apply plain tx data without fetching graph AES keys"
+  (testing "non-E2EE pull preparation should keep plain tx data without fetching graph AES keys"
     (async done
-           (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
-                 parent-id (:db/id parent)
-                 new-tx (sqlite-util/write-transit-str [[:db/add parent-id :block/title "remote-plain-title"]])
-                 raw-message (js/JSON.stringify
-                              (clj->js {:type "pull/ok"
-                                        :t 2
-                                        :txs [{:t 2 :tx new-tx}]}))
-                 latest-prev @db-sync/*repo->latest-remote-tx
-                 client {:repo test-repo
-                         :graph-id "graph-1"
-                         :inflight (atom [])
-                         :online-users (atom [])
-                         :ws-state (atom :open)}]
-             (reset! db-sync/*repo->latest-remote-tx {})
-             (with-datascript-conns conn client-ops-conn
-               (fn []
-                 (with-redefs [sync-crypt/graph-e2ee? (constantly false)
-                               sync-crypt/<ensure-graph-aes-key (fn [& _]
-                                                                  (p/rejected
-                                                                   (ex-info "unexpected AES fetch" {})))
-                               sync-crypt/<decrypt-tx-data (fn [& _]
-                                                             (p/rejected
-                                                              (ex-info "unexpected decrypt" {})))]
-                   (-> (p/let [_ (sync-handle-message/handle-message! test-repo client raw-message)
-                               parent' (d/entity @conn parent-id)]
-                         (is (= "remote-plain-title" (:block/title parent')))
-                         (is (= 2 (client-op/get-local-tx test-repo))))
-                       (p/catch
-                        (fn [error]
-                          (is false (str error))))
-                       (p/finally
-                        (fn []
-                          (reset! db-sync/*repo->latest-remote-tx latest-prev)
-                          (done)))))))))))
+           (let [plain-tx-data [[:db/add 1 :block/title "remote-plain-title"]]
+                 remote-txs [{:t 2 :tx-data plain-tx-data}]
+                 client {:graph-id "graph-1"}]
+             (with-redefs [sync-crypt/graph-e2ee? (constantly false)
+                           sync-crypt/<ensure-graph-aes-key (fn [& _]
+                                                              (p/rejected
+                                                               (ex-info "unexpected AES fetch" {})))
+                           sync-crypt/<decrypt-tx-data (fn [& _]
+                                                         (p/rejected
+                                                          (ex-info "unexpected decrypt" {})))]
+               (-> (#'sync-handle-message/<prepare-pull-remote-txs! test-repo client remote-txs)
+                   (p/then
+                    (fn [prepared-txs]
+                      (is (= remote-txs prepared-txs))))
+                   (p/catch
+                    (fn [error]
+                      (is false (str error))))
+                   (p/finally done)))))))
 
 (deftest pull-ok-batched-txs-preserve-tempid-boundaries-test
   (testing "pull/ok applies tx batches without cross-tx tempid collisions"

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -792,6 +792,36 @@
                 (is (= :db-sync/tx-rejected (-> captured :payload :type)))
                 (is (= rejected-tx (-> captured :payload :data)))))))))))
 
+(deftest tx-reject-broadcast-failure-still-surfaces-rejection-test
+  (testing "tx/reject should report the rejected tx even if state broadcast fails"
+    (let [raw-message (js/JSON.stringify
+                       (clj->js {:type "tx/reject"
+                                 :reason "db transact failed"
+                                 :t 3}))
+          captured (atom nil)
+          client {:repo test-repo
+                  :graph-id "graph-1"
+                  :inflight (atom [])
+                  :online-users (atom [])
+                  :ws-state (atom :open)}]
+      (with-redefs [client-op/get-local-tx (constantly 0)
+                    shared-service/broadcast-to-clients! (fn [& _]
+                                                           (throw (ex-info "broadcast failed" {})))
+                    sync-log-state/rtc-log (fn [type payload]
+                                             (reset! captured {:type type
+                                                              :payload payload}))]
+        (try
+          (with-silenced-console-error
+            #(sync-handle-message/handle-message! test-repo client raw-message))
+          (is false "expected tx/reject to fail-fast")
+          (catch :default error
+            (let [data (ex-data error)]
+              (is (= :db-sync/tx-rejected (:type data)))
+              (is (= "db transact failed" (:reason data)))
+              (is (= [] @(:inflight client)))
+              (is (= :rtc.log/tx-rejected (:type @captured)))
+              (is (= :db-sync/tx-rejected (-> @captured :payload :type))))))))))
+
 (deftest tx-reject-db-transact-failed-marks-inflight-op-failed-test
   (testing "non-stale tx/reject should mark inflight ops failed and clear pending state"
     (let [{:keys [conn client-ops-conn]} (setup-parent-child)
@@ -1106,6 +1136,44 @@
                      (p/finally (fn []
                                   (reset! db-sync/*repo->latest-remote-tx latest-prev)
                                   (done))))))))))
+
+(deftest pull-ok-non-e2ee-does-not-fetch-aes-key-test
+  (testing "non-E2EE pull responses should apply plain tx data without fetching graph AES keys"
+    (async done
+           (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
+                 parent-id (:db/id parent)
+                 new-tx (sqlite-util/write-transit-str [[:db/add parent-id :block/title "remote-plain-title"]])
+                 raw-message (js/JSON.stringify
+                              (clj->js {:type "pull/ok"
+                                        :t 2
+                                        :txs [{:t 2 :tx new-tx}]}))
+                 latest-prev @db-sync/*repo->latest-remote-tx
+                 client {:repo test-repo
+                         :graph-id "graph-1"
+                         :inflight (atom [])
+                         :online-users (atom [])
+                         :ws-state (atom :open)}]
+             (reset! db-sync/*repo->latest-remote-tx {})
+             (with-datascript-conns conn client-ops-conn
+               (fn []
+                 (with-redefs [sync-crypt/graph-e2ee? (constantly false)
+                               sync-crypt/<ensure-graph-aes-key (fn [& _]
+                                                                  (p/rejected
+                                                                   (ex-info "unexpected AES fetch" {})))
+                               sync-crypt/<decrypt-tx-data (fn [& _]
+                                                             (p/rejected
+                                                              (ex-info "unexpected decrypt" {})))]
+                   (-> (p/let [_ (sync-handle-message/handle-message! test-repo client raw-message)
+                               parent' (d/entity @conn parent-id)]
+                         (is (= "remote-plain-title" (:block/title parent')))
+                         (is (= 2 (client-op/get-local-tx test-repo))))
+                       (p/catch
+                        (fn [error]
+                          (is false (str error))))
+                       (p/finally
+                        (fn []
+                          (reset! db-sync/*repo->latest-remote-tx latest-prev)
+                          (done)))))))))))
 
 (deftest pull-ok-batched-txs-preserve-tempid-boundaries-test
   (testing "pull/ok applies tx batches without cross-tx tempid collisions"


### PR DESCRIPTION
## Summary
- split pull/ok preparation so non-E2EE graphs apply plain tx data without fetching/decrypting AES keys
- keep E2EE pull tx decryption behavior unchanged
- preserve tx/reject fail-fast details even if broadcasting sync state throws

## Tests
- `git diff --check`
- `clojure -M:clj-kondo --lint src/main/frontend/worker/sync/handle_message.cljs src/test/frontend/worker/db_sync_test.cljs --cache false`
- `bb dev:test -v frontend.worker.db-sync-test/pull-ok-non-e2ee-does-not-fetch-aes-key-test -v frontend.worker.db-sync-test/tx-reject-broadcast-failure-still-surfaces-rejection-test`
