### PR TITLE
[codex] Preserve imported task statuses

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -409,24 +409,59 @@
           block)]
     block'))
 
+(def ^:private built-in-status-markers
+  {"TODO" :logseq.property/status.todo
+   "LATER" :logseq.property/status.todo
+   "NOW" :logseq.property/status.doing
+   "DOING" :logseq.property/status.doing
+   "DONE" :logseq.property/status.done
+   "CANCELED" :logseq.property/status.canceled
+   "CANCELLED" :logseq.property/status.canceled})
+
+(def ^:private custom-status-marker?
+  #{"WAIT" "WAITING" "IN-PROGRESS"})
+
+(defn- find-status-choice-by-content
+  [db marker]
+  (some #(when (= marker (db-property/closed-value-content %)) %)
+        (db-property/get-closed-property-values db :logseq.property/status)))
+
+(defn- build-status-choice-tx
+  [marker block-uuid]
+  (assoc (db-property-build/build-closed-value-block
+          block-uuid
+          :default
+          marker
+          {:db/ident :logseq.property/status}
+          {})
+         :block/order (db-order/gen-key)))
+
+(defn- custom-marker-status-ref
+  [db marker {:keys [import-state custom-status-tx]}]
+  (or (get @(:custom-status-markers import-state) marker)
+      (let [status-ref (if-let [status (find-status-choice-by-content db marker)]
+                         (:db/id status)
+                         (let [block-uuid (common-uuid/gen-uuid)]
+                           (swap! custom-status-tx conj (build-status-choice-tx marker block-uuid))
+                           [:block/uuid block-uuid]))]
+        (swap! (:custom-status-markers import-state) assoc marker status-ref)
+        status-ref)))
+
 (defn- update-block-marker
   "If a block has a marker, convert it to a task object"
-  [block {:keys [log-fn]}]
+  [block db {:keys [log-fn] :as options}]
   (if-let [marker (:block/marker block)]
-    (let [old-to-new {"TODO" :logseq.property/status.todo
-                      "LATER" :logseq.property/status.todo
-                      "IN-PROGRESS" :logseq.property/status.doing
-                      "NOW" :logseq.property/status.doing
-                      "DOING" :logseq.property/status.doing
-                      "DONE" :logseq.property/status.done
-                      "WAIT" :logseq.property/status.backlog
-                      "WAITING" :logseq.property/status.backlog
-                      "CANCELED" :logseq.property/status.canceled
-                      "CANCELLED" :logseq.property/status.canceled}
-          status-ident (or (old-to-new marker)
-                           (do
-                             (log-fn :invalid-todo (str (pr-str marker) " is not a valid marker so setting it to TODO"))
-                             :logseq.property/status.todo))]
+    (let [status-ident (cond
+                         (contains? built-in-status-markers marker)
+                         (built-in-status-markers marker)
+
+                         (custom-status-marker? marker)
+                         (custom-marker-status-ref db marker options)
+
+                         :else
+                         (do
+                           (log-fn :invalid-todo (str (pr-str marker) " is not a valid marker so setting it to TODO"))
+                           :logseq.property/status.todo))]
       (-> block
           (assoc :logseq.property/status status-ident)
           (update :block/title string/replace-first (re-pattern (str marker "\\s*")) "")
@@ -1850,7 +1885,7 @@
                      (handle-embeds page-names-to-uuids walked-ast-blocks (select-keys options [:log-fn]))
                      (handle-quotes (select-keys options [:log-fn]))
                      (handle-math)
-                     (update-block-marker options)
+                     (update-block-marker db options)
                      (update-block-priority options)
                      add-missing-timestamps
                      (dissoc :block/format :block.temp/ast-blocks)
@@ -2105,6 +2140,8 @@
    :all-idents (atom {})
    ;; Set of children pages turned into classes by :property-parent-classes option
    :classes-from-property-parents (atom #{})
+   ;; Map of imported legacy task markers to their Status closed value lookup refs.
+   :custom-status-markers (atom {})
    ;; Map of block uuids to their :block/properties-text-values value.
    ;; Used if a property value changes to :default
    :block-properties-text-values (atom {})
@@ -2120,6 +2157,8 @@
     :upstream-properties (atom {})
     ;; Track per file class tx so that their tx isn't embedded in individual :block/tags and can be post processed
     :classes-tx (atom [])
+    ;; Track per file Status closed values required by imported legacy task markers.
+    :custom-status-tx (atom [])
     :user-options
     (merge user-options
            {:tag-classes (set (map string/lower-case (:tag-classes user-options)))
@@ -2354,6 +2393,7 @@
           classes-tx @(:classes-tx tx-options)
           {:keys [retract-page-tags-tx] pages-tx'' :pages-tx} (clean-extra-invalid-tags @conn pages-tx' classes-tx existing-pages)
           classes-tx' (concat classes-tx retract-page-tags-tx)
+          custom-status-tx @(:custom-status-tx tx-options)
           ;; Build indices
           pages-index (->> (map #(select-keys % [:block/uuid]) pages-tx'')
                            (concat (map #(select-keys % [:block/uuid]) classes-tx))
@@ -2368,7 +2408,7 @@
           blocks-index (set/union (set block-ids) (set block-refs-ids))
           ;; Order matters. pages-index and blocks-index needs to come before their corresponding tx for
           ;; uuids to be valid. Also upstream-properties-tx comes after blocks-tx to possibly override blocks
-          tx (concat pages-index page-properties-tx property-page-properties-tx pages-tx'' classes-tx' blocks-index blocks-tx)
+          tx (concat pages-index page-properties-tx property-page-properties-tx pages-tx'' classes-tx' custom-status-tx blocks-index blocks-tx)
           tx' (common-util/fast-remove-nils tx)
           ;; _ (prn :tx-counts (map #(vector %1 (count %2))
           ;;                        [:pages-index :page-properties-tx :property-page-properties-tx :pages-tx' :classes-tx :blocks-index :blocks-tx]

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -15,6 +15,7 @@
             [logseq.db.frontend.asset :as db-asset]
             [logseq.db.frontend.content :as db-content]
             [logseq.db.frontend.malli-schema :as db-malli-schema]
+            [logseq.db.frontend.property :as db-property]
             [logseq.db.frontend.rules :as rules]
             [logseq.db.frontend.validate :as db-validate]
             [logseq.db.test.helper :as db-test]
@@ -78,6 +79,24 @@
   (some->> (find-template-by-title db title)
            ordered-children
            (mapv block-tree-with-properties)))
+
+(defn- block-status
+  [db content]
+  (:logseq.property/status (db-test/find-block-by-content db content)))
+
+(defn- status-content
+  [db content]
+  (db-property/closed-value-content (block-status db content)))
+
+(defn- status-closed-value-contents
+  [db]
+  (set (map db-property/closed-value-content
+            (db-property/get-closed-property-values db :logseq.property/status))))
+
+(defn- status-closed-value-content-frequencies
+  [db]
+  (frequencies (map db-property/closed-value-content
+                    (db-property/get-closed-property-values db :logseq.property/status))))
 
 
 (defn- build-graph-files
@@ -266,6 +285,59 @@
           "Repeated deadline timestamp keeps its repeat properties")
       (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
           "Imported graph validates"))))
+
+(deftest-async import-preserves-legacy-task-markers-as-status-choices
+  (p/let [file (write-temp-graph-file
+                 "pages/tasks.md"
+                 "- TODO todo item\n- LATER later item\n- NOW now item\n- DOING doing item\n- WAIT waiting item\n- WAITING waiting full item\n- IN-PROGRESS in-progress item\n- DONE done item\n")
+          conn (db-test/create-conn)
+          _ (db-pipeline/add-listener conn)
+          _ (import-files-to-db [file] conn {})]
+    (is (= :logseq.property/status.todo
+           (:db/ident (block-status @conn "todo item")))
+        "TODO still imports to the built-in Todo status")
+    (is (= :logseq.property/status.doing
+           (:db/ident (block-status @conn "doing item")))
+        "DOING still imports to the built-in Doing status")
+    (is (= :logseq.property/status.done
+           (:db/ident (block-status @conn "done item")))
+        "DONE still imports to the built-in Done status")
+    (is (= :logseq.property/status.todo
+           (:db/ident (block-status @conn "later item")))
+        "LATER imports to the built-in Todo status")
+    (is (= :logseq.property/status.doing
+           (:db/ident (block-status @conn "now item")))
+        "NOW imports to the built-in Doing status")
+    (is (= "WAIT" (status-content @conn "waiting item"))
+        "WAIT imports as its own status choice")
+    (is (= "WAITING" (status-content @conn "waiting full item"))
+        "WAITING imports as its own status choice")
+    (is (= "IN-PROGRESS" (status-content @conn "in-progress item"))
+        "IN-PROGRESS imports as its own status choice")
+    (is (set/subset? #{"WAIT" "WAITING" "IN-PROGRESS"}
+                     (status-closed-value-contents @conn))
+        "Custom imported markers are added to Status closed values")
+    (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
+        "Imported graph validates")))
+
+(deftest-async import-custom-task-marker-across-multiple-files
+  (p/let [first-file (write-temp-graph-file
+                       "pages/custom-status-a.md"
+                       "- WAITING first custom status item\n")
+          second-file (write-temp-graph-file
+                        "pages/custom-status-b.md"
+                        "- WAITING second custom status item\n")
+          conn (db-test/create-conn)
+          _ (db-pipeline/add-listener conn)
+          _ (import-files-to-db [first-file second-file] conn {})]
+    (is (= "WAITING" (status-content @conn "first custom status item"))
+        "Custom status marker imports from the first file")
+    (is (= "WAITING" (status-content @conn "second custom status item"))
+        "Custom status marker imports from the second file")
+    (is (= 1 (get (status-closed-value-content-frequencies @conn) "WAITING"))
+        "Custom status closed value is shared across imported files")
+    (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
+        "Imported graph validates")))
 
 (deftest update-asset-links-in-block-title
   (are [x y]


### PR DESCRIPTION
## Summary
- Preserve legacy Markdown task markers such as WAITING, WAIT, and IN-PROGRESS as Status closed values during file graph import.
- Keep canonical TODO, DOING, DONE, and CANCELED/CANCELLED mapped to existing built-in statuses.
- Add importer regression coverage for the destructive LATER/NOW/WAITING collapse reported in logseq/db-test#176.

## Root Cause
The file-to-DB importer mapped multiple legacy task markers onto the current built-in Status choices, for example WAITING -> Backlog. That destroyed workflows that used those markers as distinct states in Markdown graphs.

## Validation
- pnpm test-v --var logseq.graph-parser.exporter-test/import-preserves-legacy-task-markers-as-status-choices
- pnpm test-v --namespace logseq.graph-parser.exporter-test

Fixes https://github.com/logseq/db-test/issues/176
