### PR TITLE
fix(editor): show add-block button on block-rooted views

### DIFF
--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -95,7 +95,7 @@
 (declare page-cp)
 
 (rum/defc add-button-inner
-  [block {:keys [container-id editing?] :as config*}]
+  [block {:keys [container-id editing? block?] :as config*}]
   (let [*ref (rum/use-ref nil)
         has-children? (:block/_parent block)
         page? (ldb/page? block)
@@ -109,7 +109,7 @@
                         has-children? "opacity-0"
                         :else "opacity-50")
         config (dissoc config* :page)]
-    (when (or page? (util/mobile?))
+    (when (or page? block? (util/mobile?))
       [:div.ls-block.block-add-button.flex-1.flex-col.rounded-sm.cursor-text.transition-opacity.ease-in.duration-100.!py-0
        {:class opacity-class
         :parentblockid (:db/id block)


### PR DESCRIPTION
## Problem

`add-button-inner` (the trailing "tap to add a child block" button at the bottom of a page's blocks tree) only rendered when the entity passed to `page-blocks-cp` was a page, or on mobile. When `page-blocks-cp` is invoked with a *block* — for example a block opened via "Open in sidebar" or rendered as the root of an embedded view — desktop users had no discoverable way to append a child block at the end of the tree.

## Fix

`page-blocks-cp` already sets `:block? (not (db/page? block))` into the hiccup-config it passes downstream. This patch destructures that flag in `add-button-inner` and adds it to the render predicate so block-rooted views surface the add button too.

```clojure
- [block {:keys [container-id editing?] :as config*}]
+ [block {:keys [container-id editing? block?] :as config*}]
...
- (when (or page? (util/mobile?))
+ (when (or page? block? (util/mobile?))
```

Mobile and page behavior is unchanged.

## Scope / non-goals

- The keyboard-nav handlers at `frontend/handler/editor.cljs:2314` and `:2390` still only auto-`.click` the `.block-add-button` when the cursor originated under `.ls-page-title`. So on block-rooted views the button is reachable via mouse and Tab/Enter (it has `:tab-index 0` and an Enter handler) but Down-arrow off the last child won't auto-click it. Bringing that parity in is a follow-up if desired.
- No new tests: this is a 2-token change to a Rum render predicate; existing snapshot/integration coverage was not affected.

## Verification

- Open a block in the right sidebar via "Open in sidebar" → the trailing add button now appears under the last child. Clicking it inserts a new sibling at the bottom.
- Open a page → unchanged.
- Mobile view → unchanged.

Local CI: full clj-kondo, carve, large-vars, ns-docstrings, lang validate/lint-hardcoded, worker/frontend separation all clean.
