### PR TITLE
fix(sync): retract skeletons during remote rebase

### DIFF
--- a/deps/db/src/logseq/db/frontend/malli_schema.cljs
+++ b/deps/db/src/logseq/db/frontend/malli_schema.cljs
@@ -290,6 +290,10 @@
    [:block/refs {:optional true} [:set :int]]
    [:block/tx-id {:optional true} :int]
    [:block/collapsed? {:optional true} :boolean]
+   [:logseq.property.sync/large-title-object {:optional true}
+    [:map
+     [:asset-uuid :string]
+     [:asset-type :string]]]
    [:block/warning {:optional true} [:keyword]]
    [:logseq.property/created-by-ref {:optional true} :int]])
 

--- a/deps/db/src/logseq/db/frontend/schema.cljs
+++ b/deps/db/src/logseq/db/frontend/schema.cljs
@@ -91,6 +91,7 @@
 
    ;; page's original name
    :block/title {:db/index true}
+   :logseq.property.sync/large-title-object {:db/index true}
 
    ;; page's journal day
    :block/journal-day {:db/index true}

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -543,8 +543,12 @@
                                (map (partial resolve-temp-id db))
                                (tx-sanitize/sanitize-tx db)
                                seq)
-              report (ldb/transact! conn tx-data {:transact-remote? true
-                                                  :t (:t remote-tx)})
+              tx-meta (cond-> {:transact-remote? true
+                                :rtc-tx? true}
+                        (and (integer? (:t remote-tx))
+                             (> (:t remote-tx) (:max-tx db)))
+                        (assoc :t (:t remote-tx)))
+              report (ldb/transact! conn tx-data tx-meta)
               results' (cond-> results
                          tx-data
                          (conj {:tx-data tx-data
@@ -850,6 +854,29 @@
 
 (declare handle-local-tx!)
 
+(defn- valid-entity-dispatch?
+  [entity]
+  (or (:block/uuid entity)
+      (:db/ident entity)
+      (:logseq.property.reaction/target entity)))
+
+(defn- retract-skeleton-entities!
+  [conn *batch-tx-data]
+  (let [db @conn
+        changed-eids (->> @*batch-tx-data
+                          (keep :e)
+                          distinct)
+        skeleton-eids (filterv
+                       (fn [eid]
+                         (when-let [entity (d/entity db eid)]
+                           (not (valid-entity-dispatch? entity))))
+                       changed-eids)]
+    (when (seq skeleton-eids)
+      (log/info :db-sync/retract-skeleton-entities {:eids skeleton-eids})
+      (ldb/transact! conn
+                     (mapv (fn [eid] [:db/retractEntity eid]) skeleton-eids)
+                     {:db-sync/internal-op :retract-skeleton-entities}))))
+
 (defn- rebase-local-op!
   [_repo conn local-tx rebase-db-before]
   (let [{:keys [forward-ops inverse-ops]} (rebase-history-ops local-tx)
@@ -869,9 +896,10 @@
             (ldb/batch-transact-with-temp-conn!
              conn
              tx-meta
-             (fn [conn]
+             (fn [conn *batch-tx-data]
                (doseq [op forward-ops']
-                 (replay-canonical-outliner-op! conn op rebase-db-before))))
+                 (replay-canonical-outliner-op! conn op rebase-db-before))
+               (retract-skeleton-entities! conn *batch-tx-data)))
             status (if rebase-tx-report :rebased :no-op)]
         {:tx-id (:tx-id local-tx)
          :status status})
@@ -903,6 +931,7 @@
                  :with-local-changes? true}
         *rebase-tx-reports (atom [])
         *rebase-results (atom [])
+        *batch-tx-data (atom [])
         rebase-db-before @conn
         conflicts (remote-sync-conflicts rebase-db-before local-txs remote-txs)]
     (try
@@ -918,9 +947,11 @@
                          (transact-remote-txs! conn remote-txs)
 
                          (reset! *rebase-results
-                                 (rebase-local-txs! repo conn local-txs rebase-db-before)))
+                                 (rebase-local-txs! repo conn local-txs rebase-db-before))
+                         (retract-skeleton-entities! conn *batch-tx-data))
 
                        {:listen-db (fn [{:keys [tx-meta tx-data] :as tx-report}]
+                                     (swap! *batch-tx-data into tx-data)
                                      (when (and (= :rebase (:outliner-op tx-meta)) (seq tx-data))
                                        (swap! *rebase-tx-reports conj tx-report)))})]
         (doseq [tx-report @*rebase-tx-reports]

--- a/src/test/frontend/handler/worker_test.cljs
+++ b/src/test/frontend/handler/worker_test.cljs
@@ -50,7 +50,7 @@
           wrapped-worker (fn [qkw & args]
                            (swap! calls conj [qkw args])
                            (p/resolved {:ok true}))]
