### PR TITLE
[codex] fix markdown tag link aliases

### DIFF
--- a/deps/db/src/logseq/db/frontend/content.cljs
+++ b/deps/db/src/logseq/db/frontend/content.cljs
@@ -96,7 +96,7 @@
     ;; Safari doesn't support look behind, don't use
     ;; TODO: parse via mldoc
     (string/replace content
-                    (re-pattern (str "(?i)(^|\\s)(" (common-util/escape-regex-chars page-name) ")(?=[,\\.]*($|\\s))"))
+                    (re-pattern (str "(?i)(^|\\s|\\()(" (common-util/escape-regex-chars page-name) ")(?=[,\\.\\)]*($|\\s|\\)))"))
                     ;;    case_insense^    ^lhs   ^_grp2                       look_ahead^         ^_grp3
                     (fn [[_match lhs _grp2 _grp3]]
                       (str lhs r)))))

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1344,11 +1344,23 @@
       :else
       (asset-reference config label s))))
 
+(defn- hashtag-search-tag-page-name
+  [s]
+  (when (and (not (string/blank? s))
+             (= \# (first s)))
+    (let [page-name (text/page-ref-un-brackets! (subs s 1))
+          page (db/get-page page-name)]
+      (when (some #(= :logseq.class/Tag (:db/ident %)) (:block/tags page))
+        page-name))))
+
 (defn- search-link-cp
   [config url s label title metadata full_text]
   (cond
     (string/blank? s)
     [:span.warning {:title (t :block/invalid-link)} full_text]
+
+    (hashtag-search-tag-page-name s)
+    (page-reference config (hashtag-search-tag-page-name s) label)
 
     (= \# (first s))
     (->elem :a {:on-click #(route-handler/jump-to-anchor! (mldoc/anchorLink (subs s 1)))} (subs s 1))

--- a/src/main/frontend/handler/db_based/editor.cljs
+++ b/src/main/frontend/handler/db_based/editor.cljs
@@ -15,6 +15,7 @@
             [frontend.util :as util]
             [logseq.common.config :as common-config]
             [logseq.db.frontend.content :as db-content]
+            [logseq.graph-parser.text :as text]
             [logseq.outliner.op]
             [promesa.core :as p]))
 
@@ -57,6 +58,35 @@
   [block]
   (not (contains? #{:code :math} (:logseq.property.node/display-type block))))
 
+(defn- markdown-hashtag-link-target
+  [target]
+  (when (and (string? target)
+             (string/starts-with? target "#"))
+    (let [page-name (-> target (subs 1) text/page-ref-un-brackets!)]
+      (when-not (string/blank? page-name)
+        page-name))))
+
+(defn- tag-page?
+  [page]
+  (some #(= :logseq.class/Tag (:db/ident %)) (:block/tags page)))
+
+(defn- existing-markdown-hashtag-link-refs
+  [ast]
+  (->> ast
+       (tree-seq coll? seq)
+       (keep (fn [form]
+               (when (and (vector? form)
+                          (= "Link" (first form))
+                          (map? (second form)))
+                 (let [[url-type target] (:url (second form))]
+                   (when (= "Search" url-type)
+                     (when-let [page (some-> target markdown-hashtag-link-target db/get-page)]
+                       (when (tag-page? page)
+                         page)))))))
+       (map #(select-keys % [:db/id :block/uuid :block/title :block/name :db/ident :block/tags]))
+       (remove nil?)
+       (util/distinct-by-last-wins :block/uuid)))
+
 (defn wrap-parse-block
   [{:block/keys [title level] :as block}]
   (let [block (or (and (:db/id block) (db/entity (:db/id block)))
@@ -73,18 +103,22 @@
                       first-elem-type (first (ffirst ast))
                       block-with-title? (mldoc/block-with-title? first-elem-type)
                       content' (str common-config/block-pattern (if block-with-title? " " "\n") title)
+                      hashtag-link-refs (existing-markdown-hashtag-link-refs ast)
                       parsed-block (block/parse-block (assoc block :block/title content'))
                       block' (-> (merge block
-                                         parsed-block
-                                         {:block/title title}
-                                         (when heading-level
-                                           {:logseq.property/heading heading-level}))
+                                        parsed-block
+                                        {:block/title title}
+                                        (when heading-level
+                                          {:logseq.property/heading heading-level}))
                                  (dissoc :block/format))]
                   (update block' :block/refs
                           (fn [refs]
-                            (-> refs
-                                remove-non-existed-refs!
-                                (use-cached-refs! block))))))
+                            (->> (concat (-> refs
+                                             remove-non-existed-refs!
+                                             (use-cached-refs! block))
+                                         hashtag-link-refs)
+                                 (remove nil?)
+                                 (util/distinct-by-last-wins :block/uuid))))))
         title' (db-content/title-ref->id-ref (or (get block :block/title) title) (:block/refs block))
         result (-> block
                    (merge (if level {:block/level level} {}))

--- a/src/main/frontend/handler/db_based/editor.cljs
+++ b/src/main/frontend/handler/db_based/editor.cljs
@@ -98,7 +98,6 @@
                        (when (tag-page? page)
                          page)))))))
        (map #(select-keys % [:db/id :block/uuid :block/title :block/name :db/ident :block/tags]))
-       (remove nil?)
        (util/distinct-by-last-wins :block/uuid)))
 
 (defn wrap-parse-block

--- a/src/main/frontend/handler/db_based/editor.cljs
+++ b/src/main/frontend/handler/db_based/editor.cljs
@@ -70,6 +70,20 @@
   [page]
   (some #(= :logseq.class/Tag (:db/ident %)) (:block/tags page)))
 
+(defn- ref-dedupe-key
+  [ref]
+  (cond
+    (and (vector? ref) (= :block/uuid (first ref)))
+    [:block/uuid (second ref)]
+
+    (map? ref)
+    (if-let [uuid (:block/uuid ref)]
+      [:block/uuid uuid]
+      ref)
+
+    :else
+    ref))
+
 (defn- existing-markdown-hashtag-link-refs
   [ast]
   (->> ast
@@ -118,7 +132,7 @@
                                              (use-cached-refs! block))
                                          hashtag-link-refs)
                                  (remove nil?)
-                                 (util/distinct-by-last-wins :block/uuid))))))
+                                 (util/distinct-by-last-wins ref-dedupe-key))))))
         title' (db-content/title-ref->id-ref (or (get block :block/title) title) (:block/refs block))
         result (-> block
                    (merge (if level {:block/level level} {}))

--- a/src/test/frontend/db/content_test.cljs
+++ b/src/test/frontend/db/content_test.cljs
@@ -1,0 +1,11 @@
+(ns frontend.db.content-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [logseq.db.frontend.content :as db-content]))
+
+(deftest title-ref->id-ref-replaces-markdown-hashtag-link-target-test
+  (testing "hashtag targets inside markdown links are stored as id refs"
+    (is (= "alias [Tag Number One](#[[5c6cd067-c602-4955-96b8-74b62e08113c]])"
+           (db-content/title-ref->id-ref "alias [Tag Number One](#Tag1)"
+                                         [{:block/title "Tag1"
+                                           :block/uuid #uuid "5c6cd067-c602-4955-96b8-74b62e08113c"}]
+                                         {:replace-tag? true})))))

--- a/src/test/frontend/handler/db_based/editor_test.cljs
+++ b/src/test/frontend/handler/db_based/editor_test.cljs
@@ -1,5 +1,6 @@
 (ns frontend.handler.db-based.editor-test
   (:require [clojure.test :refer [deftest is testing]]
+            [frontend.db :as db]
             [frontend.handler.db-based.editor :as db-editor-handler]))
 
 (deftest wrap-parse-block-markdown-heading-test
@@ -21,3 +22,20 @@
                            :logseq.property/heading
                            :logseq.property.node/display-type]))
           (str "Preserves content for " display-type)))))
