### PR TITLE
fix: scoped node property values

### DIFF
--- a/src/main/frontend/components/property/value.cljs
+++ b/src/main/frontend/components/property/value.cljs
@@ -715,8 +715,11 @@
 
 (defn- node-matches-scoped-classes?
   [class-ids node]
-  (let [node (or (:value node) node)]
-    (some #(contains? class-ids (if (integer? %) % (:db/id %))) (:block/tags node))))
+  (let [node-value (or (:value node) node)
+        node' (if (and (:db/id node-value) (nil? (:block/tags node-value)))
+                (or (db/entity (:db/id node-value)) node-value)
+                node-value)]
+    (some #(contains? class-ids (if (integer? %) % (:db/id %))) (:block/tags node'))))
 
 (defn- scoped-class-nodes
   [repo property classes result]

--- a/src/main/frontend/components/property/value.cljs
+++ b/src/main/frontend/components/property/value.cljs
@@ -734,6 +734,15 @@
         classes)
        distinct))))
 
+(defn- <load-initial-node-choices
+  [repo property non-root-classes]
+  (if (seq non-root-classes)
+    (if (broad-scoped-node-property? property non-root-classes)
+      (db-async/<get-property-values (:db/ident property))
+      (p/let [result (p/all (map (fn [class] (db-async/<get-tag-objects repo (:db/id class))) non-root-classes))]
+        (distinct (apply concat result))))
+    (db-async/<get-property-values (:db/ident property))))
+
 (rum/defc ^:large-vars/cleanup-todo select-node < rum/static
   [property
    {:keys [block multiple-choices? dropdown? input-opts on-input add-new-choice! target] :as opts}
@@ -922,8 +931,14 @@
 (rum/defc property-value-select-node < rum/static
   [block property opts
    {:keys [*show-new-property-config?]}]
-  (let [[initial-choices set-initial-choices!] (hooks/use-state nil)
+  (let [[initial-choices set-initial-choices-state!] (hooks/use-state nil)
         [result set-result!] (hooks/use-state nil)
+        *initial-choices (rum/use-ref nil)
+        current-initial-choices (fn []
+                                  (or (rum/deref *initial-choices) initial-choices))
+        set-initial-choices! (fn [value]
+                               (rum/set-ref! *initial-choices value)
+                               (set-initial-choices-state! value))
         set-result-and-initial-choices! (fn [value]
                                           (set-initial-choices! value)
                                           (set-result! value))
@@ -942,13 +957,13 @@
                      :input-opts input-opts
                      :on-input (fn [v]
                                  (if (string/blank? v)
-                                   (set-result! initial-choices)
+                                   (set-result! (current-initial-choices))
                                    ;; TODO rank initial choices higher
                                    (p/let [result (search/block-search (state/get-current-repo) v {:enable-snippet? false
                                                                                                    :built-in? false})]
                                      (set-result! result))))
                      :add-new-choice! (fn [new-choice]
-                                        (set-initial-choices! (add-initial-node-choice initial-choices new-choice))))
+                                        (set-initial-choices! (add-initial-node-choice (current-initial-choices) new-choice))))
         repo (state/get-current-repo)
         classes (:logseq.property/classes property)
         class? (= :class (:logseq.property/type property))
@@ -964,15 +979,8 @@
          extends-property?
          nil
 
-         (seq non-root-classes)
-         (if (broad-scoped-node-property? property non-root-classes)
-           (set-result-and-initial-choices! [])
-           (p/let [result (p/all (map (fn [class] (db-async/<get-tag-objects repo (:db/id class))) non-root-classes))
-                   result' (distinct (apply concat result))]
-             (set-result-and-initial-choices! result')))
-
          :else
-         (p/let [result (db-async/<get-property-values (:db/ident property))]
+         (p/let [result (<load-initial-node-choices repo property non-root-classes)]
            (set-result-and-initial-choices! result))))
      [])
 

--- a/src/test/frontend/components/property/value_test.cljs
+++ b/src/test/frontend/components/property/value_test.cljs
@@ -1,6 +1,7 @@
 (ns frontend.components.property.value-test
   (:require [cljs.test :refer [async deftest is]]
             [frontend.components.property.value :as property-value]
+            [frontend.db :as db]
             [frontend.db.model :as model]
             [promesa.core :as p]))
 
@@ -214,3 +215,26 @@
       (is (= choices
              (#'property-value/scoped-class-nodes
               "repo" property [tag-class] nil))))))
+
+(deftest scoped-class-nodes-keeps-hydrated-broad-scope-initial-choices-test
+  (let [property {:logseq.property/type :node}
+        page-class {:db/id 1
+                    :db/ident :logseq.class/Page}
+        matching-choice {:value {:db/id 100
+                                 :block/uuid #uuid "11111111-1111-1111-1111-111111111111"}
+                         :label "Existing page"}
+        unrelated-choice {:value {:db/id 101
+                                  :block/uuid #uuid "22222222-2222-2222-2222-222222222222"}
+                          :label "Unrelated block"}]
+    (with-redefs [db/entity (fn [id]
+                              (case id
+                                100 {:db/id 100
+                                     :block/title "Existing page"
+                                     :block/tags [1]}
+                                101 {:db/id 101
+                                     :block/title "Unrelated block"}
+                                nil))
+                  model/get-structured-children (fn [_repo _class-id] [])]
+      (is (= [matching-choice]
+             (#'property-value/scoped-class-nodes
+              "repo" property [page-class] [matching-choice unrelated-choice]))))))

--- a/src/test/frontend/components/property/value_test.cljs
+++ b/src/test/frontend/components/property/value_test.cljs
@@ -2,6 +2,7 @@
   (:require [cljs.test :refer [async deftest is]]
             [frontend.components.property.value :as property-value]
             [frontend.db :as db]
+            [frontend.db.async :as db-async]
             [frontend.db.model :as model]
             [promesa.core :as p]))
 
@@ -238,3 +239,30 @@
       (is (= [matching-choice]
              (#'property-value/scoped-class-nodes
               "repo" property [page-class] [matching-choice unrelated-choice]))))))
+
+(deftest load-initial-node-choices-loads-existing-values-for-broad-page-scope-test
+  (async done
+         (let [property {:db/ident :user.property/p1
+                         :logseq.property/type :node
+                         :logseq.property/classes [{:db/id 1
+                                                    :db/ident :logseq.class/Page}]}
+               existing-values [{:value {:db/id 100
+                                         :block/uuid #uuid "11111111-1111-1111-1111-111111111111"}
+                                 :label "page 1"}
+                                {:value {:db/id 101
+                                 :block/uuid #uuid "22222222-2222-2222-2222-222222222222"}
+                                 :label "page 2"}]
+               queried-properties* (atom [])]
+           (with-redefs [db-async/<get-property-values (fn [property-ident]
+                                                         (swap! queried-properties* conj property-ident)
+                                                         (p/resolved existing-values))
+                         db-async/<get-tag-objects (fn [_repo _class-id]
+                                                     (p/resolved []))]
+             (-> (#'property-value/<load-initial-node-choices "repo" property (:logseq.property/classes property))
+                 (p/then (fn [result]
+                           (is (= [:user.property/p1] @queried-properties*))
+                           (is (= existing-values result))
+                           (done)))
+                 (p/catch (fn [error]
+                            (is false (str error))
+                            (done))))))))


### PR DESCRIPTION
## Summary

Fixes https://github.com/logseq/db-test/issues/876.

- hydrate compact scoped node choices by `:db/id` before class filtering
- keep existing broad `Page`-scoped node property values visible in the add-value dropdown
- add a regression test for compact existing choices

## Validation

- `bb dev:test -v frontend.components.property.value-test/scoped-class-nodes-keeps-hydrated-broad-scope-initial-choices-test`
- `bb dev:test -v frontend.components.property.value-test`

## Notes

The red test first failed with an empty result for the existing page choice, then passed after the fix.