### PR TITLE
deprecated block-ref

### DIFF
--- a/.lsp/config.edn
+++ b/.lsp/config.edn
@@ -1,6 +1,7 @@
 {:source-aliases #{:cljs}
- :source-paths-ignore-regex ["src/resources" "target.*"]
- :paths-ignore-regex ["src/resources"]
+ :paths-ignore-regex ["src/resources", "target", ".nbb", ".shadow-cljs", ".clj-kondo/.cache", "clj-e2e", "cli-e2e"]
+ :linters {:clojure-lsp/unused-public-var {:level :off}
+           :clj-kondo/unused-namespace    {:level :off}}
  :clean {:ns-inner-blocks-indentation :same-line}
  :additional-snippets [{:name "profile"
                         :detail "Insert profile-fn"

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -2464,6 +2464,7 @@
   (when (string? title)
     (-> title
         (string/replace (block-ref/->block-ref block-uuid) "")
+        (string/replace (page-ref/->page-ref block-uuid) "")
         (string/replace #" {2,}" " ")
         string/trim)))
 

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -1294,6 +1294,13 @@
        (update :block/refs (fn [refs] (remove #(property-classes (keyword (:block/name %))) refs))))
      :properties-tx (concat properties-tx (when pvalues-tx pvalues-tx))}))
 
+(defn- convert-block-refs-to-page-refs
+  "Converts ((uuid)) block-ref syntax to [[uuid]] page-ref syntax in a title string.
+  DB graphs use [[uuid]] for all node references."
+  [title]
+  (string/replace title block-ref/block-ref-re
+                  (fn [[_ id]] (page-ref/->page-ref id))))
+
 (defn- update-block-refs
   "Updates the attributes of a block ref as this is where a new page is defined. Also
    updates block content effected by refs"
@@ -1320,7 +1327,8 @@
                                           ;; ignore deadline related refs that don't affect content
                                           (and (keyword? %) (db-malli-schema/internal-ident? %))))
                              (map #(add-uuid-to-page-map % page-names-to-uuids)))]
-               (db-content/title-ref->id-ref (:block/title block) refs {:replace-tag? false}))))
+               (-> (db-content/title-ref->id-ref (:block/title block) refs {:replace-tag? false})
+                   convert-block-refs-to-page-refs))))
     block))
 
 (defn- fix-pre-block-references

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -694,6 +694,10 @@
              (mapv :db/id (:block/refs (db-test/find-block-by-content @conn #"ref to"))))
           "block with a block-ref has correct :block/refs")
 
+      (is (= "ref to [[65cbb772-fb79-462d-87c8-6f0dad751dee]]"
+             (:block/title (db-test/find-block-by-content @conn #"ref to")))
+          "block-ref ((uuid)) is converted to page-ref [[uuid]] in block title on import")
+
       (is (= 20221126
              (-> (db-test/readable-properties (db-test/find-block-by-content @conn "only deadline"))
                  :logseq.property/deadline

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -105,9 +105,6 @@
   (atom nil))
 (def *move-to (atom nil))
 
-;; TODO: dynamic
-(defonce max-depth-of-links 5)
-
 ;; TODO:
 ;; add `key`
 

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1405,16 +1405,7 @@
   (let [{:keys [url label title metadata full_text]} link]
     (match url
       ["Block_ref" id]
-      (let [label* (if (seq (mldoc/plain->text label)) label nil)
-            {:keys [link-depth]} config
-            link-depth (or link-depth 0)]
-        (if (> link-depth max-depth-of-links)
-          [:p.warning.text-sm (t :block/ref-nesting-too-deep)]
-          (block-reference (assoc config
-                                  :reference? true
-                                  :link-depth (inc link-depth)
-                                  :block/uuid id)
-                           id label*)))
+      (str block-ref/left-parens id block-ref/right-parens)
 
       ["Page_ref" page]
       (let [label* (if (seq (mldoc/plain->text label)) label nil)]

--- a/src/resources/dicts/af.edn
+++ b/src/resources/dicts/af.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "Maak blokverwysings oop"
  :block/practice "Oefen"
  :block/practice-cards "Oefen kaarte"
- :block/ref-nesting-too-deep "Blokverwysing-nesting is te diep"
  :block/remove-tag "Verwyder etiket"
  :block/remove-this-tag "Verwyder hierdie etiket"
  :block/render-error "Blokweergawe-fout:"

--- a/src/resources/dicts/ar.edn
+++ b/src/resources/dicts/ar.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "فتح مراجع الكتلة"
  :block/practice "تدريب"
  :block/practice-cards "تدريب البطاقات"
- :block/ref-nesting-too-deep "تداخل مرجع الكتلة عميق جدًا"
  :block/remove-tag "إزالة الوسم"
  :block/remove-this-tag "إزالة هذا الوسم"
  :block/render-error "خطأ في عرض الكتلة:"

--- a/src/resources/dicts/ca.edn
+++ b/src/resources/dicts/ca.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "Obrir les referències del bloc"
  :block/practice "Practicar"
  :block/practice-cards "Practicar targetes"
- :block/ref-nesting-too-deep "L'anidament de referències de bloc és massa profund"
  :block/remove-tag "Eliminar etiqueta"
  :block/remove-this-tag "Eliminar aquesta etiqueta"
  :block/render-error "Error de renderització del bloc:"

--- a/src/resources/dicts/cs.edn
+++ b/src/resources/dicts/cs.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "Otevřít reference bloku"
  :block/practice "Procvičovat"
  :block/practice-cards "Procvičovat kartičky"
- :block/ref-nesting-too-deep "Zanoření reference bloku je příliš hluboké"
  :block/remove-tag "Odebrat tag"
  :block/remove-this-tag "Odebrat tento tag"
  :block/render-error "Chyba vykreslení bloku:"

--- a/src/resources/dicts/de.edn
+++ b/src/resources/dicts/de.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "Block-Referenzen öffnen"
  :block/practice "Üben"
  :block/practice-cards "Karteikarten üben"
- :block/ref-nesting-too-deep "Block-Referenz-Verschachtelung ist zu tief"
  :block/remove-tag "Tag entfernen"
  :block/remove-this-tag "Diesen Tag entfernen"
  :block/render-error "Block-Renderfehler:"

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "Open block references"
  :block/practice "Practice"
  :block/practice-cards "Practice cards"
- :block/ref-nesting-too-deep "Block ref nesting is too deep"
  :block/remove-tag "Remove tag"
  :block/remove-this-tag "Remove this tag"
  :block/render-error "Block Render Error:"

--- a/src/resources/dicts/es.edn
+++ b/src/resources/dicts/es.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "Abrir referencias del bloque"
  :block/practice "Practicar"
  :block/practice-cards "Practicar tarjetas"
- :block/ref-nesting-too-deep "La anidación de referencias de bloque es demasiado profunda"
  :block/remove-tag "Eliminar etiqueta"
  :block/remove-this-tag "Eliminar esta etiqueta"
  :block/render-error "Error de renderizado del bloque:"

--- a/src/resources/dicts/fa.edn
+++ b/src/resources/dicts/fa.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "باز کردن مراجع بلوک"
  :block/practice "تمرین"
  :block/practice-cards "تمرین کارت‌ها"
- :block/ref-nesting-too-deep "تودرتویی مرجع بلوک بیش از حد عمیق است"
  :block/remove-tag "حذف برچسب"
  :block/remove-this-tag "حذف این برچسب"
  :block/render-error "خطای رندر بلوک:"

--- a/src/resources/dicts/fr.edn
+++ b/src/resources/dicts/fr.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "Ouvrir les références du bloc"
  :block/practice "Pratiquer"
  :block/practice-cards "Pratiquer les cartes"
- :block/ref-nesting-too-deep "L'imbrication des références de bloc est trop profonde"
  :block/remove-tag "Retirer le tag"
  :block/remove-this-tag "Retirer ce tag"
  :block/render-error "Erreur de rendu du bloc :"

--- a/src/resources/dicts/id.edn
+++ b/src/resources/dicts/id.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "Buka referensi blok"
  :block/practice "Latihan"
  :block/practice-cards "Latihan kartu"
- :block/ref-nesting-too-deep "Referensi blok terlalu dalam"
  :block/remove-tag "Hapus tag"
  :block/remove-this-tag "Hapus tag ini"
  :block/render-error "Kesalahan Render Blok:"

--- a/src/resources/dicts/it.edn
+++ b/src/resources/dicts/it.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "Apri riferimenti del blocco"
  :block/practice "Esercitati"
  :block/practice-cards "Esercitati con le carte"
- :block/ref-nesting-too-deep "Annidamento del riferimento al blocco troppo profondo"
  :block/remove-tag "Rimuovi tag"
  :block/remove-this-tag "Rimuovi questo tag"
  :block/render-error "Errore rendering blocco:"

--- a/src/resources/dicts/ja.edn
+++ b/src/resources/dicts/ja.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "ブロック参照を開く"
  :block/practice "練習"
  :block/practice-cards "カードを練習"
- :block/ref-nesting-too-deep "ブロック参照のネストが深すぎます"
  :block/remove-tag "タグを削除"
  :block/remove-this-tag "このタグを削除"
  :block/render-error "ブロック描画エラー："

--- a/src/resources/dicts/ko.edn
+++ b/src/resources/dicts/ko.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "블록 참조 열기"
  :block/practice "연습"
  :block/practice-cards "카드 연습"
- :block/ref-nesting-too-deep "블록 참조 중첩이 너무 깊습니다"
  :block/remove-tag "태그 제거"
  :block/remove-this-tag "이 태그 제거"
  :block/render-error "블록 렌더링 오류:"

--- a/src/resources/dicts/nb-no.edn
+++ b/src/resources/dicts/nb-no.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "Åpne blokkreferanser"
  :block/practice "Øv"
  :block/practice-cards "Øv på kort"
- :block/ref-nesting-too-deep "Blokkreferanse-nesting er for dyp"
  :block/remove-tag "Fjern tagg"
  :block/remove-this-tag "Fjern denne taggen"
  :block/render-error "Feil ved blokkgjengivelse:"

--- a/src/resources/dicts/nl.edn
+++ b/src/resources/dicts/nl.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "Blokreferenties openen"
  :block/practice "Oefenen"
  :block/practice-cards "Kaarten oefenen"
- :block/ref-nesting-too-deep "Blokreferentie is te diep genest"
  :block/remove-tag "Tag verwijderen"
  :block/remove-this-tag "Deze tag verwijderen"
  :block/render-error "Blok-renderfout:"

--- a/src/resources/dicts/pl.edn
+++ b/src/resources/dicts/pl.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "Otwórz odniesienia bloków"
  :block/practice "Ćwicz"
  :block/practice-cards "Ćwicz karty"
- :block/ref-nesting-too-deep "Zagnieżdżenie odniesień bloku jest zbyt głębokie"
  :block/remove-tag "Usuń tag"
  :block/remove-this-tag "Usuń ten tag"
  :block/render-error "Błąd renderowania bloku:"

--- a/src/resources/dicts/pt-br.edn
+++ b/src/resources/dicts/pt-br.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "Abrir referências do bloco"
  :block/practice "Praticar"
  :block/practice-cards "Praticar cartões"
- :block/ref-nesting-too-deep "Aninhamento de referência de bloco é muito profundo"
  :block/remove-tag "Remover tag"
  :block/remove-this-tag "Remover esta tag"
  :block/render-error "Erro de renderização do bloco:"

--- a/src/resources/dicts/pt-pt.edn
+++ b/src/resources/dicts/pt-pt.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "Abrir referências do bloco"
  :block/practice "Praticar"
  :block/practice-cards "Praticar cartões"
- :block/ref-nesting-too-deep "Aninhamento de referências de bloco demasiado profundo"
  :block/remove-tag "Remover etiqueta"
  :block/remove-this-tag "Remover esta etiqueta"
  :block/render-error "Erro de renderização do bloco:"

--- a/src/resources/dicts/ru.edn
+++ b/src/resources/dicts/ru.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "Открыть ссылки на блок"
  :block/practice "Практика"
  :block/practice-cards "Практика карточек"
- :block/ref-nesting-too-deep "Слишком глубокая вложенность ссылок на блок"
  :block/remove-tag "Удалить тег"
  :block/remove-this-tag "Удалить этот тег"
  :block/render-error "Ошибка отрисовки блока:"

--- a/src/resources/dicts/sk.edn
+++ b/src/resources/dicts/sk.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "Otvoriť referencie bloku"
  :block/practice "Precvičovať"
  :block/practice-cards "Precvičovať kartičky"
- :block/ref-nesting-too-deep "Vnorenie referencie bloku je príliš hlboké"
  :block/remove-tag "Odstrániť tag"
  :block/remove-this-tag "Odstrániť tento tag"
  :block/render-error "Chyba zobrazenia bloku:"

--- a/src/resources/dicts/tr.edn
+++ b/src/resources/dicts/tr.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "Blok referanslarını aç"
  :block/practice "Alıştırma"
  :block/practice-cards "Kartlarla alıştırma"
- :block/ref-nesting-too-deep "Blok referansı iç içe geçmesi çok derin"
  :block/remove-tag "Etiketi kaldır"
  :block/remove-this-tag "Bu etiketi kaldır"
  :block/render-error "Blok İşleme Hatası:"

--- a/src/resources/dicts/uk.edn
+++ b/src/resources/dicts/uk.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "Відкрити посилання на блок"
  :block/practice "Практика"
  :block/practice-cards "Практикувати картки"
- :block/ref-nesting-too-deep "Занадто глибока вкладеність посилань на блок"
  :block/remove-tag "Видалити тег"
  :block/remove-this-tag "Видалити цей тег"
  :block/render-error "Помилка відображення блоку:"

--- a/src/resources/dicts/zh-cn.edn
+++ b/src/resources/dicts/zh-cn.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "打开块引用"
  :block/practice "练习"
  :block/practice-cards "练习卡片"
- :block/ref-nesting-too-deep "块引用嵌套层级过深"
  :block/remove-tag "移除标签"
  :block/remove-this-tag "移除此标签"
  :block/render-error "块渲染错误："

--- a/src/resources/dicts/zh-hant.edn
+++ b/src/resources/dicts/zh-hant.edn
@@ -93,7 +93,6 @@
  :block/open-block-references "開啟區塊引用"
  :block/practice "練習"
  :block/practice-cards "練習卡片"
- :block/ref-nesting-too-deep "區塊引用巢狀層級過深"
  :block/remove-tag "移除標籤"
  :block/remove-this-tag "移除此標籤"
  :block/render-error "區塊渲染錯誤："


### PR DESCRIPTION
- When importing, convert ((uuid)) to [[uuid]]
- Deprecated `Block_ref` syntax