### PR TITLE
[codex] Fix block selection while scrolling

### DIFF
--- a/clj-e2e/test/logseq/e2e/editor_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/editor_basic_test.clj
@@ -1,6 +1,7 @@
 (ns logseq.e2e.editor-basic-test
   (:require
    [clojure.set :as set]
+   [clojure.string :as string]
    [clojure.test :refer [deftest testing is use-fixtures]]
    [jsonista.core :as json]
    [logseq.e2e.assert :as assert]
@@ -9,8 +10,7 @@
    [logseq.e2e.keyboard :as k]
    [logseq.e2e.page :as p]
    [logseq.e2e.util :as util]
-   [wally.main :as w]
-   [wally.repl :as repl]))
+   [wally.main :as w]))
 
 (use-fixtures :once fixtures/open-page)
 
@@ -117,6 +117,84 @@
         (util/exit-edit)
         (let [{:keys [delta] :as alignment} (multiline-heading-control-alignment title true)]
           (is (<= delta 3) (assoc alignment :heading heading)))))))
+
+(defn- select-blocks-while-scrolling!
+  [block-count]
+  (w/eval-js
+   (format
+    "(async () => {
+      const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+      const nextFrame = () => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      const blocks = Array.from(document.querySelectorAll('.ls-page-blocks .page-blocks-inner .ls-block:not(.block-add-button)')).slice(0, %d);
+
+      if (blocks.length !== %d) {
+        throw new Error(`Expected %d blocks, got ${blocks.length}`);
+      }
+
+      const firstContent = blocks[0].querySelector('.block-content');
+      firstContent.scrollIntoView({ block: 'center' });
+      await nextFrame();
+
+      const firstRect = firstContent.getBoundingClientRect();
+      const clientX = Math.floor(firstRect.left + 24);
+      const clientY = Math.floor(firstRect.top + Math.min(20, firstRect.height / 2));
+      const pointerInit = {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        buttons: 1,
+        clientX,
+        clientY
+      };
+
+      firstContent.dispatchEvent(new PointerEvent('pointerdown', pointerInit));
+      await delay(100);
+
+      let previousTarget = firstContent;
+      for (const block of blocks.slice(1)) {
+        block.scrollIntoView({ block: 'center' });
+        await nextFrame();
+
+        const target = block.querySelector('.block-main-container');
+        previousTarget.dispatchEvent(new MouseEvent('mouseout', {
+          ...pointerInit,
+          relatedTarget: target
+        }));
+        target.dispatchEvent(new MouseEvent('mouseover', {
+          ...pointerInit,
+          relatedTarget: previousTarget
+        }));
+        previousTarget = target;
+        await delay(30);
+      }
+
+      document.querySelector('#app-container-wrapper')?.dispatchEvent(new PointerEvent('pointerup', {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        buttons: 0,
+        clientX,
+        clientY
+      }));
+
+      return Array.from(document.querySelectorAll('.ls-page-blocks .page-blocks-inner .ls-block.selected'))
+        .map((block) => block.textContent.trim());
+    })();"
+    block-count
+    block-count
+    block-count)))
+
+(deftest copy-blocks-selected-while-scrolling
+  (testing "copy includes blocks selected by dragging while the page scrolls"
+    (let [blocks (mapv #(format "scroll-copy-block-%02d" %) (range 1 26))]
+      (b/new-blocks blocks)
+      (util/exit-edit)
+      (is (= (count blocks)
+             (count (select-blocks-while-scrolling! (count blocks)))))
+      (b/copy)
+      (let [clipboard (w/clipboard-text)]
+        (doseq [block blocks]
+          (is (string/includes? clipboard block)))))))
 
 (deftest drag-and-drop-asset-does-not-create-blank-asset
   (testing "dragging and dropping a file should keep non-empty asset title"

--- a/clj-e2e/test/logseq/e2e/editor_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/editor_basic_test.clj
@@ -184,6 +184,240 @@
     block-count
     block-count)))
 
+(defn- enable-virtualized-rendering!
+  []
+  (w/eval-js
+   "() => {
+      history.replaceState(null, '', location.pathname + location.hash);
+    }")
+  (w/refresh)
+  (assert/assert-graph-loaded?))
+
+(defn- select-block-titles-while-scrolling!
+  [blocks]
+  (w/eval-js
+   (format
+    "(async () => {
+      const blockTitles = %s;
+      const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+      const nextFrame = () => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      const scrollContainer = document.querySelector('#main-content-container');
+
+      const blockByTitle = (title) => Array.from(document.querySelectorAll('.ls-page-blocks .page-blocks-inner .ls-block:not(.block-add-button)'))
+        .find((block) => block.textContent.includes(title));
+
+      const scrollToBlock = async (title) => {
+        for (let i = 0; i < 80; i++) {
+          const block = blockByTitle(title);
+          if (block) {
+            block.scrollIntoView({ block: 'center' });
+            await nextFrame();
+            return block;
+          }
+          scrollContainer.scrollTop += 260;
+          await nextFrame();
+        }
+        throw new Error(`Could not find mounted block ${title}`);
+      };
+
+      if (!document.querySelector('[data-virtuoso-scroller]')) {
+        throw new Error('Expected virtualized list scroller');
+      }
+
+      const firstBlock = await scrollToBlock(blockTitles[0]);
+      const firstContent = firstBlock.querySelector('.block-content');
+      const firstRect = firstContent.getBoundingClientRect();
+      const clientX = Math.floor(firstRect.left + 24);
+      const clientY = Math.floor(firstRect.top + Math.min(20, firstRect.height / 2));
+      const pointerInit = {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        buttons: 1,
+        clientX,
+        clientY
+      };
+
+      firstContent.dispatchEvent(new PointerEvent('pointerdown', pointerInit));
+      await delay(100);
+
+      let previousTarget = firstContent;
+      for (const title of blockTitles.slice(1)) {
+        const block = await scrollToBlock(title);
+        const target = block.querySelector('.block-main-container');
+        if (previousTarget.isConnected) {
+          previousTarget.dispatchEvent(new MouseEvent('mouseout', {
+            ...pointerInit,
+            relatedTarget: target
+          }));
+        }
+        target.dispatchEvent(new MouseEvent('mouseover', {
+          ...pointerInit,
+          relatedTarget: previousTarget
+        }));
+        previousTarget = target;
+        await delay(30);
+      }
+
+      document.querySelector('#app-container-wrapper')?.dispatchEvent(new PointerEvent('pointerup', {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        buttons: 0,
+        clientX,
+        clientY
+      }));
+
+      return Array.from(document.querySelectorAll('.ls-page-blocks .page-blocks-inner .ls-block.selected'))
+        .map((block) => block.textContent.trim());
+    })();"
+    (json/write-value-as-string blocks))))
+
+(defn- insert-current-page-blocks!
+  [blocks]
+  (w/eval-js
+   (format
+    "(async () => {
+      const page = await window.logseq.api.get_current_page();
+      await window.logseq.api.insert_batch_block(
+        page.uuid,
+        %s.map((content) => ({ content })),
+        { sibling: false }
+      );
+      await window.logseq.api.exit_editing_mode(false);
+      window.logseq.api.push_state('page', { name: page.uuid }, null);
+    })();"
+    (json/write-value-as-string blocks))))
+
+(defn- select-block-range-with-fast-scroll!
+  [blocks]
+  (w/eval-js
+   (format
+    "(async () => {
+      const blockTitles = %s;
+      const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+      const nextFrame = () => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      const scrollContainer = document.querySelector('#main-content-container');
+
+      const blockByTitle = (title) => Array.from(document.querySelectorAll('.ls-page-blocks .page-blocks-inner .ls-block:not(.block-add-button)'))
+        .find((block) => block.textContent.includes(title));
+
+      const scrollToBlock = async (title, step) => {
+        for (let i = 0; i < 120; i++) {
+          const block = blockByTitle(title);
+          if (block) {
+            block.scrollIntoView({ block: 'center' });
+            await nextFrame();
+            return block;
+          }
+          scrollContainer.scrollTop += step;
+          await nextFrame();
+        }
+        throw new Error(`Could not find mounted block ${title}`);
+      };
+
+      if (!document.querySelector('[data-virtuoso-scroller]')) {
+        throw new Error('Expected virtualized list scroller');
+      }
+
+      scrollContainer.scrollTop = 0;
+      await nextFrame();
+
+      const firstBlock = await scrollToBlock(blockTitles[0], -1000);
+      const firstContent = firstBlock.querySelector('.block-content');
+      const firstRect = firstContent.getBoundingClientRect();
+      const clientX = Math.floor(firstRect.left + 24);
+      const clientY = Math.floor(firstRect.top + Math.min(20, firstRect.height / 2));
+      const pointerInit = {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        buttons: 1,
+        clientX,
+        clientY
+      };
+
+      firstContent.dispatchEvent(new PointerEvent('pointerdown', pointerInit));
+      await delay(100);
+
+      await scrollToBlock(blockTitles[blockTitles.length - 1], 1400);
+      await delay(200);
+
+      document.querySelector('#app-container-wrapper')?.dispatchEvent(new PointerEvent('pointerup', {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        buttons: 0,
+        clientX,
+        clientY
+      }));
+
+      return ((await window.logseq.api.get_selected_blocks()) || [])
+        .map((block) => block.title || block.content);
+    })();"
+    (json/write-value-as-string blocks))))
+
+(defn- seed-journals!
+  [journals]
+  (w/eval-js
+   (format
+    "(async () => {
+      const journals = %s;
+
+      for (const journal of journals) {
+        const page = await window.logseq.api.create_journal_page(journal.date);
+        await window.logseq.api.insert_batch_block(
+          page.uuid,
+          journal.blocks.map((content) => ({ content })),
+          { sibling: false }
+        );
+      }
+
+      await window.logseq.api.exit_editing_mode(false);
+      window.logseq.api.push_state('all-journals', null, null);
+    })();"
+    (json/write-value-as-string journals))))
+
+(defn- multiline-heading-bullet-alignment
+  [title]
+  (-> (w/eval-js
+       (format
+        "(async () => {
+          const title = %s;
+          const nextFrame = () => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+          const block = Array.from(document.querySelectorAll('.ls-page-blocks .page-blocks-inner .ls-block:not(.block-add-button)'))
+            .find((block) => block.textContent.includes(title));
+
+          if (!block) {
+            throw new Error(`Block not found: ${title}`);
+          }
+
+          const wrapper = block.querySelector('.block-content-wrapper');
+          const bullet = block.querySelector('.bullet-container');
+          const heading = block.querySelector('.block-title-wrap.as-heading');
+
+          if (!wrapper || !bullet || !heading) {
+            throw new Error('Expected heading block with bullet controls');
+          }
+
+          wrapper.style.maxWidth = '160px';
+          await nextFrame();
+
+          const bulletRect = bullet.getBoundingClientRect();
+          const headingRect = heading.getBoundingClientRect();
+          const lineHeight = Number.parseFloat(window.getComputedStyle(heading).lineHeight);
+          const firstLineCenterY = headingRect.top + (lineHeight / 2);
+          const bulletCenterY = bulletRect.top + (bulletRect.height / 2);
+
+          return JSON.stringify({
+            bulletCenterY,
+            firstLineCenterY,
+            delta: Math.abs(bulletCenterY - firstLineCenterY)
+          });
+        })();"
+        (json/write-value-as-string title)))
+      (json/read-value json/keyword-keys-object-mapper)))
+
 (deftest copy-blocks-selected-while-scrolling
   (testing "copy includes blocks selected by dragging while the page scrolls"
     (let [blocks (mapv #(format "scroll-copy-block-%02d" %) (range 1 26))]
@@ -191,6 +425,56 @@
       (util/exit-edit)
       (is (= (count blocks)
              (count (select-blocks-while-scrolling! (count blocks)))))
+      (b/copy)
+      (let [clipboard (w/clipboard-text)]
+        (doseq [block blocks]
+          (is (string/includes? clipboard block)))))))
+
+(deftest multiline-heading-keeps-bullet-on-first-line
+  (testing "heading block bullet aligns with the first line when the heading wraps"
+    (doseq [heading (map #(str "h" %) (range 1 7))]
+      (let [title (format "Multiline %s heading bullet should stay on the first visual line" heading)]
+        (b/new-block title)
+        (util/input-command heading)
+        (util/exit-edit)
+        (let [{:keys [delta] :as alignment} (multiline-heading-bullet-alignment title)]
+          (is (<= delta 3) (assoc alignment :heading heading)))))))
+
+(deftest copy-blocks-selected-while-scrolling-virtualized-list
+  (testing "copy includes virtualized blocks selected by dragging while the page scrolls"
+    (let [blocks (mapv #(format "virtual-scroll-copy-block-%02d" %) (range 1 31))]
+      (b/new-blocks blocks)
+      (util/exit-edit)
+      (enable-virtualized-rendering!)
+      (is (pos? (count (select-block-titles-while-scrolling! blocks))))
+      (b/copy)
+      (let [clipboard (w/clipboard-text)]
+        (doseq [block blocks]
+          (is (string/includes? clipboard block)))))))
+
+(deftest copy-blocks-selected-after-fast-scroll-virtualized-list
+  (testing "copy includes virtualized blocks selected after fast scrolling a long page"
+    (let [blocks (mapv #(format "fast-scroll-copy-block-%03d" %) (range 1 101))]
+      (insert-current-page-blocks! blocks)
+      (enable-virtualized-rendering!)
+      (is (set/subset? (set blocks)
+                       (set (select-block-range-with-fast-scroll! blocks))))
+      (b/copy)
+      (let [clipboard (w/clipboard-text)]
+        (doseq [block blocks]
+          (is (string/includes? clipboard block)))))))
+
+(deftest copy-blocks-selected-while-scrolling-journals-list
+  (testing "copy includes blocks selected across virtualized journals while scrolling"
+    (let [journals (mapv (fn [idx]
+                           {:date (format "2026-02-%02dT00:00:00.000Z" idx)
+                            :blocks (mapv #(format "journal-%02d-scroll-copy-block-%02d" idx %)
+                                          (range 1 31))})
+                         (range 1 5))
+          blocks (mapcat :blocks (reverse journals))]
+      (seed-journals! journals)
+      (w/wait-for "#journals [data-virtuoso-scroller]")
+      (is (pos? (count (select-block-titles-while-scrolling! blocks))))
       (b/copy)
       (let [clipboard (w/clipboard-text)]
         (doseq [block blocks]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -12,6 +12,7 @@
             [electron.ipc :as ipc]
             [frontend.components.block.breadcrumb-model :as breadcrumb-model]
             [frontend.components.block.macros :as block-macros]
+            [frontend.components.block.selection :as block-selection]
             [frontend.components.icon :as icon-component]
             [frontend.components.lazy-editor :as lazy-editor]
             [frontend.components.macro :as macro]
@@ -3437,12 +3438,17 @@
 
 (defn- block-mouse-over
   [^js e block *control-show? block-id doc-mode?]
-  (let [mouse-moving? (not= (some-> @*block-last-mouse-event (.-clientY)) (.-clientY e))
+  (let [last-client-y (some-> @*block-last-mouse-event (.-clientY))
+        client-y (.-clientY e)
         block-dom-node (util/rec-get-node (.-target e) "ls-block")]
     (reset! *control-show? true)
-    (when (and mouse-moving?
-               (not @*dragging?)
-               (not= (:block/uuid block) (:block/uuid (state/get-edit-block))))
+    (when (block-selection/select-on-hover?
+           {:last-client-y last-client-y
+            :client-y client-y
+            :dragging? @*dragging?
+            :editing-same-block? (= (:block/uuid block)
+                                    (:block/uuid (state/get-edit-block)))
+            :active-selection? (seq (state/get-selection-blocks))})
       (.preventDefault e)
       (when-let [parent (gdom/getElement block-id)]
         (let [node (.querySelector parent ".bullet-container")]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -3435,12 +3435,70 @@
     (block-drag-end event *move-to')))
 
 (defonce *block-last-mouse-event (atom nil))
+(defonce *block-scroll-selection-raf (atom nil))
+(defonce *block-last-scroll-top (atom nil))
 
+(defn- remember-block-pointer!
+  [^js e]
+  (reset! *block-last-mouse-event
+          {:client-x (.-clientX e)
+           :client-y (.-clientY e)}))
+
+(defn- visible-selection-boundary-block
+  [selection-block-ids scroll-direction]
+  (let [selection-block-id-set (set (map str selection-block-ids))
+        blocks (->> (dom/sel ".ls-page-blocks .page-blocks-inner .ls-block[blockid]")
+                    (filter #(contains? selection-block-id-set (dom/attr % "blockid"))))]
+    (case scroll-direction
+      :down (last blocks)
+      :up (first blocks)
+      nil)))
+
+(defn- block-under-pointer
+  []
+  (when-let [{:keys [client-x client-y]} @*block-last-mouse-event]
+    (when-let [target (.elementFromPoint js/document client-x client-y)]
+      (util/rec-get-node target "ls-block"))))
+
+(defn- select-block-under-pointer!
+  [selection-block-ids scroll-direction]
+  (when (and (seq selection-block-ids)
+             (or (state/get-selection-start-block)
+                 (seq (state/get-selection-blocks))))
+    (when-let [block-dom-node (or (visible-selection-boundary-block selection-block-ids scroll-direction)
+                                  (block-under-pointer))]
+      (when-let [block-id (.-id block-dom-node)]
+        (when-not (string/blank? block-id)
+          (editor-handler/highlight-selection-area! block-id block-dom-node
+                                                    {:append? true
+                                                     :block-ids selection-block-ids}))))))
+
+(defn- schedule-select-block-under-pointer!
+  [selection-block-ids scroll-container]
+  (when (seq selection-block-ids)
+    (let [scroll-top (some-> scroll-container .-scrollTop)
+          last-scroll-top @*block-last-scroll-top
+          scroll-direction (cond
+                             (and scroll-top last-scroll-top (> scroll-top last-scroll-top)) :down
+                             (and scroll-top last-scroll-top (< scroll-top last-scroll-top)) :up
+                             :else nil)]
+      (reset! *block-last-scroll-top scroll-top)
+      (when-let [raf-id @*block-scroll-selection-raf]
+        (js/cancelAnimationFrame raf-id))
+      (reset! *block-scroll-selection-raf
+              (js/requestAnimationFrame
+               (fn []
+                 (reset! *block-scroll-selection-raf
+                         (js/requestAnimationFrame
+                          (fn []
+                            (reset! *block-scroll-selection-raf nil)
+                            (select-block-under-pointer! selection-block-ids scroll-direction))))))))))
 (defn- block-mouse-over
-  [^js e block *control-show? block-id doc-mode?]
-  (let [last-client-y (some-> @*block-last-mouse-event (.-clientY))
+  [^js e block *control-show? block-id doc-mode? selection-block-ids]
+  (let [last-client-y (:client-y @*block-last-mouse-event)
         client-y (.-clientY e)
         block-dom-node (util/rec-get-node (.-target e) "ls-block")]
+    (remember-block-pointer! e)
     (reset! *control-show? true)
     (when (block-selection/select-on-hover?
            {:last-client-y last-client-y
@@ -3457,7 +3515,9 @@
       (when (non-dragging? e)
         (when-let [container (gdom/getElement "app-container-wrapper")]
           (dom/add-class! container "blocks-selection-mode"))
-        (editor-handler/highlight-selection-area! block-id block-dom-node {:append? true})))))
+        (editor-handler/highlight-selection-area! block-id block-dom-node
+                                                  {:append? true
+                                                   :block-ids selection-block-ids})))))
 
 (defn- block-mouse-leave
   [*control-show? block-id doc-mode?]
@@ -3919,9 +3979,10 @@
                                   :else -30)})
          :data-has-heading (block-heading-level block level)
          :on-mouse-enter (fn [e]
-                           (block-mouse-over e block *control-show? block-id doc-mode?))
-         :on-mouse-move (fn [e]
-                          (reset! *block-last-mouse-event e))
+                           (block-mouse-over e block *control-show? block-id doc-mode?
+                                             (:selection/block-ids config)))
+           :on-mouse-move (fn [e]
+                            (remember-block-pointer! e))
          :on-mouse-leave (fn [_e]
                            (block-mouse-leave *control-show? block-id doc-mode?))}
 
@@ -4612,13 +4673,20 @@
                                       {:top? top?
                                        :bottom? bottom?}))))
         virtualized? (and virtualized? (seq blocks))
+        virtualized-block-ids (when virtualized? (mapv :block/uuid blocks))
+        selection-block-ids (or (:selection/block-ids config)
+                                virtualized-block-ids)
+        scroll-container (or (:scroll-container config)
+                             (if-let [node (js/document.getElementById (:blocks-node-id config))]
+                               (util/app-scroll-container-node node)
+                               (util/app-scroll-container-node)))
+        scroll-container (if (fn? scroll-container)
+                           (scroll-container)
+                           scroll-container)
         *virtualized-ref (hooks/use-ref nil)
         virtual-opts (when virtualized?
                        {:ref *virtualized-ref
-                        :custom-scroll-parent (or (:scroll-container config)
-                                                  (if-let [node (js/document.getElementById (:blocks-node-id config))]
-                                                    (util/app-scroll-container-node node)
-                                                    (util/app-scroll-container-node)))
+                        :custom-scroll-parent scroll-container
                         :compute-item-key (fn [idx]
                                             (let [block (nth blocks idx)]
                                               (str (:container-id config) "-" (:db/id block))))
@@ -4631,6 +4699,7 @@
                                               bottom? (= (dec blocks-count) idx)
                                               block (nth blocks idx)
                                               config' (cond-> (assoc config :top? top?)
+                                                        true (assoc :selection/block-ids selection-block-ids)
                                                         (and root-level? defer-root-render?) (assoc :defer-top-index idx)
                                                         (and root-level? defer-root-render?) (assoc :defer-ready-index defer-ready-index)
                                                         (and root-level? defer-root-render?) (assoc :defer-children-render-complete-by-root* *defer-children-render-complete-by-root))]
@@ -4692,6 +4761,14 @@
                     (vreset! *ob ob))))))
            #(some-> @*ob (.disconnect)))))
      [])
+    (hooks/use-effect!
+     (fn []
+       (if (and scroll-container (seq selection-block-ids))
+         (let [handler #(schedule-select-block-under-pointer! selection-block-ids scroll-container)]
+           (.addEventListener scroll-container "scroll" handler #js {:passive true})
+           #(.removeEventListener scroll-container "scroll" handler))
+         (fn [])))
+     [scroll-container selection-block-ids])
 
     [:div.blocks-list-wrap
      {:data-level (or (:level config) 0)

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -3506,7 +3506,7 @@
             :dragging? @*dragging?
             :editing-same-block? (= (:block/uuid block)
                                     (:block/uuid (state/get-edit-block)))
-            :active-selection? (seq (state/get-selection-blocks))})
+            :active-selection? (boolean (seq (state/get-selection-blocks)))})
       (.preventDefault e)
       (when-let [parent (gdom/getElement block-id)]
         (let [node (.querySelector parent ".bullet-container")]

--- a/src/main/frontend/components/block/selection.cljs
+++ b/src/main/frontend/components/block/selection.cljs
@@ -6,3 +6,17 @@
            active-selection?)
        (not dragging?)
        (not editing-same-block?)))
+
+(defn block-id-range
+  [block-ids start-block-id end-block-id]
+  (let [block-ids (vec block-ids)
+        start-idx (.indexOf block-ids start-block-id)
+        end-idx (.indexOf block-ids end-block-id)]
+    (when (and (<= 0 start-idx)
+               (<= 0 end-idx))
+      (let [direction (if (> start-idx end-idx) :up :down)
+            from-idx (min start-idx end-idx)
+            to-idx (inc (max start-idx end-idx))
+            ids (subvec block-ids from-idx to-idx)]
+        {:direction direction
+         :block-ids (if (= direction :up) (vec (reverse ids)) ids)}))))

--- a/src/main/frontend/components/block/selection.cljs
+++ b/src/main/frontend/components/block/selection.cljs
@@ -1,0 +1,8 @@
+(ns frontend.components.block.selection)
+
+(defn select-on-hover?
+  [{:keys [last-client-y client-y dragging? editing-same-block? active-selection?]}]
+  (and (or (not= last-client-y client-y)
+           active-selection?)
+       (not dragging?)
+       (not editing-same-block?)))

--- a/src/main/frontend/components/journal.cljs
+++ b/src/main/frontend/components/journal.cljs
@@ -1,21 +1,34 @@
 (ns frontend.components.journal
   (:require [frontend.components.page :as page]
+            [frontend.db :as db]
             [frontend.components.views :as views]
             [frontend.db-mixins :as db-mixins]
             [frontend.db.react :as react]
             [frontend.state :as state]
             [frontend.ui :as ui]
             [frontend.util :as util]
+            [logseq.db :as ldb]
             [promesa.core :as p]
             [rum.core :as rum]))
 
 (rum/defc journal-cp < rum/static
-  [id last?]
+  [id last? selection-block-ids]
   [:div.journal-item.content
    (when last?
      {:class "journal-last-item"})
    (page/page-cp {:db/id id
-                  :journals? true})])
+                  :journals? true
+                  :selection/block-ids selection-block-ids})])
+
+(defn- journal-block-ids
+  [journal-ids]
+  (->> journal-ids
+       (mapcat (fn [id]
+                 (some->> (db/entity id)
+                          :block/_parent
+                          ldb/sort-by-order
+                          (map :block/uuid))))
+       vec))
 
 (defn- sub-journals
   []
@@ -32,15 +45,16 @@
   []
   (let [data (sub-journals)]
     (when (seq data)
-      [:div#journals
-       (ui/virtualized-list
-        {:custom-scroll-parent (util/app-scroll-container-node)
-         :increase-viewport-by {:top 100 :bottom 100}
-         :compute-item-key (fn [idx]
-                             (let [id (util/nth-safe data idx)]
-                               (str "journal-" id)))
-         :total-count (count data)
-         :item-content (fn [idx]
-                         (let [id (util/nth-safe data idx)
-                               last? (= (inc idx) (count data))]
-                           (journal-cp id last?)))})])))
+      (let [selection-block-ids (journal-block-ids data)]
+        [:div#journals
+         (ui/virtualized-list
+          {:custom-scroll-parent (util/app-scroll-container-node)
+           :increase-viewport-by {:top 100 :bottom 100}
+           :compute-item-key (fn [idx]
+                               (let [id (util/nth-safe data idx)]
+                                 (str "journal-" id)))
+           :total-count (count data)
+           :item-content (fn [idx]
+                           (let [id (util/nth-safe data idx)
+                                 last? (= (inc idx) (count data))]
+                             (journal-cp id last? selection-block-ids)))})]))))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1174,9 +1174,16 @@
 
 (defn- selection-node-block-id
   [node]
-  (some-> node
-          (dom/attr "blockid")
-          uuid))
+  (let [id (cond
+             (string? node)
+             (some-> node
+                     (string/replace #"^ls-block-" ""))
+
+             (some-> node .-getAttribute)
+             (or (dom/attr node "blockid")
+                 (some-> node (dom/attr "id") (string/replace #"^ls-block-" ""))))]
+    (when (util/uuid-string? id)
+      (uuid id))))
 
 (defn- selection-node-for-block-id
   [block-id]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -5,6 +5,7 @@
             [clojure.walk :as w]
             [dommy.core :as dom]
             [frontend.commands :as commands]
+            [frontend.components.block.selection :as block-selection]
             [frontend.config :as config]
             [frontend.context.i18n :refer [t]]
             [frontend.date :as date]
@@ -1171,8 +1172,31 @@
       (state/set-block-op-type! :cut)
       (delete-block-aux! block))))
 
+(defn- selection-node-block-id
+  [node]
+  (some-> node
+          (dom/attr "blockid")
+          uuid))
+
+(defn- selection-node-for-block-id
+  [block-id]
+  (or (first (dom/sel (util/format "[blockid='%s']" block-id)))
+      (let [node (.createElement js/document "div")]
+        (.setAttribute node "blockid" (str block-id))
+        (.setAttribute node "id" (str "ls-block-" block-id))
+        node)))
+
+(defn- selection-blocks-by-block-ids
+  [block-ids start-node end-node]
+  (when-let [range (and (seq block-ids)
+                        (block-selection/block-id-range block-ids
+                                                        (selection-node-block-id start-node)
+                                                        (selection-node-block-id end-node)))]
+    {:direction (:direction range)
+     :blocks (mapv selection-node-for-block-id (:block-ids range))}))
+
 (defn highlight-selection-area!
-  [end-block-id block-dom-element & {:keys [append?]}]
+  [end-block-id block-dom-element & {:keys [append? block-ids]}]
   (when-let [start-node (state/get-selection-start-block-or-first)]
     (let [end-block-node block-dom-element
           select-direction (state/get-selection-direction)
@@ -1180,7 +1204,9 @@
           last-node (last selected-blocks)
           latest-visible-block (or last-node start-node)
           latest-block-id (when latest-visible-block (.-id latest-visible-block))]
-      (if (and start-node end-block-node)
+      (if-let [{:keys [blocks direction]} (selection-blocks-by-block-ids block-ids start-node end-block-node)]
+        (state/exit-editing-and-set-selected-blocks! blocks direction)
+        (if (and start-node end-block-node)
         (let [blocks (util/get-nodes-between-two-nodes start-node end-block-node "ls-block")
               direction (util/get-direction-between-two-nodes start-node end-block-node "ls-block")
               blocks (if (= direction :up) (reverse blocks) blocks)]
@@ -1196,7 +1222,7 @@
                   (if (and select-direction (not= direction select-direction))
                     (state/drop-selection-blocks-starts-with! end-block-node)
                     (state/conj-selection-block! blocks direction)))
-              (state/exit-editing-and-set-selected-blocks! blocks direction))))))))
+              (state/exit-editing-and-set-selected-blocks! blocks direction)))))))))
 
 (defonce *action-bar-timeout (atom nil))
 

