### PR TITLE
fix(editor): keep caret at end-of-line on Up/Down navigation

### DIFF
--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -69,14 +69,16 @@
 (defn- text-range-by-lst-fst-line [content [direction pos]]
   (case direction
     :up
-    (let [last-new-line (or (string/last-index-of content \newline) -1)
-          end (+ last-new-line pos 1)]
-      (subs content 0 end))
+    (if (= :end pos)
+      content
+      (let [last-new-line (or (string/last-index-of content \newline) -1)
+            end (+ last-new-line pos 1)]
+        (subs content 0 end)))
     :down
-    (-> (string/split-lines content)
-        first
-        (or "")
-        (subs 0 pos))))
+    (let [fst-line (or (first (string/split-lines content)) "")]
+      (if (= :end pos)
+        fst-line
+        (subs fst-line 0 pos)))))
 
 (defn mark-last-input-time!
   [repo]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2493,7 +2493,10 @@
                        block (db/entity [:block/uuid new-uuid])]
                    (edit-block! block
                                 (or (:pos move-opts)
-                                    (when input [direction (util/get-line-pos (.-value input) (util/get-selection-start input))])
+                                    (when input
+                                      [direction (if (cursor/end-of-line? input)
+                                                   :end
+                                                   (util/get-line-pos (.-value input) (util/get-selection-start input)))])
                                     0)
                                 {:container-id container-id
                                  :direction direction}))))))

--- a/src/main/frontend/util/cursor.cljs
+++ b/src/main/frontend/util/cursor.cljs
@@ -107,6 +107,24 @@
           (when-let [pre-char (subs content (dec pos') pos')]
             (= pre-char \newline))))))
 