+
+(deftest wrap-parse-block-markdown-hashtag-link-test
+  (testing "markdown link targets that resolve to existing hashtag pages are saved as refs"
+    (let [tag-uuid #uuid "5c6cd067-c602-4955-96b8-74b62e08113c"
+          tag-page {:db/id 12
+                    :block/title "Tag1"
+                    :block/name "tag1"
+                    :block/uuid tag-uuid
+                    :block/tags [{:db/ident :logseq.class/Tag}]}]
+      (with-redefs [db/get-page (fn [page]
+                                  (when (= "Tag1" page)
+                                    tag-page))]
+        (let [result (db-editor-handler/wrap-parse-block
+                      {:block/title "alias [Tag Number One](#Tag1)"})]
+          (is (= (str "alias [Tag Number One](#[[" tag-uuid "]])")
+                 (:block/title result)))
+          (is (= [tag-uuid] (map :block/uuid (:block/refs result)))))))))

--- a/src/test/frontend/handler/db_based/editor_test.cljs
+++ b/src/test/frontend/handler/db_based/editor_test.cljs
@@ -39,3 +39,20 @@
           (is (= (str "alias [Tag Number One](#[[" tag-uuid "]])")
                  (:block/title result)))
           (is (= [tag-uuid] (map :block/uuid (:block/refs result)))))))))
+
+(deftest wrap-parse-block-preserves-multiple-block-refs-test
+  (testing "multiple block refs are preserved when markdown hashtag refs are merged"
+    (let [block-uuid #uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+          ref-uuid-a #uuid "11111111-1111-1111-1111-111111111111"
+          ref-uuid-b #uuid "22222222-2222-2222-2222-222222222222"]
+      (with-redefs [db/entity (fn [lookup]
+                                (when (and (vector? lookup)
+                                           (= :block/uuid (first lookup)))
+                                  {:block/uuid (second lookup)}))]
+        (let [result (db-editor-handler/wrap-parse-block
+                      {:block/uuid block-uuid
+                       :block/title (str "((" ref-uuid-a ")) ((" ref-uuid-b "))")})]
+          (is (= #{[:block/uuid ref-uuid-a]
+                   [:block/uuid ref-uuid-b]}
+                 (set (:block/refs result))))
+          (is (= 2 (count (:block/refs result)))))))))


### PR DESCRIPTION
Fixes https://github.com/logseq/db-test/issues/391

## Summary
- Resolve markdown hashtag link targets like `[Tag Number One](#Tag1)` to existing tag pages during DB editor parsing.
- Store those targets as UUID refs so linked references and click behavior are preserved.
- Render resolved hashtag link targets through page references while keeping the alias label visible.

## Root cause
Markdown `#...` link targets were treated as anchors during rendering and were not added to `:block/refs` during DB editor parsing. The saved title therefore stayed as `#Tag1`, so the alias label lost page-reference behavior.

## Tests
- `bb dev:test -v frontend.handler.db-based.editor-test`
- `bb dev:test -v frontend.db.content-test`
