### PR TITLE
fix(ux): incorrect reaction for the order list sibling blocks

### DIFF
--- a/src/main/frontend/worker/react.cljs
+++ b/src/main/frontend/worker/react.cljs
@@ -58,9 +58,17 @@
   (or (block-attr? attr)
       (contains? block-query-affecting-attrs attr)))
 
+(defn- property-value->content-string
+  [value]
+  (cond
+    (string? value) value
+    (keyword? value) (name value)
+    :else (db-property/property-value-content value)))
+
 (defn- order-list-type
   [block]
-  (some-> (db-property/lookup block :logseq.property/order-list-type) str))
+  (some-> (db-property/lookup block :logseq.property/order-list-type)
+          property-value->content-string))
 
 (defn- collect-right-order-list-siblings
   [block target-order-list-type]

--- a/src/main/frontend/worker/react.cljs
+++ b/src/main/frontend/worker/react.cljs
@@ -45,7 +45,7 @@
 (def ^:private block-query-affecting-attrs
   #{:logseq.property/order-list-type})
 
-(def ^:private order-list-sibling-affecting-attrs
+(def ^:private order-list-affecting-attrs
   #{:block/parent :block/page :block/order :logseq.property/order-list-type})
 
 (defn- block-attr?
@@ -57,17 +57,13 @@
   (or (block-attr? attr)
       (contains? block-query-affecting-attrs attr)))
 
-(defn- property-value->content-string
-  [value]
-  (cond
-    (string? value) value
-    (keyword? value) (name value)
-    :else (db-property/property-value-content value)))
+(defn- block-key
+  [block]
+  [::block (:db/id block)])
 
 (defn- order-list-type
   [block]
-  (some-> (db-property/lookup block :logseq.property/order-list-type)
-          property-value->content-string))
+  (db-property/lookup block :logseq.property/order-list-type))
 
 (defn- sibling-entities
   [block]
@@ -95,9 +91,10 @@
 
 (defn- collect-right-order-list-sibling-keys
   [siblings target-order-list-type]
-  (->> siblings
-       (take-while #(= target-order-list-type (order-list-type %)))
-       (mapv (fn [sibling] [::block (:db/id sibling)]))))
+  (when target-order-list-type
+    (->> siblings
+         (take-while #(= target-order-list-type (order-list-type %)))
+         (map block-key))))
 
 (defn- affected-right-order-list-sibling-keys
   [db block-id]
@@ -105,10 +102,20 @@
     (let [right-siblings (right-ordered-siblings block)
           right-sibling (first right-siblings)]
       (concat
-       (when-let [type (order-list-type block)]
-         (collect-right-order-list-sibling-keys right-siblings type))
-       (when-let [right-type (order-list-type right-sibling)]
-         (collect-right-order-list-sibling-keys right-siblings right-type))))))
+       (collect-right-order-list-sibling-keys right-siblings (order-list-type block))
+       (collect-right-order-list-sibling-keys right-siblings (order-list-type right-sibling))))))
+
+(defn- affected-order-list-descendant-keys
+  [db block-id]
+  (when-let [block (and db (d/entity db block-id))]
+    (letfn [(collect [parent]
+              (when-let [parent-list-type (order-list-type parent)]
+                (mapcat
+                 (fn [child]
+                   (when (= parent-list-type (order-list-type child))
+                     (cons (block-key child) (collect child))))
+                 (:block/_parent parent))))]
+      (collect block))))
 
 (defn get-affected-queries-keys
   "Get affected queries through transaction datoms."
@@ -148,10 +155,10 @@
                              tx-data)
         other-blocks (->> (filter (fn [datom] (block-query-affecting-attr? (:a datom))) tx-data)
                           (map :e))