--- a/src/test/frontend/components/block/selection_test.cljs
+++ b/src/test/frontend/components/block/selection_test.cljs
@@ -1,0 +1,35 @@
+(ns frontend.components.block.selection-test
+  (:require [cljs.test :refer [are deftest is]]
+            [frontend.components.block.selection :as selection]))
+
+(deftest select-on-hover-keeps-active-selection-while-scroll-moves-block-under-pointer
+  (is (true?
+       (selection/select-on-hover?
+        {:last-client-y 320
+         :client-y 320
+         :dragging? false
+         :editing-same-block? false
+         :active-selection? true}))))
+
+(deftest select-on-hover-preserves-existing-guards
+  (are [expected opts] (= expected (selection/select-on-hover? opts))
+    true  {:last-client-y 320
+           :client-y 321
+           :dragging? false
+           :editing-same-block? false
+           :active-selection? false}
+    false {:last-client-y 320
+           :client-y 320
+           :dragging? false
+           :editing-same-block? false
+           :active-selection? false}
+    false {:last-client-y 320
+           :client-y 321
+           :dragging? true
+           :editing-same-block? false
+           :active-selection? true}
+    false {:last-client-y 320
+           :client-y 321
+           :dragging? false
+           :editing-same-block? true
+           :active-selection? true}))

