### PR TITLE
fix: comment shortcut focus from editing block

### DIFF
--- a/src/main/frontend/handler/comments.cljs
+++ b/src/main/frontend/handler/comments.cljs
@@ -270,12 +270,12 @@
   []
   (when-let [block (state/get-edit-block)]
     (editor-handler/save-current-block!)
-    (db-property-handler/set-block-property! (:db/id block)
-                                             :block/tags
-                                             comments-model/comments-tag-ident)
-    (state/clear-edit!)
-    (reveal-comments-area! block {:focus-editor? true})
-    block))
+    (p/let [_ (db-property-handler/set-block-property! (:db/id block)
+                                                       :block/tags
+                                                       comments-model/comments-tag-ident)]
+      (state/clear-edit!)
+      (reveal-comments-area! block {:focus-editor? true})
+      block)))
 
 (defn add-comment-to-blocks!
   [blocks]

--- a/src/main/frontend/handler/comments.cljs
+++ b/src/main/frontend/handler/comments.cljs
@@ -246,7 +246,7 @@
 
 (defn- selected-block-entities
   []
-  (keep #(db/entity [:block/uuid %]) (state/get-selection-block-ids)))
+  (vec (keep #(db/entity [:block/uuid %]) (state/get-selection-block-ids))))
 
 (defn- edit-block-entity
   []
@@ -255,8 +255,9 @@
 
 (defn- comment-shortcut-targets
   []
-  (or (seq (selected-block-entities))
-      (some-> (edit-block-entity) vector)))
+  (or (when (state/editing?)
+        (some-> (edit-block-entity) vector seq))
+      (seq (selected-block-entities))))
 
 (defn- current-edit-block-blank?
   []
@@ -290,10 +291,11 @@
   (if (and (state/editing?)
            (current-edit-block-blank?))
     (set-current-block-as-comments-area!)
-    (do
+    (let [comment-targets (comment-shortcut-targets)]
       (when (state/editing?)
-        (editor-handler/save-current-block!))
-      (add-comment-to-blocks! (comment-shortcut-targets)))))
+        (editor-handler/save-current-block!)
+        (state/clear-edit!))
+      (add-comment-to-blocks! comment-targets))))
 
 (defn insert-comment!
   [comments-block content]

--- a/src/test/frontend/handler/editor_async_test.cljs
+++ b/src/test/frontend/handler/editor_async_test.cljs
@@ -455,6 +455,53 @@
                   (is @cleared-selection?)
                   (is (= [[:editor/hide-action-bar]] @events)))))))
 
+(deftest-async add-comment-to-non-empty-edit-block-focuses-comment-box
+  (let [block-uuid (random-uuid)
+        selected-uuid (random-uuid)
+        block {:block/uuid block-uuid
+               :db/id 1
+               :block/title "typing"
+               :block/page {:db/id 10}}
+        selected-block {:block/uuid selected-uuid
+                        :db/id 2
+                        :block/title "stale selection"
+                        :block/page {:db/id 10}}
+        comments-area {:block/uuid (random-uuid)
+                       :block/title "Comments"
+                       :block/tags #{comments-model/comments-tag-ident}}
+        saved? (atom false)
+        cleared? (atom false)
+        revealed (atom nil)]
+    (-> (p/with-redefs [state/editing? (constantly true)
+                        state/get-edit-block (constantly block)
+                        state/get-edit-content (constantly "typing")
+                        state/get-selection-block-ids (constantly [selected-uuid])
+                        db/entity (fn [lookup-ref]
+                                    (case lookup-ref
+                                      [:block/uuid block-uuid] block
+                                      [:block/uuid selected-uuid] selected-block
+                                      nil))
+                        block-handler/get-top-level-blocks identity
+                        editor/save-current-block! #(reset! saved? true)
+                        state/clear-edit! #(reset! cleared? true)
+                        comments-handler/ensure-comments-area-for-selected-blocks! (fn [blocks]
+                                                                                     (is (= [block] blocks)
+                                                                                         "The editing block should take precedence over stale selection state")
+                                                                                     (p/resolved comments-area))
+                        comments-handler/reveal-comments-area! (fn [area opts]
+                                                                 (reset! revealed [area opts]))
+                        state/clear-selection! (fn [])
+                        state/pub-event! (fn [_])]
+          (comments-handler/add-comment-to-current-context!)
+          (p/resolved nil))
+        (p/then (fn [_]
+                  (is @saved?)
+                  (is @cleared?
+                      "Moving focus to the comment box should leave the original block editor")
+                  (is (= [comments-area {:focus-editor? true}]
+                         @revealed)
+                      "Adding a comment while typing should open and focus the reply editor"))))))
+
 (deftest-async add-comment-to-empty-edit-block
   (let [block {:block/uuid (random-uuid)
                :db/id 1

--- a/src/test/frontend/handler/editor_async_test.cljs
+++ b/src/test/frontend/handler/editor_async_test.cljs
@@ -533,6 +533,31 @@
                          @revealed)
                       "Empty /Add comment should open the reply editor"))))))
 
+(deftest-async add-comment-to-empty-edit-block-reveals-after-comments-tag-is-saved
+  (let [block {:block/uuid (random-uuid)
+               :db/id 1
+               :block/title ""}
+        property-save (p/deferred)
+        revealed (atom nil)]
+    (-> (p/with-redefs [state/editing? (constantly true)
+                        state/get-edit-block (constantly block)
+                        state/get-edit-content (constantly "")
+                        editor/save-current-block! (fn [])
+                        db-property-handler/set-block-property! (fn [_db-id _property _value]
+                                                                  property-save)
+                        state/clear-edit! (fn [])
+                        comments-handler/reveal-comments-area! (fn [area opts]
+                                                                 (reset! revealed [area opts]))]
+          (let [result (comments-handler/add-comment-to-current-context!)]
+            (is (nil? @revealed)
+                "The reply editor cannot be focused until the blank block is saved as a comments area")
+            (p/resolve! property-save :saved)
+            result))
+        (p/then (fn [_]
+                  (is (= [block {:focus-editor? true}]
+                         @revealed)
+                      "The converted comments area should be revealed after the property transaction finishes"))))))
+
 (deftest-async empty-comment-submit-creates-sibling-block-after-comments
   (let [comments-area {:block/uuid (random-uuid)
                        :block/title "Comments"

--- a/src/test/frontend/handler/editor_async_test.cljs
+++ b/src/test/frontend/handler/editor_async_test.cljs
@@ -492,8 +492,7 @@
                                                                  (reset! revealed [area opts]))
                         state/clear-selection! (fn [])
                         state/pub-event! (fn [_])]
-          (comments-handler/add-comment-to-current-context!)
-          (p/resolved nil))
+          (comments-handler/add-comment-to-current-context!))
         (p/then (fn [_]
                   (is @saved?)
                   (is @cleared?


### PR DESCRIPTION
## Summary
- Prefer the active editing block when the add-comment shortcut runs while typing.
- Save and clear the old block editor before opening the comments reply box.
- Add a regression test for stale selection while editing a top-level block.

## Root cause
When Ctrl+Space was pressed while editing, the handler could resolve stale selected blocks before the active edit block and kept the original editor state active while attempting to focus the comments reply editor.

## Test plan
- bb dev:test -v frontend.handler.editor-async-test/add-comment-to-non-empty-edit-block-focuses-comment-box
- bb dev:test -v frontend.handler.editor-async-test
- bb dev:test -v frontend.modules.shortcut.core-test/test-add-comment-shortcut