### PR TITLE
fix: avatar initials for non-latin usernames

### DIFF
--- a/src/main/frontend/components/avatar.cljs
+++ b/src/main/frontend/components/avatar.cljs
@@ -4,6 +4,26 @@
             [logseq.shui.util :as shui-util]
             [rum.core :as rum]))
 
+(defonce ^:private latin-or-number-re
+  (js/RegExp. "^[\\p{Script=Latin}\\p{Number}]" "u"))
+
+(defn- graphemes
+  [s]
+  (if (exists? js/Intl.Segmenter)
+    (let [segmenter (js/Intl.Segmenter. js/undefined #js {:granularity "grapheme"})]
+      (map #(.-segment %) (array-seq (js/Array.from (.segment segmenter s)))))
+    (array-seq (js/Array.from s))))
+
+(defn- latin-or-number?
+  [s]
+  (.test latin-or-number-re s))
+
+(defn- fallback-grapheme-count
+  [letters n]
+  (if (some-> letters first latin-or-number?)
+    n
+    1))
+
 (defn initials
   ([name]
    (initials name 2))
@@ -11,8 +31,10 @@
    (when (some? name)
      (let [name (string/trim (str name))]
        (when-not (string/blank? name)
-         (-> (subs name 0 (min n (count name)))
-             string/upper-case))))))
+         (let [letters (graphemes name)]
+           (-> (string/join (take (fallback-grapheme-count letters n)
+                                  letters))
+               string/upper-case)))))))
 
 (rum/defc user-avatar
   [{:keys [name title uuid avatar-src class style fallback fallback-length fallback-props image-props]

--- a/src/main/frontend/components/avatar.cljs
+++ b/src/main/frontend/components/avatar.cljs
@@ -7,11 +7,14 @@
 (defonce ^:private latin-or-number-re
   (js/RegExp. "^[\\p{Script=Latin}\\p{Number}]" "u"))
 
+(defonce ^:private grapheme-segmenter
+  (when (exists? js/Intl.Segmenter)
+    (js/Intl.Segmenter. js/undefined #js {:granularity "grapheme"})))
+
 (defn- graphemes
   [s]
-  (if (exists? js/Intl.Segmenter)
-    (let [segmenter (js/Intl.Segmenter. js/undefined #js {:granularity "grapheme"})]
-      (map #(.-segment %) (array-seq (js/Array.from (.segment segmenter s)))))
+  (if grapheme-segmenter
+    (map #(.-segment %) (array-seq (js/Array.from (.segment grapheme-segmenter s))))
     (array-seq (js/Array.from s))))
 
 (defn- latin-or-number?

--- a/src/test/frontend/components/avatar_test.cljs
+++ b/src/test/frontend/components/avatar_test.cljs
@@ -1,0 +1,13 @@
+(ns frontend.components.avatar-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [frontend.components.avatar :as avatar]))
+
+(deftest initials-uses-two-letters-for-latin-names-without-spaces
+  (is (= "AL" (avatar/initials "alice"))))
+
+(deftest initials-uses-one-grapheme-for-non-latin-names-without-spaces
+  (testing "CJK names fit avatar fallback"
+    (is (= "会" (avatar/initials "会爬树的猫"))))
+  (testing "other non-Latin names do not use arbitrary first two characters"
+    (is (= "А" (avatar/initials "Алексей")))))
+


### PR DESCRIPTION
## Summary
- Use Unicode grapheme segmentation for avatar fallback initials.
- Show one grapheme for no-space non-Latin usernames while preserving two-character Latin fallback.
- Add regression tests for Chinese, Cyrillic, and Latin usernames.

## Root Cause
Avatar fallback used the first one string code units for every username, so no-space non-Latin names like `会爬树的猫` rendered as `会`.

## Test Plan
- `bb dev:test -v frontend.components.avatar-test`