### PR TITLE
fix: block property values deletion

### DIFF
--- a/deps/outliner/src/logseq/outliner/property.cljs
+++ b/deps/outliner/src/logseq/outliner/property.cljs
@@ -356,7 +356,7 @@
 
 (defn- find-or-create-property-value
   "Find or create a property value. Only to be used with properties that have ref types"
-  [conn property-id v]
+  [conn property-id v block-id]
   (let [property (d/entity @conn property-id)
         closed-values? (seq (entity-plus/lookup-kv-then-entity property :property/closed-values))
         default-or-url? (contains? #{:default :url} (:logseq.property/type property))]
@@ -370,7 +370,7 @@
       (and default-or-url?
            ;; FIXME: remove this when :logseq.property/order-list-type updated to closed values
            (not= property-id :logseq.property/order-list-type))
-      (let [v-uuid (create-property-text-block! conn nil property-id v {})]
+      (let [v-uuid (create-property-text-block! conn block-id property-id v {})]
         (:db/id (d/entity @conn [:block/uuid v-uuid])))
 
       :else
@@ -381,7 +381,7 @@
 (defn- convert-ref-property-value
   "Converts a ref property's value whether it's an integer or a string. Creates
    a property ref value for a string value if necessary"
-  [conn property-id v property-type]
+  [conn property-id v property-type block-id]
   (let [number-property? (= property-type :number)]
     (cond
       (and (qualified-keyword? v) (not= :keyword property-type))
@@ -418,14 +418,14 @@
       (when-let [v' (if (and number-property? (string? v))
                       (parse-double v)
                       v)]
-        (find-or-create-property-value conn property-id v')))))
+        (find-or-create-property-value conn property-id v' block-id)))))
 
 (defn- convert-ref-property-values
-  [conn property-id value property-type {:keys [many?]}]
+  [conn property-id value property-type {:keys [many? block-id]}]
   (if-not (and many? (or (sequential? value) (set? value)))
-    (convert-ref-property-value conn property-id value property-type)
+    (convert-ref-property-value conn property-id value property-type block-id)
     (try
-      (mapv #(convert-ref-property-value conn property-id % property-type) value)
+      (mapv #(convert-ref-property-value conn property-id % property-type block-id) value)
       (catch :default e
         (throw (ex-info "Failed to convert many property values"
                         (merge
@@ -514,6 +514,14 @@
      (if (number? v) (d/entity @conn v) v)
      (map #(d/entity @conn %) block-eids))))
 
+(defn- normalize-default-url-property-value
+  [conn property value]
+  (if (number? value)
+    (do
+      (throw-error-if-invalid-property-value @conn property value)
+      (:block/title (d/entity @conn value)))
+    value))
+
 (defn batch-set-property!
   "Sets properties for multiple blocks. Automatically handles property value refs.
    Does no validation of property values. For :many properties, passing a collection
@@ -537,7 +545,9 @@
            default-url-not-closed? (and (contains? #{:default :url} property-type)
                                         (not (seq (entity-plus/lookup-kv-then-entity property :property/closed-values))))
            v' (if (and ref? (not entity-id?))
-                (convert-ref-property-values conn property-id v property-type {:many? many?})
+                (if default-url-not-closed?
+                  v
+                  (convert-ref-property-values conn property-id v property-type {:many? many?}))
                 v)
            _ (when (nil? v')
                (throw (ex-info "Property value must be not nil" {:v v})))
@@ -546,18 +556,13 @@
                  (fn [eid]
                    (if-let [block (d/entity @conn eid)]
                      (let [v' (if (and default-url-not-closed?
-                                       (not (and (keyword? v) entity-id?)))
-                                (let [normalize-default-url-value
-                                      (fn [value]
-                                        (if (number? value)
-                                          (do
-                                            (throw-error-if-invalid-property-value @conn property value)
-                                            (:block/title (d/entity @conn value)))
-                                          value))
-                                      value' (if (and many? (or (sequential? v') (set? v')))
-                                               (mapv normalize-default-url-value v')
-                                               (normalize-default-url-value v'))]
-                                  (convert-ref-property-values conn property-id value' property-type {:many? many?}))
+                                        (not (and (keyword? v) entity-id?)))
+                                (let [value' (if (and many? (or (sequential? v') (set? v')))
+                                               (mapv #(normalize-default-url-property-value conn property %) v')
+                                               (normalize-default-url-property-value conn property v'))]
+                                  (convert-ref-property-values conn property-id value' property-type
+                                                               {:many? many?
+                                                                :block-id (:db/id block)}))
                                 v')]
                        (throw-error-if-self-value block v' ref?)
                        (throw-error-if-invalid-property-value @conn property v')
@@ -639,7 +644,7 @@
             property-type (get property :logseq.property/type :default)
             ref? (db-property-type/all-ref-property-types property-type)
             v' (if ref?
-                 (convert-ref-property-value conn property-id v property-type)
+                 (convert-ref-property-value conn property-id v property-type block-eid)
                  v)]
         (when-not (and block property)
           (throw (ex-info "Set block property failed: block or property doesn't exist"

--- a/deps/outliner/src/logseq/outliner/property.cljs
+++ b/deps/outliner/src/logseq/outliner/property.cljs
@@ -291,6 +291,16 @@
                  value)]
     (validate! property schema value')))
 
+(defn- throw-error-if-invalid-new-property-value
+  [db property value]
+  (let [property-type (:logseq.property/type property)
+        many? (= :db.cardinality/many (:db/cardinality property))
+        schema (get-property-value-schema db property-type property :new-closed-value? true)
+        value' (if (and many? (not (or (sequential? value) (set? value))))
+                 #{value}
+                 value)]
+    (validate! property schema value')))
+
 (defn- ->eid
   [id]
   (if (uuid? id) [:block/uuid id] id))
@@ -305,9 +315,11 @@
     (ldb/transact! conn tx-data {:outliner-op :save-block})))
 
 (defn create-property-text-block!
-  "Creates a property value block for the given property and value. Adds it to
-  block if given block."
-  [conn block-id property-id value {:keys [new-block-id]}]
+  "Creates a property value block for the given property and value.
+
+  Adds it to `block-id` unless `:set-block-property?` is false."
+  [conn block-id property-id value {:keys [new-block-id set-block-property?]
+                                    :or {set-block-property? true}}]
   (let [property (d/entity @conn property-id)
         block (when block-id (d/entity @conn block-id))
         _ (assert (some? property) (str "Property " property-id " doesn't exist yet"))
@@ -327,7 +339,7 @@
      (fn [conn]
        (ldb/transact! conn [new-value-block] {:outliner-op :insert-blocks})
        (let [property-id (:db/ident property)]
-         (when (and property-id block)
+         (when (and property-id block set-block-property?)
            (when-let [block-id (:db/id (d/entity @conn [:block/uuid (:block/uuid new-value-block)]))]
              (raw-set-block-property! conn block property block-id))))))
     (:block/uuid new-value-block)))
@@ -370,7 +382,8 @@
       (and default-or-url?
            ;; FIXME: remove this when :logseq.property/order-list-type updated to closed values
            (not= property-id :logseq.property/order-list-type))
-      (let [v-uuid (create-property-text-block! conn block-id property-id v {})]
+      (let [_ (throw-error-if-invalid-new-property-value @conn property v)
+            v-uuid (create-property-text-block! conn block-id property-id v {:set-block-property? false})]
         (:db/id (d/entity @conn [:block/uuid v-uuid])))
 
       :else
@@ -522,6 +535,19 @@
       (:block/title (d/entity @conn value)))
     value))
 
+(defn- normalize-and-validate-default-url-property-value
+  [conn property value]
+  (let [value' (normalize-default-url-property-value conn property value)]
+    (when-not (qualified-keyword? value')
+      (throw-error-if-invalid-new-property-value @conn property value'))
+    value'))
+
+(defn- normalize-and-validate-default-url-property-values
+  [conn property value many?]
+  (if (and many? (or (sequential? value) (set? value)))
+    (mapv #(normalize-and-validate-default-url-property-value conn property %) value)
+    (normalize-and-validate-default-url-property-value conn property value)))
+
 (defn batch-set-property!
   "Sets properties for multiple blocks. Automatically handles property value refs.
    Does no validation of property values. For :many properties, passing a collection
@@ -546,7 +572,7 @@
                                         (not (seq (entity-plus/lookup-kv-then-entity property :property/closed-values))))
            v' (if (and ref? (not entity-id?))
                 (if default-url-not-closed?
-                  v
+                  (normalize-and-validate-default-url-property-values conn property v many?)
                   (convert-ref-property-values conn property-id v property-type {:many? many?}))
                 v)
            _ (when (nil? v')
@@ -557,12 +583,9 @@
                    (if-let [block (d/entity @conn eid)]
                      (let [v' (if (and default-url-not-closed?
                                         (not (and (keyword? v) entity-id?)))
-                                (let [value' (if (and many? (or (sequential? v') (set? v')))
-                                               (mapv #(normalize-default-url-property-value conn property %) v')
-                                               (normalize-default-url-property-value conn property v'))]
-                                  (convert-ref-property-values conn property-id value' property-type
-                                                               {:many? many?
-                                                                :block-id (:db/id block)}))
+                                (convert-ref-property-values conn property-id v' property-type
+                                                             {:many? many?
+                                                              :block-id (:db/id block)})
                                 v')]
                        (throw-error-if-self-value block v' ref?)
                        (throw-error-if-invalid-property-value @conn property v')

--- a/deps/outliner/src/logseq/outliner/property.cljs
+++ b/deps/outliner/src/logseq/outliner/property.cljs
@@ -962,11 +962,14 @@
         (assert (every? uuid? values') "existing values should all be UUIDs")
         (let [values (keep #(d/entity @conn [:block/uuid %]) values')]
           (when (seq values)
-            (let [value-property-tx (map (fn [id]
+            (let [property-db-id (:db/id property)
+                  value-property-tx (map (fn [id]
                                            {:db/id id
-                                            :block/closed-value-property (:db/id property)})
+                                            :block/closed-value-property property-db-id
+                                            :block/parent property-db-id
+                                            :block/page property-db-id})
                                          (map :db/id values))
-                  property-tx (outliner-core/block-with-updated-at {:db/id (:db/id property)})]
+                  property-tx (outliner-core/block-with-updated-at {:db/id property-db-id})]
               (ldb/transact! conn (cons property-tx value-property-tx)
                              {:outliner-op :add-existing-values-to-closed-values}))))))))
 

--- a/deps/outliner/test/logseq/outliner/property_test.cljs
+++ b/deps/outliner/test/logseq/outliner/property_test.cljs
@@ -4,6 +4,7 @@
             [logseq.db :as ldb]
             [logseq.db.frontend.property :as db-property]
             [logseq.db.test.helper :as db-test]
+            [logseq.outliner.core :as outliner-core]
             [logseq.outliner.property :as outliner-property]))
 
 (deftest upsert-property!
@@ -337,6 +338,32 @@
         _ (outliner-property/add-existing-values-to-closed-values! conn :user.property/num values)]
     (is (= [1 2]
            (map db-property/closed-value-content (:block/_closed-value-property (d/entity @conn :user.property/num)))))))
+
+(deftest add-existing-generated-value-to-closed-values-reparents-to-property
+  (let [conn (db-test/create-conn-with-blocks
+              {:properties {:user.property/reproducible-steps {:logseq.property/type :default
+                                                               :db/cardinality :db.cardinality/many
+                                                               :logseq.property/public? true}}
+               :pages-and-blocks [{:page {:block/title "page1"}
+                                   :blocks [{:block/title "target"}]}]})
+        property (d/entity @conn :user.property/reproducible-steps)
+        block (db-test/find-block-by-content @conn "target")
+        block-uuid (:block/uuid block)]
+    (outliner-property/batch-set-property! conn [block-uuid] :user.property/reproducible-steps ["Step 1"])
+    (let [generated-value (first (:user.property/reproducible-steps (d/entity @conn [:block/uuid block-uuid])))
+          value-uuid (:block/uuid generated-value)]
+      (is (= (:db/id block) (:db/id (:block/parent generated-value))))
+
+      (outliner-property/add-existing-values-to-closed-values! conn :user.property/reproducible-steps [value-uuid])
+      (let [closed-value (d/entity @conn [:block/uuid value-uuid])]
+        (is (= #{(:db/id property)}
+               (set (map :db/id (:block/closed-value-property closed-value)))))
+        (is (= (:db/id property) (:db/id (:block/parent closed-value))))
+        (is (= (:db/id property) (:db/id (:block/page closed-value))))
+        (is (= "Step 1" (db-property/closed-value-content closed-value)))
+
+        (outliner-core/delete-blocks! conn [(d/entity @conn [:block/uuid block-uuid])] {})
+        (is (some? (d/entity @conn [:block/uuid value-uuid])))))))
 
 (deftest upsert-closed-value!
   (let [conn (db-test/create-conn-with-blocks

--- a/src/test/frontend/db/property_values_test.cljs
+++ b/src/test/frontend/db/property_values_test.cljs
@@ -7,6 +7,7 @@
             [logseq.db.common.view :as db-view]
             [logseq.db.frontend.property :as db-property]
             [logseq.db.test.helper :as db-test]
+            [logseq.outliner.core :as outliner-core]
             [logseq.outliner.property :as outliner-property]))
 
 (def repo test-helper/test-db)
@@ -47,6 +48,27 @@
         property (d/entity db :user.property/closed-values-visibility)
         values (entity-plus/lookup-kv-then-entity property :property/closed-values)]
     (is (= ["Visible closed value"] (map :block/title values)))))
+
+(deftest deleting-block-removes-cli-created-default-property-values-test
+  (let [property-ident :user.property/xxx-IiHzt48w
+        conn (db-test/create-conn-with-blocks
+              {:properties {property-ident {:logseq.property/type :default
+                                            :db/cardinality :db.cardinality/many
+                                            :logseq.property/public? true
+                                            :block/title "xxx"}}
+               :pages-and-blocks [{:page {:block/title "page1"}
+                                   :blocks [{:block/title "block1"}]}]})
+        block (db-test/find-block-by-content @conn "block1")
+        block-uuid (:block/uuid block)]
+    (outliner-property/batch-set-property! conn [block-uuid] property-ident "x1")
+    (let [block (d/entity @conn [:block/uuid block-uuid])
+          value (first (get block property-ident))
+          value-id (:db/id value)]
+      (is (= (:db/id block) (:db/id (:block/parent value)))
+          "Generated default property value blocks should be owned by their block")
+      (outliner-core/delete-blocks! conn [block] {})
+      (is (nil? (d/entity @conn value-id))
+          "Deleting the owning block removes its generated property value block"))))
 
 (deftest class-add-property-keeps-scoped-choices-unchanged-test
   (let [conn (db-test/create-conn-with-blocks

--- a/src/test/frontend/db/property_values_test.cljs
+++ b/src/test/frontend/db/property_values_test.cljs
@@ -49,26 +49,64 @@
         values (entity-plus/lookup-kv-then-entity property :property/closed-values)]
     (is (= ["Visible closed value"] (map :block/title values)))))
 
-(deftest deleting-block-removes-cli-created-default-property-values-test
-  (let [property-ident :user.property/xxx-IiHzt48w
+(defn- assert-deleting-block-removes-cli-created-property-values
+  [property-type property-ident value]
+  (let [property-title (name property-ident)
         conn (db-test/create-conn-with-blocks
-              {:properties {property-ident {:logseq.property/type :default
+              {:properties {property-ident {:logseq.property/type property-type
                                             :db/cardinality :db.cardinality/many
                                             :logseq.property/public? true
-                                            :block/title "xxx"}}
+                                            :block/title property-title}}
                :pages-and-blocks [{:page {:block/title "page1"}
                                    :blocks [{:block/title "block1"}]}]})
         block (db-test/find-block-by-content @conn "block1")
         block-uuid (:block/uuid block)]
-    (outliner-property/batch-set-property! conn [block-uuid] property-ident "x1")
+    (outliner-property/batch-set-property! conn [block-uuid] property-ident value)
     (let [block (d/entity @conn [:block/uuid block-uuid])
           value (first (get block property-ident))
           value-id (:db/id value)]
       (is (= (:db/id block) (:db/id (:block/parent value)))
-          "Generated default property value blocks should be owned by their block")
+          "Generated property value blocks should be owned by their block")
       (outliner-core/delete-blocks! conn [block] {})
       (is (nil? (d/entity @conn value-id))
           "Deleting the owning block removes its generated property value block"))))
+
+(deftest deleting-block-removes-cli-created-default-property-values-test
+  (assert-deleting-block-removes-cli-created-property-values
+   :default
+   :user.property/xxx-IiHzt48w
+   "x1"))
+
+(deftest deleting-block-removes-cli-created-url-property-values-test
+  (assert-deleting-block-removes-cli-created-property-values
+   :url
+   :user.property/url-IiHzt48w
+   "https://example.com/x1"))
+
+(deftest batch-set-property-does-not-partially-write-generated-values-test
+  (let [property-ident :user.property/atomic-IiHzt48w
+        conn (db-test/create-conn-with-blocks
+              {:properties {property-ident {:logseq.property/type :default
+                                            :db/cardinality :db.cardinality/many
+                                            :logseq.property/public? true
+                                            :block/title "atomic"}}
+               :pages-and-blocks [{:page {:block/title "page1"}
+                                   :blocks [{:block/title "block1"}]}]})
+        block (db-test/find-block-by-content @conn "block1")
+        block-uuid (:block/uuid block)]
+    (is (thrown? js/Error
+                 (outliner-property/batch-set-property! conn [block-uuid] property-ident ["x1" {}])))
+    (let [block (d/entity @conn [:block/uuid block-uuid])
+          generated-values (d/q '[:find [?v ...]
+                                  :in $ ?property-ident
+                                  :where
+                                  [?v :logseq.property/created-from-property ?property-ident]]
+                                @conn
+                                property-ident)]
+      (is (empty? (get block property-ident))
+          "Failed updates should not leave generated values on the block")
+      (is (empty? generated-values)
+          "Failed updates should not leave generated value blocks"))))
 
 (deftest class-add-property-keeps-scoped-choices-unchanged-test
   (let [conn (db-test/create-conn-with-blocks


### PR DESCRIPTION
### Summary

Fixes generated default/url property value blocks so they are owned by the block that uses them when values are created through block property updates.

Previously, CLI-style property updates such as `upsert block --update-properties '{"xxx" "x1"}'` could create the generated value block under the property entity. When the owning block was deleted, that value block was outside the deleted block subtree and remained in the graph database.

This change passes the owning block context into property value creation for default/url ref values, so generated values are attached to the block and are removed with it.

### Testing

- `bb dev:test -v frontend.db.property-values-test/deleting-block-removes-cli-created-default-property-values-test`
- `bb dev:test -n frontend.db.property-values-test`
- `bb -f cli-e2e/bb.edn build`
- Manual CLI reproduction with a temporary graph:
  - created a `many` default property `xxx`
  - set `{"xxx" "x1"}` on `block1`
  - verified the generated value block parent is `block1`
  - deleted `block1`
  - verified the generated value block returns `entity-not-found`
- `clojure -M:clj-kondo --lint src test` in `deps/outliner`
- `bb lint:carve` in `deps/outliner`
- `bb lint:large-vars` in `deps/outliner`
