### PR TITLE
fix(sync): drop stale asset ops

### DIFF
--- a/src/main/frontend/worker/sync/assets.cljs
+++ b/src/main/frontend/worker/sync/assets.cljs
@@ -154,6 +154,18 @@
                             :base base
                             :graph-id graph-id})))))
 
+(defn- drop-asset-op!
+  [repo asset-uuid reason data current-client-f broadcast-rtc-state!-f]
+  (log/warn :db-sync/drop-asset-op
+            (merge data
+                   {:repo repo
+                    :asset-uuid asset-uuid
+                    :reason reason}))
+  (client-op/remove-asset-op repo asset-uuid)
+  (when-let [client (current-client-f repo)]
+    (broadcast-rtc-state!-f client))
+  (p/resolved nil))
+
 (defn process-asset-op!
   [repo graph-id asset-op {:keys [current-client-f broadcast-rtc-state!-f fail-fast-f]}]
   (let [asset-uuid (:block/uuid asset-op)
@@ -170,18 +182,21 @@
               asset-type (:logseq.property.asset/type ent)
               checksum (:logseq.property.asset/checksum ent)
               size (:logseq.property.asset/size ent 0)]
-          (when-not asset-type
-            (fail-fast-f :db-sync/missing-field {:repo repo
-                                                 :field :asset-type
-                                                 :op :update-asset
-                                                 :asset-uuid asset-uuid}))
-          (when-not checksum
-            (fail-fast-f :db-sync/missing-field {:repo repo
-                                                 :field :checksum
-                                                 :op :update-asset
-                                                 :asset-uuid asset-uuid
-                                                 :asset-type asset-type}))
           (cond
+            (nil? ent)
+            (drop-asset-op! repo asset-uuid :missing-asset-entity {:op :update-asset}
+                            current-client-f broadcast-rtc-state!-f)
+
+            (not (seq asset-type))
+            (drop-asset-op! repo asset-uuid :missing-asset-type {:op :update-asset}
+                            current-client-f broadcast-rtc-state!-f)
+
+            (not (seq checksum))
+            (drop-asset-op! repo asset-uuid :missing-checksum
+                            {:op :update-asset
+                             :asset-type asset-type}
+                            current-client-f broadcast-rtc-state!-f)
+
             (> size max-asset-size)
             (do
               (log/info :db-sync/asset-too-large {:repo repo

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -1585,6 +1585,87 @@
             (is (= asset-uuid (get-in asset-op [:update-asset 2 :block-uuid])))
             (is (= :update-asset (first (:update-asset asset-op))))))))))
 
+(defn- process-pending-asset-op!
+  [asset-uuid]
+  (client-op/add-asset-ops test-repo [[:update-asset 10 {:block-uuid asset-uuid}]])
+  (let [fail-fast-called? (atom false)
+        broadcast-count (atom 0)
+        asset-op (first (client-op/get-all-asset-ops test-repo))]
+    (#'sync-assets/process-asset-op!
+     test-repo
+     "graph-id"
+     asset-op
+     {:current-client-f (constantly {:repo test-repo})
+      :broadcast-rtc-state!-f (fn [_client] (swap! broadcast-count inc))
+      :fail-fast-f (fn [tag data]
+                     (reset! fail-fast-called? true)
+                     (throw (ex-info (name tag) data)))})
+    {:fail-fast-called? @fail-fast-called?
+     :broadcast-count @broadcast-count
+     :pending-count (client-op/get-unpushed-asset-ops-count test-repo)}))
+
+(deftest process-asset-op-drops-update-when-asset-entity-is-missing-test
+  (testing "stale asset upload ops should not block sync when the entity no longer exists"
+    (let [{:keys [conn client-ops-conn]} (setup-parent-child)
+          asset-uuid (random-uuid)]
+      (with-datascript-conns
+        conn
+        client-ops-conn
+        (fn []
+          (let [result (process-pending-asset-op! asset-uuid)]
+            (is (false? (:fail-fast-called? result)))
+            (is (= 1 (:broadcast-count result)))
+            (is (= 0 (:pending-count result)))))))))
+
+(deftest process-asset-op-drops-update-when-asset-type-is-missing-test
+  (testing "asset upload ops should be dropped when the entity is missing asset type"
+    (let [{:keys [conn client-ops-conn]} (setup-parent-child)
+          asset-uuid (random-uuid)]
+      (d/transact! conn [{:block/uuid asset-uuid
+                          :block/title "asset-without-type"
+                          :logseq.property.asset/checksum "sha-256-value"}])
+      (with-datascript-conns
+        conn
+        client-ops-conn
+        (fn []
+          (let [result (process-pending-asset-op! asset-uuid)]
+            (is (false? (:fail-fast-called? result)))
+            (is (= 1 (:broadcast-count result)))
+            (is (= 0 (:pending-count result)))))))))
+
+(deftest process-asset-op-drops-update-when-asset-checksum-is-missing-test
+  (testing "asset upload ops should be dropped when the entity is missing checksum"
+    (let [{:keys [conn client-ops-conn]} (setup-parent-child)
+          asset-uuid (random-uuid)]
+      (d/transact! conn [{:block/uuid asset-uuid
+                          :block/title "asset.png"
+                          :logseq.property.asset/type "png"}])
+      (with-datascript-conns
+        conn
+        client-ops-conn
+        (fn []
+          (let [result (process-pending-asset-op! asset-uuid)]
+            (is (false? (:fail-fast-called? result)))
+            (is (= 1 (:broadcast-count result)))
+            (is (= 0 (:pending-count result)))))))))
+
+(deftest process-asset-op-drops-update-when-required-asset-attributes-are-blank-test
+  (testing "asset upload ops should be dropped when required attributes are blank"
+    (let [{:keys [conn client-ops-conn]} (setup-parent-child)
+          asset-uuid (random-uuid)]
+      (d/transact! conn [{:block/uuid asset-uuid
+                          :block/title "asset.png"
+                          :logseq.property.asset/type "png"
+                          :logseq.property.asset/checksum ""}])
+      (with-datascript-conns
+        conn
+        client-ops-conn
+        (fn []
+          (let [result (process-pending-asset-op! asset-uuid)]
+            (is (false? (:fail-fast-called? result)))
+            (is (= 1 (:broadcast-count result)))
+            (is (= 0 (:pending-count result)))))))))
+
 (deftest apply-history-action-does-not-reuse-original-tx-id-test
   (testing "undo/redo history actions should not overwrite the original pending tx row"
     (let [{:keys [conn client-ops-conn child1]} (setup-parent-child)


### PR DESCRIPTION
## Summary
- Drop pending asset upload ops when the asset entity no longer exists.
- Drop pending asset upload ops when required asset attributes are missing or blank.
- Add regression tests for missing entity, missing type, missing checksum, and blank attributes.

## Root cause
Asset upload ops persist only the block UUID. On reconnect, sync re-reads the current Datascript entity. If that entity was deleted or no longer has valid asset metadata, the old op used to fail-fast and could block sync startup.

## Verification
- `bb dev:test -v frontend.worker.db-sync-test/handle-local-tx-enqueues-asset-op-for-local-asset-checksum-test -v frontend.worker.db-sync-test/process-asset-op-drops-update-when-asset-entity-is-missing-test -v frontend.worker.db-sync-test/process-asset-op-drops-update-when-asset-type-is-missing-test -v frontend.worker.db-sync-test/process-asset-op-drops-update-when-asset-checksum-is-missing-test -v frontend.worker.db-sync-test/process-asset-op-drops-update-when-required-asset-attributes-are-blank-test -v frontend.worker.sync.assets-test`