### PR TITLE
[codex] fix dark right sidebar header

### DIFF
--- a/clj-e2e/test/logseq/e2e/right_sidebar_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/right_sidebar_basic_test.clj
@@ -1,0 +1,45 @@
+(ns logseq.e2e.right-sidebar-basic-test
+  (:require
+   [clojure.string :as string]
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [logseq.e2e.assert :as assert]
+   [logseq.e2e.fixtures :as fixtures]
+   [logseq.e2e.util :as util]
+   [wally.main :as w]))
+
+(use-fixtures :once fixtures/open-page)
+(use-fixtures :each fixtures/new-logseq-page fixtures/validate-graph)
+
+(defn- use-dark-neutral-theme!
+  []
+  (w/eval-js
+   "window.logseq.api.set_theme_mode('dark');
+    window.logseq.api.set_state_from_store(['ui/system-theme?'], false);
+    window.logseq.api.set_state_from_store(['ui/radix-color'], 'none');")
+  (util/wait-timeout 100))
+
+(defn- right-sidebar-backgrounds
+  []
+  (-> (w/eval-js
+       "(() => {
+          const topbar = document.querySelector('.cp__right-sidebar-topbar');
+          const inner = document.querySelector('.cp__right-sidebar-inner');
+          return [
+            getComputedStyle(topbar).backgroundColor,
+            getComputedStyle(inner).backgroundColor,
+            document.documentElement.dataset.theme,
+            document.documentElement.dataset.color
+          ].join('|');
+        })()")
+      (string/split #"\|")))
+
+(deftest right-sidebar-topbar-uses-dark-neutral-background
+  (testing "right sidebar header stays dark with neutral accent color"
+    (use-dark-neutral-theme!)
+    (w/click ".toggle-right-sidebar")
+    (assert/assert-is-visible ".cp__right-sidebar.open .cp__right-sidebar-topbar")
+    (assert/assert-is-visible ".cp__right-sidebar .sidebar-item")
+    (let [[topbar-bg inner-bg theme color] (right-sidebar-backgrounds)]
+      (is (= "dark" theme))
+      (is (= "none" color))
+      (is (= inner-bg topbar-bg)))))

--- a/src/main/frontend/components/container.css
+++ b/src/main/frontend/components/container.css
@@ -777,8 +777,13 @@ html[data-theme='dark'] {
   }
 
   .cp__right-sidebar {
+    &-inner,
+    &-topbar {
+      background-color: var(--lx-gray-02, var(--ls-secondary-background-color, var(--rx-gray-01)));
+    }
+
     .sidebar-item {
-      background-color: var(--lx-gray-03, var(--ls-secondary-background-color));
+      background-color: var(--lx-gray-03, var(--ls-secondary-background-color, var(--rx-gray-03)));
     }
   }
 }


### PR DESCRIPTION
## Summary
- Keep the right sidebar topbar on the dark sidebar background when dark mode uses the neutral accent color
- Preserve the sidebar item panel background with a dark fallback
- Add a focused clj-e2e regression for dark + neutral accent right sidebar colors

## Root cause
The right sidebar topbar used a light hard-coded fallback when neutral accent mode did not provide the Logseq-specific color variables. In dark neutral mode this made the sticky header render light while the rest of the sidebar stayed dark.

## Validation
- `pnpm css:build`
- `bb test -p 3001 -n logseq.e2e.right-sidebar-basic-test -v logseq.e2e.right-sidebar-basic-test/right-sidebar-topbar-uses-dark-neutral-background`
- Chrome verification on `http://localhost:3001/?rtc-test=true` in dark + neutral accent mode

## Notes
- `pnpm style:lint` was run and fails on existing repository-wide CSS lint violations in unrelated files (for example `src/main/frontend/common.css`, `src/main/frontend/ui.css`, and extension CSS files). The new changed file was not reported in the visible failures.