### PR TITLE
fix: desktop deep links

### DIFF
--- a/src/electron/electron/link.cljs
+++ b/src/electron/electron/link.cljs
@@ -1,0 +1,8 @@
+(ns electron.link)
+
+(def shell-open-protocols
+  #{"https:" "http:" "mailto:" "logseq:"})
+
+(defn shell-open-url?
+  [^js/URL parsed-url]
+  (contains? shell-open-protocols (.-protocol parsed-url)))

--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -9,6 +9,7 @@
             [electron.context-menu :as context-menu]
             [electron.db-worker :as db-worker]
             [electron.i18n :refer [t]]
+            [electron.link :as link]
             [electron.logger :as logger]
             [electron.spell-check :as spell-check]
             [electron.state :as state]
@@ -126,7 +127,7 @@
   (let [URL (.-URL URL)
         parsed-url (try (URL. url) (catch :default _ nil))]
     (when parsed-url
-      (if (contains? #{"https:" "http:" "mailto:"} (.-protocol parsed-url))
+      (if (link/shell-open-url? parsed-url)
         (.openExternal shell url)
         (when-let [^js res (and (fn? default-open)
                                 (.showMessageBoxSync dialog

--- a/src/test/electron/link_test.cljs
+++ b/src/test/electron/link_test.cljs
@@ -1,0 +1,10 @@
+(ns electron.link-test
+  (:require [cljs.test :refer [deftest is]]
+            [electron.link :as link]))
+
+(deftest logseq-links-open-through-electron-shell
+  (is (true?
+       (link/shell-open-url?
+        (js/URL. "logseq://graph/demo?block-id=00000000-0000-0000-0000-000000000001"))))
+  (is (true? (link/shell-open-url? (js/URL. "https://logseq.com"))))
+  (is (false? (link/shell-open-url? (js/URL. "file:///tmp/graph.edn")))))


### PR DESCRIPTION
## Summary
- Route logseq:// desktop links through Electron shell.openExternal so the registered app protocol handler receives them.
- Add a focused test for protocols that should use Electron shell opening.

## Root cause
Desktop window navigation treated logseq:// links as non-shell URLs, so they fell through to the generic opener path instead of the deep-link protocol path.

## Verification
- bb dev:test -v electron.link-test/logseq-links-open-through-electron-shell
- pnpm exec shadow-cljs compile electron (completed with existing electron.core inference warning)