### PR TITLE
fix: share block unique title for search

### DIFF
--- a/deps/db/.carve/config.edn
+++ b/deps/db/.carve/config.edn
@@ -11,6 +11,8 @@
                   logseq.db.frontend.asset
                   ;; Used outside deps/db by frontend worker and electron modules.
                   logseq.db.sqlite.backup
+                  ;; Used outside deps/db by frontend handler and worker search.
+                  logseq.db.frontend.block-title
                   ;; Some fns are used by frontend but not worth moving over yet
                   logseq.db.frontend.schema
                   logseq.db.frontend.validate

--- a/deps/db/src/logseq/db/frontend/block_title.cljs
+++ b/deps/db/src/logseq/db/frontend/block_title.cljs
@@ -1,0 +1,118 @@
+(ns logseq.db.frontend.block-title
+  "Shared block title formatting for DB graph entities."
+  (:require [clojure.string :as string]
+            [datascript.core :as d]
+            [datascript.impl.entity :as de]
+            [logseq.common.util.namespace :as ns-util]
+            [logseq.db.frontend.class :as db-class]
+            [logseq.db.frontend.db :as db-db]
+            [logseq.db.frontend.entity-util :as entity-util]))
+
+(defn- resolve-entity
+  [db lookup-ref]
+  (when db
+    (d/entity db lookup-ref)))
+
+(defn- needs-resolved-block?
+  [block]
+  (or (nil? (:block/title block))
+      (entity-util/class? block)
+      (some number? (:block/tags block))))
+
+(defn- resolve-block
+  [db block]
+  (cond
+    (de/entity? block)
+    block
+
+    (and (needs-resolved-block? block)
+         (number? (:db/id block)))
+    (or (resolve-entity db (:db/id block)) block)
+
+    (and (needs-resolved-block? block)
+         (uuid? (:block/uuid block)))
+    (or (resolve-entity db [:block/uuid (:block/uuid block)]) block)
+
+    :else
+    block))
+
+(defn- class-title-conflicts?
+  [db class-entity]
+  (let [class-title (:block/title class-entity)
+        class-id (:db/id class-entity)]
+    (when (and db class-title class-id)
+      (boolean
+       (d/q '[:find ?other .
+              :in $ ?class-title ?class-id
+              :where
+              [?other :block/title ?class-title]
+              [?other :block/tags :logseq.class/Tag]
+              [(not= ?other ?class-id)]
+              (not [?other :logseq.property/deleted-at])]
+            db class-title class-id)))))
+
+(defn- class-title-with-extends
+  [class-entity title]
+  (let [extends (some->> (:logseq.property.class/extends class-entity)
+                         (remove (fn [extend]
+                                   (or (:logseq.property/built-in? extend)
+                                       (= (:block/title class-entity) (:block/title extend)))))
+                         vec)]
+    (if (seq extends)
+      (str (if (= 1 (count extends))
+             (:block/title (first extends))
+             (->> (take 2 extends)
+                  (map :block/title)
+                  (string/join " | ")))
+           ns-util/parent-char
+           title)
+      title)))
+
+(defn- resolve-tag
+  [db tag]
+  (if (number? tag)
+    (resolve-entity db tag)
+    tag))
+
+(defn block-unique-title
+  "Return a display title that disambiguates duplicate class titles and appends
+  user-visible tags.
+
+  `title` may be supplied when a caller has already prepared a display title,
+  such as a search snippet with highlight markers."
+  [db block & {:keys [with-tags? alias truncate? title]
+               :or {with-tags? true
+                    truncate? true}}]
+  (let [block-e (resolve-block db block)]
+    (if (entity-util/built-in? block-e)
+      (:block/title block-e)
+      (let [class? (entity-util/class? block-e)
+            tags (when (and with-tags? (not class?))
+                   (remove (fn [tag]
+                             (or (some-> (:block/raw-title block-e) (db-db/inline-tag? tag))
+                                 (db-class/private-tags (:db/ident tag))))
+                           (map #(resolve-tag db %) (or (:block/tags block)
+                                                        (:block/tags block-e)))))
+            base-title (if class?
+                         (let [display-title (or title (:block/title block-e))]
+                           (if (class-title-conflicts? db block-e)
+                             (class-title-with-extends block-e display-title)
+                             display-title))
+                         (or title (:block/title block)))
+            trunc-title (if (and truncate? base-title (> (count base-title) 256))
+                          (subs base-title 0 256)
+                          base-title)
+            title (if (seq tags)
+                    (str (or trunc-title "")
+                         " "
+                         (string/join
+                          ", "
+                          (keep (fn [tag]
+                                  (when-let [title (:block/title tag)]
+                                    (str "#" title)))
+                                tags)))
+                    trunc-title)]
+        (when title
+          (str title
+               (when alias
+                 (str " -> alias: " alias))))))))

--- a/deps/db/src/logseq/db/frontend/block_title.cljs
+++ b/deps/db/src/logseq/db/frontend/block_title.cljs
@@ -80,9 +80,9 @@
 
   `title` may be supplied when a caller has already prepared a display title,
   such as a search snippet with highlight markers."
