### PR TITLE
fix(cli): hide empty property ids in show

### DIFF
--- a/src/main/logseq/cli/command/show.cljs
+++ b/src/main/logseq/cli/command/show.cljs
@@ -296,6 +296,13 @@
        (= :block/uuid (first value))
        (uuid? (second value))))
 
+(defn- db-id-ref?
+  [value]
+  (and (vector? value)
+       (= 2 (count value))
+       (= :db/id (first value))
+       (number? (second value))))
+
 (defn- epoch-ms->iso-string
   [ms]
   (when-not (number? ms)
@@ -475,6 +482,9 @@
   [{:keys [root linked-references]}]
   (letfn [(collect-value [acc value]
             (cond
+              (db-id-ref? value)
+              (update acc :ids conj (second value))
+
               (lookup-ref? value)
               (update acc :uuids conj (second value))
 
@@ -609,14 +619,22 @@
               built-in-pairs (transport/invoke config :thread-api/q
                                                [repo [built-in-query built-in-idents]])
               ident-type-pairs (into (vec user-pairs) built-in-pairs)
+              property-type-by-ident (into {} ident-type-pairs)
               datetime-idents (set (keep (fn [[a type]] (when (= :datetime type) a)) ident-type-pairs))
               property-idents (vec (map first ident-type-pairs))]
         (if (seq property-idents)
           (p/let [rows (transport/invoke config :thread-api/q
                                          [repo [props-query ids property-idents]])]
             (reduce (fn [acc [block-id attr value]]
-                      (let [value (if (and (number? value) (contains? datetime-idents attr))
+                      (let [property-type (get property-type-by-ident attr)
+                            value (cond
+                                    (and (number? value) (contains? datetime-idents attr))
                                     (epoch-ms->iso-string value)
+
+                                    (and (number? value) (not= :number property-type))
+                                    [:db/id value]
+
+                                    :else
                                     value)]
                         (update-in acc [block-id attr] merge-fetched-property-value value)))
                     {}

--- a/src/main/logseq/cli/tree_text.cljs
+++ b/src/main/logseq/cli/tree_text.cljs
@@ -64,6 +64,13 @@
        (= :block/uuid (first value))
        (uuid? (second value))))
 
+(defn- db-id-ref?
+  [value]
+  (and (vector? value)
+       (= 2 (count value))
+       (= :db/id (first value))
+       (number? (second value))))
+
 (defn- property-value->string
   ([value] (property-value->string value nil nil))
   ([value labels] (property-value->string value labels nil))
@@ -76,6 +83,8 @@
        (string? value) (render-visible value)
        (number? value) (render-visible (or (get labels value) (str value)))
        (uuid? value) (render-visible (or (get labels value) (str value)))
+       (db-id-ref? value) (let [id (second value)]
+                            (render-visible (get labels id)))
        (lookup-ref? value) (let [uuid (second value)]
                              (render-visible (or (get labels uuid) (str uuid))))
        (boolean? value) (str value)
@@ -100,6 +109,8 @@
   ([value labels uuid->label]
    (let [values (cond
                   (set? value) (seq value)
+                  (or (db-id-ref? value)
+                      (lookup-ref? value)) [value]
                   (sequential? value) value
                   (nil? value) nil
                   :else [value])

--- a/src/test/logseq/cli/command/show_test.cljs
+++ b/src/test/logseq/cli/command/show_test.cljs
@@ -165,6 +165,33 @@
                (p/catch (fn [e] (is false (str "unexpected error: " e))))
                (p/finally done)))))
 
+(deftest test-fetch-user-properties-marks-default-numeric-values-as-db-id-refs
+  (let [fetch #'show-command/fetch-user-properties
+        call-count (atom 0)
+        mock-invoke (fn [_ _method _args]
+                      (let [call-idx (swap! call-count inc)]
+                        (p/resolved
+                         (case call-idx
+                           ;; First call: user idents-query returns property idents with types
+                           1 [[:user.property/reproducible-steps :default]
+                              [:user.property/count :number]]
+                           ;; Second call: built-in idents-query returns built-in property types
+                           2 []
+                           ;; Third call: props-query returns raw values
+                           3 [[10 :user.property/reproducible-steps 13941]
+                              [10 :user.property/count 42]]
+                           []))))]
+    (async done
+           (-> (p/with-redefs [transport/invoke mock-invoke]
+                 (p/let [result (fetch {} "demo" [10])]
+                   (testing "default property numeric values are treated as db/id refs"
+                     (is (= [:db/id 13941]
+                            (get-in result [10 :user.property/reproducible-steps]))))
+                   (testing "number property values are still rendered as scalar numbers"
+                     (is (= 42 (get-in result [10 :user.property/count]))))))
+               (p/catch (fn [e] (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
 (defn- call-private
   [sym & args]
   (when-let [v (get (ns-interns 'logseq.cli.command.show) sym)]
@@ -761,6 +788,17 @@
     (is (string/includes? output "Reproducible steps:"))
     (is (string/includes? output "- Step [[Resolved nested step]]"))
     (is (string/includes? output "- Verify output"))))
+
+(deftest test-tree->text-skips-unresolved-db-id-property-refs
+  (let [output (-> (show-command/tree->text
+                    {:root {:db/id 1
+                            :block/title "Root"
+                            :user.property/reproducible-steps [:db/id 13941]}
+                     :property-titles {:user.property/reproducible-steps "Reproducible steps"}
+                     :property-value-labels {}})
+                   style/strip-ansi)]
+    (is (not (string/includes? output "13941")))
+    (is (not (string/includes? output "Reproducible steps")))))
 
 (defn- contains-block-uuid?
   [value]


### PR DESCRIPTION
## Summary
- Treat numeric values from non-number properties as db/id refs when fetching CLI show properties
- Skip unresolved db/id property refs in tree text output instead of rendering raw ids
- Add regression coverage for fetch and render behavior

## Tests
- bb dev:lint-and-test
- bb dev:cli-e2e
- bb dev:cli-e2e-sync --skip-build