### PR TITLE
[codex] fix tag alias completion

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1602,8 +1602,6 @@
                       non-page-block?
                       (conj (db/entity :logseq.class/Page)))
         classes (->> all-classes
-                     (mapcat (fn [class]
-                               (conj (:block/alias class) class)))
                      (common-util/distinct-by :db/id)
                      (map (fn [e] (select-keys e [:block/uuid :block/title]))))]
     (search/fuzzy-search classes q {:extract-fn :block/title})))

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -122,6 +122,20 @@
   ;; Reset state
   (state/set-editor-action! nil))
 
+(deftest get-matched-classes-excludes-class-aliases
+  (test-helper/create-page! "Project Tag" :redirect? false :class? true)
+  (test-helper/create-page! "Alias Only" :redirect? false)
+  (let [class (db/get-case-page "Project Tag")
+        alias (db/get-case-page "Alias Only")]
+    (db/transact! test-helper/test-db [{:db/id (:db/id class)
+                                        :block/alias #{(:db/id alias)}}]))
+  (is (= ["Project Tag"]
+         (map :block/title (editor/get-matched-classes "Project Tag")))
+      "Existing tag title matching still works")
+  (is (empty? (filter #(= "Alias Only" (:block/title %))
+                      (editor/get-matched-classes "Alias Only")))
+      "Tag aliases are not separate tag completion choices"))
+
 (defn- default-keyup-result
   [{:keys [value cursor-pos key code action is-processed?]
     :or {code "KeyA"


### PR DESCRIPTION
## Summary
- hide tag alias pages from hashtag tag completion results
- keep actual tag/class title matching intact
- add a regression test for alias exclusion

## Root cause
The tag completion matcher expanded every class with its :block/alias pages before fuzzy search, so alias pages could appear as standalone tag choices.

## Verification
- bb dev:test -v frontend.handler.editor-test/get-matched-classes-excludes-class-aliases
- bb dev:test -v frontend.handler.editor-test