### PR TITLE
fix: scope RSA key pair cache by server URL

### DIFF
--- a/src/main/frontend/worker/sync/crypt.cljs
+++ b/src/main/frontend/worker/sync/crypt.cljs
@@ -246,8 +246,8 @@
   (str "rtc-encrypted-aes-key###" graph-id))
 
 (defn- user-rsa-key-pair-idb-key
-  [user-id]
-  (str "rtc-user-rsa-key-pair###" user-id))
+  [base user-id]
+  (str "rtc-user-rsa-key-pair###" base "###" user-id))
 
 (defn <fetch-user-rsa-key-pair-raw
   [base]
@@ -266,14 +266,14 @@
   (when (and (string? base)
              (string? user-id)
              (user-rsa-key-pair-valid? pair))
-    (<set-item! (user-rsa-key-pair-idb-key user-id)
+    (<set-item! (user-rsa-key-pair-idb-key base user-id)
                 (ldb/write-transit-str pair)))
   pair)
 
 (defn- <get-user-rsa-key-pair-from-idb
   [base user-id]
   (when (and (string? base) (string? user-id))
-    (p/let [pair-str (<get-item (user-rsa-key-pair-idb-key user-id))
+    (p/let [pair-str (<get-item (user-rsa-key-pair-idb-key base user-id))
             pair (ldb/read-transit-str pair-str)]
       (when (user-rsa-key-pair-valid? pair)
         pair))))
@@ -283,7 +283,7 @@
   (let [k [base user-id]]
     (swap! *user-rsa-key-pair-inflight dissoc k)
     (when (and (string? base) (string? user-id))
-      (<clear-item! (user-rsa-key-pair-idb-key user-id)))))
+      (<clear-item! (user-rsa-key-pair-idb-key base user-id)))))
 
 (defn- <get-user-rsa-key-pair-raw
   [base]

--- a/src/main/frontend/worker/sync/download.cljs
+++ b/src/main/frontend/worker/sync/download.cljs
@@ -533,7 +533,9 @@
                                    :stage @stage*
                                    :error error
                                    :error-stack (when (instance? js/Error error)
-                                                  (.-stack error))})
+                                                  (.-stack error))
+                                   :error-cause (when (instance? js/Error error)
+                                                  (some-> (.-cause error) (.-message)))})
                        (throw (ex-info "db-sync download failed"
                                       {:repo repo
                                        :graph-id graph-id
@@ -541,7 +543,9 @@
                                        :stage @stage*
                                        :error-message (or (ex-message error)
                                                            (when (instance? js/Error error)
-                                                             (.-message error)))}
+                                                             (.-message error)))
+                                       :error-cause (when (instance? js/Error error)
+                                                      (some-> (.-cause error) (.-message)))}
                                        error))))))
       (p/rejected (ex-info "db-sync missing graph download info"
                            {:repo repo

--- a/src/test/frontend/worker/sync/crypt_test.cljs
+++ b/src/test/frontend/worker/sync/crypt_test.cljs
@@ -855,6 +855,35 @@
                           (is (zero? @clear-user-rsa-cache-calls*))
                           (done)))))))
 
+(deftest user-rsa-key-pair-cache-is-scoped-by-server-test
+  (async done
+         (let [kv-store (atom {})
+               platform-map {:env {:runtime :node :owner-source :electron}}]
+           (-> (p/with-redefs [platform/current (fn [] platform-map)
+                               platform/kv-get (fn [_ k] (p/resolved (get @kv-store k)))
+                               platform/kv-set! (fn [_ k v]
+                                                  (if (nil? v)
+                                                    (swap! kv-store dissoc k)
+                                                    (swap! kv-store assoc k v))
+                                                  (p/resolved nil))]
+                 (p/let [pair-a {:public-key "pk-a" :encrypted-private-key "enc-a"}
+                         pair-b {:public-key "pk-b" :encrypted-private-key "enc-b"}
+                         _ (#'sync-crypt/<set-user-rsa-key-pair-to-idb! "https://server-a.example" "user-1" pair-a)
+                         _ (#'sync-crypt/<set-user-rsa-key-pair-to-idb! "https://server-b.example" "user-1" pair-b)
+                         cached-a (#'sync-crypt/<get-user-rsa-key-pair-from-idb "https://server-a.example" "user-1")
+                         cached-b (#'sync-crypt/<get-user-rsa-key-pair-from-idb "https://server-b.example" "user-1")
+                         cached-c (#'sync-crypt/<get-user-rsa-key-pair-from-idb "https://server-c.example" "user-1")]
+                   (is (= "pk-a" (:public-key cached-a)) "returns server-a's key for server-a")
+                   (is (= "pk-b" (:public-key cached-b)) "returns server-b's key for server-b")
+                   (is (nil? cached-c) "cache miss for unknown server")
+                   (p/let [_ (#'sync-crypt/<clear-user-rsa-key-pair-cache! "https://server-a.example" "user-1")
+                           cleared (#'sync-crypt/<get-user-rsa-key-pair-from-idb "https://server-a.example" "user-1")
+                           intact (#'sync-crypt/<get-user-rsa-key-pair-from-idb "https://server-b.example" "user-1")]
+                     (is (nil? cleared) "server-a cleared")
+                     (is (= "pk-b" (:public-key intact)) "server-b untouched"))))
+               (p/catch (fn [e] (is false (str e))))
+               (p/finally (fn [] (done)))))))
+
 (deftest decrypt-text-value-legacy-plaintext-test
   (async done
          (-> (p/let [aes-key (crypt/<generate-aes-key)


### PR DESCRIPTION
The RSA key pair cache key was based on `user-id` only, not on the server URL. When a user connects to both the official Logseq server and a selfhosted sync server (or switches after initial login), the cached key pair from one server would be returned for the other. This caused E2EE decryption to fail with the correct password because the wrong server's private key was used.

Include the server base URL in the cache key, matching the in-memory inflight cache which already used `[base user-id]`.

I also added a log for errors in download data.  Without it, errors like `unable to verify the first certificate` are hidden behind the generic `fetch failed` message. This helped me troubleshooting an server issue.