### PR TITLE
feat: add :date-range property type with year/month/day precision + ranges

### DIFF
--- a/deps/db/src/logseq/db/common/view.cljs
+++ b/deps/db/src/logseq/db/common/view.cljs
@@ -49,8 +49,12 @@
                                          (into {})))
         get-property-value-fn (fn [entity]
                                 (if (de/entity? property)
-                                  (if (= :date (:logseq.property/type property))
-                                    (:block/journal-day (get entity db-ident))
+                                  (case (:logseq.property/type property)
+                                    :date     (:block/journal-day (get entity db-ident))
+                                    :daterange (let [v (get entity db-ident)]
+                                                 (if (de/entity? v)
+                                                   (:logseq.property.date/start v)
+                                                   (some :logseq.property.date/start v)))
                                     (get-property-value-for-search entity property))
                                   (get entity db-ident)))]
     (fn [entity]

--- a/deps/db/src/logseq/db/frontend/malli_schema.cljs
+++ b/deps/db/src/logseq/db/frontend/malli_schema.cljs
@@ -128,7 +128,10 @@
      :logseq.property.history/property :logseq.property.history/ref-value
      :logseq.property.class/extends
      :logseq.property.reaction/emoji-id
-     :logseq.property.reaction/target}))
+     :logseq.property.reaction/target
+     :logseq.property.date/precision
+     :logseq.property.date/start
+     :logseq.property.date/end}))
 
 (defn- property-entity->map
   "Provide the minimal number of property attributes to validate the property
@@ -435,6 +438,15 @@
     (remove #(#{:block/title :logseq.property/created-from-property} (first %)) block-attrs)
     page-or-block-attrs)))
 
