### PR TITLE
[codex] fix cmdk sidebar shortcut propagation

### DIFF
--- a/src/main/frontend/components/cmdk/core.cljs
+++ b/src/main/frontend/components/cmdk/core.cljs
@@ -1053,10 +1053,13 @@
       (util/stop e))
 
     (cond
-      (and meta? enter?)
-      (let [repo (state/get-current-repo)]
-        (shui/dialog-close! :ls-dialog-cmdk)
-        (state/sidebar-add-block! repo input :search))
+      (cmdk-state/consume-open-search-sidebar-keydown!
+       e
+       (fn []
+         (let [repo (state/get-current-repo)]
+           (shui/dialog-close! :ls-dialog-cmdk)
+           (state/sidebar-add-block! repo input :search))))
+      nil
       as-keydown? (if meta?
                     (show-more)
                     (do

--- a/src/main/frontend/components/cmdk/state.cljs
+++ b/src/main/frontend/components/cmdk/state.cljs
@@ -1,6 +1,7 @@
 (ns frontend.components.cmdk.state
-  "Persist query and filter group from the last cmdk query"
-  (:require [frontend.storage :as storage]))
+  "State helpers for command palette search."
+  (:require [frontend.storage :as storage]
+            [frontend.util :as util]))
 
 (def cmdk-last-search-storage-key :ls-cmdk-last-search)
 (def cmdk-empty-repo-key "__no-repo__")
@@ -42,6 +43,14 @@
                    (assoc saved (repo-storage-key repo) value)))
     (catch :default _e
       nil)))
+
+(defn consume-open-search-sidebar-keydown!
+  [event open-search!]
+  (when (and (util/meta-key? event)
+             (= "Enter" (.-key event)))
+    (util/stop event)
+    (open-search!)
+    true))
 
 (defn- explicit-mode-filter-group
   [opts search-mode]

--- a/src/test/frontend/components/cmdk/state_test.cljs
+++ b/src/test/frontend/components/cmdk/state_test.cljs
@@ -1,7 +1,23 @@
 (ns frontend.components.cmdk.state-test
   (:require [cljs.test :refer [deftest is testing]]
             [frontend.components.cmdk.state :as state]
+            [frontend.util :as util]
+            [goog.object :as gobj]
             [frontend.storage :as storage]))
+
+(defn- key-event
+  [{:keys [key ctrl? meta?]}]
+  (let [prevented? (atom false)
+        stopped? (atom false)
+        event (js-obj)]
+    (gobj/set event "key" key)
+    (gobj/set event "ctrlKey" (boolean ctrl?))
+    (gobj/set event "metaKey" (boolean meta?))
+    (gobj/set event "preventDefault" #(reset! prevented? true))
+    (gobj/set event "stopPropagation" #(reset! stopped? true))
+    {:event event
+     :prevented? prevented?
+     :stopped? stopped?}))
 
 (deftest default-cmdk-context?-true-for-global-open
   (testing "default cmdk context is true for global open"
@@ -46,6 +62,33 @@
       (is (= {:query "beta" :filter-group :code}
              (state/load-last-cmdk-search "repo-b")))
       (is (nil? (state/load-last-cmdk-search "repo-c"))))))
+
+(deftest consume-open-search-sidebar-keydown-stops-editor-shortcut
+  (testing "cmdk consumes mod+Enter before the focused editor can cycle todo"
+    (let [{:keys [event prevented? stopped?]} (key-event {:key "Enter" :ctrl? true})
+          opened? (atom false)]
+      (with-redefs [util/meta-key? (constantly true)]
+        (is (true? (state/consume-open-search-sidebar-keydown! event #(reset! opened? true))))
+        (is (true? @opened?))
+        (is (true? @prevented?))
+        (is (true? @stopped?))))))
+
+(deftest consume-open-search-sidebar-keydown-ignores-other-keys
+  (testing "cmdk leaves non-shortcut keydowns available to normal handling"
+    (let [{plain-enter :event plain-prevented? :prevented? plain-stopped? :stopped?}
+          (key-event {:key "Enter"})
+          {mod-n :event mod-n-prevented? :prevented? mod-n-stopped? :stopped?}
+          (key-event {:key "n" :ctrl? true})
+          opened* (atom 0)]
+      (with-redefs [util/meta-key? (constantly false)]
+        (is (nil? (state/consume-open-search-sidebar-keydown! plain-enter #(swap! opened* inc)))))
+      (with-redefs [util/meta-key? (constantly true)]
+        (is (nil? (state/consume-open-search-sidebar-keydown! mod-n #(swap! opened* inc)))))
+      (is (= 0 @opened*))
+      (is (false? @plain-prevented?))
+      (is (false? @plain-stopped?))
+      (is (false? @mod-n-prevented?))
+      (is (false? @mod-n-stopped?)))))
 
 (deftest init-prioritizes-initial-input-over-saved-query
   (testing "initial-input wins over persisted query when both exist"


### PR DESCRIPTION
## Summary

- consume the command palette Mod+Enter sidebar-search shortcut before editor shortcuts receive the event
- keep the existing search-to-sidebar behavior unchanged after consuming the keydown
- add regression coverage for consuming Mod+Enter and ignoring unrelated keydowns

Fixes https://github.com/logseq/db-test/issues/870

## Root Cause

The command palette handled Mod+Enter by closing the dialog and adding the search to the right sidebar, but it did not stop the original keydown event. When an editor block still had focus behind Cmd/Ctrl+K, the editor Mod+Enter shortcut also saw the same event and cycled the block todo state.

## Validation

- bb dev:test -v frontend.components.cmdk.state-test
- git diff --check
