### PR TITLE
feat: export Logseq markdown syntax

### DIFF
--- a/deps/cli/src/logseq/cli/common/file.cljs
+++ b/deps/cli/src/logseq/cli/common/file.cljs
@@ -1,9 +1,12 @@
 (ns logseq.cli.common.file
   "Convert blocks to file content. Used for frontend exports and CLI"
-  (:require [clojure.string :as string]
+  (:require [cljs-time.coerce :as tc]
+            [cljs-time.core :as t]
+            [clojure.string :as string]
             [datascript.core :as d]
             [datascript.impl.entity :as de]
             [logseq.common.util.date-time :as date-time-util]
+            [logseq.common.util.page-ref :as page-ref]
             [logseq.db :as ldb]
             [logseq.db.frontend.content :as db-content]
             [logseq.db.frontend.property :as db-property]
@@ -15,23 +18,46 @@
   (let [lines (string/split-lines content)]
     (string/join (str "\n" spaces-tabs) lines)))
 
-(defn- datetime-journal-title
+(defn- journal-day-title
+  [journal-day context]
+  (date-time-util/int->journal-title
+   journal-day
+   (or (:date-formatter context)
+       date-time-util/default-journal-title-formatter)))
+
+(defn- datetime-value->string
   [v context]
   (when (integer? v)
-    (let [journal-day (cond
-                        (<= 10000101 v 99991231)
-                        v
+    (cond
+      (<= 10000101 v 99991231)
+      (journal-day-title v context)
 
-                        (>= v 100000000000)
-                        (date-time-util/ms->journal-day v)
+      (>= v 100000000000)
+      (date-time-util/format
+       (t/to-default-time-zone (tc/from-long v))
+       (str (or (:date-formatter context)
+                date-time-util/default-journal-title-formatter)
+            " HH:mm")))))
 
-                        :else
-                        nil)]
-      (when journal-day
-        (date-time-util/int->journal-title
-         journal-day
-         (or (:date-formatter context)
-             date-time-util/default-journal-title-formatter))))))
+(declare property-value->string block-properties-content)
+
+(defn- property-value-sort-key
+  [db property item context]
+  [(if (:block/order item) 0 1)
+   (str (or (:block/order item)
+            (property-value->string db property item context)))])
+
+(defn- property-values->seq
+  [db property v context]
+  (if (set? v)
+    (sort-by #(property-value-sort-key db property % context) v)
+    [v]))
+
+(defn- property-values->string
+  [db property v context]
+  (->> (property-values->seq db property v context)
+       (map #(property-value->string db property % context))
+       (string/join ", ")))
 
 (defn- property-value->string
   [db property v context]
@@ -42,41 +68,85 @@
           (entity-content [x]
             (let [m (entity-map x)]
               (or (:block/title m)
-                  (:logseq.property/value m))))]
+                  (:logseq.property/value m))))
+          (node-ref-content [content]
+            (if (and (:export-node-property-values-as-page-refs? context)
+                     (= :node (:logseq.property/type property))
+                     (string? content)
+                     (not (string/blank? content)))
+              (page-ref/->page-ref content)
+              content))]
     (cond
       (some? (entity-content v))
-      (str (entity-content v))
+      (str (node-ref-content (entity-content v)))
 
       (some? (:db/id (entity-map v)))
       (let [entity (d/entity db (:db/id (entity-map v)))]
-        (str (or (entity-content entity)
-                 (entity-content v)
-                 "")))
+        (str (node-ref-content (or (entity-content entity)
+                                   (entity-content v)
+                                   ""))))
 
       (set? v)
-      (->> v
-           (sort-by (fn [item]
-                      [(if (:block/order item) 0 1)
-                       (str (or (:block/order item)
-                                (property-value->string db property item context)))]))
-           (map #(property-value->string db property % context))
-           (string/join ", "))
+      (property-values->string db property v context)
 
       (sequential? v)
-      (->> v
-           (map #(property-value->string db property % context))
-           (string/join ", "))
+      (property-values->string db property v context)
 
       (keyword? v)
       (name v)
 
       (and (= :datetime (:logseq.property/type property))
            (integer? v))
-      (or (datetime-journal-title v context)
+      (or (datetime-value->string v context)
           (str v))
 
       (some? v)
       (str v))))
