### PR TITLE
enhance(cli): clarify sync upload help

### DIFF
--- a/src/main/logseq/cli/command/sync.cljs
+++ b/src/main/logseq/cli/command/sync.cljs
@@ -56,9 +56,10 @@
                                    "logseq sync start --graph my-graph --e2ee-password \"my-secret\""]})
    (core/command-entry ["sync" "stop"] :sync-stop "Stop db-sync client" {}
                        {:examples ["logseq sync stop --graph my-graph"]})
-   (core/command-entry ["sync" "upload"] :sync-upload "Upload current graph snapshot" sync-upload-spec
+   (core/command-entry ["sync" "upload"] :sync-upload "Initialize upload of the entire graph" sync-upload-spec
                        {:examples ["logseq sync upload --graph my-graph"
-                                   "logseq sync upload --graph my-graph --e2ee-password \"my-secret\""]})
+                                   "logseq sync upload --graph my-graph --e2ee-password \"my-secret\""]
+                        :long-desc "This command initializes upload of the entire graph. It is not for incremental graph data syncing."})
    (core/command-entry ["sync" "download"] :sync-download "Download remote graph snapshot" sync-download-spec
                        {:examples ["logseq sync download --graph my-graph"
                                    "logseq sync download --graph my-graph --progress"

--- a/src/test/logseq/cli/commands_test.cljs
+++ b/src/test/logseq/cli/commands_test.cljs
@@ -512,6 +512,15 @@
       (is (contains-bold? summary "sync config set"))
       (is (contains-bold? summary "sync grant-access")))))
 
+(deftest test-parse-args-help-sync-upload
+  (testing "sync upload command help explains full-graph initialization upload"
+    (let [result (binding [style/*color-enabled?* true]
+                   (commands/parse-args ["sync" "upload" "--help"]))
+          summary (strip-ansi (:summary result))]
+      (is (true? (:help? result)))
+      (is (string/includes? summary "initializes upload of the entire graph"))
+      (is (string/includes? summary "not for incremental graph data syncing")))))
+
 (deftest test-parse-args-help-upsert-group
   (testing "add group is removed"
     (let [result (commands/parse-args ["add"])]


### PR DESCRIPTION
## Summary
- Clarify `sync upload --help` so it describes initializing upload of the entire graph
- Note that `sync upload` is not for incremental graph data syncing
- Add a focused CLI help parsing test

## Tests
- `bb dev:test -v logseq.cli.commands-test/test-parse-args-help-sync-upload`
- `bb dev:test -v logseq.cli.commands-test`
- `bb -f cli-e2e/bb.edn build`
- `bb -f cli-e2e/bb.edn test --skip-build`
- `node static/logseq-cli.js sync upload --help`