### PR TITLE
[codex] dedupe raw node property choices

### DIFF
--- a/src/main/frontend/components/property/value.cljs
+++ b/src/main/frontend/components/property/value.cljs
@@ -674,9 +674,11 @@
 
 (defn- add-initial-node-choice
   [initial-choices new-choice]
-  (let [node-choice-match? (fn [choice]
-                             (let [choice-value (:value choice)
-                                   new-value (:value new-choice)]
+  (let [choice-node-value (fn [choice]
+                            (or (:value choice) choice))
+        node-choice-match? (fn [choice]
+                             (let [choice-value (choice-node-value choice)
+                                   new-value (choice-node-value new-choice)]
                                (or
                                 (and (:db/id choice-value) (= (:db/id choice-value) (:db/id new-value)))
                                 (and (:block/uuid choice-value) (= (:block/uuid choice-value) (:block/uuid new-value)))

--- a/src/test/frontend/components/property/value_test.cljs
+++ b/src/test/frontend/components/property/value_test.cljs
@@ -84,6 +84,16 @@
     (is (= [existing]
            (#'property-value/add-initial-node-choice [existing] duplicate)))))
 
+(deftest add-initial-node-choice-dedupes-existing-raw-entity-test
+  (let [existing {:db/id 100
+                  :block/uuid #uuid "11111111-1111-1111-1111-111111111111"
+                  :block/title "Existing node"}
+        duplicate {:value {:db/id 100
+                           :block/uuid #uuid "11111111-1111-1111-1111-111111111111"}
+                   :label "Existing node"}]
+    (is (= [existing]
+           (#'property-value/add-initial-node-choice [existing] duplicate)))))
+
 (deftest add-initial-node-choice-keeps-distinct-node-with-same-label-test
   (let [existing {:value {:db/id 100
                           :block/uuid #uuid "11111111-1111-1111-1111-111111111111"}


### PR DESCRIPTION
## Summary

Follow-up to #12633. Normalize node picker choices before comparing identity so `add-initial-node-choice` dedupes both select item shapes and raw entity maps.

`property-value-select-node` can initialize choices from pulled entities, where `(:value choice)` is nil. The helper now compares `(or (:value choice) choice)` by `:db/id` or `:block/uuid`, preserving distinct nodes with the same label.

## Validation

- `rtk bb dev:test -v frontend.components.property.value-test`
- `rtk git diff --check`