+
+(defn- property-value-block-title
+  [db property v context]
+  (letfn [(entity-map [x]
+            (cond
+              (map? x) x
+              (de/entity? x) (into {} x)))]
+    (if-let [id (:db/id (entity-map v))]
+      (db-content/recur-replace-uuid-in-block-title
+       (d/entity db id)
+       10
+       {:replace-block-refs? (not (:preserve-block-refs? context))})
+      (property-value->string db property v context))))
+
+(defn- default-property-value-block-content
+  [db property v spaces-tabs context]
+  (let [line (str spaces-tabs "- " (property-value-block-title db property v context))
+        properties-content (when-let [id (:db/id v)]
+                             (block-properties-content db (d/entity db id) (str spaces-tabs "  ") context))]
+    (cond-> line
+      properties-content
+      (str "\n" properties-content))))
+
+(defn- property-value-blocks-content
+  [db property v spaces-tabs context]
+  (->> (property-values->seq db property v context)
+       (map #(default-property-value-block-content db property % spaces-tabs context))
+       (string/join "\n")))
+
+(defn- property-line-content
+  [property-title value spaces-tabs context]
+  (str spaces-tabs
+       (when (:export-properties-as-list-items? context) "* ")
+       property-title
+       "::"
+       (when (some? value)
+         (str " " value))))
+
+(defn- default-property-values-as-blocks?
+  [property value context]
+  (and (:export-default-property-values-as-blocks? context)
+       (= :default (:logseq.property/type property))
+       (not (if (set? value)
+              (some :block/closed-value-property value)
+              (:block/closed-value-property value)))))
 
 (defn- block-properties-content
   [db block spaces-tabs context]
@@ -89,6 +159,8 @@
                         (remove (fn [[k _]]
                                   (contains? db-property/db-attribute-properties k)))
                         (remove (fn [[k _]]
+                                  (contains? (:excluded-properties context) k)))
+                        (remove (fn [[k _]]
                                   (:logseq.property/hide? (d/entity db k))))
                         (into {}))]
     (when (seq properties)
@@ -99,12 +171,19 @@
              (keep (fn [property]
                      (let [property-ident (:db/ident property)]
                        (when (contains? properties property-ident)
-                       (str spaces-tabs
-                            (or (:block/title property)
-                                (:block/raw-title property)
-                                (name property-ident))
-                            ":: "
-                            (property-value->string db property (get properties property-ident) context))))))
+                         (let [property-title (or (:block/title property)
+                                                  (:block/raw-title property)
+                                                  (name property-ident))
+                               value (get properties property-ident)]
+                           (if (default-property-values-as-blocks? property value context)
+                             (str (property-line-content property-title nil spaces-tabs context)
+                                  "\n"
+                                  (property-value-blocks-content db property value (str spaces-tabs "  ") context))
+                             (property-line-content
+                              property-title
+                              (property-value->string db property value context)
+                              spaces-tabs
+                              context)))))))
              (string/join "\n"))))))
 
 (defn- property-value-block-content
@@ -119,12 +198,15 @@
                                               (:logseq.property/value raw-block))
                                           context)]
         (when property-title
-          (str property-title ":: " value))))))
+          (property-line-content property-title value "" context))))))
 
 (defn- block-title-content
   [db b context]
   (or (property-value-block-content db b context)
-      (db-content/recur-replace-uuid-in-block-title (d/entity db (:db/id b)))))
+      (db-content/recur-replace-uuid-in-block-title
+       (d/entity db (:db/id b))
+       10
+       {:replace-block-refs? (not (:preserve-block-refs? context))})))
 
 (defn- bounded-heading-level
   [heading level]

--- a/deps/db/src/logseq/db/frontend/content.cljs
+++ b/deps/db/src/logseq/db/frontend/content.cljs
@@ -189,52 +189,69 @@
     (sort-refs tags))
    (string/trim)))
 
