### PR TITLE
[codex] fix published roadmap task bullet overlap

### DIFF
--- a/deps/publish/src/logseq/publish/publish.css
+++ b/deps/publish/src/logseq/publish/publish.css
@@ -466,7 +466,7 @@ a:hover {
 
 .block-children .blocks {
   list-style: none;
-  padding-left: 0;
+  padding-left: 0 !important;
 }
 
 .block-children .block {

--- a/deps/publish/src/logseq/publish/publish.css
+++ b/deps/publish/src/logseq/publish/publish.css
@@ -465,8 +465,24 @@ a:hover {
 }
 
 .block-children .blocks {
-  list-style: initial;
-  padding-left: 18px;
+  list-style: none;
+  padding-left: 0;
+}
+
+.block-children .block {
+  position: relative;
+  padding-left: 24px;
+}
+
+.block-children .block::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 13px;
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: var(--muted);
 }
 
 .block {
@@ -494,7 +510,8 @@ a:hover {
 }
 
 .block-content > .positioned-properties.block-left {
-  align-self: center;
+  align-self: flex-start;
+  margin-top: 6px;
 }
 
 .positioned-properties.block-right {

--- a/scripts/test/logseq/publish-mobile-task-marker-layout.test.mjs
+++ b/scripts/test/logseq/publish-mobile-task-marker-layout.test.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+
+import { chromium } from 'playwright'
+
+const repoRoot = path.resolve(import.meta.dirname, '../../..')
+const publishCss = fs.readFileSync(
+  path.join(repoRoot, 'deps/publish/src/logseq/publish/publish.css'),
+  'utf8')
+
+test('published nested task bullets stay outside the task status row on mobile', async () => {
+  const browser = await chromium.launch()
+  const page = await browser.newPage({
+    viewport: { width: 390, height: 844 },
+    isMobile: true,
+    deviceScaleFactor: 3,
+  })
+
+  try {
+    await page.setContent(`
+      <!doctype html>
+      <html>
+        <head>
+          <style>${publishCss}</style>
+          <style>
+            .page { width: 330px; margin: 24px; }
+            .property-icon { background: rgb(0, 102, 255); }
+          </style>
+        </head>
+        <body>
+          <main class="page">
+            <div class="block-children">
+              <ul id="tasks" class="blocks">
+                <li id="task" class="block"><div id="content" class="block-content"><span id="status" class="positioned-properties block-left"><span class="positioned-property"><span class="property-value"><span class="property-icon ls-icon-Todo"></span></span></span></span><span class="block-text">Refresh the roadmap page on iPhone</span></div></li>
+              </ul>
+            </div>
+          </main>
+        </body>
+      </html>`)
+
+    const layout = await page.evaluate(() => {
+      const list = document.querySelector('#tasks')
+      const block = document.querySelector('#task')
+      const content = document.querySelector('#content')
+      const status = document.querySelector('#status')
+      const statusIcon = status.querySelector('.property-icon')
+      const before = getComputedStyle(block, '::before')
+      const listStyle = getComputedStyle(list)
+      const blockRect = block.getBoundingClientRect()
+      const contentRect = content.getBoundingClientRect()
+      const statusRect = status.getBoundingClientRect()
+      const statusIconRect = statusIcon.getBoundingClientRect()
+      const markerTop = Number.parseFloat(before.top)
+      const markerHeight = Number.parseFloat(before.height)
+
+      return {
+        listStyleType: listStyle.listStyleType,
+        markerContent: before.content,
+        markerLeft: before.left,
+        contentLeft: contentRect.left - blockRect.left,
+        statusLeft: statusRect.left - blockRect.left,
+        markerCenterY: markerTop + markerHeight / 2,
+        statusIconCenterY: statusIconRect.top - blockRect.top + statusIconRect.height / 2,
+      }
+    })
+
+    assert.equal(layout.listStyleType, 'none')
+    assert.equal(layout.markerContent, '""')
+    assert.equal(layout.markerLeft, '0px')
+    assert.ok(
+      layout.contentLeft >= 24,
+      `expected content to reserve bullet space, got ${layout.contentLeft}`)
+    assert.ok(
+      layout.statusLeft >= 24,
+      `expected status icon to start after bullet space, got ${layout.statusLeft}`)
+    assert.ok(
+      Math.abs(layout.statusIconCenterY - layout.markerCenterY) <= 1,
+      `expected status icon to align with bullet center, got status=${layout.statusIconCenterY} marker=${layout.markerCenterY}`)
+  } finally {
+    await browser.close()
+  }
+})


### PR DESCRIPTION
## Summary
- replace native nested publish list markers with positioned CSS bullets
- reserve left padding for nested task rows so status icons and text do not overlap bullets on mobile
- add a Playwright mobile layout regression test for published nested task rows

## Root cause
Published nested blocks used browser-native list markers with a narrow list padding. On iOS-sized layouts, those markers could render into the same horizontal space as block-left task status icons.

## Validation
- node scripts/test/logseq/publish-mobile-task-marker-layout.test.mjs
- bb dev:lint-and-test

fix https://github.com/logseq/db-test/issues/860