### PR TITLE
fix(search): escape quotes in SQLite FTS queries

### DIFF
--- a/src/main/frontend/worker/search.cljs
+++ b/src/main/frontend/worker/search.cljs
@@ -342,7 +342,7 @@ DROP TRIGGER IF EXISTS blocks_au;
       (and (re-find #"[^\w\s]" q)
            (or (not (some #(string/includes? match-input %) ["AND" "OR" "NOT"]))
                (string/includes? q "/")))            ; punctuations
-      (str "\"" match-input "\"*")
+      (str "\"" (string/replace match-input "\"" "\"\"") "\"*")
       (not= q match-input)
       (string/replace match-input "," "")
       :else

--- a/src/test/frontend/worker/search_test.cljs
+++ b/src/test/frontend/worker/search_test.cljs
@@ -209,6 +209,23 @@
       (is (some? result))
       (is (empty? result)))))
 
+(deftest search-blocks-escapes-quotes-for-fts
+  (testing "user quote characters are escaped before SQLite FTS receives them"
+    (let [fts-binds (atom [])
+          db #js {:exec (fn [opts]
+                          (let [sql (aget opts "sql")
+                                bind (js->clj (aget opts "bind"))]
+                            (when (string/includes? sql "title match ?")
+                              (swap! fts-binds conj (first bind)))
+                            #js []))}]
+      (with-redefs [search/combine-results (fn [_db results] results)
+                    search/search-result->block-result
+                    (fn [_conn _q _code-class _option result]
+                      result)]
+        (is (empty? (search/search-blocks (atom :large-db) db "\"" {:limit 10})))
+        (is (empty? (search/search-blocks (atom :large-db) db "foo \"bar" {:limit 10})))
+        (is (= ["\"\"\"\"*" "\"foo \"\"bar\"*"] @fts-binds))))))
+
 (deftest search-blocks-large-graph-benchmark-regression
   (testing "cmd-k and autocomplete queries must not scan the full Datascript graph while typing"
     (let [calls (atom [])


### PR DESCRIPTION
## Summary
- Escape user double quotes before building SQLite FTS phrase queries in `frontend.worker.search`.
- Add a regression test that covers quote-only input and embedded quotes in search terms.

## Testing
- `bb dev:test -v frontend.worker.search-test/search-blocks-escapes-quotes-for-fts`
- `bb dev:test -v frontend.worker.search-test`