### PR TITLE
[codex] fix property hide toggles

### DIFF
--- a/deps/db/src/logseq/db/frontend/property.cljs
+++ b/deps/db/src/logseq/db/frontend/property.cljs
@@ -772,6 +772,35 @@
   (or (:block/title ent)
       (:logseq.property/value ent)))
 
+(defn empty-value?
+  "True when `value` represents an empty property value in DB graph UI semantics."
+  [value]
+  (cond
+    (nil? value)
+    true
+
+    (= :logseq.property/empty-placeholder value)
+    true
+
+    (string? value)
+    (string/blank? value)
+
+    (or (= :logseq.property/empty-placeholder (:db/ident value))
+        (:logseq.property/created-from-property value))
+    (let [content (property-value-content value)]
+      (boolean
+       (or (= :logseq.property/empty-placeholder (:db/ident value))
+           (and (:logseq.property/created-from-property value)
+                (or (nil? content)
+                    (and (string? content) (string/blank? content)))))))
+
+    (and (coll? value) (not (map? value)))
+    (or (empty? value)
+        (every? empty-value? value))
+
+    :else
+    false))
+
 (defn get-closed-value-entity-by-name
   "Given a property, finds one of its closed values by name or nil if none
   found. Works for all closed value types"

--- a/deps/db/test/logseq/db/frontend/property_test.cljs
+++ b/deps/db/test/logseq/db/frontend/property_test.cljs
@@ -44,6 +44,23 @@
           tx-data (db-property/normalize-sorted-entities-block-order sorted-entities)]
       (is (empty? tx-data)))))
 
