### PR TITLE
fix: avoid extra breadcrumb icon

### DIFF
--- a/src/main/frontend/components/header.css
+++ b/src/main/frontend/components/header.css
@@ -336,7 +336,7 @@ html.is-zoomed-native-ios {
 
     .breadcrumb a {
         @apply !opacity-75 hover:!opacity-100;
-        span {
+        .breadcrumb__label {
             @apply whitespace-nowrap text-ellipsis inline-block overflow-x-hidden align-middle;
             max-width: 34ch;
         }


### PR DESCRIPTION
fix https://github.com/logseq/db-test/issues/871

- fixes an extra icon-like artifact that could appear in the header breadcrumb before a page title.
