### PR TITLE
enhance(mobile): add selection bar reaction

### DIFF
--- a/src/main/frontend/handler/events/ui.cljs
+++ b/src/main/frontend/handler/events/ui.cljs
@@ -257,9 +257,10 @@
      (editor-handler/save-current-block!)
      (editor-new-property block target opts))))
 
-(defn- editor-new-reaction [target]
+(defn- editor-new-reaction [block target]
   (let [editing-block (state/get-edit-block)
-        target-block-id (or (:block/uuid editing-block)
+        target-block-id (or (:block/uuid block)
+                            (:block/uuid editing-block)
                             (first (state/get-selection-block-ids)))
         target' (or target
                     (some-> (state/get-edit-input-id)
@@ -286,11 +287,11 @@
        {:align :start
         :content-props {:class "ls-icon-picker"}}))))
 
-(defmethod events/handle :editor/new-reaction [[_ {:keys [target]}]]
+(defmethod events/handle :editor/new-reaction [[_ {:keys [block target]}]]
   (when-not config/publishing?
     (p/do!
      (editor-handler/save-current-block!)
-     (editor-new-reaction target))))
+     (editor-new-reaction block target))))
 
 (defmethod events/handle :graph/new-db-graph [[_ _opts]]
   (shui/dialog-open!

--- a/src/main/frontend/handler/events/ui.cljs
+++ b/src/main/frontend/handler/events/ui.cljs
@@ -257,11 +257,18 @@
      (editor-handler/save-current-block!)
      (editor-new-property block target opts))))
 