--- a/src/test/frontend/components/block/selection_test.cljs
+++ b/src/test/frontend/components/block/selection_test.cljs
@@ -33,3 +33,13 @@
            :dragging? false
            :editing-same-block? true
            :active-selection? true}))
+
+(deftest block-id-range-uses-ordered-block-ids
+  (are [expected start-block-id end-block-id]
+       (= expected
+          (selection/block-id-range [:a :b :c :d] start-block-id end-block-id))
+    {:direction :down :block-ids [:b :c :d]} :b :d
+    {:direction :up :block-ids [:d :c :b]} :d :b
+    {:direction :down :block-ids [:c]} :c :c
+    nil :missing :c
+    nil :a :missing))


### PR DESCRIPTION
## Summary

Fixes block mouse selection stopping when the page scrolls during a drag selection, including virtualized page lists and the all-journals virtualized list.

The selection path now carries ordered block UUIDs for virtualized renderers, so unmounted blocks between the drag start and current endpoint are still included. Active selection also updates on scroll using the last pointer position and scroll direction, which covers fast wheel/trackpad scrolling where Chrome does not dispatch block mouseover events for every newly mounted row.

Added editor E2E coverage for:
- non-virtualized scrolling selection
- virtualized page selection while scrolling
- fast scrolling a 100-block virtualized page without intermediate hover events
- copying blocks across multiple virtualized journal entries with 30 blocks each

## Validation

- Google Chrome direct verification: 100-block virtualized page fast-scroll selection, no intermediate hover; all 100 target blocks selected and copied
- Google Chrome direct verification: virtualized journals list, 4 journals x 30 blocks; all 120 target blocks selected and copied
- `bb dev:test -n frontend.components.block.selection-test` (3 tests, 10 assertions)
- `clojure -M:clj-kondo --parallel --lint src/main/frontend/components/journal.cljs src/main/frontend/components/block.cljs src/main/frontend/components/block/selection.cljs src/main/frontend/handler/editor.cljs src/test/frontend/components/block/selection_test.cljs clj-e2e/test/logseq/e2e/editor_basic_test.clj --cache false`
- `pnpm cljs:build-electron` (completed; existing unrelated infer warning in `src/electron/electron/core.cljs:221`)
- `bb test -n logseq.e2e.editor-basic-test -p 4180` from `clj-e2e/` (13 tests, 362 assertions)

Fixes https://github.com/logseq/db-test/issues/334