### PR TITLE
[codex] fix quote markdown heading rendering

### DIFF
--- a/clj-e2e/test/logseq/e2e/commands_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/commands_basic_test.clj
@@ -108,6 +108,29 @@
     (util/input-command "quote")
     (w/wait-for "div[data-node-type='quote']")))
 
+(deftest quote-heading-test
+  (testing "quote headings render consistently"
+    (b/new-block "Property quote heading")
+    (util/input-command "quote")
+    (util/input-command "h1")
+    (util/exit-edit)
+    (b/new-block "# Markdown quote heading")
+    (util/input-command "quote")
+    (util/exit-edit)
+    (assert/assert-is-visible
+     "div[data-node-type='quote']:has(h1.block-title-wrap.as-heading:has-text('Property quote heading'))")
+    (assert/assert-is-visible
+     "div[data-node-type='quote']:has(h1.block-title-wrap.as-heading:has-text('Markdown quote heading'))")
+    (b/jump-to-block "Markdown quote heading")
+    (assert/assert-editor-mode)
+    (is (= "Markdown quote heading" (util/get-edit-content)))
+    (util/exit-edit)
+    (b/new-block "Plain quote")
+    (util/input-command "quote")
+    (util/exit-edit)
+    (assert/assert-is-visible
+     "div[data-node-type='quote']:has(span.block-title-wrap:has-text('Plain quote'))")))
+
 (deftest headings-test
   (testing "/heading"
     (dotimes [i 6]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2162,7 +2162,8 @@
                  (and heading-level
                       (<= heading-level 6)
                       heading-level)
-                 (pu/lookup block :logseq.property/heading))
+                 (pu/lookup block :logseq.property/heading)
+                 (:block.temp/heading block))
         heading (if (true? heading) (min (inc level) 6) heading)
         elem (if heading
                (keyword (str "h" heading ".block-title-wrap.as-heading"

--- a/src/main/frontend/format/block.cljs
+++ b/src/main/frontend/format/block.cljs
@@ -65,25 +65,35 @@ and handles unexpected failure."
 
 (defonce *blocks-ast-cache (volatile! (cache/lru-cache-factory {} :threshold 5000)))
 
+(defn- markdown-heading-level
+  [content]
+  (when-let [heading (some->> content
+                              string/triml
+                              (re-find #"^(#{1,6})\s+"))]
+    (count (second heading))))
+
 (defn- parse-title-and-body-helper
-  [_format content]
+  [_format raw-content content]
   (let [parse-config (mldoc/get-default-config :markdown)
         ast (->> (format/to-edn content parse-config)
                  (map first))
-        title (when (gp-block/heading-block? (first ast))
-                (:title (second (first ast))))
+        heading (when (gp-block/heading-block? (first ast))
+                  (second (first ast)))
+        title (:title heading)
+        heading-level (markdown-heading-level raw-content)
         body (vec (if title (rest ast) ast))
         body (drop-while gp-property/properties-ast? body)]
     (cond->
      (if (seq body) {:block.temp/ast-body body} {})
       title
-      (assoc :block.temp/ast-title title))))
+      (assoc :block.temp/ast-title title
+             :block.temp/heading heading-level))))
 
 (def ^:private cached-parse-title-and-body-helper
   (common.cache/cache-fn
    *blocks-ast-cache
-   (fn [format content]
-     [[format content] [format content]])
+   (fn [format raw-content content]
+     [[format raw-content content] [format raw-content content]])
    parse-title-and-body-helper))
 
 (defn parse-title-and-body
@@ -95,8 +105,9 @@ and handles unexpected failure."
                                   (:block/title block)))))
   ([_block-uuid format content]
    (when-not (string/blank? content)
-     (let [content (str common-config/block-pattern " " (string/triml content))]
-       (cached-parse-title-and-body-helper format content)))))
+     (let [raw-content content
+           content (str common-config/block-pattern " " (string/triml content))]
+       (cached-parse-title-and-body-helper format raw-content content)))))
 
 (defn break-line-paragraph?
   [[typ break-lines]]

--- a/src/main/frontend/handler/db_based/editor.cljs
+++ b/src/main/frontend/handler/db_based/editor.cljs
@@ -46,6 +46,17 @@
              x))
          refs)))
 
