### PR TITLE
enhance: add #Comment tag

### DIFF
--- a/deps/db/src/logseq/db/frontend/class.cljs
+++ b/deps/db/src/logseq/db/frontend/class.cljs
@@ -47,6 +47,10 @@
                    :logseq.property/icon {:type :emoji, :id "speech_balloon"}}
       :schema {:properties [:logseq.property.comments/blocks]}}
 
+     :logseq.class/Comment
+     {:title "Comment"
+      :properties {:logseq.property.class/hide-from-node true}}
+
      :logseq.class/Query
      {:title "Query"
       :properties {:logseq.property/icon {:type :tabler-icon :id "search"}}

--- a/deps/db/src/logseq/db/frontend/malli_schema.cljs
+++ b/deps/db/src/logseq/db/frontend/malli_schema.cljs
@@ -380,11 +380,11 @@
                        (let [ident (:db/ident m)]
 
                          (cond
-                           (or (some->> ident db-property/logseq-property?)
+                           (or (and ident (db-property/logseq-property? ident))
                                (contains? db-property/db-attribute-properties (:db/ident m)))
                            :internal
 
-                           (some->> ident db-property/plugin-property?)
+                           (and ident (db-property/plugin-property? ident))
                            :plugin
 
                            :else

--- a/deps/db/src/logseq/db/frontend/schema.cljs
+++ b/deps/db/src/logseq/db/frontend/schema.cljs
@@ -30,7 +30,7 @@
          (map (juxt :major :minor)
               [(parse-schema-version x) (parse-schema-version y)])))
 
-(def version (parse-schema-version "65.27"))
+(def version (parse-schema-version "65.28"))
 
 (defn major-version
   "Return a number.

--- a/deps/outliner/src/logseq/outliner/core.cljs
+++ b/deps/outliner/src/logseq/outliner/core.cljs
@@ -838,26 +838,35 @@
     (if reversed? (reverse top-level-blocks) top-level-blocks)))
 
 (def ^:private comments-tag-ident :logseq.class/Comments)
+(def ^:private comment-tag-ident :logseq.class/Comment)
 (def ^:private comments-blocks-property :logseq.property.comments/blocks)
+
+(defn- tagged-with?
+  [block tag-ident]
+  (boolean
+   (some (fn [tag]
+           (= tag-ident
+              (if (keyword? tag) tag (:db/ident tag))))
+         (:block/tags block))))
 
 (defn- comments-area?
   [block]
-  (boolean
-   (some (fn [tag]
-           (= comments-tag-ident
-              (if (keyword? tag) tag (:db/ident tag))))
-         (:block/tags block))))
+  (tagged-with? block comments-tag-ident))
+
+(defn- comment-block?
+  [block]
+  (or (tagged-with? block comment-tag-ident)
+      (comments-area? (:block/parent block))))
 
 (defn- protected-comment-block?
   [block]
   (or (comments-area? block)
-      (comments-area? (:block/parent block))))
+      (comment-block? block)))
 
 (defn- move-target-allowed-for-comments?
-  [target-block sibling?]
-  (and (not (comments-area? (:block/parent target-block)))
-       (or sibling?
-           (not (comments-area? target-block)))))
+  [target-block]
+  (and (not (comments-area? target-block))
+       (not (comment-block? target-block))))
 
 (defn- block-subtree-ids
   [db block]
@@ -1032,8 +1041,11 @@
                            :payload {:message "Built-in nodes can't be modified"
                                      :type :error}})))))
     (let [db @conn
+          current-blocks (map (fn [block]
+                                (d/entity db (:db/id block)))
+                              blocks)
           top-level-blocks (remove protected-comment-block?
-                                   (filter-top-level-blocks db blocks))]
+                                   (filter-top-level-blocks db current-blocks))]
       (when (seq top-level-blocks)
         (let [[target-block sibling?] (get-target-block db top-level-blocks target-block opts)
               non-consecutive? (and (> (count top-level-blocks) 1) (seq (ldb/get-non-consecutive-blocks db top-level-blocks)))
@@ -1046,7 +1058,7 @@
                                    block
                                    (d/entity db (:db/id block))))))
               original-position? (move-to-original-position? blocks target-block sibling? non-consecutive?)]
