### PR TITLE
fix(sync): keep remote graph refresh visible

### DIFF
--- a/src/main/frontend/components/repo.cljs
+++ b/src/main/frontend/components/repo.cljs
@@ -236,22 +236,21 @@
          (repos-inner local-graphs))]
 
       (when (and (user-handler/rtc-group?)
-                 (seq remote-graphs)
                  login?)
         [:<>
-         (when (seq own-graphs)
+         [:div
+          [:hr.mt-8]
+          [:div.flex.align-items.justify-between
+           [:h2.text-lg.font-medium.mb-4 (t :graph/remote-graphs)]
            [:div
-            [:hr.mt-8]
-            [:div.flex.align-items.justify-between
-             [:h2.text-lg.font-medium.mb-4 (t :graph/remote-graphs)]
-             [:div
-              (ui/button
-               [:span.flex.items-center (t :ui/refresh)
-                (when remotes-loading? [:small.pl-2 (ui/loading nil)])]
-               :background "gray"
-               :disabled remotes-loading?
-               :on-click (fn [] (rtc-handler/<get-remote-graphs)))]]
-            (repos-inner own-graphs)])
+            (ui/button
+             [:span.flex.items-center (t :ui/refresh)
+              (when remotes-loading? [:small.pl-2 (ui/loading nil)])]
+             :background "gray"
+             :disabled remotes-loading?
+             :on-click (fn [] (rtc-handler/<get-remote-graphs)))]]
+          (when (seq own-graphs)
+            (repos-inner own-graphs))]
 
          (when (seq shared-graphs)
            [:div


### PR DESCRIPTION
## Summary
- show the remote graph section for logged-in RTC users even before any remote graphs are listed
- keep the refresh action available for empty or stale remote graph state
- continue rendering owned and shared graph lists only when present

## Source
Split from the generic UI portion of personal-branch commit `fdbaa34d37`.

## Tests
- `git diff --check`
- `clojure -M:clj-kondo --lint src/main/frontend/components/repo.cljs --cache false`