-  [db block & {:keys [with-tags? alias truncate? title]
-               :or {with-tags? true
-                    truncate? true}}]
+  [db block {:keys [with-tags? alias truncate? title]
+             :or {with-tags? true
+                  truncate? true}}]
   (let [block-e (resolve-block db block)]
     (if (entity-util/built-in? block-e)
       (:block/title block-e)

--- a/deps/db/src/logseq/db/frontend/block_title.cljs
+++ b/deps/db/src/logseq/db/frontend/block_title.cljs
@@ -98,7 +98,7 @@
                            (if (class-title-conflicts? db block-e)
                              (class-title-with-extends block-e display-title)
                              display-title))
-                         (or title (:block/title block)))
+                         (or title (:block/title block-e)))
             trunc-title (if (and truncate? base-title (> (count base-title) 256))
                           (subs base-title 0 256)
                           base-title)

--- a/src/main/frontend/components/cmdk/core.cljs
+++ b/src/main/frontend/components/cmdk/core.cljs
@@ -347,9 +347,7 @@
         current-page? (and current-page-uuid
                            (= current-page-uuid result-page-id))
         icon (icon-component/get-node-icon-cp entity {:ignore-current-icon? true})
-        title (block-handler/block-unique-title entity
-                                                :alias (:block/title source-page)
-                                                :truncate? false)]
+        title (:block.temp/unique-title page)]
     (hash-map :icon icon
               :icon-theme :gray
               :text (if (string/includes? title "$pfts_2lqh>$") ; sqlite matched
@@ -368,7 +366,7 @@
 (defn block-item
   [repo block current-page-uuid input]
   (let [id (:block/uuid block)
-        text (block-handler/block-unique-title block :truncate? false)
+        text (:block.temp/unique-title block)
         icon (icon-component/get-node-icon-cp block {:ignore-current-icon? true})]
     {:icon icon
      :icon-theme :gray

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -97,8 +97,8 @@
 (defn block-unique-title
   "Multiple pages/objects may have the same `:block/title`.
    Notice: this doesn't prevent for pages/objects that have the same tag or created by different clients."
-  [block & opts]
-  (apply db-block-title/block-unique-title (db/get-db) block opts))
+  [block & {:as opts}]
+  (db-block-title/block-unique-title (db/get-db) block opts))
 
 (defn block-title-with-icon
   "Used for select item"

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -1,7 +1,5 @@
 (ns ^:no-doc frontend.handler.block
   (:require [clojure.string :as string]
-            [datascript.core :as d]
-            [datascript.impl.entity :as de]
             [dommy.core :as dom]
             [frontend.components.block.comments-model :as comments-model]
             [frontend.config :as config]
@@ -18,6 +16,7 @@
             [frontend.util :as util]
             [goog.object :as gobj]
             [logseq.db :as ldb]
+            [logseq.db.frontend.block-title :as db-block-title]
             [logseq.outliner.core :as outliner-core]
             [logseq.outliner.op]
             [promesa.core :as p]))
@@ -79,21 +78,6 @@
         (or "")
         (subs 0 pos))))
 
-(defn- class-title-conflicts?
-  [class-entity]
-  (let [class-title (:block/title class-entity)
-        class-id (:db/id class-entity)]
-    (when-let [db (and class-title (db/get-db))]
-      (boolean
-       (d/q '[:find ?other .
-              :in $ ?class-title ?class-id
-              :where
-              [?other :block/title ?class-title]
-              [?other :block/tags :logseq.class/Tag]
-              [(not= ?other ?class-id)]
-              (not [?other :logseq.property/deleted-at])]
-            db class-title class-id)))))
-
 (defn mark-last-input-time!
   [repo]
   (when repo
@@ -113,51 +97,8 @@
 (defn block-unique-title
   "Multiple pages/objects may have the same `:block/title`.
    Notice: this doesn't prevent for pages/objects that have the same tag or created by different clients."
-  [block & {:keys [with-tags? alias truncate?]
-            :or {with-tags? true
-                 truncate? true}}]
-  (if (ldb/built-in? block)
-    (:block/title block)
-    (let [block-e (cond
-                    (de/entity? block)
-                    block
-
-                    (number? (:db/id block))
-                    (or (db/entity (:db/id block)) block)
-
-                    (uuid? (:block/uuid block))
-                    (db/entity [:block/uuid (:block/uuid block)])
-
-                    :else
-                    block)
-          class? (ldb/class? block-e)
-          tags (when (and with-tags? (not class?))
-                 (remove (fn [t]
-                           (or (some-> (:block/raw-title block-e) (ldb/inline-tag? t))
-                               (ldb/private-tags (:db/ident t))))
-                         (map (fn [tag] (if (number? tag) (db/entity tag) tag)) (:block/tags block))))
-          base-title (if class?
-                       (if (class-title-conflicts? block-e)
-                         (ldb/get-class-title-with-extends block-e)
-                         (:block/title block-e))
-                       (:block/title block))
-          trunc-title (if (and truncate? base-title (> (count base-title) 256))
-                        (subs base-title 0 256)
-                        base-title)
-          title (if (seq tags)
-                  (str (or trunc-title "")
-                       " "
-                       (string/join
-                        ", "
-                        (keep (fn [tag]
-                                (when-let [title (:block/title tag)]
-                                  (str "#" title)))
-                              tags)))
-                  trunc-title)]
-      (when title
-        (str title
-             (when alias
-               (str " -> alias: " alias)))))))
+  [block & opts]
+  (apply db-block-title/block-unique-title (db/get-db) block opts))
 
 (defn block-title-with-icon
   "Used for select item"

--- a/src/main/frontend/worker/search.cljs
+++ b/src/main/frontend/worker/search.cljs
@@ -9,6 +9,7 @@
             [logseq.common.util :as common-util]
             [logseq.common.util.namespace :as ns-util]
             [logseq.db :as ldb]
+            [logseq.db.frontend.block-title :as db-block-title]
             [logseq.db.frontend.content :as db-content]
             [logseq.graph-parser.text :as text]))
 
@@ -658,11 +659,18 @@ DROP TRIGGER IF EXISTS blocks_au;
               tag-ids (seq (map :db/id (:block/tags block)))
               icon (:logseq.property/icon block)
               alias (some-> (first (:block/_alias block))
-                            (select-keys [:block/uuid :block/title]))]
+                            (select-keys [:block/uuid :block/title]))
+              unique-title (db-block-title/block-unique-title
+                            @conn
+                            block
+                            :title display-title
+                            :alias (:block/title alias)
+                            :truncate? false)]
           (cond-> {:db/id (:db/id block)
                    :block/uuid (:block/uuid block)
                    :block/title display-title
                    :block.temp/original-title (:block/title block)
+                   :block.temp/unique-title unique-title
                    :page? (ldb/page? block)}
             block-page
             (assoc :block/page block-page)

--- a/src/main/frontend/worker/search.cljs
+++ b/src/main/frontend/worker/search.cljs
@@ -663,9 +663,9 @@ DROP TRIGGER IF EXISTS blocks_au;
               unique-title (db-block-title/block-unique-title
                             @conn
                             block
-                            :title display-title
-                            :alias (:block/title alias)
-                            :truncate? false)]
+                            {:title display-title
+                             :alias (:block/title alias)
+                             :truncate? false})]
           (cond-> {:db/id (:db/id block)
                    :block/uuid (:block/uuid block)
                    :block/title display-title

--- a/src/test/frontend/worker/search_test.cljs
+++ b/src/test/frontend/worker/search_test.cljs
@@ -3,7 +3,8 @@
             [clojure.string :as string]
             [datascript.core :as d]
             [frontend.worker.search :as search]
-            [logseq.db :as ldb]))
+            [logseq.db :as ldb]
+            [logseq.db.test.helper :as db-test]))
 
 (defn- sql-placeholder-count
   [sql]
@@ -513,6 +514,29 @@
           (is (not (contains? result :block/tags)))
           (is (not (contains? result :logseq.property/icon)))
           (is (not (contains? result :alias))))))))
