### PR TITLE
[codex] fix sidebar asset drops

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -11,6 +11,7 @@
             [dommy.core :as dom]
             [electron.ipc :as ipc]
             [frontend.components.block.breadcrumb-model :as breadcrumb-model]
+            [frontend.components.block.drop :as block-drop]
             [frontend.components.block.macros :as block-macros]
             [frontend.components.block.selection :as block-selection]
             [frontend.components.icon :as icon-component]
@@ -3420,20 +3421,7 @@
             (state/set-state! :mobile/show-action-bar? false)
             (state/clear-selection!)))
         ;; handle DataTransfer
-        (let [data-transfer (.-dataTransfer event)
-              transfer-types (set (js->clj (.-types data-transfer)))]
-          (cond
-            (contains? transfer-types "text/plain")
-            (let [text (.getData data-transfer "text/plain")]
-              (editor-handler/api-insert-new-block!
-               text
-               {:block-uuid uuid
-                :edit-block? false
-                :sibling? (= @*move-to' :sibling)
-                :before? (= @*move-to' :top)}))
-
-            :else
-            (prn ::unhandled-drop-data-transfer-type transfer-types)))))
+        (block-drop/handle-data-transfer-drop! event uuid target-block @*move-to')))
     (block-drag-end event *move-to')))
 
 (defonce *block-last-mouse-event (atom nil))

--- a/src/main/frontend/components/block/drop.cljs
+++ b/src/main/frontend/components/block/drop.cljs
@@ -1,0 +1,41 @@
+(ns frontend.components.block.drop
+  (:require [frontend.handler.editor :as editor-handler]
+            [frontend.state :as state]
+            [frontend.util :as util]
+            [lambdaisland.glogi :as log]
+            [promesa.core :as p]))
+
+(defn- data-transfer-files
+  [data-transfer]
+  (some-> data-transfer .-files array-seq seq))
+
+(defn- save-files!
+  [files target-block]
+  (-> (editor-handler/db-based-save-assets! (state/get-current-repo) files
+                                            :last-edit-block target-block)
+      (p/catch (fn [error]
+                 (log/error :block/drop-files-failed {:error error}))))
+  nil)
+
+(defn handle-data-transfer-drop!
+  [^js event uuid target-block move-to]
+  (let [data-transfer (.-dataTransfer event)
+        transfer-types (set (js->clj (.-types data-transfer)))
+        files (data-transfer-files data-transfer)]
+    (cond
+      (and (contains? transfer-types "Files") (seq files))
+      (do
+        (util/stop event)
+        (save-files! files target-block))
+
+      (contains? transfer-types "text/plain")
+      (let [text (.getData data-transfer "text/plain")]
+        (editor-handler/api-insert-new-block!
+         text
+         {:block-uuid uuid
+          :edit-block? false
+          :sibling? (= move-to :sibling)
+          :before? (= move-to :top)}))
+
+      :else
+      (log/warn :block/unhandled-drop-data-transfer-type {:types transfer-types}))))

--- a/src/test/frontend/components/block/drop_test.cljs
+++ b/src/test/frontend/components/block/drop_test.cljs
@@ -1,0 +1,63 @@
+(ns frontend.components.block.drop-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [frontend.components.block.drop :as block-drop]
+            [frontend.handler.editor :as editor-handler]
+            [frontend.state :as state]
+            [promesa.core :as p]))
+
+(defn- file
+  [name]
+  #js {:name name
+       :size 12})
+
+(defn- drop-event
+  [types files text]
+  (let [prevent-default? (atom false)
+        stop-propagation? (atom false)
+        data-transfer #js {:types (clj->js types)
+                           :files (clj->js files)
+                           :getData (fn [type]
+                                      (case type
+                                        "text/plain" text
+                                        ""))}
+        event #js {:dataTransfer data-transfer
+                   :preventDefault #(reset! prevent-default? true)
+                   :stopPropagation #(reset! stop-propagation? true)}]
+    {:event event
+     :prevent-default? prevent-default?
+     :stop-propagation? stop-propagation?}))
+
+(deftest handle-data-transfer-drop-files-test
+  (testing "file drop into a block is saved as an asset and consumes the browser default"
+    (let [calls (atom [])
+          target-block {:block/uuid #uuid "00000000-0000-0000-0000-000000000001"
+                        :block/title "Drop target"}
+          dropped-file (file "demo.pdf")
+          {:keys [event prevent-default? stop-propagation?]}
+          (drop-event ["Files"] [dropped-file] "")]
+      (with-redefs [state/get-current-repo (constantly "test-repo")
+                    editor-handler/db-based-save-assets! (fn [repo files & opts]
+                                                           (swap! calls conj [repo files opts])
+                                                           (p/resolved :saved))]
+        (block-drop/handle-data-transfer-drop! event (:block/uuid target-block) target-block nil)
+        (is (= [["test-repo" [dropped-file] [:last-edit-block target-block]]] @calls))
+        (is (true? @prevent-default?))
+        (is (true? @stop-propagation?)))))
+
+  (testing "file drop wins over text/plain from OS file drags"
+    (let [asset-calls (atom 0)
+          text-calls (atom 0)
+          target-block {:block/uuid #uuid "00000000-0000-0000-0000-000000000002"
+                        :block/title "Drop target"}
+          dropped-file (file "demo.png")
+          {:keys [event]}
+          (drop-event ["Files" "text/plain"] [dropped-file] "C:\\Users\\me\\demo.png")]
+      (with-redefs [state/get-current-repo (constantly "test-repo")
+                    editor-handler/db-based-save-assets! (fn [& _]
+                                                           (swap! asset-calls inc)
+                                                           (p/resolved :saved))
+                    editor-handler/api-insert-new-block! (fn [& _]
+                                                           (swap! text-calls inc))]
+        (block-drop/handle-data-transfer-drop! event (:block/uuid target-block) target-block nil)
+        (is (= 1 @asset-calls))
+        (is (zero? @text-calls))))))


### PR DESCRIPTION
## Summary

- Handle file DataTransfer drops before text/plain in block drop handling.
- Save dropped files as assets on the target block so right-sidebar drops behave like block asset drops.
- Move DataTransfer drop handling into a focused helper with tests.

## Root cause

OS file drags, especially on Windows, can expose both Files and text/plain. The block drop handler only handled text/plain, so a file drop in the right sidebar could fall through to browser default behavior and ask to open the file.

Fixes logseq/db-test#868

## Validation

- bb dev:test -v frontend.components.block.drop-test/handle-data-transfer-drop-files-test
- clojure -M:clj-kondo --lint src/main/frontend/components/block.cljs src/main/frontend/components/block/drop.cljs src/test/frontend/components/block/drop_test.cljs
- clojure -M:cljs compile app