-(defn- editor-new-reaction [block target]
-  (let [editing-block (state/get-edit-block)
-        target-block-id (or (:block/uuid block)
-                            (:block/uuid editing-block)
-                            (first (state/get-selection-block-ids)))
+(defn- reaction-target-block-ids [blocks]
+  (let [blocks' (cond
+                  (nil? blocks) nil
+                  (sequential? blocks) blocks
+                  :else [blocks])]
+    (vec
+     (or (seq (keep :block/uuid blocks'))
+         (some-> (state/get-edit-block) :block/uuid vector)
+         (seq (state/get-selection-block-ids))))))
+
+(defn- editor-new-reaction [blocks target]
+  (let [target-block-ids (reaction-target-block-ids blocks)
         target' (or target
                     (some-> (state/get-edit-input-id)
                             (gdom/getElement))
@@ -271,10 +278,11 @@
                         emoji? (= :emoji (:type icon))]
                     (if emoji?
                       (do
-                        (reaction-handler/toggle-reaction! target-block-id emoji-id)
+                        (doseq [target-block-id target-block-ids]
+                          (reaction-handler/toggle-reaction! target-block-id emoji-id))
                         (shui/popup-hide! popup-id))
                       (notification/show! (t :block.reaction/emoji-required-warning) :warning))))]
-    (when (and target-block-id target')
+    (when (and (seq target-block-ids) target')
       (shui/popup-show!
        target'
        (fn [{:keys [id]}]
@@ -287,11 +295,11 @@
        {:align :start
         :content-props {:class "ls-icon-picker"}}))))
 
-(defmethod events/handle :editor/new-reaction [[_ {:keys [block target]}]]
+(defmethod events/handle :editor/new-reaction [[_ {:keys [block blocks target]}]]
   (when-not config/publishing?
     (p/do!
      (editor-handler/save-current-block!)
-     (editor-new-reaction block target))))
+     (editor-new-reaction (if (seq blocks) blocks block) target))))
 
 (defmethod events/handle :graph/new-db-graph [[_ _opts]]
   (shui/dialog-open!

--- a/src/main/mobile/components/selection_toolbar.cljs
+++ b/src/main/mobile/components/selection_toolbar.cljs
@@ -33,6 +33,7 @@
   (let [close! close-selection-bar!
         blocks (selected-blocks)
         first-block-id (:block/uuid (first blocks))
+        selection-target (first (state/get-selection-blocks))
         comment-targets (comments-model/comment-target-blocks blocks)]
     (vec
      (concat
@@ -58,6 +59,15 @@
           :system-icon "text.bubble"
           :handler (fn []
                      (comments-handler/add-comment-to-blocks! comment-targets)
+                     (close!))}])
+      (when (and first-block-id selection-target)
+        [{:id "reaction"
+          :label (t :command.editor/add-reaction)
+          :system-icon "face.smiling"
+          :handler (fn []
+                     (state/pub-event! [:editor/new-reaction
+                                        {:block {:block/uuid first-block-id}
+                                         :target selection-target}])
                      (close!))}])
       [{:id "delete"
         :label (t :ui/delete)

--- a/src/main/mobile/components/selection_toolbar.cljs
+++ b/src/main/mobile/components/selection_toolbar.cljs
@@ -33,6 +33,7 @@
   (let [close! close-selection-bar!
         blocks (selected-blocks)
         first-block-id (:block/uuid (first blocks))
+        reaction-blocks (mapv #(select-keys % [:block/uuid]) blocks)
         selection-target (first (state/get-selection-blocks))
         comment-targets (comments-model/comment-target-blocks blocks)]
     (vec
@@ -60,14 +61,17 @@
           :handler (fn []
                      (comments-handler/add-comment-to-blocks! comment-targets)
                      (close!))}])
-      (when (and first-block-id selection-target)
+      (when (and (seq reaction-blocks) selection-target)
         [{:id "reaction"
           :label (t :command.editor/add-reaction)
           :system-icon "face.smiling"
           :handler (fn []
-                     (state/pub-event! [:editor/new-reaction
-                                        {:block {:block/uuid first-block-id}
-                                         :target selection-target}])
+                     (let [opts (if (= 1 (count reaction-blocks))
+                                  {:block (first reaction-blocks)
+                                   :target selection-target}
+                                  {:blocks reaction-blocks
+                                   :target selection-target})]
+                       (state/pub-event! [:editor/new-reaction opts]))
                      (close!))}])
       [{:id "delete"
         :label (t :ui/delete)

--- a/src/test/mobile/selection_toolbar_test.cljs
+++ b/src/test/mobile/selection_toolbar_test.cljs
@@ -1,0 +1,30 @@
+(ns mobile.selection-toolbar-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [frontend.handler.editor :as editor-handler]
+            [frontend.state :as state]
+            [mobile.components.selection-toolbar :as selection-toolbar]))
+
+(deftest selection-actions-include-reaction
+  (testing "selected block can open the reaction picker from the mobile selection bar"
+    (let [block-uuid (random-uuid)
+          block-node #js {}
+          events (atom [])
+          closed? (atom false)]
+      (with-redefs [selection-toolbar/selected-blocks (constantly [{:block/uuid block-uuid}])
+                    state/get-selection-blocks (constantly [block-node])
+                    state/pub-event! (fn [event]
+                                       (swap! events conj event)
+                                       nil)
+                    editor-handler/clear-selection! #(reset! closed? true)
+                    state/set-state! (fn [& _args])
+                    selection-toolbar/dismiss-action-bar! (fn [])]
+        (let [actions (#'selection-toolbar/selection-actions)
+              action (some #(when (= "reaction" (:id %)) %) actions)]
+          (is (some? action))
+          (is (= "Add reaction" (:label action)))
+          (when action
+            ((:handler action))
+            (is (= [[:editor/new-reaction {:block {:block/uuid block-uuid}
+                                            :target block-node}]]
+                   @events))
+            (is (true? @closed?))))))))

--- a/src/test/mobile/selection_toolbar_test.cljs
+++ b/src/test/mobile/selection_toolbar_test.cljs
@@ -28,3 +28,30 @@
                                             :target block-node}]]
                    @events))
             (is (true? @closed?))))))))
+
+(deftest selection-actions-include-reaction-for-multiple-blocks
+  (testing "selected blocks can open the reaction picker from the mobile selection bar"
+    (let [block-uuid-1 (random-uuid)
+          block-uuid-2 (random-uuid)
+          block-node #js {}
+          events (atom [])
+          closed? (atom false)]
+      (with-redefs [selection-toolbar/selected-blocks (constantly [{:block/uuid block-uuid-1}
+                                                                    {:block/uuid block-uuid-2}])
+                    state/get-selection-blocks (constantly [block-node])
+                    state/pub-event! (fn [event]
+                                       (swap! events conj event)
+                                       nil)
+                    editor-handler/clear-selection! #(reset! closed? true)
+                    state/set-state! (fn [& _args])
+                    selection-toolbar/dismiss-action-bar! (fn [])]
+        (let [actions (#'selection-toolbar/selection-actions)
+              action (some #(when (= "reaction" (:id %)) %) actions)]
+          (is (some? action))
+          (when action
+            ((:handler action))
+            (is (= [[:editor/new-reaction {:blocks [{:block/uuid block-uuid-1}
+                                                     {:block/uuid block-uuid-2}]
+                                            :target block-node}]]
+                   @events))
+            (is (true? @closed?))))))))


### PR DESCRIPTION
## Summary
- Add an Add reaction action to the mobile native selection bar.
- Dispatch the existing reaction picker with explicit block and target context so clearing the selection bar does not lose the selected block.
- Add mobile selection toolbar coverage for the reaction action.

## Test plan
- bb dev:test -v mobile.selection-toolbar-test/selection-actions-include-reaction
- bb dev:test -v mobile.selection-toolbar-test
- bb dev:test -v frontend.handler.reaction-test
- bb lang:lint-hardcoded --git-changed
- bb dev:lint-and-test