### PR TITLE
fix(fsrs): cloze macro with superscript/subscript markup and render improvements

### DIFF
--- a/clj-e2e/test/logseq/e2e/commands_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/commands_basic_test.clj
@@ -321,5 +321,5 @@
     (util/input-command "cloze")
     (util/press-seq "hidden answer")
     (util/exit-edit)
-    (w/click "a.cloze")
-    (w/wait-for "a.cloze-revealed")))
+    (w/click "span.cloze")
+    (w/wait-for "span.cloze-revealed")))

--- a/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
@@ -10,6 +10,7 @@
                :default [lambdaisland.glogi :as log])
             [cljs-bean.core :as bean]
             [clojure.string :as string]
+            [clojure.walk :as walk]
             [goog.object :as gobj]
             [logseq.common.config :as common-config]
             [logseq.common.util :as common-util]
@@ -120,6 +121,200 @@
                [block pos-meta])
              [block pos-meta])) ast)))
 
+(def ^:private inline-ast-types
+  #{"Plain" "Spaces" "Link" "Nested_link" "Target" "Subscript" "Superscript"
+    "Footnote_Reference" "Cookie" "Latex_Fragment" "Macro" "Entity" "Timestamp"
+    "Radio_Target" "Export_Snippet" "Inline_Source_Block" "Email" "Inline_Hiccup"
+    "Inline_Html" "Emphasis" "Verbatim" "Code" "Break_Line" "Hard_Break_Line"})
+
+(defn- inline-coll?
+  [x]
+  (and (vector? x)
+       (seq x)
+       (every? #(and (vector? %)
+                     (string? (first %))
+                     (contains? inline-ast-types (first %)))
+               x)))
+
+(defn- inline-ast->source
+  ;; Only reconstructs the source text for the small set of node types that
+  ;; appear when mldoc splits a macro containing ^{}/{_{}. Nested rich-inline
+  ;; types (Emphasis, Code, etc.) inside a Superscript/Subscript will produce
+  ;; nil, which (apply str ...) silently drops. This is intentional: the
+  ;; function is only called during macro-recovery, not for general rendering.
+  [[typ content]]
+  (case typ
+    "Plain" content
+    "Spaces" content
+    "Link" (:full_text content)
+    "Superscript" (str "^{" (apply str (map inline-ast->source content)) "}")
+    "Subscript" (str "_{" (apply str (map inline-ast->source content)) "}")
+    nil))
+
+(defn- starts-with-at?
+  [s prefix idx]
+  (let [end (+ idx (count prefix))]
+    (and (<= end (count s))
+         (= prefix (subs s idx end)))))
+
+(defn- unclosed-script-markup?
+  [s]
+  (loop [idx 0
+         depth 0]
+    (if (< idx (count s))
+      (cond
+        (or (starts-with-at? s "^{" idx)
+            (starts-with-at? s "_{" idx))
+        (recur (+ idx 2) (inc depth))
+
+        (and (pos? depth) (= \} (nth s idx)))
+        (recur (inc idx) (dec depth))
+
+        :else
+        (recur (inc idx) depth))
+      (pos? depth))))
+
+(defn- split-macro-arguments
+  [s]
+  (if (string/blank? s)
+    []
+    (loop [idx 0
+           start 0
+           page-ref-depth 0
+           script-depth 0
+           quoted? false
+           escaped? false
+           result []]
+      (if (< idx (count s))
+        (let [c (nth s idx)]
+          (cond
+            escaped?
+            (recur (inc idx) start page-ref-depth script-depth quoted? false result)
+
+            (= \\ c)
+            (recur (inc idx) start page-ref-depth script-depth quoted? true result)
+
+            (= \" c)
+            (recur (inc idx) start page-ref-depth script-depth (not quoted?) false result)
+
+            quoted?
+            (recur (inc idx) start page-ref-depth script-depth quoted? false result)
+
+            (starts-with-at? s "[[" idx)
+            (recur (+ idx 2) start (inc page-ref-depth) script-depth quoted? false result)
+
+            (and (pos? page-ref-depth) (starts-with-at? s "]]" idx))
+            (recur (+ idx 2) start (dec page-ref-depth) script-depth quoted? false result)
+
+            (or (starts-with-at? s "^{" idx)
+                (starts-with-at? s "_{" idx))
+            (recur (+ idx 2) start page-ref-depth (inc script-depth) quoted? false result)
+
+            (and (pos? script-depth) (= \} c))
+            (recur (inc idx) start page-ref-depth (dec script-depth) quoted? false result)
+
+            (and (zero? page-ref-depth) (zero? script-depth) (= \, c))
+            (recur (inc idx) (inc idx) page-ref-depth script-depth quoted? false
+                   (conj result (string/trim (subs s start idx))))
+
+            :else
+            (recur (inc idx) start page-ref-depth script-depth quoted? false result)))
+        (conj result (string/trim (subs s start)))))))
+
+(defn- macro-source->ast
+  [s]
+  (when (and (string/starts-with? s "{{")
+             (string/ends-with? s "}}"))
+    (let [content (-> s
+                      (subs 2 (- (count s) 2))
+                      string/triml)
+          [_ name arguments] (re-matches #"([^\s]+)(?:\s+([\s\S]*))?" content)]
+      (when name
+        ["Macro" {:name name
+                  :arguments (split-macro-arguments arguments)}]))))
+
+(defn- collect-macro-source
+  [items]
+  (loop [remaining items
+         source ""]
+    (when-let [[item & more] (seq remaining)]
+      (let [[typ content] item]
+        (cond
+          (= "Plain" typ)
+          (if-let [idx (string/index-of content "}}")]
+            (let [macro-source (str source (subs content 0 (+ idx 2)))]
+              (when-let [macro (macro-source->ast macro-source)]
+                (let [suffix (subs content (+ idx 2))]
+                  {:macro macro
+                   :suffix (when-not (string/blank? suffix) ["Plain" suffix])
+                   :remaining more})))
+            (recur more (str source content)))
+
+          :else
+          (when-let [item-source (inline-ast->source item)]
+            (recur more (str source item-source))))))))
+
+(defn- close-script-markup-in-macro
+  ;; Appends a single "}" to the last argument to close the outermost
+  ;; unmatched ^{/{_ bracket. Handles only depth-1 cases; deeper nesting
+  ;; (e.g. Ca^{^{2}}) is not supported and is not expected in practice.
+  [macro]
+  (update-in macro [1 :arguments]
+             (fn [arguments]
+               (update arguments (dec (count arguments)) str "}"))))
+
+(defn- recover-inline-macros
+  [inline-list]
+  (loop [remaining inline-list
+         result []]
+    (if-let [[item & more] (seq remaining)]
+      (let [[typ content] item]
+        (cond
+          (and (= "Plain" typ)
+               (string/includes? content "{{"))
+          (let [idx (string/index-of content "{{")
+                prefix (subs content 0 idx)
+                start-item ["Plain" (subs content idx)]]
+            (if-let [{:keys [macro suffix remaining]} (collect-macro-source (cons start-item more))]
+              (recur (if suffix
+                       (cons suffix remaining)
+                       remaining)
+                     (cond-> result
+                       (not (string/blank? prefix)) (conj ["Plain" prefix])
+                       true (conj macro)))
+              (recur more (conj result item))))
+
+          (and (= "Macro" typ)
+               (seq (:arguments content))
+               (unclosed-script-markup? (last (:arguments content)))
+               (= "Plain" (ffirst more))
+               (string/starts-with? (second (first more)) "}"))
+          (let [[_ plain] (first more)
+                suffix (subs plain 1)]
+            (recur (if (string/blank? suffix)
+                     (rest more)
+                     (cons ["Plain" suffix] (rest more)))
+                   (conj result (close-script-markup-in-macro item))))
+
+          :else
+          (recur more (conj result item))))
+      result)))
+
+(defn- normalize-macro-asts
+  [ast]
+  (walk/postwalk
+   (fn [x]
+     (if (inline-coll? x)
+       (recover-inline-macros x)
+       x))
+   ast))
+
+(defn- macro-with-script-markup?
+  [content]
+  (and (string/includes? content "{{")
+       (or (string/includes? content "^{")
+           (string/includes? content "_{"))))
+
 (defn collect-page-properties
   [ast config]
   (when (seq ast)
@@ -160,6 +355,8 @@
          (-> content
              (parse-json config)
              (common-util/json->clj)
+             (cond-> (macro-with-script-markup? content)
+               (normalize-macro-asts))
              (update-src-full-content content)
              (collect-page-properties config)))
        (catch :default e
@@ -181,7 +378,9 @@
       {}
       (-> text
           (inline-parse-json config)
-          (common-util/json->clj)))
+          (common-util/json->clj)
+          (cond-> (macro-with-script-markup? text)
+            (normalize-macro-asts))))
     (catch :default _e
       [])))
 

--- a/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
@@ -137,16 +137,20 @@
                x)))
 
 (defn- inline-ast->source
-  ;; Only reconstructs the source text for the small set of node types that
-  ;; appear when mldoc splits a macro containing ^{}/{_{}. Nested rich-inline
-  ;; types (Emphasis, Code, etc.) inside a Superscript/Subscript will produce
-  ;; nil, which (apply str ...) silently drops. This is intentional: the
-  ;; function is only called during macro-recovery, not for general rendering.
+  ;; Only reconstructs the source text for the node types that appear when
+  ;; mldoc splits a macro containing ^{}/{_{}. Nested rich-inline types
+  ;; (Emphasis, Code, etc.) inside a Superscript/Subscript will produce nil,
+  ;; which (apply str ...) silently drops. This is intentional: the function
+  ;; is only called during macro-recovery, not for general rendering.
   [[typ content]]
   (case typ
     "Plain" content
     "Spaces" content
     "Link" (:full_text content)
+    ;; Nested_link is the AST node for [[page name]]; :content is the page name
+    ;; string. Without this case, collect-macro-source aborts via when-let
+    ;; whenever a page ref appears inside a fragmented macro.
+    "Nested_link" (str "[[" (:content content) "]]")
     "Superscript" (str "^{" (apply str (map inline-ast->source content)) "}")
     "Subscript" (str "_{" (apply str (map inline-ast->source content)) "}")
     nil))

--- a/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
@@ -86,12 +86,12 @@
       [["Macro" {:name "cloze" :arguments ["[[page name]]"]}]]))
 
   (testing "block parsing keeps the issue reproduction as macro nodes"
-    (is (= [["Plain" "This is usally highlighted by the accumulation of the "]
+    (is (= [["Plain" "This is usually highlighted by the accumulation of the "]
             ["Macro" {:name "cloze" :arguments ["Ca^{ +2} ions"]}]
             ["Plain" " . This will be seen as "]
             ["Macro" {:name "cloze" :arguments ["<ins>large flocculent amorphous densities in TEM</ins>"]}]]
            (-> (gp-mldoc/->edn
-                "- This is usally highlighted by the accumulation of the {{cloze Ca^{ +2} ions}} . This will be seen as {{cloze <ins>large flocculent amorphous densities in TEM</ins>}}"
+                "- This is usually highlighted by the accumulation of the {{cloze Ca^{ +2} ions}} . This will be seen as {{cloze <ins>large flocculent amorphous densities in TEM</ins>}}"
                 md-config)
                ffirst
                second

--- a/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
@@ -72,7 +72,12 @@
       [["Macro" {:name "cloze" :arguments ["Ca^{+2}"]}]]
 
       "{{foo Ca^{ +2} ions, [[a, b]], \"c, d\"}}"
-      [["Macro" {:name "foo" :arguments ["Ca^{ +2} ions" "[[a, b]]" "\"c, d\""]}]]))
+      [["Macro" {:name "foo" :arguments ["Ca^{ +2} ions" "[[a, b]]" "\"c, d\""]}]]
+
+      ;; page ref inside a macro that also has script markup — exercises
+      ;; the Nested_link case in inline-ast->source
+      "{{cloze Ca^{ +2} [[water]]}}"
+      [["Macro" {:name "cloze" :arguments ["Ca^{ +2} [[water]]"]}]]))
 
   (testing "normal macros without script markup are not modified"
     (are [content ast] (= ast (gp-mldoc/inline->edn content md-config))

--- a/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
@@ -59,6 +59,53 @@
          (first (gp-mldoc/->edn "term
 : definition" md-config)))))
 
+(deftest macro-with-script-markup-test
+  (testing "inline macros can contain superscript and subscript markup"
+    (are [content ast] (= ast (gp-mldoc/inline->edn content md-config))
+      "{{cloze Ca^{ +2} ions}}"
+      [["Macro" {:name "cloze" :arguments ["Ca^{ +2} ions"]}]]
+
+      "{{cloze H_{2}O}}"
+      [["Macro" {:name "cloze" :arguments ["H_{2}O"]}]]
+
+      "{{cloze Ca^{+2}}}"
+      [["Macro" {:name "cloze" :arguments ["Ca^{+2}"]}]]
+
+      "{{foo Ca^{ +2} ions, [[a, b]], \"c, d\"}}"
+      [["Macro" {:name "foo" :arguments ["Ca^{ +2} ions" "[[a, b]]" "\"c, d\""]}]]))
+
+  (testing "normal macros without script markup are not modified"
+    (are [content ast] (= ast (gp-mldoc/inline->edn content md-config))
+      "{{cloze simple text}}"
+      [["Macro" {:name "cloze" :arguments ["simple text"]}]]
+
+      "{{foo a, b, c}}"
+      [["Macro" {:name "foo" :arguments ["a" "b" "c"]}]]
+
+      "{{cloze [[page name]]}}"
+      [["Macro" {:name "cloze" :arguments ["[[page name]]"]}]]))
+
+  (testing "block parsing keeps the issue reproduction as macro nodes"
+    (is (= [["Plain" "This is usally highlighted by the accumulation of the "]
+            ["Macro" {:name "cloze" :arguments ["Ca^{ +2} ions"]}]
+            ["Plain" " . This will be seen as "]
+            ["Macro" {:name "cloze" :arguments ["<ins>large flocculent amorphous densities in TEM</ins>"]}]]
+           (-> (gp-mldoc/->edn
+                "- This is usally highlighted by the accumulation of the {{cloze Ca^{ +2} ions}} . This will be seen as {{cloze <ins>large flocculent amorphous densities in TEM</ins>}}"
+                md-config)
+               ffirst
+               second
+               :title)))
+
+    (is (= [["Plain" "Water formula is "]
+            ["Macro" {:name "cloze" :arguments ["H_{2}O"]}]]
+           (-> (gp-mldoc/->edn
+                "- Water formula is {{cloze H_{2}O}}"
+                md-config)
+               ffirst
+               second
+               :title)))))
+
 (defn- parse-properties
   [text]
   (->> (gp-mldoc/->edn text (gp-mldoc/default-config :org))

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2376,6 +2376,8 @@
         (dom/has-class? target "fn"))
    (dom/has-class? target "image-resize")
    (dom/closest target "a")
+   (dom/closest target ".cloze")
+   (dom/closest target ".cloze-revealed")
    (dom/closest target ".query-table")))
 
 (defn- block-content-on-pointer-down

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -1047,14 +1047,16 @@ a.filter svg {
   display: none;
 }
 
-a.cloze {
+.cloze {
   color: var(--ls-cloze-text-color);
+  cursor: pointer;
 }
 
-a.cloze-revealed {
+.cloze-revealed {
   color: var(--ls-cloze-text-color);
   text-decoration: underline;
   text-underline-position: under;
+  cursor: pointer;
 }
 
 .page-property-key {

--- a/src/main/frontend/extensions/fsrs.cljs
+++ b/src/main/frontend/extensions/fsrs.cljs
@@ -426,7 +426,9 @@
         ;; element rendered inside the revealed answer (e.g. a page ref).
         ;; An ancestor <a> should not block the toggle.
         toggle! (fn [e]
-                  (let [inner-a (some-> (.-target e) (.closest "a"))]
+                  (let [target (.-target e)
+                        inner-a (when (instance? js/Element target)
+                                  (.closest target "a"))]
                     (when (or (nil? inner-a)
                               (not (.contains (.-currentTarget e) inner-a)))
                       (swap! shown?* not))))

--- a/src/main/frontend/extensions/fsrs.cljs
+++ b/src/main/frontend/extensions/fsrs.cljs
@@ -438,6 +438,7 @@
         [answer cue] (cloze-parse (string/join ", " (:arguments options)))
         attrs {:role "button"
                :tab-index 0
+               :aria-pressed shown?
                :on-click toggle!
                :on-key-down toggle-key!}]
     (if (or shown? (:show-cloze? config))

--- a/src/main/frontend/extensions/fsrs.cljs
+++ b/src/main/frontend/extensions/fsrs.cljs
@@ -422,12 +422,14 @@
   [state config options]
   (let [shown?* (:shown? state)
         shown? (rum/react shown?*)
-        ;; Guard against clicks that originate from inner <a> elements
-        ;; (e.g. page refs rendered by inline-title), which would otherwise
-        ;; bubble up and toggle the cloze while the user intends to follow a link.
+        ;; Only suppress toggle when the click originates from a child <a>
+        ;; element rendered inside the revealed answer (e.g. a page ref).
+        ;; An ancestor <a> should not block the toggle.
         toggle! (fn [e]
-                  (when-not (.closest (.-target e) "a")
-                    (swap! shown?* not)))
+                  (let [inner-a (some-> (.-target e) (.closest "a"))]
+                    (when (or (nil? inner-a)
+                              (not (.contains (.-currentTarget e) inner-a)))
+                      (swap! shown?* not))))
         toggle-key! #(when (contains? #{"Enter" " "} (.-key %))
                        (util/stop %)
                        (swap! shown?* not))

--- a/src/main/frontend/extensions/fsrs.cljs
+++ b/src/main/frontend/extensions/fsrs.cljs
@@ -432,7 +432,7 @@
                     (when (or (nil? inner-a)
                               (not (.contains (.-currentTarget e) inner-a)))
                       (swap! shown?* not))))
-        toggle-key! #(when (contains? #{"Enter" " "} (.-key %))
+        toggle-key! #(when (contains? #{"Enter" " " "Space" "Spacebar"} (.-key %))
                        (util/stop %)
                        (swap! shown?* not))
         [answer cue] (cloze-parse (string/join ", " (:arguments options)))

--- a/src/main/frontend/extensions/fsrs.cljs
+++ b/src/main/frontend/extensions/fsrs.cljs
@@ -422,10 +422,15 @@
   [state config options]
   (let [shown?* (:shown? state)
         shown? (rum/react shown?*)
-        toggle! #(swap! shown?* not)
+        ;; Guard against clicks that originate from inner <a> elements
+        ;; (e.g. page refs rendered by inline-title), which would otherwise
+        ;; bubble up and toggle the cloze while the user intends to follow a link.
+        toggle! (fn [e]
+                  (when-not (.closest (.-target e) "a")
+                    (swap! shown?* not)))
         toggle-key! #(when (contains? #{"Enter" " "} (.-key %))
                        (util/stop %)
-                       (toggle!))
+                       (swap! shown?* not))
         [answer cue] (cloze-parse (string/join ", " (:arguments options)))
         attrs {:role "button"
                :tab-index 0

--- a/src/main/frontend/extensions/fsrs.cljs
+++ b/src/main/frontend/extensions/fsrs.cljs
@@ -423,11 +423,20 @@
   (let [shown?* (:shown? state)
         shown? (rum/react shown?*)
         toggle! #(swap! shown?* not)
-        [answer cue] (cloze-parse (string/join ", " (:arguments options)))]
+        toggle-key! #(when (contains? #{"Enter" " "} (.-key %))
+                       (util/stop %)
+                       (toggle!))
+        [answer cue] (cloze-parse (string/join ", " (:arguments options)))
+        attrs {:role "button"
+               :tab-index 0
+               :on-click toggle!
+               :on-key-down toggle-key!}]
     (if (or shown? (:show-cloze? config))
-      [:a.cloze-revealed {:on-click toggle!}
-       (util/format "[%s]" answer)]
-      [:a.cloze {:on-click toggle!}
+      [:span.cloze-revealed attrs
+       "["
+       (component-block/inline-title config answer)
+       "]"]
+      [:span.cloze attrs
        (if (string/blank? cue)
          "[...]"
          (str "(" cue ")"))])))


### PR DESCRIPTION
fix https://github.com/logseq/db-test/issues/769

- Fix parser: {{cloze Ca^{ +2} ions}} and {{cloze H_{2}O}} now produce correct Macro AST nodes instead of fragmented Plain/Superscript nodes
- Fix argument splitting: commas inside [[...]] page refs, ^{...}/_{...} script markup, and "..." quoted strings are no longer treated as argument separators
- Fix render: cloze revealed answer now renders inline markup (HTML, page refs, etc.) correctly via inline-title instead of raw string
- Change [:a.cloze] to [:span.cloze] — toggle is an action, not navigation
- Add keyboard accessibility: role="button", tab-index 0, Enter/Space support
- Update CSS selectors from a.cloze to .cloze, add cursor: pointer
