### PR TITLE
[codex] fix scoped node property value dialog performance

### DIFF
--- a/src/main/frontend/components/property/value.cljs
+++ b/src/main/frontend/components/property/value.cljs
@@ -697,6 +697,40 @@
       initial-choices'
       (conj initial-choices' new-choice))))
 
+(def ^:private broad-scoped-node-class-idents
+  #{:logseq.class/Page})
+
+(defn- broad-scoped-node-property?
+  [property classes]
+  (and (= :node (:logseq.property/type property))
+       (some #(contains? broad-scoped-node-class-idents (:db/ident %)) classes)))
+
+(defn- scoped-class-ids
+  [repo classes]
+  (->> classes
+       (mapcat (fn [class]
+                 (cons (:db/id class)
+                       (model/get-structured-children repo (:db/id class)))))
+       set))
+
+(defn- node-matches-scoped-classes?
+  [class-ids node]
+  (let [node (or (:value node) node)]
+    (some #(contains? class-ids (if (integer? %) % (:db/id %))) (:block/tags node))))
+
+(defn- scoped-class-nodes
+  [repo property classes result]
+  (let [broad-scope? (broad-scoped-node-property? property classes)]
+    (if (or (some? result) broad-scope?)
+      (let [class-ids (scoped-class-ids repo classes)]
+        (filter #(node-matches-scoped-classes? class-ids %) result))
+      (->>
+       (mapcat
+        (fn [class]
+          (model/get-class-objects repo (:db/id class)))
+        classes)
+       distinct))))
+
 (rum/defc ^:large-vars/cleanup-todo select-node < rum/static
   [property
    {:keys [block multiple-choices? dropdown? input-opts on-input add-new-choice! target] :as opts}
@@ -746,12 +780,7 @@
                 (property-handler/get-class-property-choices)
 
                 (seq classes)
-                (->>
-                 (mapcat
-                  (fn [class]
-                    (model/get-class-objects repo (:db/id class)))
-                  classes)
-                 distinct)
+                (scoped-class-nodes repo property classes result)
 
                 :else
                 (if (empty? result)
@@ -933,9 +962,11 @@
          nil
 
          (seq non-root-classes)
-         (p/let [result (p/all (map (fn [class] (db-async/<get-tag-objects repo (:db/id class))) non-root-classes))
-                 result' (distinct (apply concat result))]
-           (set-result-and-initial-choices! result'))
+         (if (broad-scoped-node-property? property non-root-classes)
+           (set-result-and-initial-choices! [])
+           (p/let [result (p/all (map (fn [class] (db-async/<get-tag-objects repo (:db/id class))) non-root-classes))
+                   result' (distinct (apply concat result))]
+             (set-result-and-initial-choices! result')))
 
          :else
          (p/let [result (db-async/<get-property-values (:db/ident property))]

--- a/src/test/frontend/components/property/value_test.cljs
+++ b/src/test/frontend/components/property/value_test.cljs
@@ -1,6 +1,7 @@
 (ns frontend.components.property.value-test
   (:require [cljs.test :refer [async deftest is]]
             [frontend.components.property.value :as property-value]
+            [frontend.db.model :as model]
             [promesa.core :as p]))
 
 (deftest resolve-journal-page-for-date-returns-existing-page-test
@@ -135,3 +136,81 @@
                     :label "Shared title"}]
     (is (= [existing new-choice]
            (#'property-value/add-initial-node-choice [existing] new-choice)))))
+
+(deftest scoped-class-nodes-skips-broad-node-property-preload-test
+  (let [calls* (atom [])
+        property {:logseq.property/type :node}
+        page-class {:db/id 1
+                    :db/ident :logseq.class/Page}
+        tag-class {:db/id 2
+                   :db/ident :logseq.class/Tag}]
+    (with-redefs [model/get-class-objects (fn [_repo class-id]
+                                            (swap! calls* conj class-id)
+                                            [{:db/id 100
+                                              :block/title "Page 100"}])
+                  model/get-structured-children (fn [_repo _class-id] [])]
+      (is (= []
+             (#'property-value/scoped-class-nodes
+              "repo" property [page-class tag-class] nil)))
+      (is (= [] @calls*)))))
+
+(deftest scoped-class-nodes-filters-search-results-by-scoped-classes-test
+  (let [calls* (atom [])
+        property {:logseq.property/type :node}
+        topic-class {:db/id 10
+                     :db/ident :user.class/Topic}
+        matching-parent {:db/id 100
+                         :block/title "Parent topic"
+                         :block/tags [10]}
+        matching-child {:db/id 101
+                        :block/title "Child topic"
+                        :block/tags [11]}
+        matching-wrapped {:value {:db/id 103
+                                  :block/title "Wrapped topic"
+                                  :block/tags [10]}
+                          :label "Wrapped topic"}
+        matching-entity-tags {:db/id 104
+                              :block/title "Entity-shaped topic"
+                              :block/tags [topic-class]}
+        unrelated {:db/id 102
+                   :block/title "Other"
+                   :block/tags [20]}]
+    (with-redefs [model/get-class-objects (fn [_repo class-id]
+                                            (swap! calls* conj class-id)
+                                            [])
+                  model/get-structured-children (fn [_repo class-id]
+                                                  (case class-id
+                                                    10 [11]
+                                                    []))]
+      (is (= [matching-parent matching-child matching-wrapped matching-entity-tags]
+             (#'property-value/scoped-class-nodes
+              "repo" property [topic-class] [matching-parent matching-child matching-wrapped matching-entity-tags unrelated])))
+      (is (= [] @calls*)))))
+
+(deftest scoped-class-nodes-preloads-narrow-node-property-choices-test
+  (let [property {:logseq.property/type :node}
+        topic-class {:db/id 10
+                     :db/ident :user.class/Topic}
+        choices [{:db/id 100
+                  :block/title "Topic 100"}]]
+    (with-redefs [model/get-class-objects (fn [_repo class-id]
+                                            (when (= 10 class-id)
+                                              choices))
+                  model/get-structured-children (fn [_repo _class-id] [])]
+      (is (= choices
+             (#'property-value/scoped-class-nodes
+              "repo" property [topic-class] nil))))))
+
+(deftest scoped-class-nodes-preloads-tag-only-node-property-choices-test
+  (let [property {:logseq.property/type :node}
+        tag-class {:db/id 2
+                   :db/ident :logseq.class/Tag}
+        choices [{:db/id 100
+                  :block/title "Tag 100"}]]
+    (with-redefs [model/get-class-objects (fn [_repo class-id]
+                                            (when (= 2 class-id)
+                                              choices))
+                  model/get-structured-children (fn [_repo _class-id] [])]
+      (is (= choices
+             (#'property-value/scoped-class-nodes
+              "repo" property [tag-class] nil))))))


### PR DESCRIPTION
## Summary

- Avoid preloading all scoped node values when a node property is scoped to the Page class.
- Filter autocomplete search results by the scoped classes and descendants instead of rebuilding all candidates.
- Keep Tag-only and custom-class scoped node properties on the existing preload path.

## Root cause

Scoped node property dialogs enumerated every object for each scoped class on open and during autocomplete. When Page was part of the scope, large graphs paid the cost of walking many pages before the dialog could respond.

## Validation

- bb dev:test -v frontend.components.property.value-test
- git diff --check

## Not run

- bb lint:kondo-git-changes: clj-kondo is not installed on PATH in this environment.
