### PR TITLE
fix(cli): normalize block content tree

### DIFF
--- a/src/main/logseq/cli/command/add.cljs
+++ b/src/main/logseq/cli/command/add.cljs
@@ -155,6 +155,19 @@
               block)))
         blocks))
 
+(defn- normalize-block-content-keys
+  [blocks]
+  (mapv (fn normalize-block-content-key [block]
+          (let [content (:block/content block)
+                block (cond-> (dissoc block :block/content)
+                        (and (contains? block :block/content)
+                             (not (contains? block :block/title)))
+                        (assoc :block/title content))]
+            (if (seq (:block/children block))
+              (update block :block/children normalize-block-content-keys)
+              block)))
+        blocks))
+
 (defn- normalize-created-ids
   [ids]
   (->> ids
@@ -1151,15 +1164,16 @@
   [action config]
   (-> (p/let [cfg (cli-server/ensure-server! config (:repo action))
               target-block-uuid (resolve-add-target cfg action)
-              ref-values (collect-page-refs (:blocks action))
+              action-blocks (normalize-block-content-keys (:blocks action))
+              ref-values (collect-page-refs action-blocks)
               {:keys [uuid-refs page-refs id-refs]} (partition-ref-values ref-values)
               _ (ensure-block-refs-exist! cfg (:repo action) uuid-refs)
               page-refs' (or (resolve-page-ref-entities cfg (:repo action) page-refs) [])
               id-refs' (or (resolve-id-ref-entities cfg (:repo action) id-refs) [])
               refs (into page-refs' id-refs')
               blocks (if (seq refs)
-                       (normalize-block-title-refs (:blocks action) refs)
-                       (:blocks action))
+                       (normalize-block-title-refs action-blocks refs)
+                       action-blocks)
               blocks-for-insert (flatten-block-tree blocks)
               status (:status action)
               tags (if (contains? action :resolved-tags)

--- a/src/test/logseq/cli/command/upsert_test.cljs
+++ b/src/test/logseq/cli/command/upsert_test.cljs
@@ -240,6 +240,72 @@
                           (is false (str "unexpected error: " e))))
                (p/finally done)))))
 
+(deftest test-execute-upsert-block-create-normalizes-content-block-tree
+  (async done
+    (let [page-uuid (random-uuid)
+          parent-uuid (random-uuid)
+          child-uuid (random-uuid)
+          inserted-blocks* (atom nil)
+          action {:type :upsert-block
+                  :mode :create
+                  :repo "demo-repo"
+                  :graph "demo-graph"
+                  :target-page-name "TestPage"
+                  :blocks [{:block/content "Parent"
+                            :block/uuid parent-uuid
+                            :block/children [{:block/content "Child"
+                                              :block/uuid child-uuid}]}]
+                  :pos "last-child"}]
+      (-> (p/with-redefs [cli-server/ensure-server! (fn [config _repo]
+                                                      (p/resolved (assoc config :base-url "http://example")))
+                          transport/invoke (fn [_ method args]
+                                             (case method
+                                               :thread-api/q
+                                               (p/resolved [{:db/id 10
+                                                            :block/uuid page-uuid
+                                                            :block/name "testpage"
+                                                            :block/title "TestPage"}])
+
+                                               :thread-api/apply-outliner-ops
+                                               (let [[_ ops _] args
+                                                     blocks (get-in ops [0 1 0])]
+                                                 (reset! inserted-blocks* blocks)
+                                                 (if (every? (fn [block]
+                                                               (and (:block/title block)
+                                                                    (not (contains? block :block/content))))
+                                                             blocks)
+                                                   (p/resolved {:tx-data blocks})
+                                                   (p/rejected (ex-info "DB write failed with invalid data"
+                                                                        {:code :exception}))))
+
+                                               :thread-api/pull
+                                               (let [[_ _ lookup] args]
+                                                 (p/resolved
+                                                  (cond
+                                                    (= lookup [:block/uuid parent-uuid])
+                                                    {:db/id 101 :block/uuid parent-uuid}
+
+                                                    (= lookup [:block/uuid child-uuid])
+                                                    {:db/id 102 :block/uuid child-uuid}
+
+                                                    :else {})))
+
+                                               (throw (ex-info "unexpected invoke"
+                                                               {:method method
+                                                                :args args}))))]
+            (p/let [result (upsert-command/execute-upsert-block action {})]
+              (is (= :ok (:status result)))
+              (is (= [101 102] (get-in result [:data :result])))
+              (is (= [{:block/title "Parent"
+                       :block/uuid parent-uuid}
+                      {:block/title "Child"
+                       :block/uuid child-uuid
+                       :block/parent [:block/uuid parent-uuid]}]
+                     @inserted-blocks*))))
+          (p/catch (fn [e]
+                     (is false (str "unexpected error: " e))))
+          (p/finally done)))))
+
 (deftest test-build-task-action-validation
   (testing "upsert task requires target selector or content/page"
     (let [result (upsert-command/build-task-action {} "logseq_db_demo")]
@@ -707,5 +773,4 @@
           (p/catch (fn [e]
                      (is false (str "unexpected error: " e))))
           (p/finally done)))))
-
 


### PR DESCRIPTION
## Summary
- Normalize CLI block tree payloads that use `:block/content` into `:block/title` before insert operations reach db-worker.
- Add a focused regression test for `upsert block --blocks` create mode with nested `:block/content` blocks.

## Root Cause
`upsert block --blocks` delegates create mode through the add-block path. EDN trees using `:block/content` were flattened and sent to `:insert-blocks` unchanged, which produced invalid db-worker transaction data because inserted blocks expect `:block/title`.

## Validation
- `bb dev:test -v logseq.cli.command.upsert-test/test-execute-upsert-block-create-normalizes-content-block-tree`
- `bb dev:test -v logseq.cli.command.add-test`
- `bb dev:test -v logseq.cli.command.upsert-test`
- `clojure -M:cljs compile db-worker-node logseq-cli`
- Verified `node static/logseq-cli.js ... upsert block --blocks '[{:block/content ...}]'` succeeds on a disposable graph and `show` displays the nested hierarchy.
