### PR TITLE
Fix calculator render

### DIFF
--- a/src/main/frontend/extensions/code.cljs
+++ b/src/main/frontend/extensions/code.cljs
@@ -436,7 +436,9 @@
                              :cursorBlinkRate -1})
                           (when config-edit?
                             {:hintOptions {}})
-                          user-options)
+                          user-options
+                          (when (= mode "calc")
+                            {:viewportMargin js/Infinity}))
         editor (when textarea
                  (from-textarea textarea (clj->js cm-options)))
         _ (when (and editor *editor-ref)
@@ -589,6 +591,9 @@
                  state)}
   [state _config id attr code _theme _options]
   [:div.extensions__code.flex.flex-1
+   (cond-> {}
+     (= (:data-lang attr) "calc")
+     (assoc :data-lang "calc"))
    (when-let [mode (:data-lang attr)]
      (when-not (= mode "calc")
        [:div.extensions__code-lang

--- a/src/main/frontend/extensions/code.css
+++ b/src/main/frontend/extensions/code.css
@@ -26,15 +26,40 @@
 
   &-calc {
     @apply text-sm;
-    padding: 0.35em 0.25em 0.25em 0.25em;
+    padding: 4px 0.25em 0.25em 0.25em;
     width: max-content;
     text-align: right;
 
     &-output-line {
-      height: 23px;
+      height: 1.45rem;
+      line-height: 1.45rem;
       white-space: pre;
       font-family: Fira Code, Monaco, Menlo, Consolas, 'COURIER NEW', monospace;
     }
+  }
+}
+
+.cp__fenced-code-block[data-lang="calc"],
+.extensions__code[data-lang="calc"] {
+  .CodeMirror,
+  .CodeMirror-scroll {
+    max-height: none;
+  }
+
+  .CodeMirror {
+    overflow: visible;
+  }
+
+  .CodeMirror-scroll {
+    overflow: visible !important;
+    margin-right: 0;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+
+  .CodeMirror-vscrollbar,
+  .CodeMirror-hscrollbar {
+    display: none !important;
   }
 }
 


### PR DESCRIPTION
fix https://github.com/logseq/db-test/issues/844

- Expand calculator CodeMirror content fully
- Hide calculator CodeMirror scrollbars
- Keep calculator results aligned with input lines