+(defn- title-ref-replacement
+  [id->title matched hash-prefix id]
+  (if-let [ref-title (get id->title id)]
+    (if (and (= "#" hash-prefix)
+             (not (string/includes? ref-title " ")))
+      (str "#" ref-title)
+      (str hash-prefix (page-ref/->page-ref ref-title)))
+    matched))
+
+(defn- replace-title-refs-once
+  [content id->title]
+  (string/replace content id-or-tag-ref-pattern
+                  #(apply title-ref-replacement id->title %)))
+
+(defn- ref->title-entry
+  [replace-block-refs? {:block/keys [title]
+                        block-uuid :block/uuid
+                        :as ref}]
+  (when (and block-uuid
+             (string? title)
+             (or replace-block-refs?
+                 (entity-util/page? ref)))
+    [(str block-uuid) title]))
+
+(defn- block-ref-id->title
+  [ent max-depth replace-block-refs?]
+  (loop [frontier (set (:block/refs ent))
+         seen-ids #{}
+         id->title {}
+         depth 0]
+    (if (or (>= depth max-depth)
+            (empty? frontier))
+      id->title
+      (let [refs (filter map? frontier)
+            new-refs (remove (fn [ref]
+                               (contains? seen-ids (:block/uuid ref)))
+                             refs)
+            seen-ids' (into seen-ids (keep :block/uuid) new-refs)
+            id->title' (into id->title
+                             (keep #(ref->title-entry replace-block-refs? %))
+                             new-refs)
+            next-frontier (->> new-refs
+                               (mapcat :block/refs)
+                               (filter map?)
+                               set)]
+        (recur next-frontier seen-ids' id->title' (inc depth))))))
+
 (defn recur-replace-uuid-in-block-title
   "Convert id ref (recursively) backs to page name refs, returns replaced title"
   ([ent]
    (recur-replace-uuid-in-block-title ent 10))
   ([ent max-depth]
+   (recur-replace-uuid-in-block-title ent max-depth {}))
+  ([ent max-depth {:keys [replace-block-refs?]
+                   :or {replace-block-refs? true}}]
    (let [title (:block/title ent)]
      (if (some->> title (re-find id-ref-pattern))
-       (let [id->title (loop [frontier (set (:block/refs ent))
-                              seen-ids #{}
-                              id->title {}
-                              depth 0]
-                         (if (or (>= depth max-depth)
-                                 (empty? frontier))
-                           id->title
-                           (let [refs (filter map? frontier)
-                                 new-refs (remove (fn [ref]
-                                                    (contains? seen-ids (:block/uuid ref)))
-                                                  refs)
-                                 seen-ids' (into seen-ids
-                                                 (keep :block/uuid)
-                                                 new-refs)
-                                 id->title' (reduce (fn [m {:block/keys [title]
-                                                            block-uuid :block/uuid}]
-                                                      (if (and block-uuid (string? title))
-                                                        (assoc m (str block-uuid) title)
-                                                        m))
-                                                    id->title
-                                                    new-refs)
-                                 next-frontier (->> new-refs
-                                                    (mapcat :block/refs)
-                                                    (filter map?)
-                                                    set)]
-                             (recur next-frontier seen-ids' id->title' (inc depth)))))]
+       (let [id->title (block-ref-id->title ent max-depth replace-block-refs?)]
          (loop [result title depth 0]
            (if (or (>= depth max-depth)
                    (not (re-find id-ref-pattern result)))
              result
-             (let [next-result
-                   (string/replace result id-or-tag-ref-pattern
-                                   (fn [[matched hash-prefix id]]
-                                     (if-let [ref-title (get id->title id)]
-                                       (if (and (= "#" hash-prefix)
-                                                (not (string/includes? ref-title " ")))
-                                         (str "#" ref-title)
-                                         (str hash-prefix (page-ref/->page-ref ref-title)))
-                                       matched)))]
+             (let [next-result (replace-title-refs-once result id->title)]
                (if (= result next-result)
                  result
                  (recur next-result (inc depth)))))))

--- a/docs/adr/0016-markdown-mirror.md
+++ b/docs/adr/0016-markdown-mirror.md
@@ -202,16 +202,23 @@ builds do not have the same graph-directory filesystem guarantees.
 ## Markdown Content
 1. Reuse the existing page-to-Markdown export pipeline used by worker export
    APIs instead of introducing a separate renderer-side serializer.
-2. The mirror output should match normal Markdown export semantics for page
-   content.
-3. Mirror files do not include Logseq-internal mirror metadata in the Markdown
-   body.
-4. Mirror files include block and page property drawers, including user
-   properties, with rendered property values.
-5. Assets are referenced as normal exported Markdown references. This ADR does
+2. The mirror output uses the Logseq Markdown syntax described in
+   `docs/logseq-markdown-syntax.md`.
+3. Mirror files always include a page `id:: <uuid>` line so the file can be
+   associated with its DB page without encoding the uuid in the file name.
+4. Blocks are Markdown list items that use `-`.
+5. User-visible page and block properties are Markdown list items that use `*`
+   and keep the Logseq property marker, for example `* owner:: [[Alice]]`.
+6. Open default property values are exported as nested value blocks below the
+   property key. Closed values remain inline with the property key.
+7. Node property values are exported as Logseq page references, for example
+   `[[Node title]]`, rather than block reference syntax.
+8. Task status is encoded on the block line, for example `- TODO ship`, and is
+   not exported as a separate property list item.
+9. Assets are referenced as normal exported Markdown references. This ADR does
    not copy assets into `mirror/markdown/`.
-6. Page references remain in Logseq wiki-link form, for example `[[Foo]]`.
-7. Ambiguous page references caused by duplicate page titles are an accepted
+10. Page references remain in Logseq wiki-link form, for example `[[Foo]]`.
+11. Ambiguous page references caused by duplicate page titles are an accepted
    limitation of Markdown Mirror. Do not rewrite page references to uuid-based
    links or relative Markdown links in this ADR.
 
@@ -269,6 +276,7 @@ bb dev:test -v frontend.worker.markdown-mirror-test/same-title-pages-write-disti
 bb dev:test -v frontend.worker.markdown-mirror-test/page-references-remain-wiki-links-test
 bb dev:test -v frontend.worker.markdown-mirror-test/page-mirror-exports-property-values-test
 bb dev:test -v frontend.worker.markdown-mirror-test/page-mirror-exports-page-property-values-test
+bb dev:test -v frontend.worker.markdown-mirror-test/page-mirror-exports-node-property-values-as-page-refs-test
 bb dev:test -v frontend.worker.markdown-mirror-test/full-regeneration-writes-existing-non-built-in-non-property-pages-test
 bb dev:test -v frontend.worker.markdown-mirror-test/invalid-filename-characters-are-normalized-test
 bb dev:test -v frontend.worker.markdown-mirror-test/windows-reserved-filename-fails-with-diagnostic-test

--- a/docs/logseq-markdown-syntax.md
+++ b/docs/logseq-markdown-syntax.md
@@ -1,0 +1,108 @@
+# Logseq Markdown Syntax
+
+This document describes the Markdown syntax used by Logseq Markdown Mirror for
+DB graphs.
+
+## Page Identity
+Mirror files start with an internal page id marker:
+
+```markdown
+id:: 11111111-1111-4111-8111-111111111111
+```
+
+The marker associates a mirror file with the DB page. It is not a normal page
+property.
+
+## Blocks
+Blocks are Markdown list items that use `-`.
+
+```markdown
+- Parent
+  - Child
+  - Another child
+- Sibling
+```
+
+Indentation defines block nesting. Markdown Mirror writes two spaces per nested
+level.
+
+## Properties
+Properties are Markdown list items that use `*` and keep the Logseq property
+marker `key::`.
+
+```markdown
+* page-property:: [[Page value]]
+
+- Block
+  * block-property:: 42
+```
+
+Page properties appear before the first block. Block properties appear under the
+block they belong to.
+
+Open `:default` property values are represented by nested value blocks:
+
+```markdown
+- Oscar Wilde
+  * description::
+    - Irish poet and playwright
+  * books::
+    - The Picture of Dorian Gray
+      * year:: 1891
+    - The Importance of Being Earnest
+      * year:: 1895
+```
+
+Closed values stay inline with the property key, including many-value
+properties:
+
+```markdown
+- Entry
+  * mood:: Joy, Sad
+```
+
+Non-default scalar values and node values also stay inline:
+
+```markdown
+- Lewis Carroll
+  * books:: [[Alice in Wonderland]]
+  * rating:: 5
+```
+
+Property value blocks can have nested blocks:
+
+```markdown
+- Book list
+  * notes::
+    - Alice
+      - Draft
+```
+
+## References
+Page and node references use Logseq page reference syntax:
+
+```markdown
+- Read [[Project Plan]]
+  * owner:: [[Alice]]
+```
+
+Node property values are exported as `[[Node title]]`. Mirror export does not
+use `((uuid))` for node property values.
+
+## Tags
+Tags are exported on block lines when they are normal user tags:
+
+```markdown
+- Call customer #sales
+- Review #[[Quarterly plan]]
+```
+
+## Task Status
+Task status is encoded on the block line:
+
+```markdown
+- TODO Write draft
+- DONE Publish note
+```
+
+Task status is not exported as a separate `* Status::` property list item.

--- a/src/main/frontend/worker/markdown_mirror.cljs
+++ b/src/main/frontend/worker/markdown_mirror.cljs
@@ -6,7 +6,9 @@
             [frontend.worker.platform :as platform]
             [lambdaisland.glogi :as log]
             [logseq.cli.common.file :as common-file]
+            [logseq.common.util :as common-util]
             [logseq.db :as ldb]
+            [logseq.db.frontend.property :as db-property]
             [promesa.core :as p]))
 
 (defn repo-mirror-dir
@@ -28,6 +30,11 @@
                 (map #(str "LPT" %) (range 1 10)))))
 
 (def ^:private max-file-stem-length 160)
+(def ^:private markdown-block-re #"^(\s*)-\s?(.*)$")
+(def ^:private markdown-property-line-re #"^(\s*)\*\s+[^:\s][^:]*::\s?.*$")
+(def ^:private property-line-re #"^(\s*)[^:\s][^:]*::\s?.*$")
+(def ^:private ref-or-tag-re #"(#?)\[\[([^\[\]]+)\]\]")
+(def ^:private simple-hashtag-re #"(?i)(^|\s)#([^\s#\[\]\(\),.;:'\"`]+)")
 
 (defonce ^:private *repo->enabled? (atom {}))
 (defonce ^:private *repo->queued-page-jobs (atom {}))
@@ -188,14 +195,202 @@
   (when journal-day
     (< 1 (count (d/datoms db :avet :block/journal-day journal-day)))))
 
+(defn- leading-space-count
+  [line]
+  (count (or (second (re-matches #"^(\s*).*$" line)) "")))
+
+(defn- property-line-indent
+  [line]
+  (or (some-> (re-matches markdown-property-line-re line) second count)
+      (some-> (re-matches property-line-re line) second count)))
+
+(defn- property-value-line?
+  [line property-indent]
+  (and (some? property-indent)
+       (not (string/blank? line))
+       (< property-indent (leading-space-count line))))
+
+(defn- content-ref-targets
+  [title]
+  (let [title (or title "")
+        page-ref-targets (keep (fn [[_ prefix page-title]]
+                                 (when-not (common-util/uuid-string? page-title)
+                                   {:title page-title
+                                    :tag? (= "#" prefix)}))
+                               (re-seq ref-or-tag-re title))
+        simple-tag-targets (keep (fn [[_ _ tag-title]]
+                                   (when-not (common-util/uuid-string? tag-title)
+                                     {:title tag-title
+                                      :tag? true}))
+                                 (re-seq simple-hashtag-re title))]
+    (distinct (concat page-ref-targets simple-tag-targets))))
+
+(defn- status-marker
+  [status]
+  (when-let [content (some-> (cond
+                               (keyword? status) (name status)
+                               :else (or (db-property/closed-value-content status)
+                                         (:block/title status)
+                                         (:logseq.property/value status)))
+                             str
+                             string/trim)]
+    (when-not (string/blank? content)
+      (-> content
+          string/upper-case
+          (string/replace #"\s+" "-")))))
+
+(defn- simple-tag-token?
+  [title]
+  (boolean
+   (re-matches #"[^\s#\[\]\(\),.;:'\"`]+" (or title ""))))
+
+(defn- tag-token
+  [tag]
+  (let [title (or (:block/title tag) (:block/name tag))]
+    (when-not (string/blank? title)
+      (if (simple-tag-token? title)
+        (str "#" title)
+        (str "#[[" title "]]")))))
+
+(defn- built-in-tag?
+  [tag]
+  (or (ldb/built-in? tag)
+      (some-> tag :db/ident namespace (= "logseq.class"))))
+
+(defn- mirror-tag-tokens
+  [block]
+  (->> (:block/tags block)
+       (remove built-in-tag?)
+       (keep tag-token)
+       sort
+       vec))
+
+(defn- id-property-line
+  [block-uuid]
+  (str "id:: " block-uuid))
+
+(defn- content-has-status-marker?
+  [content marker]
+  (or (= content marker)
+      (string/starts-with? content (str marker " "))))
+
+(defn- content-tag-titles
+  [content]
+  (->> (content-ref-targets content)
+       (keep (fn [{:keys [title tag?]}]
+               (when tag? (string/lower-case title))))
+       set))
+
+(defn- token-title
+  [token]
+  (if (string/starts-with? token "#[[")
+    (subs token 3 (- (count token) 2))
+    (subs token 1)))
+
+(defn- decorate-block-content
+  [{:keys [tag-tokens] :as block-info} content]
+  (let [content (or content "")
+        status-marker' (:status-marker block-info)
+        content (if (and status-marker'
+                         (not (content-has-status-marker? content status-marker')))
+                  (if (string/blank? content)
+                    status-marker'
+                    (str status-marker' " " content))
+                  content)
+        existing-tag-titles (content-tag-titles content)
+        tag-tokens' (remove (fn [token]
+                              (contains? existing-tag-titles
+                                         (string/lower-case (token-title token))))
+                            tag-tokens)]
+    (if (seq tag-tokens')
+      (str content " " (string/join " " tag-tokens'))
+      content)))
+
+(defn- decorate-block-line
+  [block-info line]
+  (if-let [[_ spaces title] (re-matches markdown-block-re line)]
+    (str spaces "- " (decorate-block-content block-info title))
+    line))
+
+(defn- block-line-info
+  [db block]
+  {:status-marker (when (seq (d/datoms db :eavt (:db/id block) :logseq.property/status))
+                    (some-> (:logseq.property/status block) status-marker))
+   :tag-tokens (mirror-tag-tokens block)})
+
+(defn- property-derived-block?
+  [block]
+  (or (:logseq.property/created-from-property block)
+      (:block/closed-value-property block)))
+
+(defn- outline-children
+  [block]
+  (->> (:block/_parent block)
+       (remove property-derived-block?)
+       (sort-by :block/order)))
+
+(defn- page-root-blocks
+  [page]
+  (outline-children page))
+
+(defn- outline-block-and-children
+  [block]
+  (cons block (mapcat outline-block-and-children (outline-children block))))
+
+(defn- rendered-block-line-infos
+  [db page]
+  (->> (mapcat outline-block-and-children (page-root-blocks page))
+       (map (fn [block]
+              (block-line-info db block)))))
+
+(defn- add-page-id-to-rendered-content
+  [db page content]
+  (let [block-line-infos (rendered-block-line-infos db page)]
+    (loop [[line & more] (string/split-lines (or content ""))
+           [block-line-info' & more-block-line-infos] block-line-infos
+           lines [(id-property-line (:block/uuid page))]
+           seen-block? false
+           property-indent nil]
+      (if (nil? line)
+        (string/join "\n" lines)
+        (if (property-value-line? line property-indent)
+          (recur more
+                 (cons block-line-info' more-block-line-infos)
+                 (conj lines line)
+                 seen-block?
+                 property-indent)
+          (if (re-matches markdown-block-re line)
+            (let [lines' (cond-> lines
+                           (not seen-block?) (conj "")
+                           true (conj (decorate-block-line block-line-info' line)))]
+              (recur more
+                     more-block-line-infos
+                     lines'
+                     true
+                     nil))
+            (let [property-indent' (property-line-indent line)]
+              (recur more
+                     (cons block-line-info' more-block-line-infos)
+                     (conj lines line)
+                     seen-block?
+                     property-indent'))))))))
+
 (defn- render-page-content
   [db page options]
-  (common-file/block->content
+  (add-page-id-to-rendered-content
    db
-   (:block/uuid page)
-   {:include-page-properties? true}
-   {:export-bullet-indentation (or (:export-bullet-indentation options) "  ")
-    :date-formatter (:date-formatter options)}))
+   page
+   (common-file/block->content
+    db
+    (:block/uuid page)
+    {:include-page-properties? true}
+    {:export-bullet-indentation (or (:export-bullet-indentation options) "  ")
+     :excluded-properties #{:logseq.property/status}
+     :export-properties-as-list-items? true
+     :export-node-property-values-as-page-refs? true
+     :export-default-property-values-as-blocks? true
+     :preserve-block-refs? true
+     :date-formatter (:date-formatter options)})))
 
 (defn- mirrorable-page?
   [page]

--- a/src/test/frontend/handler/export_property_test.cljs
+++ b/src/test/frontend/handler/export_property_test.cljs
@@ -1,15 +1,17 @@
 (ns frontend.handler.export-property-test
-  (:require [cljs.test :refer [deftest is]]
+  (:require [cljs-time.coerce :as tc]
+            [cljs-time.core :as t]
+            [cljs.test :refer [deftest is]]
             [datascript.core :as d]
             [logseq.cli.common.file :as common-file]
             [logseq.common.util.date-time :as date-time-util]
             [logseq.db.frontend.property :as db-property]))
 
-(deftest block-properties-content-uses-property-title-and-journal-title-for-datetime
-  (let [datetime-ms 1776441600000
-        expected-journal-title (date-time-util/int->journal-title
-                                (date-time-util/ms->journal-day datetime-ms)
-                                date-time-util/default-journal-title-formatter)
+(deftest block-properties-content-uses-property-title-and-time-for-datetime
+  (let [datetime-ms (tc/to-long (t/date-time 2026 5 14 9 30))
+        expected-datetime (date-time-util/format
+                           (t/to-default-time-zone (tc/from-long datetime-ms))
+                           "MMM do, yyyy HH:mm")
         properties (array-map
                     :logseq.property/deadline datetime-ms
                     :user.property/P1-MoCeM8Tf "hello")]
@@ -24,6 +26,6 @@
                                                            :block/title "P1"
                                                            :logseq.property/type :default}
                                nil))]
-      (is (= (str "  deadline:: " expected-journal-title "\n"
+      (is (= (str "  deadline:: " expected-datetime "\n"
                   "  P1:: hello")
              (@#'common-file/block-properties-content nil {} "  " {}))))))

--- a/src/test/frontend/worker/markdown_mirror_test.cljs
+++ b/src/test/frontend/worker/markdown_mirror_test.cljs
@@ -35,6 +35,9 @@
 (defn- page-path [path]
   (str (markdown-mirror/repo-mirror-dir test-repo) "/" path))
 
+(defn- page-marker [uuid]
+  (str "id:: " uuid))
+
 (defn- js-error
   [message data]
   (let [error (js/Error. message)]
@@ -122,7 +125,8 @@
           page (db-test/find-page-by-title @conn "Source")]
       (-> (markdown-mirror/<mirror-page! test-repo @conn (:db/id page) {:platform platform})
           (p/then (fn [_]
-                    (is (= "- See [[Foo]]"
+                    (is (= (str (page-marker (:block/uuid page)) "\n\n"
+                                "- See [[Foo]]")
                            (get @files (page-path "pages/Source.md"))))))
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
           (p/finally done)))))
@@ -150,9 +154,11 @@
           page (db-test/find-page-by-title @conn "Page A")]
       (-> (markdown-mirror/<mirror-page! test-repo @conn (:db/id page) {:platform platform})
           (p/then (fn [_]
-                    (let [path (page-path "pages/Page A.md")]
-                      (is (= "- hello\n- world" (get @files path)))
-                      (is (= [[path "- hello\n- world"]] @writes)))))
+                    (let [path (page-path "pages/Page A.md")
+                          content (str (page-marker page-uuid) "\n\n"
+                                       "- hello\n- world")]
+                      (is (= content (get @files path)))
+                      (is (= [[path content]] @writes)))))
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
           (p/finally done)))))
 
@@ -169,9 +175,11 @@
            {:platform (assoc-in platform [:storage :read-text!]
                                 (fn [_path] (p/rejected missing-error)))})
           (p/then (fn [_]
-                    (let [path (page-path "pages/Page A.md")]
-                      (is (= "- hello" (get @files path)))
-                      (is (= [[path "- hello"]] @writes)))))
+                    (let [path (page-path "pages/Page A.md")
+                          content (str (page-marker (:block/uuid page)) "\n\n"
+                                       "- hello")]
+                      (is (= content (get @files path)))
+                      (is (= [[path content]] @writes)))))
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
           (p/finally done)))))
 
@@ -212,7 +220,13 @@
       (-> (markdown-mirror/<mirror-page! test-repo @conn (:db/id page) {:platform platform})
           (p/then (fn [_]
                     (let [content (get @files (page-path "pages/Issue.md"))]
-                      (is (= "reproducible-steps:: Open settings\n- ## TODO body\n  Status:: Todo\n  reproducible-steps:: Click mirror\n  rating:: 5"
+                      (is (= (str (page-marker (:block/uuid page)) "\n"
+                                  "* reproducible-steps::\n"
+                                  "  - Open settings\n\n"
+                                  "- TODO ## TODO body\n"
+                                  "  * reproducible-steps::\n"
+                                  "    - Click mirror\n"
+                                  "  * rating:: 5")
                              content)))))
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
           (p/finally done)))))
@@ -235,7 +249,14 @@
       (-> (markdown-mirror/<mirror-page! test-repo @conn (:db/id page) {:platform platform})
           (p/then (fn [_]
                     (let [content (get @files (page-path "pages/Formats.md"))]
-                      (is (= "- ## Heading block\n- > quote line 1\n  > quote line 2\n- ```clojure\n  (println \"hi\")\n  (+ 1 2)\n  ```"
+                      (is (= (str (page-marker (:block/uuid page)) "\n\n"
+                                  "- ## Heading block\n"
+                                  "- > quote line 1\n"
+                                  "  > quote line 2\n"
+                                  "- ```clojure\n"
+                                  "  (println \"hi\")\n"
+                                  "  (+ 1 2)\n"
+                                  "  ```")
                              content)))))
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
           (p/finally done)))))
@@ -256,8 +277,33 @@
       (-> (markdown-mirror/<mirror-page! test-repo @conn (:db/id page) {:platform platform})
           (p/then (fn [_]
                     (let [content (get @files (page-path "pages/Page Props.md"))]
-                      (is (= "p1:: hello\np2:: 1\np3:: Author 1\n- body"
+                      (is (= (str (page-marker (:block/uuid page)) "\n"
+                                  "* p1::\n"
+                                  "  - hello\n"
+                                  "* p2:: 1\n"
+                                  "* p3::\n"
+                                  "  - Author 1\n\n"
+                                  "- body")
                              content)))))
+          (p/catch (fn [e] (is false (str "unexpected error: " e))))
+          (p/finally done)))))
+
+(deftest page-mirror-exports-node-property-values-as-page-refs-test
+  (async done
+    (let [{:keys [platform files]} (fake-platform)
+          conn (db-test/create-conn-with-blocks
+                {:properties {:friend {:logseq.property/type :node}}
+                 :pages-and-blocks [{:page {:block/title "Alice"
+                                             :build/properties {:friend [:build/page {:block/title "Bob"}]}}
+                                     :blocks [{:block/title "knows"}]}
+                                    {:page {:block/title "Bob"}}]})
+          page (db-test/find-page-by-title @conn "Alice")]
+      (-> (markdown-mirror/<mirror-page! test-repo @conn (:db/id page) {:platform platform})
+          (p/then (fn [_]
+                    (is (= (str (page-marker (:block/uuid page)) "\n"
+                                "* friend:: [[Bob]]\n\n"
+                                "- knows")
+                           (get @files (page-path "pages/Alice.md"))))))
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
           (p/finally done)))))
 
@@ -282,7 +328,15 @@
       (-> (markdown-mirror/<mirror-page! test-repo @conn (:db/id journal) {:platform platform})
           (p/then (fn [_]
                     (let [content (get @files (page-path "journals/2026_05_05.md"))]
-                      (is (= "p1:: hey\n- TODO hello great test\n  Status:: Todo\n  p1:: hello\n  p2:: 1\n  p3:: Author 1"
+                      (is (= (str (page-marker (:block/uuid journal)) "\n"
+                                  "* p1::\n"
+                                  "  - hey\n\n"
+                                  "- TODO hello great test\n"
+                                  "  * p1::\n"
+                                  "    - hello\n"
+                                  "  * p2:: 1\n"
+                                  "  * p3::\n"
+                                  "    - Author 1")
                              content)))))
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
           (p/finally done)))))
@@ -312,12 +366,18 @@
       (-> (<mirror-repo! test-repo @conn {:platform platform})
           (p/then (fn [result]
                     (is (not= ::missing-mirror-repo-fn result))
-                    (is (= "- alpha"
-                           (get @files (page-path "pages/Page A.md"))))
-                    (is (= "- journal"
-                           (get @files (page-path "journals/2024_05_08.md"))))
-                    (is (= "- class"
-                           (get @files (page-path "pages/Project.md"))))
+                    (let [page-a (db-test/find-page-by-title @conn "Page A")
+                          journal (db-test/find-journal-by-journal-day @conn 20240508)
+                          project (db-test/find-page-by-title @conn "Project")]
+                      (is (= (str (page-marker (:block/uuid page-a)) "\n\n"
+                                  "- alpha")
+                             (get @files (page-path "pages/Page A.md"))))
+                      (is (= (str (page-marker (:block/uuid journal)) "\n\n"
+                                  "- journal")
+                             (get @files (page-path "journals/2024_05_08.md"))))
+                      (is (= (str (page-marker (:block/uuid project)) "\n\n"
+                                  "- class")
+                             (get @files (page-path "pages/Project.md")))))
                     (is (nil? (get @files (page-path "pages/Built In.md"))))
                     (is (nil? (get @files (page-path "pages/rating.md"))))))
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
@@ -335,7 +395,8 @@
           page (db-test/find-page-by-title @conn "Page A")]
       (-> (markdown-mirror/<mirror-page! test-repo @conn (:db/id page) {:platform platform})
           (p/then (fn [_]
-                    (is (= "- desktop"
+                    (is (= (str (page-marker page-uuid) "\n\n"
+                                "- desktop")
                            (get @files (page-path "pages/Page A.md"))))))
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
           (p/finally done)))))
@@ -365,7 +426,8 @@
           journal (db-test/find-journal-by-journal-day @conn 20240506)]
       (-> (markdown-mirror/<mirror-page! test-repo @conn (:db/id journal) {:platform platform})
           (p/then (fn [_]
-                    (is (= "- journal item"
+                    (is (= (str (page-marker (:block/uuid journal)) "\n\n"
+                                "- journal item")
                            (get @files (page-path "journals/2024_05_06.md"))))))
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
           (p/finally done)))))
@@ -406,7 +468,8 @@
                                             :block/title "after"}] {:outliner-op :save-block}))
                     (markdown-mirror/<flush-repo! test-repo {:platform platform})))
           (p/then (fn [_]
-                    (is (= "- after"
+                    (is (= (str (page-marker page-uuid) "\n\n"
+                                "- after")
                            (get @files (page-path "pages/Page A.md"))))))
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
           (p/finally done)))))
@@ -451,7 +514,9 @@
                   _ (markdown-mirror/<handle-tx-report! test-repo conn tx-report-2 {:platform platform
                                                                                      :defer? true})
                   _ (markdown-mirror/<flush-repo! test-repo {:platform platform})]
-            (is (= [[(page-path "pages/Page A.md") "- latest"]]
+            (is (= [[(page-path "pages/Page A.md")
+                     (str (page-marker page-uuid) "\n\n"
+                          "- latest")]]
                    @writes)))
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
           (p/finally done)))))
@@ -466,7 +531,8 @@
                                      :blocks [{:block/title "body"}]}]})
           page (db-test/find-page-by-title @conn "Old Name")
           old-path (page-path "pages/Old Name.md")
-          _ (swap! files assoc old-path "- body")
+          _ (swap! files assoc old-path (str (page-marker page-uuid) "\n\n"
+                                             "- body"))
           tx-report (d/with @conn [{:db/id (:db/id page)
                                     :block/title "New Name"
                                     :block/name "new name"}])
@@ -475,7 +541,8 @@
       (-> (markdown-mirror/<handle-tx-report! test-repo conn tx-report {:platform platform})
           (p/then (fn [_]
                     (is (= [old-path] @deletes))
-                    (is (= "- body"
+                    (is (= (str (page-marker page-uuid) "\n\n"
+                                "- body")
                            (get @files (page-path "pages/New Name.md"))))
                     (is (nil? (get @files old-path)))))
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
@@ -492,9 +559,11 @@
           page (db-test/find-page-by-title @conn "Old Name2")
           old-path (page-path "pages/Old Name2.md")
           new-path (page-path "pages/New Name2.md")
+          content (str (page-marker page-uuid) "\n\n"
+                       "- body")
           ;; pre-populate both old and new paths with same content
-          _ (swap! files assoc old-path "- body")
-          _ (swap! files assoc new-path "- body")
+          _ (swap! files assoc old-path content)
+          _ (swap! files assoc new-path content)
           tx-report (d/with @conn [{:db/id (:db/id page)
                                     :block/title "New Name2"
                                     :block/name "new name2"}])
@@ -518,7 +587,8 @@
                                      :blocks [{:block/title "body"}]}]})
           page (db-test/find-page-by-title @conn "Delete Me")
           old-path (page-path "pages/Delete Me.md")
-          _ (swap! files assoc old-path "- body")
+          _ (swap! files assoc old-path (str (page-marker page-uuid) "\n\n"
+                                             "- body"))
           tx-report (d/with @conn [[:db/retractEntity (:db/id page)]])
           _ (d/reset-conn! conn (:db-after tx-report))]
       (markdown-mirror/set-enabled! test-repo true)
@@ -540,11 +610,14 @@
                                      :blocks [{:block/title "same"}]}]})
           page (db-test/find-page-by-title @conn "Page A")
           path (page-path "pages/Page A.md")
-          _ (swap! files assoc path "- same")]
+          _ (swap! files assoc path (str (page-marker page-uuid) "\n\n"
+                                         "- same"))]
       (-> (markdown-mirror/<mirror-page! test-repo @conn (:db/id page) {:platform platform})
           (p/then (fn [_]
                     (is (empty? @writes))
-                    (is (= "- same" (get @files path)))))
+                    (is (= (str (page-marker page-uuid) "\n\n"
+                                "- same")
+                           (get @files path)))))
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
           (p/finally done)))))
 


### PR DESCRIPTION
Move the Logseq Markdown Mirror syntax/export work out of the two-way sync branch while leaving file-to-DB sync behavior behind.

Details:
- add docs/logseq-markdown-syntax.md and update ADR 0016 with the one-way mirror syntax contract
- export mirror files with page id markers, property list items, nested default property values, node page refs, task status markers, and datetime values with time\n- preserve block refs as uuid links where needed while keeping page/node refs readable\n- update focused export and markdown mirror tests

Validation:
- bb dev:lint-and-test