### PR TITLE
fix: skip comments in publish payload

### DIFF
--- a/src/main/frontend/worker/publish.cljs
+++ b/src/main/frontend/worker/publish.cljs
@@ -34,6 +34,23 @@
                      eid))
     :else nil))
 
+(def ^:private comments-class-ident :logseq.class/Comments)
+(def ^:private comment-class-ident :logseq.class/Comment)
+
+(defn- comments-area?
+  [db block]
+  (ldb/class-instance? (d/entity db comments-class-ident) block))
+
+(defn- comment-block?
+  [db block]
+  (or (ldb/class-instance? (d/entity db comment-class-ident) block)
+      (comments-area? db (:block/parent block))))
+
+(defn- publishable-block?
+  [db block]
+  (not (or (comments-area? db block)
+           (comment-block? db block))))
+
 (defn- publish-refs-from-blocks
   [db blocks page-entity graph-uuid]
   (let [page-uuid (:block/uuid page-entity)
@@ -134,6 +151,7 @@
                   uuid (:block/uuid entity)
                   children (when uuid
                              (ldb/get-block-and-children db uuid))
+                  children (filter #(publishable-block? db %) children)
                   child-links (->> children
                                    (map :block/link)
                                    (map publish-ref-eid)
@@ -145,7 +163,7 @@
 (defn- publish-collect-page-eids
   [db entity]
   (let [page-id (:db/id entity)
-        blocks (collect-publish-blocks db entity)
+        blocks (filter #(publishable-block? db %) (collect-publish-blocks db entity))
         embedded-blocks (collect-embedded-blocks db blocks)
         blocks (concat blocks embedded-blocks)
         block-eids (map :db/id blocks)

--- a/src/test/frontend/worker/publish_test.cljs
+++ b/src/test/frontend/worker/publish_test.cljs
@@ -27,7 +27,7 @@
           _ (d/transact! conn [{:db/id embed-eid :block/link target-eid}])
           db @conn
           page-a (db-test/find-page-by-title db "Page A")
-          payload (#'worker-publish/build-publish-page-payload db page-a nil)
+          payload (#'worker-publish/build-publish-page-payload db page-a)
           datom-eids (->> (:datoms payload) (map first) set)
           child-eid (:db/id (d/entity db [:block/uuid child-uuid]))]
       (is (contains? datom-eids target-eid))
@@ -62,7 +62,7 @@
                                {:db/id (:db/id first-child) :block/link second-eid}])
           db @conn
           root-page (db-test/find-page-by-title db "Root Page")
-          payload (#'worker-publish/build-publish-page-payload db root-page nil)
+          payload (#'worker-publish/build-publish-page-payload db root-page)
           datom-eids (->> (:datoms payload) (map first) set)
           first-eid (:db/id (d/entity db [:block/uuid first-uuid]))
           second-eid (:db/id (d/entity db [:block/uuid second-uuid]))]
@@ -92,7 +92,7 @@
           page-a (db-test/find-page-by-title db "Page A")
           comments-area-eid (:db/id (d/entity db [:block/uuid comments-area-uuid]))
           comment-eid (:db/id (d/entity db [:block/uuid comment-uuid]))
-          payload (#'worker-publish/build-publish-page-payload db page-a nil)
+          payload (#'worker-publish/build-publish-page-payload db page-a)
           datom-eids (->> (:datoms payload) (map first) set)
           search-contents (set (map :block_content (:blocks payload)))]
       (is (not (contains? datom-eids comments-area-eid)))

--- a/src/test/frontend/worker/publish_test.cljs
+++ b/src/test/frontend/worker/publish_test.cljs
@@ -68,3 +68,34 @@
           second-eid (:db/id (d/entity db [:block/uuid second-uuid]))]
       (is (contains? datom-eids first-eid))
       (is (contains? datom-eids second-eid)))))
+
+(deftest publish-payload-excludes-comments
+  (testing "comment threads are not included in publish payload data"
+    (let [target-uuid (random-uuid)
+          comments-area-uuid (random-uuid)
+          comment-uuid (random-uuid)
+          conn (db-test/create-conn-with-blocks
+                {:pages-and-blocks
+                 [{:page {:block/title "Page A"}
+                   :blocks [{:block/title "Target"
+                             :block/uuid target-uuid
+                             :build/keep-uuid? true
+                             :build/children [{:block/title "Comments"
+                                               :block/uuid comments-area-uuid
+                                               :build/keep-uuid? true
+                                               :build/tags [:logseq.class/Comments]
+                                               :build/children [{:block/title "Private reply"
+                                                                 :block/uuid comment-uuid
+                                                                 :build/keep-uuid? true
+                                                                 :build/tags [:logseq.class/Comment]}]}]}]}]})
+          db @conn
+          page-a (db-test/find-page-by-title db "Page A")
+          comments-area-eid (:db/id (d/entity db [:block/uuid comments-area-uuid]))
+          comment-eid (:db/id (d/entity db [:block/uuid comment-uuid]))
+          payload (#'worker-publish/build-publish-page-payload db page-a nil)
+          datom-eids (->> (:datoms payload) (map first) set)
+          search-contents (set (map :block_content (:blocks payload)))]
+      (is (not (contains? datom-eids comments-area-eid)))
+      (is (not (contains? datom-eids comment-eid)))
+      (is (not (contains? search-contents "Comments")))
+      (is (not (contains? search-contents "Private reply"))))))


### PR DESCRIPTION
## Summary
- exclude `#Comments` areas and `#Comment` replies from worker publish payload construction
- keep comment datoms and search rows out of published page data
- add a regression test for publishing a page with a comment thread

## Root cause
The worker publish payload collected every block on the page before deriving datoms and search rows. Comment threads are stored as normal page blocks tagged with built-in comment classes, so they were included in published data.

## Test plan
- `bb dev:test -v frontend.worker.publish-test`
- `git diff --check`