### PR TITLE
fix(whiteboard): guard nil pageId/refs in shape parser (#12585)

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/whiteboard.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/whiteboard.cljs
@@ -1,6 +1,7 @@
 (ns logseq.graph-parser.whiteboard
-  "Whiteboard related parser utilities" 
-  (:require [logseq.graph-parser.util :as gp-util]
+  "Whiteboard related parser utilities"
+  (:require [clojure.string :as string]
+            [logseq.graph-parser.util :as gp-util]
             [logseq.graph-parser.util.block-ref :as block-ref]
             [logseq.graph-parser.util.page-ref :as page-ref]))
 
@@ -43,16 +44,22 @@
 
 
 (defn- get-shape-refs [shape]
-  (let [portal-refs (when (= "logseq-portal" (:type shape))
+  (let [page-id (:pageId shape)
+        portal-refs (when (and (= "logseq-portal" (:type shape))
+                               (string? page-id)
+                               (not (string/blank? page-id)))
                       [(if (= (:blockType shape) "P")
-                         {:block/name (gp-util/page-name-sanity-lc (:pageId shape))}
-                         {:block/uuid (uuid (:pageId shape))})])
+                         {:block/name (gp-util/page-name-sanity-lc page-id)}
+                         (when-let [u (parse-uuid page-id)]
+                           {:block/uuid u}))])
         shape-link-refs (->> (:refs shape)
-                             (filter (complement empty?))
-                             (map (fn [ref] (if (parse-uuid ref)
-                                              {:block/uuid (parse-uuid ref)}
+                             (filter string?)
+                             (filter (complement string/blank?))
+                             (map (fn [ref] (if-let [u (parse-uuid ref)]
+                                              {:block/uuid u}
                                               {:block/name (gp-util/page-name-sanity-lc ref)}))))]
-    (concat portal-refs shape-link-refs)))
+    (->> (concat portal-refs shape-link-refs)
+         (remove nil?))))
 
 (defn- with-whiteboard-block-refs
   [shape page-name]
@@ -77,10 +84,12 @@
   [block page-name]
   (let [shape? (shape-block? block)
         shape (block->shape block)
+        shape-id (:id shape)
+        shape-uuid (when (and shape? (string? shape-id)) (parse-uuid shape-id))
         default-page-ref {:block/name (gp-util/page-name-sanity-lc page-name)}]
-    (merge (when shape?
+    (merge (when (and shape? shape-uuid)
              (merge
-              {:block/uuid (uuid (:id shape))}
+              {:block/uuid shape-uuid}
               (with-whiteboard-block-refs shape page-name)
               (with-whiteboard-content shape)))
            (when (nil? (:block/parent block)) {:block/parent default-page-ref})


### PR DESCRIPTION
<!--
Thank you for the pull request. Please provide a description. Screenshots and gifs are appreciated for UX enhancements, new features and bug fixes!

For bug fixes and new features, please include tests and possibly benchmarks.
-->

Fixes #12585.

When importing a whiteboard `.edn` whose tldraw shapes contain a nil `:pageId`, nil `:id`, or nil entries inside `:refs` (e.g. legacy/orphaned `logseq-portal` shapes), `get-shape-refs` and `with-whiteboard-block-props` in `deps/graph-parser/src/logseq/graph_parser/whiteboard.cljs` pass nil into `cljs.core/uuid` and `gp-util/page-name-sanity-lc`. Both call `.toLowerCase` on the string, throwing `Cannot read properties of null (reading 'toLowerCase')` and aborting the whole `whiteboards/all.edn` import. Workarounds suggested in #11577 (manually rewriting `:refs [nil]`) miss the `:pageId nil` case that is also a hard crash.

This change makes the shape parser defensive:

- `get-shape-refs` only emits a portal ref when `:pageId` is a non-blank string, and only emits link refs for entries that are non-blank strings; non-uuid refs that are not parseable are silently dropped instead of throwing.
- `with-whiteboard-block-props` parses `:id` via `parse-uuid` (returns nil instead of throwing) and skips the shape-derived merge when the shape has no usable id, so the page itself still imports.

Net effect: a malformed shape in the EDN no longer takes down the entire whiteboard import; the rest of the page loads and the user can recover their graph instead of being completely blocked.