-        order-list-sibling-affected-blocks (->> (filter (fn [datom]
-                                                          (contains? order-list-sibling-affecting-attrs (:a datom))) tx-data)
-                                                (map :e)
-                                                (distinct))
+        order-list-affected-blocks (->> (filter (fn [datom]
+                                                  (contains? order-list-affecting-attrs (:a datom))) tx-data)
+                                        (map :e)
+                                        (distinct))
         blocks (-> (concat blocks other-blocks) distinct)
         block-entities (keep (fn [block-id]
                                (let [block-id (if (and (string? block-id) (common-util/uuid-string? block-id))
@@ -192,8 +199,10 @@
                         (fn [block-id]
                           (concat
                            (affected-right-order-list-sibling-keys db-before block-id)
-                           (affected-right-order-list-sibling-keys db-after block-id)))
-                        order-list-sibling-affected-blocks)
+                           (affected-right-order-list-sibling-keys db-after block-id)
+                           (affected-order-list-descendant-keys db-before block-id)
+                           (affected-order-list-descendant-keys db-after block-id)))
+                        order-list-affected-blocks)
 
                        (keep
                         (fn [tag]

--- a/src/main/frontend/worker/react.cljs
+++ b/src/main/frontend/worker/react.cljs
@@ -2,7 +2,9 @@
   "Compute reactive query affected keys"
   (:require [cljs.spec.alpha :as s]
             [datascript.core :as d]
-            [logseq.common.util :as common-util]))
+            [logseq.common.util :as common-util]
+            [logseq.db :as ldb]
+            [logseq.db.frontend.property :as db-property]))
 
 ;;; keywords specs for reactive query, used by `react/q` calls
 ;; ::block
@@ -41,6 +43,45 @@
             (= journal-tag-id (:db/id tag)))
           (:block/tags (d/entity db eid)))))
 
+(def ^:private block-query-affecting-attrs
+  #{:logseq.property/order-list-type})
+
+(def ^:private order-list-sibling-affecting-attrs
+  #{:block/parent :block/page :block/order :logseq.property/order-list-type})
+
+(defn- block-attr?
+  [attr]
+  (= "block" (namespace attr)))
+
+(defn- block-query-affecting-attr?
+  [attr]
+  (or (block-attr? attr)
+      (contains? block-query-affecting-attrs attr)))
+
+(defn- order-list-type
+  [block]
+  (some-> (db-property/lookup block :logseq.property/order-list-type) str))
+
+(defn- collect-right-order-list-siblings
+  [block target-order-list-type]
+  (loop [sibling (ldb/get-right-sibling block)
+         result []]
+    (if (and sibling (= target-order-list-type (order-list-type sibling)))
+      (recur (ldb/get-right-sibling sibling)
+             (conj result [::block (:db/id sibling)]))
+      result)))
+
+(defn- affected-right-order-list-sibling-keys
+  [db block-id]
+  (when-let [block (and db (d/entity db block-id))]
+    (let [right-sibling (ldb/get-right-sibling block)]
+      (concat
+       (when-let [type (order-list-type block)]
+         (collect-right-order-list-siblings block type))
+       (when-let [right-type (order-list-type right-sibling)]
+         (cons [::block (:db/id right-sibling)]
+               (collect-right-order-list-siblings right-sibling right-type)))))))
+
 (defn get-affected-queries-keys
   "Get affected queries through transaction datoms."
   [{:keys [tx-data db-before db-after]}]
@@ -77,8 +118,12 @@
         recycle-roots? (some (fn [datom]
                                (= :logseq.property/deleted-at (:a datom)))
                              tx-data)
-        other-blocks (->> (filter (fn [datom] (= "block" (namespace (:a datom)))) tx-data)
+        other-blocks (->> (filter (fn [datom] (block-query-affecting-attr? (:a datom))) tx-data)
                           (map :e))
+        order-list-sibling-affected-blocks (->> (filter (fn [datom]
+                                                          (contains? order-list-sibling-affecting-attrs (:a datom))) tx-data)
+                                                (map :e)
+                                                (distinct))
         blocks (-> (concat blocks other-blocks) distinct)
         block-entities (keep (fn [block-id]
                                (let [block-id (if (and (string? block-id) (common-util/uuid-string? block-id))
@@ -114,6 +159,13 @@
                           [[::block-reactions target-id]
                            [::block target-id]])
                         reaction-targets)
+
+                       (mapcat
+                        (fn [block-id]
+                          (concat
+                           (affected-right-order-list-sibling-keys db-before block-id)
+                           (affected-right-order-list-sibling-keys db-after block-id)))
+                        order-list-sibling-affected-blocks)
 
                        (keep
                         (fn [tag]

--- a/src/main/frontend/worker/react.cljs
+++ b/src/main/frontend/worker/react.cljs
@@ -70,25 +70,46 @@
   (some-> (db-property/lookup block :logseq.property/order-list-type)
           property-value->content-string))
 
-(defn- collect-right-order-list-siblings
-  [block target-order-list-type]
-  (loop [sibling (ldb/get-right-sibling block)
-         result []]
-    (if (and sibling (= target-order-list-type (order-list-type sibling)))
-      (recur (ldb/get-right-sibling sibling)
-             (conj result [::block (:db/id sibling)]))
-      result)))
+(defn- sibling-entities
+  [block]
+  (cond
+    (:block/parent block)
+    (some-> (:block/parent block) :block/_parent)
+
+    (:block/page block)
+    (some-> (:block/page block) :block/_page)
+
+    :else
+    nil))
+
+(defn- ordered-siblings
+  [block]
+  (some->> (sibling-entities block)
+           (sort-by :block/order)))
+
+(defn- right-ordered-siblings
+  [block]
+  (when-let [siblings (seq (ordered-siblings block))]
+    (->> siblings
+         (drop-while #(not= (:db/id %) (:db/id block)))
+         rest)))
+
+(defn- collect-right-order-list-sibling-keys
+  [siblings target-order-list-type]
+  (->> siblings
+       (take-while #(= target-order-list-type (order-list-type %)))
+       (mapv (fn [sibling] [::block (:db/id sibling)]))))
 
 (defn- affected-right-order-list-sibling-keys
   [db block-id]
   (when-let [block (and db (d/entity db block-id))]
-    (let [right-sibling (ldb/get-right-sibling block)]
+    (let [right-siblings (right-ordered-siblings block)
+          right-sibling (first right-siblings)]
       (concat
        (when-let [type (order-list-type block)]
-         (collect-right-order-list-siblings block type))
+         (collect-right-order-list-sibling-keys right-siblings type))
        (when-let [right-type (order-list-type right-sibling)]
-         (cons [::block (:db/id right-sibling)]
-               (collect-right-order-list-siblings right-sibling right-type)))))))
+         (collect-right-order-list-sibling-keys right-siblings right-type))))))
 
 (defn get-affected-queries-keys
   "Get affected queries through transaction datoms."

--- a/src/main/frontend/worker/react.cljs
+++ b/src/main/frontend/worker/react.cljs
@@ -3,7 +3,6 @@
   (:require [cljs.spec.alpha :as s]
             [datascript.core :as d]
             [logseq.common.util :as common-util]
-            [logseq.db :as ldb]
             [logseq.db.frontend.property :as db-property]))
 
 ;;; keywords specs for reactive query, used by `react/q` calls

--- a/src/main/frontend/worker/react.cljs
+++ b/src/main/frontend/worker/react.cljs
@@ -117,6 +117,21 @@
                  (:block/_parent parent))))]
       (collect block))))
 