+(def date-range-value
+  "Malli schema for a :date-range property value entity.
+  These entities have no :block/uuid — they are pure scalar containers
+  identified at dispatch time by :logseq.property.date/precision."
+  [:map {:error/path ["date-range-value"]}
+   [:logseq.property.date/precision [:enum :day :month :year]]
+   [:logseq.property.date/start :int]
+   [:logseq.property.date/end {:optional true} [:maybe :int]]])
+
 (def reaction-entity
   "A reaction entity referencing a target node"
   (vec
@@ -558,6 +570,10 @@
   (let [d (if (:block/uuid ent) (d/entity db [:block/uuid (:block/uuid ent)]) ent)
         ;; order matters as some block types are a subset of others e.g. :whiteboard
         dispatch-key (cond
+                       ;; daterange value entities have no :block/uuid — check
+                       ;; before the generic :block/uuid branch below.
+                       (:logseq.property.date/precision d)
+                       :daterange-value
                        (:logseq.property.reaction/target d)
                        :reaction-entity
                        (entity-util/property? d)
@@ -597,6 +613,7 @@
     :class class-page
     :hidden hidden-page
     :normal-page normal-page
+    :daterange-value date-range-value
     :reaction-entity reaction-entity
     :property-history-block property-history-block
     :closed-value-block closed-value-block
@@ -637,7 +654,8 @@
 
 (let [malli-non-ref-attrs (->> (concat property-attrs page-attrs block-attrs page-or-block-attrs (rest normal-page))
                                (concat (rest file-block) (rest property-value-block)
-                                       (rest db-ident-key-val) (rest internal-property))
+                                       (rest db-ident-key-val) (rest internal-property)
+                                       (rest date-range-value))
                                (remove #(= (last %) [:set :int]))
                                (map first)
                                set)]

--- a/deps/db/src/logseq/db/frontend/property/type.cljs
+++ b/deps/db/src/logseq/db/frontend/property/type.cljs
@@ -18,7 +18,7 @@
 
 (def user-built-in-property-types
   "Valid property types for users in order they appear in the UI"
-  [:default :number :date :datetime :checkbox :url :node :asset])
+  [:default :number :date :daterange :datetime :checkbox :url :node :asset])
 
 (def user-allowed-internal-property-types
   "Internal property types that users are allowed to store. These aren't available in the UI
@@ -33,7 +33,7 @@
 
 (def cardinality-property-types
   "Valid property types that can change cardinality"
-  #{:default :number :url :date :node :asset})
+  #{:default :number :url :date :daterange :node :asset})
 
 (def default-value-ref-property-types
   "Valid ref property :type for default value support"
@@ -62,8 +62,9 @@
 
 (def user-ref-property-types
   "User ref types. Property values that users see are stored in either
-  :logseq.property/value or :block/title. :block/title is for all the page related types"
-  (into #{:date :node :asset} value-ref-property-types))
+  :logseq.property/value or :block/title. :block/title is for all the page related types.
+  :daterange stores its value across three attributes on a dedicated entity."
+  (into #{:date :daterange :node :asset} value-ref-property-types))
 
 (assert (set/subset? user-ref-property-types
                      (set user-built-in-property-types))
@@ -160,6 +161,15 @@
     (and (some? (:block/title ent))
          (entity-util/journal? ent))))
 
+(defn- date-range?
+  "A date-range value entity must have :logseq.property.date/precision
+  (:day | :month | :year) and :logseq.property.date/start (YYYYMMDD int).
+  :logseq.property.date/end is optional (nil for single-point values)."
+  [db val]
+  (when-let [ent (d/entity db val)]
+    (and (keyword? (:logseq.property.date/precision ent))
+         (integer? (:logseq.property.date/start ent)))))
+
 ;; Internal usage
 (def internal-validation-schemas
   {:string   [:fn
@@ -207,6 +217,9 @@
     :date     [:fn
                {:error/message "should be a journal date"}
                date?]
+    :daterange [:fn
+                {:error/message "should be a daterange value entity"}
+                date-range?]
     :datetime [:fn
                {:error/message "should be a datetime"}
                number?]
@@ -231,7 +244,7 @@
 
 (def property-types-with-db
   "Property types whose validation fn requires a datascript db"
-  #{:default :url :number :date :node :asset :entity :class :property :page})
+  #{:default :url :number :date :daterange :node :asset :entity :class :property :page})
 
 ;; Helper fns
 ;; ==========

--- a/deps/db/src/logseq/db/frontend/schema.cljs
+++ b/deps/db/src/logseq/db/frontend/schema.cljs
@@ -95,6 +95,13 @@
    ;; page's journal day
    :block/journal-day {:db/index true}
 
+   ;; date-range value entity attributes — used by the :date-range property type.
+   ;; Each property value is a dedicated entity (no :block/uuid) with these three
+   ;; fields.  :logseq.property.date/end is absent for single-point values.
+   :logseq.property.date/precision {:db/index true}  ; keyword: :day | :month | :year
+   :logseq.property.date/start     {:db/index true}  ; YYYYMMDD integer
+   :logseq.property.date/end       {:db/index true}  ; YYYYMMDD integer, optional
+
    ;; latest tx that affected the block
    :block/tx-id {}
    :block/closed-value-property {:db/valueType :db.type/ref

--- a/deps/db/test/logseq/db/common/view_test.cljs
+++ b/deps/db/test/logseq/db/common/view_test.cljs
@@ -1,7 +1,8 @@
 (ns logseq.db.common.view-test
-  (:require [cljs.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is testing]]
             [datascript.core :as d]
             [logseq.db.common.view :as db-view]
+            [logseq.db.sqlite.util :as sqlite-util]
             [logseq.db.test.helper :as db-test]))
 
 (defn- create-view-id
@@ -210,3 +211,237 @@
     (is (= [1 2 10] asc-groups))
     ;; "Sort groups order" (desc?) must reverse the numeric order
     (is (= [10 2 1] desc-groups))))
+
+(deftest get-view-data-class-objects-daterange-sort-test
+  "Verify that sorting class objects by a :daterange property produces a
+   correctly ordered result.  We create three Book pages with year-precision
+   publication dates (2015, 2020, 2023) and assert that both ascending and
+   descending sorts return them in the expected order."
+  (let [conn (db-test/create-conn-with-blocks
+              {:classes {:Book {:block/title "Book"}}
+               :pages-and-blocks
+               [{:page {:block/title "Book A" :build/tags [:Book]}}
+                {:page {:block/title "Book B" :build/tags [:Book]}}
+                {:page {:block/title "Book C" :build/tags [:Book]}}]})
+        ;; 1. Create the daterange property.
+        _ (d/transact! conn
+                       [(sqlite-util/build-new-property
+                         :user.property/publication-date
+                         {:logseq.property/type :daterange}
+                         {:title "Publication Date"})])
+        ;; 2. Create three daterange value entities (year precision).
+        ;;    year 2015 → 20150000, 2020 → 20200000, 2023 → 20230000
+        tx2 (d/transact! conn
+                         [{:db/id -10
+                           :block/uuid (random-uuid)
+                           :logseq.property.date/precision :year
+                           :logseq.property.date/start 20150000}
+                          {:db/id -20
+                           :block/uuid (random-uuid)
+                           :logseq.property.date/precision :year
+                           :logseq.property.date/start 20200000}
+                          {:db/id -30
+                           :block/uuid (random-uuid)
+                           :logseq.property.date/precision :year
+                           :logseq.property.date/start 20230000}])
+        dr-2015-id (get-in tx2 [:tempids -10])
+        dr-2020-id (get-in tx2 [:tempids -20])
+        dr-2023-id (get-in tx2 [:tempids -30])
+        ;; Helper to look up a book id by title.
+        book-id #(d/q '[:find ?e . :in $ ?t :where [?e :block/title ?t]] @conn %)
+        ;; 3. Assign publication dates to each book.
+        _ (d/transact! conn
+                       [{:db/id (book-id "Book A") :user.property/publication-date dr-2020-id}
+                        {:db/id (book-id "Book B") :user.property/publication-date dr-2015-id}
+                        {:db/id (book-id "Book C") :user.property/publication-date dr-2023-id}])
+        class-id (:db/id (d/entity @conn :user.class/Book))
+        view-id  (create-view-id conn :class-objects :view-for-id class-id)
+        ;; 4. Sort ascending: expect 2015 < 2020 < 2023  →  B, A, C
+        asc-result  (db-view/get-view-data @conn view-id
+                                           {:view-feature-type :class-objects
+                                            :view-for-id class-id
+                                            :sorting [{:id :user.property/publication-date :asc? true}]})
+        asc-titles  (mapv #(:block/title (d/entity @conn %)) (:data asc-result))
+        ;; 5. Sort descending: expect 2023 > 2020 > 2015  →  C, A, B
+        desc-result (db-view/get-view-data @conn view-id
+                                           {:view-feature-type :class-objects
+                                            :view-for-id class-id
+                                            :sorting [{:id :user.property/publication-date :asc? false}]})
+        desc-titles (mapv #(:block/title (d/entity @conn %)) (:data desc-result))]
+    (is (= 3 (:count asc-result)) "All three books are returned")
+    (is (= ["Book B" "Book A" "Book C"] asc-titles)
+        "Ascending sort: 2015 < 2020 < 2023")
+    (is (= ["Book C" "Book A" "Book B"] desc-titles)
+        "Descending sort: 2023 > 2020 > 2015")))
+
+(deftest get-view-data-class-objects-daterange-month-precision-sort-test
+  (testing "Sorting by a :daterange property with :month precision"
+    ;; Books and their month-precision dates (day part is arbitrary for :month precision)
+    ;; A=Feb 2020, B=May 2019, C=Nov 2021  →  asc: B A C  /  desc: C A B
+    (let [conn (db-test/create-conn-with-blocks
+                {:classes {:Book {:block/title "Book"}}
+                 :pages-and-blocks
+                 [{:page {:block/title "Book A" :build/tags [:Book]}}
+                  {:page {:block/title "Book B" :build/tags [:Book]}}
+                  {:page {:block/title "Book C" :build/tags [:Book]}}]})
+          _ (d/transact! conn
+                         [(sqlite-util/build-new-property
+                           :user.property/pub-date
+                           {:logseq.property/type :daterange}
+                           {:title "Publication Date"})])
+          tx (d/transact! conn
+                          [{:db/id -10
+                            :logseq.property.date/precision :month
+                            :logseq.property.date/start 20200200}   ; Feb 2020
+                           {:db/id -20
+                            :logseq.property.date/precision :month
+                            :logseq.property.date/start 20190500}   ; May 2019
+                           {:db/id -30
+                            :logseq.property.date/precision :month
+                            :logseq.property.date/start 20211100}]) ; Nov 2021
+          book-id #(d/q '[:find ?e . :in $ ?t :where [?e :block/title ?t]] @conn %)
+          _ (d/transact! conn
+                         [{:db/id (book-id "Book A") :user.property/pub-date (get-in tx [:tempids -10])}
+                          {:db/id (book-id "Book B") :user.property/pub-date (get-in tx [:tempids -20])}
+                          {:db/id (book-id "Book C") :user.property/pub-date (get-in tx [:tempids -30])}])
+          class-id (:db/id (d/entity @conn :user.class/Book))
+          view-id  (create-view-id conn :class-objects :view-for-id class-id)
+          asc-titles  (mapv #(:block/title (d/entity @conn %))
+                            (:data (db-view/get-view-data @conn view-id
+                                                          {:view-feature-type :class-objects
+                                                           :view-for-id class-id
+                                                           :sorting [{:id :user.property/pub-date :asc? true}]})))
+          desc-titles (mapv #(:block/title (d/entity @conn %))
+                            (:data (db-view/get-view-data @conn view-id
+                                                          {:view-feature-type :class-objects
+                                                           :view-for-id class-id
+                                                           :sorting [{:id :user.property/pub-date :asc? false}]})))]
+      (is (= ["Book B" "Book A" "Book C"] asc-titles)
+          "Month precision ascending: May 2019 < Feb 2020 < Nov 2021")
+      (is (= ["Book C" "Book A" "Book B"] desc-titles)
+          "Month precision descending: Nov 2021 > Feb 2020 > May 2019"))))
+
+(deftest get-view-data-class-objects-daterange-day-precision-sort-test
+  (testing "Sorting by a :daterange property with :day precision"
+    ;; A=2024-03-10, B=2024-01-25, C=2024-06-05  →  asc: B A C  /  desc: C A B
+    (let [conn (db-test/create-conn-with-blocks
+                {:classes {:Book {:block/title "Book"}}
+                 :pages-and-blocks
+                 [{:page {:block/title "Book A" :build/tags [:Book]}}
+                  {:page {:block/title "Book B" :build/tags [:Book]}}
+                  {:page {:block/title "Book C" :build/tags [:Book]}}]})
+          _ (d/transact! conn
+                         [(sqlite-util/build-new-property
+                           :user.property/pub-date
+                           {:logseq.property/type :daterange}
+                           {:title "Publication Date"})])
+          tx (d/transact! conn
+                          [{:db/id -10
+                            :logseq.property.date/precision :day
+                            :logseq.property.date/start 20240310}  ; Mar 10 2024
+                           {:db/id -20
+                            :logseq.property.date/precision :day
+                            :logseq.property.date/start 20240125}  ; Jan 25 2024
+                           {:db/id -30
+                            :logseq.property.date/precision :day
+                            :logseq.property.date/start 20240605}]) ; Jun 5 2024
+          book-id #(d/q '[:find ?e . :in $ ?t :where [?e :block/title ?t]] @conn %)
+          _ (d/transact! conn
+                         [{:db/id (book-id "Book A") :user.property/pub-date (get-in tx [:tempids -10])}
+                          {:db/id (book-id "Book B") :user.property/pub-date (get-in tx [:tempids -20])}
+                          {:db/id (book-id "Book C") :user.property/pub-date (get-in tx [:tempids -30])}])
+          class-id (:db/id (d/entity @conn :user.class/Book))
+          view-id  (create-view-id conn :class-objects :view-for-id class-id)
+          asc-titles  (mapv #(:block/title (d/entity @conn %))
+                            (:data (db-view/get-view-data @conn view-id
+                                                          {:view-feature-type :class-objects
+                                                           :view-for-id class-id
+                                                           :sorting [{:id :user.property/pub-date :asc? true}]})))
+          desc-titles (mapv #(:block/title (d/entity @conn %))
+                            (:data (db-view/get-view-data @conn view-id
+                                                          {:view-feature-type :class-objects
+                                                           :view-for-id class-id
+                                                           :sorting [{:id :user.property/pub-date :asc? false}]})))]
+      (is (= ["Book B" "Book A" "Book C"] asc-titles)
+          "Day precision ascending: Jan 25 < Mar 10 < Jun 5")
+      (is (= ["Book C" "Book A" "Book B"] desc-titles)
+          "Day precision descending: Jun 5 > Mar 10 > Jan 25"))))
+
+(deftest get-view-data-class-objects-daterange-range-values-sort-by-start-test
+  (testing "Sorting by a :daterange property with start+end ranges — sort uses :start"
+    ;; All three books have ranges, but different starts.
+    ;; A: 2022-01-01 → 2022-12-31, B: 2020-06-01 → 2021-05-31, C: 2023-03-01 → 2023-09-30
+    ;; asc by start: B (2020) < A (2022) < C (2023)
+    (let [conn (db-test/create-conn-with-blocks
+                {:classes {:Book {:block/title "Book"}}
+                 :pages-and-blocks
+                 [{:page {:block/title "Book A" :build/tags [:Book]}}
+                  {:page {:block/title "Book B" :build/tags [:Book]}}
+                  {:page {:block/title "Book C" :build/tags [:Book]}}]})
+          _ (d/transact! conn
+                         [(sqlite-util/build-new-property
+                           :user.property/pub-date
+                           {:logseq.property/type :daterange}
+                           {:title "Publication Date"})])
+          tx (d/transact! conn
+                          [{:db/id -10
+                            :logseq.property.date/precision :day
+                            :logseq.property.date/start 20220101
+                            :logseq.property.date/end   20221231}
+                           {:db/id -20
+                            :logseq.property.date/precision :day
+                            :logseq.property.date/start 20200601
+                            :logseq.property.date/end   20210531}
+                           {:db/id -30
+                            :logseq.property.date/precision :day
+                            :logseq.property.date/start 20230301
+                            :logseq.property.date/end   20230930}])
+          book-id #(d/q '[:find ?e . :in $ ?t :where [?e :block/title ?t]] @conn %)
+          _ (d/transact! conn
+                         [{:db/id (book-id "Book A") :user.property/pub-date (get-in tx [:tempids -10])}
+                          {:db/id (book-id "Book B") :user.property/pub-date (get-in tx [:tempids -20])}
+                          {:db/id (book-id "Book C") :user.property/pub-date (get-in tx [:tempids -30])}])
+          class-id (:db/id (d/entity @conn :user.class/Book))
+          view-id  (create-view-id conn :class-objects :view-for-id class-id)
+          asc-titles (mapv #(:block/title (d/entity @conn %))
+                           (:data (db-view/get-view-data @conn view-id
+                                                         {:view-feature-type :class-objects
+                                                          :view-for-id class-id
+                                                          :sorting [{:id :user.property/pub-date :asc? true}]})))]
+      (is (= ["Book B" "Book A" "Book C"] asc-titles)
+          "Range values sort by :start — 2020 < 2022 < 2023"))))
+
+(deftest get-view-data-class-objects-daterange-nil-sort-test
+  (testing "Books without a daterange property value are kept in results when sorting by that property"
+    ;; Book A has a date, Books B and C do not.
+    ;; All three should appear in the result regardless of sort direction.
+    (let [conn (db-test/create-conn-with-blocks
+                {:classes {:Book {:block/title "Book"}}
+                 :pages-and-blocks
+                 [{:page {:block/title "Book A" :build/tags [:Book]}}
+                  {:page {:block/title "Book B" :build/tags [:Book]}}
+                  {:page {:block/title "Book C" :build/tags [:Book]}}]})
+          _ (d/transact! conn
+                         [(sqlite-util/build-new-property
+                           :user.property/pub-date
+                           {:logseq.property/type :daterange}
+                           {:title "Publication Date"})])
+          tx (d/transact! conn
+                          [{:db/id -10
+                            :logseq.property.date/precision :year
+                            :logseq.property.date/start 20200000}])
+          book-id #(d/q '[:find ?e . :in $ ?t :where [?e :block/title ?t]] @conn %)
+          _ (d/transact! conn
+                         [{:db/id (book-id "Book A") :user.property/pub-date (get-in tx [:tempids -10])}])
+          ;; Books B and C intentionally have no :user.property/pub-date
+          class-id (:db/id (d/entity @conn :user.class/Book))
+          view-id  (create-view-id conn :class-objects :view-for-id class-id)
+          result   (db-view/get-view-data @conn view-id
+                                          {:view-feature-type :class-objects
+                                           :view-for-id class-id
+                                           :sorting [{:id :user.property/pub-date :asc? true}]})
+          titles   (set (map #(:block/title (d/entity @conn %)) (:data result)))]
+      (is (= 3 (:count result))
+          "All three books are returned even when two lack the sort property")
+      (is (= #{"Book A" "Book B" "Book C"} titles)
+          "Books without a daterange value are not dropped from results"))))

--- a/deps/db/test/logseq/db/date_range_validate_test.cljs
+++ b/deps/db/test/logseq/db/date_range_validate_test.cljs
@@ -1,0 +1,82 @@
+(ns logseq.db.date-range-validate-test
+  "Tests for the :daterange property type: type-set membership, DB validation,
+   and correct storage of daterange value entities."
+  (:require [cljs.test :refer [deftest is testing]]
+            [datascript.core :as d]
+            [logseq.db.frontend.property.type :as db-property-type]
+            [logseq.db.frontend.validate :as db-validate]
+            [logseq.db.sqlite.util :as sqlite-util]
+            [logseq.db.test.helper :as db-test]))
+
+;; ---- Type-set membership ----
+
+(deftest daterange-is-in-correct-type-sets
+  (testing ":daterange appears in all relevant property-type sets"
+    (is (some #{:daterange} db-property-type/user-built-in-property-types)
+        ":daterange is a user-visible property type")
+    (is (contains? db-property-type/cardinality-property-types :daterange)
+        ":daterange supports cardinality switching")
+    (is (contains? db-property-type/user-ref-property-types :daterange)
+        ":daterange values are stored as ref entities")))
+
+;; ---- DB-level validation ----
+
+(deftest date-range-property-validates
+  (let [conn (db-test/create-conn)
+        _ (d/transact! conn
+                       [(sqlite-util/build-new-property
+                         :logseq.property.user/my-date-range
+                         {:logseq.property/type :daterange}
+                         {:title "my-date-range"})])
+        validation (db-validate/validate-local-db! @conn)]
+    (when (seq (:errors validation))
+      (println "ERRORS:")
+      (doseq [e (:errors validation)]
+        (println " dispatch-key:" (:dispatch-key e))
+        (println " entity keys:" (keys (:entity e)))
+        (println " errors:" (:errors e))))
+    (is (empty? (:errors validation))
+        "Graph with :daterange property has no validation errors")))
+
+(deftest daterange-value-entities-validate
+  (testing "Daterange entities with day/month/year precision and range (start+end) all pass DB validation"
+    (let [conn (db-test/create-conn-with-blocks
+                {:classes {:Book {:block/title "Book"}}
+                 :pages-and-blocks
+                 [{:page {:block/title "Book A" :build/tags [:Book]}}
+                  {:page {:block/title "Book B" :build/tags [:Book]}}
+                  {:page {:block/title "Book C" :build/tags [:Book]}}
+                  {:page {:block/title "Book D" :build/tags [:Book]}}]})
+          _ (d/transact! conn
+                         [(sqlite-util/build-new-property
+                           :user.property/pub-date
+                           {:logseq.property/type :daterange}
+                           {:title "Publication Date"})])
+          ;; One entity per precision type, plus a range value with both start and end
+          tx (d/transact! conn
+                          [{:db/id -1
+                            :logseq.property.date/precision :day
+                            :logseq.property.date/start    20250315}
+                           {:db/id -2
+                            :logseq.property.date/precision :month
+                            :logseq.property.date/start    20250300}
+                           {:db/id -3
+                            :logseq.property.date/precision :year
+                            :logseq.property.date/start    20250000}
+                           {:db/id -4
+                            :logseq.property.date/precision :day
+                            :logseq.property.date/start    20250101
+                            :logseq.property.date/end      20250315}])
+          book-id #(d/q '[:find ?e . :in $ ?t :where [?e :block/title ?t]] @conn %)
+          _ (d/transact! conn
+                         [{:db/id (book-id "Book A") :user.property/pub-date (get-in tx [:tempids -1])}
+                          {:db/id (book-id "Book B") :user.property/pub-date (get-in tx [:tempids -2])}
+                          {:db/id (book-id "Book C") :user.property/pub-date (get-in tx [:tempids -3])}
+                          {:db/id (book-id "Book D") :user.property/pub-date (get-in tx [:tempids -4])}])
+          validation (db-validate/validate-local-db! @conn)]
+      (when (seq (:errors validation))
+        (println "ERRORS:")
+        (doseq [e (:errors validation)]
+          (println " " e)))
+      (is (empty? (:errors validation))
+          "Day, month, year, and range daterange values all pass DB validation"))))

--- a/deps/outliner/src/logseq/outliner/op/construct.cljc
+++ b/deps/outliner/src/logseq/outliner/op/construct.cljc
@@ -980,12 +980,31 @@
     :else
     property-id))
 
+(defn- resolve-block-ref-attrs
+  "Resolve raw integer values for ref attributes in a block map to stable
+  entity refs (UUID lookup refs or db/ident keywords). This prevents
+  'Non-transact outliner ops contain numeric entity ids' errors in
+  derive-history-outliner-ops when a block has ref-type properties
+  (e.g. :daterange) whose values are raw DataScript db-ids."
+  [db block]
+  (when (map? block)
+    (reduce-kv (fn [m k v]
+                 (assoc m k
+                        (if (and (keyword? k)
+                                 (= :db.type/ref (:db/valueType (d/entity db k)))
+                                 (integer? v) (not (neg? v)))
+                          (stable-entity-ref db v)
+                          v)))
+               {}
+               block)))
+
 (defn- normalize-block-op-entry-ids
-  [id ids op args]
+  [db id ids op args]
   (case op
     :save-block
-    (let [[block opts] args]
-      [op [block opts]])
+    (let [[block opts] args
+          block' (or (resolve-block-ref-attrs db block) block)]
+      [op [block' opts]])
 
     :insert-blocks
     [op [(first args) (id (second args)) (nth args 2)]]
@@ -1056,7 +1075,7 @@
   (let [id (fn [v] (canonical-block-id db v))
         property-id (fn [v] (canonical-property-id db v))
         ids (fn [vs] (mapv id vs))
-        normalized (or (normalize-block-op-entry-ids id ids op args)
+        normalized (or (normalize-block-op-entry-ids db id ids op args)
                        (normalize-property-op-entry-ids id ids property-id op args))]
     (or normalized op-entry)))
 

--- a/src/main/frontend/components/date_range_picker.cljs
+++ b/src/main/frontend/components/date_range_picker.cljs
@@ -192,9 +192,9 @@
 ;;; ─── Sub-pickers ─────────────────────────────────────────────────────────────
 
 (hsx/defc year-picker
-  "Shows the current year with ‹/› navigation, sized to match the day calendar
-   width (276 px = 2×12 px padding + 7×36 px cells).  The ‹/› buttons call
-   on-navigate with the new year; clicking the year label calls on-select."
+  "Shows the current year with ‹/› navigation, sized to match the day calendar's
+   widened box (see endpoint-picker for the width rationale).  The ‹/› buttons
+   call on-navigate with the new year; clicking the year label calls on-select."
   [{:keys [year on-select on-navigate]}]
   [:div.flex.items-center.justify-center.gap-3
    {:style {:width "100%" :padding "12px"}}
@@ -210,8 +210,8 @@
                 (ui/icon "chevron-right" {:size 14}))])
 
 (hsx/defc month-grid
-  "A 4×3 month grid with year navigation, sized to match the day calendar width
-   (276 px = 2×12 px padding + 7×36 px cells).
+  "A 4×3 month grid with year navigation, sized to match the day calendar's
+   widened box (see endpoint-picker for the width rationale).
    on-navigate changes the display year;
    on-select is called with a YYYYMMDD integer for the chosen month."
   [{:keys [year month on-select on-navigate]}]
@@ -257,8 +257,12 @@
 ;;; ─── Single endpoint picker ──────────────────────────────────────────────────
 
 ;; Picker for a single start or end date.
-;; Renders inside a fixed-size 276×330 px box so that switching between
+;; Renders inside a fixed-size 340×330 px box so that switching between
 ;; Year / Month / Day precision does not resize the pop-over.
+;; Width is 340px (not 276px, the day-grid's own width) because the Day
+;; calendar's dropdown-style caption (month dropdown ~128px + year input
+;; ~100px + two 32px nav buttons, plus gaps) needs ~300px of content width;
+;; at 276px the nav buttons overlapped the year input.
 ;; on-select is called with a YYYYMMDD integer when the user picks a date.
 (hsx/defc endpoint-picker
   [{:keys [precision value on-select]}]
@@ -270,7 +274,7 @@
     ;; expands when the day calendar renders a 6-week month, which prevents the
     ;; small jump when switching away from Day precision.  330px safely covers
     ;; the tallest DayPicker layout (6 weeks × ~44px + caption + padding).
-    [:div {:style {:width "276px" :height "330px"
+    [:div {:style {:width "340px" :height "330px"
                    :display "flex" :flex-direction "column"
                    :align-items "flex-start" :overflow "hidden"}}
      (case precision
@@ -412,17 +416,26 @@
                           :start     final-start
                           :end       final-end}))))
 
-        ;; Renders a row of Year / Month / Day toggle buttons.
+        ;; Renders a "Precision:" label followed by a row of yyyy / yyyy-mm /
+        ;; yyyy-mm-dd toggle buttons.  Buttons use :xs sizing with tight
+        ;; horizontal padding so the whole row fits on one line within the
+        ;; endpoint-picker's column width.
+        precision-labels
+        {:year "yyyy" :month "yyyy-mm" :day "yyyy-mm-dd"}
+
         precision-buttons
         (fn [active-prec on-set!]
-          [:div.flex.gap-1
-           (for [p [:year :month :day]]
-             (shui/button
-              {:key      (name p)
-               :variant  (if (= p active-prec) :default :outline)
-               :size     :sm
-               :on-click (fn [] (on-set! p))}
-              (string/capitalize (name p))))])]
+          [:div.flex.items-center.gap-2
+           [:span.text-xs.text-muted-foreground "Precision:"]
+           [:div.flex.gap-1
+            (for [p [:year :month :day]]
+              (shui/button
+               {:key      (name p)
+                :variant  (if (= p active-prec) :default :outline)
+                :size     :xs
+                :class    "px-2"
+                :on-click (fn [] (on-set! p))}
+               (get precision-labels p)))]])]
 
     [:div.flex.flex-col.gap-3.p-1
 
@@ -544,7 +557,7 @@
            :size     :sm
            :on-click (fn [] (reset! *range? true))}
           (ui/icon "calendar-plus" {:size 14 :class "mr-1"})
-          "Add end"))
+          "Add end date"))
        (when range?
          (shui/button
           {:variant  :outline

--- a/src/main/frontend/components/date_range_picker.cljs
+++ b/src/main/frontend/components/date_range_picker.cljs
@@ -1,0 +1,570 @@
+(ns frontend.components.date-range-picker
+  "Date-range property value picker.
+
+  Supports three precisions (year / month / day) and optional end-date ranges.
+  The picker emits maps of the form
+    {:precision :day | :month | :year
+     :start     <YYYYMMDD integer>
+     :end       <YYYYMMDD integer | nil>}
+  via the :on-change callback.  The parent is responsible for persisting the
+  value to the DB (see property/value.cljs)."
+  (:require [cljs-time.core :as t]
+            [clojure.string :as string]
+            [frontend.state :as state]
+            [frontend.ui :as ui]
+            [frontend.util :as util]
+            [io.factorhouse.hsx.core :as hsx]
+            [logseq.shui.hooks :as hooks]
+            [logseq.shui.ui :as shui]))
+
+;;; ─── YYYYMMDD helpers ────────────────────────────────────────────────────────
+
+(defn- ymd->int
+  "Return a YYYYMMDD integer from year, month (1-12), day (1-31)."
+  [y m d]
+  (+ (* 10000 y) (* 100 m) d))
+
+(defn- int->parts
+  "Destructure a YYYYMMDD integer into [year month day]."
+  [n]
+  [(quot n 10000)
+   (mod (quot n 100) 100)
+   (mod n 100)])
+
+(defn- js-date->int
+  "Convert a js/Date to a YYYYMMDD integer using local time."
+  [^js d]
+  (ymd->int (.getFullYear d) (inc (.getMonth d)) (.getDate d)))
+
+(defn- int->js-date
+  "Convert a YYYYMMDD integer to a js/Date (midnight local time)."
+  [n]
+  (let [[y m d] (int->parts n)]
+    (js/Date. y (dec m) d 0 0 0 0)))
+
+(defn- precision-from-int
+  "Derive date precision from the YYYYMMDD integer encoding.
+   yyyy0000 → :year, yyyymm00 → :month, yyyymmdd → :day."
+  [n]
+  (cond
+    (zero? (mod n 10000)) :year
+    (zero? (mod n 100))   :month
+    :else                 :day))
+
+;;; ─── Flexible date parser ────────────────────────────────────────────────────
+
+(def ^:private month-name->int
+  {"january" 1 "jan" 1
+   "february" 2 "feb" 2
+   "march" 3 "mar" 3
+   "april" 4 "apr" 4
+   "may" 5
+   "june" 6 "jun" 6
+   "july" 7 "jul" 7
+   "august" 8 "aug" 8
+   "september" 9 "sep" 9 "sept" 9
+   "october" 10 "oct" 10
+   "november" 11 "nov" 11
+   "december" 12 "dec" 12})
+
+(defn- parse-month-name [s]
+  (get month-name->int (-> s string/lower-case (string/replace #"\." "") string/trim)))
+
+(defn- pi [s] (js/parseInt s 10))
+
+(defn- valid-ymd? [y m d]
+  (and (>= y 1000) (<= y 9999) (>= m 1) (<= m 12) (>= d 1) (<= d 31)))
+
+(defn- valid-ym? [y m]
+  (and (>= y 1000) (<= y 9999) (>= m 1) (<= m 12)))
+
+(defn parse-date-text
+  "Parse a free-form single-date string. Returns {:precision :year/:month/:day :start <YYYYMMDD>}
+   or nil when the string is unrecognisable."
+  [raw]
+  (let [s (-> raw string/trim (string/replace #"\s{2,}" " "))]
+    (when-not (string/blank? s)
+      (or
+       ;; ── ISO: YYYY-MM-DD ──────────────────────────────────────────────────
+       (when-let [[_ y m d] (re-matches #"(\d{4})-(\d{1,2})-(\d{1,2})" s)]
+         (let [yi (pi y) mi (pi m) di (pi d)]
+           (when (valid-ymd? yi mi di)
+             {:precision :day :start (ymd->int yi mi di)})))
+
+       ;; ── ISO: YYYY-MM ─────────────────────────────────────────────────────
+       (when-let [[_ y m] (re-matches #"(\d{4})-(\d{2})" s)]
+         (let [yi (pi y) mi (pi m)]
+           (when (valid-ym? yi mi)
+             {:precision :month :start (ymd->int yi mi 0)})))
+
+       ;; ── Four-digit year alone ────────────────────────────────────────────
+       (when-let [[_ y] (re-matches #"(\d{4})" s)]
+         (let [yi (pi y)]
+           (when (<= 1000 yi 9999)
+             {:precision :year :start (ymd->int yi 0 0)})))
+
+       ;; ── Slash: M/D/YYYY or M/D/YY ───────────────────────────────────────
+       (when-let [[_ m d y] (re-matches #"(\d{1,2})/(\d{1,2})/(\d{2,4})" s)]
+         (let [mi (pi m) di (pi d)
+               yi (let [yr (pi y)] (if (< yr 100) (+ 2000 yr) yr))]
+           (when (valid-ymd? yi mi di)
+             {:precision :day :start (ymd->int yi mi di)})))
+
+       ;; ── Slash: M/YYYY ────────────────────────────────────────────────────
+       (when-let [[_ m y] (re-matches #"(\d{1,2})/(\d{4})" s)]
+         (let [mi (pi m) yi (pi y)]
+           (when (valid-ym? yi mi)
+             {:precision :month :start (ymd->int yi mi 0)})))
+
+       ;; ── Day-first: "1 Sep 2025", "1 Sep. 2025", "01 September, 2025" ────
+       (when-let [[_ d mon y] (re-matches #"(\d{1,2})\s+([A-Za-z]+\.?)[,\s]+(\d{4})" s)]
+         (let [di (pi d) mi (parse-month-name mon) yi (pi y)]
+           (when (and mi (valid-ymd? yi mi di))
+             {:precision :day :start (ymd->int yi mi di)})))
+
+       ;; ── Month-first: "Sep 1, 2025", "Sep. 1 2025", "September 1 2025" ──
+       (when-let [[_ mon d y] (re-matches #"([A-Za-z]+\.?)\s+(\d{1,2})[,\s]+(\d{4})" s)]
+         (let [mi (parse-month-name mon) di (pi d) yi (pi y)]
+           (when (and mi (valid-ymd? yi mi di))
+             {:precision :day :start (ymd->int yi mi di)})))
+
+       ;; ── Month + year: "Sep 2025", "Sep. 2025", "September 2025" ─────────
+       (when-let [[_ mon y] (re-matches #"([A-Za-z]+\.?)\s+(\d{4})" s)]
+         (let [mi (parse-month-name mon) yi (pi y)]
+           (when (and mi (valid-ym? yi mi))
+             {:precision :month :start (ymd->int yi mi 0)})))))))
+
+(def ^:private range-sep-re
+  "Matches an en-dash, em-dash, or a space-prefixed hyphen as a range separator.
+   A leading space is required (so bare hyphens in ISO dates are not treated as
+   separators) but a trailing space is optional, so 'Sep 1 -' immediately shows
+   the end calendar without requiring the user to type the trailing space first."
+  #"(?:[–—]| -)")
+
+(defn- split-range-text
+  "Split raw text on the first range separator.  Returns [part1 part2] or nil.
+   Recognised separators: en-dash (–), em-dash (—), or ' - ' (space-hyphen-space)."
+  [s]
+  (when-let [[_ p1 p2] (re-matches (re-pattern (str "(.*?)\\s*" (.-source range-sep-re) "\\s*(.*)")) s)]
+    [(string/trim p1) (string/trim p2)]))
+
+(defn parse-date-range-text
+  "Parse a single date or a range separated by an en/em-dash or ' - '.
+   Returns {:precision … :start <YYYYMMDD> :end <YYYYMMDD|nil>} or nil."
+  [raw]
+  (let [s (-> raw string/trim (string/replace #"\s{2,}" " "))]
+    (when-not (string/blank? s)
+      (if-let [[p1 p2] (split-range-text s)]
+        ;; Range: both halves must parse successfully.
+        (let [start-parsed (parse-date-text p1)
+              end-parsed   (parse-date-text p2)]
+          (when (and start-parsed end-parsed)
+            (assoc start-parsed :end (:start end-parsed))))
+        ;; Single date.
+        (parse-date-text s)))))
+
+;;; ─── Display label ───────────────────────────────────────────────────────────
+
+(def ^:private month-abbr
+  ["" "Jan" "Feb" "Mar" "Apr" "May" "Jun"
+   "Jul" "Aug" "Sep" "Oct" "Nov" "Dec"])
+
+(defn- fmt-endpoint
+  "Format a single YYYYMMDD integer for display, deriving precision from
+   the integer encoding (yyyy0000 → year, yyyymm00 → month, else day)."
+  [n]
+  (let [[y m d] (int->parts n)]
+    (cond
+      (zero? (mod n 10000)) (str y)
+      (zero? (mod n 100))   (str (get month-abbr m "?") " " y)
+      :else                 (str (get month-abbr m "?") " " d ", " y))))
+
+(defn format-label
+  "Return a human-readable string for a date-range value map.
+   Precision is derived from the integer encoding; the :precision key
+   is accepted but ignored (kept for call-site backwards compat)."
+  [{:keys [start end]}]
+  (when start
+    (if end
+      (str (fmt-endpoint start) " – " (fmt-endpoint end))
+      (fmt-endpoint start))))
+
+;;; ─── Sub-pickers ─────────────────────────────────────────────────────────────
+
+(hsx/defc year-picker
+  "Shows the current year with ‹/› navigation, sized to match the day calendar
+   width (276 px = 2×12 px padding + 7×36 px cells).  The ‹/› buttons call
+   on-navigate with the new year; clicking the year label calls on-select."
+  [{:keys [year on-select on-navigate]}]
+  [:div.flex.items-center.justify-center.gap-3
+   {:style {:width "100%" :padding "12px"}}
+   (shui/button {:variant :ghost :size :icon
+                 :on-click #(on-navigate (dec year))}
+                (ui/icon "chevron-left" {:size 14}))
+   (shui/button {:variant :ghost :size :sm
+                 :class "font-semibold text-base min-w-[5rem]"
+                 :on-click #(on-select year)}
+                (str year))
+   (shui/button {:variant :ghost :size :icon
+                 :on-click #(on-navigate (inc year))}
+                (ui/icon "chevron-right" {:size 14}))])
+
+(hsx/defc month-grid
+  "A 4×3 month grid with year navigation, sized to match the day calendar width
+   (276 px = 2×12 px padding + 7×36 px cells).
+   on-navigate changes the display year;
+   on-select is called with a YYYYMMDD integer for the chosen month."
+  [{:keys [year month on-select on-navigate]}]
+  (let [rows [["Jan" "Feb" "Mar"] ["Apr" "May" "Jun"]
+              ["Jul" "Aug" "Sep"] ["Oct" "Nov" "Dec"]]]
+    [:div.flex.flex-col.gap-1
+     {:style {:width "100%" :padding "12px"}}
+     [:div.flex.items-center.justify-between
+      (shui/button {:variant :ghost :size :icon
+                    :on-click #(on-navigate (dec year))}
+                   (ui/icon "chevron-left" {:size 14}))
+      [:span.font-semibold.text-sm (str year)]
+      (shui/button {:variant :ghost :size :icon
+                    :on-click #(on-navigate (inc year))}
+                   (ui/icon "chevron-right" {:size 14}))]
+     (for [[r row] (map-indexed vector rows)]
+       [:div.flex.gap-1 {:key r}
+        (for [[c label] (map-indexed vector row)]
+          (let [m (+ (* r 3) c 1)
+                selected? (= m month)]
+            (shui/button
+             {:key     label
+              :variant (if selected? :default :ghost)
+              :size    :sm
+              :class   "flex-1"
+              :on-click #(on-select (ymd->int year m 0))}
+             label)))])]))
+
+(hsx/defc day-calendar
+  "Wraps single-calendar (no built-in text input) for day-precision selection.
+   :default-month seeds the displayed month on each mount; combined with the
+   YYYYMM-keyed remount in endpoint-picker this keeps the view in sync with
+   whatever month the value (or typed text) points at."
+  [{:keys [value on-select]}]
+  (let [initial-day (when value (int->js-date value))]
+    (ui/single-calendar
+     {:selected      initial-day
+      :default-month initial-day
+      :on-day-click  (fn [^js d]
+                       (when d
+                         (on-select (js-date->int d))))})))
+
+;;; ─── Single endpoint picker ──────────────────────────────────────────────────
+
+;; Picker for a single start or end date.
+;; Renders inside a fixed-size 276×330 px box so that switching between
+;; Year / Month / Day precision does not resize the pop-over.
+;; on-select is called with a YYYYMMDD integer when the user picks a date.
+(hsx/defc endpoint-picker
+  [{:keys [precision value on-select]}]
+  (let [*display-year (hooks/use-memo #(atom nil) [])
+        _ (hooks/use-atom *display-year)
+        [val-year val-month _] (when value (int->parts value))
+        display-year  (or @*display-year val-year (t/year (t/now)))]
+    ;; Fixed-height container.  Using height (not min-height) so the box never
+    ;; expands when the day calendar renders a 6-week month, which prevents the
+    ;; small jump when switching away from Day precision.  330px safely covers
+    ;; the tallest DayPicker layout (6 weeks × ~44px + caption + padding).
+    [:div {:style {:width "276px" :height "330px"
+                   :display "flex" :flex-direction "column"
+                   :align-items "flex-start" :overflow "hidden"}}
+     (case precision
+       :year
+       (year-picker {:year        display-year
+                     :on-navigate (fn [y] (reset! *display-year y))
+                     :on-select   (fn [y]
+                                    (on-select (ymd->int y 0 0)))})
+
+       :month
+       (month-grid  {:year        display-year
+                     :month       val-month
+                     :on-navigate (fn [y] (reset! *display-year y))
+                     :on-select   on-select})
+
+       ;; :day (default)
+       (day-calendar {:value     value
+                      :on-select on-select}))]))
+
+;;; ─── Main component ────────────────────────────────────────────────────────────────────────────
+
+(hsx/defc date-range-picker-inner
+  [{:keys [value on-change on-delete del-btn?]}]
+  (let [;; Sentinel :unset means "not yet overridden by user" — actual initial
+        ;; value is derived from the value prop on every render.  Once the user
+        ;; makes a selection the atom holds the chosen value.  Each atom is
+        ;; created once per mount via use-memo, and use-atom subscribes the
+        ;; component to re-render whenever reset!/swap! changes it.
+        *start-precision (hooks/use-memo #(atom :unset) [])
+        *end-precision   (hooks/use-memo #(atom :unset) [])
+        *range?          (hooks/use-memo #(atom :unset) [])
+        *draft-start     (hooks/use-memo #(atom :unset) [])
+        *draft-end       (hooks/use-memo #(atom :unset) [])
+        *text-input      (hooks/use-memo #(atom :unset) [])
+        *text-error      (hooks/use-memo #(atom nil) [])
+        *hint-visible?   (hooks/use-memo #(atom false) [])]
+    (hooks/use-atom *start-precision)
+    (hooks/use-atom *end-precision)
+    (hooks/use-atom *range?)
+    (hooks/use-atom *draft-start)
+    (hooks/use-atom *draft-end)
+    (hooks/use-atom *text-input)
+    (hooks/use-atom *text-error)
+    (hooks/use-atom *hint-visible?)
+    (hooks/use-effect!
+     (fn []
+       (state/set-editor-action! :property-set-date)
+       #(do
+          (shui/popup-hide!)
+          (state/set-editor-action! nil)))
+     [])
+  (let [;; Resolve effective values: user override takes priority; fall back to
+        ;; the value prop so that editing an existing value shows current data.
+        start-precision  (let [p @*start-precision]
+                           (if (= p :unset) (or (:precision value) :day) p))
+        end-precision    (let [p @*end-precision]
+                           (if (= p :unset) (or (:precision value) :day) p))
+        range?           (let [r @*range?]
+                           (if (= r :unset) (boolean (and value (:end value))) r))
+        draft-start      (let [s @*draft-start]
+                           (if (= s :unset) (:start value) s))
+        draft-end        (let [e @*draft-end]
+                           (if (= e :unset) (:end value) e))
+        ;; Text box: sentinel :unset means show the formatted existing value.
+        text-input       (let [t @*text-input]
+                           (if (= t :unset) (or (format-label value) "") t))
+        text-error       @*text-error
+
+        ;; Re-reading helpers so closures always see the latest atom values.
+        eff-start  #(let [s @*draft-start] (if (= s :unset) (:start value) s))
+        eff-end    #(let [e @*draft-end]   (if (= e :unset) (:end value) e))
+        eff-range? #(let [r @*range?]      (if (= r :unset) (boolean (and value (:end value))) r))
+
+        ;; Adjust a YYYYMMDD integer to the requested precision.
+        adjust-to-prec
+        (fn [n p]
+          (let [[y m d] (int->parts n)]
+            (case p
+              :year  (ymd->int y 0 0)
+              :month (ymd->int y (max m 1) 0)
+              (ymd->int y (max m 1) (max d 1)))))
+
+        set-start-precision!
+        (fn [p]
+          (reset! *start-precision p)
+          (when-let [cur (eff-start)]
+            (let [new-s (adjust-to-prec cur p)]
+              (reset! *draft-start new-s)
+              (reset! *text-input
+                      (format-label {:start new-s
+                                     :end   (when (eff-range?) (eff-end))})))))
+
+        set-end-precision!
+        (fn [p]
+          (reset! *end-precision p)
+          (when-let [cur (eff-end)]
+            (let [new-e (adjust-to-prec cur p)]
+              (reset! *draft-end new-e)
+              (when-let [s (eff-start)]
+                (reset! *text-input
+                        (format-label {:start s :end new-e}))))))
+
+        ;; Apply a successfully parsed text result to the draft atoms.
+        ;; When the parsed map includes :end, also update *draft-end and
+        ;; switch on range mode automatically.  Each half's precision is
+        ;; derived independently from its YYYYMMDD integer encoding.
+        apply-parsed!
+        (fn [{p :precision s :start e :end}]
+          (reset! *draft-start s)
+          (reset! *start-precision p)
+          (reset! *text-error nil)
+          (when (some? e)
+            (reset! *draft-end e)
+            (reset! *end-precision (precision-from-int e))
+            (reset! *range? true)))
+
+        ;; Called on Enter: canonicalise text if valid, show error if not.
+        commit-text!
+        (fn []
+          (let [t (string/trim text-input)]
+            (if (string/blank? t)
+              (reset! *text-error nil)
+              (if-let [parsed (parse-date-range-text t)]
+                (do (apply-parsed! parsed)
+                    (reset! *text-input (format-label parsed)))
+                (reset! *text-error "Unrecognised date — try e.g. \"Sep 1, 2025\" or \"Sep 1 – Sep 30, 2025\"")))))
+
+        ok!
+        (fn []
+          ;; Re-parse the text box so that typing then clicking OK (without Enter) works.
+          (let [from-text   (when-not (string/blank? (string/trim text-input))
+                              (parse-date-range-text text-input))
+                final-start (or (:start from-text) draft-start)
+                ;; Text end takes priority; fall back to calendar-clicked end.
+                final-end   (or (:end from-text) (when range? draft-end))
+                final-prec  (if final-start (precision-from-int final-start) start-precision)]
+            (when (and (fn? on-change) final-start)
+              (on-change {:precision final-prec
+                          :start     final-start
+                          :end       final-end}))))
+
+        ;; Renders a row of Year / Month / Day toggle buttons.
+        precision-buttons
+        (fn [active-prec on-set!]
+          [:div.flex.gap-1
+           (for [p [:year :month :day]]
+             (shui/button
+              {:key      (name p)
+               :variant  (if (= p active-prec) :default :outline)
+               :size     :sm
+               :on-click (fn [] (on-set! p))}
+              (string/capitalize (name p))))])]
+
+    [:div.flex.flex-col.gap-3.p-1
+
+     ;; ── calendars (side-by-side in range mode) ───────────────────────────────────────────
+     ;; Each endpoint is its own column: a precision-button row at the top,
+     ;; then a fixed-height endpoint-picker below.  Each endpoint-picker is
+     ;; keyed by its value's YYYYMM so that typing a date in a different
+     ;; month forces a remount and seeds the correct display month.
+     [:div.flex.flex-row.gap-6
+
+      ;; ── Start column ───────────────────────────────────────────────────────────────────
+      [:div.flex.flex-col.gap-2
+       ;; Always render the label so it occupies the same vertical space
+       ;; whether range mode is on or off, keeping the picker height stable.
+       [:span.text-xs.font-medium.uppercase.tracking-wide.text-muted-foreground
+        {:style {:visibility (if range? "visible" "hidden")}}
+        "Start"]
+       (precision-buttons start-precision set-start-precision!)
+       ^{:key (str "s-" (quot (or draft-start 0) 100))}
+       [:<> (endpoint-picker {:precision start-precision
+                              :value     draft-start
+                              :on-select (fn [v]
+                                           (reset! *draft-start v)
+                                           (reset! *text-input
+                                                   (format-label {:start v
+                                                                  :end   (when range? draft-end)})))})]]
+
+      ;; ── End column (only in range mode) ────────────────────────────────────────────────────────────
+      (when range?
+        [:div.flex.flex-col.gap-2
+         [:span.text-xs.font-medium.uppercase.tracking-wide.text-muted-foreground "End"]
+         (precision-buttons end-precision set-end-precision!)
+         ^{:key (str "e-" (quot (or draft-end 0) 100))}
+         [:<> (endpoint-picker {:precision end-precision
+                                :value     draft-end
+                                :on-select (fn [v]
+                                             (reset! *draft-end v)
+                                             (reset! *text-input
+                                                     (format-label {:start draft-start
+                                                                    :end   v})))})]])]
+
+     ;; ── text input (below calendar, auto-focused on open) ────────────────────────
+     [:div.flex.flex-col.gap-1
+      [:div.relative
+       (shui/input
+        {:auto-focus      true
+         :class           "h-8 text-sm"
+         :placeholder     "Enter date"
+         :value           text-input
+         :on-mouse-enter  #(reset! *hint-visible? true)
+         :on-mouse-leave  #(reset! *hint-visible? false)
+         :on-change       (fn [e]
+                            (let [new-text  (.. e -target -value)
+                                  ;; Capture previous text before overwriting so we can
+                                  ;; detect when the user removes the range separator.
+                                  ;; When the atom is still :unset the picker just opened
+                                  ;; with an existing value — use the formatted label so
+                                  ;; that clearing the box from that state works correctly.
+                                  prev-text (let [t @*text-input]
+                                              (if (= t :unset)
+                                                (or (format-label value) "")
+                                                t))]
+                              (reset! *text-input new-text)
+                              (reset! *text-error nil)
+                              ;; Live parse — handle single dates and ranges incrementally.
+                              ;; We parse each half independently so the end calendar
+                              ;; navigates as the user types, without waiting for the
+                              ;; whole string to be valid.
+                              (if-let [[p1 p2] (split-range-text new-text)]
+                                (do
+                                  ;; Separator present → show end calendar immediately.
+                                  ;; Even if p2 is blank the user may still be typing,
+                                  ;; so we don't collapse range mode here.
+                                  (reset! *range? true)
+                                  (when-let [sp (parse-date-text p1)]
+                                    (reset! *draft-start (:start sp))
+                                    (reset! *start-precision (:precision sp)))
+                                  (when-let [ep (parse-date-text p2)]
+                                    (reset! *draft-end (:start ep))
+                                    (reset! *end-precision (:precision ep))))
+                                (do
+                                  ;; No separator now.  If the previous text had one,
+                                  ;; the user deleted it (or cleared the whole box) —
+                                  ;; revert to single-date mode.
+                                  (when (and range?
+                                             (some? prev-text)
+                                             (split-range-text prev-text))
+                                    (reset! *range? false)
+                                    (reset! *draft-end nil))
+                                  ;; Single-date parse.
+                                  (when-let [parsed (parse-date-text new-text)]
+                                    (apply-parsed! parsed))))))
+         :on-key-down     (fn [e]
+                            (when (= "Enter" (.-key e))
+                              (.preventDefault e)
+                              (commit-text!)
+                              ;; Submit if commit-text! didn't flag an error
+                              ;; (blank text is fine — falls back to calendar selection).
+                              (when (nil? @*text-error)
+                                (ok!))))})
+       (when @*hint-visible?
+         [:div.absolute.left-0.bottom-full.mb-1.rounded.shadow-md.px-2.py-1
+          {:style {:background     "var(--ls-tooltip-background-color, #374151)"
+                   :color          "var(--ls-tooltip-text-color, #f9fafb)"
+                   :font-size      "0.75rem"
+                   :white-space    "nowrap"
+                   :z-index        1000
+                   :pointer-events "none"}}
+          "e.g. yyyy-mm, d mmm yyyy, yyyy - yyyy"])]
+      (when text-error
+        [:span.text-xs.text-destructive text-error])]
+
+     ;; ── footer ────────────────────────────────────────────────────────────────────────────
+     [:div.flex.justify-between.items-center.pt-1
+      [:div.flex.gap-1
+       (when-not range?
+         (shui/button
+          {:variant  :outline
+           :size     :sm
+           :on-click (fn [] (reset! *range? true))}
+          (ui/icon "calendar-plus" {:size 14 :class "mr-1"})
+          "Add end"))
+       (when range?
+         (shui/button
+          {:variant  :outline
+           :size     :sm
+           :on-click (fn []
+                       (reset! *range? false)
+                       (reset! *draft-end nil))}
+          "Remove end"))
+       (when del-btn?
+         (shui/button
+          {:variant  :ghost
+           :size     :icon
+           :class    "text-muted-foreground hover:text-destructive"
+           :on-click (fn [e]
+                       (util/stop-propagation e)
+                       (when (fn? on-delete) (on-delete e)))}
+          (ui/icon "trash" {:size 14})))]
+
+      (shui/button
+       {:size     :sm
+        :disabled (nil? draft-start)
+        :on-click ok!}
+       "OK")]])))

--- a/src/main/frontend/components/date_range_picker.cljs
+++ b/src/main/frontend/components/date_range_picker.cljs
@@ -565,7 +565,7 @@
            :on-click (fn []
                        (reset! *range? false)
                        (reset! *draft-end nil))}
-          "Remove end"))
+          "Remove end date"))
        (when del-btn?
          (shui/button
           {:variant  :ghost

--- a/src/main/frontend/components/property.cljs
+++ b/src/main/frontend/components/property.cljs
@@ -243,27 +243,28 @@
   (let [type (or (:logseq.property/type property) property-type :default)
         ident (:db/ident property)
         icon (cond
-	               (= ident :block/tags)
-	               "hash"
-	               (string/starts-with? (str ident) ":plugin.")
-	               "puzzle"
-	               :else
-	               (case type
-	                 :number "number"
-	                 :date "calendar"
-	                 :datetime "calendar"
-	                 :checkbox "checkbox"
-	                 :url "link"
-	                 :property "letter-p"
-	                 :page "page"
-	                 :node "point-filled"
-	                 :asset "letter-a"
-	                 nil))]
-	    (if icon
-	      (ui/icon icon {:class "opacity-50"
-	                     :size 15})
-	      [:span.bullet-container
-	       [:span.bullet]])))
+               (= ident :block/tags)
+               "hash"
+               (string/starts-with? (str ident) ":plugin.")
+               "puzzle"
+               :else
+               (case type
+                 :number "number"
+                 :date "calendar"
+                 :daterange "calendar-range"
+                 :datetime "calendar"
+                 :checkbox "checkbox"
+                 :url "link"
+                 :property "letter-p"
+                 :page "page"
+                 :node "point-filled"
+                 :asset "letter-a"
+                 nil))]
+    (if icon
+      (ui/icon icon {:class "opacity-50"
+                     :size 15})
+      [:span.bullet-container
+       [:span.bullet]])))
 
 (defn- property-input-on-chosen
   [block *property *property-key *show-new-property-config? {:keys [class-schema? remove-property?]}]

--- a/src/main/frontend/components/property/config.cljs
+++ b/src/main/frontend/components/property/config.cljs
@@ -738,6 +738,7 @@
     :default (t :property/type-text)
     :number (t :property/type-number)
     :date (t :property/type-date)
+    :daterange (t :property/type-daterange)
     :datetime (t :property/type-datetime)
     :checkbox (t :property/type-checkbox)
     :url (t :property/type-url)

--- a/src/main/frontend/components/property/value.cljs
+++ b/src/main/frontend/components/property/value.cljs
@@ -3,7 +3,9 @@
             [cljs-time.core :as t]
             [clojure.set :as set]
             [clojure.string :as string]
-            [dommy.core :as d]
+            [datascript.core :as d]
+            [dommy.core :as dommy]
+            [frontend.components.date-range-picker :as date-range-picker]
             [frontend.components.icon :as icon-component]
             [frontend.components.select :as select]
             [frontend.config :as config]
@@ -195,7 +197,7 @@
 
 (defn direct-value-picker-type?
   [type]
-  (contains? #{:date :datetime :asset} type))
+  (contains? #{:date :daterange :datetime :asset} type))
 
 (defn <create-new-block!
   [block property value & {:keys [edit-block? batch-op?]
@@ -547,6 +549,99 @@
     (.preventDefault e)
     false))
 
+(defn- find-date-range-eid
+  "Return the :db/id of an existing date-range entity matching precision+start+end,
+  or nil if none exists."
+  [db {:keys [precision start end]}]
+  (ffirst
+   (if end
+     (d/q '[:find ?e
+             :in $ ?precision ?start ?end
+             :where
+             [?e :logseq.property.date/precision ?precision]
+             [?e :logseq.property.date/start ?start]
+             [?e :logseq.property.date/end ?end]]
+           db precision start end)
+     (d/q '[:find ?e
+             :in $ ?precision ?start
+             :where
+             [?e :logseq.property.date/precision ?precision]
+             [?e :logseq.property.date/start ?start]
+             (not [?e :logseq.property.date/end])]
+           db precision start))))
+
+(defn <find-or-create-date-range-entity!
+  "Find or create a date-range value entity.  Returns a promise that resolves to
+  the entity map (with :db/id set)."
+  [{:keys [precision start end] :as dr-val}]
+  (p/let [db   (db/get-db)
+          conn (db/get-db false)
+          eid  (find-date-range-eid db dr-val)]
+    (if eid
+      (d/entity db eid)
+      (let [tx-data (cond-> {:block/uuid                     (random-uuid)
+                              :logseq.property.date/precision precision
+                              :logseq.property.date/start     start}
+                      end (assoc :logseq.property.date/end end))]
+        (p/let [_ (p/promise
+                    (ldb/transact! conn [tx-data] {:outliner-op :save-block}))]
+          (d/entity @conn (find-date-range-eid @conn dr-val)))))))
+
+;; Trigger chip and popup for :daterange property values.
+(hsx/defc date-range-picker-trigger
+  [value {:keys [block property on-change on-delete del-btn? editing? multiple-values?]}]
+  (let [*el      (hooks/use-ref nil)
+        label    (date-range-picker/format-label value)
+        content-fn (fn [{:keys [id]}]
+                     (date-range-picker/date-range-picker-inner
+                      {:value     value
+                       :del-btn?  del-btn?
+                       :on-delete on-delete
+                       :on-change (fn [dr-val]
+                                    (p/let [ent (<find-or-create-date-range-entity! dr-val)]
+                                      (when (fn? on-change)
+                                        (on-change ent))
+                                      (when-not multiple-values?
+                                        (shui/popup-hide! id)
+                                        (ui/hide-popups-until-preview-popup!))))}))
+        open-popup! (fn [e]
+                      (when-not (or (util/meta-key? e) (util/shift-key? e))
+                        (util/stop e)
+                        (editor-handler/save-current-block!)
+                        (when-not config/publishing?
+                          (shui/popup-show! (.-target e) content-fn
+                                            {:align "start" :auto-focus? true}))))]
+    (if editing?
+      (content-fn {:id :daterange-picker})
+      (if multiple-values?
+        (shui/button
+         {:class    "jtrigger h-6 empty-btn"
+          :variant  :text
+          :size     :sm
+          :on-click open-popup!
+          :on-key-down (fn [e]
+                         (when (contains? #{"Backspace" "Delete"} (util/ekey e))
+                           (delete-block-property! block property)))}
+         (ui/icon "calendar-range" {:size 16}))
+        (shui/trigger-as
+         :div.flex.flex-1.flex-row.gap-1.items-center.flex-wrap
+         {:ref      *el
+          :tabIndex 0
+          :class    "jtrigger min-h-[24px]"
+          :on-click open-popup!
+          :on-key-down (fn [e]
+                         (case (util/ekey e)
+                           ("Backspace" "Delete")
+                           (delete-block-property! block property)
+                           (" " "Enter")
+                           (do (some-> (hooks/deref *el) (.click))
+                               (util/stop e))
+                           nil))}
+         [:div.flex.flex-row.gap-1.items-center
+          (if label
+            [:span.text-sm label]
+            (property-empty-btn-value nil))])))))
+
 (hsx/defc date-picker
   [value {:keys [block property datetime? on-change on-delete del-btn? editing? multiple-values? other-position?
                  suppress-inline-edit-icon? property-position]}]
@@ -628,28 +723,48 @@
 (hsx/defc property-value-date-picker
   [block property value opts]
   (let [multiple-values? (db-property/many? property)
-        datetime? (= :datetime (:logseq.property/type property))]
-    (date-picker value
-                 (merge opts
-                        {:block block
-                         :property property
-                         :datetime? datetime?
-                         :multiple-values? multiple-values?
-                         :on-change (fn [value]
-                                      (let [blocks (get-operating-blocks block)]
-                                        (property-handler/batch-set-block-property! (map :block/uuid blocks)
-                                                                                    (:db/ident property)
-                                                                                    (if datetime?
-                                                                                      value
-                                                                                      (:db/id value)))))
-                         :del-btn? (some? value)
-                         :on-delete (fn [e]
-                                      (util/stop-propagation e)
-                                      (let [blocks (get-operating-blocks block)]
-                                        (property-handler/batch-set-block-property! (map :block/uuid blocks)
-                                                                                    (:db/ident property)
-                                                                                    nil))
-                                      (shui/popup-hide!))}))))
+        datetime?        (= :datetime (:logseq.property/type property))
+        date-range?      (= :daterange (:logseq.property/type property))
+        del-opts         {:del-btn?  (some? value)
+                          :on-delete (fn [e]
+                                       (util/stop-propagation e)
+                                       (let [blocks (get-operating-blocks block)]
+                                         (property-handler/batch-set-block-property! (map :block/uuid blocks)
+                                                                                     (:db/ident property)
+                                                                                     nil))
+                                       (shui/popup-hide!))}]
+    (if date-range?
+      ;; ── :daterange branch ────────────────────────────────────────────────
+      ;; value here is a DataScript entity map with :logseq.property.date/* keys
+      (let [dr-val (when value
+                     {:precision (:logseq.property.date/precision value)
+                      :start     (:logseq.property.date/start value)
+                      :end       (:logseq.property.date/end value)})]
+        (date-range-picker-trigger
+         dr-val
+         (merge opts del-opts
+                {:block            block
+                 :property         property
+                 :multiple-values? multiple-values?
+                 :on-change        (fn [ent]
+                                     (let [blocks (get-operating-blocks block)]
+                                       (property-handler/batch-set-block-property! (map :block/uuid blocks)
+                                                                                   (:db/ident property)
+                                                                                   (:db/id ent))))})))
+      ;; ── :date / :datetime branch (unchanged) ─────────────────────────────
+      (date-picker value
+                   (merge opts del-opts
+                          {:block            block
+                           :property         property
+                           :datetime?        datetime?
+                           :multiple-values? multiple-values?
+                           :on-change        (fn [value]
+                                               (let [blocks (get-operating-blocks block)]
+                                                 (property-handler/batch-set-block-property! (map :block/uuid blocks)
+                                                                                             (:db/ident property)
+                                                                                             (if datetime?
+                                                                                               value
+                                                                                               (:db/id value)))))})))))
 
 (defn- <create-page-if-not-exists!
   [block property classes page]
@@ -1438,6 +1553,13 @@
        (when-let [reference (state/get-component :block/reference)]
          (when value (reference {:table-view? table-view?} (:block/uuid value))))
 
+       (= type :daterange)
+       (when value
+         (inline-text-cp (date-range-picker/format-label
+                          {:precision (:logseq.property.date/precision value)
+                           :start     (:logseq.property.date/start value)
+                           :end       (:logseq.property.date/end value)})))
+
        (and (map? value) (some? (db-property/property-value-content value)))
        (let [content (str (db-property/property-value-content value))]
          (inline-text-cp content))
@@ -1480,8 +1602,8 @@
                                     (util/meta-key? e)
                                     (util/link? target)
                                     (when-let [node (.closest target "a")]
-                                      (not (or (d/has-class? node "page-ref")
-                                               (d/has-class? node "tag")))))
+                                      (not (or (dommy/has-class? node "page-ref")
+                                               (dommy/has-class? node "tag")))))
                         (show-popup! target))))]
         (shui/trigger-as
          (if (:other-position? opts) :div.jtrigger :div.jtrigger.flex.flex-1.w-full.cursor-pointer)
@@ -2036,7 +2158,7 @@
                                         :editing? editing?
                                         :value-render (fn [] (select-item property type value opts))))))
         (case type
-          (:date :datetime)
+          (:date :datetime :daterange)
           (property-value-date-picker block property value (merge opts {:editing? editing?}))
 
 	          :checkbox
@@ -2074,7 +2196,7 @@
 (hsx/defc multiple-values-inner
   [block property v {:keys [on-chosen editing?] :as opts}]
   (let [type (:logseq.property/type property)
-        date? (= type :date)
+        date? (contains? #{:date :daterange} type)
         *el (hooks/use-ref nil)
         items (cond->> (if (entity-map? v) #{v} v)
                 (= (:db/ident property) :block/tags)

--- a/src/main/frontend/components/property/value.css
+++ b/src/main/frontend/components/property/value.css
@@ -1,11 +1,11 @@
-.property-value-inner:not([data-type="default"]):not([data-type="url"]):not([data-type="number"]):not([data-type="string"]):not([data-type="date"]):not([data-type="datetime"]) {
+.property-value-inner:not([data-type="default"]):not([data-type="url"]):not([data-type="number"]):not([data-type="string"]):not([data-type="date"]):not([data-type="daterange"]):not([data-type="datetime"]) {
   @apply cursor-pointer;
   &:hover, .as-scalar-value-wrap:hover {
     @apply bg-gray-02 rounded transition-[background-color] duration-300;
   }
 }
 
-.property-value-inner[data-type="date"], .property-value-inner[data-type="datetime"] {
+.property-value-inner[data-type="date"], .property-value-inner[data-type="daterange"], .property-value-inner[data-type="datetime"] {
   @apply cursor-pointer;
 }
 

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -1382,6 +1382,7 @@
  :property/type-change-warning "Changing the property type clears some property configurations."
  :property/type-checkbox "Checkbox"
  :property/type-date "Date"
+ :property/type-daterange "DateRange"
  :property/type-datetime "DateTime"
  :property/type-locked-help "The type of this property is locked once you start using it. This is to make sure all your existing information stays correct if the property type is changed later. To unlock, all uses of a property must be deleted."
  :property/type-node "Node"


### PR DESCRIPTION
Summary
-------
Adds a new :date-range property type that lets users specify dates at a range of granularities and optionally with an end date for the chosen level of granularity.
- Year — "2026"
- Month — "May 2026"
- Day — "May 13, 2026" (existing :date behaviour, but now accessible via the new type too)
- Ranges — any combination: "May 13, 2026 – May 20, 2026" or "1715 – 1720"

The existing :date and :datetime types are unchanged (though there is no reason the proposed new property couldn't eventually just replace the existing :date property).

Storage
-------
Each value is a lightweight DataScript entity (no :block/uuid) with three new schema attributes:

| Attribute | Type | Meaning |
|---|---|---|
| `:logseq.property.date/precision` | keyword | `:year` \| `:month` \| `:day` |
| `:logseq.property.date/start` | YYYYMMDD integer | start of range (or single point) |
| `:logseq.property.date/end` | YYYYMMDD integer | end of range — absent for single-point values |

The entity type is identified in malli_schema/entity-dispatch-key by the presence of :logseq.property.date/precision, and validated by the new date-range-value malli schema.

Files changed
-------
| File | Change |
|---|---|
| `deps/db/.../schema.cljs` | 3 new DataScript attributes |
| `deps/db/.../property.cljs` | `"logseq.property.date"` namespace registered |
| `deps/db/.../property/type.cljs` | `:date-range` in 6 sets/maps |
| `deps/db/.../malli_schema.cljs` | `date-range-value` schema + dispatch key |
| `src/.../date_range_picker.cljs` | **New** — picker component |
| `src/.../property/value.cljs` | `:date-range` display + entity creation |
| `src/.../property/value.css` | CSS selectors extended |
| `src/.../property.cljs` | icon, layout, hide-key-label |
| `src/.../property/config.cljs` | `property-type-label` case |
| `src/resources/dicts/en.edn` | `"Date range"` i18n string |

UI
-------
The new picker (date-range-picker-inner) provides:
- Precision chips — [Year] [Month] [Day] — switching coerces the existing value
- Year picker — ‹ 2026 › with prev/next buttons
- Month grid — 4×3 grid of months with year navigation (shown for :month precision)
- Day calendar — delegates to the existing ui/nlp-calendar (shown for :day)
- "Add end" / "Single date" toggle — converts between point and range
- Delete button — removes the value

Test plan
-------
- [ ] Create a user property with type "Date range"
- [ ] Set a year-only value (e.g. 1715); confirm display shows "1715"
- [ ] Set a month value (e.g. May 2026); confirm display shows "May 2026"
- [ ] Set a day value; confirm display shows "May 13, 2026"
- [ ] Click "Add end" and set an end date; confirm range display "May 13 – May 20, 2026"
- [ ] Switch precision from Day to Year; confirm both start and end are coerced
- [ ] Delete the value; confirm property reverts to empty state
- [ ] Run logseq graph validate on a graph with :date-range properties
- [ ] Confirm existing :date and :datetime properties are unaffected
- [ ] Confirm the malli assert in property/type.cljs still passes (ClojureScript compile succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)