+(defn- markdown-heading-level
+  [content]
+  (when-let [heading (some->> content
+                              string/triml
+                              (re-find #"^(#{1,6})\s+"))]
+    (count (second heading))))
+
+(defn- normalize-markdown-heading?
+  [block]
+  (not (contains? #{:code :math} (:logseq.property.node/display-type block))))
+
 (defn wrap-parse-block
   [{:block/keys [title level] :as block}]
   (let [block (or (and (:db/id block) (db/entity (:db/id block)))
@@ -53,12 +64,21 @@
                   block)
         block (if (nil? title)
                 block
-                (let [ast (mldoc/->edn (string/trim title) :markdown)
+                (let [heading-level (when (normalize-markdown-heading? block)
+                                      (markdown-heading-level title))
+                      title (if heading-level
+                              (commands/clear-markdown-heading (string/triml title))
+                              title)
+                      ast (mldoc/->edn (string/trim title) :markdown)
                       first-elem-type (first (ffirst ast))
                       block-with-title? (mldoc/block-with-title? first-elem-type)
                       content' (str common-config/block-pattern (if block-with-title? " " "\n") title)
                       parsed-block (block/parse-block (assoc block :block/title content'))
-                      block' (-> (merge block parsed-block {:block/title title})
+                      block' (-> (merge block
+                                         parsed-block
+                                         {:block/title title}
+                                         (when heading-level
+                                           {:logseq.property/heading heading-level}))
                                  (dissoc :block/format))]
                   (update block' :block/refs
                           (fn [refs]

--- a/src/test/frontend/handler/db_based/editor_test.cljs
+++ b/src/test/frontend/handler/db_based/editor_test.cljs
@@ -1,0 +1,23 @@
+(ns frontend.handler.db-based.editor-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [frontend.handler.db-based.editor :as db-editor-handler]))
+
+(deftest wrap-parse-block-markdown-heading-test
+  (testing "normal blocks save markdown heading syntax as heading property"
+    (is (= {:block/title "Heading"
+            :logseq.property/heading 1}
+           (select-keys (db-editor-handler/wrap-parse-block
+                         {:block/title "# Heading"})
+                        [:block/title :logseq.property/heading]))))
+
+  (testing "raw display-type blocks preserve leading hash text"
+    (doseq [display-type [:code :math]]
+      (is (= {:block/title "# shell comment"
+              :logseq.property.node/display-type display-type}
+             (select-keys (db-editor-handler/wrap-parse-block
+                           {:block/title "# shell comment"
+                            :logseq.property.node/display-type display-type})
+                          [:block/title
+                           :logseq.property/heading
+                           :logseq.property.node/display-type]))
+          (str "Preserves content for " display-type)))))


### PR DESCRIPTION
## Summary

Fixes inconsistent heading rendering in quote blocks when a heading is authored with Markdown `#` syntax instead of the heading command/context menu.

## Root cause

Display-type blocks intentionally skip full block extraction, so quote blocks with raw Markdown headings kept the parsed title text but dropped the parsed heading level. Rendering then used `span.block-title-wrap` instead of the same `h1.block-title-wrap.as-heading` element used by explicit heading properties.

## Changes

- Preserve the parsed Markdown heading level as temporary render data.
- Use that temporary heading level when rendering block titles without an explicit heading property.
- Add an app E2E regression test covering property-based quote headings and Markdown quote headings.

Fixes logseq/db-test#599

## Verification

- `bb test -p 3001 -v logseq.e2e.commands-basic-test/quote-heading-test`