+
+(deftest search-result-includes-block-unique-title
+  (testing "search responses include the title cmdk should render"
+    (let [conn (db-test/create-conn-with-blocks
+                {:classes {:Project {:block/title "Project"}
+                           :Area {:block/title "Area"}
+                           :user.class/Milestone {:block/title "Milestone"
+                                                  :build/class-extends [:Project]}
+                           :other.class/Milestone {:block/title "Milestone"
+                                                   :build/class-extends [:Area]}}})
+          milestone (d/entity @conn :user.class/Milestone)
+          result (#'search/search-result->block-result
+                  conn
+                  "stone"
+                  nil
+                  {:enable-snippet? true}
+                  {:id (str (:block/uuid milestone))
+                   :page (str (:block/uuid milestone))
+                   :title "Milestone"})]
+      (is (= "Project/Mile$pfts_2lqh>$stone$<pfts_2lqh$"
+             (:block.temp/unique-title result)))
+      (is (= "Mile$pfts_2lqh>$stone$<pfts_2lqh$"
+             (:block/title result))))))
 
 (deftest upsert-blocks-batches-rows-into-single-sql-statement
   (let [calls (atom [])


### PR DESCRIPTION
## Summary

- move block unique title formatting into a shared DB frontend namespace
- include `:block.temp/unique-title` in worker search results
- update cmdk page/block items to render the search-provided unique title without recomputing it
- add worker search coverage for highlighted unique class titles
- mark the shared block-title namespace as deps/db carve API because it is consumed by frontend and worker code outside deps/db

## Validation

- `rtk bb dev:lint-and-test`
- `rtk clojure -M:clj-kondo --lint deps/db/src/logseq/db/frontend/block_title.cljs --cache false`
- `(cd deps/db && rtk bb lint:carve)`
- `(cd deps/db && rtk clojure -M:clj-kondo --lint src test --cache false)`
- `(cd deps/db && rtk bb lint:large-vars)`
- `(cd deps/db && rtk bb lint:ns-docstrings)`
- `(cd deps/db && rtk bb lint:rules)`