### PR TITLE
[codex] materialize class default values

### DIFF
--- a/src/main/frontend/worker/pipeline.cljs
+++ b/src/main/frontend/worker/pipeline.cljs
@@ -323,6 +323,65 @@
                         :logseq.property/query [:block/uuid value-uuid]})]))))))
          tagged-block-ids)))))
 
+(defn- scalar-property-default-value
+  [property]
+  (if-some [value (:logseq.property/scalar-default-value property)]
+    [value]
+    nil))
+
+(defn- value-block-content
+  [value-block]
+  (or (:logseq.property/value value-block)
+      (:block/title value-block)))
+
+(defn- default-property-value-tx-data
+  [block property]
+  (let [property-ident (:db/ident property)]
+    (if-let [[value] (scalar-property-default-value property)]
+      [[:db/add (:db/id block) property-ident value]]
+      (when-let [value-block (:logseq.property/default-value property)]
+        (if (and (:logseq.property/created-from-property value-block)
+                 (not (:block/closed-value-property value-block)))
+          (when-some [content (value-block-content value-block)]
+            (let [new-value-block (db-property-build/build-property-value-block
+                                   block property content
+                                   {:block-uuid (common-uuid/gen-uuid)})
+                  value-uuid (:block/uuid new-value-block)]
+              [new-value-block
+               [:db/add (:db/id block) property-ident [:block/uuid value-uuid]]]))
+          [[:db/add (:db/id block) property-ident (:db/id value-block)]])))))
+
+(defn- block-has-property-datom?
+  [db eid property-ident]
+  (seq (d/datoms db :eavt eid property-ident)))
+
+(defn- class-default-property-tx-data
+  [db eid class-ids]
+  (when-let [block (d/entity db eid)]
+    (let [classes (->> class-ids
+                       (keep #(d/entity db %))
+                       (mapcat #(cons % (ldb/get-classes-parents [%]))))
+          properties (common-util/distinct-by :db/id (mapcat :logseq.property.class/properties classes))]
+      (mapcat
+       (fn [property]
+         (let [property-ident (:db/ident property)]
+           (when (and property-ident
+                      (not (block-has-property-datom? db eid property-ident)))
+             (default-property-value-tx-data block property))))
+       properties))))
+
+(defn- materialize-class-default-properties-on-tag-additions
+  [tx-report]
+  (let [{:keys [db-after tx-data tx-meta]} tx-report]
+    (when-not (or (rtc-tx-or-download-graph? tx-meta)
+                  (:undo? tx-meta)
+                  (:redo? tx-meta))
+      (->> tx-data
+           (filter (fn [d] (and (= :block/tags (:a d)) (:added d))))
+           (group-by :e)
+           (mapcat (fn [[eid datoms]]
+                     (class-default-property-tx-data db-after eid (map :v datoms))))))))
+
 (defn- invoke-hooks-for-imported-graph [conn {:keys [tx-meta] :as tx-report}]
   (let [refs-tx-report (outliner-pipeline/transact-new-db-graph-refs conn tx-report)
         full-tx-data (concat (:tx-data tx-report) (:tx-data refs-tx-report))
@@ -450,6 +509,7 @@
                                         (toggle-page-and-block db tx-report))
         display-blocks-tx-data (add-missing-properties-to-typed-display-blocks db-after tx-data tx-meta)
         ensure-query-tx-data (ensure-query-property-on-tag-additions tx-report)
+        class-default-properties-tx-data (materialize-class-default-properties-on-tag-additions tx-report)
         commands-tx (when-not (or (:undo? tx-meta)
                                   (= :rebase (:outliner-op tx-meta))
                                   (rtc-tx-or-download-graph? tx-meta))
@@ -461,6 +521,7 @@
             toggle-page-and-block-tx-data
             display-blocks-tx-data
             ensure-query-tx-data
+            class-default-properties-tx-data
             commands-tx
             insert-templates-tx
             created-by-tx

--- a/src/test/frontend/worker/pipeline_test.cljs
+++ b/src/test/frontend/worker/pipeline_test.cljs
@@ -93,6 +93,57 @@
     ;; return global fn back to previous behavior
     (ldb/register-transact-pipeline-fn! identity)))
 
+(deftest materialize-class-default-property-values-on-tag-additions-test
+  (let [conn (db-test/create-conn-with-blocks
+              {:properties {:choice {:logseq.property/type :default
+                                     :build/properties
+                                     {:logseq.property/default-value "foo"}
+                                     :build/properties-ref-types {:entity :number}}
+                            :checked {:logseq.property/type :checkbox
+                                      :build/properties
+                                      {:logseq.property/scalar-default-value true}}}
+               :classes {:Defaults {:build/class-properties [:choice :checked]}}
+               :pages-and-blocks [{:page {:block/title "page1"}
+                                   :blocks [{:block/title "task"}
+                                            {:block/title "needs defaults"}
+                                            {:block/title "keeps explicit"
+                                             :build/properties {:choice "bar"
+                                                                :checked false}}]}]})
+        task (db-test/find-block-by-content @conn "task")
+        needs-defaults (db-test/find-block-by-content @conn "needs defaults")
+        keeps-explicit (db-test/find-block-by-content @conn "keeps explicit")
+        defaults-class (d/entity @conn :user.class/Defaults)]
+    (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
+
+    (testing "Task status default is stored on the block"
+      (ldb/transact! conn [[:db/add (:db/id task) :block/tags :logseq.class/Task]])
+      (is (= :logseq.property/status.todo
+             (get-in (d/pull @conn [{:logseq.property/status [:db/ident]}] (:db/id task))
+                     [:logseq.property/status :db/ident])))
+      (is (= [(:db/id task)]
+             (d/q '[:find [?b ...]
+                    :where [?b :logseq.property/status :logseq.property/status.todo]]
+                  @conn))))
+
+    (testing "Custom class defaults are stored without overriding explicit values"
+      (ldb/transact! conn [[:db/add (:db/id needs-defaults) :block/tags (:db/id defaults-class)]
+                           [:db/add (:db/id keeps-explicit) :block/tags (:db/id defaults-class)]])
+      (is (= "foo"
+             (-> (d/pull @conn [{:user.property/choice [:block/title]}] (:db/id needs-defaults))
+                 :user.property/choice
+                 :block/title)))
+      (is (= true
+             (:user.property/checked (d/pull @conn [:user.property/checked] (:db/id needs-defaults)))))
+      (is (= "bar"
+             (-> (d/pull @conn [{:user.property/choice [:block/title]}] (:db/id keeps-explicit))
+                 :user.property/choice
+                 :block/title)))
+      (is (= false
+             (:user.property/checked (d/pull @conn [:user.property/checked] (:db/id keeps-explicit))))))
+
+    ;; return global fn back to previous behavior
+    (ldb/register-transact-pipeline-fn! identity)))
+
 (deftest journal-name-title-updates-throw-in-transact-pipeline-test
   (let [conn (db-test/create-conn-with-blocks
               {:pages-and-blocks [{:page {:build/journal 20250203}}


### PR DESCRIPTION
## Summary
- Materialize class default property values when tags are added through the worker pipeline.
- Store Task default status so direct Datascript queries can match newly tagged tasks.
- Preserve explicit block property values and create per-block value nodes for free-text defaults.

## Validation
- bb dev:test -v frontend.worker.pipeline-test/materialize-class-default-property-values-on-tag-additions-test
- bb dev:test -v frontend.worker.pipeline-test
- bb dev:lint-and-test