+(defn end-of-line?
+  [input]
+  (let [[content pos'] (get-input-content&pos input)]
+    (when content
+      (or (= pos' (count content))
+          (when-let [next-char (subs content pos' (inc pos'))]
+            (= next-char \newline))))))
+
+(defn adjacent-line-end-pos
+  "Given block `content` and a caret position `pos'` sitting at the end of a
+   hard line, return the position of the end of the previous (:up) / next
+   (:down) hard line, or nil when there is no such line."
+  [content pos' direction]
+  (case direction
+    :up (string/last-index-of content \newline (dec pos'))
+    :down (or (string/index-of content \newline (inc pos'))
+              (count content))))
+
 (comment
   (defn line-end-pos
     [input]
@@ -220,7 +238,12 @@
 
 (defn- move-cursor-up-down
   [input direction]
-  (move-cursor-to input (next-cursor-pos-up-down direction (get-caret-pos input))))
+  (if-let [pos' (and (end-of-line? input)
+                     (adjacent-line-end-pos (gobj/get input "value")
+                                            (util/get-selection-start input)
+                                            direction))]
+    (move-cursor-to input pos')
+    (move-cursor-to input (next-cursor-pos-up-down direction (get-caret-pos input)))))
 
 (defn move-cursor-up [input]
   (move-cursor-up-down input :up))

--- a/src/test/frontend/handler/block_test.cljs
+++ b/src/test/frontend/handler/block_test.cljs
@@ -63,3 +63,14 @@
     (with-redefs [db/get-db (fn [] @conn)
                   db/entity (fn [eid] (d/entity @conn eid))]
       (is (= "Project/Milestone" (block-handler/block-unique-title plain-class-map))))))
+
+(deftest text-range-by-lst-fst-line-end-of-line
+  (let [f #'block-handler/text-range-by-lst-fst-line]
+    (testing ":end keeps caret at end of target line"
+      (is (= "longer first line" (f "longer first line\nsecond" [:down :end])))
+      (is (= "" (f "\nsecond" [:down :end])))
+      (is (= "a\nb\nlong last line" (f "a\nb\nlong last line" [:up :end])))
+      (is (= "only line" (f "only line" [:up :end]))))
+    (testing "numeric pos preserves column (unchanged behavior)"
+      (is (= "lo" (f "longer first line\nsecond" [:down 2])))
+      (is (= "a\nb\nlo" (f "a\nb\nlong last line" [:up 2]))))))

--- a/src/test/frontend/util/cursor_test.cljs
+++ b/src/test/frontend/util/cursor_test.cljs
@@ -1,0 +1,23 @@
+(ns frontend.util.cursor-test
+  (:require [cljs.test :refer [are deftest is testing]]
+            [frontend.util.cursor :as cursor]))
+
+(deftest adjacent-line-end-pos-test
+  (testing ":up returns the end of the previous hard line"
+    ;; "aaa\nbbbbbb\ncc" -> \n at 3 and 10, count 13
+    (are [pos expected] (= expected (cursor/adjacent-line-end-pos "aaa\nbbbbbb\ncc" pos :up))
+      10 3    ;; end of middle line -> end of first line
+      13 10   ;; end of content (last line) -> end of middle line
+      3 nil)) ;; end of first line -> no previous line
+  (testing ":down returns the end of the next hard line"
+    (are [pos expected] (= expected (cursor/adjacent-line-end-pos "aaa\nbbbbbb\ncc" pos :down))
+      3 10    ;; end of first line -> end of middle line
+      10 13   ;; end of middle line -> end of last line (count)
+      13 13)) ;; end of content -> stays (no next line)
+  (testing "lands at line end regardless of relative line length"
+    ;; short line "x" between two longer lines: \n at 17 and 19, count 36
+    (is (= 36 (cursor/adjacent-line-end-pos "longer first line\nx\nlonger last line" 19 :down)))
+    (is (= 17 (cursor/adjacent-line-end-pos "longer first line\nx\nlonger last line" 19 :up))))
+  (testing "single-line content has no adjacent line"
+    (is (nil? (cursor/adjacent-line-end-pos "abc" 3 :up)))
+    (is (= 3 (cursor/adjacent-line-end-pos "abc" 3 :down)))))


### PR DESCRIPTION
## Summary

- When the caret is at the **end of a line** and you press **Up/Down**, it now stays at the **end of the target line** — both when crossing block boundaries and when moving between hard lines inside a multi-line block.
- Before: cross-boundary Up/Down replayed only the numeric column, and within-block Up/Down used pixel-nearest matching, so on a longer adjacent line the caret landed mid-line instead of at its end.

## Details

- Add `cursor/end-of-line?` predicate, symmetric with the existing `beginning-of-line?`.
- **Cross-block** (`handler/editor.cljs` `move-cross-boundary-up-down` → `handler/block.cljs` `text-range-by-lst-fst-line`): pass an `:end` sentinel when the source caret is at EOL, so it lands at the end of the adjacent block's edge line (last line for `:up`, first line for `:down`). The numeric-column path is unchanged.
- **Within-block** (`util/cursor.cljs` `move-cursor-up-down`): when at EOL, jump to the end of the adjacent hard line via the new pure `adjacent-line-end-pos`; otherwise fall back to the existing pixel/mock-text navigation, so soft-wrapped rows and mid-line movement are unchanged. `select-up-down` is untouched.
- This re-adds the *"If EOL, always move cursor to previous/next EOL"* behavior that existed in the original newline-based implementation but was dropped in 237857aafe when Up/Down moved to pixel-position navigation (needed for soft-wrapped rows and proportional/wide glyphs). It is restored as a targeted guard layered on top of pixel nav, not a revert.

## Test plan

- [ ] Unit: `frontend.handler.block-test`, `frontend.util-test`, and new `frontend.util.cursor-test` — 12 tests / 74 assertions, 0 failures, 0 errors.
- [ ] `clj-kondo` clean on all changed files; node-test build compiles with 0 warnings.
- [ ] Manual in a running app (not executed here):
  - Multi-line block: caret at end of an interior line, press Up/Down → caret at end of adjacent line.
  - Caret at end of a block, Up/Down across the boundary → end of the adjacent block's edge line.
  - Regression: mid-line Up/Down still preserves the visual column.
  - Regression: a long soft-wrapped line still moves by visual row on Up/Down.