### PR TITLE
[codex] Fix repeated schedule import

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/block.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/block.cljs
@@ -266,23 +266,30 @@
    (map last)
    (into {})))
 
+(defn- timestamp->scheduled-or-deadline-value
+  [{:keys [date repetition] timestamp-time :time}]
+  (let [{:keys [year month day]} date
+        day (js/parseInt (str year (common-util/zero-pad month) (common-util/zero-pad day)))]
+    (if (or timestamp-time repetition)
+      (cond-> {:date-int day}
+        timestamp-time
+        (assoc :time timestamp-time)
+        repetition
+        (assoc :repetition repetition))
+      day)))
+
 ;; {"Deadline" {:date {:year 2020, :month 10, :day 20}, :wday "Tue", :time {:hour 8, :min 0}, :repetition [["DoublePlus"] ["Day"] 1], :active true}}
 (defn timestamps->scheduled-and-deadline
   [timestamps]
   (let [timestamps (update-keys timestamps (comp keyword string/lower-case))
         m (some->> (select-keys timestamps [:scheduled :deadline])
                    (map (fn [[k v]]
-                          (let [{:keys [date repetition]} v
-                                {:keys [year month day]} date
-                                day (js/parseInt (str year (common-util/zero-pad month) (common-util/zero-pad day)))]
-                            (cond->
-                             (case k
-                               :scheduled
-                               {:scheduled day}
-                               :deadline
-                               {:deadline day})
-                              repetition
-                              (assoc :repeated? true))))))]
+                          (let [value (timestamp->scheduled-or-deadline-value v)]
+                            (case k
+                              :scheduled
+                              {:scheduled value}
+                              :deadline
+                              {:deadline value})))))]
     (apply merge m)))
 
 (defn- convert-page-if-journal-impl

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -445,11 +445,53 @@
   (or (entity-util/page? entity)
       (contains? #{"page" "journal"} (:block/type entity))))
 
+(declare ->property-value-tx-m)
+
+(defn- deadline-scheduled-date-int
+  [value]
+  (if (map? value) (:date-int value) value))
+
+(defn- deadline-scheduled-time-ms
+  [value]
+  (let [date-int (deadline-scheduled-date-int value)
+        date (date-time-util/int->local-date date-int)
+        {:keys [hour] timestamp-min :min} (when (map? value) (:time value))]
+    (when hour
+      (.setHours date hour (or timestamp-min 0) 0 0))
+    (tc/to-long date)))
+
+(def ^:private repeat-recur-units
+  {"Minute" :logseq.property.repeat/recur-unit.minute
+   "Hour" :logseq.property.repeat/recur-unit.hour
+   "Day" :logseq.property.repeat/recur-unit.day
+   "Week" :logseq.property.repeat/recur-unit.week
+   "Month" :logseq.property.repeat/recur-unit.month
+   "Year" :logseq.property.repeat/recur-unit.year})
+
+(defn- repeat-properties
+  [temporal-property value]
+  (when-let [[_ unit frequency] (and (map? value) (:repetition value))]
+    (let [unit-ident (get repeat-recur-units (first unit))]
+      (assert unit-ident (str "Unknown repeat unit: " (pr-str unit)))
+      {:logseq.property.repeat/repeated? true
+       :logseq.property.repeat/temporal-property temporal-property
+       :logseq.property.repeat/recur-frequency frequency
+       :logseq.property.repeat/recur-unit unit-ident})))
+
+(defn- build-repeat-properties
+  [block properties]
+  (let [pvalue-tx-m (->property-value-tx-m (dissoc block :block/page) properties (constantly nil) {})
+        pvalues-tx (into (mapcat #(if (set? %) % [%]) (vals pvalue-tx-m)))]
+    {:block-properties (merge properties
+                              (db-property-build/build-properties-with-ref-values pvalue-tx-m))
+     :properties-tx pvalues-tx}))
+
 (defn- find-or-create-deadline-scheduled-value
   "Given a :block/scheduled or :block/deadline value, creates the datetime property value
    and any optional journal tx associated with that value"
-  [date-int page-names-to-uuids user-config]
-  (let [title (date-time-util/int->journal-title date-int (get-date-formatter user-config))
+  [value page-names-to-uuids user-config]
+  (let [date-int (deadline-scheduled-date-int value)
+        title (date-time-util/int->journal-title date-int (get-date-formatter user-config))
         existing-journal-page (some->> title
                                        common-util/page-name-sanity-lc
                                        (get @page-names-to-uuids)
@@ -460,26 +502,34 @@
                                       :block/uuid (common-uuid/gen-uuid :journal-page-uuid date-int)
                                       :block/journal-day date-int)))
                          (assoc :block/tags #{:logseq.class/Journal}))
-        time-long (tc/to-long (date-time-util/int->local-date date-int))]
+        time-long (deadline-scheduled-time-ms value)]
     {:property-value time-long
      :journal-tx (when-not existing-journal-page [journal-page])}))
 
 (defn- update-block-deadline-and-scheduled
   "Converts :block/deadline and :block/scheduled to their new logseq properties."
   [block page-names-to-uuids {:keys [user-config]}]
-  (let [{deadline-value :property-value deadline-tx :journal-tx}
-        (when (:block/deadline block)
-          (find-or-create-deadline-scheduled-value (:block/deadline block) page-names-to-uuids user-config))
+  (let [deadline (:block/deadline block)
+        scheduled (:block/scheduled block)
+        {deadline-value :property-value deadline-tx :journal-tx}
+        (when deadline
+          (find-or-create-deadline-scheduled-value deadline page-names-to-uuids user-config))
         {scheduled-value :property-value scheduled-tx :journal-tx}
-        (when (:block/scheduled block)
-          (find-or-create-deadline-scheduled-value (:block/scheduled block) page-names-to-uuids user-config))]
+        (when scheduled
+          (find-or-create-deadline-scheduled-value scheduled page-names-to-uuids user-config))
+        repeat-properties' (merge (repeat-properties :logseq.property/deadline deadline)
+                                  (repeat-properties :logseq.property/scheduled scheduled))
+        {repeat-block-properties :block-properties repeat-properties-tx :properties-tx}
+        (build-repeat-properties block repeat-properties')]
     {:block
      (cond-> (dissoc block :block/deadline :block/scheduled :block/repeated?)
        (some? deadline-value)
        (assoc :logseq.property/deadline deadline-value)
        (some? scheduled-value)
-       (assoc :logseq.property/scheduled scheduled-value))
-     :properties-tx (distinct (concat deadline-tx scheduled-tx))}))
+       (assoc :logseq.property/scheduled scheduled-value)
+       (seq repeat-block-properties)
+       (merge repeat-block-properties))
+     :properties-tx (distinct (concat deadline-tx scheduled-tx repeat-properties-tx))}))
 
 (defn- text-with-refs?
   "Detects if a property value has text with refs e.g. `#Logseq is #awesome`

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -221,6 +221,52 @@
     (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
         "Imported graph validates")))
 
+(deftest-async import-repeated-deadline-and-scheduled
+  (p/let [file (write-temp-graph-file
+                 "pages/repeated-tasks.md"
+                 (str "- TODO wish [[name]] a happy birthday\n"
+                      "  SCHEDULED: <2025-11-01 Sat 08:00 .+1y>\n"
+                      "- TODO prepare weekly report\n"
+                      "  DEADLINE: <2025-11-07 Fri +2w>\n"))
+          conn (db-test/create-conn)
+          _ (db-pipeline/add-listener conn)
+          _ (import-files-to-db [file] conn {})]
+    (let [birthday-properties (db-test/readable-properties
+                               (db-test/find-block-by-content @conn #"happy birthday"))
+          report-properties (db-test/readable-properties
+                             (db-test/find-block-by-content @conn #"weekly report"))
+          birthday-scheduled (:logseq.property/scheduled birthday-properties)
+          birthday-date (js/Date. birthday-scheduled)]
+      (is (= 20251101 (date-time-util/ms->journal-day birthday-scheduled))
+          "Repeated scheduled timestamp keeps its scheduled date")
+      (is (= [8 0] [(.getHours birthday-date) (.getMinutes birthday-date)])
+          "Repeated scheduled timestamp keeps its time")
+      (is (= {:logseq.property.repeat/repeated? true
+              :logseq.property.repeat/temporal-property :logseq.property/scheduled
+              :logseq.property.repeat/recur-frequency 1
+              :logseq.property.repeat/recur-unit :logseq.property.repeat/recur-unit.year}
+             (select-keys birthday-properties
+                          [:logseq.property.repeat/repeated?
+                           :logseq.property.repeat/temporal-property
+                           :logseq.property.repeat/recur-frequency
+                           :logseq.property.repeat/recur-unit]))
+          "Repeated scheduled timestamp keeps its repeat properties")
+      (is (= {:logseq.property/deadline 20251107
+              :logseq.property.repeat/repeated? true
+              :logseq.property.repeat/temporal-property :logseq.property/deadline
+              :logseq.property.repeat/recur-frequency 2
+              :logseq.property.repeat/recur-unit :logseq.property.repeat/recur-unit.week}
+             (-> report-properties
+                 (update :logseq.property/deadline date-time-util/ms->journal-day)
+                 (select-keys [:logseq.property/deadline
+                               :logseq.property.repeat/repeated?
+                               :logseq.property.repeat/temporal-property
+                               :logseq.property.repeat/recur-frequency
+                               :logseq.property.repeat/recur-unit])))
+          "Repeated deadline timestamp keeps its repeat properties")
+      (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
+          "Imported graph validates"))))
+
 (deftest update-asset-links-in-block-title
   (are [x y]
        (= y (@#'gp-exporter/update-asset-links-in-block-title (first x) {(second x) "UUID"} (atom {})))


### PR DESCRIPTION
## Summary

Fixes logseq/db-test#250.

File-to-DB import now preserves Org-mode repeat metadata from `SCHEDULED` and `DEADLINE` timestamps. Repeated tasks import with the scheduled/deadline datetime plus Logseq repeat properties for temporal property, frequency, and unit.

## Root Cause

The graph parser detected timestamp repetition but only carried a boolean `:repeated?` marker, and DB export then dropped that marker while converting old `:block/scheduled` / `:block/deadline` fields into DB graph properties. Timestamp time was also collapsed to the date-only local midnight value.

## Changes

- Preserve timestamp time and repetition metadata during graph parsing when present.
- Convert repeated scheduled/deadline metadata into existing Logseq repeat properties during DB export.
- Add regression coverage for repeated scheduled and repeated deadline Markdown imports.

## Validation

```bash
pnpm exec nbb-logseq -cp src:test:../outliner/src -m logseq.graph-parser.test-runner --var logseq.graph-parser.exporter-test/import-repeated-deadline-and-scheduled --var logseq.graph-parser.exporter-test/export-basic-graph-with-convert-all-tags
```

Passed: 2 tests, 131 assertions.
