### PR TITLE
[codex] fix tag alias conversion

### DIFF
--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -172,6 +172,10 @@
                                                  :other-attrs {:block/link (:db/id page')}}))))
     (page-handler/on-chosen-handler input id pos format)))
 
+(defn- class-alias?
+  [page]
+  (some ldb/class? (:block/_alias page)))
+
 (defn- matched-pages-with-new-page [partial-matched-pages db-tag? q]
   (let [ids (db/page-exists? q (if db-tag?
                                  #{:logseq.class/Tag}
@@ -180,7 +184,7 @@
                                  db-class/page-classes))
         page-exists? (some (fn [id] (nil? (:block/parent (db/entity id)))) ids)]
     (if (or page-exists?
-            (and db-tag? (some ldb/class? (:block/_alias (db/get-page q)))))
+            (and db-tag? (class-alias? (db/get-page q))))
       partial-matched-pages
       (if db-tag?
         (concat
@@ -200,7 +204,8 @@
                      (let [classes (editor-handler/get-matched-classes q)]
                        (if (and (ldb/internal-page? block)
                                 (= (:block/title block) q)
-                                (not (ldb/built-in? block)))
+                                (not (ldb/built-in? block))
+                                (not (class-alias? block)))
                          (cons {:block/title q
                                 :db/id (:db/id block)
                                 :block/uuid (:block/uuid block)

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1602,6 +1602,8 @@
                       non-page-block?
                       (conj (db/entity :logseq.class/Page)))
         classes (->> all-classes
+                     (mapcat (fn [class]
+                               (conj (:block/alias class) class)))
                      (common-util/distinct-by :db/id)
                      (map (fn [e] (select-keys e [:block/uuid :block/title]))))]
     (search/fuzzy-search classes q {:extract-fn :block/title})))

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -1,7 +1,9 @@
 (ns frontend.handler.editor-test
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.test :refer [async deftest is testing use-fixtures]]
             [frontend.commands :as commands]
+            [frontend.components.editor :as editor-component]
             [frontend.db :as db]
+            [frontend.db.async :as db-async]
             [frontend.db.model :as model]
             [frontend.handler.editor :as editor]
             [frontend.state :as state]
@@ -9,9 +11,13 @@
             [frontend.util :as util]
             [frontend.util.cursor :as cursor]
             [goog.dom :as gdom]
-            [logseq.outliner.core :as outliner-core]))
+            [logseq.outliner.core :as outliner-core]
+            [promesa.core :as p]))
 
-(use-fixtures :each test-helper/start-and-destroy-db)
+(use-fixtures :each {:before test-helper/start-test-db!
+                     :after (fn []
+                              (state/set-current-repo! nil)
+                              (test-helper/destroy-test-db!))})
 
 (deftest extract-nearest-link-from-text-test
   (testing "Page, block and tag links"
@@ -122,19 +128,38 @@
   ;; Reset state
   (state/set-editor-action! nil))
 
-(deftest get-matched-classes-excludes-class-aliases
+(defn- create-tag-with-alias!
+  []
   (test-helper/create-page! "Project Tag" :redirect? false :class? true)
   (test-helper/create-page! "Alias Only" :redirect? false)
   (let [class (db/get-case-page "Project Tag")
         alias (db/get-case-page "Alias Only")]
     (db/transact! test-helper/test-db [{:db/id (:db/id class)
-                                        :block/alias #{(:db/id alias)}}]))
+                                        :block/alias #{(:db/id alias)}}])))
+
+(deftest get-matched-classes-includes-class-aliases
+  (create-tag-with-alias!)
   (is (= ["Project Tag"]
          (map :block/title (editor/get-matched-classes "Project Tag")))
       "Existing tag title matching still works")
-  (is (empty? (filter #(= "Alias Only" (:block/title %))
-                      (editor/get-matched-classes "Alias Only")))
-      "Tag aliases are not separate tag completion choices"))
+  (is (= ["Alias Only"]
+         (map :block/title (editor/get-matched-classes "Alias Only")))
+      "Tag aliases stay available as tag completion choices"))
+
+(deftest tag-search-does-not-convert-class-aliases
+  (async done
+    (create-tag-with-alias!)
+    (let [matched-pages (atom nil)]
+      (-> (p/with-redefs [db-async/<get-block (fn [_repo _title _opts]
+                                                (p/resolved (db/get-page "Alias Only")))]
+            (#'editor-component/search-pages "Alias Only" true #(reset! matched-pages %)))
+          (.then
+           (fn []
+             (is (some #(= "Alias Only" (:block/title %)) @matched-pages)
+                 "The alias is still selectable from tag completion")
+             (is (not-any? :convert-page-to-tag? @matched-pages)
+                 "A class alias must not show a redundant Convert action")
+             (done)))))))
 
 (defn- default-keyup-result
   [{:keys [value cursor-pos key code action is-processed?]


### PR DESCRIPTION
## Summary
- restore tag alias matches in hashtag completion
- suppress the redundant Convert action when the exact match is already a tag alias
- update editor regression coverage for alias completion and conversion actions

## Root cause
PR #12639 removed tag aliases from get-matched-classes, which hid the bad conversion entry but also broke selecting aliases from the tag dropdown. The convert action path still treated an exact alias page as a plain internal page.

## Verification
- bb dev:test -v frontend.handler.editor-test/get-matched-classes-includes-class-aliases
- bb dev:test -v frontend.handler.editor-test/tag-search-does-not-convert-class-aliases
- bb dev:test -v frontend.handler.editor-test
- git diff --check