### PR TITLE
feat(cli): add agent bridge diagnostics and lifecycle logging

### DIFF
--- a/.agents/skills/logseq-cli/SKILL.md
+++ b/.agents/skills/logseq-cli/SKILL.md
@@ -29,7 +29,7 @@ Use `logseq` to inspect and edit graph entities, run Datascript queries, and con
 - `doctor`
 - `sync status|start|stop|upload|download|remote-graphs|ensure-keys|grant-access|config set|get|unset`
 - Authentication: `login|logout`
-- Utilities: `completion`, `debug`, `example`, `skill`
+- Utilities: `agent bridge|agent bridge list`, `completion`, `debug`, `example`, `skill`
 
 ## Global options
 
@@ -116,6 +116,9 @@ Use `logseq` to inspect and edit graph entities, run Datascript queries, and con
 ## Tips
 
 - `query list` returns both built-ins and `custom-queries` from `cli.edn`.
+- `agent bridge --dry-run` checks the local bridge setup, resolves `:agent-name` or hostname, registers the AgentBridge name in the graph, finds routable `#Task` TODO blocks assigned to that AgentBridge name, and prints the Codex commands it would run without starting Codex or writing `agent-session-id`.
+- `agent bridge` starts/reuses db-worker-node, listens to db-worker-node events, scans routable tasks on startup and each event, starts `codex exec --json` for matched tasks, stores the Codex session/thread id in `agent-bridge-sessions.edn`, and writes it to the task's `agent-session-id` property.
+- `agent bridge list` reads root-dir scoped bridge session records and hides completed sessions by default; use `--all` to include them.
 - `show --id` accepts either one db/id or an EDN vector of ids.
 - `remove block --id` also accepts one db/id or an EDN vector.
 - `upsert block` enters update mode when `--id` or `--uuid` is provided.

--- a/.agents/skills/logseq-review-workflow/SKILL.md
+++ b/.agents/skills/logseq-review-workflow/SKILL.md
@@ -87,7 +87,7 @@ Then read every matching module below.
 
 ### 3. Launch independent pass subagents
 
-Launch all pass subagents in parallel in one delegation round. Do not run pass subagents serially unless the environment cannot start them in parallel. Give every read-only subagent:
+Launch read-only pass subagents with a maximum concurrency of 4. Start the first batch of up to 4 pass subagents, wait for at least one to finish, then start the next pending pass subagent until every pass has been launched. Do not exceed 4 running pass subagents at the same time. Do not run pass subagents serially unless the environment cannot support concurrent subagents. Give every read-only subagent:
 
 - the diff, commit range, PR, patch, or changed file list under review
 - the scope collected in step 1
@@ -109,7 +109,7 @@ Passes:
 | Test coverage | [`rules/passes/test-coverage.md`](./rules/passes/test-coverage.md) |
 | Repository convention | [`rules/passes/repository-convention.md`](./rules/passes/repository-convention.md) |
 
-Ask each subagent to inspect only its assigned pass and return only candidate findings, supporting evidence, checks already run, and unresolved questions. While the subagents run in parallel, the main agent may prepare aggregation and validation steps but must wait for every pass report before the final review. If subagents are unavailable or parallel launch is not possible, run each pass locally with the same rule files and state that delegation or parallelism was unavailable in the verification summary.
+Ask each subagent to inspect only its assigned pass and return only candidate findings, supporting evidence, checks already run, and unresolved questions. While up to 4 subagents run in parallel, the main agent may prepare aggregation and validation steps but must keep launching pending passes as slots open and must wait for every pass report before the final review. If subagents are unavailable or concurrent launch is not possible, run each pass locally with the same rule files and state that delegation or concurrency was unavailable in the verification summary.
 
 ### 4. Aggregate pass results
 
@@ -156,11 +156,14 @@ Each finding should include:
 
 ```markdown
 - **Severity:** Blocking | Important | Minor | Question
+- **Category:** Correctness | Data contract | Regression | Failure mode | Migration validation | Performance | Test coverage | Repository convention
 - **Location:** `path/to/file.cljs:line`
 - **Issue:** What is wrong.
 - **Impact:** Concrete user, data, runtime, or maintenance impact.
 - **Suggestion:** Smallest actionable fix or verification step.
 ```
+
+Separate findings with a horizontal rule (`---`) when reporting more than one finding.
 
 If there are no findings, say what was reviewed and which rule modules were applied.
 
@@ -170,7 +173,7 @@ Add a short verification summary after findings or after the no-findings stateme
 
 - Did you apply `rules/common.md`?
 - Did you route every touched library/module to its rule file?
-- Did you launch one read-only subagent for each independent pass in parallel, or state why delegation or parallelism was unavailable?
+- Did you launch one read-only subagent for each independent pass with at most 4 running concurrently, starting new pass subagents as slots opened, or state why delegation or concurrency was unavailable?
 - Did each subagent only collect issues and avoid modifying code?
 - Did you wait for all pass reports before writing the final review?
 - Did you deduplicate and validate actionable findings before including them?

--- a/.agents/skills/logseq-review-workflow/SKILL.md
+++ b/.agents/skills/logseq-review-workflow/SKILL.md
@@ -1,15 +1,17 @@
 ---
 name: logseq-review-workflow
-description: Review Logseq changes with a structured workflow that routes findings through general repository rules, third-party library rules, Logseq module-specific rules, and targeted runtime verification across the web app, desktop app, and Logseq CLI.
+description: Review Logseq code changes, PRs, patches, commit ranges, or implementation plans through one main-agent orchestration workflow that routes read-only subagents across independent review passes, then deduplicates, validates, and reports findings for the web app, desktop app, and Logseq CLI.
 ---
 
 # Logseq Review Workflow
 
-Use this skill when reviewing a Logseq code change, PR, patch, commit range, or implementation plan for correctness, regressions, maintainability, and repository convention compliance.
-
 ## Core principle
 
-Review the change through three layers:
+The main agent drives the review. It identifies scope, loads routing rules, launches independent read-only subagents for each review pass, collects candidate findings, validates the actionable ones, deduplicates overlap, and writes the final conclusion.
+
+Each pass subagent only collects issues. It must not edit files, stage changes, commit, push, or rewrite code. It returns candidate findings, evidence, checks already run, and unresolved questions to the main agent.
+
+Review every pass through three layers:
 
 1. **Repository-wide rules** — always apply shared review behavior from `rules/common.md`.
 2. **Library/runtime/tooling rules** — apply when the diff uses or changes a specific library, language/runtime surface, or tooling dependency.
@@ -19,7 +21,7 @@ Use the routing tables below to load the most specific matching rule files.
 
 Prefer concrete findings backed by code paths, invariants, tests, or runtime behavior. Do not list speculative issues unless you can explain the failure mode and affected scenario.
 
-Every actionable finding must be validated through at least one real Logseq interaction path before it is included in the final review. Use `logseq-repl`, `logseq-cli`, `chrome`, or `computer-use` depending on the touched surface. Static reasoning and unit tests are useful for narrowing the issue, but they do not replace this per-finding runtime or tool-based validation requirement.
+Every actionable finding with an executable Logseq behavior path must be validated through at least one real Logseq interaction path before it is included in the final review. Use `logseq-repl`, `logseq-cli`, `chrome`, or `computer-use` depending on the touched surface. For implementation plans, docs-only changes, static configuration errors, missing migrations, schema/protocol invariant breaks, or other findings without an executable behavior path, validate through code paths, invariant evidence, tests, build/lint output, or documented contracts and state why runtime interaction does not apply.
 
 ## Read these first
 
@@ -39,7 +41,7 @@ Collect:
 
 - changed files and touched namespaces
 - target runtime: renderer, Electron main process, db-worker-node, CLI, mobile, server/worker, tests, docs
-- changed public contracts: APIs, CLI output, DB schema, protocol messages, migrations, translations, config, or persisted data
+- changed public contracts: APIs, CLI output, DB schema, `frontend.worker.db.migrate/schema-version->updates`, migration `migrate-updates`, protocol messages, translations, config, or persisted data
 - dependencies and libraries involved
 
 ### 2. Load matching rule modules
@@ -47,6 +49,7 @@ Collect:
 Always read:
 
 - [`rules/common.md`](./rules/common.md)
+- [`rules/passes/subagent-output.md`](./rules/passes/subagent-output.md)
 
 Then read every matching module below.
 
@@ -82,21 +85,49 @@ Then read every matching module below.
 | Mobile/Capacitor platform behavior | [`rules/modules/mobile.md`](./rules/modules/mobile.md) |
 | Whiteboard/canvas/tldraw-style interactions | [`rules/modules/whiteboard.md`](./rules/modules/whiteboard.md) |
 
-### 3. Review in ordered passes
+### 3. Launch independent pass subagents
 
-1. **Correctness pass** — identify broken invariants, invalid state transitions, contract mismatches, async races, schema/query errors, and missing migrations.
-2. **Regression pass** — check compatibility with existing graph data, DB graphs, file graphs, mobile/desktop runtimes, and persisted settings.
-3. **Failure-mode pass** — check error propagation, logging, cancellation, transaction atomicity, partial writes, and fail-fast behavior.
-4. **Performance pass** — check query shape, repeated schema construction, large data conversions, render loops, memory retention, and cache invalidation.
-5. **Test pass** — verify that tests cover the behavior contract and failure cases, not just happy paths.
-6. **Finding validation pass** — for each candidate actionable finding, run at least one actual check through an appropriate Logseq interaction path:
+Launch all pass subagents in parallel in one delegation round. Do not run pass subagents serially unless the environment cannot start them in parallel. Give every read-only subagent:
+
+- the diff, commit range, PR, patch, or changed file list under review
+- the scope collected in step 1
+- `rules/common.md`
+- [`rules/passes/subagent-output.md`](./rules/passes/subagent-output.md)
+- that pass's rule file
+- any matching library/module rules relevant to that pass
+
+Passes:
+
+| Pass | Rule file |
+|---|---|
+| Correctness | [`rules/passes/correctness.md`](./rules/passes/correctness.md) |
+| Data contract | [`rules/passes/data-contract.md`](./rules/passes/data-contract.md) |
+| Regression | [`rules/passes/regression.md`](./rules/passes/regression.md) |
+| Failure mode | [`rules/passes/failure-mode.md`](./rules/passes/failure-mode.md) |
+| Migration validation | [`rules/passes/migration-validation.md`](./rules/passes/migration-validation.md) |
+| Performance | [`rules/passes/performance.md`](./rules/passes/performance.md) |
+| Test coverage | [`rules/passes/test-coverage.md`](./rules/passes/test-coverage.md) |
+| Repository convention | [`rules/passes/repository-convention.md`](./rules/passes/repository-convention.md) |
+
+Ask each subagent to inspect only its assigned pass and return only candidate findings, supporting evidence, checks already run, and unresolved questions. While the subagents run in parallel, the main agent may prepare aggregation and validation steps but must wait for every pass report before the final review. If subagents are unavailable or parallel launch is not possible, run each pass locally with the same rule files and state that delegation or parallelism was unavailable in the verification summary.
+
+### 4. Aggregate pass results
+
+Wait for all pass subagents before writing the final review. Then:
+
+1. Merge all candidate findings.
+2. Deduplicate overlapping reports across passes.
+3. Discard findings without concrete evidence or turn them into questions.
+4. Preserve the originating pass name for each retained finding.
+5. Validate every actionable finding before including it.
+
+For executable behavior paths, validate with an appropriate Logseq interaction path:
    - `logseq-repl` for ClojureScript functions, DataScript state, importer/exporter behavior, renderer state, Electron, or worker runtime behavior.
    - `logseq-cli` for CLI command behavior, db-worker-node graph interactions, command output, and graph mutations.
    - `chrome` or `computer-use` for UI, keyboard, accessibility, browser-visible rendering, Electron window behavior, and user workflows.
-   Record the exact command, REPL expression, or UI workflow and the observed result. If no actual check can be run, do not present the item as a confirmed finding; either continue investigating, downgrade it to a clearly labeled question, or explain the blocker.
-7. **Repository-convention pass** — apply naming, i18n, logging, keyword, migration, and command conventions.
+For findings without an executable behavior path, validate with code-path evidence, schema/protocol invariants, migration evidence, tests, build/lint output, or documented contracts. Record the exact command, REPL expression, UI workflow, or static evidence and the observed result. If no applicable check can be run, do not present the item as a confirmed finding; either continue investigating, downgrade it to a clearly labeled question, or explain the blocker.
 
-### 4. Run targeted runtime verification
+### 5. Run targeted runtime verification
 
 After static code inspection, exercise the reviewed functionality in the runtime surfaces affected by the diff. Keep the scenarios narrow: validate the changed behavior, the likely regression path, or the exact failure mode behind a finding.
 
@@ -110,7 +141,7 @@ Prefer isolated test graphs, temporary root directories, or disposable app state
 
 If a surface is relevant but cannot be exercised, say exactly why. Do not describe unrun checks as verified.
 
-### 5. Severity guidance
+### 6. Severity guidance
 
 Use concise severity labels:
 
@@ -119,7 +150,7 @@ Use concise severity labels:
 - **Minor** — readability, naming, local maintainability, missing small cleanup.
 - **Question** — unclear intent or missing context that prevents confident review.
 
-### 6. Finding format
+### 7. Finding format
 
 Each finding should include:
 
@@ -133,17 +164,22 @@ Each finding should include:
 
 If there are no findings, say what was reviewed and which rule modules were applied.
 
-Add a short verification summary after findings or after the no-findings statement. Include the CLI commands, REPL probes, Chrome/browser scenarios, Desktop UI actions, and any relevant checks that could not be run.
+Add a short verification summary after findings or after the no-findings statement. Include the CLI commands, REPL probes, Chrome/browser scenarios, Desktop UI actions, static evidence, and any relevant checks that could not be run.
 
 ## Review checklist before final response
 
 - Did you apply `rules/common.md`?
 - Did you route every touched library/module to its rule file?
+- Did you launch one read-only subagent for each independent pass in parallel, or state why delegation or parallelism was unavailable?
+- Did each subagent only collect issues and avoid modifying code?
+- Did you wait for all pass reports before writing the final review?
+- Did you deduplicate and validate actionable findings before including them?
 - Did you run targeted runtime verification after static inspection for every affected web-app, desktop-app, and Logseq CLI surface?
 - Did you separate verified behavior from checks that could not be run?
 - Did you distinguish proven issues from questions?
 - Did you check persisted data, migrations, or protocol compatibility when relevant?
+- Did you run the migration validation pass and explicitly decide whether the reviewed change requires `frontend.worker.db.migrate/schema-version->updates`, migration `migrate-updates`, a `logseq.db.frontend.schema/version` bump, or migration tests?
 - Did you check tests and name exact missing test coverage?
-- Did every actionable finding have at least one actual validation via `logseq-repl`, `logseq-cli`, `chrome`, or `computer-use`, with observed evidence?
+- Did every actionable finding have applicable validation evidence, using `logseq-repl`, `logseq-cli`, `chrome`, or `computer-use` for executable behavior paths and static/protocol/build evidence for non-executable findings?
 - Did you avoid asking for broad rewrites when a targeted fix is enough?
 - Did you mention any verification you could not perform?

--- a/.agents/skills/logseq-review-workflow/rules/README.md
+++ b/.agents/skills/logseq-review-workflow/rules/README.md
@@ -3,6 +3,7 @@
 The rule files are intentionally modular:
 
 - `common.md` is always applied.
+- `passes/` files define independent read-only subagent review passes and their output contract.
 - `libraries/` files apply based on imported libraries, data structures, or runtime tooling.
 - `modules/` files apply based on Logseq product/runtime area.
 

--- a/.agents/skills/logseq-review-workflow/rules/passes/correctness.md
+++ b/.agents/skills/logseq-review-workflow/rules/passes/correctness.md
@@ -1,0 +1,14 @@
+# Correctness Pass
+
+Inspect the reviewed change for broken behavior and invalid state.
+
+Check:
+
+- broken invariants and invalid state transitions
+- incorrect branching, nil handling, ordering, identity, or lifecycle behavior
+- contract mismatches between callers and callees
+- async races, cancellation mistakes, stale state, and promise/task misuse
+- schema, query, transaction, migration, and persistence mistakes
+- behavior that contradicts documented API, CLI, protocol, or UI contracts
+
+Return results using [`subagent-output.md`](./subagent-output.md).

--- a/.agents/skills/logseq-review-workflow/rules/passes/data-contract.md
+++ b/.agents/skills/logseq-review-workflow/rules/passes/data-contract.md
@@ -1,0 +1,19 @@
+# Data-contract Pass
+
+Use this file when running the independent data-contract review pass for `logseq-review-workflow`.
+
+## Mission
+
+Inspect the reviewed change for data-contract drift. Identify the canonical data shape proven by current callers, tests, public contracts, persisted data, protocol decoders, DB queries, pull selectors, schemas, or explicit boundary requirements. Flag defensive fallbacks, input-shape guessing, silent coercion, unnecessary normalizers, and compatibility ladders that are not justified by that evidence.
+
+## Required checks
+
+- Map every changed data path to its source of truth and canonical shape.
+- Treat already-contracted domain data as valid. Examples: a valid datom is already a datom; a DB pull result follows its selector; a schema-validated value is already validated; a protocol decoder defines the decoded payload shape.
+- Do not require normalizers for already-contracted domain data merely to make downstream access defensive or uniform.
+- Allow normalization only at actual external, persisted, user, CLI, network, or JS/native interop boundaries that must accept multiple shapes.
+- Require downstream code to use one clear contract after boundary validation or normalization.
+- Flag broad `or` chains, generic stringification, map/string/keyword guessing, alternate field-name ladders, unchecked dynamic access, and default values that hide missing required data.
+- Ask for unsupported-shape tests only when the changed code owns boundary validation. Do not ask for invalid-shape tests for data guaranteed by an upstream contract.
+
+Return results using [`subagent-output.md`](./subagent-output.md). If there are no findings, say which changed data paths were inspected and what canonical contracts were confirmed.

--- a/.agents/skills/logseq-review-workflow/rules/passes/failure-mode.md
+++ b/.agents/skills/logseq-review-workflow/rules/passes/failure-mode.md
@@ -1,0 +1,14 @@
+# Failure-mode Pass
+
+Inspect how the reviewed change behaves when operations fail or stop halfway.
+
+Check:
+
+- error propagation, user-visible errors, logs, and swallowed exceptions
+- fail-fast behavior versus silent recovery from programmer errors
+- cancellation, retries, timeouts, and async cleanup
+- transaction atomicity, partial writes, duplicate writes, and rollback assumptions
+- file system, network, IPC, worker, and interop failures
+- resource cleanup, listener cleanup, and state consistency after failure
+
+Return results using [`subagent-output.md`](./subagent-output.md).

--- a/.agents/skills/logseq-review-workflow/rules/passes/migration-validation.md
+++ b/.agents/skills/logseq-review-workflow/rules/passes/migration-validation.md
@@ -1,0 +1,28 @@
+# Migration-validation Pass
+
+Inspect the reviewed change for missing or incorrect frontend DB migrations. Decide whether changed persisted graph state requires updates in `frontend.worker.db.migrate`, especially `schema-version->updates` and the migration maps returned as `:migrate-updates`.
+
+## Required checks
+
+- Identify every changed persisted attribute, built-in property, built-in class, schema entry, kv entry, datom shape, or invariant that can already exist in user graphs.
+- Check whether the change requires a new `frontend.worker.db.migrate/schema-version->updates` entry and a matching `logseq.db.frontend.schema/version` bump.
+- For new built-in properties or classes, verify that the migration map uses the correct `:properties` or `:classes` entry so `upgrade-version!` returns accurate `:migrate-updates`.
+- For data rewrites, backfills, or invariant repairs, verify that the migration map uses `:fix` and that the returned tx report includes the intended `:migrate-updates` for sync handling.
+- For deleted properties, verify `:delete-properties` coverage and check whether the deleted attrs must also be listed in `logseq.db-sync.tx-sanitize/migration-deleted-attrs`.
+- Check that older graph versions are migrated deterministically without relying on runtime fallback defaults or broad compatibility code.
+- Check migration tests under `src/test/frontend/worker/migrate_test.cljs` or an equivalent targeted test for the old-version graph state and the post-migration state.
+
+## Red flags
+
+- A new built-in property/class or persisted attr is only added to creation-time data, schema, or property definitions, with no `schema-version->updates` entry for existing graphs.
+- `logseq.db.frontend.schema/version` is bumped without a corresponding migration entry, or a migration entry exceeds the current schema version.
+- Migration tx data changes existing user graph state but `:migrate-updates` does not describe the migration map that sync consumers need.
+- Deleted attrs are removed locally but still leak through db-sync sanitization or old local tx replay.
+- Tests cover newly-created graphs only, not migration from the previous schema version.
+
+## Suggested validation
+
+- Static evidence: inspect `src/main/frontend/worker/db/migrate.cljs`, `deps/db/src/logseq/db/frontend/schema.cljs`, built-in property/class definitions, and db-sync sanitization when attrs are deleted.
+- Test evidence: run a focused migration test with `bb dev:test -v frontend.worker.migrate-test/<test-name>` when a migration finding is actionable.
+
+Return results using [`subagent-output.md`](./subagent-output.md). If there are no findings, state which persisted changes were inspected and why no migration, `migrate-updates`, schema version bump, or migration test is required.

--- a/.agents/skills/logseq-review-workflow/rules/passes/performance.md
+++ b/.agents/skills/logseq-review-workflow/rules/passes/performance.md
@@ -1,0 +1,14 @@
+# Performance Pass
+
+Inspect the reviewed change for realistic performance and resource regressions.
+
+Check:
+
+- query shape, indexes, pull selectors, repeated scans, and N+1 access
+- repeated schema construction, parsing, serialization, or large data conversions
+- render loops, reactive recomputation, cache invalidation, and unnecessary subscriptions
+- memory retention, listener leaks, unbounded collections, and long-lived references
+- work that scales poorly with large graphs, many blocks, many pages, or sync history
+- startup, command latency, import/export, search, and background worker impact
+
+Return results using [`subagent-output.md`](./subagent-output.md).

--- a/.agents/skills/logseq-review-workflow/rules/passes/regression.md
+++ b/.agents/skills/logseq-review-workflow/rules/passes/regression.md
@@ -1,0 +1,14 @@
+# Regression Pass
+
+Inspect the reviewed change for behavior that may break existing users, graphs, runtimes, or persisted data.
+
+Check:
+
+- compatibility with existing DB graphs, file graphs, synced graphs, and persisted settings
+- migration, schema, property, protocol, and config compatibility
+- changed CLI output, command behavior, user workflows, keyboard flows, or public APIs
+- renderer, Desktop, Electron main-process, db-worker-node, mobile, and server/runtime differences
+- removed compatibility that is not justified by a current contract
+- edge cases in older graph data or partially migrated state
+
+Return results using [`subagent-output.md`](./subagent-output.md).

--- a/.agents/skills/logseq-review-workflow/rules/passes/repository-convention.md
+++ b/.agents/skills/logseq-review-workflow/rules/passes/repository-convention.md
@@ -1,0 +1,15 @@
+# Repository-convention Pass
+
+Inspect the reviewed change for Logseq repository conventions and maintainability.
+
+Check:
+
+- root and directory-specific `AGENTS.md` rules
+- naming, namespace layout, keyword definitions, and built-in property conventions
+- i18n rules for shipped user-facing text and translation dictionaries
+- logging, console output, CLI output, and error message conventions
+- migration placement, db-sync deleted attrs, and schema update rules
+- dependency, npm interop, Electron/Node/browser boundary conventions
+- unnecessary compatibility layers, broad rewrites, or unrelated refactors
+
+Return results using [`subagent-output.md`](./subagent-output.md).

--- a/.agents/skills/logseq-review-workflow/rules/passes/subagent-output.md
+++ b/.agents/skills/logseq-review-workflow/rules/passes/subagent-output.md
@@ -1,0 +1,38 @@
+# Review Pass Subagent Output
+
+Use this output contract for every `logseq-review-workflow` pass subagent.
+
+## Hard constraints
+
+- Stay read-only: do not edit files, stage changes, commit, push, or rewrite code.
+- Inspect only the assigned pass. Mention cross-pass concerns as notes, not primary findings.
+- Report candidate findings only when backed by concrete evidence.
+- Set each finding's `Category` to the assigned pass type. Do not invent categories.
+- Include questions when intent or contract ambiguity prevents a confident finding.
+
+## Output
+
+```markdown
+## <Pass Name> Pass Result
+
+### Candidate findings
+
+- **Severity:** Blocking | Important | Minor | Question
+- **Category:** Correctness | Data contract | Regression | Failure mode | Migration validation | Performance | Test coverage | Repository convention
+- **Location:** `path/to/file.cljs:line`
+- **Issue:** What is wrong.
+- **Evidence:** Code path, invariant, test, runtime observation, contract, or command output inspected.
+- **Impact:** Concrete user, data, runtime, or maintenance impact.
+- **Suggested validation:** Exact command, REPL probe, CLI workflow, UI workflow, or static check the main agent can use.
+- **Suggestion:** Smallest actionable fix.
+
+### Checks run
+
+- Exact commands, REPL probes, static files, or reasoning paths inspected.
+
+### Questions
+
+- Ambiguities that should remain questions unless the main agent finds more evidence.
+```
+
+If there are no findings, state the files and behavior areas inspected and why they passed this pass.

--- a/.agents/skills/logseq-review-workflow/rules/passes/test-coverage.md
+++ b/.agents/skills/logseq-review-workflow/rules/passes/test-coverage.md
@@ -1,0 +1,15 @@
+# Test-coverage Pass
+
+Inspect whether the reviewed change has useful tests for the behavior it changes.
+
+Check:
+
+- tests cover the changed contract, not only happy paths
+- regression tests exist for fixed bugs or risky behavior
+- boundary validation is tested when the changed code owns that boundary
+- tests avoid unsupported-shape cases when upstream contracts already guarantee the shape
+- unit, CLI E2E, clj-e2e, or runtime probes match the touched surface
+- assertions verify observable behavior rather than implementation details only
+- test names, fixtures, and graph setup remain maintainable
+
+Return results using [`subagent-output.md`](./subagent-output.md).

--- a/cli-e2e/scripts/agent_bridge_demo.sh
+++ b/cli-e2e/scripts/agent_bridge_demo.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: agent_bridge_demo.sh [options]
+
+Creates a fresh Logseq graph, starts `logseq agent bridge`, writes a routable
+task after the bridge listener is ready, and verifies that a fake Codex worker
+executed the task and that AgentBridge wrote agent-session-id.
+
+Options:
+  --cli PATH          Path to static/logseq-cli.js. Default: <repo-root>/static/logseq-cli.js
+  --root-dir DIR     Logseq CLI root dir. Default: a new temp dir
+  --graph NAME       Graph name. Default: agent-bridge-demo-<timestamp>
+  --repo-root DIR    Repository root. Default: inferred from this script
+  --timeout-sec N    Wait timeout for bridge events. Default: 45
+  -h, --help         Show this help
+USAGE
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+cli_path=""
+root_dir=""
+graph="agent-bridge-demo-$(date +%s)"
+timeout_sec=45
+agent_name="AgentBridgeDemo"
+task_title="AgentBridge demo task: mark this block done"
+expected_session="thread-agent-bridge-demo"
+bridge_pid=""
+graph_created=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cli)
+      cli_path="$2"
+      shift 2
+      ;;
+    --root-dir)
+      root_dir="$2"
+      shift 2
+      ;;
+    --graph)
+      graph="$2"
+      shift 2
+      ;;
+    --repo-root)
+      repo_root="$2"
+      shift 2
+      ;;
+    --timeout-sec)
+      timeout_sec="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+cli_path="${cli_path:-$repo_root/static/logseq-cli.js}"
+root_dir="${root_dir:-$(mktemp -d "${TMPDIR:-/tmp}/logseq-agent-bridge-demo.XXXXXX")}"
+config_path="$root_dir/cli.edn"
+work_dir="$root_dir/agent-bridge-demo"
+fake_bin="$work_dir/fake-bin"
+bridge_log="$work_dir/agent-bridge.log"
+bridge_err="$work_dir/agent-bridge.err"
+codex_log="$work_dir/codex-invocations.jsonl"
+
+cleanup() {
+  local status=$?
+  if [[ -n "${bridge_pid:-}" ]] && kill -0 "$bridge_pid" 2>/dev/null; then
+    kill "$bridge_pid" 2>/dev/null || true
+    wait "$bridge_pid" 2>/dev/null || true
+  fi
+  if [[ "$graph_created" -eq 1 ]]; then
+    node "$cli_path" --root-dir "$root_dir" --config "$config_path" --output json server stop --graph "$graph" >/dev/null 2>&1 || true
+  fi
+  exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required command is missing: $1" >&2
+    exit 2
+  fi
+}
+
+json_result() {
+  python3 -c 'import json,sys; print(json.load(sys.stdin)["data"]["result"])'
+}
+
+json_result_first() {
+  python3 -c 'import json,sys; r=json.load(sys.stdin)["data"]["result"]; print(r[0] if isinstance(r, list) else r)'
+}
+
+run_cli_json() {
+  node "$cli_path" --root-dir "$root_dir" --config "$config_path" --output json "$@"
+}
+
+wait_for_file_text() {
+  local path="$1"
+  local text="$2"
+  local deadline=$((SECONDS + timeout_sec))
+  while (( SECONDS < deadline )); do
+    if [[ -f "$path" ]] && grep -Fq "$text" "$path"; then
+      return 0
+    fi
+    if [[ -n "${bridge_pid:-}" ]] && ! kill -0 "$bridge_pid" 2>/dev/null; then
+      echo "agent bridge exited before '$text'" >&2
+      [[ -f "$bridge_log" ]] && cat "$bridge_log" >&2
+      [[ -f "$bridge_err" ]] && cat "$bridge_err" >&2
+      exit 1
+    fi
+    sleep 0.2
+  done
+  echo "Timed out waiting for '$text' in $path" >&2
+  [[ -f "$bridge_log" ]] && cat "$bridge_log" >&2
+  [[ -f "$bridge_err" ]] && cat "$bridge_err" >&2
+  exit 1
+}
+
+query_task_status() {
+  run_cli_json query --graph "$graph" --query "[:find ?status-ident . :where [$1 :logseq.property/status ?status] [?status :db/ident ?status-ident]]" | json_result
+}
+
+query_agent_session() {
+  local payload
+  payload="$(run_cli_json query --graph "$graph" --query "[:find ?session . :where [$1 ?attr ?session] [?p :block/name \"agent-session-id\"] [?p :db/ident ?attr]]")"
+  python3 - "$root_dir" "$config_path" "$graph" "$cli_path" "$payload" <<'PY'
+import json
+import subprocess
+import sys
+
+payload = json.loads(sys.argv[5])
+value = payload.get("data", {}).get("result")
+if isinstance(value, int):
+    root_dir, config_path, graph, cli_path = sys.argv[1:5]
+    query = f"[:find ?title . :where [{value} :block/title ?title]]"
+    resolved = subprocess.check_output(
+        [
+            "node",
+            cli_path,
+            "--root-dir",
+            root_dir,
+            "--config",
+            config_path,
+            "--output",
+            "json",
+            "query",
+            "--graph",
+            graph,
+            "--query",
+            query,
+        ],
+        text=True,
+    )
+    value = json.loads(resolved)["data"]["result"]
+print("" if value is None else value)
+PY
+}
+
+write_fake_codex() {
+  mkdir -p "$fake_bin"
+  cat > "$fake_bin/codex" <<'FAKE_CODEX'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -eq 1 && "$1" == "--version" ]]; then
+  echo "codex-cli 0.0.0-agent-bridge-demo"
+  exit 0
+fi
+
+if [[ "$#" -ge 3 && "$1" == "exec" && "$2" == "--json" ]]; then
+  prompt="$3"
+  python3 - "$CODEX_FAKE_LOG" "$prompt" "$@" <<'PY'
+import json
+import pathlib
+import sys
+
+log_path = pathlib.Path(sys.argv[1])
+prompt = sys.argv[2]
+args = sys.argv[3:]
+log_path.parent.mkdir(parents=True, exist_ok=True)
+with log_path.open("a", encoding="utf8") as f:
+    f.write(json.dumps({"args": args, "prompt": prompt}, ensure_ascii=False) + "\n")
+PY
+  block_uuid="$(python3 - "$prompt" <<'PY'
+import re
+import sys
+
+match = re.search(r"^Block UUID:\s*([0-9a-fA-F-]+)\s*$", sys.argv[1], re.MULTILINE)
+if not match:
+    raise SystemExit("Block UUID not found in AgentBridge prompt")
+print(match.group(1))
+PY
+)"
+  node "$DEMO_CLI" --root-dir "$DEMO_ROOT_DIR" --config "$DEMO_CONFIG" --output json upsert task --graph "$DEMO_GRAPH" --uuid "$block_uuid" --status done >/dev/null
+  printf '{"type":"thread.started","thread_id":"thread-agent-bridge-demo"}\n'
+  exit 0
+fi
+
+echo "unexpected codex args: $*" >&2
+exit 2
+FAKE_CODEX
+  chmod +x "$fake_bin/codex"
+}
+
+require_command node
+require_command python3
+
+mkdir -p "$work_dir"
+printf '{:output-format :json :agent-name "%s"}\n' "$agent_name" > "$config_path"
+write_fake_codex
+
+echo "creating graph: $graph"
+echo "root dir: $root_dir"
+run_cli_json graph create --graph "$graph" >/dev/null
+graph_created=1
+
+echo "starting agent bridge"
+PATH="$fake_bin:$PATH" \
+CODEX_FAKE_LOG="$codex_log" \
+DEMO_CLI="$cli_path" \
+DEMO_ROOT_DIR="$root_dir" \
+DEMO_CONFIG="$config_path" \
+DEMO_GRAPH="$graph" \
+  node "$cli_path" --root-dir "$root_dir" --config "$config_path" --output human agent bridge --graph "$graph" >"$bridge_log" 2>"$bridge_err" &
+bridge_pid=$!
+
+wait_for_file_text "$bridge_log" "listening graph changes"
+
+task_id="$(run_cli_json upsert task --graph "$graph" --target-page AgentBridgeDemo --content "$task_title" --status todo | json_result_first)"
+run_cli_json upsert block --graph "$graph" --id "$task_id" --update-properties "{\"Assignee\" \"$agent_name\"}" >/dev/null
+
+deadline=$((SECONDS + timeout_sec))
+task_status=""
+agent_session=""
+while (( SECONDS < deadline )); do
+  task_status="$(query_task_status "$task_id")"
+  agent_session="$(query_agent_session "$task_id")"
+  if [[ "$task_status" == "logseq.property/status.done" && "$agent_session" == "$expected_session" ]]; then
+    break
+  fi
+  if [[ -n "${bridge_pid:-}" ]] && ! kill -0 "$bridge_pid" 2>/dev/null; then
+    echo "agent bridge exited before verification completed" >&2
+    cat "$bridge_log" >&2
+    cat "$bridge_err" >&2
+    exit 1
+  fi
+  sleep 0.5
+done
+
+if [[ "$task_status" != "logseq.property/status.done" ]]; then
+  echo "Expected task status done, got: ${task_status:-<empty>}" >&2
+  cat "$bridge_log" >&2
+  cat "$bridge_err" >&2
+  exit 1
+fi
+
+if [[ "$agent_session" != "$expected_session" ]]; then
+  echo "Expected agent-session-id $expected_session, got: ${agent_session:-<empty>}" >&2
+  cat "$bridge_log" >&2
+  cat "$bridge_err" >&2
+  exit 1
+fi
+
+python3 - "$codex_log" "$task_title" "$graph" <<'PY'
+import json
+import pathlib
+import sys
+
+log_path = pathlib.Path(sys.argv[1])
+task_title = sys.argv[2]
+graph = sys.argv[3]
+lines = [json.loads(line) for line in log_path.read_text(encoding="utf8").splitlines() if line.strip()]
+if len(lines) != 1:
+    raise SystemExit(f"expected one Codex invocation, got {len(lines)}")
+prompt = lines[0]["prompt"]
+if task_title not in prompt:
+    raise SystemExit("task title missing from Codex prompt")
+if f"Graph: {graph}" not in prompt:
+    raise SystemExit("graph missing from Codex prompt")
+if "Block UUID:" not in prompt:
+    raise SystemExit("block uuid missing from Codex prompt")
+PY
+
+echo "task status: done"
+echo "agent-session-id: $agent_session"
+echo "agent bridge demo completed"

--- a/cli-e2e/scripts/agent_bridge_demo.sh
+++ b/cli-e2e/scripts/agent_bridge_demo.sh
@@ -134,7 +134,7 @@ query_task_status() {
 
 query_agent_session() {
   local payload
-  payload="$(run_cli_json query --graph "$graph" --query "[:find ?session . :where [$1 ?attr ?session] [?p :block/name \"agent-session-id\"] [?p :db/ident ?attr]]")"
+  payload="$(run_cli_json query --graph "$graph" --query "[:find ?session . :where [$1 :logseq.property.agent/session-id ?session]]")"
   python3 - "$root_dir" "$config_path" "$graph" "$cli_path" "$payload" <<'PY'
 import json
 import subprocess

--- a/cli-e2e/scripts/agent_bridge_demo.sh
+++ b/cli-e2e/scripts/agent_bridge_demo.sh
@@ -179,8 +179,8 @@ if [[ "$#" -eq 1 && "$1" == "--version" ]]; then
   exit 0
 fi
 
-if [[ "$#" -ge 3 && "$1" == "exec" && "$2" == "--json" ]]; then
-  prompt="$3"
+if [[ "$#" -ge 6 && "$1" == "--sandbox" && "$2" == "danger-full-access" && "$3" == "exec" && "$4" == "--json" && "$5" == "--skip-git-repo-check" ]]; then
+  prompt="$6"
   python3 - "$CODEX_FAKE_LOG" "$prompt" "$@" <<'PY'
 import json
 import pathlib

--- a/cli-e2e/scripts/agent_bridge_e2e.py
+++ b/cli-e2e/scripts/agent_bridge_e2e.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import pathlib
+import subprocess
+import time
+
+
+TASK_TITLE = "测试 agent bridge 功能，把当前task status设置为done"
+EXPECTED_SESSION = "thread-e2e-agent-bridge"
+
+
+def write_fake_codex(fake_bin):
+    fake_codex = fake_bin / "codex"
+    fake_codex.parent.mkdir(parents=True, exist_ok=True)
+    fake_codex.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import sys
+
+args = sys.argv[1:]
+if args == ["--version"]:
+    print("codex-cli 0.0.0-e2e")
+    sys.exit(0)
+
+if args[:2] == ["exec", "--json"]:
+    prompt = args[2] if len(args) > 2 else ""
+    log_path = pathlib.Path(os.environ["CODEX_FAKE_LOG"])
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf8") as f:
+        f.write(json.dumps({"args": args, "prompt": prompt}, ensure_ascii=False) + "\\n")
+    print(json.dumps({"type": "thread.started", "thread_id": "thread-e2e-agent-bridge"}), flush=True)
+    sys.exit(0)
+
+print("unexpected codex args: " + repr(args), file=sys.stderr)
+sys.exit(2)
+""",
+        encoding="utf8",
+    )
+    fake_codex.chmod(0o755)
+
+
+def run_json(cli, repo_root, root_dir, config, graph, query):
+    result = subprocess.run(
+        cli
+        + [
+            "--root-dir",
+            root_dir,
+            "--config",
+            config,
+            "--output",
+            "json",
+            "query",
+            "--graph",
+            graph,
+            "--query",
+            query,
+        ],
+        cwd=repo_root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        return None
+    return json.loads(result.stdout).get("data", {}).get("result")
+
+
+def run_cli(cli, repo_root, root_dir, config, graph, extra_args):
+    result = subprocess.run(
+        cli
+        + [
+            "--root-dir",
+            root_dir,
+            "--config",
+            config,
+            "--output",
+            "json",
+        ]
+        + extra_args,
+        cwd=repo_root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            "CLI command failed: {}\nstdout:\n{}\nstderr:\n{}".format(
+                " ".join(extra_args), result.stdout, result.stderr
+            )
+        )
+    return json.loads(result.stdout) if result.stdout.strip() else None
+
+
+def deref_session_value(cli, repo_root, root_dir, config, graph, value):
+    if not isinstance(value, int):
+        return value
+    return run_json(
+        cli,
+        repo_root,
+        root_dir,
+        config,
+        graph,
+        f"[:find ?title . :where [{value} :block/title ?title]]",
+    )
+
+
+def read_text(path):
+    return path.read_text(encoding="utf8", errors="replace")
+
+
+def wait_for_log(path, text, process):
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        if path.exists() and text in read_text(path):
+            return
+        if process.poll() is not None:
+            raise SystemExit(
+                "agent bridge exited before {}\nstdout:\n{}".format(
+                    text, read_text(path)
+                )
+            )
+        time.sleep(0.2)
+    raise SystemExit("agent bridge did not log {!r}\nstdout:\n{}".format(text, read_text(path)))
+
+
+def assign_task(cli, repo_root, root_dir, config, graph):
+    task_id = run_json(
+        cli,
+        repo_root,
+        root_dir,
+        config,
+        graph,
+        '[:find ?e . :where [?e :block/title "{}"]]'.format(TASK_TITLE),
+    )
+    if task_id is None:
+        raise SystemExit("task block was not found")
+    run_cli(
+        cli,
+        repo_root,
+        root_dir,
+        config,
+        graph,
+        [
+            "upsert",
+            "block",
+            "--graph",
+            graph,
+            "--id",
+            str(task_id),
+            "--update-properties",
+            '{{"Assignee" "{}"}}'.format(os.uname().nodename),
+        ],
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cli", required=True)
+    parser.add_argument("--root-dir", required=True)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--graph", required=True)
+    parser.add_argument("--tmp-dir", required=True)
+    parser.add_argument("--repo-root", required=True)
+    parser.add_argument("--prepare-fake-codex-only", action="store_true")
+    parser.add_argument("--assign-after-start", action="store_true")
+    args = parser.parse_args()
+
+    repo_root = pathlib.Path(args.repo_root)
+    tmp_dir = pathlib.Path(args.tmp_dir)
+    fake_bin = tmp_dir / "fake-bin"
+    bridge_log = tmp_dir / "agent-bridge.log"
+    bridge_err = tmp_dir / "agent-bridge.err"
+    codex_log = tmp_dir / "codex-invocations.jsonl"
+    cli = ["node", args.cli]
+
+    write_fake_codex(fake_bin)
+    if args.prepare_fake_codex_only:
+        return
+
+    env = os.environ.copy()
+    env["PATH"] = str(fake_bin) + os.pathsep + env.get("PATH", "")
+    env["CODEX_FAKE_LOG"] = str(codex_log)
+
+    with bridge_log.open("wb") as out, bridge_err.open("wb") as err:
+        bridge = subprocess.Popen(
+            cli
+            + [
+                "--root-dir",
+                args.root_dir,
+                "--config",
+                args.config,
+                "--output",
+                "human",
+                "agent",
+                "bridge",
+                "--graph",
+                args.graph,
+            ],
+            cwd=repo_root,
+            env=env,
+            stdout=out,
+            stderr=err,
+        )
+
+    try:
+        if args.assign_after_start:
+            wait_for_log(bridge_log, "listening graph changes", bridge)
+            assign_task(cli, repo_root, args.root_dir, args.config, args.graph)
+
+        deadline = time.time() + 30
+        session = None
+        query = (
+            '[:find ?session . :where [?e :block/title "{}"] '
+            '[?p :block/name "agent-session-id"] '
+            "[?p :db/ident ?attr] [?e ?attr ?session]]"
+        ).format(TASK_TITLE)
+
+        while time.time() < deadline:
+            session = deref_session_value(
+                cli,
+                repo_root,
+                args.root_dir,
+                args.config,
+                args.graph,
+                run_json(cli, repo_root, args.root_dir, args.config, args.graph, query),
+            )
+            if session == EXPECTED_SESSION:
+                break
+            if bridge.poll() is not None:
+                raise SystemExit(
+                    "agent bridge exited early with {}\nstdout:\n{}\nstderr:\n{}".format(
+                        bridge.returncode, read_text(bridge_log), read_text(bridge_err)
+                    )
+                )
+            time.sleep(0.5)
+        else:
+            raise SystemExit(
+                "agent-session-id was not written; last session={!r}\nstdout:\n{}\nstderr:\n{}".format(
+                    session, read_text(bridge_log), read_text(bridge_err)
+                )
+            )
+
+        lines = [
+            json.loads(line)
+            for line in codex_log.read_text(encoding="utf8").splitlines()
+            if line.strip()
+        ]
+        assert len(lines) == 1, lines
+        prompt = lines[0]["prompt"]
+        assert TASK_TITLE in prompt, prompt
+        assert "Graph: " + args.graph in prompt, prompt
+        assert "Block UUID:" in prompt, prompt
+        print("agent bridge routed task to " + session)
+    finally:
+        if bridge.poll() is None:
+            bridge.terminate()
+            try:
+                bridge.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                bridge.kill()
+                bridge.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    main()

--- a/cli-e2e/scripts/agent_bridge_e2e.py
+++ b/cli-e2e/scripts/agent_bridge_e2e.py
@@ -10,6 +10,10 @@ import time
 
 TASK_TITLE = "测试 agent bridge 功能，把当前task status设置为done"
 EXPECTED_SESSION = "thread-e2e-agent-bridge"
+PARALLEL_TASK_TITLES = [
+    "测试 agent bridge 并行执行任务 1",
+    "测试 agent bridge 并行执行任务 2",
+]
 
 
 def write_fake_codex(fake_bin):
@@ -20,7 +24,9 @@ def write_fake_codex(fake_bin):
 import json
 import os
 import pathlib
+import re
 import sys
+import time
 
 args = sys.argv[1:]
 if args == ["--version"]:
@@ -29,11 +35,26 @@ if args == ["--version"]:
 
 if args[:2] == ["exec", "--json"]:
     prompt = args[2] if len(args) > 2 else ""
+    block_uuid_match = re.search(r"^Block UUID: (.+)$", prompt, re.MULTILINE)
+    block_uuid = block_uuid_match.group(1) if block_uuid_match else None
     log_path = pathlib.Path(os.environ["CODEX_FAKE_LOG"])
     log_path.parent.mkdir(parents=True, exist_ok=True)
     with log_path.open("a", encoding="utf8") as f:
-        f.write(json.dumps({"args": args, "prompt": prompt}, ensure_ascii=False) + "\\n")
-    print(json.dumps({"type": "thread.started", "thread_id": "thread-e2e-agent-bridge"}), flush=True)
+        f.write(json.dumps(
+            {"event": "start", "time": time.time(), "args": args, "prompt": prompt, "block_uuid": block_uuid},
+            ensure_ascii=False) + "\\n")
+    delay = float(os.environ.get("CODEX_FAKE_DELAY_SECONDS", "0"))
+    if delay > 0:
+        time.sleep(delay)
+    if os.environ.get("CODEX_FAKE_SESSION_BY_UUID") == "1" and block_uuid:
+        session_id = "thread-e2e-agent-bridge-" + re.sub(r"[^A-Za-z0-9]", "", block_uuid)[-12:]
+    else:
+        session_id = "thread-e2e-agent-bridge"
+    with log_path.open("a", encoding="utf8") as f:
+        f.write(json.dumps(
+            {"event": "session", "time": time.time(), "session": session_id, "block_uuid": block_uuid},
+            ensure_ascii=False) + "\\n")
+    print(json.dumps({"type": "thread.started", "thread_id": session_id}), flush=True)
     sys.exit(0)
 
 print("unexpected codex args: " + repr(args), file=sys.stderr)
@@ -128,17 +149,44 @@ def wait_for_log(path, text, process):
     raise SystemExit("agent bridge did not log {!r}\nstdout:\n{}".format(text, read_text(path)))
 
 
-def assign_task(cli, repo_root, root_dir, config, graph):
+def find_task_id(cli, repo_root, root_dir, config, graph, title):
     task_id = run_json(
         cli,
         repo_root,
         root_dir,
         config,
         graph,
-        '[:find ?e . :where [?e :block/title "{}"]]'.format(TASK_TITLE),
+        '[:find ?e . :where [?e :block/title "{}"]]'.format(title),
     )
     if task_id is None:
-        raise SystemExit("task block was not found")
+        raise SystemExit("task block was not found: {}".format(title))
+    return task_id
+
+
+def create_task(cli, repo_root, root_dir, config, graph, title):
+    run_cli(
+        cli,
+        repo_root,
+        root_dir,
+        config,
+        graph,
+        [
+            "upsert",
+            "task",
+            "--graph",
+            graph,
+            "--target-page",
+            "AgentBridgeE2E",
+            "--content",
+            title,
+            "--status",
+            "todo",
+        ],
+    )
+
+
+def assign_task(cli, repo_root, root_dir, config, graph, title=TASK_TITLE):
+    task_id = find_task_id(cli, repo_root, root_dir, config, graph, title)
     run_cli(
         cli,
         repo_root,
@@ -158,6 +206,129 @@ def assign_task(cli, repo_root, root_dir, config, graph):
     )
 
 
+def read_codex_events(codex_log):
+    if not codex_log.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in codex_log.read_text(encoding="utf8").splitlines()
+        if line.strip()
+    ]
+
+
+def session_query_for_title(title):
+    return (
+        '[:find ?session . :where [?e :block/title "{}"] '
+        '[?p :block/name "agent-session-id"] '
+        "[?p :db/ident ?attr] [?e ?attr ?session]]"
+    ).format(title)
+
+
+def wait_for_task_sessions(cli, repo_root, root_dir, config, graph, titles, bridge, bridge_log, bridge_err):
+    deadline = time.time() + 45
+    sessions = {}
+    while time.time() < deadline:
+        sessions = {
+            title: deref_session_value(
+                cli,
+                repo_root,
+                root_dir,
+                config,
+                graph,
+                run_json(cli, repo_root, root_dir, config, graph, session_query_for_title(title)),
+            )
+            for title in titles
+        }
+        if all(sessions.values()):
+            return sessions
+        if bridge.poll() is not None:
+            raise SystemExit(
+                "agent bridge exited early with {}\nstdout:\n{}\nstderr:\n{}".format(
+                    bridge.returncode, read_text(bridge_log), read_text(bridge_err)
+                )
+            )
+        time.sleep(0.5)
+    raise SystemExit(
+        "agent-session-id was not written for every task; last sessions={!r}\nstdout:\n{}\nstderr:\n{}".format(
+            sessions, read_text(bridge_log), read_text(bridge_err)
+        )
+    )
+
+
+def run_parallel_assignment_check(cli, repo_root, root_dir, config, graph, tmp_dir):
+    for title in PARALLEL_TASK_TITLES:
+        create_task(cli, repo_root, root_dir, config, graph, title)
+
+    fake_bin = tmp_dir / "fake-bin"
+    bridge_log = tmp_dir / "agent-bridge.log"
+    bridge_err = tmp_dir / "agent-bridge.err"
+    codex_log = tmp_dir / "codex-invocations.jsonl"
+
+    env = os.environ.copy()
+    env["PATH"] = str(fake_bin) + os.pathsep + env.get("PATH", "")
+    env["CODEX_FAKE_LOG"] = str(codex_log)
+    env["CODEX_FAKE_DELAY_SECONDS"] = "5"
+    env["CODEX_FAKE_SESSION_BY_UUID"] = "1"
+
+    with bridge_log.open("wb") as out, bridge_err.open("wb") as err:
+        bridge = subprocess.Popen(
+            cli
+            + [
+                "--root-dir",
+                root_dir,
+                "--config",
+                config,
+                "--output",
+                "human",
+                "agent",
+                "bridge",
+                "--graph",
+                graph,
+            ],
+            cwd=repo_root,
+            env=env,
+            stdout=out,
+            stderr=err,
+        )
+
+    try:
+        wait_for_log(bridge_log, "listening graph changes", bridge)
+        for title in PARALLEL_TASK_TITLES:
+            assign_task(cli, repo_root, root_dir, config, graph, title)
+
+        sessions = wait_for_task_sessions(
+            cli, repo_root, root_dir, config, graph, PARALLEL_TASK_TITLES, bridge, bridge_log, bridge_err
+        )
+        events = read_codex_events(codex_log)
+        start_events = [event for event in events if event.get("event") == "start"]
+        session_events = [event for event in events if event.get("event") == "session"]
+        if len(start_events) != 2 or len(session_events) != 2:
+            raise SystemExit("expected two codex starts and sessions, got: {!r}".format(events))
+
+        first_session_time = min(event["time"] for event in session_events)
+        latest_start_time = max(event["time"] for event in start_events)
+        if latest_start_time >= first_session_time:
+            raise SystemExit(
+                "codex exec did not overlap; starts={!r}, sessions={!r}".format(
+                    [event["time"] for event in start_events],
+                    [event["time"] for event in session_events],
+                )
+            )
+
+        prompts = "\n".join(event["prompt"] for event in start_events)
+        for title in PARALLEL_TASK_TITLES:
+            assert title in prompts, prompts
+        print("agent bridge routed tasks concurrently: " + ", ".join(sorted(sessions.values())))
+    finally:
+        if bridge.poll() is None:
+            bridge.terminate()
+            try:
+                bridge.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                bridge.kill()
+                bridge.wait(timeout=5)
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--cli", required=True)
@@ -168,6 +339,7 @@ def main():
     parser.add_argument("--repo-root", required=True)
     parser.add_argument("--prepare-fake-codex-only", action="store_true")
     parser.add_argument("--assign-after-start", action="store_true")
+    parser.add_argument("--parallel-assignment-check", action="store_true")
     args = parser.parse_args()
 
     repo_root = pathlib.Path(args.repo_root)
@@ -180,6 +352,10 @@ def main():
 
     write_fake_codex(fake_bin)
     if args.prepare_fake_codex_only:
+        return
+
+    if args.parallel_assignment_check:
+        run_parallel_assignment_check(cli, repo_root, args.root_dir, args.config, args.graph, tmp_dir)
         return
 
     env = os.environ.copy()
@@ -245,13 +421,9 @@ def main():
                 )
             )
 
-        lines = [
-            json.loads(line)
-            for line in codex_log.read_text(encoding="utf8").splitlines()
-            if line.strip()
-        ]
-        assert len(lines) == 1, lines
-        prompt = lines[0]["prompt"]
+        start_events = [event for event in read_codex_events(codex_log) if event.get("event") == "start"]
+        assert len(start_events) == 1, start_events
+        prompt = start_events[0]["prompt"]
         assert TASK_TITLE in prompt, prompt
         assert "Graph: " + args.graph in prompt, prompt
         assert "Block UUID:" in prompt, prompt

--- a/cli-e2e/scripts/agent_bridge_e2e.py
+++ b/cli-e2e/scripts/agent_bridge_e2e.py
@@ -131,6 +131,27 @@ def run_cli(cli, repo_root, root_dir, config, graph, extra_args):
     return json.loads(result.stdout) if result.stdout.strip() else None
 
 
+def run_cli_with_env(cli, repo_root, root_dir, config, extra_args, env):
+    result = subprocess.run(
+        cli
+        + [
+            "--root-dir",
+            root_dir,
+            "--config",
+            config,
+            "--output",
+            "json",
+        ]
+        + extra_args,
+        cwd=repo_root,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result
+
+
 def deref_session_value(cli, repo_root, root_dir, config, graph, value):
     if not isinstance(value, int):
         return value
@@ -471,6 +492,200 @@ def run_parallel_assignment_check(cli, repo_root, root_dir, config, graph, tmp_d
                 bridge.wait(timeout=5)
 
 
+def edn_string(value):
+    return json.dumps(value, ensure_ascii=False)
+
+
+def write_task_template_file(path, marker):
+    template = "\n".join(
+        [
+            marker,
+            "Graph: {{graph}}",
+            "Block UUID: {{block-uuid}}",
+            "AgentBridge name: {{agent-name}}",
+            "{{task-block-tree}}",
+        ]
+    )
+    path.write_text(
+        """[{:block/title "Task prompt template"
+   :block/children [{:block/title "Description: Custom task template for this graph."}
+                    {:block/title "Template variables: {{graph}}, {{block-uuid}}, {{agent-name}}, and {{task-block-tree}}."}
+                    {:block/title %s}]}]"""
+        % edn_string("```text\n" + template + "\n```"),
+        encoding="utf8",
+    )
+
+
+def write_invalid_task_template_file(path):
+    path.write_text(
+        """[{:block/title "Task prompt template"
+   :block/children [{:block/title "Description: Invalid task template for lint coverage."}
+                    {:block/title %s}]}]"""
+        % edn_string("```text\nBroken {{graph}} {{unknown-var}}\n```"),
+        encoding="utf8",
+    )
+
+
+def install_task_template(cli, repo_root, root_dir, config, graph, tmp_dir, marker):
+    run_cli(
+        cli,
+        repo_root,
+        root_dir,
+        config,
+        graph,
+        ["upsert", "page", "--graph", graph, "--page", "AgentBridge"],
+    )
+    blocks_file = tmp_dir / ("task-template-" + graph + ".edn")
+    write_task_template_file(blocks_file, marker)
+    run_cli(
+        cli,
+        repo_root,
+        root_dir,
+        config,
+        graph,
+        [
+            "upsert",
+            "block",
+            "--graph",
+            graph,
+            "--target-page",
+            "AgentBridge",
+            "--blocks-file",
+            str(blocks_file),
+        ],
+    )
+
+
+def install_invalid_task_template(cli, repo_root, root_dir, config, graph, tmp_dir):
+    run_cli(
+        cli,
+        repo_root,
+        root_dir,
+        config,
+        graph,
+        ["upsert", "page", "--graph", graph, "--page", "AgentBridge"],
+    )
+    blocks_file = tmp_dir / ("invalid-task-template-" + graph + ".edn")
+    write_invalid_task_template_file(blocks_file)
+    run_cli(
+        cli,
+        repo_root,
+        root_dir,
+        config,
+        graph,
+        [
+            "upsert",
+            "block",
+            "--graph",
+            graph,
+            "--target-page",
+            "AgentBridge",
+            "--blocks-file",
+            str(blocks_file),
+        ],
+    )
+
+
+def dry_run_prompt(cli, repo_root, root_dir, config, graph, env):
+    result = run_cli_with_env(
+        cli,
+        repo_root,
+        root_dir,
+        config,
+        ["agent", "bridge", "--graph", graph, "--dry-run"],
+        env,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            "agent bridge dry-run failed for {}\nstdout:\n{}\nstderr:\n{}".format(
+                graph, result.stdout, result.stderr
+            )
+        )
+    payload = json.loads(result.stdout)
+    commands = payload.get("data", {}).get("commands", [])
+    if len(commands) != 1:
+        raise SystemExit("expected one dry-run command for {}, got {!r}".format(graph, commands))
+    command = commands[0].get("command", [])
+    if len(command) < 4:
+        raise SystemExit("dry-run command did not contain a prompt: {!r}".format(command))
+    return command[3]
+
+
+def assert_contains(text, expected):
+    if expected not in text:
+        raise SystemExit("expected {!r} in:\n{}".format(expected, text))
+
+
+def assert_not_contains(text, unexpected):
+    if unexpected in text:
+        raise SystemExit("did not expect {!r} in:\n{}".format(unexpected, text))
+
+
+def run_prompt_template_graph_check(cli, repo_root, root_dir, config, graph, tmp_dir):
+    graph_a = graph
+    graph_b = graph + "-other"
+    graph_bad = graph + "-invalid"
+    marker_a = "CUSTOM GRAPH A TEMPLATE"
+    marker_b = "CUSTOM GRAPH B TEMPLATE"
+
+    fake_bin = tmp_dir / "fake-bin"
+    env = os.environ.copy()
+    env["PATH"] = str(fake_bin) + os.pathsep + env.get("PATH", "")
+    env["CODEX_FAKE_LOG"] = str(tmp_dir / "codex-dry-run.jsonl")
+
+    for graph_name in [graph_b, graph_bad]:
+        run_cli(
+            cli,
+            repo_root,
+            root_dir,
+            config,
+            graph_name,
+            ["graph", "create", "--graph", graph_name],
+        )
+
+    for graph_name in [graph_a, graph_b, graph_bad]:
+        create_task(cli, repo_root, root_dir, config, graph_name, TASK_TITLE)
+        assign_task(cli, repo_root, root_dir, config, graph_name)
+
+    install_task_template(cli, repo_root, root_dir, config, graph_a, tmp_dir, marker_a)
+    prompt_a = dry_run_prompt(cli, repo_root, root_dir, config, graph_a, env)
+    assert_contains(prompt_a, marker_a)
+    assert_contains(prompt_a, "Graph: " + graph_a)
+    assert_not_contains(prompt_a, marker_b)
+    assert_not_contains(prompt_a, "You are handling a Logseq AgentBridge task.")
+
+    prompt_b_default = dry_run_prompt(cli, repo_root, root_dir, config, graph_b, env)
+    assert_contains(prompt_b_default, "You are handling a Logseq AgentBridge task.")
+    assert_contains(prompt_b_default, "Graph: " + graph_b)
+    assert_not_contains(prompt_b_default, marker_a)
+
+    install_task_template(cli, repo_root, root_dir, config, graph_b, tmp_dir, marker_b)
+    prompt_b = dry_run_prompt(cli, repo_root, root_dir, config, graph_b, env)
+    assert_contains(prompt_b, marker_b)
+    assert_contains(prompt_b, "Graph: " + graph_b)
+    assert_not_contains(prompt_b, marker_a)
+    assert_not_contains(prompt_b, "You are handling a Logseq AgentBridge task.")
+
+    prompt_a_again = dry_run_prompt(cli, repo_root, root_dir, config, graph_a, env)
+    assert_contains(prompt_a_again, marker_a)
+    assert_not_contains(prompt_a_again, marker_b)
+
+    install_invalid_task_template(cli, repo_root, root_dir, config, graph_bad, tmp_dir)
+    bad_result = run_cli_with_env(
+        cli,
+        repo_root,
+        root_dir,
+        config,
+        ["agent", "bridge", "--graph", graph_bad, "--dry-run"],
+        env,
+    )
+    if bad_result.returncode == 0:
+        raise SystemExit("invalid graph prompt template unexpectedly passed:\n" + bad_result.stdout)
+    assert_contains(bad_result.stdout + bad_result.stderr, "agent-prompt-template-invalid")
+
+    print("agent bridge graph prompt templates are isolated and linted")
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--cli", required=True)
@@ -483,6 +698,7 @@ def main():
     parser.add_argument("--assign-after-start", action="store_true")
     parser.add_argument("--parallel-assignment-check", action="store_true")
     parser.add_argument("--comment-mention-check", action="store_true")
+    parser.add_argument("--prompt-template-graph-check", action="store_true")
     args = parser.parse_args()
 
     repo_root = pathlib.Path(args.repo_root)
@@ -503,6 +719,10 @@ def main():
 
     if args.comment_mention_check:
         run_comment_mention_check(cli, repo_root, args.root_dir, args.config, args.graph, tmp_dir)
+        return
+
+    if args.prompt_template_graph_check:
+        run_prompt_template_graph_check(cli, repo_root, args.root_dir, args.config, args.graph, tmp_dir)
         return
 
     env = os.environ.copy()

--- a/cli-e2e/scripts/agent_bridge_e2e.py
+++ b/cli-e2e/scripts/agent_bridge_e2e.py
@@ -268,8 +268,7 @@ def read_codex_events(codex_log):
 def session_query_for_title(title):
     return (
         '[:find ?session . :where [?e :block/title "{}"] '
-        '[?p :block/name "agent-session-id"] '
-        "[?p :db/ident ?attr] [?e ?attr ?session]]"
+        "[?e :logseq.property.agent/session-id ?session]]"
     ).format(title)
 
 
@@ -759,8 +758,7 @@ def main():
         session = None
         query = (
             '[:find ?session . :where [?e :block/title "{}"] '
-            '[?p :block/name "agent-session-id"] '
-            "[?p :db/ident ?attr] [?e ?attr ?session]]"
+            "[?e :logseq.property.agent/session-id ?session]]"
         ).format(TASK_TITLE)
 
         while time.time() < deadline:

--- a/cli-e2e/scripts/agent_bridge_e2e.py
+++ b/cli-e2e/scripts/agent_bridge_e2e.py
@@ -57,6 +57,20 @@ if args[:2] == ["exec", "--json"]:
     print(json.dumps({"type": "thread.started", "thread_id": session_id}), flush=True)
     sys.exit(0)
 
+if args[:3] == ["exec", "resume", "--json"]:
+    session_id = args[3] if len(args) > 3 else ""
+    prompt = args[4] if len(args) > 4 else ""
+    comment_uuid_match = re.search(r"^Comment UUID: (.+)$", prompt, re.MULTILINE)
+    comment_uuid = comment_uuid_match.group(1) if comment_uuid_match else None
+    log_path = pathlib.Path(os.environ["CODEX_FAKE_LOG"])
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf8") as f:
+        f.write(json.dumps(
+            {"event": "resume", "time": time.time(), "args": args, "prompt": prompt, "comment_uuid": comment_uuid, "session": session_id},
+            ensure_ascii=False) + "\\n")
+    print(json.dumps({"type": "thread.started", "thread_id": session_id}), flush=True)
+    sys.exit(0)
+
 print("unexpected codex args: " + repr(args), file=sys.stderr)
 sys.exit(2)
 """,
@@ -163,6 +177,20 @@ def find_task_id(cli, repo_root, root_dir, config, graph, title):
     return task_id
 
 
+def find_task_uuid(cli, repo_root, root_dir, config, graph, title):
+    task_uuid = run_json(
+        cli,
+        repo_root,
+        root_dir,
+        config,
+        graph,
+        '[:find ?uuid . :where [?e :block/title "{}"] [?e :block/uuid ?uuid]]'.format(title),
+    )
+    if task_uuid is None:
+        raise SystemExit("task block uuid was not found: {}".format(title))
+    return task_uuid
+
+
 def create_task(cli, repo_root, root_dir, config, graph, title):
     run_cli(
         cli,
@@ -255,6 +283,120 @@ def wait_for_task_sessions(cli, repo_root, root_dir, config, graph, titles, brid
     )
 
 
+def wait_for_codex_event(codex_log, event_name, bridge, bridge_log, bridge_err):
+    deadline = time.time() + 30
+    events = []
+    while time.time() < deadline:
+        events = read_codex_events(codex_log)
+        matches = [event for event in events if event.get("event") == event_name]
+        if matches:
+            return matches
+        if bridge.poll() is not None:
+            raise SystemExit(
+                "agent bridge exited early with {}\nstdout:\n{}\nstderr:\n{}".format(
+                    bridge.returncode, read_text(bridge_log), read_text(bridge_err)
+                )
+            )
+        time.sleep(0.5)
+    raise SystemExit("codex event {!r} was not observed; events={!r}".format(event_name, events))
+
+
+def write_comment_blocks_file(path, task_uuid, hostname):
+    path.write_text(
+        """[{{:block/title "Comments"
+   :block/tags [:logseq.class/Comments]
+   :logseq.property.comments/blocks [[:block/uuid #uuid "{task_uuid}"]]
+   :block/children [{{:block/title "[[{hostname}]] please continue from the comment"
+                     :block/tags [:logseq.class/Comment]}}]}}]""".format(
+            task_uuid=task_uuid,
+            hostname=hostname,
+        ),
+        encoding="utf8",
+    )
+
+
+def run_comment_mention_check(cli, repo_root, root_dir, config, graph, tmp_dir):
+    create_task(cli, repo_root, root_dir, config, graph, TASK_TITLE)
+
+    fake_bin = tmp_dir / "fake-bin"
+    bridge_log = tmp_dir / "agent-bridge.log"
+    bridge_err = tmp_dir / "agent-bridge.err"
+    codex_log = tmp_dir / "codex-invocations.jsonl"
+
+    env = os.environ.copy()
+    env["PATH"] = str(fake_bin) + os.pathsep + env.get("PATH", "")
+    env["CODEX_FAKE_LOG"] = str(codex_log)
+
+    with bridge_log.open("wb") as out, bridge_err.open("wb") as err:
+        bridge = subprocess.Popen(
+            cli
+            + [
+                "--root-dir",
+                root_dir,
+                "--config",
+                config,
+                "--output",
+                "human",
+                "agent",
+                "bridge",
+                "--graph",
+                graph,
+            ],
+            cwd=repo_root,
+            env=env,
+            stdout=out,
+            stderr=err,
+        )
+
+    try:
+        wait_for_log(bridge_log, "listening graph changes", bridge)
+        assign_task(cli, repo_root, root_dir, config, graph)
+        session = wait_for_task_sessions(
+            cli, repo_root, root_dir, config, graph, [TASK_TITLE], bridge, bridge_log, bridge_err
+        )[TASK_TITLE]
+
+        task_id = find_task_id(cli, repo_root, root_dir, config, graph, TASK_TITLE)
+        task_uuid = find_task_uuid(cli, repo_root, root_dir, config, graph, TASK_TITLE)
+        blocks_file = tmp_dir / "comment-blocks.edn"
+        write_comment_blocks_file(blocks_file, task_uuid, os.uname().nodename)
+        run_cli(
+            cli,
+            repo_root,
+            root_dir,
+            config,
+            graph,
+            [
+                "upsert",
+                "block",
+                "--graph",
+                graph,
+                "--target-id",
+                str(task_id),
+                "--pos",
+                "last-child",
+                "--blocks-file",
+                str(blocks_file),
+            ],
+        )
+
+        resume_events = wait_for_codex_event(codex_log, "resume", bridge, bridge_log, bridge_err)
+        if resume_events[0].get("session") != session:
+            raise SystemExit("comment resumed the wrong session: {!r}".format(resume_events[0]))
+        prompt = resume_events[0].get("prompt", "")
+        assert "You are handling a Logseq AgentBridge comment request." in prompt, prompt
+        assert "Comment target context:" in prompt, prompt
+        assert "Requesting comment:" in prompt, prompt
+        print("agent bridge resumed comment request in " + session)
+    finally:
+        if bridge.poll() is None:
+            bridge.terminate()
+            try:
+                bridge.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                bridge.kill()
+                bridge.wait(timeout=5)
+
+
 def run_parallel_assignment_check(cli, repo_root, root_dir, config, graph, tmp_dir):
     for title in PARALLEL_TASK_TITLES:
         create_task(cli, repo_root, root_dir, config, graph, title)
@@ -340,6 +482,7 @@ def main():
     parser.add_argument("--prepare-fake-codex-only", action="store_true")
     parser.add_argument("--assign-after-start", action="store_true")
     parser.add_argument("--parallel-assignment-check", action="store_true")
+    parser.add_argument("--comment-mention-check", action="store_true")
     args = parser.parse_args()
 
     repo_root = pathlib.Path(args.repo_root)
@@ -356,6 +499,10 @@ def main():
 
     if args.parallel_assignment_check:
         run_parallel_assignment_check(cli, repo_root, args.root_dir, args.config, args.graph, tmp_dir)
+        return
+
+    if args.comment_mention_check:
+        run_comment_mention_check(cli, repo_root, args.root_dir, args.config, args.graph, tmp_dir)
         return
 
     env = os.environ.copy()

--- a/cli-e2e/scripts/agent_bridge_e2e.py
+++ b/cli-e2e/scripts/agent_bridge_e2e.py
@@ -33,8 +33,8 @@ if args == ["--version"]:
     print("codex-cli 0.0.0-e2e")
     sys.exit(0)
 
-if args[:2] == ["exec", "--json"]:
-    prompt = args[2] if len(args) > 2 else ""
+if args[:5] == ["--sandbox", "danger-full-access", "exec", "--json", "--skip-git-repo-check"]:
+    prompt = args[5] if len(args) > 5 else ""
     block_uuid_match = re.search(r"^Block UUID: (.+)$", prompt, re.MULTILINE)
     block_uuid = block_uuid_match.group(1) if block_uuid_match else None
     log_path = pathlib.Path(os.environ["CODEX_FAKE_LOG"])
@@ -57,9 +57,9 @@ if args[:2] == ["exec", "--json"]:
     print(json.dumps({"type": "thread.started", "thread_id": session_id}), flush=True)
     sys.exit(0)
 
-if args[:3] == ["exec", "resume", "--json"]:
-    session_id = args[3] if len(args) > 3 else ""
-    prompt = args[4] if len(args) > 4 else ""
+if args[:6] == ["--sandbox", "danger-full-access", "exec", "resume", "--json", "--skip-git-repo-check"]:
+    session_id = args[6] if len(args) > 6 else ""
+    prompt = args[7] if len(args) > 7 else ""
     comment_uuid_match = re.search(r"^Comment UUID: (.+)$", prompt, re.MULTILINE)
     comment_uuid = comment_uuid_match.group(1) if comment_uuid_match else None
     log_path = pathlib.Path(os.environ["CODEX_FAKE_LOG"])
@@ -605,9 +605,9 @@ def dry_run_prompt(cli, repo_root, root_dir, config, graph, env):
     if len(commands) != 1:
         raise SystemExit("expected one dry-run command for {}, got {!r}".format(graph, commands))
     command = commands[0].get("command", [])
-    if len(command) < 4:
+    if len(command) < 1:
         raise SystemExit("dry-run command did not contain a prompt: {!r}".format(command))
-    return command[3]
+    return command[-1]
 
 
 def assert_contains(text, expected):

--- a/cli-e2e/spec/non_sync_cases.edn
+++ b/cli-e2e/spec/non_sync_cases.edn
@@ -1322,6 +1322,19 @@ PY"
    ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json server stop --graph {{graph-arg}}"],
    :tags [:agent],
    :extends :non-sync/graph-json-env}
+  {:id "agent-bridge-routes-assigned-tasks-concurrently",
+   :cmds
+   ["python3 '{{repo-root}}/cli-e2e/scripts/agent_bridge_e2e.py' --cli '{{repo-root}}/static/logseq-cli.js' --root-dir '{{root-dir}}' --config '{{config-path}}' --graph '{{graph}}' --tmp-dir '{{tmp-dir}}' --repo-root '{{repo-root}}' --parallel-assignment-check"],
+   :expect {:exit 0, :stdout-contains ["agent bridge routed tasks concurrently:"]},
+   :covers
+   {:commands ["agent bridge"],
+    :options
+    {:global ["--config" "--graph" "--root-dir" "--output"],
+     :agent []}},
+   :cleanup
+   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json server stop --graph {{graph-arg}}"],
+   :tags [:agent],
+   :extends :non-sync/graph-json-env}
   {:id "agent-bridge-demo-script",
    :cmds
    ["bash '{{repo-root}}/cli-e2e/scripts/agent_bridge_demo.sh' --cli '{{repo-root}}/static/logseq-cli.js' --root-dir '{{tmp-dir}}/demo-root' --graph cli-e2e-agent-bridge-demo --repo-root '{{repo-root}}'"],

--- a/cli-e2e/spec/non_sync_cases.edn
+++ b/cli-e2e/spec/non_sync_cases.edn
@@ -1307,77 +1307,29 @@ PY"
      :server ["--graph"]}},
    :tags [:server],
    :extends :non-sync/graph-json-env}
-  {:id "agent-bridge-routes-assigned-task",
+  {:id "agent-bridge-workflows",
    :setup
-   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json upsert task --graph {{graph-arg}} --target-page AgentBridgeE2E --content '测试 agent bridge 功能，把当前task status设置为done' --status todo >/dev/null"],
+   ["mkdir -p '{{tmp-dir}}/assigned-root' && printf '{:output-format :json}\\n' > '{{tmp-dir}}/assigned-root/cli.edn' && {{cli}} --root-dir '{{tmp-dir}}/assigned-root' --config '{{tmp-dir}}/assigned-root/cli.edn' --output json graph create --graph cli-e2e-agent-bridge-assigned >/dev/null && {{cli}} --root-dir '{{tmp-dir}}/assigned-root' --config '{{tmp-dir}}/assigned-root/cli.edn' --output json upsert task --graph cli-e2e-agent-bridge-assigned --target-page AgentBridgeE2E --content '测试 agent bridge 功能，把当前task status设置为done' --status todo >/dev/null"
+    "mkdir -p '{{tmp-dir}}/parallel-root' && printf '{:output-format :json}\\n' > '{{tmp-dir}}/parallel-root/cli.edn' && {{cli}} --root-dir '{{tmp-dir}}/parallel-root' --config '{{tmp-dir}}/parallel-root/cli.edn' --output json graph create --graph cli-e2e-agent-bridge-parallel >/dev/null"
+    "mkdir -p '{{tmp-dir}}/comment-root' && printf '{:output-format :json}\\n' > '{{tmp-dir}}/comment-root/cli.edn' && {{cli}} --root-dir '{{tmp-dir}}/comment-root' --config '{{tmp-dir}}/comment-root/cli.edn' --output json graph create --graph cli-e2e-agent-bridge-comment >/dev/null"],
    :cmds
-   ["python3 '{{repo-root}}/cli-e2e/scripts/agent_bridge_e2e.py' --cli '{{repo-root}}/static/logseq-cli.js' --root-dir '{{root-dir}}' --config '{{config-path}}' --graph '{{graph}}' --tmp-dir '{{tmp-dir}}' --repo-root '{{repo-root}}' --assign-after-start"],
-   :expect {:exit 0, :stdout-contains ["agent bridge routed task to thread-e2e-agent-bridge"]},
-   :covers
-   {:commands ["agent bridge"],
-    :options
-    {:global ["--config" "--graph" "--root-dir" "--output"],
-     :agent []}},
-   :cleanup
-   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json server stop --graph {{graph-arg}}"],
-   :tags [:agent],
-   :extends :non-sync/graph-json-env}
-  {:id "agent-bridge-routes-assigned-tasks-concurrently",
-   :cmds
-   ["python3 '{{repo-root}}/cli-e2e/scripts/agent_bridge_e2e.py' --cli '{{repo-root}}/static/logseq-cli.js' --root-dir '{{root-dir}}' --config '{{config-path}}' --graph '{{graph}}' --tmp-dir '{{tmp-dir}}' --repo-root '{{repo-root}}' --parallel-assignment-check"],
-   :expect {:exit 0, :stdout-contains ["agent bridge routed tasks concurrently:"]},
-   :covers
-   {:commands ["agent bridge"],
-    :options
-    {:global ["--config" "--graph" "--root-dir" "--output"],
-     :agent []}},
-   :cleanup
-   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json server stop --graph {{graph-arg}}"],
-   :tags [:agent],
-   :extends :non-sync/graph-json-env}
-  {:id "agent-bridge-demo-script",
-   :cmds
-   ["bash '{{repo-root}}/cli-e2e/scripts/agent_bridge_demo.sh' --cli '{{repo-root}}/static/logseq-cli.js' --root-dir '{{tmp-dir}}/demo-root' --graph cli-e2e-agent-bridge-demo --repo-root '{{repo-root}}'"],
+   ["python3 '{{repo-root}}/cli-e2e/scripts/agent_bridge_e2e.py' --cli '{{repo-root}}/static/logseq-cli.js' --root-dir '{{tmp-dir}}/assigned-root' --config '{{tmp-dir}}/assigned-root/cli.edn' --graph cli-e2e-agent-bridge-assigned --tmp-dir '{{tmp-dir}}/assigned-work' --repo-root '{{repo-root}}' --assign-after-start"
+    "python3 '{{repo-root}}/cli-e2e/scripts/agent_bridge_e2e.py' --cli '{{repo-root}}/static/logseq-cli.js' --root-dir '{{tmp-dir}}/parallel-root' --config '{{tmp-dir}}/parallel-root/cli.edn' --graph cli-e2e-agent-bridge-parallel --tmp-dir '{{tmp-dir}}/parallel-work' --repo-root '{{repo-root}}' --parallel-assignment-check"
+    "python3 '{{repo-root}}/cli-e2e/scripts/agent_bridge_e2e.py' --cli '{{repo-root}}/static/logseq-cli.js' --root-dir '{{tmp-dir}}/comment-root' --config '{{tmp-dir}}/comment-root/cli.edn' --graph cli-e2e-agent-bridge-comment --tmp-dir '{{tmp-dir}}/comment-work' --repo-root '{{repo-root}}' --comment-mention-check"
+    "bash '{{repo-root}}/cli-e2e/scripts/agent_bridge_demo.sh' --cli '{{repo-root}}/static/logseq-cli.js' --root-dir '{{tmp-dir}}/demo-root' --graph cli-e2e-agent-bridge-demo --repo-root '{{repo-root}}'"
+    "mkdir -p '{{tmp-dir}}/list-root' && printf '{:output-format :json}\\n' > '{{tmp-dir}}/list-root/cli.edn' && {{cli}} --root-dir '{{tmp-dir}}/list-root' --config '{{tmp-dir}}/list-root/cli.edn' --output json agent bridge list --all"],
    :expect
    {:exit 0,
-    :stdout-contains ["agent bridge demo completed"
-                      "task status: done"
-                      "agent-session-id: thread-agent-bridge-demo"]},
+    :stdout-json-paths {[:status] "ok", [:data :sessions] []}},
    :covers
-   {:commands ["agent bridge"],
+   {:commands ["agent bridge" "agent bridge list"],
     :options
     {:global ["--config" "--graph" "--root-dir" "--output"],
-     :agent []}},
-   :tags [:agent]}
-  {:id "agent-bridge-dry-run-json",
-   :setup
-   ["python3 '{{repo-root}}/cli-e2e/scripts/agent_bridge_e2e.py' --cli '{{repo-root}}/static/logseq-cli.js' --root-dir '{{root-dir}}' --config '{{config-path}}' --graph '{{graph}}' --tmp-dir '{{tmp-dir}}' --repo-root '{{repo-root}}' --prepare-fake-codex-only"
-    "{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json upsert task --graph {{graph-arg}} --target-page AgentBridgeE2E --content '测试 agent bridge 功能，把当前task status设置为done' --status todo >/dev/null"
-    "TASK_ID=\"$({{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json query --graph {{graph-arg}} --query '[:find ?e . :where [?e :block/title \"测试 agent bridge 功能，把当前task status设置为done\"]]' | python3 -c 'import sys,json; print(json.load(sys.stdin)[\"data\"][\"result\"])')\"; {{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json upsert block --graph {{graph-arg}} --id \"$TASK_ID\" --update-properties \"{\\\"Assignee\\\" \\\"$(hostname)\\\"}\" >/dev/null"],
-   :cmds
-   ["CODEX_FAKE_LOG={{tmp-dir-arg}}/dry-run-codex.jsonl PATH={{tmp-dir-arg}}/fake-bin:$PATH {{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json agent bridge --graph {{graph-arg}} --dry-run"],
-   :expect
-   {:exit 0,
-    :stdout-json-paths {[:status] "ok", [:data :mode] "dry-run"},
-    :stdout-contains ["测试 agent bridge 功能，把当前task status设置为done"]},
-   :covers
-   {:commands ["agent bridge"],
-    :options
-    {:global ["--config" "--graph" "--root-dir" "--output"],
-     :agent ["--dry-run"]}},
-   :cleanup
-   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json server stop --graph {{graph-arg}}"],
-   :tags [:agent],
-   :extends :non-sync/graph-json-env}
-  {:id "agent-bridge-list-all-json",
-   :cmds
-   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json agent bridge list --all"],
-   :expect {:exit 0, :stdout-json-paths {[:status] "ok", [:data :sessions] []}},
-   :covers
-   {:commands ["agent bridge list"],
-    :options
-    {:global ["--config" "--root-dir" "--output"],
      :agent ["--all"]}},
+   :cleanup
+   ["{{cli}} --root-dir '{{tmp-dir}}/assigned-root' --config '{{tmp-dir}}/assigned-root/cli.edn' --output json server stop --graph cli-e2e-agent-bridge-assigned"
+    "{{cli}} --root-dir '{{tmp-dir}}/parallel-root' --config '{{tmp-dir}}/parallel-root/cli.edn' --output json server stop --graph cli-e2e-agent-bridge-parallel"
+    "{{cli}} --root-dir '{{tmp-dir}}/comment-root' --config '{{tmp-dir}}/comment-root/cli.edn' --output json server stop --graph cli-e2e-agent-bridge-comment"],
    :tags [:agent]}
   {:id "skill-show-human",
    :cmds ["{{cli}} skill show"],

--- a/cli-e2e/spec/non_sync_cases.edn
+++ b/cli-e2e/spec/non_sync_cases.edn
@@ -1331,6 +1331,24 @@ PY"
     "{{cli}} --root-dir '{{tmp-dir}}/parallel-root' --config '{{tmp-dir}}/parallel-root/cli.edn' --output json server stop --graph cli-e2e-agent-bridge-parallel"
     "{{cli}} --root-dir '{{tmp-dir}}/comment-root' --config '{{tmp-dir}}/comment-root/cli.edn' --output json server stop --graph cli-e2e-agent-bridge-comment"],
    :tags [:agent]}
+  {:id "agent-bridge-prompt-template-graphs",
+   :setup
+   ["mkdir -p '{{tmp-dir}}/prompt-template-root' && printf '{:output-format :json}\\n' > '{{tmp-dir}}/prompt-template-root/cli.edn' && {{cli}} --root-dir '{{tmp-dir}}/prompt-template-root' --config '{{tmp-dir}}/prompt-template-root/cli.edn' --output json graph create --graph cli-e2e-agent-bridge-template-a >/dev/null"],
+   :cmds
+   ["python3 '{{repo-root}}/cli-e2e/scripts/agent_bridge_e2e.py' --cli '{{repo-root}}/static/logseq-cli.js' --root-dir '{{tmp-dir}}/prompt-template-root' --config '{{tmp-dir}}/prompt-template-root/cli.edn' --graph cli-e2e-agent-bridge-template-a --tmp-dir '{{tmp-dir}}/prompt-template-work' --repo-root '{{repo-root}}' --prompt-template-graph-check"],
+   :expect
+   {:exit 0,
+    :stdout-contains ["agent bridge graph prompt templates are isolated and linted"]},
+   :covers
+   {:commands ["agent bridge"],
+    :options
+    {:global ["--config" "--graph" "--root-dir" "--output"],
+     :agent ["--dry-run"]}},
+   :cleanup
+   ["{{cli}} --root-dir '{{tmp-dir}}/prompt-template-root' --config '{{tmp-dir}}/prompt-template-root/cli.edn' --output json server stop --graph cli-e2e-agent-bridge-template-a"
+    "{{cli}} --root-dir '{{tmp-dir}}/prompt-template-root' --config '{{tmp-dir}}/prompt-template-root/cli.edn' --output json server stop --graph cli-e2e-agent-bridge-template-a-other"
+    "{{cli}} --root-dir '{{tmp-dir}}/prompt-template-root' --config '{{tmp-dir}}/prompt-template-root/cli.edn' --output json server stop --graph cli-e2e-agent-bridge-template-a-invalid"],
+   :tags [:agent]}
   {:id "skill-show-human",
    :cmds ["{{cli}} skill show"],
    :expect

--- a/cli-e2e/spec/non_sync_cases.edn
+++ b/cli-e2e/spec/non_sync_cases.edn
@@ -1307,6 +1307,65 @@ PY"
      :server ["--graph"]}},
    :tags [:server],
    :extends :non-sync/graph-json-env}
+  {:id "agent-bridge-routes-assigned-task",
+   :setup
+   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json upsert task --graph {{graph-arg}} --target-page AgentBridgeE2E --content '测试 agent bridge 功能，把当前task status设置为done' --status todo >/dev/null"],
+   :cmds
+   ["python3 '{{repo-root}}/cli-e2e/scripts/agent_bridge_e2e.py' --cli '{{repo-root}}/static/logseq-cli.js' --root-dir '{{root-dir}}' --config '{{config-path}}' --graph '{{graph}}' --tmp-dir '{{tmp-dir}}' --repo-root '{{repo-root}}' --assign-after-start"],
+   :expect {:exit 0, :stdout-contains ["agent bridge routed task to thread-e2e-agent-bridge"]},
+   :covers
+   {:commands ["agent bridge"],
+    :options
+    {:global ["--config" "--graph" "--root-dir" "--output"],
+     :agent []}},
+   :cleanup
+   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json server stop --graph {{graph-arg}}"],
+   :tags [:agent],
+   :extends :non-sync/graph-json-env}
+  {:id "agent-bridge-demo-script",
+   :cmds
+   ["bash '{{repo-root}}/cli-e2e/scripts/agent_bridge_demo.sh' --cli '{{repo-root}}/static/logseq-cli.js' --root-dir '{{tmp-dir}}/demo-root' --graph cli-e2e-agent-bridge-demo --repo-root '{{repo-root}}'"],
+   :expect
+   {:exit 0,
+    :stdout-contains ["agent bridge demo completed"
+                      "task status: done"
+                      "agent-session-id: thread-agent-bridge-demo"]},
+   :covers
+   {:commands ["agent bridge"],
+    :options
+    {:global ["--config" "--graph" "--root-dir" "--output"],
+     :agent []}},
+   :tags [:agent]}
+  {:id "agent-bridge-dry-run-json",
+   :setup
+   ["python3 '{{repo-root}}/cli-e2e/scripts/agent_bridge_e2e.py' --cli '{{repo-root}}/static/logseq-cli.js' --root-dir '{{root-dir}}' --config '{{config-path}}' --graph '{{graph}}' --tmp-dir '{{tmp-dir}}' --repo-root '{{repo-root}}' --prepare-fake-codex-only"
+    "{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json upsert task --graph {{graph-arg}} --target-page AgentBridgeE2E --content '测试 agent bridge 功能，把当前task status设置为done' --status todo >/dev/null"
+    "TASK_ID=\"$({{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json query --graph {{graph-arg}} --query '[:find ?e . :where [?e :block/title \"测试 agent bridge 功能，把当前task status设置为done\"]]' | python3 -c 'import sys,json; print(json.load(sys.stdin)[\"data\"][\"result\"])')\"; {{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json upsert block --graph {{graph-arg}} --id \"$TASK_ID\" --update-properties \"{\\\"Assignee\\\" \\\"$(hostname)\\\"}\" >/dev/null"],
+   :cmds
+   ["CODEX_FAKE_LOG={{tmp-dir-arg}}/dry-run-codex.jsonl PATH={{tmp-dir-arg}}/fake-bin:$PATH {{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json agent bridge --graph {{graph-arg}} --dry-run"],
+   :expect
+   {:exit 0,
+    :stdout-json-paths {[:status] "ok", [:data :mode] "dry-run"},
+    :stdout-contains ["测试 agent bridge 功能，把当前task status设置为done"]},
+   :covers
+   {:commands ["agent bridge"],
+    :options
+    {:global ["--config" "--graph" "--root-dir" "--output"],
+     :agent ["--dry-run"]}},
+   :cleanup
+   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json server stop --graph {{graph-arg}}"],
+   :tags [:agent],
+   :extends :non-sync/graph-json-env}
+  {:id "agent-bridge-list-all-json",
+   :cmds
+   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json agent bridge list --all"],
+   :expect {:exit 0, :stdout-json-paths {[:status] "ok", [:data :sessions] []}},
+   :covers
+   {:commands ["agent bridge list"],
+    :options
+    {:global ["--config" "--root-dir" "--output"],
+     :agent ["--all"]}},
+   :tags [:agent]}
   {:id "skill-show-human",
    :cmds ["{{cli}} skill show"],
    :expect

--- a/cli-e2e/spec/non_sync_inventory.edn
+++ b/cli-e2e/spec/non_sync_inventory.edn
@@ -157,8 +157,7 @@
   :agent
   {:commands ["agent bridge"
               "agent bridge list"]
-   :options ["--dry-run"
-             "--all"]}
+   :options ["--all"]}
 
   :completion
   {:commands ["completion"]

--- a/cli-e2e/spec/non_sync_inventory.edn
+++ b/cli-e2e/spec/non_sync_inventory.edn
@@ -154,6 +154,12 @@
   {:commands ["doctor"]
    :options ["--dev-script"]}
 
+  :agent
+  {:commands ["agent bridge"
+              "agent bridge list"]
+   :options ["--dry-run"
+             "--all"]}
+
   :completion
   {:commands ["completion"]
    :options ["bash"

--- a/deps/db/src/logseq/db/frontend/property.cljs
+++ b/deps/db/src/logseq/db/frontend/property.cljs
@@ -398,7 +398,15 @@
                                                :schema {:type :property
                                                         :hide? true}}
 
-     ;; TODO: Add more props :Assignee, :Estimate, :Cycle, :Project
+     :logseq.property/assignee {:title "Assignee"
+                                :schema {:type :node
+                                         :cardinality :many
+                                         :public? true
+                                         :ui-position :block-below}
+                                :properties {:logseq.property/hide-empty-value true}
+                                :queryable? true}
+
+     ;; TODO: Add more props :Estimate, :Cycle, :Project
 
      :logseq.property/icon {:title "Icon"
                             :schema {:type :map}}

--- a/deps/db/src/logseq/db/frontend/property.cljs
+++ b/deps/db/src/logseq/db/frontend/property.cljs
@@ -402,8 +402,8 @@
                                 :schema {:type :node
                                          :cardinality :many
                                          :public? true
-                                         :ui-position :block-below}
-                                :classes #{:logseq.class/Page}
+                                         :ui-position :block-below
+                                         :classes #{:logseq.class/Page}}
                                 :properties {:logseq.property/hide-empty-value true}
                                 :queryable? true}
 

--- a/deps/db/src/logseq/db/frontend/property.cljs
+++ b/deps/db/src/logseq/db/frontend/property.cljs
@@ -646,6 +646,11 @@
                                        :schema {:type :node
                                                 :public? false
                                                 :hide? true}}
+     :logseq.property.agent/session-id {:title "agent session id"
+                                        :schema {:type :string
+                                                 :db/cardinality :db.cardinality/one
+                                                 :public? false
+                                                 :hide? true}}
      :logseq.property/used-template {:title "Used template"
                                      :schema {:type :node
                                               :public? false

--- a/deps/db/src/logseq/db/frontend/property.cljs
+++ b/deps/db/src/logseq/db/frontend/property.cljs
@@ -648,7 +648,6 @@
                                                 :hide? true}}
      :logseq.property.agent/session-id {:title "agent session id"
                                         :schema {:type :string
-                                                 :db/cardinality :db.cardinality/one
                                                  :public? false
                                                  :hide? true}}
      :logseq.property/used-template {:title "Used template"
@@ -723,7 +722,7 @@
     "logseq.property.journal" "logseq.property.class" "logseq.property.view"
     "logseq.property.user" "logseq.property.history"
     "logseq.property.reaction" "logseq.property.sync" "logseq.property.publish"
-    "logseq.property.recycle" "logseq.property.comments"})
+    "logseq.property.recycle" "logseq.property.comments" "logseq.property.agent"})
 
 (defn logseq-property?
   "Determines if keyword is a logseq property"

--- a/deps/db/src/logseq/db/frontend/property.cljs
+++ b/deps/db/src/logseq/db/frontend/property.cljs
@@ -646,10 +646,12 @@
                                        :schema {:type :node
                                                 :public? false
                                                 :hide? true}}
-     :logseq.property.agent/session-id {:title "agent session id"
+     :logseq.property.agent/session-id {:title "Agent Session ID"
                                         :schema {:type :string
-                                                 :public? false
-                                                 :hide? true}}
+                                                 :public? true
+                                                 :hide? true}
+                                        :properties
+                                        {:logseq.property/description "Stores the AgentBridge session ID for a routed task."}}
      :logseq.property/used-template {:title "Used template"
                                      :schema {:type :node
                                               :public? false

--- a/deps/db/src/logseq/db/frontend/property.cljs
+++ b/deps/db/src/logseq/db/frontend/property.cljs
@@ -403,6 +403,7 @@
                                          :cardinality :many
                                          :public? true
                                          :ui-position :block-below}
+                                :classes #{:logseq.class/Page}
                                 :properties {:logseq.property/hide-empty-value true}
                                 :queryable? true}
 

--- a/deps/db/src/logseq/db/frontend/schema.cljs
+++ b/deps/db/src/logseq/db/frontend/schema.cljs
@@ -30,7 +30,7 @@
          (map (juxt :major :minor)
               [(parse-schema-version x) (parse-schema-version y)])))
 
-(def version (parse-schema-version "65.29"))
+(def version (parse-schema-version "65.31"))
 
 (defn major-version
   "Return a number.

--- a/deps/db/src/logseq/db/sqlite/create_graph.cljs
+++ b/deps/db/src/logseq/db/sqlite/create_graph.cljs
@@ -260,7 +260,8 @@
         hidden-pages (concat (build-initial-views) (build-favorites-page) (build-recycle-page))
         ;; These classes bootstrap our tags and properties as they depend on each other e.g.
         ;; Root <-> Tag, classes-tx depends on logseq.property.class/extends, properties-tx depends on Property
-        bootstrap-class? (fn [c] (contains? #{:logseq.class/Root :logseq.class/Property :logseq.class/Tag :logseq.class/Template} (:db/ident c)))
+        bootstrap-class? (fn [c] (contains? #{:logseq.class/Root :logseq.class/Property :logseq.class/Tag
+                                              :logseq.class/Page :logseq.class/Template} (:db/ident c)))
         bootstrap-classes (filter bootstrap-class? default-classes)
         bootstrap-class-ids (map #(select-keys % [:db/ident :block/uuid]) bootstrap-classes)
         classes-tx (concat (map #(dissoc % :db/ident) bootstrap-classes)

--- a/deps/db/test/logseq/db/frontend/property_test.cljs
+++ b/deps/db/test/logseq/db/frontend/property_test.cljs
@@ -1,17 +1,6 @@
 (ns logseq.db.frontend.property-test
-  (:require ["fs" :as fs]
-            ["path" :as node-path]
-            [cljs.reader :as reader]
-            [cljs.test :refer [deftest is testing]]
+  (:require [cljs.test :refer [deftest is testing]]
             [logseq.db.frontend.property :as db-property]))
-
-(defn- read-dict
-  [filename]
-  (reader/read-string
-   (.toString
-    (fs/readFileSync
-     (node-path/join (.cwd js/process) "src" "resources" "dicts" filename))
-    "utf8")))
 
 (deftest sort-properties
   (let [p1 {:db/id 1, :block/order "a", :block/uuid "uuid-a"}
@@ -98,25 +87,3 @@
       (is (= true (:queryable? property)))
       (is (contains? db-property/public-built-in-properties :logseq.property/assignee))
       (is (db-property/logseq-property? :logseq.property/assignee)))))
-
-(deftest agent-session-id-built-in-property
-  (let [property (get db-property/built-in-properties :logseq.property.agent/session-id)]
-    (testing "schema"
-      (is (= "Agent Session ID" (:title property)))
-      (is (= :string (get-in property [:schema :type])))
-      (is (not (contains? (:schema property) :db/cardinality)))
-      (is (= true (get-in property [:schema :public?])))
-      (is (= true (get-in property [:schema :hide?]))))
-
-    (testing "built-in logseq property"
-      (is (= "Stores the AgentBridge session ID for a routed task."
-             (get-in property [:properties :logseq.property/description])))
-      (is (contains? db-property/public-built-in-properties :logseq.property.agent/session-id))
-      (is (db-property/logseq-property? :logseq.property.agent/session-id))
-      (is (db-property/internal-property? :logseq.property.agent/session-id)))
-
-    (testing "localized display title"
-      (let [i18n-key (db-property/built-in-ident->i18n-key :logseq.property.agent/session-id)]
-        (is (= :property.built-in/agent-session-id i18n-key))
-        (is (contains? (read-dict "en.edn") i18n-key))
-        (is (contains? (read-dict "zh-cn.edn") i18n-key))))))

--- a/deps/db/test/logseq/db/frontend/property_test.cljs
+++ b/deps/db/test/logseq/db/frontend/property_test.cljs
@@ -93,10 +93,11 @@
     (testing "schema"
       (is (= "agent session id" (:title property)))
       (is (= :string (get-in property [:schema :type])))
-      (is (= :db.cardinality/one (get-in property [:schema :db/cardinality])))
+      (is (not (contains? (:schema property) :db/cardinality)))
       (is (= false (get-in property [:schema :public?])))
       (is (= true (get-in property [:schema :hide?]))))
 
     (testing "internal built-in logseq property"
       (is (not (contains? db-property/public-built-in-properties :logseq.property.agent/session-id)))
-      (is (db-property/logseq-property? :logseq.property.agent/session-id)))))
+      (is (db-property/logseq-property? :logseq.property.agent/session-id))
+      (is (db-property/internal-property? :logseq.property.agent/session-id)))))

--- a/deps/db/test/logseq/db/frontend/property_test.cljs
+++ b/deps/db/test/logseq/db/frontend/property_test.cljs
@@ -87,3 +87,16 @@
       (is (= true (:queryable? property)))
       (is (contains? db-property/public-built-in-properties :logseq.property/assignee))
       (is (db-property/logseq-property? :logseq.property/assignee)))))
+
+(deftest agent-session-id-built-in-property
+  (let [property (get db-property/built-in-properties :logseq.property.agent/session-id)]
+    (testing "schema"
+      (is (= "agent session id" (:title property)))
+      (is (= :string (get-in property [:schema :type])))
+      (is (= :db.cardinality/one (get-in property [:schema :db/cardinality])))
+      (is (= false (get-in property [:schema :public?])))
+      (is (= true (get-in property [:schema :hide?]))))
+
+    (testing "internal built-in logseq property"
+      (is (not (contains? db-property/public-built-in-properties :logseq.property.agent/session-id)))
+      (is (db-property/logseq-property? :logseq.property.agent/session-id)))))

--- a/deps/db/test/logseq/db/frontend/property_test.cljs
+++ b/deps/db/test/logseq/db/frontend/property_test.cljs
@@ -1,6 +1,17 @@
 (ns logseq.db.frontend.property-test
-  (:require [cljs.test :refer [deftest is testing]]
+  (:require ["fs" :as fs]
+            ["path" :as node-path]
+            [cljs.reader :as reader]
+            [cljs.test :refer [deftest is testing]]
             [logseq.db.frontend.property :as db-property]))
+
+(defn- read-dict
+  [filename]
+  (reader/read-string
+   (.toString
+    (fs/readFileSync
+     (node-path/join (.cwd js/process) "src" "resources" "dicts" filename))
+    "utf8")))
 
 (deftest sort-properties
   (let [p1 {:db/id 1, :block/order "a", :block/uuid "uuid-a"}
@@ -102,4 +113,10 @@
              (get-in property [:properties :logseq.property/description])))
       (is (contains? db-property/public-built-in-properties :logseq.property.agent/session-id))
       (is (db-property/logseq-property? :logseq.property.agent/session-id))
-      (is (db-property/internal-property? :logseq.property.agent/session-id)))))
+      (is (db-property/internal-property? :logseq.property.agent/session-id)))
+
+    (testing "localized display title"
+      (let [i18n-key (db-property/built-in-ident->i18n-key :logseq.property.agent/session-id)]
+        (is (= :property.built-in/agent-session-id i18n-key))
+        (is (contains? (read-dict "en.edn") i18n-key))
+        (is (contains? (read-dict "zh-cn.edn") i18n-key))))))

--- a/deps/db/test/logseq/db/frontend/property_test.cljs
+++ b/deps/db/test/logseq/db/frontend/property_test.cljs
@@ -74,3 +74,16 @@
     (is (= false (get-in props [property :schema :public?])))
     (is (= true (get-in props [property :schema :hide?])))
     (is (db-property/logseq-property? property))))
+
+(deftest assignee-built-in-property
+  (let [property (get db-property/built-in-properties :logseq.property/assignee)]
+    (testing "schema"
+      (is (= "Assignee" (:title property)))
+      (is (= :node (get-in property [:schema :type])))
+      (is (= :many (get-in property [:schema :cardinality])))
+      (is (= true (get-in property [:schema :public?]))))
+
+    (testing "queryable built-in logseq property"
+      (is (= true (:queryable? property)))
+      (is (contains? db-property/public-built-in-properties :logseq.property/assignee))
+      (is (db-property/logseq-property? :logseq.property/assignee)))))

--- a/deps/db/test/logseq/db/frontend/property_test.cljs
+++ b/deps/db/test/logseq/db/frontend/property_test.cljs
@@ -91,13 +91,15 @@
 (deftest agent-session-id-built-in-property
   (let [property (get db-property/built-in-properties :logseq.property.agent/session-id)]
     (testing "schema"
-      (is (= "agent session id" (:title property)))
+      (is (= "Agent Session ID" (:title property)))
       (is (= :string (get-in property [:schema :type])))
       (is (not (contains? (:schema property) :db/cardinality)))
-      (is (= false (get-in property [:schema :public?])))
+      (is (= true (get-in property [:schema :public?])))
       (is (= true (get-in property [:schema :hide?]))))
 
-    (testing "internal built-in logseq property"
-      (is (not (contains? db-property/public-built-in-properties :logseq.property.agent/session-id)))
+    (testing "built-in logseq property"
+      (is (= "Stores the AgentBridge session ID for a routed task."
+             (get-in property [:properties :logseq.property/description])))
+      (is (contains? db-property/public-built-in-properties :logseq.property.agent/session-id))
       (is (db-property/logseq-property? :logseq.property.agent/session-id))
       (is (db-property/internal-property? :logseq.property.agent/session-id)))))

--- a/deps/outliner/test/logseq/outliner/property_test.cljs
+++ b/deps/outliner/test/logseq/outliner/property_test.cljs
@@ -143,8 +143,10 @@
           _ (outliner-property/set-block-property! conn [:block/uuid block-uuid] :user.property/num (:db/id property-value))]
       (is (= (:db/id property-value)
              (:db/id (:user.property/num (db-test/find-block-by-content @conn "b2")))))
-      (outliner-property/set-block-property! conn [:block/uuid block-uuid] :user.property/num (:db/id (d/entity @conn :logseq.property/empty-placeholder)))
-      (is (= 9 (:logseq.property/value (:user.property/num (d/entity @conn [:block/uuid block-uuid])))))))
+      (let [empty-placeholder-id (:db/id (d/entity @conn :logseq.property/empty-placeholder))]
+        (outliner-property/set-block-property! conn [:block/uuid block-uuid] :user.property/num empty-placeholder-id)
+        (is (= empty-placeholder-id
+               (:logseq.property/value (:user.property/num (d/entity @conn [:block/uuid block-uuid]))))))))
 
   (testing "Update a :number value with existing value"
     (let [conn (db-test/create-conn-with-blocks

--- a/docs/agent-guide/logseq-cli/001-logseq-cli.md
+++ b/docs/agent-guide/logseq-cli/001-logseq-cli.md
@@ -112,6 +112,8 @@ The top-level help groups commands into graph inspection/editing, graph manageme
 
 - `login`
 - `logout`
+- `agent bridge`
+- `agent bridge list`
 - `completion`
 - `debug pull`
 - `skill show`
@@ -119,6 +121,12 @@ The top-level help groups commands into graph inspection/editing, graph manageme
 - `example <selector...>`
 
 `example` entries are generated from command metadata for the inspect/edit families `list`, `upsert`, `remove`, `query`, `search`, and `show`. Use exact selectors such as `example upsert page` or prefix selectors such as `example upsert`.
+
+### Agent bridge
+
+`agent bridge` is the first AgentBridge command surface. It resolves the target graph using normal CLI config precedence, resolves the AgentBridge name from `:agent-name` in `cli.edn` or the machine hostname, checks that `codex` is available, starts or reuses the graph's db-worker-node, registers the AgentBridge name in the graph, scans TODO `#Task` blocks assigned to that AgentBridge name, and listens to db-worker-node events for follow-up scans. Matched tasks are routed to `codex exec --json`; the bridge records the Codex session/thread id in `agent-bridge-sessions.edn` and writes it to the task's `agent-session-id` property. `--dry-run` performs the setup and scan but only prints the Codex commands it would run.
+
+`agent bridge list` reads root-dir scoped bridge session records from `agent-bridge-sessions.edn`. Human output uses the columns `SESSION`, `STATUS`, `BACKEND`, `GRAPH`, `BLOCK`, `AGENT`, `STARTED`, and `UPDATED`, ending with `Count: N`. Completed sessions are hidden by default; use `--all` to include them.
 
 ## Global flags and output modes
 

--- a/src/main/frontend/worker/db/migrate.cljs
+++ b/src/main/frontend/worker/db/migrate.cljs
@@ -127,7 +127,8 @@
    ["65.28" {:classes [:logseq.class/Comment]
              :fix tag-comment-blocks}]
    ["65.29" {:fix add-single-block-comment-targets}]
-   ["65.30" {:properties [:logseq.property/assignee]}]])
+   ["65.30" {:properties [:logseq.property/assignee]}]
+   ["65.31" {:properties [:logseq.property.agent/session-id]}]])
 
 (let [[major minor] (last (sort (map (comp (juxt :major :minor) db-schema/parse-schema-version first)
                                      schema-version->updates)))]

--- a/src/main/frontend/worker/db/migrate.cljs
+++ b/src/main/frontend/worker/db/migrate.cljs
@@ -126,7 +126,8 @@
              :properties [:logseq.property.comments/blocks]}]
    ["65.28" {:classes [:logseq.class/Comment]
              :fix tag-comment-blocks}]
-   ["65.29" {:fix add-single-block-comment-targets}]])
+   ["65.29" {:fix add-single-block-comment-targets}]
+   ["65.30" {:properties [:logseq.property/assignee]}]])
 
 (let [[major minor] (last (sort (map (comp (juxt :major :minor) db-schema/parse-schema-version first)
                                      schema-version->updates)))]

--- a/src/main/frontend/worker/db_worker_node.cljs
+++ b/src/main/frontend/worker/db_worker_node.cljs
@@ -1,8 +1,6 @@
 (ns frontend.worker.db-worker-node
   "Node.js daemon entrypoint for db-worker."
-  (:require ["fs" :as fs]
-            ["http" :as http]
-            ["path" :as node-path]
+  (:require ["http" :as http]
             [clojure.string :as string]
             [frontend.worker.db-core :as db-core]
             [frontend.worker.db-worker-node-lock :as db-lock]
@@ -14,13 +12,13 @@
             [logseq.cli.root-dir :as root-dir]
             [logseq.cli.style :as style]
             [logseq.db :as ldb]
+            [logseq.db-worker.log :as db-worker-log]
             [logseq.db-worker.server-list :as server-list]
             [promesa.core :as p]))
 
 (defonce ^:private *ready? (atom false))
 (defonce ^:private *sse-clients (atom #{}))
 (defonce ^:private *lock-info (atom nil))
-(defonce ^:private *file-handler (atom nil))
 (defonce ^:private *server-list-file (atom nil))
 
 (defn- server-list-file-path
@@ -412,69 +410,6 @@
      :sync-download-graph? true}
     {}))
 
-(defn- pad2
-  [value]
-  (if (< value 10)
-    (str "0" value)
-    (str value)))
-
-(defn- yyyymmdd
-  [^js date]
-  (str (.getFullYear date)
-       (pad2 (inc (.getMonth date)))
-       (pad2 (.getDate date))))
-
-(defn- log-path
-  [root-dir repo]
-  (let [root-dir (db-lock/resolve-root-dir root-dir)
-        repo-dir (db-lock/repo-dir (db-lock/graphs-dir root-dir) repo)
-        date-str (yyyymmdd (js/Date.))]
-    (node-path/join repo-dir (str "db-worker-node-" date-str ".log"))))
-
-(defn- log-files
-  [repo-dir]
-  (->> (when (fs/existsSync repo-dir)
-         (fs/readdirSync repo-dir))
-       (filter (fn [^js name]
-                 (re-matches #"db-worker-node-\d{8}\.log" name)))
-       (sort)))
-
-(defn- enforce-log-retention!
-  [repo-dir]
-  (let [files (log-files repo-dir)
-        excess (max 0 (- (count files) 7))]
-    (doseq [name (take excess files)]
-      (fs/unlinkSync (node-path/join repo-dir name)))))
-
-(defn- format-log-line
-  [{:keys [time level message logger-name exception]}]
-  (let [ts (.toISOString (js/Date. time))
-        base (str ts
-                  " ["
-                  (name level)
-                  "] ["
-                  logger-name
-                  "] "
-                  (pr-str message))]
-    (str base (when exception (str " " (pr-str exception))) "\n")))
-
-(defn- install-file-logger!
-  [{:keys [root-dir repo log-level]}]
-  (let [root-dir (db-lock/resolve-root-dir root-dir)
-        repo-dir (db-lock/repo-dir (db-lock/graphs-dir root-dir) repo)
-        file-path (log-path root-dir repo)]
-    (fs/mkdirSync repo-dir #js {:recursive true})
-    (fs/writeFileSync file-path "" #js {:flag "a"})
-    (enforce-log-retention! repo-dir)
-    (when-let [handler @*file-handler]
-      (log/remove-handler handler))
-    (let [handler (fn [record]
-                    (fs/appendFileSync file-path (format-log-line record)))]
-      (reset! *file-handler handler)
-      (log/add-handler handler))
-    (log/set-levels {:glogi/root log-level})
-    file-path))
-
 (defn- assert-lock-owner!
   []
   (let [{:keys [path lock]} @*lock-info]
@@ -534,7 +469,8 @@
             (p/finally
              (fn []
                (when (fn? on-stopped!)
-                 (on-stopped!)))))))))
+                 (on-stopped!))
+               (db-worker-log/uninstall!))))))))
 
 (defn- resolve-listening-daemon!
   [{:keys [server proxy repo host port* stop!* stopped? on-stopped!]} resolve]
@@ -606,9 +542,9 @@
       (try
         (let [root-dir (root-dir/ensure-root-dir! root-dir)
               server-list-file (server-list-file-path root-dir)]
-          (install-file-logger! {:root-dir root-dir
-                                 :repo repo
-                                 :log-level (keyword (or log-level "info"))})
+          (db-worker-log/install! {:root-dir root-dir
+                                   :repo repo
+                                   :log-level (keyword (or log-level "info"))})
           (log/info :db-worker-node-version {:build-time (build-version/build-time)
                                              :revision (build-version/revision)})
           (reset! *ready? false)

--- a/src/main/frontend/worker/db_worker_node.cljs
+++ b/src/main/frontend/worker/db_worker_node.cljs
@@ -609,6 +609,8 @@
           (install-file-logger! {:root-dir root-dir
                                  :repo repo
                                  :log-level (keyword (or log-level "info"))})
+          (log/info :db-worker-node-version {:build-time (build-version/build-time)
+                                             :revision (build-version/revision)})
           (reset! *ready? false)
           (reset! *lock-info nil)
           (reset! *server-list-file server-list-file)

--- a/src/main/logseq/cli/command/agent.cljs
+++ b/src/main/logseq/cli/command/agent.cljs
@@ -1,0 +1,825 @@
+(ns logseq.cli.command.agent
+  "Agent bridge command helpers."
+  (:require ["child_process" :as child-process]
+            ["fs" :as fs]
+            ["os" :as os]
+            ["path" :as node-path]
+            [cljs.reader :as reader]
+            [clojure.string :as string]
+            [lambdaisland.glogi :as log]
+            [logseq.cli.command.core :as core]
+            [logseq.cli.command.show :as show-command]
+            [logseq.cli.server :as cli-server]
+            [logseq.cli.transport :as transport]
+            [logseq.common.util :as common-util]
+            [promesa.core :as p]))
+
+(def ^:private bridge-spec
+  {:dry-run {:desc "Print Codex commands without starting Codex or writing agent-session-id"
+             :coerce :boolean}})
+
+(def ^:private bridge-list-spec
+  {:all {:desc "Include completed sessions"
+         :coerce :boolean}})
+
+(def entries
+  [(core/command-entry ["agent" "bridge"]
+                       :agent-bridge
+                       "Run task agent bridge"
+                       bridge-spec
+                       {:examples ["logseq agent bridge --graph my-graph"
+                                   "logseq agent bridge --graph my-graph --dry-run"]})
+   (core/command-entry ["agent" "bridge" "list"]
+                       :agent-bridge-list
+                       "List agent bridge sessions"
+                       bridge-list-spec
+                       {:examples ["logseq agent bridge list"
+                                   "logseq agent bridge list --all"]})])
+
+(defn- trim-non-empty
+  [value]
+  (some-> value str string/trim not-empty))
+
+(defn resolve-agent-name
+  ([config]
+   (resolve-agent-name config {:hostname (.hostname os)}))
+  ([config {:keys [hostname]}]
+   (let [configured? (contains? config :agent-name)
+         configured (trim-non-empty (:agent-name config))
+         hostname (trim-non-empty hostname)
+         agent-name (if configured?
+                      configured
+                      hostname)]
+     (if (seq agent-name)
+       {:ok? true
+        :agent-name agent-name}
+       {:ok? false
+        :error {:code :agent-name-invalid
+                :message (if configured?
+                           "agent-name in cli.edn must be a non-empty string"
+                           "agent-name cannot be resolved from cli.edn or hostname")}}))))
+
+(defn build-action
+  [command options repo graph]
+  (case command
+    :agent-bridge
+    (if-not (seq repo)
+      {:ok? false
+       :error {:code :missing-repo
+               :message "repo is required for agent bridge"}}
+      {:ok? true
+       :action {:type :agent-bridge
+                :repo repo
+                :graph graph
+                :dry-run? (boolean (:dry-run options))}})
+
+    :agent-bridge-list
+    {:ok? true
+     :action {:type :agent-bridge-list
+              :all? (boolean (:all options))}}
+
+    {:ok? false
+     :error {:code :unknown-command
+             :message (str "unknown agent command: " command)}}))
+
+(defn- value-ident
+  [value]
+  (cond
+    (keyword? value) value
+    (map? value) (:db/ident value)
+    :else nil))
+
+(defn- value-title
+  [value]
+  (cond
+    (nil? value) nil
+    (string? value) value
+    (keyword? value) (name value)
+    (map? value) (or (:block/title value)
+                     (:name value)
+                     (some-> (:db/ident value) name))
+    :else (str value)))
+
+(defn- value-titles
+  [value]
+  (if (and (sequential? value)
+           (not (string? value)))
+    (keep value-title value)
+    (keep value-title [value])))
+
+(defn- task-tag?
+  [tag]
+  (or (= :logseq.class/Task (value-ident tag))
+      (= "Task" (value-title tag))))
+
+(defn- property-key-name
+  [k]
+  (cond
+    (keyword? k) (name k)
+    (string? k) k
+    :else nil))
+
+(defn- property-value-by-name
+  [block property-name]
+  (some (fn [[k v]]
+          (when (= property-name (property-key-name k))
+            v))
+        block))
+
+(defn- assignee-values
+  [block]
+  (->> (concat (mapcat (fn [k]
+                         (value-titles (get block k)))
+                       ["Assignee" :Assignee :assignee :logseq.property/assignee])
+               (value-titles (property-value-by-name block "assignee"))
+               (value-titles (property-value-by-name block "Assignee")))
+       (keep trim-non-empty)
+       set))
+
+(defn- agent-session-id
+  [block]
+  (or (some (fn [k]
+              (trim-non-empty (get block k)))
+            ["agent-session-id" :agent-session-id :logseq.property/agent-session-id])
+      (some-> (property-value-by-name block "agent-session-id") trim-non-empty)))
+
+(defn routable-task-decision
+  [block agent-name]
+  (let [uuid (:block/uuid block)
+        status-ident (value-ident (:logseq.property/status block))
+        assignees (assignee-values block)]
+    (cond
+      (nil? uuid)
+      {:routable? false :reason :missing-stable-uuid}
+
+      (not-any? task-tag? (:block/tags block))
+      {:routable? false :reason :missing-task-tag}
+
+      (not= :logseq.property/status.todo status-ident)
+      {:routable? false :reason :not-todo}
+
+      (not (contains? assignees agent-name))
+      {:routable? false :reason :assignee-mismatch}
+
+      (seq (agent-session-id block))
+      {:routable? false :reason :already-routed}
+
+      :else
+      {:routable? true})))
+
+(defn routable-task?
+  [block agent-name]
+  (true? (:routable? (routable-task-decision block agent-name))))
+
+(defn- block-uuid-str
+  [block]
+  (some-> (:block/uuid block) str))
+
+(defn build-codex-prompt
+  [{:keys [graph agent-name block tree-text]}]
+  (string/join
+   "\n"
+   ["You are handling a Logseq AgentBridge task."
+    ""
+    (str "Graph: " graph)
+    (str "Block UUID: " (block-uuid-str block))
+    (str "AgentBridge name: " agent-name)
+    ""
+    "Do not operate outside the target graph."
+    "Write task results back into the graph."
+    "Report the final status, files changed, commands run, verification, and any blockers."
+    ""
+    "Task block tree:"
+    (or tree-text (:block/title block) "")]))
+
+(defn build-codex-command
+  [prompt {:keys [codex-bin]}]
+  [(or (trim-non-empty codex-bin) "codex") "exec" "--json" prompt])
+
+(defn- shell-quote
+  [value]
+  (let [text (str value)]
+    (if (re-matches #"[A-Za-z0-9._:/=-]+" text)
+      text
+      (str "'" (string/replace text #"'" "'\"'\"'") "'"))))
+
+(defn command-preview
+  [command]
+  (string/join " " (map shell-quote command)))
+
+(defn codex-available?
+  [codex-bin]
+  (let [result (.spawnSync child-process
+                           (or (trim-non-empty codex-bin) "codex")
+                           #js ["--version"]
+                           #js {:encoding "utf8"})]
+    (zero? (or (.-status result) 1))))
+
+(defn parse-codex-session-id-line
+  [line]
+  (try
+    (let [payload (js->clj (js/JSON.parse line) :keywordize-keys true)]
+      (or (:session-id payload)
+          (:session_id payload)
+          (:thread-id payload)
+          (:thread_id payload)
+          (get-in payload [:session :id])
+          (get-in payload [:session :session-id])
+          (get-in payload [:session :session_id])
+          (get-in payload [:thread :id])
+          (get-in payload [:thread :thread-id])
+          (get-in payload [:thread :thread_id])))
+    (catch :default _
+      nil)))
+
+(defn start-codex!
+  [command {:keys [on-exit]}]
+  (p/create
+   (fn [resolve reject]
+     (let [bin (first command)
+           args (clj->js (vec (rest command)))
+           child (.spawn child-process bin args #js {:stdio #js ["ignore" "pipe" "pipe"]})
+           settled? (atom false)
+           session-id* (atom nil)
+           child-closed? (atom false)
+           stdout-closed? (atom false)
+           exit-code* (atom nil)
+           stdout-buffer (atom "")
+           settle! (fn [f value]
+                     (when-not @settled?
+                       (reset! settled? true)
+                       (f value)))
+           handle-line! (fn [line]
+                          (when-let [session-id (parse-codex-session-id-line line)]
+                            (reset! session-id* session-id)
+                            (settle! resolve {:session session-id
+                                              :status :running
+                                              :process child})))
+           flush-stdout-buffer! (fn []
+                                  (when (seq @stdout-buffer)
+                                    (handle-line! @stdout-buffer)
+                                    (reset! stdout-buffer "")))
+           finalize! (fn []
+                       (when (and @child-closed? @stdout-closed?)
+                         (flush-stdout-buffer!)
+                         (when (fn? on-exit)
+                           (on-exit @exit-code* @session-id*))
+                         (when-not @settled?
+                           (if (zero? (or @exit-code* 1))
+                             (settle! reject (ex-info "codex exited before reporting a session id"
+                                                      {:code :codex-session-id-missing}))
+                             (settle! reject (ex-info "codex exited before startup completed"
+                                                      {:code :codex-start-failed
+                                                       :exit-code @exit-code*}))))))]
+       (.on child "error"
+            (fn [error]
+              (settle! reject (ex-info "failed to start codex"
+                                       {:code :codex-start-failed
+                                        :cause error}))))
+       (.on (.-stdout child) "data"
+            (fn [chunk]
+              (let [text (str @stdout-buffer (.toString chunk "utf8"))
+                    lines (vec (.split text #"\r?\n"))
+                    complete-lines (butlast lines)
+                    trailing (last lines)]
+                (reset! stdout-buffer trailing)
+                (doseq [line complete-lines]
+                  (handle-line! line)))))
+       (.on (.-stdout child) "close"
+            (fn []
+              (reset! stdout-closed? true)
+              (finalize!)))
+       (.on (.-stderr child) "data" (fn [_chunk] nil))
+       (.on child "close"
+            (fn [code _signal]
+              (reset! exit-code* code)
+              (reset! child-closed? true)
+              (finalize!)))))))
+
+(defn session-store-path
+  [{:keys [root-dir]}]
+  (node-path/join root-dir "agent-bridge-sessions.edn"))
+
+(defn- read-session-store
+  [config]
+  (let [path (session-store-path config)]
+    (if (fs/existsSync path)
+      (reader/read-string (fs/readFileSync path "utf8"))
+      {:sessions []})))
+
+(defn- write-session-store!
+  [config store]
+  (let [path (session-store-path config)
+        dir (node-path/dirname path)]
+    (fs/mkdirSync dir #js {:recursive true})
+    (fs/writeFileSync path (pr-str store) "utf8")
+    store))
+
+(def ^:private terminal-session-statuses #{:completed :failed})
+
+(defn- merge-session-record
+  [existing session]
+  (let [merged (merge existing session)]
+    (if (and (contains? terminal-session-statuses (:status existing))
+             (= :running (:status session)))
+      (assoc merged :status (:status existing))
+      merged)))
+
+(defn record-session!
+  [config session]
+  (let [store (read-session-store config)
+        sessions (vec (:sessions store))
+        session-id (:session session)
+        sessions' (if (some #(= session-id (:session %)) sessions)
+                    (mapv (fn [existing]
+                            (if (= session-id (:session existing))
+                              (merge-session-record existing session)
+                              existing))
+                          sessions)
+                    (conj sessions session))]
+    (write-session-store! config (assoc store :sessions sessions'))
+    session))
+
+(defn update-session-status!
+  [config session-id status]
+  (record-session! config {:session session-id
+                           :status status
+                           :updated-at (js/Date.now)}))
+
+(defn list-sessions
+  [config {:keys [all?]}]
+  (let [sessions (vec (:sessions (read-session-store config)))]
+    (if all?
+      sessions
+      (vec (remove #(= :completed (:status %)) sessions)))))
+
+(defn execute-list
+  [action config]
+  {:status :ok
+   :command :agent-bridge-list
+   :data {:sessions (list-sessions config {:all? (:all? action)})}})
+
+(defn- now-iso
+  []
+  (.toISOString (js/Date.)))
+
+(defn- log-line
+  [message]
+  (str (now-iso) " " message))
+
+(defn- bridge-error
+  [code message]
+  {:status :error
+   :command :agent-bridge
+   :error {:code code
+           :message message}})
+
+(defn- log-bridge-exit!
+  [{:keys [repo graph agent-name reason exit-code error]}]
+  (log/info :agent-bridge-exit
+            (cond-> {:reason reason
+                     :exit-code exit-code
+                     :repo repo
+                     :graph graph
+                     :agent-name agent-name
+                     :message (or (some-> error ex-message)
+                                  (some-> error str))}
+              (some-> error ex-data :code)
+              (assoc :error-code (-> error ex-data :code)))))
+
+(def agent-bridge-registry-page "AgentBridge")
+
+(def agent-bridge-registry-page-query
+  '[:find [(pull ?p [:db/id :block/uuid :block/name :block/title]) ...]
+    :in $ ?page-name
+    :where
+    [?p :block/name ?page-name]])
+
+(def registered-agent-query
+  '[:find [(pull ?b [:db/id :block/uuid :block/title]) ...]
+    :in $ ?page-id ?agent-name
+    :where
+    [?b :block/parent ?page-id]
+    [?b :block/title ?agent-name]])
+
+(defn random-bridge-block-uuid
+  []
+  (random-uuid))
+
+(defn- first-entity
+  [entities]
+  (first (filter :db/id entities)))
+
+(defn- registry-page-name
+  []
+  (common-util/page-name-sanity-lc agent-bridge-registry-page))
+
+(defn- pull-registry-page
+  [cfg repo]
+  (p/let [pages (transport/invoke cfg :thread-api/q
+                                  [repo [agent-bridge-registry-page-query
+                                         (registry-page-name)]])]
+    (first-entity pages)))
+
+(defn- ensure-registry-page!
+  [cfg repo]
+  (p/let [existing (pull-registry-page cfg repo)]
+    (if (:db/id existing)
+      existing
+      (p/let [result (transport/invoke cfg :thread-api/apply-outliner-ops
+                                       [repo [[:create-page [agent-bridge-registry-page {}]]] {}])
+              page-uuid (second result)]
+        (if page-uuid
+          (transport/invoke cfg :thread-api/pull
+                            [repo [:db/id :block/uuid :block/name :block/title] [:block/uuid page-uuid]])
+          (pull-registry-page cfg repo))))))
+
+(defn register-agent-bridge!
+  [cfg repo agent-name]
+  (p/let [page (ensure-registry-page! cfg repo)
+          page-id (:db/id page)
+          page-uuid (:block/uuid page)
+          _ (when-not page-id
+              (throw (ex-info "agent bridge registry page not found"
+                              {:code :agent-registration-failed})))
+          _ (when-not page-uuid
+              (throw (ex-info "agent bridge registry page uuid not found"
+                              {:code :agent-registration-failed})))
+          existing (transport/invoke cfg :thread-api/q
+                                     [repo [registered-agent-query page-id agent-name]])]
+    (if (first-entity existing)
+      true
+      (p/let [_ (transport/invoke cfg :thread-api/apply-outliner-ops
+                                  [repo [[:insert-blocks [[{:block/title agent-name
+                                                            :block/uuid (random-bridge-block-uuid)}]
+                                                          page-uuid
+                                                          {:outliner-op :insert-blocks
+                                                           :sibling? false
+                                                           :bottom? true
+                                                           :keep-uuid? true}]]]
+                                   {}])]
+        true))))
+
+(def agent-session-id-property-name "agent-session-id")
+
+(def agent-session-id-property-schema
+  {:logseq.property/type :default
+   :db/cardinality :db.cardinality/one})
+
+(def agent-session-id-property-query
+  '[:find [(pull ?p [:db/id :db/ident :block/name :block/title]) ...]
+    :in $ ?property-name
+    :where
+    [?p :block/name ?property-name]
+    [?p :db/ident]])
+
+(defn- pull-agent-session-id-property
+  [cfg repo]
+  (p/let [properties (transport/invoke cfg :thread-api/q
+                                       [repo [agent-session-id-property-query
+                                              (common-util/page-name-sanity-lc agent-session-id-property-name)]])]
+    (first-entity properties)))
+
+(defn- ensure-agent-session-id-property!
+  [cfg repo]
+  (p/let [existing (pull-agent-session-id-property cfg repo)]
+    (if (:db/ident existing)
+      existing
+      (p/let [_ (transport/invoke cfg :thread-api/apply-outliner-ops
+                                  [repo [[:upsert-property [nil
+                                                            agent-session-id-property-schema
+                                                            {:property-name agent-session-id-property-name}]]]
+                                   {}])
+              created (pull-agent-session-id-property cfg repo)]
+        (if (:db/ident created)
+          created
+          (throw (ex-info "agent-session-id property not found after upsert"
+                          {:code :agent-session-id-write-failed})))))))
+
+(defn write-agent-session-id!
+  [cfg repo block-uuid session-id]
+  (p/let [property (ensure-agent-session-id-property! cfg repo)
+          property-ident (:db/ident property)
+          _ (when-not property-ident
+              (throw (ex-info "agent-session-id property ident missing"
+                              {:code :agent-session-id-write-failed})))
+          _ (transport/invoke cfg :thread-api/apply-outliner-ops
+                              [repo [[:batch-set-property [[block-uuid] property-ident session-id {}]]] {}])]
+    true))
+
+(def ^:private routable-task-query
+  '[:find [(pull ?e [:db/id
+                     :block/uuid
+                     :block/title
+                     {:block/tags [:db/ident :block/title]}
+                     {:logseq.property/status [:db/ident :block/title]}
+                     *]) ...]
+    :in $ ?agent-name
+    :where
+    [?e :block/tags :logseq.class/Task]
+    [?e :logseq.property/status ?status]
+    [?status :db/ident :logseq.property/status.todo]
+    [?assignee-property :block/name "assignee"]
+    [?assignee-property :db/ident ?assignee-attr]
+    [?e ?assignee-attr ?assignee-ref]
+    [?assignee-ref :block/title ?agent-name]])
+
+(defn list-routable-tasks
+  [cfg repo agent-name]
+  (p/let [blocks (transport/invoke cfg :thread-api/q [repo [routable-task-query agent-name]])]
+    (p/all
+     (mapv (fn [block]
+             (p/let [show-result (show-command/execute-show {:type :show
+                                                             :repo repo
+                                                             :uuid (block-uuid-str block)
+                                                             :level 100
+                                                             :linked-references? false
+                                                             :ref-id-footer? false}
+                                                            cfg)]
+               {:block block
+                :tree-text (or (get-in show-result [:data :message])
+                               (:block/title block))}))
+           (filter #(routable-task? % agent-name)
+                   (map #(assoc % "Assignee" agent-name) blocks))))))
+
+(defn- dry-run-commands
+  [graph agent-name tasks]
+  (mapv (fn [{:keys [block tree-text]}]
+          (let [prompt (build-codex-prompt {:graph graph
+                                            :agent-name agent-name
+                                            :block block
+                                            :tree-text tree-text})
+                command (build-codex-command prompt {})]
+            {:block (block-uuid-str block)
+             :backend :codex
+             :command command
+             :preview (command-preview command)}))
+        tasks))
+
+(defn- emit-log!
+  [config line]
+  (if-let [f (:log-fn config)]
+    (f line)
+    (.write (.-stdout js/process) (str line "\n"))))
+
+(defn- session-record
+  [graph agent-name block session-id status]
+  {:session session-id
+   :status status
+   :backend :codex
+   :graph graph
+   :block (block-uuid-str block)
+   :agent agent-name
+   :started-at (js/Date.now)
+   :updated-at (js/Date.now)})
+
+(defn- route-task!
+  [cfg {:keys [repo graph agent-name]} {:keys [block tree-text]}]
+  (let [prompt (build-codex-prompt {:graph graph
+                                    :agent-name agent-name
+                                    :block block
+                                    :tree-text tree-text})
+        command (build-codex-command prompt {})
+        preview (command-preview command)]
+    (emit-log! cfg (log-line (str "Codex command prepared for " (block-uuid-str block) ": " preview)))
+    (p/let [{:keys [session]} (start-codex! command
+                                            {:on-exit (fn [code session-id]
+                                                        (when session-id
+                                                          (update-session-status! cfg session-id
+                                                                                  (if (zero? (or code 1))
+                                                                                    :completed
+                                                                                    :failed))))})
+            _ (when-not (seq session)
+                (throw (ex-info "codex session id missing"
+                                {:code :codex-session-id-missing})))
+            cfg* (cli-server/ensure-server! cfg repo)
+            _ (record-session! cfg* (session-record graph agent-name block session :running))
+            _ (write-agent-session-id! cfg* repo (:block/uuid block) session)]
+      (emit-log! cfg (log-line (str "agent-session-id written for " (block-uuid-str block))))
+      {:block (block-uuid-str block)
+       :session session
+       :backend :codex
+       :preview preview})))
+
+(defn- process-tasks!
+  [cfg {:keys [repo graph agent-name]}]
+  (p/let [tasks (list-routable-tasks cfg repo agent-name)]
+    (p/all (mapv #(route-task! cfg {:repo repo
+                                    :graph graph
+                                    :agent-name agent-name}
+                               %)
+                 tasks))))
+
+(def ^:private assignee-property-ident :logseq.property/assignee)
+
+(def ^:private assignee-value-selector
+  [:db/id :block/title :block/name])
+
+(def ^:private assignee-property-selector
+  [:db/id :db/ident])
+
+(def ^:private task-block-selector
+  [:db/id
+   :block/uuid
+   :block/title
+   {:block/tags [:db/ident :block/title]}
+   {:logseq.property/status [:db/ident :block/title]}
+   {:logseq.property/assignee [:db/id :block/title :block/name :db/ident]}
+   '*])
+
+(defn- datom-added?
+  [datom]
+  (cond
+    (map? datom)
+    (not (false? (if (contains? datom :added)
+                   (:added datom)
+                   (:added? datom))))
+
+    (and (sequential? datom) (<= 5 (count datom)))
+    (not (false? (nth datom 4)))
+
+    :else
+    (not (false? (or (unchecked-get datom "added")
+                     (unchecked-get datom "added?")
+                     true)))))
+
+(defn- datom-e
+  [datom]
+  (cond
+    (map? datom) (:e datom)
+    (sequential? datom) (first datom)
+    :else (unchecked-get datom "e")))
+
+(defn- datom-attr
+  [datom]
+  (cond
+    (map? datom) (:a datom)
+    (sequential? datom) (second datom)
+    :else (unchecked-get datom "a")))
+
+(defn- datom-value
+  [datom]
+  (cond
+    (map? datom) (:v datom)
+    (sequential? datom) (nth datom 2 nil)
+    :else (unchecked-get datom "v")))
+
+(defn- unknown-attr-datom?
+  [datom]
+  (let [attr (datom-attr datom)]
+    (and (datom-added? datom)
+         (some? attr)
+         (not (keyword? attr)))))
+
+(defn- direct-assignee-datom?
+  [datom]
+  (and (datom-added? datom)
+       (= assignee-property-ident (datom-attr datom))))
+
+(defn- pull-assignee-property
+  [cfg repo]
+  (transport/invoke cfg :thread-api/pull [repo assignee-property-selector assignee-property-ident]))
+
+(defn- resolve-assignee-datoms
+  [cfg repo tx-data]
+  (let [direct-datoms (filter direct-assignee-datom? tx-data)
+        unknown-attr-datoms (filter unknown-attr-datom? tx-data)]
+    (if (seq unknown-attr-datoms)
+      (p/let [property (pull-assignee-property cfg repo)
+              property-id (:db/id property)]
+        (concat direct-datoms
+                (filter #(= property-id (datom-attr %)) unknown-attr-datoms)))
+      (p/resolved direct-datoms))))
+
+(defn- direct-assignee-title
+  [value]
+  (when (or (string? value)
+            (keyword? value)
+            (map? value))
+    (trim-non-empty (value-title value))))
+
+(defn- assignee-value-matches?
+  [cfg repo value agent-name]
+  (if-let [title (direct-assignee-title value)]
+    (p/resolved (= agent-name title))
+    (p/let [entity (transport/invoke cfg :thread-api/pull [repo assignee-value-selector value])]
+      (= agent-name (trim-non-empty (value-title entity))))))
+
+(defn- pull-task-block
+  [cfg repo block-id]
+  (transport/invoke cfg :thread-api/pull [repo task-block-selector block-id]))
+
+(defn- show-task-tree
+  [cfg repo block]
+  (p/let [show-result (show-command/execute-show {:type :show
+                                                  :repo repo
+                                                  :uuid (block-uuid-str block)
+                                                  :level 100
+                                                  :linked-references? false
+                                                  :ref-id-footer? false}
+                                                 cfg)]
+    (or (get-in show-result [:data :message])
+        (:block/title block))))
+
+(defn- route-assignee-datom!
+  [cfg {:keys [repo agent-name] :as opts} datom]
+  (let [block-id (datom-e datom)
+        assignee-value (datom-value datom)]
+    (when block-id
+      (p/let [matches? (assignee-value-matches? cfg repo assignee-value agent-name)]
+        (when matches?
+          (p/let [block (pull-task-block cfg repo block-id)]
+            (when (routable-task? block agent-name)
+              (p/let [tree-text (show-task-tree cfg repo block)]
+                (route-task! cfg opts {:block block
+                                       :tree-text tree-text})))))))))
+
+(defn- process-sync-db-changes-event!
+  [cfg {:keys [repo] :as opts} {:keys [tx-data]}]
+  (p/let [assignee-datoms (resolve-assignee-datoms cfg repo tx-data)]
+    (when (seq assignee-datoms)
+      (p/all (mapv #(route-assignee-datom! cfg opts %) assignee-datoms)))))
+
+(defn- listen-forever!
+  [cfg {:keys [repo graph agent-name]}]
+  (let [processing* (atom (p/resolved nil))
+        process! (fn [payload]
+                   (swap! processing*
+                          (fn [previous]
+                            (-> previous
+                                (p/catch (fn [_] nil))
+                                (p/then (fn [_]
+                                          (process-sync-db-changes-event! cfg
+                                                                          {:repo repo
+                                                                           :graph graph
+                                                                           :agent-name agent-name}
+                                                                          payload)))
+                                (p/catch (fn [e]
+                                           (emit-log! cfg (log-line (str "Codex invocation failed: "
+                                                                         (or (ex-message e) (str e)))))
+                                           (log-bridge-exit! {:repo repo
+                                                              :graph graph
+                                                              :agent-name agent-name
+                                                              :reason :task-processing-failed
+                                                              :exit-code 1
+                                                              :error e})
+                                           (.exit js/process 1)))))))]
+    (transport/connect-events! cfg
+                               (fn [event-type payload]
+                                 (when (= :sync-db-changes event-type)
+                                   (emit-log! cfg (log-line "got graph changes: sync-db-changes"))
+                                   (process! payload))))
+    (p/create (fn [_resolve _reject] nil))))
+
+(defn execute-bridge
+  [action config]
+  (let [repo (:repo action)
+        graph (:graph action)
+        logs [(log-line "checking the environment ...")
+              (log-line (str "using graph: " graph))]]
+    (p/let [agent-name-result (resolve-agent-name config)]
+      (if-not (:ok? agent-name-result)
+        (bridge-error (get-in agent-name-result [:error :code])
+                      (get-in agent-name-result [:error :message]))
+        (let [agent-name (:agent-name agent-name-result)
+              logs (conj logs
+                         (log-line (str "using agent name: " agent-name))
+                         (log-line "checking codex cli ..."))]
+          (if-not (codex-available? nil)
+            (bridge-error :codex-not-found "codex executable is not available")
+            (p/let [cfg (cli-server/ensure-server! config repo)
+                    logs (conj logs (log-line "registering agent bridge ..."))
+                    _ (register-agent-bridge! cfg repo agent-name)]
+              (if (:dry-run? action)
+                (p/let [tasks (list-routable-tasks cfg repo agent-name)
+                        commands (dry-run-commands graph agent-name tasks)
+                        logs (into (conj logs (log-line "listening graph changes ..."))
+                                   (map (fn [{:keys [block preview]}]
+                                          (log-line (str "would run Codex command for " block ": " preview)))
+                                        commands))]
+                  {:status :ok
+                   :command :agent-bridge
+                   :data {:mode :dry-run
+                          :graph graph
+                          :agent-name agent-name
+                          :logs logs
+                          :commands commands}})
+                (do
+                  (doseq [line (conj logs (log-line "listening graph changes ..."))]
+                    (emit-log! cfg line))
+                  (if (:process-once? action)
+                    (p/let [routed (process-tasks! cfg {:repo repo
+                                                        :graph graph
+                                                        :agent-name agent-name})]
+                      {:status :ok
+                       :command :agent-bridge
+                       :data {:mode :processed-once
+                              :graph graph
+                              :agent-name agent-name
+                              :routed routed}})
+                    (p/let [_ (process-tasks! cfg {:repo repo
+                                                   :graph graph
+                                                   :agent-name agent-name})]
+                      (listen-forever! cfg {:repo repo
+                                            :graph graph
+                                            :agent-name agent-name}))))))))))))

--- a/src/main/logseq/cli/command/agent.cljs
+++ b/src/main/logseq/cli/command/agent.cljs
@@ -283,13 +283,21 @@
     "comment-thread-context" (or comments-area-tree-text (:block/title (:block/parent comment-block)) "")
     "requesting-comment" (or comment-tree-text (:block/title comment-block) "")}))
 
+(defn- codex-exec-prefix
+  [codex-bin]
+  [(or (trim-non-empty codex-bin) "codex")
+   "--sandbox" "danger-full-access"
+   "exec"])
+
 (defn build-codex-command
   [prompt {:keys [codex-bin]}]
-  [(or (trim-non-empty codex-bin) "codex") "exec" "--json" prompt])
+  (conj (codex-exec-prefix codex-bin)
+        "--json" "--skip-git-repo-check" prompt))
 
 (defn- build-codex-resume-command
   [session-id prompt {:keys [codex-bin]}]
-  [(or (trim-non-empty codex-bin) "codex") "exec" "resume" "--json" session-id prompt])
+  (conj (codex-exec-prefix codex-bin)
+        "resume" "--json" "--skip-git-repo-check" session-id prompt))
 
 (defn- shell-quote
   [value]

--- a/src/main/logseq/cli/command/agent.cljs
+++ b/src/main/logseq/cli/command/agent.cljs
@@ -601,13 +601,38 @@
        :backend :codex
        :preview preview})))
 
+(defn- claim-routing-block!
+  [routing-blocks* block-id]
+  (loop []
+    (let [routing-blocks @routing-blocks*]
+      (cond
+        (contains? routing-blocks block-id)
+        false
+
+        (compare-and-set! routing-blocks* routing-blocks (conj routing-blocks block-id))
+        true
+
+        :else
+        (recur)))))
+
+(defn- route-task-once!
+  [cfg {:keys [routing-blocks*] :as opts} {:keys [block] :as task}]
+  (let [block-id (block-uuid-str block)]
+    (if (and routing-blocks* block-id)
+      (if (claim-routing-block! routing-blocks* block-id)
+        (-> (route-task! cfg opts task)
+            (p/finally (fn []
+                         (swap! routing-blocks* disj block-id))))
+        (p/resolved nil))
+      (route-task! cfg opts task))))
+
 (defn- process-tasks!
   [cfg {:keys [repo graph agent-name]}]
   (p/let [tasks (list-routable-tasks cfg repo agent-name)]
-    (p/all (mapv #(route-task! cfg {:repo repo
-                                    :graph graph
-                                    :agent-name agent-name}
-                               %)
+    (p/all (mapv #(route-task-once! cfg {:repo repo
+                                         :graph graph
+                                         :agent-name agent-name}
+                                    %)
                  tasks))))
 
 (def ^:private assignee-property-ident :logseq.property/assignee)
@@ -731,8 +756,8 @@
           (p/let [block (pull-task-block cfg repo block-id)]
             (when (routable-task? block agent-name)
               (p/let [tree-text (show-task-tree cfg repo block)]
-                (route-task! cfg opts {:block block
-                                       :tree-text tree-text})))))))))
+                (route-task-once! cfg opts {:block block
+                                            :tree-text tree-text})))))))))
 
 (defn- process-sync-db-changes-event!
   [cfg {:keys [repo] :as opts} {:keys [tx-data]}]
@@ -742,28 +767,28 @@
 
 (defn- listen-forever!
   [cfg {:keys [repo graph agent-name]}]
-  (let [processing* (atom (p/resolved nil))
+  (let [routing-blocks* (atom #{})
+        handle-error! (fn [e]
+                        (emit-log! cfg (log-line (str "Codex invocation failed: "
+                                                      (or (ex-message e) (str e)))))
+                        (log-bridge-exit! {:repo repo
+                                           :graph graph
+                                           :agent-name agent-name
+                                           :reason :task-processing-failed
+                                           :exit-code 1
+                                           :error e})
+                        (.exit js/process 1))
         process! (fn [payload]
-                   (swap! processing*
-                          (fn [previous]
-                            (-> previous
-                                (p/catch (fn [_] nil))
-                                (p/then (fn [_]
-                                          (process-sync-db-changes-event! cfg
-                                                                          {:repo repo
-                                                                           :graph graph
-                                                                           :agent-name agent-name}
-                                                                          payload)))
-                                (p/catch (fn [e]
-                                           (emit-log! cfg (log-line (str "Codex invocation failed: "
-                                                                         (or (ex-message e) (str e)))))
-                                           (log-bridge-exit! {:repo repo
-                                                              :graph graph
-                                                              :agent-name agent-name
-                                                              :reason :task-processing-failed
-                                                              :exit-code 1
-                                                              :error e})
-                                           (.exit js/process 1)))))))]
+                   (try
+                     (-> (process-sync-db-changes-event! cfg
+                                                         {:repo repo
+                                                          :graph graph
+                                                          :agent-name agent-name
+                                                          :routing-blocks* routing-blocks*}
+                                                         payload)
+                         (p/catch handle-error!))
+                     (catch :default e
+                       (handle-error! e))))]
     (transport/connect-events! cfg
                                (fn [event-type payload]
                                  (when (= :sync-db-changes event-type)

--- a/src/main/logseq/cli/command/agent.cljs
+++ b/src/main/logseq/cli/command/agent.cljs
@@ -544,11 +544,18 @@
     [?p :block/name ?page-name]])
 
 (def registered-agent-query
-  '[:find [(pull ?b [:db/id :block/uuid :block/title]) ...]
-    :in $ ?page-id ?agent-name
+  '[:find [(pull ?p [:db/id
+                     :block/uuid
+                     :block/name
+                     :block/title
+                     :logseq.property/deleted-at
+                     {:block/parent [:db/id
+                                     :logseq.property/deleted-at
+                                     {:block/parent [:db/id
+                                                     :logseq.property/deleted-at]}]}]) ...]
+    :in $ ?agent-page-name
     :where
-    [?b :block/parent ?page-id]
-    [?b :block/title ?agent-name]])
+    [?p :block/name ?agent-page-name]])
 
 (declare ensure-registry-page!)
 
@@ -782,10 +789,6 @@
                  {}
                  [:task :comment]))))))
 
-(defn random-bridge-block-uuid
-  []
-  (random-uuid))
-
 (defn- first-entity
   [entities]
   (first (filter :db/id entities)))
@@ -797,6 +800,10 @@
 (defn- registry-page-name
   []
   (common-util/page-name-sanity-lc agent-bridge-registry-page))
+
+(defn- agent-page-name
+  [agent-name]
+  (common-util/page-name-sanity-lc agent-name))
 
 (defn- pull-registry-page
   [cfg repo]
@@ -830,19 +837,21 @@
               (throw (ex-info "agent bridge registry page uuid not found"
                               {:code :agent-registration-failed})))
           existing (transport/invoke cfg :thread-api/q
-                                     [repo [registered-agent-query page-id agent-name]])]
-    (if (first-entity existing)
+                                     [repo [registered-agent-query
+                                            (agent-page-name agent-name)]])]
+    (if (first-live-entity existing)
       true
-      (p/let [_ (transport/invoke cfg :thread-api/apply-outliner-ops
-                                  [repo [[:insert-blocks [[{:block/title agent-name
-                                                            :block/uuid (random-bridge-block-uuid)}]
-                                                          page-uuid
-                                                          {:outliner-op :insert-blocks
-                                                           :sibling? false
-                                                           :bottom? true
-                                                           :keep-uuid? true}]]]
-                                   {}])]
-        true))))
+      (p/let [result (transport/invoke cfg :thread-api/apply-outliner-ops
+                                       [repo [[:create-page [agent-name {}]]] {}])]
+        (if (second result)
+          true
+          (p/let [created (transport/invoke cfg :thread-api/q
+                                            [repo [registered-agent-query
+                                                   (agent-page-name agent-name)]])]
+            (if (first-live-entity created)
+              true
+              (throw (ex-info "agent bridge agent page not found after create"
+                              {:code :agent-registration-failed})))))))))
 
 (def agent-session-id-property-name "agent-session-id")
 

--- a/src/main/logseq/cli/command/agent.cljs
+++ b/src/main/logseq/cli/command/agent.cljs
@@ -936,15 +936,27 @@
         (p/resolved nil))
       (route-task! cfg opts task))))
 
+(def ^:private max-concurrent-routes 4)
+
+(defn- p-map-batched
+  [limit f coll]
+  (reduce (fn [result-promise batch]
+            (p/let [result result-promise
+                    batch-result (p/all (mapv f batch))]
+              (into result batch-result)))
+          (p/resolved [])
+          (partition-all limit coll)))
+
 (defn- process-tasks!
   [cfg {:keys [repo graph agent-name prompt-templates]}]
   (p/let [tasks (list-routable-tasks cfg repo agent-name)]
-    (p/all (mapv #(route-task-once! cfg {:repo repo
-                                         :graph graph
-                                         :agent-name agent-name
-                                         :prompt-templates prompt-templates}
-                                    %)
-                 tasks))))
+    (p-map-batched max-concurrent-routes
+                   #(route-task-once! cfg {:repo repo
+                                           :graph graph
+                                           :agent-name agent-name
+                                           :prompt-templates prompt-templates}
+                                      %)
+                   tasks)))
 
 (def ^:private assignee-property-ident :logseq.property/assignee)
 
@@ -1023,6 +1035,14 @@
        (string? (:v datom))
        (or (string/includes? (:v datom) (str "[[" agent-name "]]"))
            (string/includes? (:v datom) "[["))))
+
+(defn- task-routability-datom?
+  [datom]
+  (and (true? (:added datom))
+       (or (and (= :block/tags (:a datom))
+                (= :logseq.class/Task (:v datom)))
+           (and (= :logseq.property/status (:a datom))
+                (= :logseq.property/status.todo (:v datom))))))
 
 (defn- pull-assignee-property
   [cfg repo]
@@ -1212,6 +1232,15 @@
                 (route-task-once! cfg opts {:block block
                                             :tree-text tree-text})))))))))
 
+(defn- route-routability-datom!
+  [cfg {:keys [repo agent-name] :as opts} datom]
+  (when-let [block-id (:e datom)]
+    (p/let [block (pull-task-block cfg repo block-id)]
+      (when (routable-task? block agent-name)
+        (p/let [tree-text (show-task-tree cfg repo block)]
+          (route-task-once! cfg opts {:block block
+                                      :tree-text tree-text}))))))
+
 (defn- route-comment-datom!
   [cfg {:keys [repo agent-name] :as opts} datom]
   (when-let [block-id (:e datom)]
@@ -1222,8 +1251,10 @@
 (defn- process-sync-db-changes-event!
   [cfg {:keys [repo] :as opts} {:keys [tx-data]}]
   (p/let [assignee-datoms (resolve-assignee-datoms cfg repo tx-data)]
-    (let [comment-datoms (filter #(comment-title-datom? % (:agent-name opts)) tx-data)
+    (let [routability-datoms (filter task-routability-datom? tx-data)
+          comment-datoms (filter #(comment-title-datom? % (:agent-name opts)) tx-data)
           routing (vec (concat (map #(route-assignee-datom! cfg opts %) assignee-datoms)
+                               (map #(route-routability-datom! cfg opts %) routability-datoms)
                                (map #(route-comment-datom! cfg opts %) comment-datoms)))]
       (when (seq routing)
         (p/all routing)))))
@@ -1295,10 +1326,10 @@
                           :agent-name agent-name
                           :logs logs
                           :commands commands}})
-                (do
-                  (doseq [line (conj logs (log-line "listening graph changes ..."))]
-                    (emit-log! cfg line))
-                  (if (:process-once? action)
+                (if (:process-once? action)
+                  (do
+                    (doseq [line (conj logs (log-line "listening graph changes ..."))]
+                      (emit-log! cfg line))
                     (p/let [routed (process-tasks! cfg {:repo repo
                                                         :graph graph
                                                         :agent-name agent-name
@@ -1308,12 +1339,15 @@
                        :data {:mode :processed-once
                               :graph graph
                               :agent-name agent-name
-                              :routed routed}})
+                              :routed routed}}))
+                  (let [listen-promise (listen-forever! cfg {:repo repo
+                                                             :graph graph
+                                                             :agent-name agent-name
+                                                             :prompt-templates prompt-templates})]
+                    (doseq [line (conj logs (log-line "listening graph changes ..."))]
+                      (emit-log! cfg line))
                     (p/let [_ (process-tasks! cfg {:repo repo
                                                    :graph graph
                                                    :agent-name agent-name
                                                    :prompt-templates prompt-templates})]
-                      (listen-forever! cfg {:repo repo
-                                            :graph graph
-                                            :agent-name agent-name
-                                            :prompt-templates prompt-templates}))))))))))))
+                      listen-promise)))))))))))

--- a/src/main/logseq/cli/command/agent.cljs
+++ b/src/main/logseq/cli/command/agent.cljs
@@ -5,6 +5,7 @@
             ["os" :as os]
             ["path" :as node-path]
             [cljs.reader :as reader]
+            [clojure.set :as set]
             [clojure.string :as string]
             [lambdaisland.glogi :as log]
             [logseq.cli.command.core :as core]
@@ -12,6 +13,7 @@
             [logseq.cli.server :as cli-server]
             [logseq.cli.transport :as transport]
             [logseq.common.util :as common-util]
+            [logseq.db :as ldb]
             [promesa.core :as p]))
 
 (def ^:private bridge-spec
@@ -175,51 +177,156 @@
   [block]
   (some-> (:block/uuid block) str))
 
-(defn build-codex-prompt
-  [{:keys [graph agent-name block tree-text]}]
+(def task-prompt-template-title "Task prompt template")
+
+(def comment-prompt-template-title "Comment prompt template")
+
+(def ^:private default-task-prompt-template
   (string/join
    "\n"
    ["You are handling a Logseq AgentBridge task."
     ""
-    (str "Graph: " graph)
-    (str "Block UUID: " (block-uuid-str block))
-    (str "AgentBridge name: " agent-name)
+    "Graph: {{graph}}"
+    "Block UUID: {{block-uuid}}"
+    "AgentBridge name: {{agent-name}}"
     ""
     "Do not operate outside the target graph."
     "Write task results back into the graph."
     "Report the final status, files changed, commands run, verification, and any blockers."
     ""
     "Task block tree:"
-    (or tree-text (:block/title block) "")]))
+    "{{task-block-tree}}"]))
 
-(defn- build-comment-codex-prompt
-  [{:keys [graph agent-name comment-tree-text comments-area-tree-text target-tree-texts]
-    comment-block :comment}]
+(def ^:private default-comment-prompt-template
   (string/join
    "\n"
    ["You are handling a Logseq AgentBridge comment request."
     ""
-    (str "Graph: " graph)
-    (str "Comment UUID: " (block-uuid-str comment-block))
-    (str "AgentBridge name: " agent-name)
+    "Graph: {{graph}}"
+    "Comment UUID: {{comment-uuid}}"
+    "AgentBridge name: {{agent-name}}"
     ""
     "Do not operate outside the target graph."
     "Complete the request from the mentioned comment."
     "Report the final status, files changed, commands run, verification, and any blockers."
     ""
     "Comment target context:"
-    (string/join "\n" (remove string/blank? target-tree-texts))
+    "{{comment-target-context}}"
     ""
     "Comment thread context:"
-    (or comments-area-tree-text (:block/title (:block/parent comment-block)) "")
+    "{{comment-thread-context}}"
     ""
     "Requesting comment:"
-    (or comment-tree-text (:block/title comment-block) "")
+    "{{requesting-comment}}"
     ""
     "Reply instructions:"
     "For a short reply, append a comment after the requesting comment."
     "For a long reply, write a normal block tree after the comments area and append a comment that references that tree."
     "If the request is blocked or fails, make that clear in the reply."]))
+
+(def ^:private prompt-template-vars
+  {:task #{"graph"
+           "block-uuid"
+           "agent-name"
+           "task-block-tree"}
+   :comment #{"graph"
+              "comment-uuid"
+              "agent-name"
+              "comment-target-context"
+              "comment-thread-context"
+              "requesting-comment"}})
+
+(def ^:private required-prompt-template-vars prompt-template-vars)
+
+(defn- renderable-prompt-template-var-names
+  [template]
+  (->> (re-seq #"('?)(\{\{([A-Za-z0-9-]+)\}\})('?)" (or template ""))
+       (keep (fn [[_ open-quote _ var-name close-quote]]
+               (when-not (and (= "'" open-quote)
+                              (= "'" close-quote))
+                 var-name)))
+       set))
+
+(defn validate-prompt-template
+  [template-kind template]
+  (let [vars (renderable-prompt-template-var-names template)
+        allowed-vars (get prompt-template-vars template-kind)
+        required-vars (get required-prompt-template-vars template-kind)]
+    (if (nil? allowed-vars)
+      {:ok? false
+       :error {:code :unknown-template-kind
+               :template template-kind}}
+      (let [unknown-vars (set/difference vars allowed-vars)
+            missing-vars (set/difference required-vars vars)]
+        (cond
+          (string/blank? (or template ""))
+          {:ok? false
+           :error {:code :missing-template-code-block
+                   :template template-kind}}
+
+          (seq unknown-vars)
+          {:ok? false
+           :error {:code :unknown-template-vars
+                   :template template-kind
+                   :vars unknown-vars}}
+
+          (seq missing-vars)
+          {:ok? false
+           :error {:code :missing-template-vars
+                   :template template-kind
+                   :vars missing-vars}}
+
+          :else
+          {:ok? true})))))
+
+(defn- validate-prompt-templates!
+  [templates]
+  (doseq [[template-kind template] templates]
+    (let [result (validate-prompt-template template-kind template)]
+      (when-not (:ok? result)
+        (throw (ex-info "agent bridge prompt template is invalid"
+                        (assoc (:error result)
+                               :code :agent-prompt-template-invalid
+                               :reason (get-in result [:error :code])))))))
+  templates)
+
+(defn- render-prompt-template
+  [template-kind template vars]
+  (validate-prompt-templates! {template-kind template})
+  (string/replace
+   template
+   #"\{\{([A-Za-z0-9-]+)\}\}"
+   (fn [[_ var-name]]
+     (if (contains? vars var-name)
+       (str (get vars var-name))
+       (throw (ex-info "agent bridge prompt template var has no value"
+                       {:code :agent-prompt-template-var-missing
+                        :template template-kind
+                        :var var-name}))))))
+
+(defn build-codex-prompt
+  [{:keys [graph agent-name block tree-text prompt-template]}]
+  (render-prompt-template
+   :task
+   (or prompt-template default-task-prompt-template)
+   {"graph" graph
+    "block-uuid" (block-uuid-str block)
+    "agent-name" agent-name
+    "task-block-tree" (or tree-text (:block/title block) "")}))
+
+(defn- build-comment-codex-prompt
+  [{:keys [graph agent-name comment-tree-text comments-area-tree-text target-tree-texts]
+    comment-block :comment
+    prompt-template :prompt-template}]
+  (render-prompt-template
+   :comment
+   (or prompt-template default-comment-prompt-template)
+   {"graph" graph
+    "comment-uuid" (block-uuid-str comment-block)
+    "agent-name" agent-name
+    "comment-target-context" (string/join "\n" (remove string/blank? target-tree-texts))
+    "comment-thread-context" (or comments-area-tree-text (:block/title (:block/parent comment-block)) "")
+    "requesting-comment" (or comment-tree-text (:block/title comment-block) "")}))
 
 (defn build-codex-command
   [prompt {:keys [codex-bin]}]
@@ -423,7 +530,15 @@
 (def agent-bridge-registry-page "AgentBridge")
 
 (def agent-bridge-registry-page-query
-  '[:find [(pull ?p [:db/id :block/uuid :block/name :block/title]) ...]
+  '[:find [(pull ?p [:db/id
+                     :block/uuid
+                     :block/name
+                     :block/title
+                     :logseq.property/deleted-at
+                     {:block/parent [:db/id
+                                     :logseq.property/deleted-at
+                                     {:block/parent [:db/id
+                                                     :logseq.property/deleted-at]}]}]) ...]
     :in $ ?page-name
     :where
     [?p :block/name ?page-name]])
@@ -435,6 +550,238 @@
     [?b :block/parent ?page-id]
     [?b :block/title ?agent-name]])
 
+(declare ensure-registry-page!)
+
+(def agent-bridge-prompt-template-blocks-query
+  '[:find [(pull ?b [:db/id
+                     :block/uuid
+                     :block/title
+                     :block/order
+                     {:block/_parent [:db/id
+                                      :block/uuid
+                                      :block/title
+                                      :block/order
+                                      {:block/_parent [:db/id
+                                                       :block/uuid
+                                                       :block/title
+                                                       :block/order]}]}]) ...]
+    :in $ ?page-id
+    :where
+    [?b :block/parent ?page-id]])
+
+(defn- prompt-template-default
+  [template-kind]
+  (case template-kind
+    :task default-task-prompt-template
+    :comment default-comment-prompt-template))
+
+(defn- prompt-template-title
+  [template-kind]
+  (case template-kind
+    :task task-prompt-template-title
+    :comment comment-prompt-template-title))
+
+(defn- prompt-template-var-description
+  [template-kind]
+  (case template-kind
+    :task
+    (string/join
+     "\n"
+     ["Template variables:"
+      "```text"
+      "'{{graph}}': The graph name passed to `logseq agent bridge`."
+      "'{{block-uuid}}': The UUID of the routed task block."
+      "'{{agent-name}}': The current AgentBridge name."
+      "'{{task-block-tree}}': The routed task block tree rendered as outline text."
+      "```"])
+
+    :comment
+    (string/join
+     "\n"
+     ["Template variables:"
+      "```text"
+      "'{{graph}}': The graph name passed to `logseq agent bridge`."
+      "'{{comment-uuid}}': The UUID of the requesting comment block."
+      "'{{agent-name}}': The current AgentBridge name."
+      "'{{comment-target-context}}': The block trees targeted by the comments area."
+      "'{{comment-thread-context}}': The complete comments area block tree."
+      "'{{requesting-comment}}': The requesting comment block tree."
+      "```"])))
+
+(defn- prompt-template-description
+  [template-kind]
+  (case template-kind
+    :task
+    "Description: Used when AgentBridge routes an assigned TODO Task block to Codex."
+    :comment
+    "Description: Used when AgentBridge routes an AgentBridge mention in a Comment block to Codex."))
+
+(defn- default-prompt-template-block
+  [template-kind]
+  {:block/title (prompt-template-title template-kind)
+   :block/children [{:block/title (prompt-template-description template-kind)}
+                    {:block/title (prompt-template-var-description template-kind)}
+                    {:block/title (str "```text\n"
+                                       (prompt-template-default template-kind)
+                                       "\n```")}]})
+
+(defn- ensure-prompt-template-block-uuids
+  [blocks]
+  (mapv (fn ensure-block-uuid [block]
+          (let [block (cond-> block
+                        (nil? (:block/uuid block))
+                        (assoc :block/uuid (random-uuid)))]
+            (if (seq (:block/children block))
+              (update block :block/children ensure-prompt-template-block-uuids)
+              block)))
+        blocks))
+
+(defn- flatten-prompt-template-blocks
+  [blocks]
+  (letfn [(walk [parent-uuid block]
+            (let [children (:block/children block)
+                  block-uuid (:block/uuid block)
+                  block (cond-> (dissoc block :block/children)
+                          parent-uuid
+                          (assoc :block/parent [:block/uuid parent-uuid]))]
+              (into [block]
+                    (mapcat #(walk block-uuid %) children))))]
+    (->> blocks
+         ensure-prompt-template-block-uuids
+         (mapcat #(walk nil %))
+         vec)))
+
+(defn- child-blocks
+  [block]
+  (->> (or (:block/children block)
+           (:block/_parent block)
+           [])
+       (sort-by #(or (:block/order %) 0))))
+
+(defn- block-title-tree
+  [block]
+  (cons (:block/title block)
+        (mapcat block-title-tree (child-blocks block))))
+
+(defn- code-blocks-in-text
+  [text]
+  (when (string? text)
+    (map second (re-seq #"(?s)```[^\n`]*\n(.*?)```" text))))
+
+(defn- prompt-template-from-block
+  [template-kind block]
+  (let [templates (vec (mapcat code-blocks-in-text (block-title-tree block)))
+        renderable-templates (filterv #(-> (validate-prompt-template template-kind %) :ok?)
+                                      templates)]
+    (cond
+      (empty? templates)
+      (throw (ex-info "agent bridge prompt template code block is missing"
+                      {:code :agent-prompt-template-invalid
+                       :reason :missing-template-code-block
+                       :template template-kind}))
+
+      (= 1 (count renderable-templates))
+      (first renderable-templates)
+
+      (> (count renderable-templates) 1)
+      (throw (ex-info "agent bridge prompt template must contain one code block"
+                      {:code :agent-prompt-template-invalid
+                       :reason :multiple-template-code-blocks
+                       :template template-kind}))
+
+      (= 1 (count templates))
+      (do
+        (validate-prompt-templates! {template-kind (first templates)})
+        (first templates))
+
+      :else
+      (throw (ex-info "agent bridge prompt template code block is missing"
+                      {:code :agent-prompt-template-invalid
+                       :reason :missing-template-code-block
+                       :template template-kind})))))
+
+(defn- missing-template-code-block-error?
+  [error]
+  (let [data (ex-data error)]
+    (and (= :agent-prompt-template-invalid (:code data))
+         (= :missing-template-code-block (:reason data)))))
+
+(defn- prompt-template-blocks-by-title
+  [blocks]
+  (reduce (fn [acc block]
+            (let [title (:block/title block)]
+              (if (contains? #{task-prompt-template-title
+                               comment-prompt-template-title}
+                             title)
+                (assoc acc title block)
+                acc)))
+          {}
+          blocks))
+
+(defn ensure-agent-bridge-prompt-templates!
+  [cfg repo]
+  (p/let [page (ensure-registry-page! cfg repo)
+          page-id (:db/id page)
+          page-uuid (:block/uuid page)
+          _ (when-not page-id
+              (throw (ex-info "agent bridge registry page not found"
+                              {:code :agent-prompt-template-initialization-failed})))
+          _ (when-not page-uuid
+              (throw (ex-info "agent bridge registry page uuid not found"
+                              {:code :agent-prompt-template-initialization-failed})))
+          blocks (transport/invoke cfg :thread-api/q
+                                   [repo [agent-bridge-prompt-template-blocks-query page-id]])]
+    (let [blocks-by-title (prompt-template-blocks-by-title blocks)
+          template-state (reduce (fn [state template-kind]
+                                   (if-let [block (get blocks-by-title (prompt-template-title template-kind))]
+                                     (try
+                                       (assoc-in state [:templates template-kind]
+                                                 (prompt-template-from-block template-kind block))
+                                       (catch :default e
+                                         (if (missing-template-code-block-error? e)
+                                           (assoc-in state [:repair-blocks template-kind] block)
+                                           (throw e))))
+                                     (update state :missing-kinds conj template-kind)))
+                                 {:templates {}
+                                  :missing-kinds []
+                                  :repair-blocks {}}
+                                 [:task :comment])
+          existing-templates (:templates template-state)
+          _ (validate-prompt-templates! existing-templates)
+          missing-kinds (:missing-kinds template-state)
+          repair-blocks (:repair-blocks template-state)]
+      (p/let [_ (when (seq missing-kinds)
+                  (transport/invoke cfg :thread-api/apply-outliner-ops
+                                    [repo [[:insert-blocks [(flatten-prompt-template-blocks
+                                                             (mapv default-prompt-template-block missing-kinds))
+                                                            page-uuid
+                                                            {:outliner-op :insert-blocks
+                                                             :sibling? false
+                                                             :bottom? true
+                                                             :keep-uuid? true}]]]
+                                     {}]))
+              _ (when (seq repair-blocks)
+                  (p/all
+                   (mapv (fn [[template-kind block]]
+                           (transport/invoke cfg :thread-api/apply-outliner-ops
+                                             [repo [[:insert-blocks [(flatten-prompt-template-blocks
+                                                                      (:block/children (default-prompt-template-block template-kind)))
+                                                                     (:block/uuid block)
+                                                                     {:outliner-op :insert-blocks
+                                                                      :sibling? false
+                                                                      :bottom? true
+                                                                      :keep-uuid? true}]]]
+                                              {}]))
+                         repair-blocks)))]
+        (validate-prompt-templates!
+         (reduce (fn [templates template-kind]
+                   (assoc templates
+                          template-kind
+                          (or (get existing-templates template-kind)
+                              (prompt-template-default template-kind))))
+                 {}
+                 [:task :comment]))))))
+
 (defn random-bridge-block-uuid
   []
   (random-uuid))
@@ -442,6 +789,10 @@
 (defn- first-entity
   [entities]
   (first (filter :db/id entities)))
+
+(defn- first-live-entity
+  [entities]
+  (first (remove ldb/recycled? (filter :db/id entities))))
 
 (defn- registry-page-name
   []
@@ -452,7 +803,7 @@
   (p/let [pages (transport/invoke cfg :thread-api/q
                                   [repo [agent-bridge-registry-page-query
                                          (registry-page-name)]])]
-    (first-entity pages)))
+    (first-live-entity pages)))
 
 (defn- ensure-registry-page!
   [cfg repo]
@@ -576,12 +927,13 @@
                    (map #(assoc % "Assignee" agent-name) blocks))))))
 
 (defn- dry-run-commands
-  [graph agent-name tasks]
+  [graph agent-name prompt-templates tasks]
   (mapv (fn [{:keys [block tree-text]}]
           (let [prompt (build-codex-prompt {:graph graph
                                             :agent-name agent-name
                                             :block block
-                                            :tree-text tree-text})
+                                            :tree-text tree-text
+                                            :prompt-template (:task prompt-templates)})
                 command (build-codex-command prompt {})]
             {:block (block-uuid-str block)
              :backend :codex
@@ -607,11 +959,12 @@
    :updated-at (js/Date.now)})
 
 (defn- route-task!
-  [cfg {:keys [repo graph agent-name]} {:keys [block tree-text]}]
+  [cfg {:keys [repo graph agent-name prompt-templates]} {:keys [block tree-text]}]
   (let [prompt (build-codex-prompt {:graph graph
                                     :agent-name agent-name
                                     :block block
-                                    :tree-text tree-text})
+                                    :tree-text tree-text
+                                    :prompt-template (:task prompt-templates)})
         command (build-codex-command prompt {})
         preview (command-preview command)]
     (emit-log! cfg (log-line (str "Codex command prepared for " (block-uuid-str block) ": " preview)))
@@ -660,11 +1013,12 @@
       (route-task! cfg opts task))))
 
 (defn- process-tasks!
-  [cfg {:keys [repo graph agent-name]}]
+  [cfg {:keys [repo graph agent-name prompt-templates]}]
   (p/let [tasks (list-routable-tasks cfg repo agent-name)]
     (p/all (mapv #(route-task-once! cfg {:repo repo
                                          :graph graph
-                                         :agent-name agent-name}
+                                         :agent-name agent-name
+                                         :prompt-templates prompt-templates}
                                     %)
                  tasks))))
 
@@ -897,7 +1251,7 @@
                 trim-non-empty))))
 
 (defn- route-comment!
-  [cfg {:keys [repo graph agent-name]} comment-block]
+  [cfg {:keys [repo graph agent-name prompt-templates]} comment-block]
   (p/catch
    (p/let [comment-uuid (:block/uuid comment-block)
            _ (when-not comment-uuid
@@ -920,7 +1274,8 @@
                                                :comment comment-block
                                                :target-tree-texts target-tree-texts
                                                :comments-area-tree-text comments-area-tree-text
-                                               :comment-tree-text comment-tree-text})
+                                               :comment-tree-text comment-tree-text
+                                               :prompt-template (:comment prompt-templates)})
            resume-session-id (some #(comment-target-session-id agent-name session-property-ident %) target-blocks)
            command (if resume-session-id
                      (build-codex-resume-command resume-session-id prompt {})
@@ -997,7 +1352,7 @@
         (p/all routing)))))
 
 (defn- listen-forever!
-  [cfg {:keys [repo graph agent-name]}]
+  [cfg {:keys [repo graph agent-name prompt-templates]}]
   (let [routing-blocks* (atom #{})
         handle-error! (fn [e]
                         (emit-log! cfg (log-line (str "Codex invocation failed: "
@@ -1015,6 +1370,7 @@
                                                          {:repo repo
                                                           :graph graph
                                                           :agent-name agent-name
+                                                          :prompt-templates prompt-templates
                                                           :routing-blocks* routing-blocks*}
                                                          payload)
                          (p/catch handle-error!))
@@ -1044,11 +1400,13 @@
           (if-not (codex-available? nil)
             (bridge-error :codex-not-found "codex executable is not available")
             (p/let [cfg (cli-server/ensure-server! config repo)
+                    logs (conj logs (log-line "checking prompt templates ..."))
+                    prompt-templates (ensure-agent-bridge-prompt-templates! cfg repo)
                     logs (conj logs (log-line "registering agent bridge ..."))
                     _ (register-agent-bridge! cfg repo agent-name)]
               (if (:dry-run? action)
                 (p/let [tasks (list-routable-tasks cfg repo agent-name)
-                        commands (dry-run-commands graph agent-name tasks)
+                        commands (dry-run-commands graph agent-name prompt-templates tasks)
                         logs (into (conj logs (log-line "listening graph changes ..."))
                                    (map (fn [{:keys [block preview]}]
                                           (log-line (str "would run Codex command for " block ": " preview)))
@@ -1066,7 +1424,8 @@
                   (if (:process-once? action)
                     (p/let [routed (process-tasks! cfg {:repo repo
                                                         :graph graph
-                                                        :agent-name agent-name})]
+                                                        :agent-name agent-name
+                                                        :prompt-templates prompt-templates})]
                       {:status :ok
                        :command :agent-bridge
                        :data {:mode :processed-once
@@ -1075,7 +1434,9 @@
                               :routed routed}})
                     (p/let [_ (process-tasks! cfg {:repo repo
                                                    :graph graph
-                                                   :agent-name agent-name})]
+                                                   :agent-name agent-name
+                                                   :prompt-templates prompt-templates})]
                       (listen-forever! cfg {:repo repo
                                             :graph graph
-                                            :agent-name agent-name}))))))))))))
+                                            :agent-name agent-name
+                                            :prompt-templates prompt-templates}))))))))))))

--- a/src/main/logseq/cli/command/agent.cljs
+++ b/src/main/logseq/cli/command/agent.cljs
@@ -192,9 +192,42 @@
     "Task block tree:"
     (or tree-text (:block/title block) "")]))
 
+(defn- build-comment-codex-prompt
+  [{:keys [graph agent-name comment-tree-text comments-area-tree-text target-tree-texts]
+    comment-block :comment}]
+  (string/join
+   "\n"
+   ["You are handling a Logseq AgentBridge comment request."
+    ""
+    (str "Graph: " graph)
+    (str "Comment UUID: " (block-uuid-str comment-block))
+    (str "AgentBridge name: " agent-name)
+    ""
+    "Do not operate outside the target graph."
+    "Complete the request from the mentioned comment."
+    "Report the final status, files changed, commands run, verification, and any blockers."
+    ""
+    "Comment target context:"
+    (string/join "\n" (remove string/blank? target-tree-texts))
+    ""
+    "Comment thread context:"
+    (or comments-area-tree-text (:block/title (:block/parent comment-block)) "")
+    ""
+    "Requesting comment:"
+    (or comment-tree-text (:block/title comment-block) "")
+    ""
+    "Reply instructions:"
+    "For a short reply, append a comment after the requesting comment."
+    "For a long reply, write a normal block tree after the comments area and append a comment that references that tree."
+    "If the request is blocked or fails, make that clear in the reply."]))
+
 (defn build-codex-command
   [prompt {:keys [codex-bin]}]
   [(or (trim-non-empty codex-bin) "codex") "exec" "--json" prompt])
+
+(defn- build-codex-resume-command
+  [session-id prompt {:keys [codex-bin]}]
+  [(or (trim-non-empty codex-bin) "codex") "exec" "resume" "--json" session-id prompt])
 
 (defn- shell-quote
   [value]
@@ -652,6 +685,46 @@
    {:logseq.property/assignee [:db/id :block/title :block/name :db/ident]}
    '*])
 
+(def ^:private comment-block-selector
+  [:db/id
+   :block/uuid
+   :block/title
+   {:block/tags [:db/ident :block/title]}
+   {:block/refs [:db/id :block/title :block/name]}
+   {:block/parent [:db/id :block/uuid :block/title {:block/tags [:db/ident :block/title]}]}
+   '*])
+
+(defn- comment-target-block-selector
+  [session-property-ident]
+  (cond-> [:db/id
+           :block/uuid
+           :block/title
+           {:logseq.property/assignee [:db/id :block/title :block/name :db/ident]}
+           '*]
+    session-property-ident
+    (conj {session-property-ident [:db/id :block/title :block/name]})))
+
+(defn- comments-area-selector
+  [session-property-ident]
+  [:db/id
+   :block/uuid
+   :block/title
+   {:block/tags [:db/ident :block/title]}
+   {:logseq.property.comments/blocks (comment-target-block-selector session-property-ident)}])
+
+(def ^:private comment-start-reaction "eyes")
+(def ^:private comment-complete-reaction "white_check_mark")
+(def ^:private comment-failed-reaction "x")
+
+(def ^:private comment-reaction-query
+  '[:find ?r .
+    :in $ ?target-uuid ?emoji-id
+    :where
+    [?target :block/uuid ?target-uuid]
+    [?r :logseq.property.reaction/target ?target]
+    [?r :logseq.property.reaction/emoji-id ?emoji-id]
+    [(missing? $ ?r :logseq.property/created-by-ref)]])
+
 (defn- datom-added?
   [datom]
   (cond
@@ -701,6 +774,15 @@
   (and (datom-added? datom)
        (= assignee-property-ident (datom-attr datom))))
 
+(defn- comment-title-datom?
+  [datom agent-name]
+  (and (datom-added? datom)
+       (seq agent-name)
+       (= :block/title (datom-attr datom))
+       (string? (datom-value datom))
+       (or (string/includes? (datom-value datom) (str "[[" agent-name "]]"))
+           (string/includes? (datom-value datom) "[["))))
+
 (defn- pull-assignee-property
   [cfg repo]
   (transport/invoke cfg :thread-api/pull [repo assignee-property-selector assignee-property-ident]))
@@ -746,6 +828,145 @@
     (or (get-in show-result [:data :message])
         (:block/title block))))
 
+(defn- show-block-tree
+  [cfg repo block]
+  (p/let [show-result (show-command/execute-show {:type :show
+                                                  :repo repo
+                                                  :uuid (block-uuid-str block)
+                                                  :level 100
+                                                  :linked-references? false
+                                                  :ref-id-footer? false}
+                                                 cfg)]
+    (or (get-in show-result [:data :message])
+        (:block/title block))))
+
+(defn- comment-tag?
+  [tag]
+  (or (= :logseq.class/Comment (value-ident tag))
+      (= "Comment" (value-title tag))))
+
+(defn- comments-area-tag?
+  [tag]
+  (or (= :logseq.class/Comments (value-ident tag))
+      (= "Comments" (value-title tag))))
+
+(defn- comment-block?
+  [block agent-name]
+  (and (:block/uuid block)
+       (some comment-tag? (:block/tags block))
+       (or (string/includes? (or (:block/title block) "") (str "[[" agent-name "]]"))
+           (contains? (set (keep value-title (:block/refs block))) agent-name))))
+
+(defn- comments-area?
+  [block]
+  (some comments-area-tag? (:block/tags block)))
+
+(defn- pull-comment-block
+  [cfg repo block-id]
+  (transport/invoke cfg :thread-api/pull [repo comment-block-selector block-id]))
+
+(defn- pull-comments-area
+  [cfg repo comment-block session-property-ident]
+  (let [parent-id (get-in comment-block [:block/parent :db/id])]
+    (when-not parent-id
+      (throw (ex-info "comment block parent is missing"
+                      {:code :agent-comment-parent-missing
+                       :block (block-uuid-str comment-block)})))
+    (transport/invoke cfg :thread-api/pull [repo (comments-area-selector session-property-ident) parent-id])))
+
+(defn- ensure-comment-reaction!
+  [cfg repo target-uuid emoji-id]
+  (p/let [existing (transport/invoke cfg :thread-api/q [repo [comment-reaction-query target-uuid emoji-id]])]
+    (when-not (if (sequential? existing)
+                (seq existing)
+                (some? existing))
+      (transport/invoke cfg :thread-api/apply-outliner-ops
+                        [repo [[:toggle-reaction [target-uuid emoji-id nil]]] {}]))))
+
+(defn- comment-session-record
+  [graph agent-name comment-block session-id status]
+  (assoc (session-record graph agent-name comment-block session-id status)
+         :request :comment))
+
+(defn- comment-target-session-id
+  [agent-name session-property-ident block]
+  (when (contains? (assignee-values block) agent-name)
+    (or (agent-session-id block)
+        (some-> (get block session-property-ident)
+                value-title
+                trim-non-empty))))
+
+(defn- route-comment!
+  [cfg {:keys [repo graph agent-name]} comment-block]
+  (p/catch
+   (p/let [comment-uuid (:block/uuid comment-block)
+           _ (when-not comment-uuid
+               (throw (ex-info "comment block uuid is missing"
+                               {:code :agent-comment-uuid-missing})))
+           session-property (pull-agent-session-id-property cfg repo)
+           session-property-ident (:db/ident session-property)
+           comments-area (pull-comments-area cfg repo comment-block session-property-ident)
+           _ (when-not (comments-area? comments-area)
+               (throw (ex-info "comment parent is not a comments area"
+                               {:code :agent-comment-parent-invalid
+                                :block (block-uuid-str comment-block)})))
+           target-blocks (vec (:logseq.property.comments/blocks comments-area))
+           _ (ensure-comment-reaction! cfg repo comment-uuid comment-start-reaction)
+           target-tree-texts (p/all (mapv #(show-block-tree cfg repo %) target-blocks))
+           comments-area-tree-text (show-block-tree cfg repo comments-area)
+           comment-tree-text (show-block-tree cfg repo comment-block)
+           prompt (build-comment-codex-prompt {:graph graph
+                                               :agent-name agent-name
+                                               :comment comment-block
+                                               :target-tree-texts target-tree-texts
+                                               :comments-area-tree-text comments-area-tree-text
+                                               :comment-tree-text comment-tree-text})
+           resume-session-id (some #(comment-target-session-id agent-name session-property-ident %) target-blocks)
+           command (if resume-session-id
+                     (build-codex-resume-command resume-session-id prompt {})
+                     (build-codex-command prompt {}))
+           preview (command-preview command)
+           _ (emit-log! cfg (log-line (str "Codex command prepared for comment " (block-uuid-str comment-block) ": " preview)))
+           {:keys [session]} (start-codex! command
+                                           {:on-exit (fn [code session-id]
+                                                       (when session-id
+                                                         (update-session-status! cfg session-id
+                                                                                 (if (zero? (or code 1))
+                                                                                   :completed
+                                                                                   :failed)))
+                                                       (-> (ensure-comment-reaction! cfg repo comment-uuid
+                                                                                     (if (zero? (or code 1))
+                                                                                       comment-complete-reaction
+                                                                                       comment-failed-reaction))
+                                                           (p/catch (fn [e]
+                                                                      (log/error :agent-bridge-comment-reaction-failed e)))))})
+           _ (when-not (seq session)
+               (throw (ex-info "codex session id missing"
+                               {:code :codex-session-id-missing})))
+           cfg* (cli-server/ensure-server! cfg repo)
+           _ (record-session! cfg* (comment-session-record graph agent-name comment-block session :running))]
+     {:block (block-uuid-str comment-block)
+      :session session
+      :backend :codex
+      :preview preview
+      :request :comment})
+   (fn [e]
+     (if-let [comment-uuid (:block/uuid comment-block)]
+       (p/let [_ (ensure-comment-reaction! cfg repo comment-uuid comment-failed-reaction)]
+         (throw e))
+       (p/rejected e)))))
+
+(defn- route-comment-once!
+  [cfg {:keys [routing-blocks*] :as opts} comment-block]
+  (let [block-id (block-uuid-str comment-block)]
+    (if (and routing-blocks* block-id)
+      (if (claim-routing-block! routing-blocks* block-id)
+        (-> (route-comment! cfg opts comment-block)
+            (p/finally (fn []
+                         (swap! routing-blocks* disj block-id))))
+        (p/resolved nil))
+      (route-comment! cfg opts comment-block))))
+
 (defn- route-assignee-datom!
   [cfg {:keys [repo agent-name] :as opts} datom]
   (let [block-id (datom-e datom)
@@ -759,11 +980,21 @@
                 (route-task-once! cfg opts {:block block
                                             :tree-text tree-text})))))))))
 
+(defn- route-comment-datom!
+  [cfg {:keys [repo agent-name] :as opts} datom]
+  (when-let [block-id (datom-e datom)]
+    (p/let [comment-block (pull-comment-block cfg repo block-id)]
+      (when (comment-block? comment-block agent-name)
+        (route-comment-once! cfg opts comment-block)))))
+
 (defn- process-sync-db-changes-event!
   [cfg {:keys [repo] :as opts} {:keys [tx-data]}]
   (p/let [assignee-datoms (resolve-assignee-datoms cfg repo tx-data)]
-    (when (seq assignee-datoms)
-      (p/all (mapv #(route-assignee-datom! cfg opts %) assignee-datoms)))))
+    (let [comment-datoms (filter #(comment-title-datom? % (:agent-name opts)) tx-data)
+          routing (vec (concat (map #(route-assignee-datom! cfg opts %) assignee-datoms)
+                               (map #(route-comment-datom! cfg opts %) comment-datoms)))]
+      (when (seq routing)
+        (p/all routing)))))
 
 (defn- listen-forever!
   [cfg {:keys [repo graph agent-name]}]

--- a/src/main/logseq/cli/command/agent.cljs
+++ b/src/main/logseq/cli/command/agent.cljs
@@ -84,71 +84,26 @@
      :error {:code :unknown-command
              :message (str "unknown agent command: " command)}}))
 
-(defn- value-ident
-  [value]
-  (cond
-    (keyword? value) value
-    (map? value) (:db/ident value)
-    :else nil))
-
-(defn- value-title
-  [value]
-  (cond
-    (nil? value) nil
-    (string? value) value
-    (keyword? value) (name value)
-    (map? value) (or (:block/title value)
-                     (:name value)
-                     (some-> (:db/ident value) name))
-    :else (str value)))
-
-(defn- value-titles
-  [value]
-  (if (and (sequential? value)
-           (not (string? value)))
-    (keep value-title value)
-    (keep value-title [value])))
+(def ^:private agent-session-id-property-ident :logseq.property.agent/session-id)
 
 (defn- task-tag?
   [tag]
-  (or (= :logseq.class/Task (value-ident tag))
-      (= "Task" (value-title tag))))
-
-(defn- property-key-name
-  [k]
-  (cond
-    (keyword? k) (name k)
-    (string? k) k
-    :else nil))
-
-(defn- property-value-by-name
-  [block property-name]
-  (some (fn [[k v]]
-          (when (= property-name (property-key-name k))
-            v))
-        block))
+  (= :logseq.class/Task (:db/ident tag)))
 
 (defn- assignee-values
   [block]
-  (->> (concat (mapcat (fn [k]
-                         (value-titles (get block k)))
-                       ["Assignee" :Assignee :assignee :logseq.property/assignee])
-               (value-titles (property-value-by-name block "assignee"))
-               (value-titles (property-value-by-name block "Assignee")))
-       (keep trim-non-empty)
+  (->> (:logseq.property/assignee block)
+       (keep (comp trim-non-empty :block/title))
        set))
 
-(defn- agent-session-id
+(defn- agent-session-id-present?
   [block]
-  (or (some (fn [k]
-              (trim-non-empty (get block k)))
-            ["agent-session-id" :agent-session-id :logseq.property/agent-session-id])
-      (some-> (property-value-by-name block "agent-session-id") trim-non-empty)))
+  (some? (get block agent-session-id-property-ident)))
 
 (defn routable-task-decision
   [block agent-name]
   (let [uuid (:block/uuid block)
-        status-ident (value-ident (:logseq.property/status block))
+        status-ident (get-in block [:logseq.property/status :db/ident])
         assignees (assignee-values block)]
     (cond
       (nil? uuid)
@@ -163,7 +118,7 @@
       (not (contains? assignees agent-name))
       {:routable? false :reason :assignee-mismatch}
 
-      (seq (agent-session-id block))
+      (agent-session-id-present? block)
       {:routable? false :reason :already-routed}
 
       :else
@@ -789,10 +744,6 @@
                  {}
                  [:task :comment]))))))
 
-(defn- first-entity
-  [entities]
-  (first (filter :db/id entities)))
-
 (defn- first-live-entity
   [entities]
   (first (remove ldb/recycled? (filter :db/id entities))))
@@ -853,51 +804,14 @@
               (throw (ex-info "agent bridge agent page not found after create"
                               {:code :agent-registration-failed})))))))))
 
-(def agent-session-id-property-name "agent-session-id")
-
-(def agent-session-id-property-schema
-  {:logseq.property/type :default
-   :db/cardinality :db.cardinality/one})
-
-(def agent-session-id-property-query
-  '[:find [(pull ?p [:db/id :db/ident :block/name :block/title]) ...]
-    :in $ ?property-name
-    :where
-    [?p :block/name ?property-name]
-    [?p :db/ident]])
-
-(defn- pull-agent-session-id-property
-  [cfg repo]
-  (p/let [properties (transport/invoke cfg :thread-api/q
-                                       [repo [agent-session-id-property-query
-                                              (common-util/page-name-sanity-lc agent-session-id-property-name)]])]
-    (first-entity properties)))
-
-(defn- ensure-agent-session-id-property!
-  [cfg repo]
-  (p/let [existing (pull-agent-session-id-property cfg repo)]
-    (if (:db/ident existing)
-      existing
-      (p/let [_ (transport/invoke cfg :thread-api/apply-outliner-ops
-                                  [repo [[:upsert-property [nil
-                                                            agent-session-id-property-schema
-                                                            {:property-name agent-session-id-property-name}]]]
-                                   {}])
-              created (pull-agent-session-id-property cfg repo)]
-        (if (:db/ident created)
-          created
-          (throw (ex-info "agent-session-id property not found after upsert"
-                          {:code :agent-session-id-write-failed})))))))
-
 (defn write-agent-session-id!
   [cfg repo block-uuid session-id]
-  (p/let [property (ensure-agent-session-id-property! cfg repo)
-          property-ident (:db/ident property)
-          _ (when-not property-ident
-              (throw (ex-info "agent-session-id property ident missing"
-                              {:code :agent-session-id-write-failed})))
-          _ (transport/invoke cfg :thread-api/apply-outliner-ops
-                              [repo [[:batch-set-property [[block-uuid] property-ident session-id {}]]] {}])]
+  (p/let [_ (transport/invoke cfg :thread-api/apply-outliner-ops
+                              [repo [[:batch-set-property [[block-uuid]
+                                                            agent-session-id-property-ident
+                                                            session-id
+                                                            {}]]]
+                               {}])]
     true))
 
 (def ^:private routable-task-query
@@ -906,6 +820,8 @@
                      :block/title
                      {:block/tags [:db/ident :block/title]}
                      {:logseq.property/status [:db/ident :block/title]}
+                     {:logseq.property/assignee [:db/id :block/title :block/name :db/ident]}
+                     :logseq.property.agent/session-id
                      *]) ...]
     :in $ ?agent-name
     :where
@@ -932,8 +848,7 @@
                {:block block
                 :tree-text (or (get-in show-result [:data :message])
                                (:block/title block))}))
-           (filter #(routable-task? % agent-name)
-                   (map #(assoc % "Assignee" agent-name) blocks))))))
+           (filter #(routable-task? % agent-name) blocks)))))
 
 (defn- dry-run-commands
   [graph agent-name prompt-templates tasks]
@@ -1046,6 +961,7 @@
    {:block/tags [:db/ident :block/title]}
    {:logseq.property/status [:db/ident :block/title]}
    {:logseq.property/assignee [:db/id :block/title :block/name :db/ident]}
+   :logseq.property.agent/session-id
    '*])
 
 (def ^:private comment-block-selector
@@ -1062,10 +978,9 @@
   (cond-> [:db/id
            :block/uuid
            :block/title
-           {:logseq.property/assignee [:db/id :block/title :block/name :db/ident]}
-           '*]
-    session-property-ident
-    (conj {session-property-ident [:db/id :block/title :block/name]})))
+           {:logseq.property/assignee [:db/id :block/title :block/name :db/ident]}]
+    session-property-ident (conj session-property-ident)
+    true (conj '*)))
 
 (defn- comments-area-selector
   [session-property-ident]
@@ -1088,63 +1003,26 @@
     [?r :logseq.property.reaction/emoji-id ?emoji-id]
     [(missing? $ ?r :logseq.property/created-by-ref)]])
 
-(defn- datom-added?
-  [datom]
-  (cond
-    (map? datom)
-    (not (false? (if (contains? datom :added)
-                   (:added datom)
-                   (:added? datom))))
-
-    (and (sequential? datom) (<= 5 (count datom)))
-    (not (false? (nth datom 4)))
-
-    :else
-    (not (false? (or (unchecked-get datom "added")
-                     (unchecked-get datom "added?")
-                     true)))))
-
-(defn- datom-e
-  [datom]
-  (cond
-    (map? datom) (:e datom)
-    (sequential? datom) (first datom)
-    :else (unchecked-get datom "e")))
-
-(defn- datom-attr
-  [datom]
-  (cond
-    (map? datom) (:a datom)
-    (sequential? datom) (second datom)
-    :else (unchecked-get datom "a")))
-
-(defn- datom-value
-  [datom]
-  (cond
-    (map? datom) (:v datom)
-    (sequential? datom) (nth datom 2 nil)
-    :else (unchecked-get datom "v")))
-
 (defn- unknown-attr-datom?
   [datom]
-  (let [attr (datom-attr datom)]
-    (and (datom-added? datom)
+  (let [attr (:a datom)]
+    (and (true? (:added datom))
          (some? attr)
          (not (keyword? attr)))))
 
 (defn- direct-assignee-datom?
   [datom]
-  (and (datom-added? datom)
-       (= assignee-property-ident (datom-attr datom))))
+  (and (true? (:added datom))
+       (= assignee-property-ident (:a datom))))
 
 (defn- comment-title-datom?
   [datom agent-name]
-  (and (datom-added? datom)
+  (and (true? (:added datom))
        (seq agent-name)
-       (= :block/title (datom-attr datom))
-       (string? (datom-value datom))
-       (or (string/includes? (datom-value datom) (str "[[" agent-name "]]"))
-           (string/includes? (datom-value datom) "[["))))
+       (= :block/title (:a datom))
+       (string? (:v datom))
+       (or (string/includes? (:v datom) (str "[[" agent-name "]]"))
+           (string/includes? (:v datom) "[["))))
 
 (defn- pull-assignee-property
   [cfg repo]
@@ -1158,22 +1036,17 @@
       (p/let [property (pull-assignee-property cfg repo)
               property-id (:db/id property)]
         (concat direct-datoms
-                (filter #(= property-id (datom-attr %)) unknown-attr-datoms)))
+                (filter #(= property-id (:a %)) unknown-attr-datoms)))
       (p/resolved direct-datoms))))
 
 (defn- direct-assignee-title
   [value]
-  (when (or (string? value)
-            (keyword? value)
-            (map? value))
-    (trim-non-empty (value-title value))))
+  (trim-non-empty (:block/title value)))
 
 (defn- assignee-value-matches?
   [cfg repo value agent-name]
-  (if-let [title (direct-assignee-title value)]
-    (p/resolved (= agent-name title))
-    (p/let [entity (transport/invoke cfg :thread-api/pull [repo assignee-value-selector value])]
-      (= agent-name (trim-non-empty (value-title entity))))))
+  (p/let [entity (transport/invoke cfg :thread-api/pull [repo assignee-value-selector value])]
+    (= agent-name (direct-assignee-title entity))))
 
 (defn- pull-task-block
   [cfg repo block-id]
@@ -1205,20 +1078,18 @@
 
 (defn- comment-tag?
   [tag]
-  (or (= :logseq.class/Comment (value-ident tag))
-      (= "Comment" (value-title tag))))
+  (= :logseq.class/Comment (:db/ident tag)))
 
 (defn- comments-area-tag?
   [tag]
-  (or (= :logseq.class/Comments (value-ident tag))
-      (= "Comments" (value-title tag))))
+  (= :logseq.class/Comments (:db/ident tag)))
 
 (defn- comment-block?
   [block agent-name]
   (and (:block/uuid block)
        (some comment-tag? (:block/tags block))
-       (or (string/includes? (or (:block/title block) "") (str "[[" agent-name "]]"))
-           (contains? (set (keep value-title (:block/refs block))) agent-name))))
+       (or (string/includes? (:block/title block) (str "[[" agent-name "]]"))
+           (contains? (set (keep :block/title (:block/refs block))) agent-name))))
 
 (defn- comments-area?
   [block]
@@ -1240,9 +1111,7 @@
 (defn- ensure-comment-reaction!
   [cfg repo target-uuid emoji-id]
   (p/let [existing (transport/invoke cfg :thread-api/q [repo [comment-reaction-query target-uuid emoji-id]])]
-    (when-not (if (sequential? existing)
-                (seq existing)
-                (some? existing))
+    (when-not (some? existing)
       (transport/invoke cfg :thread-api/apply-outliner-ops
                         [repo [[:toggle-reaction [target-uuid emoji-id nil]]] {}]))))
 
@@ -1252,12 +1121,10 @@
          :request :comment))
 
 (defn- comment-target-session-id
-  [agent-name session-property-ident block]
-  (when (contains? (assignee-values block) agent-name)
-    (or (agent-session-id block)
-        (some-> (get block session-property-ident)
-                value-title
-                trim-non-empty))))
+  [agent-name block]
+  (if (contains? (assignee-values block) agent-name)
+    (p/resolved (trim-non-empty (get block agent-session-id-property-ident)))
+    (p/resolved nil)))
 
 (defn- route-comment!
   [cfg {:keys [repo graph agent-name prompt-templates]} comment-block]
@@ -1266,8 +1133,7 @@
            _ (when-not comment-uuid
                (throw (ex-info "comment block uuid is missing"
                                {:code :agent-comment-uuid-missing})))
-           session-property (pull-agent-session-id-property cfg repo)
-           session-property-ident (:db/ident session-property)
+           session-property-ident agent-session-id-property-ident
            comments-area (pull-comments-area cfg repo comment-block session-property-ident)
            _ (when-not (comments-area? comments-area)
                (throw (ex-info "comment parent is not a comments area"
@@ -1285,7 +1151,9 @@
                                                :comments-area-tree-text comments-area-tree-text
                                                :comment-tree-text comment-tree-text
                                                :prompt-template (:comment prompt-templates)})
-           resume-session-id (some #(comment-target-session-id agent-name session-property-ident %) target-blocks)
+           target-session-ids (p/all (mapv #(comment-target-session-id agent-name %)
+                                           target-blocks))
+           resume-session-id (first (keep identity target-session-ids))
            command (if resume-session-id
                      (build-codex-resume-command resume-session-id prompt {})
                      (build-codex-command prompt {}))
@@ -1333,8 +1201,8 @@
 
 (defn- route-assignee-datom!
   [cfg {:keys [repo agent-name] :as opts} datom]
-  (let [block-id (datom-e datom)
-        assignee-value (datom-value datom)]
+  (let [block-id (:e datom)
+        assignee-value (:v datom)]
     (when block-id
       (p/let [matches? (assignee-value-matches? cfg repo assignee-value agent-name)]
         (when matches?
@@ -1346,7 +1214,7 @@
 
 (defn- route-comment-datom!
   [cfg {:keys [repo agent-name] :as opts} datom]
-  (when-let [block-id (datom-e datom)]
+  (when-let [block-id (:e datom)]
     (p/let [comment-block (pull-comment-block cfg repo block-id)]
       (when (comment-block? comment-block agent-name)
         (route-comment-once! cfg opts comment-block)))))

--- a/src/main/logseq/cli/command/core.cljs
+++ b/src/main/logseq/cli/command/core.cljs
@@ -122,9 +122,10 @@
                 {:title "Authentication"
                  :commands #{"login" "logout"}}
                 {:title "Utilities"
-                 :commands #{"completion" "debug" "example" "qmd" "skill"}
+                 :commands #{"agent" "completion" "debug" "example" "qmd" "skill"}
                  :top-level-only? true
-                 :desc-overrides {"debug" "Pull raw entity data for debugging"
+                 :desc-overrides {"agent" "Run task agent bridge"
+                                  "debug" "Pull raw entity data for debugging"
                                   "example" "Show command examples"
                                   "qmd" "Initialize and manage QMD search"
                                   "skill" "Show/install built-in logseq-cli skill"}}]

--- a/src/main/logseq/cli/commands.cljs
+++ b/src/main/logseq/cli/commands.cljs
@@ -2,6 +2,7 @@
   "Command parsing and action building for the Logseq CLI."
   (:require [babashka.cli :as cli]
             [clojure.string :as string]
+            [logseq.cli.command.agent :as agent-command]
             [logseq.cli.command.auth :as auth-command]
             [logseq.cli.command.completion :as completion-command]
             [logseq.cli.command.core :as command-core]
@@ -93,6 +94,7 @@
 
 (def ^:private base-table
   (vec (concat graph-command/entries
+               agent-command/entries
                server-command/entries
                list-command/entries
                upsert-command/entries
@@ -636,6 +638,9 @@
         (:graph-list :graph-create :graph-switch :graph-remove :graph-validate :graph-info)
         (graph-command/build-graph-action command graph repo options)
 
+        (:agent-bridge :agent-bridge-list)
+        (agent-command/build-action command options repo graph)
+
         :graph-backup-list
         (graph-command/build-backup-list-action repo)
 
@@ -750,6 +755,8 @@
                        :else
                        (case (:type action)
                          :graph-list (graph-command/execute-graph-list action config)
+                         :agent-bridge (agent-command/execute-bridge action config)
+                         :agent-bridge-list (agent-command/execute-list action config)
                          :graph-backup-list (graph-command/execute-graph-backup-list action config)
                          :graph-backup-create (graph-command/execute-graph-backup-create action config)
                          :graph-backup-restore (graph-command/execute-graph-backup-restore action config)

--- a/src/main/logseq/cli/format.cljs
+++ b/src/main/logseq/cli/format.cljs
@@ -214,6 +214,9 @@
     :server-revision-mismatch "Logseq will restart revision-mismatched db-worker-node servers automatically; retry after stopping any lingering server manually"
     :server-revision-mismatch-restart-failed "Logseq tried to restart a revision-mismatched db-worker-node server and failed. Stop the server manually, then retry"
     :server-revision-mismatch-after-restart "Logseq restarted db-worker-node, but the replacement still reports a different revision. Check the installed Logseq build and retry"
+    :agent-name-invalid "Set :agent-name in cli.edn to a non-empty string or ensure hostname is available"
+    :codex-not-found "Install Codex CLI and ensure `codex` is on PATH"
+    :bridge-listener-failed "Retry with --dry-run or check db-worker-node event support"
     nil))
 
 (defn- format-candidates
@@ -720,6 +723,32 @@
       (str table "\n\n" warning)
       table)))
 
+(defn- format-agent-bridge-list
+  [sessions now-ms]
+  (let [session-field (fn [value]
+                        (cond
+                          (keyword? value) (name value)
+                          (nil? value) nil
+                          :else (str value)))]
+    (format-counted-table
+     ["SESSION" "STATUS" "BACKEND" "GRAPH" "BLOCK" "AGENT" "STARTED" "UPDATED"]
+     (mapv (fn [session]
+             [(session-field (:session session))
+              (session-field (:status session))
+              (session-field (:backend session))
+              (session-field (:graph session))
+              (session-field (:block session))
+              (session-field (:agent session))
+              (human-ago (:started-at session) now-ms)
+              (human-ago (:updated-at session) now-ms)])
+           (or sessions [])))))
+
+(defn- format-agent-bridge
+  [data]
+  (if (seq (:logs data))
+    (string/join "\n" (:logs data))
+    (pr-str data)))
+
 (defn- format-query-results
   [result]
   (let [edn-str (pr-str result)
@@ -1168,6 +1197,8 @@
         (format-graph-action command context data)
         :server-list (format-server-list (:servers data)
                                          (get-in human [:server-list :revision-mismatch]))
+        :agent-bridge (format-agent-bridge data)
+        :agent-bridge-list (format-agent-bridge-list (:sessions data) now-ms)
         :server-cleanup (format-server-cleanup data)
         (:server-start :server-stop :server-restart)
         (format-server-action command data)

--- a/src/main/logseq/cli/server.cljs
+++ b/src/main/logseq/cli/server.cljs
@@ -340,6 +340,16 @@
       (p/let [stop-result (profile/time! (:profile-session config)
                                           "server.restart-version-mismatch"
                                           (fn []
+                                            (log/info :cli-server-restart-version-mismatch
+                                                      {:repo repo
+                                                       :expected-revision expected
+                                                       :current-revision (:revision server)
+                                                       :owner-source (:owner-source server)
+                                                       :pid (:pid server)
+                                                       :host (:host server)
+                                                       :port (:port server)
+                                                       :root-dir (:root-dir server)
+                                                       :status (:status server)})
                                             (stop-version-mismatched-server! config repo server)))]
         (when-not (:ok? stop-result)
           (throw (ex-info "db-worker-node revision mismatch and restart failed"

--- a/src/main/logseq/db_worker/daemon.cljs
+++ b/src/main/logseq/db_worker/daemon.cljs
@@ -5,6 +5,7 @@
             ["http" :as http]
             [clojure.string :as string]
             [lambdaisland.glogi :as log]
+            [logseq.db-worker.log :as db-worker-log]
             [promesa.core :as p]))
 
 (def ^:private valid-owner-sources
@@ -231,11 +232,20 @@
       (do
         (log/warn :db-worker-daemon/missing-script {:repo repo :root-dir root-dir})
         nil)
-      (let [child (.spawn child-process (.-execPath js/process) args #js {:detached detached?
-                                                                          :stdio (if detached?
-                                                                                   "ignore"
-                                                                                   "inherit")
-                                                                          :env env})]
+      (let [stdio-config (when detached?
+                           (db-worker-log/child-stdio! {:root-dir root-dir
+                                                        :repo repo}))
+            _ (when detached?
+                (aset env db-worker-log/stdio-redirected-env "1"))
+            child (try
+                    (.spawn child-process (.-execPath js/process) args #js {:detached detached?
+                                                                            :stdio (if detached?
+                                                                                     (:stdio stdio-config)
+                                                                                     "inherit")
+                                                                            :env env})
+                    (finally
+                      (when-let [close! (:close! stdio-config)]
+                        (close!))))]
         (when detached?
           (.unref child))
         child))))

--- a/src/main/logseq/db_worker/log.cljs
+++ b/src/main/logseq/db_worker/log.cljs
@@ -110,8 +110,13 @@
      (instance? js/Error value)
      (or (.-stack value) (.-message value) (str value))
 
+     (and encoding
+          (exists? js/Buffer)
+          (.isBuffer js/Buffer value))
+     (.toString value encoding)
+
      (and value (fn? (.-toString value)))
-     (.toString value (or encoding "utf8"))
+     (.toString value)
 
      :else
      (str value))))

--- a/src/main/logseq/db_worker/log.cljs
+++ b/src/main/logseq/db_worker/log.cljs
@@ -1,0 +1,293 @@
+(ns logseq.db-worker.log
+  "Unified db-worker-node logging."
+  (:require ["fs" :as fs]
+            ["path" :as node-path]
+            [clojure.string :as string]
+            [goog.log :as glog]
+            [lambdaisland.glogi :as log]
+            [logseq.cli.root-dir :as root-dir]
+            [logseq.common.graph-dir :as graph-dir]))
+
+(def stdio-redirected-env "LOGSEQ_DB_WORKER_NODE_STDIO_REDIRECTED_TO_LOG")
+
+(defonce ^:private *installed (atom nil))
+(defonce ^:private *writing? (atom false))
+(defonce ^:private *forwarding? (atom false))
+
+(defn- pad2
+  [value]
+  (if (< value 10)
+    (str "0" value)
+    (str value)))
+
+(defn- yyyymmdd
+  [^js date]
+  (str (.getFullYear date)
+       (pad2 (inc (.getMonth date)))
+       (pad2 (.getDate date))))
+
+(defn resolve-root-dir
+  [root-dir]
+  (root-dir/normalize-root-dir root-dir))
+
+(defn graphs-dir
+  [root-dir]
+  (root-dir/graphs-dir (resolve-root-dir root-dir)))
+
+(defn repo-dir
+  [root-dir repo]
+  (when-not (seq repo)
+    (throw (ex-info "repo is required" {:code :missing-repo})))
+  (node-path/join (graphs-dir root-dir)
+                  (graph-dir/repo->encoded-graph-dir-name repo)))
+
+(defn log-path
+  [root-dir repo]
+  (node-path/join (repo-dir root-dir repo)
+                  (str "db-worker-node-" (yyyymmdd (js/Date.)) ".log")))
+
+(defn- log-files
+  [graph-dir-path]
+  (->> (when (fs/existsSync graph-dir-path)
+         (fs/readdirSync graph-dir-path))
+       (filter (fn [^js name]
+                 (re-matches #"db-worker-node-\d{8}\.log" name)))
+       (sort)))
+
+(defn enforce-retention!
+  [graph-dir-path]
+  (let [files (log-files graph-dir-path)
+        excess (max 0 (- (count files) 7))]
+    (doseq [name (take excess files)]
+      (fs/unlinkSync (node-path/join graph-dir-path name)))))
+
+(defn- ensure-log-file!
+  [{:keys [root-dir repo]}]
+  (let [graph-dir-path (repo-dir root-dir repo)
+        file-path (log-path root-dir repo)]
+    (fs/mkdirSync graph-dir-path #js {:recursive true})
+    (fs/writeFileSync file-path "" #js {:flag "a"})
+    (enforce-retention! graph-dir-path)
+    {:repo-dir graph-dir-path
+     :file-path file-path}))
+
+(defn- format-glogi-line
+  [{:keys [time level message logger-name exception]}]
+  (let [ts (.toISOString (js/Date. time))
+        base (str ts
+                  " ["
+                  (name level)
+                  "] ["
+                  logger-name
+                  "] "
+                  (pr-str message))]
+    (str base (when exception (str " " (pr-str exception))) "\n")))
+
+(defn- goog-get-level
+  [^js logger]
+  (if (exists? glog/getLevel)
+    (^:cljs.analyzer/no-resolve glog/getLevel logger)
+    (.getLevel logger)))
+
+(defn- current-root-level
+  []
+  (let [level (goog-get-level log/root-logger)]
+    (some (fn [[k v]]
+            (when (= v level)
+              k))
+          log/levels)))
+
+(defn- value->text
+  ([value] (value->text value nil))
+  ([value encoding]
+   (cond
+     (nil? value)
+     ""
+
+     (string? value)
+     value
+
+     (instance? js/Error value)
+     (or (.-stack value) (.-message value) (str value))
+
+     (and value (fn? (.-toString value)))
+     (.toString value (or encoding "utf8"))
+
+     :else
+     (str value))))
+
+(defn- args->text
+  [args]
+  (->> args
+       (map value->text)
+       (string/join " ")))
+
+(defn- chunk-args->text
+  [args]
+  (let [payload (first args)
+        encoding (when (string? (second args))
+                   (second args))]
+    (value->text payload encoding)))
+
+(defn- append-lines!
+  [file-path source text]
+  (when-not (or @*writing? @*forwarding?)
+    (reset! *writing? true)
+    (try
+      (let [text (string/replace (str text) #"\r\n?" "\n")
+            text (string/replace text #"\n$" "")
+            lines (if (string/blank? text)
+                    [""]
+                    (string/split text #"\n"))]
+        (doseq [line lines]
+          (fs/appendFileSync file-path
+                             (str (.toISOString (js/Date.))
+                                  " [stdio] ["
+                                  source
+                                  "] "
+                                  line
+                                  "\n"))))
+      (finally
+        (reset! *writing? false)))))
+
+(defn- call-original
+  [f this args]
+  (reset! *forwarding? true)
+  (try
+    (.apply f this (to-array args))
+    (finally
+      (reset! *forwarding? false))))
+
+(defn- call-print-original
+  [f value]
+  (reset! *forwarding? true)
+  (try
+    (f value)
+    (finally
+      (reset! *forwarding? false))))
+
+(defn- wrap-print!
+  [{:keys [file-path stdio-redirected?] :as state}]
+  (let [original-print-fn *print-fn*
+        original-print-err-fn *print-err-fn*]
+    (set-print-fn!
+     (fn [value]
+       (append-lines! file-path "stdout" value)
+       (when-not stdio-redirected?
+         (call-print-original original-print-fn value))))
+    (set-print-err-fn!
+     (fn [value]
+       (append-lines! file-path "stderr" value)
+       (when-not stdio-redirected?
+         (call-print-original original-print-err-fn value))))
+    (assoc state
+           :original-print-fn original-print-fn
+           :original-print-err-fn original-print-err-fn)))
+
+(defn- wrap-console!
+  [{:keys [file-path stdio-redirected?] :as state}]
+  (let [original-log (.-log js/console)
+        original-warn (.-warn js/console)
+        original-error (.-error js/console)]
+    (set! (.-log js/console)
+          (fn [& args]
+            (append-lines! file-path "console.log" (args->text args))
+            (when-not stdio-redirected?
+              (call-original original-log js/console args))))
+    (set! (.-warn js/console)
+          (fn [& args]
+            (append-lines! file-path "console.warn" (args->text args))
+            (when-not stdio-redirected?
+              (call-original original-warn js/console args))))
+    (set! (.-error js/console)
+          (fn [& args]
+            (append-lines! file-path "console.error" (args->text args))
+            (when-not stdio-redirected?
+              (call-original original-error js/console args))))
+    (assoc state
+           :original-console-log original-log
+           :original-console-warn original-warn
+           :original-console-error original-error)))
+
+(defn- wrap-stream!
+  [stream source file-path stdio-redirected?]
+  (let [original-write (.-write stream)]
+    (set! (.-write stream)
+          (fn [& args]
+            (append-lines! file-path source (chunk-args->text args))
+            (if stdio-redirected?
+              true
+              (call-original original-write stream args))))
+    original-write))
+
+(defn- wrap-streams!
+  [{:keys [file-path stdio-redirected?] :as state}]
+  (assoc state
+         :original-stdout-write (wrap-stream! (.-stdout js/process) "stdout" file-path stdio-redirected?)
+         :original-stderr-write (wrap-stream! (.-stderr js/process) "stderr" file-path stdio-redirected?)))
+
+(defn uninstall!
+  []
+  (when-let [{:keys [handler
+                     original-print-fn
+                     original-print-err-fn
+                     original-console-log
+                     original-console-warn
+                     original-console-error
+                     original-stdout-write
+                     original-stderr-write
+                     original-root-level]} @*installed]
+    (when handler
+      (log/remove-handler handler))
+    (when original-print-fn
+      (set-print-fn! original-print-fn))
+    (when original-print-err-fn
+      (set-print-err-fn! original-print-err-fn))
+    (when original-console-log
+      (set! (.-log js/console) original-console-log))
+    (when original-console-warn
+      (set! (.-warn js/console) original-console-warn))
+    (when original-console-error
+      (set! (.-error js/console) original-console-error))
+    (when original-stdout-write
+      (set! (.-write (.-stdout js/process)) original-stdout-write))
+    (when original-stderr-write
+      (set! (.-write (.-stderr js/process)) original-stderr-write))
+    (when original-root-level
+      (log/set-level :glogi/root original-root-level))
+    (reset! *installed nil)))
+
+(defn install!
+  [{:keys [root-dir repo log-level]}]
+  (uninstall!)
+  (let [{:keys [file-path]} (ensure-log-file! {:root-dir root-dir :repo repo})
+        stdio-redirected? (= "1" (aget (.-env js/process) stdio-redirected-env))
+        original-root-level (current-root-level)
+        handler (fn [record]
+                  (when-not @*forwarding?
+                    (fs/appendFileSync file-path (format-glogi-line record))))
+        state (-> {:file-path file-path
+                   :handler handler
+                   :original-root-level original-root-level
+                   :stdio-redirected? stdio-redirected?}
+                  wrap-print!
+                  wrap-console!
+                  wrap-streams!)]
+    (log/add-handler handler)
+    (log/set-levels {:glogi/root (or log-level :info)})
+    (reset! *installed state)
+    file-path))
+
+(defn child-stdio!
+  [{:keys [root-dir repo]}]
+  (let [{:keys [file-path]} (ensure-log-file! {:root-dir root-dir :repo repo})
+        stdout-fd (fs/openSync file-path "a")]
+    (try
+      (let [stderr-fd (fs/openSync file-path "a")]
+        {:stdio #js ["ignore" stdout-fd stderr-fd]
+         :close! (fn []
+                   (fs/closeSync stdout-fd)
+                   (fs/closeSync stderr-fd))})
+      (catch :default e
+        (fs/closeSync stdout-fd)
+        (throw e)))))

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -1390,6 +1390,7 @@
  :property/update-success "Property updated!"
  :property/use-choice-in-tag "Use in #{1}"
 
+ :property.built-in/agent-session-id "Agent Session ID"
  :property.built-in/alias "Alias"
  :property.built-in/asset "Asset"
  :property.built-in/asset-align "Asset alignment"

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -1403,6 +1403,7 @@
  :property.built-in/asset-size "File Size"
  :property.built-in/asset-type "File Type"
  :property.built-in/asset-width "Image width"
+ :property.built-in/assignee "Assignee"
  :property.built-in/background-color "Background color"
  :property.built-in/built-in "Built in?"
  :property.built-in/checkbox-display-properties "Properties displayed as checkbox"

--- a/src/resources/dicts/zh-cn.edn
+++ b/src/resources/dicts/zh-cn.edn
@@ -1392,6 +1392,7 @@
  :property.built-in/asset-size "文件大小"
  :property.built-in/asset-type "文件类型"
  :property.built-in/asset-width "图片宽度"
+ :property.built-in/assignee "负责人"
  :property.built-in/background-color "背景颜色"
  :property.built-in/built-in "是否内置？"
  :property.built-in/checkbox-display-properties "显示为复选框的属性"

--- a/src/resources/dicts/zh-cn.edn
+++ b/src/resources/dicts/zh-cn.edn
@@ -1379,6 +1379,7 @@
  :property/update-success "属性已更新！"
  :property/use-choice-in-tag "用于 #{1}"
 
+ :property.built-in/agent-session-id "Agent 会话 ID"
  :property.built-in/alias "别名"
  :property.built-in/asset "附件"
  :property.built-in/asset-align "附件对齐"

--- a/src/test/frontend/worker/db_worker_node_test.cljs
+++ b/src/test/frontend/worker/db_worker_node_test.cljs
@@ -17,6 +17,7 @@
             [logseq.common.config :as common-config]
             [logseq.common.version :as build-version]
             [logseq.db :as ldb]
+            [logseq.db-worker.log :as db-worker-log]
             [promesa.core :as p]))
 
 (defn- http-request
@@ -102,23 +103,9 @@
   [root-dir repo]
   (db-lock/lock-path root-dir repo))
 
-(defn- pad2
-  [value]
-  (if (< value 10)
-    (str "0" value)
-    (str value)))
-
-(defn- yyyymmdd
-  [^js date]
-  (str (.getFullYear date)
-       (pad2 (inc (.getMonth date)))
-       (pad2 (.getDate date))))
-
 (defn- log-path
   [root-dir repo]
-  (let [repo-dir (db-lock/repo-dir (db-lock/graphs-dir root-dir) repo)
-        date-str (yyyymmdd (js/Date.))]
-    (node-path/join repo-dir (str "db-worker-node-" date-str ".log"))))
+  (db-worker-log/log-path root-dir repo))
 
 (defn- start-daemon!
   "Start daemon with quiet logging by default"
@@ -152,7 +139,7 @@
   (reset! @#'db-worker-node/*ready? false)
   (reset! @#'db-worker-node/*sse-clients #{})
   (reset! @#'db-worker-node/*lock-info nil)
-  (reset! @#'db-worker-node/*file-handler nil))
+  (db-worker-log/uninstall!))
 
 (defn- normalize-db-worker-state-before
   []
@@ -280,9 +267,74 @@
                               (-> (stop!) (p/finally (fn [] (done))))
                               (done))))))))
 
+(deftest db-worker-node-logs-println-output
+  (async done
+         (let [daemon (atom nil)
+               data-dir (node-helper/create-tmp-dir "db-worker-log-println")
+               repo (str "logseq_db_log_println_" (subs (str (random-uuid)) 0 8))
+               log-file (log-path data-dir repo)
+               message (str "println output " (random-uuid))]
+           (-> (p/let [{:keys [stop!]}
+                       (start-daemon! {:root-dir data-dir
+                                       :repo repo})
+                       _ (reset! daemon {:stop! stop!})
+                       _ (println message)
+                       _ (p/delay 50)
+                       contents (.toString (fs/readFileSync log-file) "utf8")]
+                 (is (string/includes? contents message)))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (if-let [stop! (:stop! @daemon)]
+                              (-> (stop!) (p/finally (fn [] (done))))
+                              (done))))))))
+
+(deftest db-worker-node-logs-console-error-output
+  (async done
+         (let [daemon (atom nil)
+               data-dir (node-helper/create-tmp-dir "db-worker-log-console-error")
+               repo (str "logseq_db_log_console_error_" (subs (str (random-uuid)) 0 8))
+               log-file (log-path data-dir repo)
+               message (str "console error output " (random-uuid))]
+           (-> (p/let [{:keys [stop!]}
+                       (start-daemon! {:root-dir data-dir
+                                       :repo repo})
+                       _ (reset! daemon {:stop! stop!})
+                       _ (.error js/console message)
+                       _ (p/delay 50)
+                       contents (.toString (fs/readFileSync log-file) "utf8")]
+                 (is (string/includes? contents message)))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (if-let [stop! (:stop! @daemon)]
+                              (-> (stop!) (p/finally (fn [] (done))))
+                              (done))))))))
+
+(deftest db-worker-node-logs-process-stdout-output
+  (async done
+         (let [daemon (atom nil)
+               data-dir (node-helper/create-tmp-dir "db-worker-log-stdout")
+               repo (str "logseq_db_log_stdout_" (subs (str (random-uuid)) 0 8))
+               log-file (log-path data-dir repo)
+               message (str "stdout output " (random-uuid))]
+           (-> (p/let [{:keys [stop!]}
+                       (start-daemon! {:root-dir data-dir
+                                       :repo repo})
+                       _ (reset! daemon {:stop! stop!})
+                       _ (.write (.-stdout js/process) (str message "\n"))
+                       _ (p/delay 50)
+                       contents (.toString (fs/readFileSync log-file) "utf8")]
+                 (is (string/includes? contents message)))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (if-let [stop! (:stop! @daemon)]
+                              (-> (stop!) (p/finally (fn [] (done))))
+                              (done))))))))
+
 (deftest db-worker-node-log-retention
-  (let [enforce-log-retention! #'db-worker-node/enforce-log-retention!
-        data-dir (node-helper/create-tmp-dir "db-worker-log-retention")
+  (let [data-dir (node-helper/create-tmp-dir "db-worker-log-retention")
         repo (str "logseq_db_log_retention_" (subs (str (random-uuid)) 0 8))
         repo-dir (db-lock/repo-dir data-dir repo)
         days ["20240101" "20240102" "20240103" "20240104" "20240105"
@@ -292,7 +344,7 @@
     (fs/mkdirSync repo-dir #js {:recursive true})
     (doseq [day days]
       (fs/writeFileSync (make-log day) "log\n"))
-    (enforce-log-retention! repo-dir)
+    (db-worker-log/enforce-retention! repo-dir)
     (let [remaining (->> (fs/readdirSync repo-dir)
                          (filter (fn [^js name]
                                    (re-matches #"db-worker-node-\d{8}\.log" name)))

--- a/src/test/frontend/worker/db_worker_node_test.cljs
+++ b/src/test/frontend/worker/db_worker_node_test.cljs
@@ -15,6 +15,7 @@
             [logseq.cli.style :as style]
             [logseq.cli.test-helper :as test-helper]
             [logseq.common.config :as common-config]
+            [logseq.common.version :as build-version]
             [logseq.db :as ldb]
             [promesa.core :as p]))
 
@@ -249,6 +250,29 @@
                  (is (= 500 status))
                  (is (fs/existsSync log-file))
                  (is (pos? (count contents))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (if-let [stop! (:stop! @daemon)]
+                              (-> (stop!) (p/finally (fn [] (done))))
+                              (done))))))))
+
+(deftest db-worker-node-logs-version-on-startup
+  (async done
+         (let [daemon (atom nil)
+               data-dir (node-helper/create-tmp-dir "db-worker-log-version")
+               repo (str "logseq_db_log_version_" (subs (str (random-uuid)) 0 8))
+               log-file (log-path data-dir repo)]
+           (-> (p/let [{:keys [stop!]}
+                       (start-daemon! {:root-dir data-dir
+                                       :repo repo
+                                       :log-level "info"})
+                       _ (reset! daemon {:stop! stop!})
+                       _ (p/delay 50)
+                       contents (.toString (fs/readFileSync log-file) "utf8")]
+                 (is (string/includes? contents ":db-worker-node-version"))
+                 (is (string/includes? contents (str ":build-time " (pr-str (build-version/build-time)))))
+                 (is (string/includes? contents (str ":revision " (pr-str (build-version/revision))))))
                (p/catch (fn [e]
                           (is false (str "unexpected error: " e))))
                (p/finally (fn []

--- a/src/test/frontend/worker/db_worker_node_test.cljs
+++ b/src/test/frontend/worker/db_worker_node_test.cljs
@@ -311,6 +311,27 @@
                               (-> (stop!) (p/finally (fn [] (done))))
                               (done))))))))
 
+(deftest db-worker-node-logs-console-number-output
+  (async done
+         (let [daemon (atom nil)
+               data-dir (node-helper/create-tmp-dir "db-worker-log-console-number")
+               repo (str "logseq_db_log_console_number_" (subs (str (random-uuid)) 0 8))
+               log-file (log-path data-dir repo)]
+           (-> (p/let [{:keys [stop!]}
+                       (start-daemon! {:root-dir data-dir
+                                       :repo repo})
+                       _ (reset! daemon {:stop! stop!})
+                       _ (.error js/console 123)
+                       _ (p/delay 50)
+                       contents (.toString (fs/readFileSync log-file) "utf8")]
+                 (is (string/includes? contents "123")))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (if-let [stop! (:stop! @daemon)]
+                              (-> (stop!) (p/finally (fn [] (done))))
+                              (done))))))))
+
 (deftest db-worker-node-logs-process-stdout-output
   (async done
          (let [daemon (atom nil)

--- a/src/test/frontend/worker/migrate_test.cljs
+++ b/src/test/frontend/worker/migrate_test.cljs
@@ -197,10 +197,12 @@
              (:kv/value (d/entity @conn :logseq.kv/schema-version))))
       (let [property (d/entity @conn :logseq.property.agent/session-id)]
         (is (some? property))
-        (is (= "agent session id" (:block/title property)))
+        (is (= "Agent Session ID" (:block/title property)))
         (is (= :string (:logseq.property/type property)))
-        (is (false? (:logseq.property/public? property)))
-        (is (true? (:logseq.property/hide? property))))
+        (is (true? (:logseq.property/public? property)))
+        (is (true? (:logseq.property/hide? property)))
+        (is (= "Stores the AgentBridge session ID for a routed task."
+               (:block/title (:logseq.property/description property)))))
       (is (some #(= {:properties [:logseq.property.agent/session-id]}
                     (:migrate-updates %))
                 (:upgrade-result-coll result))))))

--- a/src/test/frontend/worker/migrate_test.cljs
+++ b/src/test/frontend/worker/migrate_test.cljs
@@ -187,6 +187,24 @@
                       (d/entity @conn [:block/uuid range-comments-uuid])))))
         "Existing range comment targets should be preserved")))
 
+(deftest migrate-65-30-adds-assignee-property
+  (let [conn (d/create-conn db-schema/schema)]
+    (d/transact! conn [{:db/ident :logseq.kv/schema-version
+                        :kv/value {:major 65 :minor 29}}])
+
+    (let [result (db-migrate/migrate conn :target-version {:major 65 :minor 30})]
+      (is (= {:major 65 :minor 30}
+             (:kv/value (d/entity @conn :logseq.kv/schema-version))))
+      (let [property (d/entity @conn :logseq.property/assignee)]
+        (is (some? property))
+        (is (= "Assignee" (:block/title property)))
+        (is (= :node (:logseq.property/type property)))
+        (is (= :db.cardinality/many (:db/cardinality property)))
+        (is (true? (:logseq.property/public? property))))
+      (is (some #(= {:properties [:logseq.property/assignee]}
+                    (:migrate-updates %))
+                (:upgrade-result-coll result))))))
+
 (deftest migrate-65-31-adds-agent-session-id-property
   (let [conn (d/create-conn db-schema/schema)]
     (d/transact! conn [{:db/ident :logseq.kv/schema-version

--- a/src/test/frontend/worker/migrate_test.cljs
+++ b/src/test/frontend/worker/migrate_test.cljs
@@ -186,3 +186,21 @@
                      (:logseq.property.comments/blocks
                       (d/entity @conn [:block/uuid range-comments-uuid])))))
         "Existing range comment targets should be preserved")))
+
+(deftest migrate-65-31-adds-agent-session-id-property
+  (let [conn (d/create-conn db-schema/schema)]
+    (d/transact! conn [{:db/ident :logseq.kv/schema-version
+                        :kv/value {:major 65 :minor 30}}])
+
+    (let [result (db-migrate/migrate conn)]
+      (is (= {:major 65 :minor 31}
+             (:kv/value (d/entity @conn :logseq.kv/schema-version))))
+      (let [property (d/entity @conn :logseq.property.agent/session-id)]
+        (is (some? property))
+        (is (= "agent session id" (:block/title property)))
+        (is (= :string (:logseq.property/type property)))
+        (is (false? (:logseq.property/public? property)))
+        (is (true? (:logseq.property/hide? property))))
+      (is (some #(= {:properties [:logseq.property.agent/session-id]}
+                    (:migrate-updates %))
+                (:upgrade-result-coll result))))))

--- a/src/test/logseq/cli/command/agent_test.cljs
+++ b/src/test/logseq/cli/command/agent_test.cljs
@@ -1,0 +1,703 @@
+(ns logseq.cli.command.agent-test
+  (:require ["child_process" :as child-process]
+            ["events" :as events]
+            ["fs" :as fs]
+            ["os" :as os]
+            ["path" :as node-path]
+            [cljs.reader :as reader]
+            [cljs.test :refer [async deftest is testing]]
+            [clojure.string :as string]
+            [lambdaisland.glogi :as log]
+            [logseq.cli.command.agent :as agent-command]
+            [logseq.cli.command.show :as show-command]
+            [logseq.cli.commands :as commands]
+            [logseq.cli.format :as cli-format]
+            [logseq.cli.server :as cli-server]
+            [logseq.cli.transport :as transport]
+            [logseq.db.frontend.property :as db-property]
+            [promesa.core :as p]))
+
+(defn- temp-root
+  []
+  (.mkdtempSync fs (node-path/join (.tmpdir os) "logseq-agent-bridge-test-")))
+
+(defn- task-block
+  [overrides]
+  (merge {:db/id 42
+          :block/uuid #uuid "11111111-1111-1111-1111-111111111111"
+          :block/title "Ship the CLI bridge"
+          :block/tags [{:block/title "Task"}]
+          :logseq.property/status {:db/ident :logseq.property/status.todo}
+          "Assignee" "build-host"}
+         overrides))
+
+(deftest test-assignee-built-in-property
+  (let [property (get db-property/built-in-properties :logseq.property/assignee)]
+    (is (= "Assignee" (:title property)))
+    (is (= :node (get-in property [:schema :type])))
+    (is (= :many (get-in property [:schema :cardinality])))
+    (is (= true (get-in property [:schema :public?])))
+    (is (= true (:queryable? property)))
+    (is (contains? db-property/public-built-in-properties :logseq.property/assignee))))
+
+(deftest test-agent-command-entries
+  (testing "parse agent bridge command surface"
+    (let [bridge (commands/parse-args ["agent" "bridge" "--graph" "demo" "--dry-run"])
+          list-result (commands/parse-args ["agent" "bridge" "list"])]
+      (is (true? (:ok? bridge)))
+      (is (= :agent-bridge (:command bridge)))
+      (is (= "demo" (get-in bridge [:options :graph])))
+      (is (true? (get-in bridge [:options :dry-run])))
+      (is (true? (:ok? list-result)))
+      (is (= :agent-bridge-list (:command list-result)))))
+
+  (testing "top-level help exposes the agent utility group"
+    (let [summary (:summary (commands/parse-args ["--help"]))]
+      (is (string/includes? summary "agent"))
+      (is (string/includes? summary "Run task agent bridge")))))
+
+(deftest test-build-action
+  (testing "agent bridge requires a resolved graph"
+    (let [result (commands/build-action {:ok? true
+                                         :command :agent-bridge
+                                         :options {}
+                                         :args []}
+                                        {})]
+      (is (false? (:ok? result)))
+      (is (= :missing-repo (get-in result [:error :code])))))
+
+  (testing "agent bridge uses normal graph config precedence"
+    (let [parsed {:ok? true
+                  :command :agent-bridge
+                  :options {:dry-run true}
+                  :args []}
+          result (commands/build-action parsed {:graph "demo"})]
+      (is (true? (:ok? result)))
+      (is (= :agent-bridge (get-in result [:action :type])))
+      (is (= "demo" (get-in result [:action :graph])))
+      (is (= "logseq_db_demo" (get-in result [:action :repo])))
+      (is (true? (get-in result [:action :dry-run?])))))
+
+  (testing "agent bridge list is root-dir scoped and does not require graph"
+    (let [result (commands/build-action {:ok? true
+                                         :command :agent-bridge-list
+                                         :options {}
+                                         :args []}
+                                        {})]
+      (is (true? (:ok? result)))
+      (is (= :agent-bridge-list (get-in result [:action :type]))))))
+
+(deftest test-resolve-agent-name
+  (testing "config overrides hostname"
+    (is (= {:ok? true :agent-name "bridge-a"}
+           (agent-command/resolve-agent-name {:agent-name " bridge-a "}
+                                             {:hostname "fallback-host"}))))
+
+  (testing "hostname is the default when config omits agent-name"
+    (is (= {:ok? true :agent-name "fallback-host"}
+           (agent-command/resolve-agent-name {}
+                                             {:hostname "fallback-host"}))))
+
+  (testing "blank config value fails instead of falling back"
+    (let [result (agent-command/resolve-agent-name {:agent-name "   "}
+                                                   {:hostname "fallback-host"})]
+      (is (false? (:ok? result)))
+      (is (= :agent-name-invalid (get-in result [:error :code])))))
+
+  (testing "missing hostname fails when no config value exists"
+    (let [result (agent-command/resolve-agent-name {}
+                                                   {:hostname ""})]
+      (is (false? (:ok? result)))
+      (is (= :agent-name-invalid (get-in result [:error :code]))))))
+
+(deftest test-routable-task
+  (testing "routes opted-in TODO Task assigned to current AgentBridge"
+    (is (true? (agent-command/routable-task? (task-block {}) "build-host"))))
+
+  (testing "routes built-in Assignee node values with many cardinality"
+    (is (true? (agent-command/routable-task?
+                (task-block {"Assignee" nil
+                             :logseq.property/assignee [{:db/id 101
+                                                         :block/title "build-host"}]})
+                "build-host"))))
+
+  (testing "rejects non-routable blocks with explicit reasons"
+    (is (= :missing-stable-uuid
+           (:reason (agent-command/routable-task-decision (task-block {:block/uuid nil}) "build-host"))))
+    (is (= :missing-task-tag
+           (:reason (agent-command/routable-task-decision (task-block {:block/tags []}) "build-host"))))
+    (is (= :not-todo
+           (:reason (agent-command/routable-task-decision (task-block {:logseq.property/status {:db/ident :logseq.property/status.done}})
+                                                          "build-host"))))
+    (is (= :assignee-mismatch
+           (:reason (agent-command/routable-task-decision (task-block {"Assignee" "other-host"})
+                                                          "build-host"))))
+    (is (= :already-routed
+           (:reason (agent-command/routable-task-decision (task-block {"agent-session-id" "codex-1"})
+                                                          "build-host"))))))
+
+(deftest test-prompt-and-command
+  (let [prompt (agent-command/build-codex-prompt
+                {:graph "demo"
+                 :agent-name "build-host"
+                 :block (task-block {})
+                 :tree-text "- Ship the CLI bridge\n  - Add tests"})
+        command (agent-command/build-codex-command prompt {:codex-bin "codex"})
+        preview (agent-command/command-preview command)]
+    (testing "prompt carries graph, block, tree, identity, and write-back instructions"
+      (is (string/includes? prompt "Graph: demo"))
+      (is (string/includes? prompt "Block UUID: 11111111-1111-1111-1111-111111111111"))
+      (is (string/includes? prompt "AgentBridge name: build-host"))
+      (is (string/includes? prompt "Do not operate outside the target graph."))
+      (is (string/includes? prompt "Write task results back into the graph."))
+      (is (string/includes? prompt "- Ship the CLI bridge")))
+
+    (testing "codex command uses exec and shell-safe preview"
+      (is (= ["codex" "exec" "--json" prompt] command))
+      (is (string/starts-with? preview "codex exec --json '"))
+      (is (string/includes? preview "Ship the CLI bridge")))))
+
+(deftest test-codex-session-id-capture
+  (testing "captures the first Codex JSONL session id"
+    (is (= "session-123"
+           (agent-command/parse-codex-session-id-line
+            "{\"type\":\"session_configured\",\"session_id\":\"session-123\"}"))))
+
+  (testing "captures the current Codex JSONL thread id"
+    (is (= "thread-123"
+           (agent-command/parse-codex-session-id-line
+            "{\"type\":\"thread.started\",\"thread_id\":\"thread-123\"}"))))
+
+  (testing "ignores non-session JSONL events"
+    (is (nil? (agent-command/parse-codex-session-id-line
+               "{\"type\":\"agent_message\",\"message\":\"hello\"}")))))
+
+(deftest test-start-codex-waits-for-stdout-after-exit
+  (async done
+         (let [original-spawn (.-spawn child-process)]
+           (set! (.-spawn child-process)
+                 (fn [_bin _args _opts]
+                   (let [child (events/EventEmitter.)
+                         stdout (events/EventEmitter.)
+                         stderr (events/EventEmitter.)]
+                     (set! (.-stdout child) stdout)
+                     (set! (.-stderr child) stderr)
+                     (js/setTimeout (fn []
+                                      (.emit child "exit" 0 nil)
+                                      (.emit stdout "data" "{\"type\":\"thread.started\",\"thread_id\":\"thread-late\"}\n")
+                                      (.emit stdout "close")
+                                      (.emit child "close" 0 nil))
+                                    0)
+                     child)))
+           (-> (agent-command/start-codex! ["codex" "exec" "--json" "prompt"] {})
+               (p/then (fn [result]
+                         (is (= {:session "thread-late"
+                                  :status :running}
+                                (select-keys result [:session :status])))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (set! (.-spawn child-process) original-spawn)
+                            (done)))))))
+
+(deftest test-start-codex-parses-complete-jsonl-before-later-output
+  (async done
+         (let [original-spawn (.-spawn child-process)]
+           (set! (.-spawn child-process)
+                 (fn [_bin _args _opts]
+                   (let [child (events/EventEmitter.)
+                         stdout (events/EventEmitter.)
+                         stderr (events/EventEmitter.)]
+                     (set! (.-stdout child) stdout)
+                     (set! (.-stderr child) stderr)
+                     (js/setTimeout (fn []
+                                      (.emit stdout "data" "{\"type\":\"thread.started\",\"thread_id\":\"thread-first\"}\n")
+                                      (.emit stdout "data" "{\"type\":\"turn.started\"}\n")
+                                      (.emit stdout "close")
+                                      (.emit child "close" 0 nil))
+                                    0)
+                     child)))
+           (-> (agent-command/start-codex! ["codex" "exec" "--json" "prompt"] {})
+               (p/then (fn [result]
+                         (is (= "thread-first" (:session result)))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (set! (.-spawn child-process) original-spawn)
+                            (done)))))))
+
+(deftest test-start-codex-waits-for-stdout-close-after-child-close
+  (async done
+         (let [original-spawn (.-spawn child-process)]
+           (set! (.-spawn child-process)
+                 (fn [_bin _args _opts]
+                   (let [child (events/EventEmitter.)
+                         stdout (events/EventEmitter.)
+                         stderr (events/EventEmitter.)]
+                     (set! (.-stdout child) stdout)
+                     (set! (.-stderr child) stderr)
+                     (js/setTimeout (fn []
+                                      (.emit child "close" 0 nil)
+                                      (.emit stdout "data" "{\"type\":\"thread.started\",\"thread_id\":\"thread-after-close\"}\n")
+                                      (.emit stdout "close"))
+                                    0)
+                     child)))
+           (-> (agent-command/start-codex! ["codex" "exec" "--json" "prompt"] {})
+               (p/then (fn [result]
+                         (is (= "thread-after-close" (:session result)))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (set! (.-spawn child-process) original-spawn)
+                            (done)))))))
+
+(deftest test-registration-writes-agent-name-to-graph
+  (async done
+         (let [calls* (atom [])
+               page-uuid (uuid "33333333-3333-3333-3333-333333333333")]
+           (p/finally
+             (p/catch
+              (p/with-redefs [agent-command/random-bridge-block-uuid (fn [] (uuid "44444444-4444-4444-4444-444444444444"))
+                              transport/invoke (fn [_ method args]
+                                                 (swap! calls* conj [method args])
+                                                 (case method
+                                                   :thread-api/q
+                                                   (let [[_ [query & query-args]] args]
+                                                     (cond
+                                                       (= query agent-command/agent-bridge-registry-page-query)
+                                                       (p/resolved [])
+
+                                                       (= query agent-command/registered-agent-query)
+                                                       (p/resolved [])
+
+                                                       :else
+                                                       (p/rejected (ex-info "unexpected query"
+                                                                            {:query query
+                                                                             :query-args query-args}))))
+
+                                                   :thread-api/apply-outliner-ops
+                                                   (let [[_ ops _] args]
+                                                     (if (= [[:create-page [agent-command/agent-bridge-registry-page {}]]] ops)
+                                                       (p/resolved [agent-command/agent-bridge-registry-page page-uuid])
+                                                       (p/resolved {:ok true})))
+
+                                                   :thread-api/pull
+                                                   (p/resolved {:db/id 300
+                                                                :block/uuid page-uuid
+                                                                :block/title agent-command/agent-bridge-registry-page})
+
+                                                   (p/rejected (ex-info "unexpected invoke"
+                                                                        {:method method
+                                                                         :args args}))))]
+                (p/let [_ (agent-command/register-agent-bridge! {:root-dir "/tmp/logseq"} "logseq_db_demo" "build-host")]
+                  (let [apply-ops (->> @calls*
+                                       (filter #(= :thread-api/apply-outliner-ops (first %)))
+                                       (mapv (comp second second)))]
+                    (is (= [[:create-page [agent-command/agent-bridge-registry-page {}]]]
+                           (first apply-ops)))
+                    (is (= [[:insert-blocks [[{:block/title "build-host"
+                                               :block/uuid (uuid "44444444-4444-4444-4444-444444444444")}]
+                                             page-uuid
+                                             {:outliner-op :insert-blocks
+                                              :sibling? false
+                                              :bottom? true
+                                              :keep-uuid? true}]]]
+                           (second apply-ops))))))
+              (fn [e]
+                (is false (str "unexpected error: " e))))
+             done))))
+
+(deftest test-write-agent-session-id
+  (async done
+         (let [ops* (atom [])
+               property-query-count* (atom 0)
+               property-ident :user.property/agent-session-id
+               block-uuid (uuid "11111111-1111-1111-1111-111111111111")]
+           (-> (p/with-redefs [transport/invoke (fn [_ method args]
+                                                  (case method
+                                                    :thread-api/q
+                                                    (let [[_ [query & _query-args]] args]
+                                                      (if (= query agent-command/agent-session-id-property-query)
+                                                        (p/resolved (if (= 1 (swap! property-query-count* inc))
+                                                                      []
+                                                                      [{:db/id 700
+                                                                        :db/ident property-ident
+                                                                        :block/title "agent-session-id"}]))
+                                                        (p/rejected (ex-info "unexpected query"
+                                                                             {:query query}))))
+
+                                                    :thread-api/apply-outliner-ops
+                                                    (let [[_ ops _] args]
+                                                      (swap! ops* into ops)
+                                                      (p/resolved {:ok true}))
+
+                                                    (p/rejected (ex-info "unexpected invoke"
+                                                                         {:method method
+                                                                          :args args}))))]
+                 (p/let [_ (agent-command/write-agent-session-id! {:root-dir "/tmp/logseq"}
+                                                                  "logseq_db_demo"
+                                                                  block-uuid
+                                                                  "session-123")]
+                   (is (= [[:upsert-property [nil
+                                              {:logseq.property/type :default
+                                               :db/cardinality :db.cardinality/one}
+                                              {:property-name "agent-session-id"}]]
+                           [:batch-set-property [[block-uuid] property-ident "session-123" {}]]]
+                          @ops*))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
+(deftest test-session-store
+  (let [root (temp-root)
+        config {:root-dir root}]
+    (try
+      (agent-command/record-session! config {:session "codex-running"
+                                             :status :running
+                                             :backend :codex
+                                             :graph "demo"
+                                             :block "11111111-1111-1111-1111-111111111111"
+                                             :agent "build-host"
+                                             :started-at 1000
+                                             :updated-at 2000})
+      (agent-command/record-session! config {:session "codex-done"
+                                             :status :completed
+                                             :backend :codex
+                                             :graph "demo"
+                                             :block "22222222-2222-2222-2222-222222222222"
+                                             :agent "build-host"
+                                             :started-at 1000
+                                             :updated-at 3000})
+      (testing "list hides completed sessions by default"
+        (is (= ["codex-running"]
+               (mapv :session (agent-command/list-sessions config {})))))
+      (testing "list can include completed sessions"
+        (is (= ["codex-running" "codex-done"]
+               (mapv :session (agent-command/list-sessions config {:all? true})))))
+      (testing "session file is EDN data"
+        (let [payload (reader/read-string (fs/readFileSync (agent-command/session-store-path config) "utf8"))]
+          (is (= 2 (count (:sessions payload))))))
+      (finally
+        (fs/rmSync root #js {:recursive true :force true})))))
+
+(deftest test-session-store-keeps-terminal-status-after-late-running-record
+  (let [root (temp-root)
+        config {:root-dir root}]
+    (try
+      (agent-command/update-session-status! config "codex-fast" :completed)
+      (agent-command/record-session! config {:session "codex-fast"
+                                             :status :running
+                                             :backend :codex
+                                             :graph "demo"
+                                             :block "11111111-1111-1111-1111-111111111111"
+                                             :agent "build-host"
+                                             :started-at 1000
+                                             :updated-at 2000})
+      (let [session (first (agent-command/list-sessions config {:all? true}))]
+        (is (= :completed (:status session)))
+        (is (= :codex (:backend session)))
+        (is (= "demo" (:graph session)))
+        (is (= "11111111-1111-1111-1111-111111111111" (:block session)))
+        (is (= "build-host" (:agent session)))
+        (is (= 1000 (:started-at session)))
+        (is (= 2000 (:updated-at session))))
+      (finally
+        (fs/rmSync root #js {:recursive true :force true})))))
+
+(deftest test-execute-agent-bridge-list-and-format
+  (let [root (temp-root)]
+    (try
+      (agent-command/record-session! {:root-dir root}
+                                     {:session "codex-running"
+                                      :status :running
+                                      :backend :codex
+                                      :graph "demo"
+                                      :block "11111111-1111-1111-1111-111111111111"
+                                      :agent "build-host"
+                                      :started-at 1000
+                                      :updated-at 2000})
+      (let [result (agent-command/execute-list {:type :agent-bridge-list} {:root-dir root})
+            output (cli-format/format-result result {:output-format :human :now-ms 3000})]
+        (is (= :ok (:status result)))
+        (is (string/includes? output "SESSION"))
+        (is (string/includes? output "STATUS"))
+        (is (string/includes? output "BACKEND"))
+        (is (string/includes? output "codex-running"))
+        (is (string/includes? output "running"))
+        (is (not (string/includes? output ":running")))
+        (is (not (string/includes? output ":codex")))
+        (is (string/includes? output "Count: 1")))
+      (finally
+        (fs/rmSync root #js {:recursive true :force true})))))
+
+(deftest test-format-agent-bridge-logs
+  (let [output (cli-format/format-result {:status :ok
+                                          :command :agent-bridge
+                                          :data {:logs ["2026-05-16T00:00:00.000Z checking the environment ..."
+                                                        "2026-05-16T00:00:01.000Z listening graph changes ..."]}}
+                                         {:output-format :human})]
+    (is (= "2026-05-16T00:00:00.000Z checking the environment ...\n2026-05-16T00:00:01.000Z listening graph changes ..."
+           output))))
+
+(deftest test-execute-agent-bridge-dry-run
+  (async done
+         (let [calls (atom [])]
+           (-> (p/with-redefs [agent-command/codex-available? (fn [_] true)
+                               cli-server/ensure-server! (fn [cfg repo]
+                                                           (swap! calls conj [:ensure-server (:root-dir cfg) repo])
+                                                           (assoc cfg :base-url "http://127.0.0.1:1234"))
+                               agent-command/register-agent-bridge! (fn [cfg repo agent-name]
+                                                                      (swap! calls conj [:register (:root-dir cfg) repo agent-name])
+                                                                      (p/resolved true))
+                               agent-command/list-routable-tasks (fn [_cfg repo agent-name]
+                                                                   (swap! calls conj [:list repo agent-name])
+                                                                   (p/resolved [{:block (task-block {})
+                                                                                 :tree-text "- Ship the CLI bridge"}]))]
+                 (p/let [result (agent-command/execute-bridge {:type :agent-bridge
+                                                               :repo "logseq_db_demo"
+                                                               :graph "demo"
+                                                               :dry-run? true}
+                                                              {:root-dir "/tmp/logseq"
+                                                               :agent-name "build-host"})]
+                   (is (= :ok (:status result)))
+                   (is (= :dry-run (get-in result [:data :mode])))
+                   (is (= [[:ensure-server "/tmp/logseq" "logseq_db_demo"]
+                           [:register "/tmp/logseq" "logseq_db_demo" "build-host"]
+                           [:list "logseq_db_demo" "build-host"]]
+                          @calls))
+                   (is (= 1 (count (get-in result [:data :commands]))))
+                   (is (string/includes? (first (get-in result [:data :logs]))
+                                         "checking the environment"))
+                   (is (string/includes? (last (get-in result [:data :logs]))
+                                         "would run Codex command"))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
+(deftest test-execute-agent-bridge-non-dry-run-routes-task
+  (async done
+         (let [root (temp-root)
+               calls (atom [])
+               block (task-block {})]
+           (try
+             (p/finally
+               (p/catch
+                (p/with-redefs [agent-command/codex-available? (fn [_] true)
+                                cli-server/ensure-server! (fn [cfg repo]
+                                                            (swap! calls conj [:ensure-server (:root-dir cfg) repo])
+                                                            (assoc cfg :base-url "http://127.0.0.1:1234"))
+                                agent-command/register-agent-bridge! (fn [_cfg repo agent-name]
+                                                                       (swap! calls conj [:register repo agent-name])
+                                                                       (p/resolved true))
+                                agent-command/list-routable-tasks (fn [_cfg repo agent-name]
+                                                                    (swap! calls conj [:list repo agent-name])
+                                                                    (p/resolved [{:block block
+                                                                                  :tree-text "- Ship the CLI bridge"}]))
+                                agent-command/start-codex! (fn [command _opts]
+                                                             (swap! calls conj [:codex command])
+                                                             (p/resolved {:session "session-123"
+                                                                          :status :running}))
+                                agent-command/write-agent-session-id! (fn [_cfg repo block-uuid session-id]
+                                                                        (swap! calls conj [:write-session repo block-uuid session-id])
+                                                                        (p/resolved true))]
+                  (p/let [result (agent-command/execute-bridge {:type :agent-bridge
+                                                                :repo "logseq_db_demo"
+                                                                :graph "demo"
+                                                                :dry-run? false
+                                                                :process-once? true}
+                                                               {:root-dir root
+                                                                :agent-name "build-host"
+                                                                :log-fn (fn [_] nil)})]
+                    (is (= :ok (:status result)))
+                    (is (= :processed-once (get-in result [:data :mode])))
+                    (is (= [[:ensure-server root "logseq_db_demo"]
+                            [:register "logseq_db_demo" "build-host"]
+                            [:list "logseq_db_demo" "build-host"]
+                            [:codex ["codex" "exec" "--json" (agent-command/build-codex-prompt
+                                                              {:graph "demo"
+                                                               :agent-name "build-host"
+                                                               :block block
+                                                               :tree-text "- Ship the CLI bridge"})]]
+                            [:ensure-server root "logseq_db_demo"]
+                            [:write-session "logseq_db_demo" (:block/uuid block) "session-123"]]
+                           @calls))
+                    (let [sessions (agent-command/list-sessions {:root-dir root} {})]
+                      (is (= [{:session "session-123"
+                               :status :running
+                               :backend :codex
+                               :graph "demo"
+                               :block "11111111-1111-1111-1111-111111111111"
+                               :agent "build-host"}]
+                             (mapv #(select-keys % [:session :status :backend :graph :block :agent]) sessions))))))
+                (fn [e]
+                  (is false (str "unexpected error: " e))))
+               (fn []
+                 (fs/rmSync root #js {:recursive true :force true})
+                 (done)))
+             (catch :default e
+               (fs/rmSync root #js {:recursive true :force true})
+               (is false (str "unexpected setup error: " e))
+               (done))))))
+
+(deftest test-agent-bridge-listener-ignores-unrelated-events
+  (async done
+         (let [handler* (atom nil)
+               broad-scans* (atom 0)]
+           (-> (p/with-redefs [transport/connect-events! (fn [_cfg handler]
+                                                           (reset! handler* handler)
+                                                           {:close! (fn [] nil)})
+                               agent-command/list-routable-tasks (fn [_cfg _repo _agent-name]
+                                                                   (swap! broad-scans* inc)
+                                                                   (p/resolved []))]
+                 (do
+                   (#'agent-command/listen-forever! {:root-dir "/tmp/logseq"
+                                                     :base-url "http://127.0.0.1:1234"
+                                                     :log-fn (fn [_] nil)}
+                                                    {:repo "logseq_db_demo"
+                                                     :graph "demo"
+                                                     :agent-name "build-host"})
+                   (@handler* :rtc-log {:tx-data [{:e 42
+                                                   :a :logseq.property/assignee
+                                                   :v {:db/id 101
+                                                       :block/title "build-host"}}]})
+                   (@handler* :sync-db-changes {:tx-data [{:e 42
+                                                           :a :block/title
+                                                           :v "renamed"}]})
+                   (@handler* :sync-db-changes {:tx-data [{:e 42
+                                                           :a :logseq.property/assignee
+                                                           :v {:db/id 102
+                                                               :block/title "other-host"}}]})
+                   (p/let [_ (p/delay 5)]
+                     (is (= 0 @broad-scans*)))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
+(deftest test-agent-bridge-listener-logs-exit-reason-before-process-exit
+  (async done
+         (let [handler* (atom nil)
+               exit-calls* (atom [])
+               info-logs* (atom [])
+               original-exit (.-exit js/process)
+               log-handler (fn [record]
+                             (when-let [data (get (:message record) :agent-bridge-exit)]
+                               (swap! info-logs* conj data)))]
+           (set! (.-exit js/process)
+                 (fn [code]
+                   (swap! exit-calls* conj code)))
+           (log/add-handler log-handler)
+           (-> (p/with-redefs [transport/connect-events! (fn [_cfg handler]
+                                                           (reset! handler* handler)
+                                                           {:close! (fn [] nil)})
+                               transport/invoke (fn [_cfg _method _args]
+                                                  (p/rejected (ex-info "db-worker unavailable"
+                                                                       {:code :db-worker-unavailable})))]
+                 (do
+                   (#'agent-command/listen-forever! {:root-dir "/tmp/logseq"
+                                                     :base-url "http://127.0.0.1:1234"
+                                                     :log-fn (fn [_] nil)}
+                                                    {:repo "logseq_db_demo"
+                                                     :graph "demo"
+                                                     :agent-name "build-host"})
+                   (@handler* :sync-db-changes {:tx-data [{:e 42
+                                                           :a :logseq.property/assignee
+                                                           :v {:db/id 101
+                                                               :block/title "build-host"}}]})
+                   (p/let [_ (p/delay 5)]
+                     (is (= [1] @exit-calls*))
+                     (is (= [{:reason :task-processing-failed
+                              :exit-code 1
+                              :repo "logseq_db_demo"
+                              :graph "demo"
+                              :agent-name "build-host"
+                              :error-code :db-worker-unavailable
+                              :message "db-worker unavailable"}]
+                            @info-logs*)))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (log/remove-handler log-handler)
+                            (set! (.-exit js/process) original-exit)
+                            (done)))))))
+
+(deftest test-agent-bridge-listener-routes-assignee-datom-without-broad-scan
+  (async done
+         (let [root (temp-root)
+               handler* (atom nil)
+               calls (atom [])
+               block (task-block {"Assignee" nil
+                                  :logseq.property/assignee [{:db/id 101
+                                                              :block/title "build-host"}]})]
+           (try
+             (-> (p/with-redefs [transport/connect-events! (fn [_cfg handler]
+                                                             (reset! handler* handler)
+                                                             {:close! (fn [] nil)})
+                                 agent-command/list-routable-tasks (fn [_cfg repo agent-name]
+                                                                     (swap! calls conj [:broad-scan repo agent-name])
+                                                                     (p/resolved []))
+                                 transport/invoke (fn [_cfg method args]
+                                                    (swap! calls conj [method args])
+                                                    (case method
+                                                 :thread-api/pull
+                                                 (let [[_repo selector lookup] args]
+                                                   (cond
+                                                     (= lookup :logseq.property/assignee)
+                                                     (p/resolved {:db/id 900
+                                                                  :db/ident :logseq.property/assignee})
+
+                                                     (= lookup 101)
+                                                     (p/resolved {:db/id 101
+                                                                  :block/title "build-host"})
+
+                                                          (= lookup 42)
+                                                          (p/resolved block)
+
+                                                          :else
+                                                          (p/rejected (ex-info "unexpected pull"
+                                                                               {:selector selector
+                                                                                :lookup lookup}))))
+
+                                                      (p/rejected (ex-info "unexpected invoke"
+                                                                           {:method method
+                                                                            :args args}))))
+                                 show-command/execute-show (fn [action _cfg]
+                                                             (swap! calls conj [:show action])
+                                                             (p/resolved {:status :ok
+                                                                          :data {:message "- Ship the CLI bridge"}}))
+                                 cli-server/ensure-server! (fn [cfg repo]
+                                                             (swap! calls conj [:ensure-server (:root-dir cfg) repo])
+                                                             (assoc cfg :base-url "http://127.0.0.1:1234"))
+                                 agent-command/start-codex! (fn [command _opts]
+                                                              (swap! calls conj [:codex command])
+                                                              (p/resolved {:session "session-123"
+                                                                           :status :running}))
+                                 agent-command/write-agent-session-id! (fn [_cfg repo block-uuid session-id]
+                                                                         (swap! calls conj [:write-session repo block-uuid session-id])
+                                                                         (p/resolved true))]
+                   (do
+                     (#'agent-command/listen-forever! {:root-dir root
+                                                       :base-url "http://127.0.0.1:1234"
+                                                       :log-fn (fn [_] nil)}
+                                                      {:repo "logseq_db_demo"
+                                                       :graph "demo"
+                                                       :agent-name "build-host"})
+                     (@handler* :sync-db-changes {:tx-data [{:e 42
+                                                             :a 900
+                                                             :v 101}]})
+                     (p/let [_ (p/delay 5)]
+                       (is (not-any? #(= :broad-scan (first %)) @calls))
+                       (is (some #(= [:thread-api/pull ["logseq_db_demo" [:db/id :db/ident] :logseq.property/assignee]] %)
+                                 @calls))
+                       (is (some #(= [:thread-api/pull ["logseq_db_demo" [:db/id :block/title :block/name] 101]] %)
+                                 @calls))
+                       (is (some #(= [:write-session "logseq_db_demo" (:block/uuid block) "session-123"] %)
+                                 @calls)))))
+                 (p/catch (fn [e]
+                            (is false (str "unexpected error: " e))))
+                 (p/finally (fn []
+                              (fs/rmSync root #js {:recursive true :force true})
+                              (done))))
+             (catch :default e
+               (fs/rmSync root #js {:recursive true :force true})
+               (is false (str "unexpected setup error: " e))
+               (done))))))

--- a/src/test/logseq/cli/command/agent_test.cljs
+++ b/src/test/logseq/cli/command/agent_test.cljs
@@ -67,6 +67,12 @@
                                               :block/title "Target block B"}]}
          overrides))
 
+(def codex-exec-prefix
+  ["codex" "--sandbox" "danger-full-access" "exec" "--json" "--skip-git-repo-check"])
+
+(def codex-resume-prefix
+  ["codex" "--sandbox" "danger-full-access" "exec" "resume" "--json" "--skip-git-repo-check"])
+
 (defn- assert-comment-request-prompt
   [prompt]
   (doseq [expected ["You are handling a Logseq AgentBridge comment request."
@@ -235,8 +241,8 @@
       (is (string/includes? prompt "- Ship the CLI bridge")))
 
     (testing "codex command uses exec and shell-safe preview"
-      (is (= ["codex" "exec" "--json" prompt] command))
-      (is (string/starts-with? preview "codex exec --json '"))
+      (is (= (conj codex-exec-prefix prompt) command))
+      (is (string/starts-with? preview "codex --sandbox danger-full-access exec --json --skip-git-repo-check '"))
       (is (string/includes? preview "Ship the CLI bridge")))))
 
 (deftest test-prompt-templates
@@ -581,7 +587,7 @@
                          (let [[_ command] (some #(when (= :codex (first %)) %) @calls)]
                            (is (some? command))
                            (when command
-                             (assert-comment-request-prompt (nth command 3))))
+                             (assert-comment-request-prompt (last command))))
                          (is (fn? @start-on-exit*))
                          (p/let [_ (p/delay 10)]
                            (is (some #(= [:thread-api/apply-outliner-ops
@@ -714,8 +720,8 @@
                (p/then (fn [_]
                          (let [[_ command] (some #(when (= :codex (first %)) %) @calls)]
                            (is (some? command))
-                           (is (= ["codex" "exec" "resume" "--json" "existing-session-123"]
-                                  (vec (take 5 command))))
+                           (is (= (conj codex-resume-prefix "existing-session-123")
+                                  (vec (take 8 command))))
                            (when command
                              (assert-basic-comment-request-prompt (last command))))))
                (p/catch (fn [e]
@@ -778,8 +784,8 @@
                (p/then (fn [_]
                          (let [[_ command] (some #(when (= :codex (first %)) %) @calls)]
                            (is (some? command))
-                           (is (= ["codex" "exec" "--json"]
-                                  (vec (take 3 command))))
+                           (is (= codex-exec-prefix
+                                  (vec (take (count codex-exec-prefix) command))))
                            (when command
                              (assert-basic-comment-request-prompt (last command))))))
                (p/catch (fn [e]
@@ -1241,9 +1247,9 @@
                            [:list "logseq_db_demo" "build-host"]]
                           @calls))
                    (is (= 1 (count (get-in result [:data :commands]))))
-                   (is (string/includes? (get-in result [:data :commands 0 :command 3])
+                   (is (string/includes? (last (get-in result [:data :commands 0 :command]))
                                          "Custom task demo"))
-                   (is (not (string/includes? (get-in result [:data :commands 0 :command 3])
+                   (is (not (string/includes? (last (get-in result [:data :commands 0 :command]))
                                                "You are handling a Logseq AgentBridge task.")))
                    (is (string/includes? (first (get-in result [:data :logs]))
                                          "checking the environment"))
@@ -1298,7 +1304,7 @@
                             [:prompt-templates "logseq_db_demo"]
                             [:register "logseq_db_demo" "build-host"]
                             [:list "logseq_db_demo" "build-host"]
-                            [:codex ["codex" "exec" "--json" "Task demo 11111111-1111-1111-1111-111111111111 build-host\n- Ship the CLI bridge"]]
+                            [:codex (conj codex-exec-prefix "Task demo 11111111-1111-1111-1111-111111111111 build-host\n- Ship the CLI bridge")]
                             [:ensure-server root "logseq_db_demo"]
                             [:write-session "logseq_db_demo" (:block/uuid block) "session-123"]]
                            @calls))

--- a/src/test/logseq/cli/command/agent_test.cljs
+++ b/src/test/logseq/cli/command/agent_test.cljs
@@ -21,6 +21,14 @@
   []
   (.mkdtempSync fs (node-path/join (.tmpdir os) "logseq-agent-bridge-test-")))
 
+(defn- read-dict
+  [filename]
+  (reader/read-string
+   (.toString
+    (fs/readFileSync
+     (node-path/join (.cwd js/process) "src" "resources" "dicts" filename))
+    "utf8")))
+
 (defn- task-block
   [overrides]
   (merge {:db/id 42
@@ -108,7 +116,11 @@
              (get-in property [:properties :logseq.property/description])))
       (is (contains? db-property/public-built-in-properties :logseq.property.agent/session-id))
       (is (db-property/logseq-property? :logseq.property.agent/session-id))
-      (is (db-property/internal-property? :logseq.property.agent/session-id)))))
+      (is (db-property/internal-property? :logseq.property.agent/session-id))
+      (let [i18n-key (db-property/built-in-ident->i18n-key :logseq.property.agent/session-id)]
+        (is (= :property.built-in/agent-session-id i18n-key))
+        (is (contains? (read-dict "en.edn") i18n-key))
+        (is (contains? (read-dict "zh-cn.edn") i18n-key))))))
 
 (deftest test-agent-command-entries
   (testing "parse agent bridge command surface"
@@ -1308,6 +1320,110 @@
                (is false (str "unexpected setup error: " e))
                (done))))))
 
+(deftest test-execute-agent-bridge-connects-listener-before-ready-log-and-initial-scan
+  (async done
+         (let [calls (atom [])
+               call-index (fn [pred]
+                            (first (keep-indexed (fn [idx call]
+                                                   (when (pred call) idx))
+                                                 @calls)))]
+           (-> (p/with-redefs [agent-command/codex-available? (fn [_] true)
+                               cli-server/ensure-server! (fn [cfg repo]
+                                                           (swap! calls conj [:ensure-server repo])
+                                                           (assoc cfg :base-url "http://127.0.0.1:1234"))
+                               agent-command/register-agent-bridge! (fn [_cfg repo agent-name]
+                                                                      (swap! calls conj [:register repo agent-name])
+                                                                      (p/resolved true))
+                               agent-command/ensure-agent-bridge-prompt-templates!
+                               (fn [_cfg repo]
+                                 (swap! calls conj [:prompt-templates repo])
+                                 (p/resolved {:task "Task {{graph}} {{block-uuid}} {{agent-name}}\n{{task-block-tree}}"
+                                              :comment "Comment {{graph}} {{comment-uuid}} {{agent-name}}\n{{comment-target-context}}\n{{comment-thread-context}}\n{{requesting-comment}}"}))
+                               transport/connect-events! (fn [_cfg _handler]
+                                                           (swap! calls conj [:connect])
+                                                           {:close! (fn [] nil)})
+                               agent-command/list-routable-tasks (fn [_cfg repo agent-name]
+                                                                   (swap! calls conj [:list repo agent-name])
+                                                                   (p/resolved []))]
+                 (do
+                   (agent-command/execute-bridge {:type :agent-bridge
+                                                  :repo "logseq_db_demo"
+                                                  :graph "demo"
+                                                  :dry-run? false}
+                                                 {:root-dir "/tmp/logseq"
+                                                  :agent-name "build-host"
+                                                  :log-fn (fn [line]
+                                                            (swap! calls conj [:log line]))})
+                   (p/let [_ (p/delay 10)]
+                     (let [connect-index (call-index #(= [:connect] %))
+                           listening-index (call-index #(and (= :log (first %))
+                                                             (string/includes? (second %) "listening graph changes")))
+                           list-index (call-index #(= :list (first %)))]
+                       (is (some? connect-index))
+                       (is (some? listening-index))
+                       (is (some? list-index))
+                       (is (< connect-index listening-index))
+                       (is (< connect-index list-index))))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
+(deftest test-execute-agent-bridge-bounds-initial-task-routing-concurrency
+  (async done
+         (let [root (temp-root)
+               active* (atom 0)
+               max-active* (atom 0)
+               routed* (atom [])
+               blocks (mapv (fn [idx]
+                               (task-block {:db/id (+ 42 idx)
+                                            :block/uuid (uuid (str "11111111-1111-1111-1111-11111111111" idx))}))
+                             (range 5))]
+           (try
+             (-> (p/with-redefs [agent-command/codex-available? (fn [_] true)
+                                 cli-server/ensure-server! (fn [cfg _repo]
+                                                             (assoc cfg :base-url "http://127.0.0.1:1234"))
+                                 agent-command/register-agent-bridge! (fn [_cfg _repo _agent-name]
+                                                                        (p/resolved true))
+                                 agent-command/ensure-agent-bridge-prompt-templates!
+                                 (fn [_cfg _repo]
+                                   (p/resolved {:task "Task {{graph}} {{block-uuid}} {{agent-name}}\n{{task-block-tree}}"
+                                                :comment "Comment {{graph}} {{comment-uuid}} {{agent-name}}\n{{comment-target-context}}\n{{comment-thread-context}}\n{{requesting-comment}}"}))
+                                 agent-command/list-routable-tasks (fn [_cfg _repo _agent-name]
+                                                                     (p/resolved (mapv (fn [block]
+                                                                                         {:block block
+                                                                                          :tree-text (:block/title block)})
+                                                                                       blocks)))
+                                 agent-command/start-codex! (fn [_command _opts]
+                                                              (let [active (swap! active* inc)]
+                                                                (swap! max-active* max active)
+                                                                (p/let [_ (p/delay 20)]
+                                                                  (swap! active* dec)
+                                                                  {:session (str "session-" (random-uuid))
+                                                                   :status :running})))
+                                 agent-command/write-agent-session-id! (fn [_cfg _repo block-uuid session-id]
+                                                                         (swap! routed* conj [block-uuid session-id])
+                                                                         (p/resolved true))]
+                   (p/let [result (agent-command/execute-bridge {:type :agent-bridge
+                                                                 :repo "logseq_db_demo"
+                                                                 :graph "demo"
+                                                                 :dry-run? false
+                                                                 :process-once? true}
+                                                                {:root-dir root
+                                                                 :agent-name "build-host"
+                                                                 :log-fn (fn [_] nil)})]
+                     (is (= :ok (:status result)))
+                     (is (= 5 (count @routed*)))
+                     (is (<= @max-active* 4))))
+                 (p/catch (fn [e]
+                            (is false (str "unexpected error: " e))))
+                 (p/finally (fn []
+                              (fs/rmSync root #js {:recursive true :force true})
+                              (done))))
+             (catch :default e
+               (fs/rmSync root #js {:recursive true :force true})
+               (is false (str "unexpected setup error: " e))
+               (done))))))
+
 (deftest test-agent-bridge-listener-ignores-unrelated-events
   (async done
          (let [handler* (atom nil)
@@ -1478,6 +1594,78 @@
                                  @calls))
                        (is (some #(= [:write-session "logseq_db_demo" (:block/uuid block) "session-123"] %)
                                  @calls)))))
+                 (p/catch (fn [e]
+                            (is false (str "unexpected error: " e))))
+                 (p/finally (fn []
+                              (fs/rmSync root #js {:recursive true :force true})
+                              (done))))
+             (catch :default e
+               (fs/rmSync root #js {:recursive true :force true})
+               (is false (str "unexpected setup error: " e))
+               (done))))))
+
+(deftest test-agent-bridge-listener-routes-task-tag-and-status-datoms
+  (async done
+         (let [root (temp-root)
+               handler* (atom nil)
+               calls (atom [])
+               status-block (task-block {:db/id 42})
+               tag-block (task-block {:db/id 43
+                                      :block/uuid #uuid "22222222-2222-2222-2222-222222222222"})]
+           (try
+             (-> (p/with-redefs [transport/connect-events! (fn [_cfg handler]
+                                                             (reset! handler* handler)
+                                                             {:close! (fn [] nil)})
+                                 agent-command/list-routable-tasks (fn [_cfg repo agent-name]
+                                                                     (swap! calls conj [:broad-scan repo agent-name])
+                                                                     (p/resolved []))
+                                 transport/invoke (fn [_cfg method args]
+                                                    (swap! calls conj [method args])
+                                                    (case method
+                                                      :thread-api/pull
+                                                      (let [[_repo _selector lookup] args]
+                                                        (cond
+                                                          (= lookup 42) (p/resolved status-block)
+                                                          (= lookup 43) (p/resolved tag-block)
+                                                          :else (p/rejected (ex-info "unexpected pull"
+                                                                                     {:lookup lookup}))))
+                                                      (p/rejected (ex-info "unexpected invoke"
+                                                                           {:method method
+                                                                            :args args}))))
+                                 show-command/execute-show (fn [action _cfg]
+                                                             (swap! calls conj [:show action])
+                                                             (p/resolved {:status :ok
+                                                                          :data {:message "- Routed task"}}))
+                                 cli-server/ensure-server! (fn [cfg repo]
+                                                             (swap! calls conj [:ensure-server (:root-dir cfg) repo])
+                                                             (assoc cfg :base-url "http://127.0.0.1:1234"))
+                                 agent-command/start-codex! (fn [_command _opts]
+                                                              (p/resolved {:session (str "session-" (random-uuid))
+                                                                           :status :running}))
+                                 agent-command/write-agent-session-id! (fn [_cfg repo block-uuid session-id]
+                                                                         (swap! calls conj [:write-session repo block-uuid session-id])
+                                                                         (p/resolved true))]
+                   (do
+                     (#'agent-command/listen-forever! {:root-dir root
+                                                       :base-url "http://127.0.0.1:1234"
+                                                       :log-fn (fn [_] nil)}
+                                                      {:repo "logseq_db_demo"
+                                                       :graph "demo"
+                                                       :agent-name "build-host"})
+                     (@handler* :sync-db-changes {:tx-data [{:e 42
+                                                             :a :logseq.property/status
+                                                             :v :logseq.property/status.todo
+                                                             :added true}
+                                                            {:e 43
+                                                             :a :block/tags
+                                                             :v :logseq.class/Task
+                                                             :added true}]})
+                     (p/let [_ (p/delay 10)]
+                       (is (not-any? #(= :broad-scan (first %)) @calls))
+                       (is (= #{(:block/uuid status-block)
+                                (:block/uuid tag-block)}
+                              (set (map #(nth % 2)
+                                        (filter #(= :write-session (first %)) @calls))))))))
                  (p/catch (fn [e]
                             (is false (str "unexpected error: " e))))
                  (p/finally (fn []

--- a/src/test/logseq/cli/command/agent_test.cljs
+++ b/src/test/logseq/cli/command/agent_test.cljs
@@ -99,12 +99,14 @@
 
   (testing "agent session id is an internal built-in property"
     (let [property (get db-property/built-in-properties :logseq.property.agent/session-id)]
-      (is (= "agent session id" (:title property)))
+      (is (= "Agent Session ID" (:title property)))
       (is (= :string (get-in property [:schema :type])))
       (is (not (contains? (:schema property) :db/cardinality)))
-      (is (= false (get-in property [:schema :public?])))
+      (is (= true (get-in property [:schema :public?])))
       (is (= true (get-in property [:schema :hide?])))
-      (is (not (contains? db-property/public-built-in-properties :logseq.property.agent/session-id)))
+      (is (= "Stores the AgentBridge session ID for a routed task."
+             (get-in property [:properties :logseq.property/description])))
+      (is (contains? db-property/public-built-in-properties :logseq.property.agent/session-id))
       (is (db-property/logseq-property? :logseq.property.agent/session-id))
       (is (db-property/internal-property? :logseq.property.agent/session-id)))))
 

--- a/src/test/logseq/cli/command/agent_test.cljs
+++ b/src/test/logseq/cli/command/agent_test.cljs
@@ -101,10 +101,12 @@
     (let [property (get db-property/built-in-properties :logseq.property.agent/session-id)]
       (is (= "agent session id" (:title property)))
       (is (= :string (get-in property [:schema :type])))
-      (is (= :db.cardinality/one (get-in property [:schema :db/cardinality])))
+      (is (not (contains? (:schema property) :db/cardinality)))
       (is (= false (get-in property [:schema :public?])))
       (is (= true (get-in property [:schema :hide?])))
-      (is (not (contains? db-property/public-built-in-properties :logseq.property.agent/session-id))))))
+      (is (not (contains? db-property/public-built-in-properties :logseq.property.agent/session-id)))
+      (is (db-property/logseq-property? :logseq.property.agent/session-id))
+      (is (db-property/internal-property? :logseq.property.agent/session-id)))))
 
 (deftest test-agent-command-entries
   (testing "parse agent bridge command surface"

--- a/src/test/logseq/cli/command/agent_test.cljs
+++ b/src/test/logseq/cli/command/agent_test.cljs
@@ -31,6 +31,60 @@
           "Assignee" "build-host"}
          overrides))
 
+(defn- comment-block
+  [overrides]
+  (merge {:db/id 50
+          :block/uuid #uuid "55555555-5555-5555-5555-555555555555"
+          :block/title "[[build-host]] please summarize the selected blocks"
+          :block/tags [{:db/ident :logseq.class/Comment
+                        :block/title "Comment"}]
+          :block/parent {:db/id 60
+                         :block/uuid #uuid "66666666-6666-6666-6666-666666666666"}}
+         overrides))
+
+(defn- comments-area-block
+  [overrides]
+  (merge {:db/id 60
+          :block/uuid #uuid "66666666-6666-6666-6666-666666666666"
+          :block/title "Comments"
+          :block/tags [{:db/ident :logseq.class/Comments
+                        :block/title "Comments"}]
+          :logseq.property.comments/blocks [{:db/id 70
+                                              :block/uuid #uuid "77777777-7777-7777-7777-777777777777"
+                                              :block/title "Target block A"}
+                                             {:db/id 80
+                                              :block/uuid #uuid "88888888-8888-8888-8888-888888888888"
+                                              :block/title "Target block B"}]}
+         overrides))
+
+(defn- assert-comment-request-prompt
+  [prompt]
+  (doseq [expected ["You are handling a Logseq AgentBridge comment request."
+                    "Graph: demo"
+                    "Comment UUID: 55555555-5555-5555-5555-555555555555"
+                    "AgentBridge name: build-host"
+                    "Comment target context:"
+                    "- Target block A\n  - Target A child"
+                    "- Target block B\n  - Target B child"
+                    "Comment thread context:"
+                    "- Comments\n  - [[build-host]] please summarize the selected blocks"
+                    "Requesting comment:"
+                    "For a short reply, append a comment after the requesting comment."
+                    "For a long reply, write a normal block tree after the comments area and append a comment that references that tree."]]
+    (is (string/includes? prompt expected))))
+
+(defn- assert-basic-comment-request-prompt
+  [prompt]
+  (doseq [expected ["You are handling a Logseq AgentBridge comment request."
+                    "Graph: demo"
+                    "Comment UUID: 55555555-5555-5555-5555-555555555555"
+                    "AgentBridge name: build-host"
+                    "Comment target context:"
+                    "Comment thread context:"
+                    "Requesting comment:"
+                    "Reply instructions:"]]
+    (is (string/includes? prompt expected))))
+
 (deftest test-assignee-built-in-property
   (let [property (get db-property/built-in-properties :logseq.property/assignee)]
     (is (= "Assignee" (:title property)))
@@ -157,6 +211,389 @@
       (is (string/starts-with? preview "codex exec --json '"))
       (is (string/includes? preview "Ship the CLI bridge")))))
 
+(deftest test-agent-bridge-listener-routes-comment-mention-with-context-and-reactions
+  (async done
+         (let [root (temp-root)
+               calls (atom [])
+               start-on-exit* (atom nil)
+               request-comment (comment-block {})
+               comments-area (comments-area-block {})
+               comment-uuid (:block/uuid request-comment)
+               tree-by-uuid {"55555555-5555-5555-5555-555555555555"
+                             "- [[build-host]] please summarize the selected blocks"
+                             "66666666-6666-6666-6666-666666666666"
+                             "- Comments\n  - [[build-host]] please summarize the selected blocks\n  - Earlier comment"
+                             "77777777-7777-7777-7777-777777777777"
+                             "- Target block A\n  - Target A child"
+                             "88888888-8888-8888-8888-888888888888"
+                             "- Target block B\n  - Target B child"}]
+           (-> (p/with-redefs [agent-command/list-routable-tasks
+                                (fn [_cfg repo agent-name]
+                                  (swap! calls conj [:broad-scan repo agent-name])
+                                  (p/resolved []))
+                                transport/invoke
+                                (fn [_cfg method args]
+                                  (swap! calls conj [method args])
+                                  (case method
+                                    :thread-api/pull
+                                    (let [[_repo _selector lookup] args]
+                                      (case lookup
+                                        50 (p/resolved request-comment)
+                                        60 (p/resolved comments-area)
+                                        (p/rejected (ex-info "unexpected pull"
+                                                             {:lookup lookup}))))
+
+                                    :thread-api/q
+                                    (p/resolved [])
+
+                                    :thread-api/apply-outliner-ops
+                                    (p/resolved {:ok true})
+
+                                    (p/rejected (ex-info "unexpected invoke"
+                                                         {:method method
+                                                          :args args}))))
+                                show-command/execute-show
+                                (fn [action _cfg]
+                                  (swap! calls conj [:show action])
+                                  (p/resolved {:status :ok
+                                               :data {:message (get tree-by-uuid (:uuid action))}}))
+                                cli-server/ensure-server!
+                                (fn [cfg repo]
+                                  (swap! calls conj [:ensure-server (:root-dir cfg) repo])
+                                  (assoc cfg :base-url "http://127.0.0.1:1234"))
+                                agent-command/start-codex!
+                                (fn [command opts]
+                                  (swap! calls conj [:codex command])
+                                  (reset! start-on-exit* (:on-exit opts))
+                                  ((:on-exit opts) 0 "comment-session-123")
+                                  (p/resolved {:session "comment-session-123"
+                                               :status :running}))]
+                 (#'agent-command/process-sync-db-changes-event!
+                  {:root-dir root
+                   :base-url "http://127.0.0.1:1234"
+                   :log-fn (fn [_] nil)}
+                  {:repo "logseq_db_demo"
+                   :graph "demo"
+                   :agent-name "build-host"
+                   :routing-blocks* (atom #{})}
+                  {:tx-data [{:e 50
+                              :a :block/title
+                              :v (:block/title request-comment)}]}))
+               (p/then (fn [_]
+                         (is (not-any? #(= :broad-scan (first %)) @calls))
+                         (is (some #(= [:thread-api/apply-outliner-ops
+                                        ["logseq_db_demo"
+                                         [[:toggle-reaction [comment-uuid "eyes" nil]]]
+                                         {}]]
+                                       %)
+                                   @calls))
+                         (let [[_ command] (some #(when (= :codex (first %)) %) @calls)]
+                           (is (some? command))
+                           (when command
+                             (assert-comment-request-prompt (nth command 3))))
+                         (is (fn? @start-on-exit*))
+                         (p/let [_ (p/delay 10)]
+                           (is (some #(= [:thread-api/apply-outliner-ops
+                                          ["logseq_db_demo"
+                                           [[:toggle-reaction [comment-uuid "white_check_mark" nil]]]
+                                           {}]]
+                                         %)
+                                     @calls)))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (fs/rmSync root #js {:recursive true :force true})
+                            (done)))))))
+
+(deftest test-agent-bridge-listener-routes-normalized-comment-mention-ref
+  (async done
+         (let [root (temp-root)
+               calls (atom [])
+               request-comment (comment-block {:block/title "[[aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa]] please summarize"
+                                               :block/refs [{:db/id 101
+                                                             :block/title "build-host"}]})
+               comments-area (comments-area-block {})
+               comment-uuid (:block/uuid request-comment)]
+           (-> (p/with-redefs [transport/invoke
+                                (fn [_cfg method args]
+                                  (swap! calls conj [method args])
+                                  (case method
+                                    :thread-api/pull
+                                    (let [[_repo _selector lookup] args]
+                                      (case lookup
+                                        50 (p/resolved request-comment)
+                                        60 (p/resolved comments-area)
+                                        (p/rejected (ex-info "unexpected pull"
+                                                             {:lookup lookup}))))
+                                    :thread-api/q
+                                    (p/resolved [])
+                                    :thread-api/apply-outliner-ops
+                                    (p/resolved {:ok true})
+                                    (p/rejected (ex-info "unexpected invoke"
+                                                         {:method method
+                                                          :args args}))))
+                                show-command/execute-show
+                                (fn [_action _cfg]
+                                  (p/resolved {:status :ok
+                                               :data {:message "- context"}}))
+                                cli-server/ensure-server!
+                                (fn [cfg _repo] cfg)
+                                agent-command/start-codex!
+                                (fn [command _opts]
+                                  (swap! calls conj [:codex command])
+                                  (p/resolved {:session "comment-session-ref"
+                                               :status :running}))]
+                 (#'agent-command/process-sync-db-changes-event!
+                  {:root-dir root
+                   :base-url "http://127.0.0.1:1234"
+                   :log-fn (fn [_] nil)}
+                  {:repo "logseq_db_demo"
+                   :graph "demo"
+                   :agent-name "build-host"
+                   :routing-blocks* (atom #{})}
+                  {:tx-data [{:e 50
+                              :a :block/title
+                              :v (:block/title request-comment)}]}))
+               (p/then (fn [_]
+                         (is (some #(= :codex (first %)) @calls))
+                         (is (some #(= [:thread-api/apply-outliner-ops
+                                        ["logseq_db_demo"
+                                         [[:toggle-reaction [comment-uuid "eyes" nil]]]
+                                         {}]]
+                                       %)
+                                   @calls))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (fs/rmSync root #js {:recursive true :force true})
+                            (done)))))))
+
+(deftest test-agent-bridge-listener-resumes-commented-block-session-when-assignee-matches
+  (async done
+         (let [root (temp-root)
+               calls (atom [])
+               request-comment (comment-block {})
+               commented-block (assoc (first (:logseq.property.comments/blocks (comments-area-block {})))
+                                      "agent-session-id" "existing-session-123"
+                                      :logseq.property/assignee [{:db/id 101
+                                                                  :block/title "build-host"}])
+               comments-area (comments-area-block {:logseq.property.comments/blocks [commented-block]})]
+           (-> (p/with-redefs [transport/invoke
+                                (fn [_cfg method args]
+                                  (swap! calls conj [method args])
+                                  (case method
+                                    :thread-api/pull
+                                    (let [[_repo _selector lookup] args]
+                                      (case lookup
+                                        50 (p/resolved request-comment)
+                                        60 (p/resolved comments-area)
+                                        (p/rejected (ex-info "unexpected pull"
+                                                             {:lookup lookup}))))
+                                    :thread-api/q
+                                    (p/resolved [])
+                                    :thread-api/apply-outliner-ops
+                                    (p/resolved {:ok true})
+                                    (p/rejected (ex-info "unexpected invoke"
+                                                         {:method method
+                                                          :args args}))))
+                                show-command/execute-show
+                                (fn [_action _cfg]
+                                  (p/resolved {:status :ok
+                                               :data {:message "- context"}}))
+                                cli-server/ensure-server!
+                                (fn [cfg _repo] cfg)
+                                agent-command/start-codex!
+                                (fn [command _opts]
+                                  (swap! calls conj [:codex command])
+                                  (p/resolved {:session "existing-session-123"
+                                               :status :running}))]
+                 (#'agent-command/process-sync-db-changes-event!
+                  {:root-dir root
+                   :base-url "http://127.0.0.1:1234"
+                   :log-fn (fn [_] nil)}
+                  {:repo "logseq_db_demo"
+                   :graph "demo"
+                   :agent-name "build-host"
+                   :routing-blocks* (atom #{})}
+                  {:tx-data [{:e 50
+                              :a :block/title
+                              :v (:block/title request-comment)}]}))
+               (p/then (fn [_]
+                         (let [[_ command] (some #(when (= :codex (first %)) %) @calls)]
+                           (is (some? command))
+                           (is (= ["codex" "exec" "resume" "--json" "existing-session-123"]
+                                  (vec (take 5 command))))
+                           (when command
+                             (assert-basic-comment-request-prompt (last command))))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (fs/rmSync root #js {:recursive true :force true})
+                            (done)))))))
+
+(deftest test-agent-bridge-listener-starts-temporary-comment-session-when-assignee-mismatches
+  (async done
+         (let [root (temp-root)
+               calls (atom [])
+               request-comment (comment-block {})
+               commented-block (assoc (first (:logseq.property.comments/blocks (comments-area-block {})))
+                                      "agent-session-id" "existing-session-123"
+                                      :logseq.property/assignee [{:db/id 101
+                                                                  :block/title "other-host"}])
+               comments-area (comments-area-block {:logseq.property.comments/blocks [commented-block]})]
+           (-> (p/with-redefs [transport/invoke
+                                (fn [_cfg method args]
+                                  (swap! calls conj [method args])
+                                  (case method
+                                    :thread-api/pull
+                                    (let [[_repo _selector lookup] args]
+                                      (case lookup
+                                        50 (p/resolved request-comment)
+                                        60 (p/resolved comments-area)
+                                        (p/rejected (ex-info "unexpected pull"
+                                                             {:lookup lookup}))))
+                                    :thread-api/q
+                                    (p/resolved [])
+                                    :thread-api/apply-outliner-ops
+                                    (p/resolved {:ok true})
+                                    (p/rejected (ex-info "unexpected invoke"
+                                                         {:method method
+                                                          :args args}))))
+                                show-command/execute-show
+                                (fn [_action _cfg]
+                                  (p/resolved {:status :ok
+                                               :data {:message "- context"}}))
+                                cli-server/ensure-server!
+                                (fn [cfg _repo] cfg)
+                                agent-command/start-codex!
+                                (fn [command _opts]
+                                  (swap! calls conj [:codex command])
+                                  (p/resolved {:session "comment-session-789"
+                                               :status :running}))]
+                 (#'agent-command/process-sync-db-changes-event!
+                  {:root-dir root
+                   :base-url "http://127.0.0.1:1234"
+                   :log-fn (fn [_] nil)}
+                  {:repo "logseq_db_demo"
+                   :graph "demo"
+                   :agent-name "build-host"
+                   :routing-blocks* (atom #{})}
+                  {:tx-data [{:e 50
+                              :a :block/title
+                              :v (:block/title request-comment)}]}))
+               (p/then (fn [_]
+                         (let [[_ command] (some #(when (= :codex (first %)) %) @calls)]
+                           (is (some? command))
+                           (is (= ["codex" "exec" "--json"]
+                                  (vec (take 3 command))))
+                           (when command
+                             (assert-basic-comment-request-prompt (last command))))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (fs/rmSync root #js {:recursive true :force true})
+                            (done)))))))
+
+(deftest test-agent-bridge-listener-adds-failure-reaction-when-comment-codex-exits-nonzero
+  (async done
+         (let [root (temp-root)
+               calls (atom [])
+               start-on-exit* (atom nil)
+               request-comment (comment-block {})
+               comments-area (comments-area-block {})
+               comment-uuid (:block/uuid request-comment)]
+           (-> (p/with-redefs [transport/invoke
+                                (fn [_cfg method args]
+                                  (swap! calls conj [method args])
+                                  (case method
+                                    :thread-api/pull
+                                    (let [[_repo _selector lookup] args]
+                                      (case lookup
+                                        50 (p/resolved request-comment)
+                                        60 (p/resolved comments-area)
+                                        (p/rejected (ex-info "unexpected pull"
+                                                             {:lookup lookup}))))
+                                    :thread-api/q
+                                    (p/resolved [])
+                                    :thread-api/apply-outliner-ops
+                                    (p/resolved {:ok true})
+                                    (p/rejected (ex-info "unexpected invoke"
+                                                         {:method method
+                                                          :args args}))))
+                                show-command/execute-show
+                                (fn [_action _cfg]
+                                  (p/resolved {:status :ok
+                                               :data {:message "- context"}}))
+                                cli-server/ensure-server!
+                                (fn [cfg _repo] cfg)
+                                agent-command/start-codex!
+                                (fn [_command opts]
+                                  (reset! start-on-exit* (:on-exit opts))
+                                  ((:on-exit opts) 1 "comment-session-456")
+                                  (p/resolved {:session "comment-session-456"
+                                               :status :running}))]
+                 (#'agent-command/process-sync-db-changes-event!
+                  {:root-dir root
+                   :base-url "http://127.0.0.1:1234"
+                   :log-fn (fn [_] nil)}
+                  {:repo "logseq_db_demo"
+                   :graph "demo"
+                   :agent-name "build-host"
+                   :routing-blocks* (atom #{})}
+                  {:tx-data [{:e 50
+                              :a :block/title
+                              :v (:block/title request-comment)}]}))
+               (p/then (fn [_]
+                         (is (fn? @start-on-exit*))
+                         (p/let [_ (p/delay 10)]
+                           (is (some #(= [:thread-api/apply-outliner-ops
+                                          ["logseq_db_demo"
+                                           [[:toggle-reaction [comment-uuid "x" nil]]]
+                                           {}]]
+                                         %)
+                                     @calls)))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (fs/rmSync root #js {:recursive true :force true})
+                            (done)))))))
+
+(deftest test-agent-bridge-listener-ignores-comment-like-title-without-comment-tag
+  (async done
+         (let [handler* (atom nil)
+               calls (atom [])
+               non-comment (comment-block {:block/tags []})]
+           (-> (p/with-redefs [transport/connect-events! (fn [_cfg handler]
+                                                           (reset! handler* handler)
+                                                           {:close! (fn [] nil)})
+                               transport/invoke (fn [_cfg method args]
+                                                  (swap! calls conj [method args])
+                                                  (case method
+                                                    :thread-api/pull
+                                                    (p/resolved non-comment)
+                                                    (p/rejected (ex-info "unexpected invoke"
+                                                                         {:method method
+                                                                          :args args}))))
+                               agent-command/start-codex! (fn [command _opts]
+                                                            (swap! calls conj [:codex command])
+                                                            (p/resolved {:session "should-not-run"
+                                                                         :status :running}))]
+                 (do
+                   (#'agent-command/listen-forever! {:root-dir "/tmp/logseq"
+                                                     :base-url "http://127.0.0.1:1234"
+                                                     :log-fn (fn [_] nil)}
+                                                    {:repo "logseq_db_demo"
+                                                     :graph "demo"
+                                                     :agent-name "build-host"})
+                   (@handler* :sync-db-changes {:tx-data [{:e 50
+                                                           :a :block/title
+                                                           :v (:block/title non-comment)}]})
+                   (p/let [_ (p/delay 10)]
+                     (is (not-any? #(= :codex (first %)) @calls)))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
 (deftest test-codex-session-id-capture
   (testing "captures the first Codex JSONL session id"
     (is (= "session-123"
@@ -192,7 +629,7 @@
            (-> (agent-command/start-codex! ["codex" "exec" "--json" "prompt"] {})
                (p/then (fn [result]
                          (is (= {:session "thread-late"
-                                  :status :running}
+                                 :status :running}
                                 (select-keys result [:session :status])))))
                (p/catch (fn [e]
                           (is false (str "unexpected error: " e))))
@@ -638,16 +1075,16 @@
                                  transport/invoke (fn [_cfg method args]
                                                     (swap! calls conj [method args])
                                                     (case method
-                                                 :thread-api/pull
-                                                 (let [[_repo selector lookup] args]
-                                                   (cond
-                                                     (= lookup :logseq.property/assignee)
-                                                     (p/resolved {:db/id 900
-                                                                  :db/ident :logseq.property/assignee})
+                                                      :thread-api/pull
+                                                      (let [[_repo selector lookup] args]
+                                                        (cond
+                                                          (= lookup :logseq.property/assignee)
+                                                          (p/resolved {:db/id 900
+                                                                       :db/ident :logseq.property/assignee})
 
-                                                     (= lookup 101)
-                                                     (p/resolved {:db/id 101
-                                                                  :block/title "build-host"})
+                                                          (= lookup 101)
+                                                          (p/resolved {:db/id 101
+                                                                       :block/title "build-host"})
 
                                                           (= lookup 42)
                                                           (p/resolved block)

--- a/src/test/logseq/cli/command/agent_test.cljs
+++ b/src/test/logseq/cli/command/agent_test.cljs
@@ -950,61 +950,107 @@
                             (set! (.-spawn child-process) original-spawn)
                             (done)))))))
 
-(deftest test-registration-writes-agent-name-to-graph
+(deftest test-registration-creates-agent-name-page
   (async done
          (let [calls* (atom [])
-               page-uuid (uuid "33333333-3333-3333-3333-333333333333")]
-           (p/finally
-             (p/catch
-              (p/with-redefs [agent-command/random-bridge-block-uuid (fn [] (uuid "44444444-4444-4444-4444-444444444444"))
-                              transport/invoke (fn [_ method args]
-                                                 (swap! calls* conj [method args])
-                                                 (case method
-                                                   :thread-api/q
-                                                   (let [[_ [query & query-args]] args]
-                                                     (cond
-                                                       (= query agent-command/agent-bridge-registry-page-query)
-                                                       (p/resolved [])
+               registry-page-uuid (uuid "33333333-3333-3333-3333-333333333333")
+               agent-page-uuid (uuid "44444444-4444-4444-4444-444444444444")]
+           (-> (p/with-redefs [transport/invoke
+                                (fn [_ method args]
+                                  (swap! calls* conj [method args])
+                                  (case method
+                                    :thread-api/q
+                                    (let [[_ [query & query-args]] args]
+                                      (cond
+                                        (= query agent-command/agent-bridge-registry-page-query)
+                                        (p/resolved [])
 
-                                                       (= query agent-command/registered-agent-query)
-                                                       (p/resolved [])
+                                        (= query agent-command/registered-agent-query)
+                                        (p/resolved [])
 
-                                                       :else
-                                                       (p/rejected (ex-info "unexpected query"
-                                                                            {:query query
-                                                                             :query-args query-args}))))
+                                        :else
+                                        (p/rejected (ex-info "unexpected query"
+                                                             {:query query
+                                                              :query-args query-args}))))
 
-                                                   :thread-api/apply-outliner-ops
-                                                   (let [[_ ops _] args]
-                                                     (if (= [[:create-page [agent-command/agent-bridge-registry-page {}]]] ops)
-                                                       (p/resolved [agent-command/agent-bridge-registry-page page-uuid])
-                                                       (p/resolved {:ok true})))
+                                    :thread-api/apply-outliner-ops
+                                    (let [[_ ops _] args]
+                                      (cond
+                                        (= [[:create-page [agent-command/agent-bridge-registry-page {}]]] ops)
+                                        (p/resolved [agent-command/agent-bridge-registry-page registry-page-uuid])
 
-                                                   :thread-api/pull
-                                                   (p/resolved {:db/id 300
-                                                                :block/uuid page-uuid
-                                                                :block/title agent-command/agent-bridge-registry-page})
+                                        (= [[:create-page ["build-host" {}]]] ops)
+                                        (p/resolved ["build-host" agent-page-uuid])
 
-                                                   (p/rejected (ex-info "unexpected invoke"
-                                                                        {:method method
-                                                                         :args args}))))]
-                (p/let [_ (agent-command/register-agent-bridge! {:root-dir "/tmp/logseq"} "logseq_db_demo" "build-host")]
-                  (let [apply-ops (->> @calls*
-                                       (filter #(= :thread-api/apply-outliner-ops (first %)))
-                                       (mapv (comp second second)))]
-                    (is (= [[:create-page [agent-command/agent-bridge-registry-page {}]]]
-                           (first apply-ops)))
-                    (is (= [[:insert-blocks [[{:block/title "build-host"
-                                               :block/uuid (uuid "44444444-4444-4444-4444-444444444444")}]
-                                             page-uuid
-                                             {:outliner-op :insert-blocks
-                                              :sibling? false
-                                              :bottom? true
-                                              :keep-uuid? true}]]]
-                           (second apply-ops))))))
-              (fn [e]
-                (is false (str "unexpected error: " e))))
-             done))))
+                                        :else
+                                        (p/rejected (ex-info "unexpected apply-outliner-ops"
+                                                             {:ops ops}))))
+
+                                    :thread-api/pull
+                                    (p/resolved {:db/id 300
+                                                 :block/uuid registry-page-uuid
+                                                 :block/title agent-command/agent-bridge-registry-page})
+
+                                    (p/rejected (ex-info "unexpected invoke"
+                                                         {:method method
+                                                          :args args}))))]
+                 (p/let [_ (agent-command/register-agent-bridge! {:root-dir "/tmp/logseq"} "logseq_db_demo" "build-host")]
+                   (let [apply-ops (->> @calls*
+                                        (filter #(= :thread-api/apply-outliner-ops (first %)))
+                                        (mapv (comp second second)))]
+                     (is (= [[:create-page [agent-command/agent-bridge-registry-page {}]]]
+                            (first apply-ops)))
+                     (is (= [[:create-page ["build-host" {}]]]
+                            (second apply-ops)))
+                     (is (not-any? #(= :insert-blocks (ffirst %)) apply-ops)))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
+(deftest test-registration-keeps-existing-agent-name-page
+  (async done
+         (let [calls* (atom [])
+               registry-page {:db/id 300
+                              :block/uuid (uuid "33333333-3333-3333-3333-333333333333")
+                              :block/name "agentbridge"
+                              :block/title agent-command/agent-bridge-registry-page}
+               agent-page {:db/id 400
+                           :block/uuid (uuid "44444444-4444-4444-4444-444444444444")
+                           :block/name "build-host"
+                           :block/title "build-host"}]
+           (-> (p/with-redefs [transport/invoke
+                                (fn [_ method args]
+                                  (swap! calls* conj [method args])
+                                  (case method
+                                    :thread-api/q
+                                    (let [[_ [query & query-args]] args]
+                                      (cond
+                                        (and (= query agent-command/agent-bridge-registry-page-query)
+                                             (= ["agentbridge"] query-args))
+                                        (p/resolved [registry-page])
+
+                                        (and (= query agent-command/registered-agent-query)
+                                             (= ["build-host"] query-args))
+                                        (p/resolved [agent-page])
+
+                                        :else
+                                        (p/rejected (ex-info "unexpected query"
+                                                             {:query query
+                                                              :query-args query-args}))))
+
+                                    :thread-api/apply-outliner-ops
+                                    (p/rejected (ex-info "unexpected apply-outliner-ops"
+                                                         {:args args}))
+
+                                    (p/rejected (ex-info "unexpected invoke"
+                                                         {:method method
+                                                          :args args}))))]
+                 (p/let [result (agent-command/register-agent-bridge! {:root-dir "/tmp/logseq"} "logseq_db_demo" "build-host")]
+                   (is (true? result))
+                   (is (not-any? #(= :thread-api/apply-outliner-ops (first %)) @calls*))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
 
 (deftest test-write-agent-session-id
   (async done

--- a/src/test/logseq/cli/command/agent_test.cljs
+++ b/src/test/logseq/cli/command/agent_test.cljs
@@ -26,9 +26,11 @@
   (merge {:db/id 42
           :block/uuid #uuid "11111111-1111-1111-1111-111111111111"
           :block/title "Ship the CLI bridge"
-          :block/tags [{:block/title "Task"}]
+          :block/tags [{:db/ident :logseq.class/Task
+                        :block/title "Task"}]
           :logseq.property/status {:db/ident :logseq.property/status.todo}
-          "Assignee" "build-host"}
+          :logseq.property/assignee [{:db/id 101
+                                      :block/title "build-host"}]}
          overrides))
 
 (defn- comment-block
@@ -85,14 +87,24 @@
                     "Reply instructions:"]]
     (is (string/includes? prompt expected))))
 
-(deftest test-assignee-built-in-property
-  (let [property (get db-property/built-in-properties :logseq.property/assignee)]
-    (is (= "Assignee" (:title property)))
-    (is (= :node (get-in property [:schema :type])))
-    (is (= :many (get-in property [:schema :cardinality])))
-    (is (= true (get-in property [:schema :public?])))
-    (is (= true (:queryable? property)))
-    (is (contains? db-property/public-built-in-properties :logseq.property/assignee))))
+(deftest test-agent-bridge-built-in-properties
+  (testing "Assignee is public and queryable"
+    (let [property (get db-property/built-in-properties :logseq.property/assignee)]
+      (is (= "Assignee" (:title property)))
+      (is (= :node (get-in property [:schema :type])))
+      (is (= :many (get-in property [:schema :cardinality])))
+      (is (= true (get-in property [:schema :public?])))
+      (is (= true (:queryable? property)))
+      (is (contains? db-property/public-built-in-properties :logseq.property/assignee))))
+
+  (testing "agent session id is an internal built-in property"
+    (let [property (get db-property/built-in-properties :logseq.property.agent/session-id)]
+      (is (= "agent session id" (:title property)))
+      (is (= :string (get-in property [:schema :type])))
+      (is (= :db.cardinality/one (get-in property [:schema :db/cardinality])))
+      (is (= false (get-in property [:schema :public?])))
+      (is (= true (get-in property [:schema :hide?])))
+      (is (not (contains? db-property/public-built-in-properties :logseq.property.agent/session-id))))))
 
 (deftest test-agent-command-entries
   (testing "parse agent bridge command surface"
@@ -170,8 +182,7 @@
 
   (testing "routes built-in Assignee node values with many cardinality"
     (is (true? (agent-command/routable-task?
-                (task-block {"Assignee" nil
-                             :logseq.property/assignee [{:db/id 101
+                (task-block {:logseq.property/assignee [{:db/id 101
                                                          :block/title "build-host"}]})
                 "build-host"))))
 
@@ -184,10 +195,11 @@
            (:reason (agent-command/routable-task-decision (task-block {:logseq.property/status {:db/ident :logseq.property/status.done}})
                                                           "build-host"))))
     (is (= :assignee-mismatch
-           (:reason (agent-command/routable-task-decision (task-block {"Assignee" "other-host"})
+           (:reason (agent-command/routable-task-decision (task-block {:logseq.property/assignee [{:db/id 102
+                                                                                                    :block/title "other-host"}]})
                                                           "build-host"))))
     (is (= :already-routed
-           (:reason (agent-command/routable-task-decision (task-block {"agent-session-id" "codex-1"})
+           (:reason (agent-command/routable-task-decision (task-block {:logseq.property.agent/session-id "codex-1"})
                                                           "build-host"))))))
 
 (deftest test-prompt-and-command
@@ -506,7 +518,7 @@
                                                              {:lookup lookup}))))
 
                                     :thread-api/q
-                                    (p/resolved [])
+                                    (p/resolved nil)
 
                                     :thread-api/apply-outliner-ops
                                     (p/resolved {:ok true})
@@ -540,7 +552,8 @@
                    :routing-blocks* (atom #{})}
                   {:tx-data [{:e 50
                               :a :block/title
-                              :v (:block/title request-comment)}]}))
+                              :v (:block/title request-comment)
+                              :added true}]}))
                (p/then (fn [_]
                          (is (not-any? #(= :broad-scan (first %)) @calls))
                          (is (some #(= [:thread-api/apply-outliner-ops
@@ -588,7 +601,7 @@
                                         (p/rejected (ex-info "unexpected pull"
                                                              {:lookup lookup}))))
                                     :thread-api/q
-                                    (p/resolved [])
+                                    (p/resolved nil)
                                     :thread-api/apply-outliner-ops
                                     (p/resolved {:ok true})
                                     (p/rejected (ex-info "unexpected invoke"
@@ -615,7 +628,8 @@
                    :routing-blocks* (atom #{})}
                   {:tx-data [{:e 50
                               :a :block/title
-                              :v (:block/title request-comment)}]}))
+                              :v (:block/title request-comment)
+                              :added true}]}))
                (p/then (fn [_]
                          (is (some #(= :codex (first %)) @calls))
                          (is (some #(= [:thread-api/apply-outliner-ops
@@ -636,7 +650,7 @@
                calls (atom [])
                request-comment (comment-block {})
                commented-block (assoc (first (:logseq.property.comments/blocks (comments-area-block {})))
-                                      "agent-session-id" "existing-session-123"
+                                      :logseq.property.agent/session-id "existing-session-123"
                                       :logseq.property/assignee [{:db/id 101
                                                                   :block/title "build-host"}])
                comments-area (comments-area-block {:logseq.property.comments/blocks [commented-block]})]
@@ -652,7 +666,7 @@
                                         (p/rejected (ex-info "unexpected pull"
                                                              {:lookup lookup}))))
                                     :thread-api/q
-                                    (p/resolved [])
+                                    (p/resolved nil)
                                     :thread-api/apply-outliner-ops
                                     (p/resolved {:ok true})
                                     (p/rejected (ex-info "unexpected invoke"
@@ -679,7 +693,8 @@
                    :routing-blocks* (atom #{})}
                   {:tx-data [{:e 50
                               :a :block/title
-                              :v (:block/title request-comment)}]}))
+                              :v (:block/title request-comment)
+                              :added true}]}))
                (p/then (fn [_]
                          (let [[_ command] (some #(when (= :codex (first %)) %) @calls)]
                            (is (some? command))
@@ -699,7 +714,7 @@
                calls (atom [])
                request-comment (comment-block {})
                commented-block (assoc (first (:logseq.property.comments/blocks (comments-area-block {})))
-                                      "agent-session-id" "existing-session-123"
+                                      :logseq.property.agent/session-id "existing-session-123"
                                       :logseq.property/assignee [{:db/id 101
                                                                   :block/title "other-host"}])
                comments-area (comments-area-block {:logseq.property.comments/blocks [commented-block]})]
@@ -715,7 +730,7 @@
                                         (p/rejected (ex-info "unexpected pull"
                                                              {:lookup lookup}))))
                                     :thread-api/q
-                                    (p/resolved [])
+                                    (p/resolved nil)
                                     :thread-api/apply-outliner-ops
                                     (p/resolved {:ok true})
                                     (p/rejected (ex-info "unexpected invoke"
@@ -742,7 +757,8 @@
                    :routing-blocks* (atom #{})}
                   {:tx-data [{:e 50
                               :a :block/title
-                              :v (:block/title request-comment)}]}))
+                              :v (:block/title request-comment)
+                              :added true}]}))
                (p/then (fn [_]
                          (let [[_ command] (some #(when (= :codex (first %)) %) @calls)]
                            (is (some? command))
@@ -776,7 +792,7 @@
                                         (p/rejected (ex-info "unexpected pull"
                                                              {:lookup lookup}))))
                                     :thread-api/q
-                                    (p/resolved [])
+                                    (p/resolved nil)
                                     :thread-api/apply-outliner-ops
                                     (p/resolved {:ok true})
                                     (p/rejected (ex-info "unexpected invoke"
@@ -804,7 +820,8 @@
                    :routing-blocks* (atom #{})}
                   {:tx-data [{:e 50
                               :a :block/title
-                              :v (:block/title request-comment)}]}))
+                              :v (:block/title request-comment)
+                              :added true}]}))
                (p/then (fn [_]
                          (is (fn? @start-on-exit*))
                          (p/let [_ (p/delay 10)]
@@ -849,7 +866,8 @@
                                                      :agent-name "build-host"})
                    (@handler* :sync-db-changes {:tx-data [{:e 50
                                                            :a :block/title
-                                                           :v (:block/title non-comment)}]})
+                                                           :v (:block/title non-comment)
+                                                           :added true}]})
                    (p/let [_ (p/delay 10)]
                      (is (not-any? #(= :codex (first %)) @calls)))))
                (p/catch (fn [e]
@@ -1055,21 +1073,12 @@
 (deftest test-write-agent-session-id
   (async done
          (let [ops* (atom [])
-               property-query-count* (atom 0)
-               property-ident :user.property/agent-session-id
                block-uuid (uuid "11111111-1111-1111-1111-111111111111")]
            (-> (p/with-redefs [transport/invoke (fn [_ method args]
                                                   (case method
                                                     :thread-api/q
-                                                    (let [[_ [query & _query-args]] args]
-                                                      (if (= query agent-command/agent-session-id-property-query)
-                                                        (p/resolved (if (= 1 (swap! property-query-count* inc))
-                                                                      []
-                                                                      [{:db/id 700
-                                                                        :db/ident property-ident
-                                                                        :block/title "agent-session-id"}]))
-                                                        (p/rejected (ex-info "unexpected query"
-                                                                             {:query query}))))
+                                                    (p/rejected (ex-info "agent session id is built-in and should not be queried"
+                                                                         {:args args}))
 
                                                     :thread-api/apply-outliner-ops
                                                     (let [[_ ops _] args]
@@ -1083,11 +1092,10 @@
                                                                   "logseq_db_demo"
                                                                   block-uuid
                                                                   "session-123")]
-                   (is (= [[:upsert-property [nil
-                                              {:logseq.property/type :default
-                                               :db/cardinality :db.cardinality/one}
-                                              {:property-name "agent-session-id"}]]
-                           [:batch-set-property [[block-uuid] property-ident "session-123" {}]]]
+                   (is (= [[:batch-set-property [[block-uuid]
+                                                  :logseq.property.agent/session-id
+                                                  "session-123"
+                                                  {}]]]
                           @ops*))))
                (p/catch (fn [e]
                           (is false (str "unexpected error: " e))))
@@ -1305,7 +1313,21 @@
                                                            {:close! (fn [] nil)})
                                agent-command/list-routable-tasks (fn [_cfg _repo _agent-name]
                                                                    (swap! broad-scans* inc)
-                                                                   (p/resolved []))]
+                                                                   (p/resolved []))
+                               transport/invoke (fn [_cfg method args]
+                                                  (case method
+                                                    :thread-api/pull
+                                                    (let [[_repo selector lookup] args]
+                                                      (if (and (= selector [:db/id :block/title :block/name])
+                                                               (= lookup 102))
+                                                        (p/resolved {:db/id 102
+                                                                     :block/title "other-host"})
+                                                        (p/rejected (ex-info "unexpected pull"
+                                                                             {:selector selector
+                                                                              :lookup lookup}))))
+                                                    (p/rejected (ex-info "unexpected invoke"
+                                                                         {:method method
+                                                                          :args args}))))]
                  (do
                    (#'agent-command/listen-forever! {:root-dir "/tmp/logseq"
                                                      :base-url "http://127.0.0.1:1234"
@@ -1316,14 +1338,16 @@
                    (@handler* :rtc-log {:tx-data [{:e 42
                                                    :a :logseq.property/assignee
                                                    :v {:db/id 101
-                                                       :block/title "build-host"}}]})
+                                                       :block/title "build-host"}
+                                                   :added true}]})
                    (@handler* :sync-db-changes {:tx-data [{:e 42
                                                            :a :block/title
-                                                           :v "renamed"}]})
+                                                           :v "renamed"
+                                                           :added true}]})
                    (@handler* :sync-db-changes {:tx-data [{:e 42
                                                            :a :logseq.property/assignee
-                                                           :v {:db/id 102
-                                                               :block/title "other-host"}}]})
+                                                           :v 102
+                                                           :added true}]})
                    (p/let [_ (p/delay 5)]
                      (is (= 0 @broad-scans*)))))
                (p/catch (fn [e]
@@ -1359,7 +1383,8 @@
                    (@handler* :sync-db-changes {:tx-data [{:e 42
                                                            :a :logseq.property/assignee
                                                            :v {:db/id 101
-                                                               :block/title "build-host"}}]})
+                                                               :block/title "build-host"}
+                                                           :added true}]})
                    (p/let [_ (p/delay 5)]
                      (is (= [1] @exit-calls*))
                      (is (= [{:reason :task-processing-failed
@@ -1382,8 +1407,7 @@
          (let [root (temp-root)
                handler* (atom nil)
                calls (atom [])
-               block (task-block {"Assignee" nil
-                                  :logseq.property/assignee [{:db/id 101
+               block (task-block {:logseq.property/assignee [{:db/id 101
                                                               :block/title "build-host"}]})]
            (try
              (-> (p/with-redefs [transport/connect-events! (fn [_cfg handler]
@@ -1440,7 +1464,8 @@
                                                        :agent-name "build-host"})
                      (@handler* :sync-db-changes {:tx-data [{:e 42
                                                              :a 900
-                                                             :v 101}]})
+                                                             :v 101
+                                                             :added true}]})
                      (p/let [_ (p/delay 5)]
                        (is (not-any? #(= :broad-scan (first %)) @calls))
                        (is (some #(= [:thread-api/pull ["logseq_db_demo" [:db/id :db/ident] :logseq.property/assignee]] %)

--- a/src/test/logseq/cli/command/agent_test.cljs
+++ b/src/test/logseq/cli/command/agent_test.cljs
@@ -211,6 +211,268 @@
       (is (string/starts-with? preview "codex exec --json '"))
       (is (string/includes? preview "Ship the CLI bridge")))))
 
+(deftest test-prompt-templates
+  (testing "prompt builders render supplied graph templates"
+    (let [prompt (agent-command/build-codex-prompt
+                  {:graph "demo"
+                   :agent-name "build-host"
+                   :block (task-block {})
+                   :tree-text "- Ship the CLI bridge"
+                   :prompt-template "Task {{graph}} {{block-uuid}} {{agent-name}}\n{{task-block-tree}}"})
+          comment-prompt (#'agent-command/build-comment-codex-prompt
+                          {:graph "demo"
+                           :agent-name "build-host"
+                           :comment (comment-block {})
+                           :target-tree-texts ["- Target block"]
+                           :comments-area-tree-text "- Comments"
+                           :comment-tree-text "- [[build-host]] summarize"
+                           :prompt-template "Comment {{graph}} {{comment-uuid}} {{agent-name}}\n{{comment-target-context}}\n{{comment-thread-context}}\n{{requesting-comment}}"})]
+      (is (= "Task demo 11111111-1111-1111-1111-111111111111 build-host\n- Ship the CLI bridge"
+             prompt))
+      (is (string/includes? comment-prompt
+                            "Comment demo 55555555-5555-5555-5555-555555555555 build-host"))
+      (is (string/includes? comment-prompt "- Target block"))
+      (is (string/includes? comment-prompt "- [[build-host]] summarize"))))
+
+  (testing "template lint fails on missing and unknown vars"
+    (let [missing-result (#'agent-command/validate-prompt-template
+                          :task
+                          "Task {{graph}} {{block-uuid}} {{agent-name}}")
+          unknown-result (#'agent-command/validate-prompt-template
+                          :task
+                          "Task {{graph}} {{block-uuid}} {{agent-name}} {{task-block-tree}} {{extra}}")]
+      (is (false? (:ok? missing-result)))
+      (is (= :missing-template-vars (get-in missing-result [:error :code])))
+      (is (= #{"task-block-tree"} (get-in missing-result [:error :vars])))
+      (is (false? (:ok? unknown-result)))
+      (is (= :unknown-template-vars (get-in unknown-result [:error :code])))
+      (is (= #{"extra"} (get-in unknown-result [:error :vars]))))))
+
+(deftest test-prompt-template-reader-ignores-documentation-code-fences
+  (testing "template reader ignores variable documentation code fences"
+    (let [template (#'agent-command/prompt-template-from-block
+                    :task
+                    {:block/title agent-command/task-prompt-template-title
+                     :block/children [{:block/title "```text\n'{{graph}}': Graph name\n'{{block-uuid}}': Block UUID\n'{{agent-name}}': AgentBridge name\n'{{task-block-tree}}': Task tree\n```"}
+                                      {:block/title "```text\nTask {{graph}} {{block-uuid}} {{agent-name}}\n{{task-block-tree}}\n```"}]})]
+      (is (= "Task {{graph}} {{block-uuid}} {{agent-name}}\n{{task-block-tree}}\n"
+             template)))))
+
+(deftest test-agent-bridge-initializes-default-prompt-templates
+  (async done
+         (let [calls* (atom [])
+               page-uuid (uuid "33333333-3333-3333-3333-333333333333")]
+           (-> (p/with-redefs [transport/invoke
+                                (fn [_cfg method args]
+                                  (swap! calls* conj [method args])
+                                  (case method
+                                    :thread-api/q
+                                    (let [[_ [query & _query-args]] args]
+                                      (cond
+                                        (= query agent-command/agent-bridge-registry-page-query)
+                                        (p/resolved [])
+
+                                        (= query agent-command/agent-bridge-prompt-template-blocks-query)
+                                        (p/resolved [])
+
+                                        :else
+                                        (p/rejected (ex-info "unexpected query"
+                                                             {:query query}))))
+
+                                    :thread-api/apply-outliner-ops
+                                    (let [[_ ops _] args]
+                                      (if (= [[:create-page [agent-command/agent-bridge-registry-page {}]]] ops)
+                                        (p/resolved [agent-command/agent-bridge-registry-page page-uuid])
+                                        (p/resolved {:ok true})))
+
+                                    :thread-api/pull
+                                    (p/resolved {:db/id 300
+                                                 :block/uuid page-uuid
+                                                 :block/title agent-command/agent-bridge-registry-page})
+
+                                    (p/rejected (ex-info "unexpected invoke"
+                                                         {:method method
+                                                          :args args}))))]
+                 (p/let [templates (agent-command/ensure-agent-bridge-prompt-templates!
+                                    {:root-dir "/tmp/logseq"}
+                                    "logseq_db_demo")]
+                   (is (string/includes? (:task templates) "{{task-block-tree}}"))
+                   (is (string/includes? (:comment templates) "{{requesting-comment}}"))
+                   (let [insert-ops (->> @calls*
+                                         (filter #(= :thread-api/apply-outliner-ops (first %)))
+                                         (mapv (comp second second)))]
+                     (is (= [[:create-page [agent-command/agent-bridge-registry-page {}]]]
+                            (first insert-ops)))
+                     (let [inserted-blocks (-> (second insert-ops) first second first)
+                           root-blocks (filter #(nil? (:block/parent %)) inserted-blocks)
+                           root-uuids (set (map :block/uuid root-blocks))
+                           child-blocks (remove #(nil? (:block/parent %)) inserted-blocks)]
+                       (is (= #{agent-command/task-prompt-template-title
+                                agent-command/comment-prompt-template-title}
+                              (set (map :block/title root-blocks))))
+                       (is (= 8 (count inserted-blocks)))
+                       (is (some #(string/includes? (:block/title %) "```text\n'{{graph}}'")
+                                 child-blocks))
+                       (is (not-any? #(re-find #"- \{\{[A-Za-z0-9-]+\}\}:"
+                                               (:block/title %))
+                                     child-blocks))
+                       (is (every? #(contains? root-uuids (second (:block/parent %))) child-blocks))))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
+(deftest test-agent-bridge-ignores-recycled-registry-page
+  (async done
+         (let [calls* (atom [])
+               recycled-page {:db/id 188
+                              :block/uuid (uuid "22222222-2222-2222-2222-222222222222")
+                              :block/name "agentbridge"
+                              :block/title agent-command/agent-bridge-registry-page
+                              :block/parent {:db/id 183
+                                             :logseq.property/deleted-at 1}}
+               live-page-uuid (uuid "33333333-3333-3333-3333-333333333333")
+               live-page {:db/id 300
+                          :block/uuid live-page-uuid
+                          :block/name "agentbridge"
+                          :block/title agent-command/agent-bridge-registry-page}]
+           (-> (p/with-redefs [transport/invoke
+                                (fn [_cfg method args]
+                                  (swap! calls* conj [method args])
+                                  (case method
+                                    :thread-api/q
+                                    (let [[_ [query & _query-args]] args]
+                                      (cond
+                                        (= query agent-command/agent-bridge-registry-page-query)
+                                        (p/resolved [recycled-page])
+
+                                        (= query agent-command/agent-bridge-prompt-template-blocks-query)
+                                        (p/resolved [])
+
+                                        :else
+                                        (p/rejected (ex-info "unexpected query"
+                                                             {:query query}))))
+
+                                    :thread-api/apply-outliner-ops
+                                    (let [[_ ops _] args]
+                                      (if (= [[:create-page [agent-command/agent-bridge-registry-page {}]]] ops)
+                                        (p/resolved [agent-command/agent-bridge-registry-page live-page-uuid])
+                                        (p/resolved {:ok true})))
+
+                                    :thread-api/pull
+                                    (p/resolved live-page)
+
+                                    (p/rejected (ex-info "unexpected invoke"
+                                                         {:method method
+                                                          :args args}))))]
+                 (p/let [templates (agent-command/ensure-agent-bridge-prompt-templates!
+                                    {:root-dir "/tmp/logseq"}
+                                    "logseq_db_demo")]
+                   (is (string/includes? (:task templates) "{{task-block-tree}}"))
+                   (is (some #(= [:thread-api/apply-outliner-ops
+                                  ["logseq_db_demo"
+                                   [[:create-page [agent-command/agent-bridge-registry-page {}]]]
+                                   {}]]
+                                %)
+                             @calls*))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
+(deftest test-agent-bridge-repairs-template-root-without-code-block
+  (async done
+         (let [calls* (atom [])
+               page-uuid (uuid "33333333-3333-3333-3333-333333333333")
+               comment-template-uuid (uuid "44444444-4444-4444-4444-444444444444")
+               page {:db/id 300
+                     :block/uuid page-uuid
+                     :block/title agent-command/agent-bridge-registry-page}
+               broken-comment-template {:db/id 401
+                                        :block/uuid comment-template-uuid
+                                        :block/title agent-command/comment-prompt-template-title}]
+           (-> (p/with-redefs [transport/invoke
+                                (fn [_cfg method args]
+                                  (swap! calls* conj [method args])
+                                  (case method
+                                    :thread-api/q
+                                    (let [[_ [query & _query-args]] args]
+                                      (cond
+                                        (= query agent-command/agent-bridge-registry-page-query)
+                                        (p/resolved [page])
+
+                                        (= query agent-command/agent-bridge-prompt-template-blocks-query)
+                                        (p/resolved [broken-comment-template])
+
+                                        :else
+                                        (p/rejected (ex-info "unexpected query"
+                                                             {:query query}))))
+
+                                    :thread-api/apply-outliner-ops
+                                    (p/resolved {:ok true})
+
+                                    (p/rejected (ex-info "unexpected invoke"
+                                                         {:method method
+                                                          :args args}))))]
+                 (p/let [templates (agent-command/ensure-agent-bridge-prompt-templates!
+                                    {:root-dir "/tmp/logseq"}
+                                    "logseq_db_demo")]
+                   (is (string/includes? (:task templates) "{{task-block-tree}}"))
+                   (is (string/includes? (:comment templates) "{{requesting-comment}}"))
+                   (let [insert-ops (->> @calls*
+                                         (filter #(= :thread-api/apply-outliner-ops (first %)))
+                                         (mapv (comp second second)))
+                         child-repair-op (first (filter #(= comment-template-uuid
+                                                             (-> % first second second))
+                                                        insert-ops))]
+                     (is (some? child-repair-op))
+                     (is (some #(string/includes? (:block/title %) "{{requesting-comment}}")
+                               (-> child-repair-op first second first))))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
+(deftest test-agent-bridge-template-initialization-lints-existing-page
+  (async done
+         (let [bad-template-block {:db/id 401
+                                   :block/title agent-command/task-prompt-template-title
+                                   :block/children [{:db/id 402
+                                                     :block/title "```text\nTask {{graph}} {{block-uuid}} {{agent-name}} {{unknown}}\n```"}]}
+               page {:db/id 300
+                     :block/uuid (uuid "33333333-3333-3333-3333-333333333333")
+                     :block/title agent-command/agent-bridge-registry-page}]
+           (-> (p/with-redefs [transport/invoke
+                                (fn [_cfg method args]
+                                  (case method
+                                    :thread-api/q
+                                    (let [[_ [query & _query-args]] args]
+                                      (cond
+                                        (= query agent-command/agent-bridge-registry-page-query)
+                                        (p/resolved [page])
+
+                                        (= query agent-command/agent-bridge-prompt-template-blocks-query)
+                                        (p/resolved [bad-template-block])
+
+                                        :else
+                                        (p/rejected (ex-info "unexpected query"
+                                                             {:query query}))))
+
+                                    :thread-api/apply-outliner-ops
+                                    (p/resolved {:ok true})
+
+                                    (p/rejected (ex-info "unexpected invoke"
+                                                         {:method method
+                                                          :args args}))))]
+                 (agent-command/ensure-agent-bridge-prompt-templates!
+                  {:root-dir "/tmp/logseq"}
+                  "logseq_db_demo"))
+               (p/then (fn [_]
+                         (is false "expected template lint to fail")))
+               (p/catch (fn [e]
+                          (is (= :agent-prompt-template-invalid
+                                 (:code (ex-data e))))
+                          (is (= :task
+                                 (:template (ex-data e))))))
+               (p/finally done)))))
+
 (deftest test-agent-bridge-listener-routes-comment-mention-with-context-and-reactions
   (async done
          (let [root (temp-root)
@@ -886,6 +1148,11 @@
                                agent-command/register-agent-bridge! (fn [cfg repo agent-name]
                                                                       (swap! calls conj [:register (:root-dir cfg) repo agent-name])
                                                                       (p/resolved true))
+                               agent-command/ensure-agent-bridge-prompt-templates!
+                               (fn [cfg repo]
+                                 (swap! calls conj [:prompt-templates (:root-dir cfg) repo])
+                                 (p/resolved {:task "Custom task {{graph}} {{block-uuid}} {{agent-name}}\n{{task-block-tree}}"
+                                              :comment "Custom comment {{graph}} {{comment-uuid}} {{agent-name}}\n{{comment-target-context}}\n{{comment-thread-context}}\n{{requesting-comment}}"}))
                                agent-command/list-routable-tasks (fn [_cfg repo agent-name]
                                                                    (swap! calls conj [:list repo agent-name])
                                                                    (p/resolved [{:block (task-block {})
@@ -899,10 +1166,15 @@
                    (is (= :ok (:status result)))
                    (is (= :dry-run (get-in result [:data :mode])))
                    (is (= [[:ensure-server "/tmp/logseq" "logseq_db_demo"]
+                           [:prompt-templates "/tmp/logseq" "logseq_db_demo"]
                            [:register "/tmp/logseq" "logseq_db_demo" "build-host"]
                            [:list "logseq_db_demo" "build-host"]]
                           @calls))
                    (is (= 1 (count (get-in result [:data :commands]))))
+                   (is (string/includes? (get-in result [:data :commands 0 :command 3])
+                                         "Custom task demo"))
+                   (is (not (string/includes? (get-in result [:data :commands 0 :command 3])
+                                               "You are handling a Logseq AgentBridge task.")))
                    (is (string/includes? (first (get-in result [:data :logs]))
                                          "checking the environment"))
                    (is (string/includes? (last (get-in result [:data :logs]))
@@ -926,6 +1198,11 @@
                                 agent-command/register-agent-bridge! (fn [_cfg repo agent-name]
                                                                        (swap! calls conj [:register repo agent-name])
                                                                        (p/resolved true))
+                                agent-command/ensure-agent-bridge-prompt-templates!
+                                (fn [_cfg repo]
+                                  (swap! calls conj [:prompt-templates repo])
+                                  (p/resolved {:task "Task {{graph}} {{block-uuid}} {{agent-name}}\n{{task-block-tree}}"
+                                               :comment "Comment {{graph}} {{comment-uuid}} {{agent-name}}\n{{comment-target-context}}\n{{comment-thread-context}}\n{{requesting-comment}}"}))
                                 agent-command/list-routable-tasks (fn [_cfg repo agent-name]
                                                                     (swap! calls conj [:list repo agent-name])
                                                                     (p/resolved [{:block block
@@ -948,13 +1225,10 @@
                     (is (= :ok (:status result)))
                     (is (= :processed-once (get-in result [:data :mode])))
                     (is (= [[:ensure-server root "logseq_db_demo"]
+                            [:prompt-templates "logseq_db_demo"]
                             [:register "logseq_db_demo" "build-host"]
                             [:list "logseq_db_demo" "build-host"]
-                            [:codex ["codex" "exec" "--json" (agent-command/build-codex-prompt
-                                                              {:graph "demo"
-                                                               :agent-name "build-host"
-                                                               :block block
-                                                               :tree-text "- Ship the CLI bridge"})]]
+                            [:codex ["codex" "exec" "--json" "Task demo 11111111-1111-1111-1111-111111111111 build-host\n- Ship the CLI bridge"]]
                             [:ensure-server root "logseq_db_demo"]
                             [:write-session "logseq_db_demo" (:block/uuid block) "session-123"]]
                            @calls))

--- a/src/test/logseq/cli/server_test.cljs
+++ b/src/test/logseq/cli/server_test.cljs
@@ -7,6 +7,7 @@
             [cljs.test :refer [async deftest is]]
             [clojure.string :as string]
             [frontend.test.node-helper :as node-helper]
+            [lambdaisland.glogi :as log]
             [logseq.cli.config :as cli-config]
             [logseq.cli.profile :as profile]
             [logseq.cli.server :as cli-server]
@@ -171,6 +172,11 @@
                discover-calls (atom 0)
                spawn-calls (atom 0)
                shutdown-calls (atom 0)
+               info-logs (atom [])
+               log-handler (fn [record]
+                             (when-let [data (get (:message record)
+                                                  :cli-server-restart-version-mismatch)]
+                               (swap! info-logs conj data)))
                old-server (revision-test-server {:repo repo
                                                  :port 9411
                                                  :owner-source :cli
@@ -199,6 +205,7 @@
                                                                             [new-server]))))
                                daemon/wait-for-lock (fn [_] (p/resolved true))
                                daemon/wait-for-ready (fn [_] (p/resolved true))]
+                 (log/add-handler log-handler)
                  (cli-server/ensure-server! {:root-dir root-dir
                                              :owner-source :cli
                                              :expected-revision "expected-revision"}
@@ -206,10 +213,22 @@
                (p/then (fn [config]
                          (is (= "http://127.0.0.1:9412" (:base-url config)))
                          (is (= 1 @shutdown-calls))
-                         (is (= 1 @spawn-calls))))
+                         (is (= 1 @spawn-calls))
+                         (is (= [{:repo repo
+                                  :expected-revision "expected-revision"
+                                  :current-revision "old-revision"
+                                  :owner-source :cli
+                                  :pid (.-pid js/process)
+                                  :host "127.0.0.1"
+                                  :port 9411
+                                  :root-dir root-dir
+                                  :status :ready}]
+                                @info-logs))))
                (p/catch (fn [e]
                           (is false (str "unexpected error: " e))))
-               (p/finally done)))))
+               (p/finally (fn []
+                            (log/remove-handler log-handler)
+                            (done)))))))
 
 (deftest ensure-server-restarts-cross-owner-mismatched-revision
   (async done

--- a/src/test/logseq/db_worker/daemon_test.cljs
+++ b/src/test/logseq/db_worker/daemon_test.cljs
@@ -36,6 +36,12 @@
       (is (not-any? #{"/tmp/server-list"} (:args @captured)))
       (is (not-any? #{"--host" "--port"} (:args @captured)))
       (is (= true (get-in @captured [:opts :detached])))
+      (let [stdio (get-in @captured [:opts :stdio])]
+        (is (vector? stdio))
+        (is (= "ignore" (first stdio)))
+        (is (number? (second stdio)))
+        (is (number? (nth stdio 2))))
+      (is (= "1" (get-in @captured [:opts :env :LOGSEQ_DB_WORKER_NODE_STDIO_REDIRECTED_TO_LOG])))
       (is (= "1" (get-in @captured [:opts :env :ELECTRON_RUN_AS_NODE])))
       (is (= true @unref-called?))
       (finally


### PR DESCRIPTION
## Summary
- Add agent bridge command support for routing tasks, recording sessions, and listing bridge runs.
- Improve `db-worker-node` and CLI server lifecycle logging for startup version, restart mismatch details, and exit reasons.
- Add AgentBridge session-id built-in property support, including schema migration, property classification, and description metadata.
- Extend CLI docs, e2e coverage, and db property/schema support for the agent bridge workflow.

## Testing
- Unit tests added/updated for agent bridge routing, exit logging, server restart diagnostics, db-worker-node startup logging, AgentBridge session-id property metadata, and schema migration.
- `bb dev:test -v logseq.cli.command.agent-test/test-agent-bridge-built-in-properties`
- `bb dev:test -v frontend.worker.migrate-test/migrate-65-31-adds-agent-session-id-property`
- `bb dev:test -v frontend.worker.migrate-test`
- `bb dev:test -v logseq.cli.command.agent-test`
- `git diff --check`
- `logseq-cli` compiled successfully.
- CLI non-sync e2e passed.