### PR TITLE
fix(graph-parser): correct markdown table cell splitting for escaped pipes and code-span pipes

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
@@ -393,8 +393,9 @@
 
 (defn- split-markdown-table-row
   [line]
-  (let [s (cond-> (string/trim line)
-            (string/starts-with? (string/trim line) "|") (subs 1))
+  (let [line' (string/trim line)
+        s (cond-> line'
+            (string/starts-with? line' "|") (subs 1))
         trailing-pipe? (string/ends-with? s "|")]
     (loop [idx 0
            start 0

--- a/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
@@ -323,7 +323,7 @@
   [text config]
   (try
     (if (string/blank? text)
-      {}
+      []
       (-> text
           (inline-parse-json config)
           (common-util/json->clj)

--- a/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
@@ -375,7 +375,9 @@
           (= \` c)
           (let [run-length (backtick-run-length source idx)
                 end-idx (matching-backtick-index source idx run-length)]
-            (recur (+ idx run-length) end-idx))
+            (if end-idx
+              (recur (+ idx run-length) end-idx)
+              true))
 
           (and (= \| c)
                (some? code-end))

--- a/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
@@ -319,6 +319,209 @@
        (or (string/includes? content "^{")
            (string/includes? content "_{"))))
 
+(declare inline->edn)
+
+(defn- markdown-config?
+  [config]
+  (and (string? config)
+       (boolean (re-find #"\"format\"\s*:\s*\"Markdown\"" config))))
+
+(defn- backtick-run-length
+  [s idx]
+  (loop [idx' idx]
+    (if (and (< idx' (count s))
+             (= \` (nth s idx')))
+      (recur (inc idx'))
+      (- idx' idx))))
+
+(defn- matching-backtick-index
+  [s start-idx run-length]
+  (loop [idx (+ start-idx run-length)]
+    (when (< idx (count s))
+      (let [c (nth s idx)]
+        (if (= \` c)
+          (let [run-length' (backtick-run-length s idx)]
+            (if (= run-length run-length')
+              idx
+              (recur (+ idx run-length'))))
+          (recur (inc idx)))))))
+
+(defn- escaped-pipe?
+  [s idx]
+  (loop [idx' (dec idx)
+         n 0]
+    (if (and (not (neg? idx'))
+             (= \\ (nth s idx')))
+      (recur (dec idx') (inc n))
+      (odd? n))))
+
+(defn- markdown-table-source-needs-normalization?
+  [source]
+  (loop [idx 0
+         code-end nil]
+    (if (< idx (count source))
+      (let [c (nth source idx)]
+        (cond
+          (and (some? code-end)
+               (= idx code-end))
+          (recur (+ idx (backtick-run-length source idx)) nil)
+
+          (= \` c)
+          (let [run-length (backtick-run-length source idx)
+                end-idx (matching-backtick-index source idx run-length)]
+            (recur (+ idx run-length) end-idx))
+
+          (and (= \| c)
+               (some? code-end))
+          true
+
+          (and (= \| c)
+               (escaped-pipe? source idx))
+          true
+
+          :else
+          (recur (inc idx) code-end)))
+      false)))
+
+(defn- split-markdown-table-row
+  [line]
+  (let [s (cond-> (string/trim line)
+            (string/starts-with? (string/trim line) "|") (subs 1))
+        trailing-pipe? (string/ends-with? s "|")]
+    (loop [idx 0
+           start 0
+           code-end nil
+           cells []]
+      (if (< idx (count s))
+        (let [c (nth s idx)]
+          (cond
+            (and (some? code-end)
+                 (= idx code-end))
+            (recur (+ idx (backtick-run-length s idx)) start nil cells)
+
+            (= \` c)
+            (let [run-length (backtick-run-length s idx)
+                  end-idx (matching-backtick-index s idx run-length)]
+              (recur (+ idx run-length) start end-idx cells))
+
+            (and (= \| c)
+                 (nil? code-end)
+                 (not (escaped-pipe? s idx)))
+            (recur (inc idx) (inc idx) code-end
+                   (conj cells (subs s start idx)))
+
+            :else
+            (recur (inc idx) start code-end cells)))
+        (let [cells' (conj cells (subs s start))]
+          (mapv string/trim
+                (if (and trailing-pipe?
+                         (string/blank? (peek cells')))
+                  (pop cells')
+                  cells')))))))
+
+(defn- markdown-table-separator-line?
+  [line]
+  (let [line' (string/trim line)]
+    (and (string/includes? line' "-")
+         (boolean (re-matches #"[\s|:-]+" line')))))
+
+(defn- unescape-markdown-table-pipes
+  [s]
+  (loop [idx 0
+         code-end nil
+         result-parts []]
+    (if (< idx (count s))
+      (let [c (nth s idx)]
+        (cond
+          (and (some? code-end)
+               (= idx code-end))
+          (let [run-length (backtick-run-length s idx)]
+            (recur (+ idx run-length) nil
+                   (conj result-parts (subs s idx (+ idx run-length)))))
+
+          (= \` c)
+          (let [run-length (backtick-run-length s idx)
+                tick-run (subs s idx (+ idx run-length))
+                end-idx (matching-backtick-index s idx run-length)]
+            (recur (+ idx run-length) end-idx (conj result-parts tick-run)))
+
+          (and (nil? code-end)
+               (= \\ c)
+               (< (inc idx) (count s))
+               (= \| (nth s (inc idx))))
+          (recur (+ idx 2) code-end (conj result-parts "|"))
+
+          :else
+          (recur (inc idx) code-end (conj result-parts c))))
+      (apply str result-parts))))
+
+(defn- table-cell->inline-ast
+  [cell config]
+  (let [cell' (unescape-markdown-table-pipes (string/trim cell))]
+    (if (string/blank? cell')
+      [["Plain" ""]]
+      (inline->edn cell' config))))
+
+(defn- table-row->inline-asts
+  [line config]
+  (mapv #(table-cell->inline-ast % config)
+        (split-markdown-table-row line)))
+
+(defn- table-body-groups
+  [lines config]
+  (loop [lines lines
+         current []
+         groups []]
+    (if-let [[line & more] (seq lines)]
+      (if (markdown-table-separator-line? line)
+        (recur more [] (cond-> groups
+                         (seq current) (conj current)))
+        (recur more
+               (conj current (table-row->inline-asts line config))
+               groups))
+      (cond-> groups
+        (seq current) (conj current)))))
+
+(defn- table-col-groups
+  [fallback-table col-count]
+  (let [col-groups (:col_groups fallback-table)]
+    (if (and (seq col-groups)
+             (= col-count (reduce + col-groups)))
+      col-groups
+      [col-count])))
+
+(defn- source->markdown-table
+  [source config fallback-table]
+  (let [lines (remove string/blank? (string/split-lines source))]
+    (if-let [header-line (first lines)]
+      (let [header (table-row->inline-asts header-line config)
+            body-lines (rest lines)
+            groups (table-body-groups body-lines config)
+            col-count (apply max (count header)
+                             (mapcat (fn [group] (map count group)) groups))]
+        (assoc fallback-table
+               :header header
+               :groups groups
+               :col_groups (table-col-groups fallback-table col-count)))
+      fallback-table)))
+
+(defn- normalize-markdown-table-asts
+  [ast content config]
+  (if (markdown-config? config)
+    (let [payload (utf8/encode content)]
+      (mapv (fn [[block pos-meta :as item]]
+              (if (and (vector? block)
+                       (= "Table" (first block)))
+                (let [{:keys [start_pos end_pos]} pos-meta
+                      source (utf8/substring payload start_pos end_pos)]
+                  (if (markdown-table-source-needs-normalization? source)
+                    [["Table" (source->markdown-table source config (second block))]
+                     pos-meta]
+                    item))
+                item))
+            ast))
+    ast))
+
 (defn collect-page-properties
   [ast config]
   (when (seq ast)
@@ -359,6 +562,7 @@
          (-> content
              (parse-json config)
              (common-util/json->clj)
+             (normalize-markdown-table-asts content config)
              (cond-> (macro-with-script-markup? content)
                (normalize-macro-asts))
              (update-src-full-content content)

--- a/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
@@ -494,10 +494,10 @@
         (seq current) (conj current)))))
 
 (defn- table-col-groups
-  [fallback-table col-count]
+  [fallback-table header-col-count col-count]
   (let [col-groups (:col_groups fallback-table)]
     (if (and (seq col-groups)
-             (= col-count (reduce + col-groups)))
+             (= header-col-count (reduce + col-groups)))
       col-groups
       [col-count])))
 
@@ -513,7 +513,7 @@
         (assoc fallback-table
                :header header
                :groups groups
-               :col_groups (table-col-groups fallback-table col-count)))
+               :col_groups (table-col-groups fallback-table (count header) col-count)))
       fallback-table)))
 
 (defn- table-ast-item?

--- a/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/mldoc.cljc
@@ -319,12 +319,18 @@
        (or (string/includes? content "^{")
            (string/includes? content "_{"))))
 
-(declare inline->edn)
-
-(defn- markdown-config?
-  [config]
-  (and (string? config)
-       (boolean (re-find #"\"format\"\s*:\s*\"Markdown\"" config))))
+(defn inline->edn
+  [text config]
+  (try
+    (if (string/blank? text)
+      {}
+      (-> text
+          (inline-parse-json config)
+          (common-util/json->clj)
+          (cond-> (macro-with-script-markup? text)
+            (normalize-macro-asts))))
+    (catch :default _e
+      [])))
 
 (defn- backtick-run-length
   [s idx]
@@ -413,11 +419,10 @@
             :else
             (recur (inc idx) start code-end cells)))
         (let [cells' (conj cells (subs s start))]
-          (mapv string/trim
-                (if (and trailing-pipe?
-                         (string/blank? (peek cells')))
-                  (pop cells')
-                  cells')))))))
+          (if (and trailing-pipe?
+                   (string/blank? (peek cells')))
+            (pop cells')
+            cells'))))))
 
 (defn- markdown-table-separator-line?
   [line]
@@ -460,7 +465,10 @@
   (let [cell' (unescape-markdown-table-pipes (string/trim cell))]
     (if (string/blank? cell')
       [["Plain" ""]]
-      (inline->edn cell' config))))
+      (let [ast (inline->edn cell' config)]
+        (if (seq ast)
+          ast
+          [["Plain" cell']])))))
 
 (defn- table-row->inline-asts
   [line config]
@@ -505,13 +513,18 @@
                :col_groups (table-col-groups fallback-table col-count)))
       fallback-table)))
 
+(defn- table-ast-item?
+  [[block _pos-meta]]
+  (and (vector? block)
+       (= "Table" (first block))))
+
 (defn- normalize-markdown-table-asts
   [ast content config]
-  (if (markdown-config? config)
+  (if-not (some table-ast-item? ast)
+    ast
     (let [payload (utf8/encode content)]
       (mapv (fn [[block pos-meta :as item]]
-              (if (and (vector? block)
-                       (= "Table" (first block)))
+              (if (table-ast-item? item)
                 (let [{:keys [start_pos end_pos]} pos-meta
                       source (utf8/substring payload start_pos end_pos)]
                   (if (markdown-table-source-needs-normalization? source)
@@ -519,8 +532,7 @@
                      pos-meta]
                     item))
                 item))
-            ast))
-    ast))
+            ast))))
 
 (defn collect-page-properties
   [ast config]
@@ -578,19 +590,6 @@
   "Wrapper around ->edn for DB graphs"
   [content format]
   (->edn "logseq_db_repo_stub" content format))
-
-(defn inline->edn
-  [text config]
-  (try
-    (if (string/blank? text)
-      {}
-      (-> text
-          (inline-parse-json config)
-          (common-util/json->clj)
-          (cond-> (macro-with-script-markup? text)
-            (normalize-macro-asts))))
-    (catch :default _e
-      [])))
 
 (defn ast-link?
   [[type link]]

--- a/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
@@ -189,18 +189,6 @@
               []]
              [header groups col_groups]))))
 
-  (testing "non-markdown configs are not normalized"
-    (let [ast [[["Table" {:header [[["Plain" "A"]]
-                                    [["Plain" "B"]]]
-                          :groups []
-                          :col_groups [1 1]}]
-                {:start_pos 0 :end_pos 14}]]]
-      (is (= ast
-             (normalize-markdown-table-asts
-              ast
-              "|A \\||`B | C`|"
-              (gp-mldoc/default-config :org))))))
-
   (testing "fallback table column groups are preserved"
     (let [ast [[["Table" {:header [[["Plain" "A"]]
                                     [["Plain" "B"]]]
@@ -213,6 +201,21 @@
            "|A \\||`B | C`|"
            md-config)]
       (is (= [1 1] (:col_groups table)))))
+
+  (testing "cell content is preserved when inline parsing fails"
+    (let [ast [[["Table" {:header [[["Plain" "A"]]]
+                          :groups []
+                          :col_groups [1]}]
+                {:start_pos 0 :end_pos 6}]]
+          [[[_ table] _pos-meta]]
+          (normalize-markdown-table-asts
+           ast
+           "|A \\||"
+           "invalid config")]
+      (is (= [[[["Plain" "A |"]]]
+              []
+              [1]]
+             [(:header table) (:groups table) (:col_groups table)]))))
 
   (testing "unclosed code spans do not hide cell boundaries"
     (let [{:keys [header groups col_groups]}

--- a/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
@@ -202,6 +202,20 @@
            md-config)]
       (is (= [1 1] (:col_groups table)))))
 
+  (testing "fallback column groups survive malformed rows"
+    (let [ast [[["Table" {:header [[["Plain" "A"]]
+                                    [["Plain" "B"]]]
+                          :groups []
+                          :col_groups [1 1]}]
+                {:start_pos 0 :end_pos 16}]]
+          [[[_ table] _pos-meta]]
+          (normalize-markdown-table-asts
+           ast
+           "|A \\||B|
+|1|2|3|"
+           md-config)]
+      (is (= [1 1] (:col_groups table)))))
+
   (testing "cell content is preserved when inline parsing fails"
     (let [ast [[["Table" {:header [[["Plain" "A"]]]
                           :groups []
@@ -230,6 +244,19 @@
                  [["Plain" "bar"]]
                  [["Plain" "baz |"]]]]]
               [3]]
+             [header groups col_groups]))))
+
+  (testing "unclosed code spans trigger normalization without escaped pipes"
+    (let [{:keys [header groups col_groups]}
+          (markdown-table
+           "|A|B|
+|---|---|
+|`foo | bar|")]
+      (is (= [[[["Plain" "A"]]
+               [["Plain" "B"]]]
+              [[[[["Plain" "`foo"]]
+                 [["Plain" "bar"]]]]]
+              [2]]
              [header groups col_groups])))))
 
 (defn- parse-properties

--- a/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/mldoc_test.cljs
@@ -37,6 +37,16 @@
               [(keyword k) (text/parse-property k v ast {})]))
        (into {})))
 
+(defn- markdown-table
+  [text]
+  (let [[block _pos-meta] (first (gp-mldoc/->edn text md-config))]
+    (is (= "Table" (first block)))
+    (second block)))
+
+(defn- normalize-markdown-table-asts
+  [ast content config]
+  ((deref (var gp-mldoc/normalize-markdown-table-asts)) ast content config))
+
 (deftest md-properties-test
   (are [x y] (= y (get-properties x))
 
@@ -110,6 +120,114 @@
                ffirst
                second
                :title)))))
+
+(deftest markdown-table-cell-boundary-test
+  (testing "escaped pipes and code spans do not split table cells"
+    (let [{:keys [header groups col_groups]}
+          (markdown-table
+           "|Column A|Column B|
+|---|---|
+|Row 1|Some text|
+|Row 2, \\||Pipe character with escape \\||
+|Row 3, `|`|Pipe character between `|`|")]
+      (is (= [[["Plain" "Column A"]]
+              [["Plain" "Column B"]]]
+             header))
+      (is (= [[[[["Plain" "Row 1"]]
+                [["Plain" "Some text"]]]
+               [[["Plain" "Row 2, |"]]
+                [["Plain" "Pipe character with escape |"]]]
+               [[["Plain" "Row 3, "]
+                 ["Code" "|"]]
+                [["Plain" "Pipe character between "]
+                 ["Code" "|"]]]]]
+             groups))
+      (is (= [2] col_groups))))
+
+  (testing "header cells can contain escaped pipes and code-span pipes"
+    (let [{:keys [header groups col_groups]}
+          (markdown-table
+           "|Label \\||Code `a | b`|
+|---|---|
+|left \\| right|`x | y`|")]
+      (is (= [[[["Plain" "Label |"]]
+               [["Plain" "Code "]
+                ["Code" "a | b"]]]
+              [[[[["Plain" "left | right"]]
+                 [["Code" "x | y"]]]]]
+              [2]]
+             [header groups col_groups]))))
+
+  (testing "separator rows still split table body groups"
+    (let [{:keys [header groups col_groups]}
+          (markdown-table
+           "|A|B|
+|---|---|
+|one \\| two|`three | four`|
+|---|---|
+|five|six \\||")]
+      (is (= [[[["Plain" "A"]]
+               [["Plain" "B"]]]
+              [[[[["Plain" "one | two"]]
+                 [["Code" "three | four"]]]]
+               [[[["Plain" "five"]]
+                 [["Plain" "six |"]]]]]
+              [2]]
+             [header groups col_groups]))))
+
+  (testing "ordinary markdown tables keep mldoc's original AST"
+    (let [{:keys [header groups col_groups]}
+          (markdown-table
+           "|A|B|
+|---|---|
+|---|---|
+|1|2|")]
+      (is (= [[[["Plain" "A"]]
+               [["Plain" "B"]]]
+              [[], [[[["Plain" "1"]]
+                     [["Plain" "2"]]]]]
+              []]
+             [header groups col_groups]))))
+
+  (testing "non-markdown configs are not normalized"
+    (let [ast [[["Table" {:header [[["Plain" "A"]]
+                                    [["Plain" "B"]]]
+                          :groups []
+                          :col_groups [1 1]}]
+                {:start_pos 0 :end_pos 14}]]]
+      (is (= ast
+             (normalize-markdown-table-asts
+              ast
+              "|A \\||`B | C`|"
+              (gp-mldoc/default-config :org))))))
+
+  (testing "fallback table column groups are preserved"
+    (let [ast [[["Table" {:header [[["Plain" "A"]]
+                                    [["Plain" "B"]]]
+                          :groups []
+                          :col_groups [1 1]}]
+                {:start_pos 0 :end_pos 14}]]
+          [[[_ table] _pos-meta]]
+          (normalize-markdown-table-asts
+           ast
+           "|A \\||`B | C`|"
+           md-config)]
+      (is (= [1 1] (:col_groups table)))))
+
+  (testing "unclosed code spans do not hide cell boundaries"
+    (let [{:keys [header groups col_groups]}
+          (markdown-table
+           "|A|B|C|
+|---|---|---|
+|`foo | bar | baz \\||")]
+      (is (= [[[["Plain" "A"]]
+               [["Plain" "B"]]
+               [["Plain" "C"]]]
+              [[[[["Plain" "`foo"]]
+                 [["Plain" "bar"]]
+                 [["Plain" "baz |"]]]]]
+              [3]]
+             [header groups col_groups])))))
 
 (defn- parse-properties
   [text]


### PR DESCRIPTION
fix https://github.com/logseq/db-test/issues/513