### PR TITLE
fix: add mobile selection comment action

### DIFF
--- a/android/app/src/main/java/com/logseq/app/MaterialIconResolver.kt
+++ b/android/app/src/main/java/com/logseq/app/MaterialIconResolver.kt
@@ -1,6 +1,7 @@
 package com.logseq.app
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Comment
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.Circle
 import androidx.compose.material.icons.filled.CloudUpload
@@ -67,6 +68,7 @@ object MaterialIconResolver {
             "camera" -> Icons.Outlined.CameraAlt
             "keyboard-chevron-compact-down", "keyboard-hide" -> Icons.Outlined.KeyboardHide
             "doc-on-doc", "copy" -> Icons.Outlined.ContentCopy
+            "text-bubble", "comment" -> Icons.AutoMirrored.Outlined.Comment
             "trash", "delete" -> Icons.Outlined.Delete
             "r-square", "bookmark-ref" -> Icons.Outlined.BookmarkAdd
             "link" -> Icons.Outlined.Link

--- a/src/main/mobile/components/selection_toolbar.cljs
+++ b/src/main/mobile/components/selection_toolbar.cljs
@@ -1,7 +1,9 @@
 (ns mobile.components.selection-toolbar
   "Selection action bar, activated when swipe on a block"
-  (:require [frontend.db :as db]
+  (:require [frontend.components.block.comments-model :as comments-model]
+            [frontend.db :as db]
             [frontend.context.i18n :refer [t]]
+            [frontend.handler.comments :as comments-handler]
             [frontend.handler.editor :as editor-handler]
             [frontend.mobile.util :as mobile-util]
             [frontend.state :as state]
@@ -20,64 +22,76 @@
   (state/set-state! :mobile/show-action-bar? false)
   (editor-handler/clear-selection!))
 
-(defn- selected-block-ids
+(defn- selected-blocks
   []
   (->> (state/get-selection-block-ids)
        (keep (fn [id]
-               (some-> (db/entity [:block/uuid id])
-                       :block/uuid)))))
+               (db/entity [:block/uuid id])))))
 
 (defn- selection-actions
   []
-  (let [close! close-selection-bar!]
-    [{:id "copy"
-      :label (t :ui/copy)
-      :system-icon "doc.on.doc"
-      :handler (fn []
-                 (editor-handler/copy-selection-blocks false)
-                 (close!))}
-     {:id "outdent"
-      :label (t :mobile.toolbar/outdent)
-      :system-icon "arrow.left"
-      :handler (fn []
-                 (editor-handler/on-tab :left))}
-     {:id "indent"
-      :label (t :mobile.toolbar/indent)
-      :system-icon "arrow.right"
-      :handler (fn []
-                 (editor-handler/on-tab :right))}
-     {:id "delete"
-      :label (t :ui/delete)
-      :system-icon "trash"
-      :handler (fn []
-                 (editor-handler/cut-selection-blocks false {:mobile-action-bar? true})
-                 (close!))}
-     {:id "copy-ref"
-      :label (t :mobile.toolbar/copy-ref)
-      :system-icon "r.square"
-      :handler (fn []
-                 (editor-handler/copy-block-refs)
-                 (close!))}
-     {:id "copy-url"
-      :label (t :mobile.toolbar/copy-url)
-      :system-icon "link"
-      :handler (fn []
-                 (let [current-repo (state/get-current-repo)
-                       tap-f (fn [block-id]
-                               (url-util/get-logseq-graph-uuid-url nil current-repo block-id))]
-                   (when-let [block-id (first (selected-block-ids))]
-                     (editor-handler/copy-block-ref! block-id tap-f)))
-                 (close!))}
-     {:id "unselect"
-      :label (t :mobile.toolbar/unselect)
-      :system-icon "xmark"
-      :handler (fn []
-                 (state/clear-selection!)
-                 (close!))}]))
+  (let [close! close-selection-bar!
+        blocks (selected-blocks)
+        first-block-id (:block/uuid (first blocks))
+        comment-targets (comments-model/comment-target-blocks blocks)]
+    (vec
+     (concat
+      [{:id "copy"
+        :label (t :ui/copy)
+        :system-icon "doc.on.doc"
+        :handler (fn []
+                   (editor-handler/copy-selection-blocks false)
+                   (close!))}
+       {:id "outdent"
+        :label (t :mobile.toolbar/outdent)
+        :system-icon "arrow.left"
+        :handler (fn []
+                   (editor-handler/on-tab :left))}
+       {:id "indent"
+        :label (t :mobile.toolbar/indent)
+        :system-icon "arrow.right"
+        :handler (fn []
+                   (editor-handler/on-tab :right))}]
+      (when (seq comment-targets)
+        [{:id "comment"
+          :label (t :block.comments/add-comment)
+          :system-icon "text.bubble"
+          :handler (fn []
+                     (comments-handler/add-comment-to-blocks! comment-targets)
+                     (close!))}])
+      [{:id "delete"
+        :label (t :ui/delete)
+        :system-icon "trash"
+        :handler (fn []
+                   (editor-handler/cut-selection-blocks false {:mobile-action-bar? true})
+                   (close!))}
+       {:id "copy-ref"
+        :label (t :mobile.toolbar/copy-ref)
+        :system-icon "r.square"
+        :handler (fn []
+                   (editor-handler/copy-block-refs)
+                   (close!))}
+       {:id "copy-url"
+        :label (t :mobile.toolbar/copy-url)
+        :system-icon "link"
+        :handler (fn []
+                   (let [current-repo (state/get-current-repo)
+                         tap-f (fn [block-id]
+                                 (url-util/get-logseq-graph-uuid-url nil current-repo block-id))]
+                     (when first-block-id
+                       (editor-handler/copy-block-ref! first-block-id tap-f)))
+                   (close!))}
+       {:id "unselect"
+        :label (t :mobile.toolbar/unselect)
+        :system-icon "xmark"
+        :handler (fn []
+                   (state/clear-selection!)
+                   (close!))}]))))
 
 (rum/defc action-bar
   []
   (let [actions (selection-actions)
+        action-ids (mapv :id actions)
         handlers-ref (hooks/use-ref nil)]
     (set! (.-current handlers-ref) (into {} (map (juxt :id :handler) actions)))
 
@@ -104,6 +118,6 @@
              (cond
                (and listener (.-remove listener)) ((.-remove listener))
                listener (.then listener (fn [^js handle] (.remove handle))))))))
-     [])
+     [action-ids])
 
     [:<>]))


### PR DESCRIPTION
## Summary

- Add a mobile native selection action for adding comments to selected blocks.
- Reuse the shared comment target filtering so comment blocks/comment areas are not offered as targets.
- Place the comment action immediately after indent in the mobile selection toolbar.

## Validation

- `bb lang:lint-hardcoded --git-changed`
- `clojure -M:test compile test`
