### PR TITLE
[codex] fix node property choice duplication

### DIFF
--- a/src/main/frontend/components/property/value.cljs
+++ b/src/main/frontend/components/property/value.cljs
@@ -672,6 +672,20 @@
                           :close-modal? false
                           k f'))))
 
+(defn- add-initial-node-choice
+  [initial-choices new-choice]
+  (let [node-choice-match? (fn [choice]
+                             (let [choice-value (:value choice)
+                                   new-value (:value new-choice)]
+                               (or
+                                (and (:db/id choice-value) (= (:db/id choice-value) (:db/id new-value)))
+                                (and (:block/uuid choice-value) (= (:block/uuid choice-value) (:block/uuid new-value)))
+                                (= choice-value new-value))))
+        initial-choices' (vec initial-choices)]
+    (if (some node-choice-match? initial-choices')
+      initial-choices'
+      (conj initial-choices' new-choice))))
+
 (rum/defc ^:large-vars/cleanup-todo select-node < rum/static
   [property
    {:keys [block multiple-choices? dropdown? input-opts on-input add-new-choice! target] :as opts}
@@ -891,7 +905,7 @@
                                                                                                    :built-in? false})]
                                      (set-result! result))))
                      :add-new-choice! (fn [new-choice]
-                                        (set-initial-choices! (conj (vec initial-choices) new-choice))))
+                                        (set-initial-choices! (add-initial-node-choice initial-choices new-choice))))
         repo (state/get-current-repo)
         classes (:logseq.property/classes property)
         class? (= :class (:logseq.property/type property))

--- a/src/test/frontend/components/property/value_test.cljs
+++ b/src/test/frontend/components/property/value_test.cljs
@@ -65,3 +65,31 @@
                       :block/uuid #uuid "11111111-1111-1111-1111-111111111111"}]
     (is (= (:logseq.property/default-value property)
            (#'property-value/resolved-property-value-for-render loaded-block property false)))))
+
+(deftest add-initial-node-choice-dedupes-existing-db-id-test
+  (let [existing {:value {:db/id 100
+                          :block/uuid #uuid "11111111-1111-1111-1111-111111111111"}
+                  :label "Existing node"}
+        duplicate {:value {:db/id 100
+                           :block/uuid #uuid "22222222-2222-2222-2222-222222222222"}
+                   :label "Existing node"}]
+    (is (= [existing]
+           (#'property-value/add-initial-node-choice [existing] duplicate)))))
+
+(deftest add-initial-node-choice-dedupes-existing-uuid-test
+  (let [existing {:value {:block/uuid #uuid "11111111-1111-1111-1111-111111111111"}
+                  :label "Existing node"}
+        duplicate {:value {:block/uuid #uuid "11111111-1111-1111-1111-111111111111"}
+                   :label "Existing node"}]
+    (is (= [existing]
+           (#'property-value/add-initial-node-choice [existing] duplicate)))))
+
+(deftest add-initial-node-choice-keeps-distinct-node-with-same-label-test
+  (let [existing {:value {:db/id 100
+                          :block/uuid #uuid "11111111-1111-1111-1111-111111111111"}
+                  :label "Shared title"}
+        new-choice {:value {:db/id 101
+                            :block/uuid #uuid "22222222-2222-2222-2222-222222222222"}
+                    :label "Shared title"}]
+    (is (= [existing new-choice]
+           (#'property-value/add-initial-node-choice [existing] new-choice)))))


### PR DESCRIPTION
## Summary

Fix duplicate node entries in the Node property value picker when the selected/searched node is already present in the picker's initial choices.

The picker previously appended the chosen node back into the cached initial choices without checking whether the same node was already present. It now dedupes by `:db/id` or `:block/uuid`, while preserving distinct nodes that happen to share a title.

Fixes logseq/db-test#869.

## Validation

- `rtk bb dev:test -v frontend.components.property.value-test`
- `rtk git diff --check`