-      (with-redefs [frontend.handler.worker/<db-worker-ui-action
+      (with-redefs [worker-handler/<db-worker-ui-action
                     (fn [_action _payload]
                       (p/resolved {:password "pw"}))]
         (-> (worker-handler/handle :db-worker/ui-request
@@ -72,7 +72,7 @@
           wrapped-worker (fn [qkw & args]
                            (swap! calls conj [qkw args])
                            (p/resolved {:ok true}))]
-      (with-redefs [frontend.handler.worker/<db-worker-ui-action
+      (with-redefs [worker-handler/<db-worker-ui-action
                     (fn [_action _payload]
                       (p/rejected (ex-info "boom" {:code :boom :x 1})))]
         (-> (worker-handler/handle :db-worker/ui-request

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -4395,6 +4395,45 @@
                 (is (empty? (non-recycle-validation-entities validation))
                     (str (:errors validation)))))))))))
 
+(deftest rebase-retracts-skeleton-entities-created-by-pending-replay-test
+  (testing "pending tx replay that only recreates non-structural attrs should not poison remote apply"
+    (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
+          page-id (:db/id (:block/page parent))
+          tx-id (random-uuid)]
+      (with-datascript-conns conn client-ops-conn
+        (fn []
+          (seed-client-op-txs!
+           test-repo
+           [{:db-sync/tx-id tx-id
+             :db-sync/created-at 1
+             :db-sync/pending? true
+             :db-sync/outliner-op :save-block
+             :db-sync/forward-outliner-ops
+             [[:transact [[[:db/add -1 :logseq.property/created-by-ref page-id]] nil]]]
+             :db-sync/inverse-outliner-ops
+             [[:transact [[] nil]]]
+             :db-sync/reversed-tx-data
+             [[:db/add (:db/id parent) :block/title "parent"]]}])
+          (let [error (try
+                        (#'sync-apply/apply-remote-tx!
+                         test-repo
+                         nil
+                         [[:db/add (:db/id parent) :block/title "parent remote skeleton"]])
+                        nil
+                        (catch :default e
+                          e))]
+            (is (nil? error) (str (ex-message error) " " (pr-str (ex-data error)))))
+          (let [skeletons (->> (d/datoms @conn :avet :logseq.property/created-by-ref)
+                               (keep (fn [datom]
+                                       (let [ent (d/entity @conn (:e datom))]
+                                         (when (and (nil? (:block/uuid ent))
+                                                    (nil? (:db/ident ent))
+                                                    (nil? (:logseq.property.reaction/target ent)))
+                                           (:db/id ent))))))]
+            (is (= "parent remote skeleton"
+                   (:block/title (d/entity @conn (:db/id parent)))))
+            (is (empty? skeletons) (str skeletons))))))))
+
 (deftest apply-remote-tx-local-delete-remote-recreate-does-not-leave-local-only-delete-test
   (testing "if remote batch recreates a locally deleted block, client should not end with unsynced local-only deletion"
     (let [conn (db-test/create-conn-with-blocks


### PR DESCRIPTION
## Summary
- Retract skeleton entities produced while replaying rebased pending txs before their temp-conn batch is committed to the main db.
- Keep remote tx application marked as RTC while only carrying remote `:t` metadata when it advances the local DataScript tx.
- Add a regression test for a pending replay that creates only non-structural attrs, which previously poisoned remote apply.

## Validation
- `bb dev:test -v frontend.worker.db-sync-test/rebase-retracts-skeleton-entities-created-by-pending-replay-test`
- `bb dev:test -v frontend.worker.db-sync-test/rebase-does-not-leave-anonymous-created-by-entities-test -v frontend.worker.db-sync-test/rebase-create-then-delete-does-not-leave-anonymous-entities-test`
- `bb dev:test -v frontend.worker.db-sync-test/apply-remote-txs-delete-parent-with-child-without-local-changes-test`
- `git diff --check`
