### PR TITLE
[codex] fix import namespaced inline tags

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -359,6 +359,25 @@
     (sort > tags))
    (string/trim)))
 
+(defn- replace-namespaced-tags-with-id-refs
+  [content tags]
+  (->>
+   (reduce
+    (fn [content tag]
+      (if (ns-util/namespace-page? (:block/name tag))
+        (let [id-ref (page-ref/->page-ref (:block/uuid tag))]
+          (-> content
+              (common-util/replace-ignore-case
+               (str "#" (:block/name tag))
+               (str "#" id-ref))
+              (common-util/replace-ignore-case
+               (str "#" (page-ref/->page-ref (:block/name tag)))
+               (str "#" id-ref))))
+        content))
+    content
+    (sort-by (comp count :block/name) > tags))
+   (string/trim)))
+
 (defn- update-block-tags
   [block db {:keys [remove-inline-tags?] :as user-options} per-file-state all-idents]
   (let [block'
@@ -375,6 +394,10 @@
                       (->> original-tags
                            (filter convert-tag?')
                            (map :block/title)))
+              (not remove-inline-tags?)
+              (update :block/title
+                      replace-namespaced-tags-with-id-refs
+                      (filter convert-tag?' original-tags))
               true
               (update :block/title
                       db-content/replace-tags-with-id-refs

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -1197,7 +1197,21 @@
           files (mapv #(path/path-join file-graph-dir %) ["journals/2024_02_07.md"
                                                           "journals/2026_01_27.md"])
           conn (db-test/create-conn)
-          _ (import-files-to-db files conn {:remove-inline-tags? false :convert-all-tags? true})]
+          _ (import-files-to-db files conn {:remove-inline-tags? false :convert-all-tags? true})
+          namespaced-file (write-temp-graph-file
+                           "pages/namespace-inline-tag.md"
+                           "- #parent/child\n")
+          namespaced-conn (db-test/create-conn)
+          _ (import-files-to-db [namespaced-file] namespaced-conn {:remove-inline-tags? false :convert-all-tags? true})
+          [block tag] (->> (d/q '[:find ?b ?t
+                                  :where
+                                  [?b :block/tags ?t]
+                                  [?b :block/page]
+                                  [?t :db/ident :user.class/parent___child]]
+                                @namespaced-conn)
+                           first
+                           (map #(d/entity @namespaced-conn %)))
+          raw-title (:block/title block)]
 
     (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
         "Created graph has no validation errors")
@@ -1206,7 +1220,15 @@
         "block with tag preserves inline tag")
     (is (string/includes? (:block/title (db-test/find-block-by-content @conn #"block with multi word tag"))
                           "#[[another test]]")
-        "block with multi word tag preserves inline tag")))
+        "block with multi word tag preserves inline tag")
+    (testing "namespaced inline tag on first line is preserved as inline tag"
+      (is (some? block)
+          "imported first-line namespaced tag block")
+      (is (string? raw-title)
+          "imported block has raw title")
+      (when (string? raw-title)
+        (is (ldb/inline-tag? raw-title tag)
+            "first-line namespaced tag is stored as an inline tag")))))
 
 (deftest-async export-files-with-ignored-properties
   (p/let [file-graph-dir "test/resources/exporter-test-graph"


### PR DESCRIPTION
## Summary

- Normalize preserved namespaced inline tags during file graph to DB graph import so they use hashtag id-ref syntax.
- Add a regression test for importing `#parent/child` on the first line with inline tag removal disabled.

## Root Cause

DB graph inline tag rendering/hiding checks look for `#` followed by the imported tag id-ref. Namespaced class tags were kept as literal `#parent/child`, so the block had the class tag but the title was not recognized as an inline tag.

## Validation

- `pnpm exec nbb-logseq -cp src:../db/src:../outliner/src:test -m logseq.graph-parser.test-runner -v logseq.graph-parser.exporter-test/export-files-with-remove-inline-tags`
- `bb dev:test -v logseq.graph-parser.exporter-test/export-files-with-remove-inline-tags` compiled successfully but ran 0 tests for this node-only nbb test.
- Full exporter namespace reached and passed the changed test, then stopped later on an existing fixture/import issue: missing page uuid for `2021_12_06` in `CreativeWork.md`.

Fixes https://github.com/logseq/db-test/issues/460