### PR TITLE
fix: prevent blocks from being outdented past zoom root

### DIFF
--- a/clj-e2e/test/logseq/e2e/outliner_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/outliner_basic_test.clj
@@ -1,5 +1,6 @@
 (ns logseq.e2e.outliner-basic-test
   (:require
+   [clojure.string :as string]
    [clojure.test :refer [deftest testing is use-fixtures]]
    [logseq.e2e.assert :as assert]
    [logseq.e2e.block :as b]
@@ -7,8 +8,7 @@
    [logseq.e2e.keyboard :as k]
    [logseq.e2e.page :as p]
    [logseq.e2e.util :as util]
-   [wally.main :as w]
-   [wally.repl :as repl]))
+   [wally.main :as w]))
 
 (use-fixtures :once fixtures/open-page)
 (use-fixtures :each
@@ -75,6 +75,48 @@
   (util/repeat-keyboard 2 (str (if util/mac? "Meta" "Alt") "+Shift+ArrowDown"))
   (let [contents (util/get-page-blocks-contents)]
     (is (= contents ["b1" "b2" "b3" "b4"]))))
+
+(defn- zoom-in-shortcut []
+  (k/press (if util/mac? "Meta+Shift+." "Alt+ArrowRight")))
+
+(defn- current-location-hash []
+  (w/eval-js "window.location.hash"))
+
+(defn- current-editing-block-id []
+  (w/eval-js
+   "(() => {
+      const editor = document.querySelector('.editor-wrapper textarea');
+      return editor?.closest('[blockid]')?.getAttribute('blockid') ?? null;
+    })();"))
+
+(deftest focused-root-block-cannot-indent-or-move-test
+  (testing "Focused root block ignores indent/outdent/move-up/move-down commands"
+    (b/new-blocks ["focused-root" "focused-child"])
+    (k/arrow-up)
+    (let [root-id (current-editing-block-id)]
+      (is (string? root-id))
+      (zoom-in-shortcut)
+      (util/wait-timeout 400)
+      ;; Retry once in case the first key event gets swallowed by the editor.
+      (when-not (string/includes? (or (current-location-hash) "") root-id)
+        (zoom-in-shortcut)
+        (util/wait-timeout 400))
+      (is (string/includes? (or (current-location-hash) "") root-id))
+      (util/wait-editor-visible)
+      (is (= "focused-root" (util/get-edit-content)))
+      (let [before-hash (current-location-hash)
+            before-block-contents (util/get-page-blocks-contents)]
+        (k/tab)
+        (util/wait-timeout 100)
+        (k/shift+tab)
+        (util/wait-timeout 100)
+        (k/meta+shift+arrow-up)
+        (util/wait-timeout 100)
+        (k/meta+shift+arrow-down)
+        (util/wait-timeout 100)
+        (is (= "focused-root" (util/get-edit-content)))
+        (is (= before-hash (current-location-hash)))
+        (is (= before-block-contents (util/get-page-blocks-contents)))))))
 
 (defn delete []
   (testing "Delete blocks case 1"

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1642,8 +1642,17 @@
 (defn on-tab
   "`direction` = :left | :right."
   [direction]
-  (let [blocks (get-selected-ordered-blocks)]
-    (block-handler/indent-outdent-blocks! blocks (= direction :right) nil)))
+  (let [blocks (get-selected-ordered-blocks)
+        indent? (= direction :right)
+        page (state/get-current-page)
+        zoom-root (when (and (not indent?) page (util/uuid-string? page))
+                    (db/entity [:block/uuid (parse-uuid page)]))
+        blocks (if zoom-root
+                 (remove (fn [b]
+                           (= (:db/id (:block/parent b)) (:db/id zoom-root)))
+                         blocks)
+                 blocks)]
+    (block-handler/indent-outdent-blocks! blocks indent? nil)))
 
 (defn- get-link [format link label]
   (let [link (or link "")
@@ -2486,11 +2495,18 @@
     (when block
       (let [node block-container
             prev-container-id (get-node-container-id node)
-            container-id (get-new-container-id (if indent? :indent :outdent) {})]
-        (p/do!
-         (block-handler/indent-outdent-blocks! [block] indent? save-current-block!)
-         (when (and (not= prev-container-id container-id) container-id)
-           (state/set-editing-block-id! [container-id (:block/uuid block)])))))))
+            container-id (get-new-container-id (if indent? :indent :outdent) {})
+            outdent-past-zoom-root? (when-not indent?
+                                      (let [page (state/get-current-page)]
+                                        (and page
+                                             (util/uuid-string? page)
+                                             (let [zoom-root (db/entity [:block/uuid (parse-uuid page)])]
+                                               (= (:db/id (:block/parent block)) (:db/id zoom-root))))))]
+        (when-not outdent-past-zoom-root?
+          (p/do!
+           (block-handler/indent-outdent-blocks! [block] indent? save-current-block!)
+           (when (and (not= prev-container-id container-id) container-id)
+             (state/set-editing-block-id! [container-id (:block/uuid block)]))))))))
 
 (defn keydown-tab-handler
   [direction]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1599,12 +1599,40 @@
                  (>= pos 1))
         (util/nth-safe value pos)))))
 
