### PR TITLE
[codex] stabilize clj-e2e basic suite

### DIFF
--- a/clj-e2e/src/logseq/e2e/page.clj
+++ b/clj-e2e/src/logseq/e2e/page.clj
@@ -26,11 +26,19 @@
   ;; Question: what's the best way to close all the popups?
   ;; close popup, exit editing
   ;; (repl/pause)
-  (util/search title)
-  (let [create-page-item (loc/filter ".search-results > div"
-                                     :has-text (str "Create page called '" title "'"))]
-    (w/wait-for create-page-item)
-    (w/click (.first create-page-item)))
+  (try
+    (util/search title)
+    (let [create-page-item (loc/filter ".search-results > div"
+                                       :has-text (str "Create page called '" title "'"))]
+      (w/wait-for create-page-item)
+      (w/click (.first create-page-item)))
+    (catch TimeoutError _e
+      (k/esc)
+      (util/search title)
+      (let [create-page-item (loc/filter ".search-results > div"
+                                         :has-text (str "Create page called '" title "'"))]
+        (w/wait-for create-page-item)
+        (w/click (.first create-page-item)))))
   (util/wait-editor-visible))
 
 (defn delete-page

--- a/clj-e2e/test/logseq/e2e/editor_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/editor_basic_test.clj
@@ -17,6 +17,13 @@
   fixtures/new-logseq-page
   fixtures/validate-graph)
 
+(defn- choose-move-target!
+  [target]
+  (w/fill "input[placeholder=\"Move blocks to\"]" target)
+  (let [result (.first (w/get-by-test-id target))]
+    (assert/assert-is-visible result)
+    (w/click result)))
+
 (defn- drag-and-drop-file!
   [file-name file-type]
   (w/eval-js
@@ -80,10 +87,7 @@
     (b/new-blocks ["b1" "b2" "b3"])
     (b/select-blocks 3)
     (k/press "ControlOrMeta+Shift+m")
-    (w/fill "input[placeholder=\"Move blocks to\"]" "Target page")
-    (w/wait-for (w/get-by-test-id "Target page"))
-    (.focus (w/-query ".cp__cmdk-search-input"))
-    (k/enter)
+    (choose-move-target! "Target page")
     (assert/assert-have-count ".ls-page-blocks .page-blocks-inner .ls-block" 0)))
 
 (deftest move-blocks-cmdk
@@ -93,11 +97,7 @@
     (b/new-blocks ["b1" "b2" "b3"])
     (b/select-blocks 3)
     (util/search-and-click "Move blocks to")
-    (w/fill "input[placeholder=\"Move blocks to\"]" "Target page 2")
-    (w/wait-for (w/get-by-test-id "Target page 2"))
-    (.focus (w/-query ".cp__cmdk-search-input"))
-    (k/arrow-down)
-    (k/enter)
+    (choose-move-target! "Target page 2")
     (assert/assert-have-count ".ls-page-blocks .page-blocks-inner .ls-block" 0)))
 
 (deftest move-pages-to-library

--- a/clj-e2e/test/logseq/e2e/outliner_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/outliner_basic_test.clj
@@ -15,6 +15,12 @@
   fixtures/new-logseq-page
   fixtures/validate-graph)
 
+(defn- block-text-position
+  [text]
+  (let [locator (w/find-one-by-text "span" text)]
+    (assert/assert-is-visible locator)
+    (first (util/bounding-xy locator))))
+
 (defn create-test-page-and-insert-blocks []
   ;; a page block and a child block
   (is (= 2 (util/blocks-count)))
@@ -34,7 +40,7 @@
     (k/arrow-up)
     (b/indent)
     (util/exit-edit)
-    (let [[x1 x2 x3] (map (comp first util/bounding-xy #(w/find-one-by-text "span" %)) ["b1" "b2" "b3"])]
+    (let [[x1 x2 x3] (map block-text-position ["b1" "b2" "b3"])]
       (is (< x1 x2 x3))))
 
   (testing "unindent a block with its children"
@@ -44,7 +50,7 @@
     (k/arrow-up)
     (b/outdent)
     (util/exit-edit)
-    (let [[x2 x3 x4 x5] (map (comp first util/bounding-xy #(w/find-one-by-text "span" %)) ["b2" "b3" "b4" "b5"])]
+    (let [[x2 x3 x4 x5] (map block-text-position ["b2" "b3" "b4" "b5"])]
       (is (and (= x2 x4) (= x3 x5) (< x2 x3))))))
 
 (defn indent-outdent-embed-page []
@@ -61,7 +67,7 @@
   (b/outdent)
   (b/indent)
   (util/exit-edit)
-  (let [[x2 x3 x4] (map (comp first util/bounding-xy #(w/find-one-by-text "span" %)) ["b2" "b3" "b4"])]
+  (let [[x2 x3 x4] (map block-text-position ["b2" "b3" "b4"])]
     (is (= x2 x4))
     (is (< x3 x2))))
 

--- a/clj-e2e/test/logseq/e2e/plugins_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/plugins_basic_test.clj
@@ -219,6 +219,7 @@
                                 {:content "b2"}]
                                {:schema {"z3" "page"
                                          "z4" "page"}})
+          _ (assert/assert-is-visible ".block-title-wrap:text('Page 3')")
           contents (util/get-page-blocks-contents)]
       (is (= contents
              ["b1" "test" "b1.1" "b1.1.1" "Page 1" "Page 2" "Page 3" "b1.1.2" "b1.2" "b2"]))


### PR DESCRIPTION
## Summary

Stabilizes timing-sensitive checks in the `clj-e2e` basic suite.

- Select move-block targets by clicking the visible command result instead of relying on focus plus Enter timing.
- Wait for block text locators before reading bounding boxes in outliner indent/outdent assertions.

## Why

The basic suite exposed intermittent failures where UI elements existed slightly later than the test assumed. The assertions should wait at the user-visible boundary before checking final state or geometry.

## Validation

- `bb dev -p 3035 -n logseq.e2e.editor-basic-test`
- `bb dev -p 3036 -n logseq.e2e.outliner-basic-test`
- `bb dev -p 3037` passed: 71 tests, 336 assertions, 0 failures, 0 errors
