### PR TITLE
fix(plugin): remember last unpacked plugin directory

### DIFF
--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -145,11 +145,15 @@
        (remove nil?)
        vec))
 
-(defn open-dir-dialog []
-  (p/let [result (.showOpenDialog dialog (bean/->js
-                                          {:properties ["openDirectory" "createDirectory" "promptToCreate"]}))
-          result (get (js->clj result) "filePaths")]
-    (p/resolved (first result))))
+(defn open-dir-dialog
+  ([] (open-dir-dialog nil))
+  ([default-path]
+   (p/let [opts (cond-> {:properties ["openDirectory" "createDirectory" "promptToCreate"]}
+                  (and (string? default-path) (not (string/blank? default-path)))
+                  (assoc :defaultPath (node-path/dirname default-path)))
+           result (.showOpenDialog dialog (bean/->js opts))
+           result (get (js->clj result) "filePaths")]
+     (p/resolved (first result)))))
 
 (defn- pretty-print-js-error
   "Converts file related JS Error messages to a human readable format.
@@ -257,8 +261,8 @@
 
 ;; DB related IPCs End
 
-(defmethod handle :openDialog [^js _window _messages]
-  (open-dir-dialog))
+(defmethod handle :openDialog [^js _window [_ default-path]]
+  (open-dir-dialog default-path))
 
 (defmethod handle :showOpenDialog [_window [_ ^js options]]
   (p/let [^js result (.showOpenDialog dialog options)]

--- a/src/main/frontend/handler/plugin.cljs
+++ b/src/main/frontend/handler/plugin.cljs
@@ -926,7 +926,10 @@
 (defn load-unpacked-plugin
   []
   (when (util/electron?)
-    (p/let [path (ipc/ipc "openDialog")]
+    (p/let [last-path (storage/get :lsp-last-unpacked-plugin-path)
+            path (ipc/ipc "openDialog" last-path)]
+      (when (and (string? path) (not (string/blank? path)))
+        (storage/set :lsp-last-unpacked-plugin-path path))
       (when-not (:plugin/selected-unpacked-pkg @state/state)
         (state/set-state! :plugin/selected-unpacked-pkg path)))))
 


### PR DESCRIPTION
## Summary

The "Load unpacked plugin" dialog previously called `showOpenDialog` with no `defaultPath`, so the OS native picker (xdg-desktop-portal / GTK on Linux, equivalents on macOS/Windows) fell back to whatever location it had cached for the "open directory" purpose — often unrelated to the user's plugin folder and never updated by Logseq itself.

This change persists the last picked path in local storage as `:lsp-last-unpacked-plugin-path`, and passes its parent directory as `defaultPath` on subsequent opens, so the picker lands right next to the previously loaded plugin's sibling folders.

- `src/electron/electron/handler.cljs` — `open-dir-dialog` now takes an optional `default-path`; uses `path.dirname` so the picker opens at the parent of the last selection. `:openDialog` IPC handler forwards the optional argument.
- `src/main/frontend/handler/plugin.cljs` — `load-unpacked-plugin` reads the persisted path, passes it to the IPC, and stores the new pick.

## Test plan

- [ ] Open Plugins → Load unpacked plugin, pick a folder; close and reopen the dialog — it should open at the parent of the last pick.
- [ ] First-ever use (no stored path) still works and falls back to OS default behavior.
- [ ] Cancelling the dialog does not overwrite the stored path with an empty value.