+(defn- get-focused-root-block
+  []
+  (let [page (state/get-current-page)]
+    (when (and page (util/uuid-string? page))
+      (db/entity [:block/uuid (parse-uuid page)]))))
+
+(defn- focused-root-block?
+  [block root-block]
+  (and block root-block
+       (= (:db/id block) (:db/id root-block))))
+
+(defn- outdent-past-focused-root?
+  [block root-block]
+  (= (:db/id (:block/parent block)) (:db/id root-block)))
+
+(defn- block-eligible-for-indent-outdent?
+  [block indent? root-block]
+  (and block
+       (not (focused-root-block? block root-block))
+       (or indent?
+           (not (outdent-past-focused-root? block root-block)))))
+
+(defn- block-eligible-for-move-up-down?
+  [block root-block]
+  (and block
+       (not (focused-root-block? block root-block))))
+
 (defn move-up-down
   [up?]
   (fn [event]
     (util/stop event)
     (state/pub-event! [:editor/hide-action-bar])
     (let [edit-block-id (:block/uuid (state/get-edit-block))
+          root-block (get-focused-root-block)
           move-nodes (fn [blocks]
                        (let [blocks' (block-handler/get-top-level-blocks blocks)
                              result (ui-outliner-tx/transact!
@@ -1616,20 +1644,25 @@
       (if edit-block-id
         (when-let [block (db/entity [:block/uuid edit-block-id])]
           (let [blocks [(assoc block :block/title (state/get-edit-content))]
+                blocks (filter #(block-eligible-for-move-up-down? % root-block) blocks)
                 container-id (get-new-container-id (if up? :move-up :move-down) {})]
-            (p/do!
-             (save-current-block!)
-             (move-nodes blocks)
-             (if container-id
-               (state/set-editing-block-id! [container-id edit-block-id])
-               (when-let [input (some-> (state/get-edit-input-id) gdom/getElement)]
-                 (.focus input)
-                 (util/scroll-editor-cursor input))))))
+            (when (seq blocks)
+              (p/do!
+               (save-current-block!)
+               (move-nodes blocks)
+               (if container-id
+                 (state/set-editing-block-id! [container-id edit-block-id])
+                 (when-let [input (some-> (state/get-edit-input-id) gdom/getElement)]
+                   (.focus input)
+                   (util/scroll-editor-cursor input)))))))
         (let [ids (state/get-selection-block-ids)]
           (when (seq ids)
             (let [lookup-refs (map (fn [id] [:block/uuid id]) ids)
-                  blocks (map db/entity lookup-refs)]
-              (move-nodes blocks))))))))
+                  blocks (->> lookup-refs
+                              (map db/entity)
+                              (filter #(block-eligible-for-move-up-down? % root-block)))]
+              (when (seq blocks)
+                (move-nodes blocks)))))))))
 
 (defn get-selected-ordered-blocks
   []
@@ -1644,15 +1677,10 @@
   [direction]
   (let [blocks (get-selected-ordered-blocks)
         indent? (= direction :right)
-        page (state/get-current-page)
-        zoom-root (when (and (not indent?) page (util/uuid-string? page))
-                    (db/entity [:block/uuid (parse-uuid page)]))
-        blocks (if zoom-root
-                 (remove (fn [b]
-                           (= (:db/id (:block/parent b)) (:db/id zoom-root)))
-                         blocks)
-                 blocks)]
-    (block-handler/indent-outdent-blocks! blocks indent? nil)))
+        root-block (get-focused-root-block)
+        blocks (filter #(block-eligible-for-indent-outdent? % indent? root-block) blocks)]
+    (when (seq blocks)
+      (block-handler/indent-outdent-blocks! blocks indent? nil))))
 
 (defn- get-link [format link label]
   (let [link (or link "")
@@ -2496,13 +2524,8 @@
       (let [node block-container
             prev-container-id (get-node-container-id node)
             container-id (get-new-container-id (if indent? :indent :outdent) {})
-            outdent-past-zoom-root? (when-not indent?
-                                      (let [page (state/get-current-page)]
-                                        (and page
-                                             (util/uuid-string? page)
-                                             (let [zoom-root (db/entity [:block/uuid (parse-uuid page)])]
-                                               (= (:db/id (:block/parent block)) (:db/id zoom-root))))))]
-        (when-not outdent-past-zoom-root?
+            root-block (get-focused-root-block)]
+        (when (block-eligible-for-indent-outdent? block indent? root-block)
           (p/do!
            (block-handler/indent-outdent-blocks! [block] indent? save-current-block!)
            (when (and (not= prev-container-id container-id) container-id)

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -268,3 +268,23 @@
       (is (nil? (:logseq.property/deleted-at source')))
       (is (nil? (:logseq.property.recycle/original-page source')))
       (is (not= (:db/id recycle-page) (:db/id (:block/page source')))))))
+
+(deftest focused-root-block-operation-guards-test
+  (let [root-block {:db/id 1}
+        focused-root-block {:db/id 1}
+        root-child-block {:db/id 2
+                          :block/parent {:db/id 1}}
+        non-root-block {:db/id 3
+                        :block/parent {:db/id 9}}]
+    (testing "Root block cannot be indented or outdented when focused"
+      (is (false? (#'editor/block-eligible-for-indent-outdent? root-block true focused-root-block)))
+      (is (false? (#'editor/block-eligible-for-indent-outdent? root-block false focused-root-block))))
+    (testing "A direct child of focused root cannot be outdented but can be indented"
+      (is (false? (#'editor/block-eligible-for-indent-outdent? root-child-block false focused-root-block)))
+      (is (true? (#'editor/block-eligible-for-indent-outdent? root-child-block true focused-root-block))))
+    (testing "Non-root blocks keep normal indent/outdent behavior"
+      (is (true? (#'editor/block-eligible-for-indent-outdent? non-root-block true focused-root-block)))
+      (is (true? (#'editor/block-eligible-for-indent-outdent? non-root-block false focused-root-block))))
+    (testing "Root block cannot move up/down when focused"
+      (is (false? (#'editor/block-eligible-for-move-up-down? root-block focused-root-block)))
+      (is (true? (#'editor/block-eligible-for-move-up-down? non-root-block focused-root-block))))))


### PR DESCRIPTION
## Summary

- Prevent blocks from being outdented past the zoom root in focused/zoom view
- When viewing a page in zoom mode (clicking a block's bullet), pressing `Shift+Tab` could outdent blocks beyond the zoom boundary, causing them to disappear from the focused view
- Adds guards in both single-block (`indent-outdent`) and multi-block (`on-tab`) code paths

Fixes #12582

## Test plan

- [ ] Create a nested outline: 一级 > 二级 > 三级 > 4-1, 4-2, 4-3
- [ ] Zoom into 二级 by clicking its bullet
- [ ] Place cursor on 4-2 and press `Shift+Tab` — block should outdent but NOT disappear
- [ ] Press `Shift+Tab` again — block should stay at zoom root level, not go past it
- [ ] Select multiple blocks (e.g., 4-1 and 4-2) and press `Shift+Tab` — same behavior
- [ ] In normal (non-zoom) page view, verify outdent still works as expected