### PR TITLE
Preserve mixed quote blocks during DB export

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -1519,15 +1519,93 @@
           (assoc :asset-blocks-tx asset-blocks)))
       (p/resolved {:block block}))))
 
+(defn- quote-node->markdown
+  "Converts a Quote AST node to markdown, preserving nested quote structure.
+   Content at depth=0 (used for Quote-block titles) has no outer prefix — the
+   Quote-block display-type provides the outermost blockquote styling.
+   Content at depth>=1 (used for mixed blocks) gets '> ' prefix at each level."
+  [quote-node opts depth]
+  (let [inner-elements (second quote-node)
+        parts (for [el inner-elements
+                    :let [el-type (first el)]]
+                (cond
+                  (= "Quote" el-type)
+                  ;; Nested quote: recurse one level deeper
+                  (quote-node->markdown el opts (inc depth))
+                  :else
+                  ;; Other content (Paragraph, Src, etc.): extract as text
+                  (let [text (ast->text el opts)]
+                    (if (pos? depth)
+                      (->> (string/split-lines text)
+                           (map #(str "> " %))
+                           (string/join "\n"))
+                      text))))]
+    (string/join "\n" (remove string/blank? parts))))
+
 (defn- handle-quotes
-  "If a block contains a quote, convert block to #Quote node"
+  "Handles blocks containing markdown blockquotes or #+BEGIN_QUOTE:
+   - Pure quote blocks (empty heading + all body elements are Quote nodes):
+     convert to #Quote-block with quote content as title. Nested quotes are
+     preserved using '> ' markdown prefix at each nesting level.
+   - Blocks where the title contains #+BEGIN_QUOTE and has Quote body elements
+     but are not pure quote blocks: retain as regular block with '> ' prefix
+     added to quote content so it renders as a blockquote in the DB graph."
   [block opts]
-  (if-let [ast-block (first (filter #(= "Quote" (first %)) (:block.temp/ast-blocks block)))]
-    (merge block
-           {:block/title (ast->text ast-block opts)
-            :logseq.property.node/display-type :quote
-            :block/tags [:logseq.class/Quote-block]})
-    block))
+  (let [ast-blocks (:block.temp/ast-blocks block)
+        heading (first (filter #(= "Heading" (first %)) ast-blocks))
+        heading-title (when heading (get-in (second heading) [:title]))
+        heading-empty? (or (nil? heading) (empty? heading-title))
+        body-elements (remove #(= "Heading" (first %)) ast-blocks)
+        all-body-quotes? (and (seq body-elements) (every? #(= "Quote" (first %)) body-elements))
+        has-quote-body? (some #(= "Quote" (first %)) body-elements)
+        org-quote? (boolean (re-find #"(?i)#\+BEGIN_QUOTE" (str (:block/title block))))]
+    (cond
+      (and heading-empty? all-body-quotes?)
+      ;; Pure quote block: convert to Quote-block with depth=0.
+      ;; The Quote-block display-type provides the visual blockquote styling, so
+      ;; no '> ' prefix is added to content. Nested '>>' gets '> ' prefix via
+      ;; recursion into depth=1 inside quote-node->markdown.
+      (let [combined-title (->> body-elements
+                                (map #(quote-node->markdown % opts 0))
+                                (remove string/blank?)
+                                (string/join "\n"))]
+        (merge block
+               {:block/title combined-title
+                :logseq.property.node/display-type :quote
+                :block/tags [:logseq.class/Quote-block]}))
+
+      (and has-quote-body? org-quote?)
+      ;; Mixed block with #+BEGIN_QUOTE: keep as regular block but add '> ' prefix
+      ;; to quote content so it renders as a blockquote in the DB graph.
+      ;; ast-blocks body is accumulated in reverse file order by extract-blocks
+      ;; (due to (reverse ast) + conj). Restore file order: keep the Heading
+      ;; first, then reverse the rest back to original file position order.
+      ;; After a Quote element, use a blank line as separator before any following
+      ;; content: unlike #+BEGIN_QUOTE/#+END_QUOTE delimiters, the markdown '>'
+      ;; blockquote ends at the first blank line, so a blank line is required to
+      ;; prevent subsequent non-quote text from being absorbed into the blockquote.
+      (let [ordered-blocks (into [(first ast-blocks)] (reverse (rest ast-blocks)))
+            tagged-parts (->> ordered-blocks
+                              (map (fn [el]
+                                     {:quote? (= "Quote" (first el))
+                                      :text   (case (first el)
+                                                "Heading" (let [title (get-in (second el) [:title])]
+                                                            (when (seq title)
+                                                              (ast->text ["Paragraph" title] opts)))
+                                                "Quote" (quote-node->markdown el opts 1)
+                                                (ast->text el opts))}))
+                              (remove #(string/blank? (:text %))))
+            combined (first (reduce (fn [[result prev-quote?] {:keys [quote? text]}]
+                                      [(if (string/blank? result)
+                                         text
+                                         (str result (if prev-quote? "\n\n" "\n") text))
+                                       quote?])
+                                    ["" false]
+                                    tagged-parts))]
+        (assoc block :block/title combined))
+
+      :else
+      block)))
 
 (defn- handle-math
   "If a block's entire content is a single displayed math formula, convert to #Math node.

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -370,7 +370,7 @@
       (is (= 2 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Code-block]] @conn))))
       (is (= 1 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Math-block]] @conn))))
       (is (= 9 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Template]] @conn))))
-      (is (= 5 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Quote-block]] @conn))))
+      (is (= 6 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Quote-block]] @conn))))
       (is (= 7 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Pdf-annotation]] @conn))))
 
       ;; Properties and tags aren't included in this count as they aren't a Page
