### PR TITLE
fix(cli): bound truncate-preview printing

### DIFF
--- a/src/main/logseq/cli/log.cljs
+++ b/src/main/logseq/cli/log.cljs
@@ -6,6 +6,12 @@
 
 (defonce ^:private handler-installed? (atom false))
 
+(defn- bounded-pr-str
+  [value limit]
+  (binding [*print-length* (inc limit)
+            *print-level* 4]
+    (pr-str value)))
+
 (defn truncate-preview
   "Returns a preview map with `:preview`, `:length`, and `:truncated?` for `value`.
 
@@ -17,9 +23,9 @@
   ([value]
    (truncate-preview value default-preview-limit))
   ([value max-len]
-   (let [text (if (string? value) value (pr-str value))
+   (let [limit (max 0 (or max-len 0))
+         text (if (string? value) value (bounded-pr-str value limit))
          length (count text)
-         limit (max 0 (or max-len 0))
          truncated? (> length limit)
          preview (if truncated?
                    (subs text 0 limit)

--- a/src/main/logseq/cli/log.cljs
+++ b/src/main/logseq/cli/log.cljs
@@ -8,8 +8,7 @@
 
 (defn- bounded-pr-str
   [value limit]
-  (binding [*print-length* (inc limit)
-            *print-level* 4]
+  (binding [*print-length* (inc limit)]
     (pr-str value)))
 
 (defn truncate-preview

--- a/src/test/logseq/cli/log_test.cljs
+++ b/src/test/logseq/cli/log_test.cljs
@@ -29,7 +29,18 @@
     (let [result (cli-log/truncate-preview nil 10)]
       (is (= 3 (:length result)))
       (is (= "nil" (:preview result)))
-      (is (false? (:truncated? result))))))
+      (is (false? (:truncated? result)))))
+
+  (testing "does not realize a full lazy collection for a short preview"
+    (let [realized (atom 0)
+          value (map (fn [n]
+                       (swap! realized inc)
+                       n)
+                     (range 1000))
+          result (cli-log/truncate-preview value 10)]
+      (is (= 10 (count (:preview result))))
+      (is (true? (:truncated? result)))
+      (is (< @realized 100)))))
 
 (deftest test-debug-logging-gated-by-verbose
   (let [records (atom [])

--- a/src/test/logseq/cli/log_test.cljs
+++ b/src/test/logseq/cli/log_test.cljs
@@ -31,6 +31,14 @@
       (is (= "nil" (:preview result)))
       (is (false? (:truncated? result)))))
 
+  (testing "preserves deep values when the preview limit is large enough"
+    (let [value {:a {:b {:c {:d {:e 1}}}}}
+          expected (pr-str value)
+          result (cli-log/truncate-preview value 1000)]
+      (is (= expected (:preview result)))
+      (is (= (count expected) (:length result)))
+      (is (false? (:truncated? result)))))
+
   (testing "does not realize a full lazy collection for a short preview"
     (let [realized (atom 0)
           value (map (fn [n]


### PR DESCRIPTION
## Summary
- Replace eager `pr-str` preview generation with a bounded printer in `truncate-preview`
- Avoid fully realizing large or lazy values when building CLI debug previews
- Add a regression test that verifies short previews do not force full lazy collection realization

## Testing
- `bb dev:test -v logseq.cli.log-test`
- `bb dev:test -v logseq.cli.transport-test`