+(defn- affected-block-keys
+  [block]
+  (let [page-id (or
+                 (when (:block/name block) (:db/id block))
+                 (:db/id (:block/page block)))
+        blocks [(when-let [parent-id (:db/id (:block/parent block))]
+                  [::block parent-id])
+                [::block (:db/id block)]]
+        refs (->> (keep (fn [ref]
+                          (when-not (= (:db/id ref) page-id)
+                            [[::refs (:db/id ref)]
+                             [::block (:db/id ref)]])) (:block/refs block))
+                  (apply concat))]
+    (concat blocks refs)))
+
 (defn get-affected-queries-keys
   "Get affected queries through transaction datoms."
   [{:keys [tx-data db-before db-after]}]
@@ -167,20 +182,7 @@
                                  (d/entity db-after block-id))) blocks)
         affected-keys (concat
                        (mapcat
-                        (fn [block]
-                          (let [page-id (or
-                                         (when (:block/name block) (:db/id block))
-                                         (:db/id (:block/page block)))
-                                blocks [(when-let [parent-id (:db/id (:block/parent block))]
-                                          [::block parent-id])
-                                        [::block (:db/id block)]]
-                                block-refs (:block/refs block)
-                                refs (->> (keep (fn [ref]
-                                                  (when-not (= (:db/id ref) page-id)
-                                                    [[::refs (:db/id ref)]
-                                                     [::block (:db/id ref)]])) block-refs)
-                                          (apply concat))]
-                            (concat blocks refs)))
+                        affected-block-keys
                         block-entities)
 
                        (mapcat

--- a/src/test/frontend/worker/react_test.cljs
+++ b/src/test/frontend/worker/react_test.cljs
@@ -2,6 +2,7 @@
   (:require [cljs.test :refer [deftest is testing]]
             [datascript.core :as d]
             [frontend.worker.react :as worker-react]
+            [logseq.db.common.order :as db-order]
             [logseq.db.test.helper :as db-test]))
 
 (deftest affected-keys-block-reactions
@@ -19,6 +20,46 @@
                                    :logseq.property.reaction/target target-id}])
           affected (worker-react/get-affected-queries-keys tx-report)]
       (is (some #{[:frontend.worker.react/block-reactions target-id]} affected)))))
+
+(deftest affected-keys-order-list-type
+  (testing "changing order list type affects block query key"
+    (let [conn (db-test/create-conn-with-blocks
+                [{:page {:block/title "Test"}
+                  :blocks [{:block/title "Block"
+                            :build/properties {:logseq.property/order-list-type "number"}}]}])
+          block (db-test/find-block-by-content @conn "Block")
+          target-id (:db/id block)
+          tx-report (d/transact! conn
+                                 [[:db/retract target-id :logseq.property/order-list-type
+                                   (:db/id (:logseq.property/order-list-type block))]])
+          affected (worker-react/get-affected-queries-keys tx-report)]
+      (is (some #{[:frontend.worker.react/block target-id]} affected)))))
+
+(deftest affected-keys-order-list-right-siblings
+  (testing "inserting a block before ordered-list siblings affects their block query keys"
+    (let [conn (db-test/create-conn-with-blocks
+                [{:page {:block/title "Test"}
+                  :blocks [{:block/title "Block 1"
+                            :build/properties {:logseq.property/order-list-type "number"}}
+                           {:block/title "Block 2"
+                            :build/properties {:logseq.property/order-list-type "number"}}
+                           {:block/title "Block 3"
+                            :build/properties {:logseq.property/order-list-type "number"}}]}])
+          block-1 (db-test/find-block-by-content @conn "Block 1")
+          block-2 (db-test/find-block-by-content @conn "Block 2")
+          block-3 (db-test/find-block-by-content @conn "Block 3")
+          tx-report (d/transact! conn
+                                 [{:block/uuid (random-uuid)
+                                   :block/title "Inserted"
+                                   :block/page (:db/id (:block/page block-1))
+                                   :block/parent (:db/id (:block/parent block-1))
+                                   :block/order (db-order/gen-key (:block/order block-1)
+                                                                  (:block/order block-2))
+                                   :block/created-at 1
+                                   :block/updated-at 1}])
+          affected (worker-react/get-affected-queries-keys tx-report)]
+      (is (some #{[:frontend.worker.react/block (:db/id block-2)]} affected))
+      (is (some #{[:frontend.worker.react/block (:db/id block-3)]} affected)))))
 
 (deftest affected-keys-journals-when-journal-recycled
   (testing "recycling a journal page should refresh journals query key"

--- a/src/test/frontend/worker/react_test.cljs
+++ b/src/test/frontend/worker/react_test.cljs
@@ -61,6 +61,26 @@
       (is (some #{[:frontend.worker.react/block (:db/id block-2)]} affected))
       (is (some #{[:frontend.worker.react/block (:db/id block-3)]} affected)))))
 
+(deftest affected-keys-order-list-descendants
+  (testing "changing ordered-list parent type affects nested ordered-list descendants"
+    (let [conn (db-test/create-conn-with-blocks
+                [{:page {:block/title "Test"}
+                  :blocks [{:block/title "Parent"
+                            :build/properties {:logseq.property/order-list-type "number"}
+                            :build/children [{:block/title "Child"
+                                              :build/properties {:logseq.property/order-list-type "number"}
+                                              :build/children [{:block/title "Grandchild"
+                                                                :build/properties {:logseq.property/order-list-type "number"}}]}]}]}])
+          parent (db-test/find-block-by-content @conn "Parent")
+          child (db-test/find-block-by-content @conn "Child")
+          grandchild (db-test/find-block-by-content @conn "Grandchild")
+          tx-report (d/transact! conn
+                                 [[:db/retract (:db/id parent) :logseq.property/order-list-type
+                                   (:db/id (:logseq.property/order-list-type parent))]])
+          affected (worker-react/get-affected-queries-keys tx-report)]
+      (is (some #{[:frontend.worker.react/block (:db/id child)]} affected))
+      (is (some #{[:frontend.worker.react/block (:db/id grandchild)]} affected)))))
+
 (deftest affected-keys-journals-when-journal-recycled
   (testing "recycling a journal page should refresh journals query key"
     (let [conn (db-test/create-conn-with-blocks


### PR DESCRIPTION
## Before

https://github.com/user-attachments/assets/c4b05eeb-645c-4b3e-85aa-d8c430751480

## After

https://github.com/user-attachments/assets/4db42251-8ae5-4158-9d30-9f22231ed540

