### PR TITLE
fix: AppImage CLI launcher popup

### DIFF
--- a/src/electron/electron/cli_install.cljs
+++ b/src/electron/electron/cli_install.cljs
@@ -31,6 +31,14 @@
        "set ELECTRON_RUN_AS_NODE=1\r\n"
        "\"" exe-path "\" \"" cli-path "\" %*\r\n"))
 
+(defn- launcher-exe-path
+  [{:keys [windows? exe-path appimage-path]}]
+  (if windows?
+    exe-path
+    (if (string/blank? appimage-path)
+      exe-path
+      appimage-path)))
+
 (defn- write-cli-launcher!
   [{:keys [target-path content windows? exists? read-file! write-file! chmod!]}]
   (let [should-write? (if (exists? target-path)
@@ -67,6 +75,7 @@
 
         :else
         (let [target-path (path-join cli-dir (if windows? "logseq.cmd" "logseq"))
+              exe-path (launcher-exe-path deps)
               content (if windows?
                         (render-win-cli-launcher exe-path cli-path)
                         (render-unix-cli-launcher exe-path cli-path))

--- a/src/electron/electron/cli_install.cljs
+++ b/src/electron/electron/cli_install.cljs
@@ -58,7 +58,7 @@
       (str error)))
 
 (defn install-cli-launcher!
-  [{:keys [windows? cli-path cli-dir cli-dir! exe-path path-join exists? show-message-box!
+  [{:keys [windows? cli-path cli-dir cli-dir! path-join exists? show-message-box!
            show-error-box! t log-info! log-warn!]
     :as deps}]
   (try

--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -334,6 +334,7 @@
       :cli-path cli-path
       :cli-dir! cli-dir!
       :exe-path (.getPath app "exe")
+      :appimage-path (.-APPIMAGE js/process.env)
       :path-join path-join
       :exists? #(fs/existsSync %)
       :read-file! #(.readFileSync fs % "utf8")

--- a/src/test/electron/cli_install_test.cljs
+++ b/src/test/electron/cli_install_test.cljs
@@ -1,11 +1,12 @@
 (ns electron.cli-install-test
-  (:require [cljs.test :refer [deftest is testing]]
+  (:require ["path" :as node-path]
+            [cljs.test :refer [deftest is testing]]
             [clojure.string :as string]
             [electron.cli-install :as cli-install]))
 
 (defn- path-join
   [& parts]
-  (string/join "/" parts))
+  (apply node-path/join parts))
 
 (defn- t
   [k & args]

--- a/src/test/electron/cli_install_test.cljs
+++ b/src/test/electron/cli_install_test.cljs
@@ -68,6 +68,30 @@
                :message "Logseq CLI was installed to ~/.local/bin"}]
              (:messages result))))))
 
+(deftest install-cli-launcher-uses-stable-appimage-path
+  (testing "Linux AppImage launchers use APPIMAGE instead of the temporary mounted executable path"
+    (let [result (run-install! {:existing-files #{"/app/logseq-cli.js"}
+                                :exe-path "/tmp/.mount_LogseqA1B2C3/logseq"
+                                :appimage-path "/home/me/Logseq.AppImage"})
+          content (second (first (:writes result)))]
+      (is (string/includes? content "\"/home/me/Logseq.AppImage\""))
+      (is (not (string/includes? content "/tmp/.mount_LogseqA1B2C3/logseq"))))))
+
+(deftest install-cli-launcher-skips-dialog-when-appimage-mount-path-changes
+  (testing "Linux AppImage restarts do not rewrite the launcher when only the temporary mount path changes"
+    (let [stable-content (str "#!/usr/bin/env sh\n"
+                              "# " cli-install/CLI_LAUNCHER_MARKER "\n"
+                              "set -eu\n"
+                              "ELECTRON_RUN_AS_NODE=1 exec \"/home/me/Logseq.AppImage\" \"/app/logseq-cli.js\" \"$@\"\n")
+          result (run-install! {:existing-files #{"/app/logseq-cli.js" "/home/me/.local/bin/logseq"}
+                                :existing-contents {"/home/me/.local/bin/logseq" stable-content}
+                                :exe-path "/tmp/.mount_LogseqD4E5F6/logseq"
+                                :appimage-path "/home/me/Logseq.AppImage"})]
+      (is (= [] (:writes result)))
+      (is (= [] (:chmods result)))
+      (is (= [] (:messages result)))
+      (is (= [] (:errors result))))))
+
 (deftest install-cli-launcher-keeps-windows-path
   (testing "Windows keeps the existing Windows install path behavior and reports that directory"
     (let [windows-dir "C:/Users/me/AppData/Local/Microsoft/WindowsApps"


### PR DESCRIPTION
## Summary
- Use the stable APPIMAGE path when generating the Unix CLI launcher.
- Avoid rewriting ~/.local/bin/logseq on every AppImage startup when only the temporary mount path changes.
- Add tests for AppImage launcher content and restart behavior.

## Root Cause
AppImage exposes Electron through a temporary /tmp/.mount_* executable path. The CLI launcher embedded that path, so each startup generated different launcher content and triggered the install success dialog again.

## Validation
- bb dev:test -v electron.cli-install-test/install-cli-launcher-uses-stable-appimage-path -v electron.cli-install-test/install-cli-launcher-skips-dialog-when-appimage-mount-path-changes
- bb dev:test -n electron.cli-install-test
