### PR TITLE
Support fullwidth left square bracket input with IME auto-completion

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2704,34 +2704,83 @@
         :else
         nil))))
 
-(defn- input-page-ref?
-  [k current-pos blank-selected? last-key-code]
-  (and blank-selected?
-       (contains? keycode/left-square-brackets-keys k)
-       (= (:key last-key-code) k)
-       (> current-pos 0)))
+(def ^:private block-ref-trigger-keys
+  (conj keycode/left-square-brackets-keys "Process"))
+
+(defn- block-ref-trigger-key?
+  [k]
+  (contains? block-ref-trigger-keys k))
+
+(defn- replacement-edit
+  [value replacement {:keys [start end]}]
+  {:value (str (subs value 0 start) replacement (subs value end))
+   :pos (+ start 2)})
+
+(defn- double-left-trigger-edit
+  [value current-pos left replacement]
+  (let [start (- current-pos (* 2 (count left)))]
+    (when (and (>= start 0)
+               (= (subs value start current-pos) (str left left)))
+      (replacement-edit value replacement {:start start :end current-pos}))))
+
+(def ^:private fullwidth-block-ref-patterns
+  #{"【【"
+    "【【】"
+    "【【】】"
+    "【】【"
+    "【】【】"})
+
+(defn- fullwidth-block-ref-trigger-range
+  [value current-pos]
+  (let [min-start (max 0 (- current-pos 4))
+        ;; Patterns can extend up to 3 chars past cursor (e.g. cursor at pos 1 in "【【】】").
+        ;; Use +4 so the full 4-char pattern is always reachable.
+        max-end (min (count value) (+ current-pos 4))
+        candidates (for [start (range min-start current-pos)
+                         end (range current-pos (inc max-end))
+                         :let [text (subs value start end)]
+                         :when (contains? fullwidth-block-ref-patterns text)]
+                     {:start start
+                      :end end})]
+    (when (seq candidates)
+      (apply max-key #(- (:end %) (:start %)) candidates))))
+
+(defn- fullwidth-block-ref-trigger-edit
+  [value current-pos]
+  (when-let [range (fullwidth-block-ref-trigger-range value current-pos)]
+    (replacement-edit value page-ref/left-and-right-brackets range)))
+
+(defn- block-ref-trigger-edit
+  [value current-pos k]
+  (or (fullwidth-block-ref-trigger-edit value current-pos)
+      (when (contains? keycode/left-square-brackets-keys k)
+        (double-left-trigger-edit value current-pos "[" page-ref/left-and-right-brackets))))
+
+(defn- apply-bracket-trigger!
+  [input {:keys [value pos]} command-step]
+  (state/set-block-content-and-last-pos! (.-id input) value pos)
+  (commands/handle-step command-step)
+  (cursor/move-cursor-to input pos)
+  (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)}))
 
 (defn- default-case-for-keyup-handler
   [input current-pos k code is-processed?]
-  (let [last-key-code (state/get-last-key-code)
-        blank-selected? (string/blank? (util/get-selected-text))
+  (let [blank-selected? (string/blank? (util/get-selected-text))
         non-enter-processed? (and is-processed? ;; #3251
                                   (not= code keycode/enter-code))  ;; #3459
-        editor-action (state/get-editor-action)]
-    (if (and (= editor-action :page-search-hashtag)
-             (input-page-ref? k current-pos blank-selected? last-key-code))
-      (do
-        (commands/handle-step [:editor/input page-ref/right-brackets {:last-pattern :skip-check
-                                                                      :backward-pos 2}])
-        (commands/handle-step [:editor/search-page])
-        (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)}))
+        editor-action (state/get-editor-action)
+        value (gobj/get input "value")
+        block-ref-trigger? (and blank-selected? (block-ref-trigger-key? k))
+        block-ref-edit (when block-ref-trigger?
+                         (block-ref-trigger-edit value current-pos k))]
+    (if (and (= editor-action :page-search-hashtag) block-ref-edit)
+      (apply-bracket-trigger! input block-ref-edit [:editor/search-page-hashtag])
       (when (and (not editor-action) (not non-enter-processed?))
         (cond
          ;; When you type text inside square brackets
           (and (not (contains? #{"ArrowDown" "ArrowLeft" "ArrowRight" "ArrowUp" "Escape"} k))
                (wrapped-by? input page-ref/left-brackets page-ref/right-brackets))
           (let [orig-pos (cursor/get-caret-pos input)
-                value (gobj/get input "value")
                 square-pos (string/last-index-of (subs value 0 (:pos orig-pos)) page-ref/left-brackets)
                 pos (+ square-pos 2)
                 _ (state/set-editor-last-pos! pos)
@@ -2742,26 +2791,9 @@
             (commands/handle-step [command-step])
             (state/set-editor-action-data! {:pos pos}))
 
-         ;; Handle non-ascii square brackets
-          (and (input-page-ref? k current-pos blank-selected? last-key-code)
+          (and block-ref-edit
                (not (wrapped-by? input page-ref/left-brackets page-ref/right-brackets)))
-          (do
-            (commands/handle-step [:editor/input page-ref/left-and-right-brackets {:backward-truncate-number 2
-                                                                                   :backward-pos 2}])
-            (commands/handle-step [:editor/search-page])
-            (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)}))
-
-         ;; Handle non-ascii parentheses
-          (and blank-selected?
-               (contains? keycode/left-paren-keys k)
-               (= (:key last-key-code) k)
-               (> current-pos 0)
-               (not (wrapped-by? input block-ref/left-parens block-ref/right-parens)))
-          (do
-            (commands/handle-step [:editor/input block-ref/left-and-right-parens {:backward-truncate-number 2
-                                                                                  :backward-pos 2}])
-            (commands/handle-step [:editor/search-block :reference])
-            (state/set-editor-action-data! {:pos (cursor/get-caret-pos input)}))
+          (apply-bracket-trigger! input block-ref-edit [:editor/search-page])
 
           :else
           nil)))))
@@ -2835,7 +2867,7 @@
                                      :key k
                                      :shift? (.-shiftKey e)}))
         (when-not (state/get-editor-action)
-          (state/set-editor-last-pos! current-pos))))))
+          (state/set-editor-last-pos! (cursor/pos input)))))))
 
 (defn editor-on-click!
   [id]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2775,10 +2775,15 @@
                          (block-ref-trigger-edit value current-pos k))]
     (if (and (= editor-action :page-search-hashtag) block-ref-edit)
       (apply-bracket-trigger! input block-ref-edit [:editor/search-page-hashtag])
-      (when (and (not editor-action) (not non-enter-processed?))
+      (when-not editor-action
         (cond
-         ;; When you type text inside square brackets
-          (and (not (contains? #{"ArrowDown" "ArrowLeft" "ArrowRight" "ArrowUp" "Escape"} k))
+          (and block-ref-edit
+               (not (wrapped-by? input page-ref/left-brackets page-ref/right-brackets)))
+          (apply-bracket-trigger! input block-ref-edit [:editor/search-page])
+
+          ;; When you type text inside square brackets
+          (and (not non-enter-processed?)
+               (not (contains? #{"ArrowDown" "ArrowLeft" "ArrowRight" "ArrowUp" "Escape"} k))
                (wrapped-by? input page-ref/left-brackets page-ref/right-brackets))
           (let [orig-pos (cursor/get-caret-pos input)
                 square-pos (string/last-index-of (subs value 0 (:pos orig-pos)) page-ref/left-brackets)
@@ -2790,10 +2795,6 @@
                                :editor/search-page)]
             (commands/handle-step [command-step])
             (state/set-editor-action-data! {:pos pos}))
-
-          (and block-ref-edit
-               (not (wrapped-by? input page-ref/left-brackets page-ref/right-brackets)))
-          (apply-bracket-trigger! input block-ref-edit [:editor/search-page])
 
           :else
           nil)))))

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -1,10 +1,12 @@
 (ns frontend.handler.editor-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [frontend.commands :as commands]
             [frontend.db :as db]
             [frontend.db.model :as model]
             [frontend.handler.editor :as editor]
             [frontend.state :as state]
             [frontend.test.helper :as test-helper]
+            [frontend.util :as util]
             [frontend.util.cursor :as cursor]
             [logseq.outliner.core :as outliner-core]))
 
@@ -118,6 +120,70 @@
         "Completion stays open when typing tag before another tag"))
   ;; Reset state
   (state/set-editor-action! nil))