-          (when (and (move-target-allowed-for-comments? target-block sibling?)
+          (when (and (move-target-allowed-for-comments? target-block)
                      (not (contains? (set (map :db/id blocks)) (:db/id target-block)))
                      (not original-position?))
             (let [parents' (->> (ldb/get-block-parents db (:block/uuid target-block) {})

--- a/deps/outliner/test/logseq/outliner/core_test.cljs
+++ b/deps/outliner/test/logseq/outliner/core_test.cljs
@@ -170,3 +170,52 @@
     (is (thrown-with-msg? js/Error #"Built-in.*can't be modified"
           (db-test/silence-stderr
             (outliner-core/move-blocks! conn [placeholder] target {:sibling? true}))))))
+
+(deftest move-blocks-protects-comment-blocks
+  (let [conn (db-test/create-conn-with-blocks
+              [{:page {:block/title "page1"}
+                :blocks [{:block/title "target"}
+                         {:block/title "tagged comment"}
+                         {:block/title "normal parent"
+                          :build/children [{:block/title "ordinary"}]}
+                         {:block/title "Comments"}]}])
+        page (ldb/get-page @conn "page1")
+        target (db-test/find-block-by-content @conn "target")
+        tagged-comment (db-test/find-block-by-content @conn "tagged comment")
+        ordinary (db-test/find-block-by-content @conn "ordinary")
+        comments-area (db-test/find-block-by-content @conn "Comments")
+        original-comment-parent-id (:db/id (:block/parent tagged-comment))
+        original-ordinary-parent-id (:db/id (:block/parent ordinary))]
+    (d/transact! conn [{:db/id -1
+                        :db/ident :logseq.class/Tag
+                        :block/uuid (random-uuid)
+                        :block/title "Tag"
+                        :block/tags #{-1}}
+                       {:db/ident :logseq.class/Comments
+                        :block/uuid (random-uuid)
+                        :block/title "Comments"
+                        :block/tags #{-1}}
+                       {:db/ident :logseq.class/Comment
+                        :block/uuid (random-uuid)
+                        :block/title "Comment"
+                        :block/tags #{-1}}
+                       [:db/add (:db/id comments-area) :block/tags :logseq.class/Comments]
+                       [:db/add (:db/id tagged-comment) :block/tags :logseq.class/Comment]])
+
+    (testing "#Comment blocks cannot be moved after creation"
+      (outliner-core/move-blocks! conn [tagged-comment] target {:sibling? false})
+      (is (= original-comment-parent-id
+             (:db/id (:block/parent (d/entity @conn (:db/id tagged-comment)))))))
+
+    (testing "ordinary blocks cannot be moved to #Comments blocks"
+      (outliner-core/move-blocks! conn [ordinary] comments-area {:sibling? true})
+      (let [ordinary' (d/entity @conn (:db/id ordinary))]
+        (is (= original-ordinary-parent-id
+               (:db/id (:block/parent ordinary'))))
+        (is (not= (:db/id page)
+                  (:db/id (:block/parent ordinary'))))))
+
+    (testing "ordinary blocks cannot be moved to #Comment blocks"
+      (outliner-core/move-blocks! conn [ordinary] tagged-comment {:sibling? false})
+      (is (= original-ordinary-parent-id
+             (:db/id (:block/parent (d/entity @conn (:db/id ordinary)))))))))

--- a/src/main/frontend/components/block/comments_model.cljs
+++ b/src/main/frontend/components/block/comments_model.cljs
@@ -4,21 +4,31 @@
             [goog.object :as gobj]))
 
 (def comments-tag-ident :logseq.class/Comments)
+(def comment-tag-ident :logseq.class/Comment)
 (def comments-blocks-property :logseq.property.comments/blocks)
 
-(defn comments-area?
-  [block]
+(defn- tagged-with?
+  [block tag-ident]
   (boolean
    (some (fn [tag]
-           (= comments-tag-ident
+           (= tag-ident
               (if (keyword? tag)
                 tag
                 (:db/ident tag))))
          (:block/tags block))))
 
+(defn comments-area?
+  [block]
+  (tagged-with? block comments-tag-ident))
+
+(defn tagged-comment-block?
+  [block]
+  (tagged-with? block comment-tag-ident))
+
 (defn comment-block?
   [block]
-  (comments-area? (:block/parent block)))
+  (or (tagged-comment-block? block)
+      (comments-area? (:block/parent block))))
 
 (defn protected-comment-block?
   [block]
@@ -28,14 +38,13 @@
 (defn move-allowed?
   ([blocks target-block]
    (move-allowed? blocks target-block {}))
-  ([blocks target-block opts]
+  ([blocks target-block _opts]
    (boolean
     (and (seq blocks)
          target-block
          (not-any? protected-comment-block? blocks)
          (not (comment-block? target-block))
-         (or (:sibling? opts)
-             (not (comments-area? target-block)))))))
+         (not (comments-area? target-block))))))
 
 (defn comment-target-blocks
   [blocks]

--- a/src/main/frontend/handler/comments.cljs
+++ b/src/main/frontend/handler/comments.cljs
@@ -207,7 +207,8 @@
    content
    {:block-uuid (:block/uuid comments-block)
     :end? true
-    :edit-block? false}))
+    :edit-block? false
+    :other-attrs {:block/tags #{comments-model/comment-tag-ident}}}))
 
 (defn create-sibling-block-after-comments!
   [comments-block]

--- a/src/main/frontend/worker/db/migrate.cljs
+++ b/src/main/frontend/worker/db/migrate.cljs
@@ -70,6 +70,16 @@
 (defn- deprecated-ensure-graph-uuid
   [_db])
 
+(defn- tag-comment-blocks
+  [db]
+  (->> (d/q '[:find [?comment ...]
+              :where
+              [?comments-area :block/tags :logseq.class/Comments]
+              [?comment :block/parent ?comments-area]]
+            db)
+       (map (fn [comment-id]
+              [:db/add comment-id :block/tags :logseq.class/Comment]))))
+
 (def schema-version->updates
   "A vec of tuples defining datascript migrations. Each tuple consists of the
    schema version integer and a migration map. A migration map can have keys of :properties, :classes
@@ -101,7 +111,9 @@
                                  :logseq.property.embedding/hnsw-label-updated-at]}]
    ["65.26" {:properties [:logseq.property.repeat/repeat-type]}]
    ["65.27" {:classes [:logseq.class/Comments]
-             :properties [:logseq.property.comments/blocks]}]])
+             :properties [:logseq.property.comments/blocks]}]
+   ["65.28" {:classes [:logseq.class/Comment]
+             :fix tag-comment-blocks}]])
 
 (let [[major minor] (last (sort (map (comp (juxt :major :minor) db-schema/parse-schema-version first)
                                      schema-version->updates)))]

--- a/src/test/frontend/components/block/comments_model_test.cljs
+++ b/src/test/frontend/components/block/comments_model_test.cljs
@@ -19,20 +19,25 @@
   (let [comments-area {:block/tags [{:db/ident :logseq.class/Comments}]}
         comment-block {:block/title "comment"
                        :block/parent comments-area}
+        tagged-comment-block {:block/title "tagged comment"
+                              :block/tags [{:db/ident :logseq.class/Comment}]}
         ordinary-block {:block/title "ordinary"}
         ordinary-target {:block/title "target"}]
     (testing "comment area and its children are protected comment blocks"
       (is (true? (comments-model/protected-comment-block? comments-area)))
       (is (true? (comments-model/protected-comment-block? comment-block)))
+      (is (true? (comments-model/protected-comment-block? tagged-comment-block)))
       (is (false? (comments-model/protected-comment-block? ordinary-block))))
     (testing "comment blocks cannot be moved"
       (is (false? (comments-model/move-allowed? [comments-area] ordinary-target)))
-      (is (false? (comments-model/move-allowed? [comment-block] ordinary-target))))
-    (testing "ordinary blocks cannot be moved into comments"
+      (is (false? (comments-model/move-allowed? [comment-block] ordinary-target)))
+      (is (false? (comments-model/move-allowed? [tagged-comment-block] ordinary-target))))
+    (testing "ordinary blocks cannot be moved to comment blocks"
       (is (false? (comments-model/move-allowed? [ordinary-block] comments-area)))
-      (is (false? (comments-model/move-allowed? [ordinary-block] comment-block))))
-    (testing "ordinary blocks can still move next to the comments area"
-      (is (true? (comments-model/move-allowed? [ordinary-block] comments-area {:sibling? true}))))
+      (is (false? (comments-model/move-allowed? [ordinary-block] comment-block)))
+      (is (false? (comments-model/move-allowed? [ordinary-block] tagged-comment-block)))
+      (is (false? (comments-model/move-allowed? [ordinary-block] comments-area {:sibling? true})))
+      (is (false? (comments-model/move-allowed? [ordinary-block] tagged-comment-block {:sibling? true}))))
     (testing "ordinary moves outside comments stay allowed"
       (is (true? (comments-model/move-allowed? [ordinary-block] ordinary-target))))))
 

--- a/src/test/frontend/handler/editor_async_test.cljs
+++ b/src/test/frontend/handler/editor_async_test.cljs
@@ -506,6 +506,25 @@
                          @inserted)
                       "Empty Enter in the reply box should create an editable sibling after #Comments"))))))
 
