### PR TITLE
fix: upload map form sync txs

### DIFF
--- a/src/main/frontend/worker/sync/large_title.cljs
+++ b/src/main/frontend/worker/sync/large_title.cljs
@@ -126,20 +126,18 @@
            acc []]
     (if (empty? remaining)
       acc
-      (let [item (first remaining)
-            op (nth item 0 nil)
-            attr (nth item 2 nil)
-            value (nth item 3 nil)]
+      (let [item (first remaining)]
         (if (and (vector? item)
-                 (= :db/add op)
-                 (= :block/title attr)
-                 (string? value)
-                 (large-title? value))
-          (p/let [obj (upload-fn repo graph-id value aes-key)
-                  placeholder (assoc-datom-value item "")]
-            (p/recur (rest remaining)
-                     (conj acc placeholder
-                           [:db/add (nth item 1) large-title-object-attr obj])))
+                 (= :db/add (nth item 0 nil))
+                 (= :block/title (nth item 2 nil))
+                 (string? (nth item 3 nil))
+                 (large-title? (nth item 3 nil)))
+          (let [title (nth item 3)]
+            (p/let [obj (upload-fn repo graph-id title aes-key)
+                    placeholder (assoc-datom-value item "")]
+              (p/recur (rest remaining)
+                       (conj acc placeholder
+                             [:db/add (nth item 1) large-title-object-attr obj]))))
           (p/recur (rest remaining) (conj acc item)))))))
 
 (defn rehydrate-large-titles!

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -4690,6 +4690,27 @@
                             (is false (str e))))
                  (p/finally done))))))
 
+(deftest offload-large-title-preserves-map-form-tx-items-test
+  (testing "map-form tx items from built-in repair should not crash upload preparation"
+    (async done
+           (let [tx-data [{:db/ident :logseq.class/Comments
+                           :block/uuid #uuid "00000002-2556-9161-5000-000000000000"
+                           :block/title "Comments"}
+                          [:db/add [:block/uuid #uuid "00000002-2556-9161-5000-000000000000"]
+                           :block/title "Comments"]]
+                 upload-fn (fn [_repo _graph-id _title _aes-key]
+                             (p/rejected (ex-info "unexpected upload" {})))]
+             (-> (p/let [result (sync-large-title/offload-large-titles
+                                 tx-data
+                                 {:repo test-repo
+                                  :graph-id "graph-1"
+                                  :upload-fn upload-fn
+                                  :aes-key nil})]
+                   (is (= tx-data result)))
+                 (p/catch (fn [e]
+                            (is false (str e))))
+                 (p/finally done))))))
+
 (deftest offload-large-title-datoms-drops-stale-object-for-same-entity-test
   (testing "snapshot upload should not keep an old large-title object when offloading the same entity title"
     (async done


### PR DESCRIPTION
## Summary
- allow large-title upload preparation to preserve map-form tx items
- prevent flush-pending from failing when repair/migration sync txs contain entity maps
- add regression coverage for map-form tx upload preparation

## Validation
- bb dev:test -v frontend.worker.db-sync-test/offload-large-title-preserves-map-form-tx-items-test -v frontend.worker.db-sync-test/offload-large-title-test -v frontend.worker.db-sync-test/offload-small-title-test
- bb dev:test -v frontend.worker.db-core-test
- bb dev:test -v frontend.worker.db-sync-test/prepare-upload-tx-entries-drops-empty-txs-test