### PR TITLE
fix(editor): open missing journal links from shortcut

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1094,6 +1094,17 @@
             (let [value (gobj/get input "value")]
               (extract-nearest-link-from-text value pos))))))))
 
+(defn- <follow-page-link!
+  [page]
+  (state/clear-edit!)
+  (if (util/uuid-string? page)
+    (route-handler/redirect-to-page! page)
+    (p/let [page-entity (or (db/get-page page)
+                            (db-async/<get-block (state/get-current-repo) page {:children? false}))]
+      (if page-entity
+        (route-handler/redirect-to-page! page)
+        (state/pub-event! [:page/create page])))))
+
 (defn follow-link-under-cursor!
   []
   (when-let [page (get-nearest-page-or-url)]
@@ -1103,9 +1114,7 @@
        (save-current-block!)
        (if (re-find url-regex page)
          (js/window.open page)
-         (do
-           (state/clear-edit!)
-           (route-handler/redirect-to-page! page)))))))
+         (<follow-page-link! page))))))
 
 (defn open-link-in-sidebar!
   []

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -6,6 +6,7 @@
             [frontend.db.async :as db-async]
             [frontend.db.model :as model]
             [frontend.handler.editor :as editor]
+            [frontend.handler.route :as route-handler]
             [frontend.state :as state]
             [frontend.test.helper :as test-helper]
             [frontend.util :as util]
@@ -58,6 +59,71 @@
          (editor/extract-nearest-link-from-text
           "[[https://github.com/logseq/logseq][logseq]] is #awesome :)" 0 editor/url-regex))
       "Finds url in org link correctly"))
+
+(defn- follow-page-link-result
+  [{:keys [page-title existing-page? worker-page?]}]
+  (let [events (atom [])
+        redirects (atom [])
+        worker-page-uuid (random-uuid)
+        input-id "edit-block-test"
+        input #js {:value (str "Open [[" page-title "]]")}]
+    (p/with-redefs [state/get-edit-block (constantly {:block/uuid (random-uuid)})
+                    state/get-edit-input-id (constantly input-id)
+                    gdom/getElement (fn [id]
+                                      (when (= input-id id)
+                                        input))
+                    cursor/pos (constantly 10)
+                    editor/save-current-block! (constantly nil)
+                    state/clear-editor-action! (constantly nil)
+                    state/clear-edit! (constantly nil)
+                    db/get-page (fn [title]
+                                  (when (and existing-page? (= page-title title))
+                                    {:block/title title
+                                     :block/uuid (random-uuid)}))
+                    db-async/<get-block (fn [_repo title _opts]
+                                          (p/resolved
+                                           (when (and worker-page? (= page-title title))
+                                             {:block/title title
+                                              :block/uuid worker-page-uuid})))
+                    state/pub-event! (fn [event]
+                                       (swap! events conj event)
+                                       (p/resolved nil))
+                    route-handler/redirect-to-page! (fn [& args]
+                                                      (swap! redirects conj args))]
+      (p/let [_ (editor/follow-link-under-cursor!)]
+        {:events @events
+         :redirects @redirects}))))
+
+(deftest follow-link-under-cursor-opens-existing-page-test
+  (async done
+    (-> (follow-page-link-result {:page-title "Project"
+                                  :existing-page? true})
+        (p/then
+         (fn [{:keys [events redirects]}]
+           (is (empty? events))
+           (is (= [["Project"]] redirects))
+           (done))))))
+
+(deftest follow-link-under-cursor-creates-missing-page-test
+  (async done
+    (-> (follow-page-link-result {:page-title "May 15th, 2026"
+                                  :existing-page? false})
+        (p/then
+         (fn [{:keys [events redirects]}]
+           (is (= [[:page/create "May 15th, 2026"]] events))
+           (is (empty? redirects))
+           (done))))))
+
+(deftest follow-link-under-cursor-uses-worker-page-before-creating-test
+  (async done
+    (-> (follow-page-link-result {:page-title "May 15th, 2026"
+                                  :existing-page? false
+                                  :worker-page? true})
+        (p/then
+         (fn [{:keys [events redirects]}]
+           (is (empty? events))
+           (is (= [["May 15th, 2026"]] redirects))
+           (done))))))
 
 (defn- keyup-handler
   "Spied version of editor/keyup-handler"


### PR DESCRIPTION
## Summary
- create missing page refs when following links with the editor shortcut
- check the worker DB before creating, so pages not yet present in the UI DB still open normally
- add shortcut coverage for existing UI pages, missing pages, and worker-only pages

## Root cause
`follow-link-under-cursor!` redirected directly to a page title. When a journal page created by `/date` was not yet present in the renderer DB, the route opened as a blank page instead of creating or resolving the page first.

## Test plan
- `rtk bb dev:test -v frontend.handler.editor-test`

related to https://github.com/logseq/db-test/issues/879