### PR TITLE
fix: improve mobile flashcards layout

### DIFF
--- a/src/main/frontend/extensions/fsrs.cljs
+++ b/src/main/frontend/extensions/fsrs.cljs
@@ -257,20 +257,21 @@
       (let [phase (rum/react *phase)
             _card-index (rum/react *card-index)
             next-phase (phase->next-phase block-entity phase)]
-        [:div.ls-card.content.flex.flex-col.overflow-y-auto.overflow-x-hidden
+        [:div.ls-card.content.flex.flex-col.overflow-hidden
          {:class (when (:mobile? opts) "ls-mobile-card")}
-         [:div.mb-4.ml-2.opacity-70.text-sm
-          (component-block/breadcrumb {} repo (:block/uuid block-entity) {})]
-         (let [option (case phase
-                        :init
-                        {:hide-children? true}
-                        :show-cloze
-                        {:show-cloze? true
-                         :hide-children? true}
-                        {:show-cloze? true
-                         :ignore-block-collapsed? true})]
-           (component-block/blocks-container option [block-entity]))
-         [:div.mt-8.pb-2
+         [:div.ls-card-scroll.flex-1.min-h-0.overflow-y-auto.overflow-x-hidden
+          [:div.mb-4.ml-2.opacity-70.text-sm
+           (component-block/breadcrumb {} repo (:block/uuid block-entity) {})]
+          (let [option (case phase
+                         :init
+                         {:hide-children? true}
+                         :show-cloze
+                         {:show-cloze? true
+                          :hide-children? true}
+                         {:show-cloze? true
+                          :ignore-block-collapsed? true})]
+            (component-block/blocks-container option [block-entity]))]
+         [:div.mt-8.pb-2.shrink-0
           {:class (when (:mobile? opts) "ls-mobile-card-actions")}
           (if (contains? #{:show-cloze :show-answer} next-phase)
             (btn-with-shortcut {:btn-text (case next-phase
@@ -366,7 +367,7 @@
           (on-selector-change {:cards all-cards
                                :cards-id cards-id
                                :select-card! select-card!})))
-      [:div#cards-modal.flex.flex-col.gap-8.flex-1
+      [:div#cards-modal.flex.flex-col.gap-8.flex-1.min-h-0
        (when-not mobile?
          [:div.flex.flex-row.items-center.gap-2
           (shui/select
@@ -398,7 +399,7 @@
        (let [block-id (nth block-ids card-index nil)]
          (cond
            block-id
-           [:div.flex.flex-col
+           [:div.flex.flex-col.flex-1.min-h-0
             (rum/with-key
               (card-view repo block-id *card-index *phase opts)
               (str "card-" block-id))]

--- a/src/main/mobile/components/app.css
+++ b/src/main/mobile/components/app.css
@@ -137,11 +137,11 @@ ul {
   @apply h-full flex flex-col px-1 py-2;
 
   #cards-modal {
-    @apply h-full gap-2;
+    @apply h-full min-h-0 gap-2;
   }
 
   #cards-modal .ls-card {
-    @apply flex-1 border-0 bg-transparent px-0 py-2 shadow-none;
+    @apply flex-1 min-h-0 border-0 bg-transparent px-0 py-2 shadow-none;
   }
 
   #cards-modal .ls-card > .blocks-container {
@@ -160,12 +160,12 @@ ul {
     @apply min-h-0;
   }
 
-  .ls-mobile-card > .mb-4 {
+  .ls-mobile-card .ls-card-scroll > .mb-4 {
     @apply ml-0 mb-3;
   }
 
   .ls-mobile-card-actions {
-    @apply mt-4 pb-0;
+    @apply mt-4 pb-6;
   }
 
   .ls-mobile-card-rating-buttons {

--- a/src/main/mobile/tabs.cljs
+++ b/src/main/mobile/tabs.cljs
@@ -15,7 +15,7 @@
     :systemImage "tray"
     :role "normal"}
    {:id "flashcards"
-    :title-key :nav/flashcards
+    :title-key :mobile.tab/flashcards
     :systemImage "infinity"
     :role "normal"}
    {:id "go to"

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -1013,6 +1013,7 @@
  :mobile.share/unsupported-import-type "Import {1} file is not supported. You can report it on {2}. We will look into it soon."
 
  :mobile.tab/capture "Capture"
+ :mobile.tab/flashcards "Cards"
  :mobile.tab/go-to "Go To"
  :mobile.tab/graphs "Graphs"
 

--- a/src/resources/dicts/zh-cn.edn
+++ b/src/resources/dicts/zh-cn.edn
@@ -1009,6 +1009,7 @@
  :mobile.share/unsupported-import-type "不支持导入 {1} 文件。您可以在 {2} 上反馈，我们会尽快处理。"
 
  :mobile.tab/capture "速记"
+ :mobile.tab/flashcards "闪卡"
  :mobile.tab/go-to "跳转"
  :mobile.tab/graphs "图谱"
 


### PR DESCRIPTION
## Summary
- keep mobile flashcard review controls visible while long card content scrolls
- add bottom spacing for mobile flashcard actions
- use the shorter mobile tab label “Cards” with zh-CN “闪卡”

## Validation
- bb lang:validate-translations
- bb lang:lint-hardcoded --git-changed
- bb dev:test -v mobile.tabs-test
- bb lang:format-dicts
- pnpm css:mobile-build
- clojure -M:cljs compile mobile
- git diff --check