### PR TITLE
fix: preserve resized network image width

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -12,6 +12,7 @@
             [electron.ipc :as ipc]
             [frontend.components.block.breadcrumb-model :as breadcrumb-model]
             [frontend.components.block.drop :as block-drop]
+            [frontend.components.block.image :as block-image]
             [frontend.components.block.macros :as block-macros]
             [frontend.components.block.selection :as block-selection]
             [frontend.components.icon :as icon-component]
@@ -391,6 +392,7 @@
         positioned? (:property-position config)
         asset-block (:asset-block config)
         asset-align (normalize-asset-align (:logseq.property.asset/align asset-block))
+        metadata (block-image/effective-image-metadata config asset-block metadata)
         width (:width metadata)
         *width (get state ::size)
         width (or @*width width)

--- a/src/main/frontend/components/block/image.cljs
+++ b/src/main/frontend/components/block/image.cljs
@@ -1,0 +1,11 @@
+(ns frontend.components.block.image
+  "Helpers for rendering image blocks and asset image references.")
+
+(defn effective-image-metadata
+  [config asset-block metadata]
+  (let [resize-metadata (if asset-block
+                          (:logseq.property.asset/resize-metadata asset-block)
+                          (get-in config [:block :logseq.property.asset/resize-metadata]))]
+    (if (map? resize-metadata)
+      (merge metadata resize-metadata)
+      metadata)))

--- a/src/test/frontend/components/block/image_test.cljs
+++ b/src/test/frontend/components/block/image_test.cljs
@@ -1,0 +1,19 @@
+(ns frontend.components.block.image-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [frontend.components.block.image :as block-image]))
+
+(deftest effective-image-metadata-test
+  (testing "uses block resize metadata for network images"
+    (is (= {:alt "image"
+            :width 480}
+           (block-image/effective-image-metadata
+            {:block {:logseq.property.asset/resize-metadata {:width 480}}}
+            nil
+            {:alt "image"}))))
+
+  (testing "asset block resize metadata has priority for local assets"
+    (is (= {:width 720}
+           (block-image/effective-image-metadata
+            {:block {:logseq.property.asset/resize-metadata {:width 480}}}
+            {:logseq.property.asset/resize-metadata {:width 720}}
+            nil)))))


### PR DESCRIPTION
- Use persisted block resize metadata when rendering network images without asset blocks

fix https://github.com/logseq/db-test/issues/461