+
+(defn- default-keyup-result
+  [{:keys [value cursor-pos key code action]
+    :or {code "KeyA"}}]
+  (let [pos (or cursor-pos (count value))
+        input #js {:id "edit-block-test"
+                   :value value}
+        content (atom nil)
+        cursor-pos' (atom nil)
+        steps (atom [])]
+    (with-redefs [state/get-editor-action (constantly action)
+                  state/set-block-content-and-last-pos! (fn [_input-id value' pos']
+                                                          (reset! content value')
+                                                          (reset! cursor-pos' pos'))
+                  state/set-editor-action-data! (constantly nil)
+                  state/set-editor-last-pos! (fn [pos']
+                                               (reset! cursor-pos' pos'))
+                  state/clear-editor-action! (constantly nil)
+                  util/get-selected-text (constantly "")
+                  cursor/pos (constantly pos)
+                  cursor/get-caret-pos (fn [_] {:pos @cursor-pos'})
+                  cursor/move-cursor-to (fn [_ pos' & _]
+                                          (reset! cursor-pos' pos'))
+                  commands/handle-step (fn [step]
+                                         (swap! steps conj step))]
+      (#'editor/default-case-for-keyup-handler input pos key code false)
+      {:content @content
+       :cursor-pos @cursor-pos'
+       :steps @steps})))
+
+(deftest default-keyup-handler-normalizes-fullwidth-page-ref-input
+  (doseq [[value cursor-pos expected-content expected-pos]
+          [["【【" 2 "[[]]" 2]
+           ["【【】" 3 "[[]]" 2]
+           ["【】【】" 4 "[[]]" 2]
+           ["【【】】" 2 "[[]]" 2]
+           ;; cursor=1: IME may place cursor early; full pattern must still match
+           ["【【】】" 1 "[[]]" 2]
+           ["abc【【】】def" 5 "abc[[]]def" 5]
+           ["abc【】【】def" 7 "abc[[]]def" 5]]]
+    (is (= {:content expected-content
+            :cursor-pos expected-pos
+            :steps [[:editor/search-page]]}
+           (default-keyup-result {:value value
+                                  :cursor-pos cursor-pos
+                                  :key "Process"}))
+        (str "Normalizes " value " at cursor " cursor-pos))))
+
+(deftest default-keyup-handler-normalizes-hashtag-fullwidth-page-ref-input
+  (is (= {:content "#[[]]"
+          :cursor-pos 3
+          :steps [[:editor/search-page-hashtag]]}
+         (default-keyup-result {:value "#【】【】"
+                                :cursor-pos 5
+                                :key "Process"
+                                :action :page-search-hashtag}))))
+
+(deftest default-keyup-handler-ignores-non-page-ref-trigger-key
+  (is (= {:content nil
+          :cursor-pos nil
+          :steps []}
+         (default-keyup-result {:value "【【】】"
+                                :cursor-pos 2
+                                :key "a"}))))
 
 (defn- handle-last-input-handler
   "Spied version of editor/handle-last-input"

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -122,8 +122,9 @@
   (state/set-editor-action! nil))
 
 (defn- default-keyup-result
-  [{:keys [value cursor-pos key code action]
-    :or {code "KeyA"}}]
+  [{:keys [value cursor-pos key code action is-processed?]
+    :or {code "KeyA"
+         is-processed? false}}]
   (let [pos (or cursor-pos (count value))
         input #js {:id "edit-block-test"
                    :value value}
@@ -145,7 +146,7 @@
                                           (reset! cursor-pos' pos'))
                   commands/handle-step (fn [step]
                                          (swap! steps conj step))]
-      (#'editor/default-case-for-keyup-handler input pos key code false)
+      (#'editor/default-case-for-keyup-handler input pos key code is-processed?)
       {:content @content
        :cursor-pos @cursor-pos'
        :steps @steps})))
@@ -165,7 +166,8 @@
             :steps [[:editor/search-page]]}
            (default-keyup-result {:value value
                                   :cursor-pos cursor-pos
-                                  :key "Process"}))
+                                  :key "Process"
+                                  :is-processed? true}))
         (str "Normalizes " value " at cursor " cursor-pos))))
 
 (deftest default-keyup-handler-normalizes-hashtag-fullwidth-page-ref-input
@@ -175,6 +177,7 @@
          (default-keyup-result {:value "#【】【】"
                                 :cursor-pos 5
                                 :key "Process"
+                                :is-processed? true
                                 :action :page-search-hashtag}))))
 
 (deftest default-keyup-handler-ignores-non-page-ref-trigger-key


### PR DESCRIPTION
- normalize IME-produced fullwidth left square bracket patterns like `【【】】` and `【】【】` to `[[]]`, like WeChat input method input `【` will be automatically completed as `【】`