### PR TITLE
[codex] Preserve code block language

### DIFF
--- a/src/main/frontend/worker/pipeline.cljs
+++ b/src/main/frontend/worker/pipeline.cljs
@@ -283,11 +283,15 @@
               (contains? ldb/node-display-type-classes (:db/ident (d/entity db (:v d))))
               (:added d))
          (when-let [display-type (ldb/get-display-type-by-class-ident (:db/ident (d/entity db (:v d))))]
-           [(cond->
-             {:db/id (:e d)
-              :logseq.property.node/display-type display-type}
-              (and (= display-type :code) (d/entity db :logseq.kv/latest-code-lang))
-              (assoc :logseq.property.code/lang (:kv/value (d/entity db :logseq.kv/latest-code-lang))))])))
+           (let [block (d/entity db (:e d))
+                 latest-code-lang (:kv/value (d/entity db :logseq.kv/latest-code-lang))]
+             [(cond->
+               {:db/id (:e d)
+                :logseq.property.node/display-type display-type}
+                (and (= display-type :code)
+                     (nil? (:logseq.property.code/lang block))
+                     latest-code-lang)
+                (assoc :logseq.property.code/lang latest-code-lang))]))))
      datoms)))
 
 (defn- ensure-query-property-on-tag-additions

--- a/src/test/frontend/worker/pipeline_test.cljs
+++ b/src/test/frontend/worker/pipeline_test.cljs
@@ -93,6 +93,44 @@
     ;; return global fn back to previous behavior
     (ldb/register-transact-pipeline-fn! identity)))
 
+(deftest code-block-tag-addition-preserves-explicit-code-lang-test
+  (let [conn (db-test/create-conn-with-blocks
+              {:pages-and-blocks [{:page {:block/title "page1"}}]})
+        page (ldb/get-page @conn "page1")
+        now (js/Date.now)
+        code-block-uuid (random-uuid)
+        code-block-without-lang-uuid (random-uuid)]
+    (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
+    (try
+      (ldb/transact! conn [{:db/ident :logseq.kv/latest-code-lang
+                            :kv/value "pascal"}])
+      (ldb/transact! conn [{:block/uuid code-block-uuid
+                            :block/title "1 + 2"
+                            :block/created-at now
+                            :block/updated-at now
+                            :block/page (:db/id page)
+                            :block/parent (:db/id page)
+                            :block/order (db-order/gen-key)
+                            :block/tags [:logseq.class/Code-block]
+                            :logseq.property.code/lang "calc"}])
+      (let [block (d/entity @conn [:block/uuid code-block-uuid])]
+        (is (= :code (:logseq.property.node/display-type block)))
+        (is (= "calc" (:logseq.property.code/lang block))))
+      (ldb/transact! conn [{:block/uuid code-block-without-lang-uuid
+                            :block/title "plain code"
+                            :block/created-at now
+                            :block/updated-at now
+                            :block/page (:db/id page)
+                            :block/parent (:db/id page)
+                            :block/order (db-order/gen-key)
+                            :block/tags [:logseq.class/Code-block]}])
+      (let [block (d/entity @conn [:block/uuid code-block-without-lang-uuid])]
+        (is (= :code (:logseq.property.node/display-type block)))
+        (is (= "pascal" (:logseq.property.code/lang block))))
+      (finally
+        ;; return global fn back to previous behavior
+        (ldb/register-transact-pipeline-fn! identity)))))
+
 (deftest journal-name-title-updates-throw-in-transact-pipeline-test
   (let [conn (db-test/create-conn-with-blocks
               {:pages-and-blocks [{:page {:build/journal 20250203}}


### PR DESCRIPTION
Fix https://github.com/logseq/db-test/issues/872

## Summary
- Preserve explicit code block language when the worker pipeline auto-adds display-type properties from `#Code-block`.
- Keep the existing `latest-code-lang` behavior for code blocks created without an explicit language.
- Add regression coverage for the template-copy transaction shape behind db-test issue 872.

## Validation
- `bb dev:test -v frontend.worker.pipeline-test/code-block-tag-addition-preserves-explicit-code-lang-test`
- `bb dev:test -v frontend.worker.pipeline-test`