### PR TITLE
dev: remove developer command cycle

### DIFF
--- a/src/main/frontend/handler/common/developer.cljs
+++ b/src/main/frontend/handler/common/developer.cljs
@@ -12,9 +12,9 @@
             [frontend.handler.notification :as notification]
             [frontend.persist-db :as persist-db]
             [frontend.state :as state]
-            [frontend.ui :as ui]
             [frontend.util :as util]
             [frontend.util.page :as page-util]
+            [logseq.shui.ui :as shui]
             [logseq.db :as ldb]
             [logseq.db.frontend.property :as db-property]
             [promesa.core :as p]))
@@ -48,8 +48,9 @@
       [:pre.code (str "ID: " (:db/id result) "\n"
                       pull-data)]
       [:br]
-      (ui/button (t :ui/copy-to-clipboard)
-                 :on-click #(.writeText js/navigator.clipboard pull-data))]
+      (shui/button {:size :sm
+                    :on-click #(.writeText js/navigator.clipboard pull-data)}
+                   (t :ui/copy-to-clipboard))]
      :success
      false)))
 
@@ -62,8 +63,9 @@
     (notification/show!
      [:div.ls-wrap-widen
       ;; Show clipboard at top since content is really long for pages
-      (ui/button (t :ui/copy-to-clipboard)
-                 :on-click #(.writeText js/navigator.clipboard ast-data))
+      (shui/button {:size :sm
+                    :on-click #(.writeText js/navigator.clipboard ast-data)}
+                   (t :ui/copy-to-clipboard))
       [:br]
       [:pre.code ast-data]]
      :success


### PR DESCRIPTION
## Summary

- Remove the broad `frontend.ui` dependency from `frontend.handler.common.developer`
- Use the lower-level Shui button component for developer copy-to-clipboard notifications
- Break the dependency cycle:
  `frontend.handler.common.developer -> frontend.ui -> frontend.modules.shortcut.core -> frontend.modules.shortcut.config -> frontend.handler.common.developer`

## Verification

- `pnpm test`
  - 1324 tests, 6712 assertions, 0 failures, 0 errors
- `pnpm test:node-adapter`
  - 115 tests, 3658 assertions, 0 failures, 0 errors
- `pnpm --dir deps/cli test`
  - 2 tests, 12 assertions, 0 failures, 0 errors
- `pnpm --dir deps/common test`
  - 14 tests, 67 assertions, 0 failures, 0 errors
- `pnpm --dir deps/db test`
  - 85 tests, 323 assertions, 0 failures, 0 errors
- `pnpm --dir deps/graph-parser test`
  - 38 tests, 379 assertions, 0 failures, 0 errors
- `pnpm --dir deps/outliner test`
  - 69 tests, 245 assertions, 0 failures, 0 errors
- `pnpm --dir deps/publishing test`
  - 6 tests, 15 assertions, 0 failures, 0 errors
- `pnpm --dir deps/publish test`
  - 30 tests, 80 assertions, 0 failures, 0 errors
- `pnpm --dir scripts test`
  - 21 tests, 53 assertions, 0 failures, 0 errors
- `bb --config cli-e2e/bb.edn unit-test`
  - 80 tests, 306 assertions, 0 failures, 0 errors
- `bb --config cli-e2e/bb.edn test`
  - 77 passed, 0 failed

Additional local checks:

- SCIP graph check: no circular dependencies found after the change

Notes:

- `pnpm cljs:test-no-worker && pnpm cljs:run-test-no-worker` failed locally with existing broad DB/query/db-sync no-worker failures not related to this namespace.
- `clj-e2e/bb test` requires a static app server at `localhost:3002`; running it directly failed with `net::ERR_CONNECTION_REFUSED`.