@@ -801,15 +801,41 @@
             "Zotero imported pdf area highlight links to correct asset"))
 
       ;; Quotes
-      (is (= {:block/tags [:logseq.class/Quote-block]
-              :logseq.property.node/display-type :quote}
-             (db-test/readable-properties (db-test/find-block-by-content @conn #"Saito"))))
+      (is (string/starts-with? (:block/title (db-test/find-block-by-content @conn #"Saito")) "From Inception:\n> Saito:")
+          "Mixed #+BEGIN_QUOTE block: heading retained and quote content prefixed with '>'")
+      (is (nil? (:logseq.property.node/display-type (db-test/find-block-by-content @conn #"Saito")))
+          "Mixed #+BEGIN_QUOTE block is not converted to a Quote-block")
       (is (= "markdown quote\n[[wut]]\nline 3"
              (:block/title (db-test/find-block-by-content @conn #"markdown quote")))
           "Markdown quote imports as full multi-line quote")
-      (is (= "*Italic* ~~Strikethrough~~ ^^Highlight^^ #[[foo]]\n**Learn Datalog Today** is an interactive tutorial designed to teach you the [Datomic](http://datomic.com/) dialect of [Datalog](http://en.wikipedia.org/wiki/Datalog). Datalog is a declarative **database query language** with roots in logic programming. Datalog has similar expressive power as [SQL](http://en.wikipedia.org/wiki/Sql)."
-             (:block/title (db-test/find-block-by-content @conn #"Learn Datalog")))
-          "Imports full quote with various ast types"))
+      (is (string/starts-with? (:block/title (db-test/find-block-by-content @conn #"Learn Datalog"))
+                                "Test of various ast types:\n> *Italic*")
+          "Mixed #+BEGIN_QUOTE block retains heading and quote content in block title")
+      (is (= "Blockquotes\n> Nested Blockquotes"
+             (:block/title (db-test/find-block-by-content @conn #"Nested Blockquotes")))
+          "Nested '>> quote' is preserved as '> ' prefix in Quote-block title")
+      (is (= :quote (:logseq.property.node/display-type (db-test/find-block-by-content @conn #"Nested Blockquotes")))
+          "Nested markdown quote block is tagged as Quote-block")
+      (is (= "it's a\n\norg blockquote"
+             (:block/title (db-test/find-block-by-content @conn #"org blockquote")))
+          "#+BEGIN_QUOTE pure block title has no '> ' prefix — display-type provides blockquote styling")
+      (is (= :quote (:logseq.property.node/display-type (db-test/find-block-by-content @conn #"org blockquote")))
+          "#+BEGIN_QUOTE pure block is tagged as Quote-block")
+      (is (= "> Blockquotes\n> and\n\nsomething else"
+             (:block/title (db-test/find-block-by-content @conn #"Blockquotes\n> and")))
+          "Mixed #+BEGIN_QUOTE at start of block: quote content prefixed with '>' and blank line separates following text")
+      (is (nil? (:logseq.property.node/display-type (db-test/find-block-by-content @conn #"Blockquotes\n> and")))
+          "Mixed #+BEGIN_QUOTE block at start is not converted to a Quote-block")
+      (let [block (db-test/find-block-by-content @conn #"Question 1")]
+        (is (string/includes? (:block/title block) "\n>> nested")
+            "Mixed markdown quote block preserves nested quote depth")
+        (is (nil? (:logseq.property.node/display-type block))
+            "Mixed markdown quote block is not converted to a Quote-block"))
+      (let [block (db-test/find-block-by-content @conn #"Question 2")]
+        (is (string/includes? (:block/title block) "> Question 3")
+            "Mixed markdown quote child block preserves separated quote lines")
+        (is (string/includes? (:block/title block) "> Answer 3")
+            "Mixed markdown quote child block preserves quote content after blank quote line")))
 
     (testing "embeds"
       (is (= {:block/title ""}

--- a/deps/graph-parser/test/resources/exporter-test-graph/journals/2025_06_12.md
+++ b/deps/graph-parser/test/resources/exporter-test-graph/journals/2025_06_12.md
@@ -22,3 +22,40 @@
 - test block embed
   id:: 685434e1-0bb9-468c-a660-1642b00b2854
 - {{embed ((685434e1-0bb9-468c-a660-1642b00b2854))}}
+- > Blockquotes
+- > Blockquotes
+  and
+  
+  something else
+- #+BEGIN_QUOTE
+  Blockquotes
+  and
+  #+END_QUOTE
+  something else
+- > Blockquotes
+  >> Nested Blockquotes
+- Q:
+  > Question 1
+  
+  A:
+  > Answer 1
+  and
+  >> nested
+  
+  and something else
+	- Q:
+	  
+	  > Question 2
+	  
+	  > Question 3
+	  
+	  A:
+	  
+	  > Answer 2
+	  >
+	  > Answer 3
+- #+BEGIN_QUOTE
+  it's a
+  
+  org blockquote
+  #+END_QUOTE

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2465,7 +2465,10 @@
                                 (some? (mldoc/extract-first-query-from-ast body))))))
           [:div.block-body
            (let [body (block/trim-break-lines! (:block.temp/ast-body block))
-                 uuid (:block/uuid block)]
+                 uuid (:block/uuid block)
+                 raw-content (or (:block/raw-title block) (:block/title block) "")
+                 deprecated-org-quote? (boolean (re-find #"(?i)^\s*#\+BEGIN_QUOTE" (str raw-content)))
+                 config (if deprecated-org-quote? (assoc config :deprecated-org-quote? true) config)]
              (for [[idx child] (medley/indexed body)]
                (when-let [block (markup-element-cp config child)]
                  (rum/with-key (block-child block)
@@ -4391,8 +4394,10 @@
       ["Example" l]
       [:pre.pre-wrap-white-space
        (join-lines l)]
-      ["Quote" _l]
-      [:div.warning (t :block/deprecated-quote)]
+      ["Quote" l]
+      (if (:deprecated-org-quote? config)
+        [:div.warning (t :block/deprecated-quote)]
+        [:blockquote.ls-blockquote (markup-elements-cp config l)])
       ["Raw_Html" content]
       (when (not html-export?)
         [:div.raw_html.inline-block


### PR DESCRIPTION
- Preserve the entire block when importing mixed quote content, instead of dropping non-quote content and converting only the quote part into a Quote-block.
- Keep pure quote-only blocks converted to Quote-block nodes.
- Render non-deprecated markdown quotes normally in block bodies.
- Add exporter coverage for nested and mixed quote import cases.

fix https://github.com/logseq/db-test/issues/820 https://github.com/logseq/db-test/issues/740