+(deftest-async insert-comment-tags-created-comment-block
+  (let [comments-area {:block/uuid (random-uuid)
+                       :block/title "Comments"
+                       :block/tags #{comments-model/comments-tag-ident}}
+        inserted (atom nil)]
+    (-> (p/with-redefs [editor/api-insert-new-block! (fn [content opts]
+                                                       (reset! inserted {:content content
+                                                                         :opts opts})
+                                                       (p/resolved {:block/uuid (random-uuid)}))]
+          (comments-handler/insert-comment! comments-area "review this"))
+        (p/then (fn [_]
+                  (is (= {:content "review this"
+                          :opts {:block-uuid (:block/uuid comments-area)
+                                 :end? true
+                                 :edit-block? false
+                                 :other-attrs {:block/tags #{:logseq.class/Comment}}}}
+                         @inserted)
+                      "Inserted comment blocks should be tagged as #Comment"))))))
+
 (deftest delete-comment-targets
   (let [delete-targets (resolve 'frontend.handler.comments/comment-delete-targets)
         first-comment {:block/uuid (random-uuid)

--- a/src/test/frontend/worker/migrate_test.cljs
+++ b/src/test/frontend/worker/migrate_test.cljs
@@ -105,3 +105,42 @@
       (is (= :node (:logseq.property/type property)))
       (is (true? (:logseq.property/hide? property)))
       (is (false? (:logseq.property/public? property))))))
+
+(deftest migrate-65-28-tags-existing-comment-blocks
+  (let [conn (d/create-conn db-schema/schema)
+        comments-area-uuid #uuid "11111111-1111-1111-1111-111111111111"
+        first-comment-uuid #uuid "22222222-2222-2222-2222-222222222222"
+        second-comment-uuid #uuid "33333333-3333-3333-3333-333333333333"
+        ordinary-child-uuid #uuid "44444444-4444-4444-4444-444444444444"]
+    (d/transact! conn
+                 [{:db/ident :logseq.kv/schema-version
+                   :kv/value {:major 65 :minor 27}}
+                  {:db/ident :logseq.class/Comments
+                   :block/title "Comments"}
+                  {:db/ident :logseq.class/Task
+                   :block/title "Task"}
+                  {:block/uuid comments-area-uuid
+                   :block/title "Comments"
+                   :block/tags #{:logseq.class/Comments}}
+                  {:block/uuid first-comment-uuid
+                   :block/title "first comment"
+                   :block/parent [:block/uuid comments-area-uuid]}
+                  {:block/uuid second-comment-uuid
+                   :block/title "second comment"
+                   :block/parent [:block/uuid comments-area-uuid]
+                   :block/tags #{:logseq.class/Task}}
+                  {:block/uuid ordinary-child-uuid
+                   :block/title "ordinary child"}])
+
+    (db-migrate/migrate conn :target-version {:major 65 :minor 28})
+
+    (is (= {:major 65 :minor 28}
+           (:kv/value (d/entity @conn :logseq.kv/schema-version))))
+    (is (some? (d/entity @conn :logseq.class/Comment)))
+    (is (= #{:logseq.class/Comment}
+           (set (map :db/ident (:block/tags (d/entity @conn [:block/uuid first-comment-uuid]))))))
+    (is (= #{:logseq.class/Task :logseq.class/Comment}
+           (set (map :db/ident (:block/tags (d/entity @conn [:block/uuid second-comment-uuid]))))))
+    (is (= #{:logseq.class/Comments}
+           (set (map :db/ident (:block/tags (d/entity @conn [:block/uuid comments-area-uuid]))))))
+    (is (empty? (:block/tags (d/entity @conn [:block/uuid ordinary-child-uuid]))))))


### PR DESCRIPTION
## Summary

- add the built-in `#Comment` class and migrate existing comments under `#Comments` areas
- tag newly inserted comment blocks with `#Comment`
- prevent `#Comment` blocks from moving and prevent moves onto `#Comment` or `#Comments` blocks
- replace fragile Malli `some->>` dispatch checks that generated invalid CLJS in the full test suite

## Validation

- `bb dev:lint-and-test`
- `pnpm test` in `deps/outliner`
- `clojure -M:clj-kondo --lint src test` in `deps/outliner`
- `bb lint:carve` in `deps/outliner`
- `bb lint:large-vars` in `deps/outliner`
- `bb lint:ns-docstrings` in `deps/outliner`
- `bb lint:minimize-public-vars` in `deps/outliner`