+(deftest empty-value-test
+  (testing "empty placeholders and blank property value blocks are empty"
+    (is (true? (db-property/empty-value? nil)))
+    (is (true? (db-property/empty-value? :logseq.property/empty-placeholder)))
+    (is (true? (db-property/empty-value? {:db/ident :logseq.property/empty-placeholder})))
+    (is (true? (db-property/empty-value? {:block/title ""
+                                          :logseq.property/created-from-property {:db/id 1}})))
+    (is (true? (db-property/empty-value? {:logseq.property/value " "
+                                          :logseq.property/created-from-property {:db/id 1}}))))
+
+  (testing "normal scalar and entity values are not empty"
+    (is (false? (db-property/empty-value? false)))
+    (is (false? (db-property/empty-value? 0)))
+    (is (false? (db-property/empty-value? {:block/title "todo"
+                                           :logseq.property/created-from-property {:db/id 1}})))
+    (is (false? (db-property/empty-value? {:db/id 1})))))
+
 (deftest reaction-built-in-properties
   (let [props db-property/built-in-properties]
     (testing "entries exist"

--- a/deps/outliner/src/logseq/outliner/property.cljs
+++ b/deps/outliner/src/logseq/outliner/property.cljs
@@ -817,7 +817,9 @@
       (and
        (= property-position position)
        (not (and (:logseq.property/hide-empty-value property)
-                 (nil? (get block property-id))))
+                 (not= :logseq.property/empty-placeholder
+                       (:db/ident (get block property-id)))
+                 (db-property/empty-value? (get block property-id))))
        (not (:logseq.property/hide? property))
        (not (and
              (= property-position :block-below)

--- a/deps/outliner/test/logseq/outliner/property_test.cljs
+++ b/deps/outliner/test/logseq/outliner/property_test.cljs
@@ -427,6 +427,33 @@
     (is (= [:user.property/p1 :user.property/p2 :user.property/p3]
            (map :db/ident (:classes-properties (outliner-property/get-block-classes-properties @conn (:db/id block))))))))
 
+(deftest get-block-positioned-properties-hides-empty-text-values
+  (let [conn (db-test/create-conn-with-blocks
+              {:properties {:p1 {:logseq.property/type :default
+                                 :logseq.property/ui-position :block-below
+                                 :build/properties {:logseq.property/hide-empty-value true}}}
+               :classes {:c1 {:build/class-properties [:p1]}}
+               :pages-and-blocks
+               [{:page {:block/title "p1"}
+                 :blocks [{:block/title "o1"
+                           :build/tags [:c1]
+                           :build/properties {:p1 ""}}]}]})
+        block (db-test/find-block-by-content @conn "o1")]
+    (is (= []
+           (map :db/ident
+                (outliner-property/get-block-positioned-properties @conn (:db/id block) :block-below))))))
+
+(deftest get-block-positioned-properties-keeps-explicit-empty-placeholders
+  (let [conn (db-test/create-conn-with-blocks
+              [{:page {:block/title "p1"}
+                :blocks [{:block/title "o1"
+                          :block.temp/property-keys [:logseq.property/priority]
+                          :build/properties {:logseq.property/priority :logseq.property/empty-placeholder}}]}])
+        block (db-test/find-block-by-content @conn "o1")]
+    (is (= [:logseq.property/priority]
+           (map :db/ident
+                (outliner-property/get-block-positioned-properties @conn (:db/id block) :block-left))))))
+
 (deftest extends-cycle
   (testing "Fail when creating a cycle of extends"
     (let [conn (db-test/create-conn-with-blocks

--- a/src/main/frontend/components/property.cljs
+++ b/src/main/frontend/components/property.cljs
@@ -633,6 +633,29 @@
     :recycled-only-property-ids #{}}
    properties))
 
+(defn- hide-property-for-display?
+  [property property-value {:keys [show-empty-and-hidden-properties?
+                                   state-hide-empty-properties?
+                                   publishing?]}]
+  (boolean
+   (cond
+     show-empty-and-hidden-properties?
+     false
+     (:logseq.property/hide? property)
+     true
+     publishing?
+     (and (not= :logseq.property/empty-placeholder (:db/ident property-value))
+          (db-property/empty-value? property-value))
+     state-hide-empty-properties?
+     (and (not= :logseq.property/empty-placeholder (:db/ident property-value))
+          (db-property/empty-value? property-value))
+     (and (:logseq.property/hide-empty-value property)
+          (not= :logseq.property/empty-placeholder (:db/ident property-value))
+          (db-property/empty-value? property-value))
+     true
+     :else
+     false)))
+
 (rum/defc ordered-properties
   [block properties* sorted-property-entities opts]
   (let [[properties set-properties!] (hooks/use-state properties*)
@@ -763,34 +786,14 @@
                                   (remove (fn [[id _]] (classes-properties-set id))))
         state-hide-empty-properties? (:ui/hide-empty-properties? (state/get-config))
         ;; This section produces own-properties and full-hidden-properties
-        hide-with-property-id (fn [property-id]
-                                (let [property (db/entity property-id)]
-                                  (boolean
-                                   (cond
-                                     show-empty-and-hidden-properties?
-                                     false
-                                     state-hide-empty-properties?
-                                     (nil? (get properties property-id))
-                                     (and (:logseq.property/hide-empty-value property)
-                                          (nil? (get properties property-id)))
-                                     true
-                                     :else
-                                     (boolean (:logseq.property/hide? property))))))
-        property-hide-f (cond
-                          config/publishing?
-                          ;; Publishing is read only so hide all blank properties as they
-                          ;; won't be edited and distract from properties that have values
-                          (fn [[property-id property-value]]
-                            (or (nil? property-value)
-                                (hide-with-property-id property-id)))
-                          state-hide-empty-properties?
-                          (fn [[property-id property-value]]
-                            ;; User's selection takes precedence over config
-                            (if (:logseq.property/hide? (db/entity property-id))
-                              (hide-with-property-id property-id)
-                              (nil? property-value)))
-                          :else
-                          (comp hide-with-property-id first))
+        hide-property? (fn [[property-id property-value]]
+                         (hide-property-for-display?
+                          (db/entity property-id)
+                          property-value
+                          {:show-empty-and-hidden-properties? show-empty-and-hidden-properties?
+                           :state-hide-empty-properties? state-hide-empty-properties?
+                           :publishing? config/publishing?}))
+        property-hide-f hide-property?
         {block-hidden-properties true
          block-own-properties' false} (group-by property-hide-f block-own-properties)
         class-properties (loop [classes all-classes

--- a/src/test/frontend/components/property/property_test.cljs
+++ b/src/test/frontend/components/property/property_test.cljs
@@ -1,5 +1,5 @@
 (ns frontend.components.property.property-test
-  (:require [cljs.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is testing]]
             [frontend.components.property :as property-component]))
 
 (deftest sanitize-property-values-for-display-filters-recycled-entity-values-test
@@ -33,3 +33,34 @@
     (is (nil? (:user.property/nodes properties)))
     (is (= #{:user.property/nodes}
            recycled-only-property-ids))))
+
+(deftest hide-property-for-display-test
+  (testing "show all overrides hidden and empty property settings"
+    (is (false?
+         (#'property-component/hide-property-for-display?
+          {:logseq.property/hide? true}
+          "value"
+          {:show-empty-and-hidden-properties? true
+           :state-hide-empty-properties? true}))))
+
+  (testing "hide by default takes precedence over global empty-property hiding"
+    (is (true?
+         (#'property-component/hide-property-for-display?
+          {:logseq.property/hide? true}
+          "value"
+          {:state-hide-empty-properties? true}))))
+
+  (testing "hide empty value treats blank property value blocks as empty"
+    (is (true?
+         (#'property-component/hide-property-for-display?
+          {:logseq.property/hide-empty-value true}
+          {:block/title ""
+           :logseq.property/created-from-property {:db/id 1}}
+          {}))))
+
+  (testing "explicit empty placeholders stay visible"
+    (is (false?
+         (#'property-component/hide-property-for-display?
+          {:logseq.property/hide-empty-value true}
+          {:db/ident :logseq.property/empty-placeholder}
+          {:state-hide-empty-properties? true})))))


### PR DESCRIPTION
Fix https://github.com/logseq/db-test/issues/472

## Summary
- Treat blank DB property value blocks as empty values
- Keep hidden-by-default properties hidden even when global empty-property hiding is enabled
- Apply the same empty-value behavior to positioned properties and add regressions

## Root cause
Text/default property values can be stored as property value blocks with blank content instead of nil. The visibility code only checked nil, so hide-empty-value and some hidden property paths still rendered those properties.

## Validation
- rtk bb dev:test -n frontend.components.property.property-test
- rtk pnpm exec nbb-logseq -cp test -e "(require '[cljs.test :as t] 'logseq.outliner.property-test) (t/run-tests 'logseq.outliner.property-test)"
- rtk pnpm exec nbb-logseq -cp test -e "(require '[cljs.test :as t] 'logseq.db.frontend.property-test) (t/run-tests 'logseq.db.frontend.property-test)"
- rtk git diff --check