### PR TITLE
fix: preserve breadcrumb icon layout

### DIFF
--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -102,7 +102,7 @@
     width: unset !important;
   }
 
-  a, svg, div {
+  a {
     @apply inline;
   }
 


### PR DESCRIPTION
## Summary
- Narrow the legacy breadcrumb inline display rule so it only targets breadcrumb anchors.
- Stop breadcrumb CSS from forcing nested icon wrapper `div` and `svg` descendants to `display: inline`.

## Root cause
The header breadcrumb renders custom page icons through nested icon wrappers. The old `.breadcrumb a, svg, div` rule was broad enough to override those wrappers, which broke icon alignment and exposed stray stacked marks beside the page icon.

Related to https://github.com/logseq/db-test/issues/871.

## Validation
- `pnpm css:build`
- Focused Playwright regression check: breadcrumb segment remains `inline-flex`, icon wrappers remain `flex`, label display remains unchanged.
- In-app browser visual check on a breadcrumb fixture using the rebuilt stylesheet.
- `git diff --check`

## Notes
`pnpm style:lint` and `pnpm exec stylelint src/main/frontend/components/block.css` currently fail on pre-existing CSS lint issues unrelated to this one-line change.