### PR TITLE
fix(cli): validate query datom clauses using :db/id

### DIFF
--- a/src/main/logseq/cli/command/query.cljs
+++ b/src/main/logseq/cli/command/query.cljs
@@ -219,7 +219,7 @@
 (defn- db-id-datom-clause?
   [form]
   (and (vector? form)
-       (<= 3 (count form))
+       (<= 2 (count form))
        (= :db/id (second form))))
 
 (def ^:private logical-clause-ops

--- a/src/main/logseq/cli/command/query.cljs
+++ b/src/main/logseq/cli/command/query.cljs
@@ -208,6 +208,52 @@
                  :message "recent-days must be a positive integer"}}))
     {:ok? true :value inputs}))
 
+(defn- where-clauses
+  [query]
+  (when (vector? query)
+    (when-let [where-index (first (keep-indexed (fn [index value]
+                                                  (when (= :where value) index))
+                                                query))]
+      (subvec query (inc where-index)))))
+
+(defn- db-id-datom-clause?
+  [form]
+  (and (vector? form)
+       (<= 3 (count form))
+       (= :db/id (second form))))
+
+(def ^:private logical-clause-ops
+  '#{and not not-join or or-join})
+
+(defn- logical-clause?
+  [form]
+  (and (seq? form)
+       (contains? logical-clause-ops (first form))))
+
+(defn- logical-subclauses
+  [form]
+  (let [op (first form)
+        clauses (rest form)]
+    (if (contains? '#{not-join or-join} op)
+      (rest clauses)
+      clauses)))
+
+(defn- contains-db-id-datom-clause?
+  [form]
+  (cond
+    (db-id-datom-clause? form) true
+    (logical-clause? form) (some contains-db-id-datom-clause? (logical-subclauses form))
+    :else false))
+
+(defn- validate-query
+  [query]
+  (if (some contains-db-id-datom-clause? (where-clauses query))
+    {:ok? false
+     :error {:code :invalid-query
+             :message (str "invalid query: :db/id cannot be used as a datom attribute "
+                           "in :where clauses. Bind entity ids through :in and --inputs.")}}
+    {:ok? true :value query}))
+
 (defn build-action
   [options repo config]
   (if-not (seq repo)
@@ -239,8 +285,12 @@
             query-result
             (let [inputs-text (some-> (:inputs options) string/trim)
                   inputs-result (when (seq inputs-text)
-                                  (parse-edn "inputs" inputs-text))]
+                                  (parse-edn "inputs" inputs-text))
+                  query-validation (validate-query (:value query-result))]
               (cond
+                (not (:ok? query-validation))
+                query-validation
+
                 (and inputs-result (not (:ok? inputs-result)))
                 inputs-result
 

--- a/src/test/logseq/cli/command/query_test.cljs
+++ b/src/test/logseq/cli/command/query_test.cljs
@@ -55,6 +55,14 @@
       (is (string/includes? message "--inputs"))
       (is (not (string/includes? message "identity")))))
 
+  (testing "two-element :db/id datom clauses are rejected"
+    (let [result (query-command/build-action
+                  {:query "[:find ?b :where [?b :db/id]]"}
+                  "logseq_db_demo"
+                  {})]
+      (is (false? (:ok? result)))
+      (is (= :invalid-query (get-in result [:error :code])))))
+
   (testing ":db/id can still be used in pull selectors"
     (let [result (query-command/build-action
                   {:query "[:find [(pull ?b [:db/id :block/title]) ...] :where [?b :block/title]]"}

--- a/src/test/logseq/cli/command/query_test.cljs
+++ b/src/test/logseq/cli/command/query_test.cljs
@@ -42,6 +42,33 @@
       (is (= :invalid-options (get-in result [:error :code])))
       (is (string/includes? (get-in result [:error :message]) "inputs")))))
 
+(deftest test-build-action-rejects-db-id-datom-clause
+  (testing ":db/id is rejected as a datom attribute in query where clauses"
+    (let [result (query-command/build-action
+                  {:query "[:find (pull ?v [*]) :where [?b :db/id 400] [?b :user.property/owner ?v]]"}
+                  "logseq_db_demo"
+                  {})
+          message (or (get-in result [:error :message]) "")]
+      (is (false? (:ok? result)))
+      (is (= :invalid-query (get-in result [:error :code])))
+      (is (string/includes? message ":db/id"))
+      (is (string/includes? message "--inputs"))
+      (is (not (string/includes? message "identity")))))
+
+  (testing ":db/id can still be used in pull selectors"
+    (let [result (query-command/build-action
+                  {:query "[:find [(pull ?b [:db/id :block/title]) ...] :where [?b :block/title]]"}
+                  "logseq_db_demo"
+                  {})]
+      (is (true? (:ok? result)))))
+
+  (testing ":db/id inside expression data is not treated as a datom attribute"
+    (let [result (query-command/build-action
+                  {:query "[:find ?value :in $ :where [(identity [:literal :db/id 400]) ?value]]"}
+                  "logseq_db_demo"
+                  {})]
+      (is (true? (:ok? result))))))
+
 (deftest test-build-action-named-query
   (testing "named query resolves from config"
     (let [config {:custom-queries {"my-query"


### PR DESCRIPTION
## Summary
- Reject `logseq query` inputs that use `:db/id` as a datom attribute in `:where` clauses
- Keep valid query shapes working, including `:db/id` in pull selectors and expression data
- Narrow the error message to recommend binding entity ids through `:in` and `--inputs`

## Testing
- Added focused unit coverage for the invalid query case and two non-regression cases
- Verified the full `logseq.cli.command.query-test` and `logseq.cli.commands-test` namespaces pass
- Ran CLI lint checks and exercised the behavior with real `logseq query` commands