### PR TITLE
fix: limit mobile comment toolbar

### DIFF
--- a/src/main/mobile/components/editor_toolbar.cljs
+++ b/src/main/mobile/components/editor_toolbar.cljs
@@ -39,23 +39,22 @@
 
 (defn- insert-page-ref!
   []
-  (let [{:keys [block]} (editor-handler/get-state)]
-    (when block
-      (let [input (state/get-input)]
-        (state/clear-editor-action!)
-        (let [selection (editor-handler/get-selection-and-format)
-              {:keys [selection-start selection-end selection]} selection]
-          (if selection
-            (do
-              (editor-handler/delete-and-update input selection-start selection-end)
-              (editor-handler/insert (page-ref/->page-ref selection)))
-            (insert-text page-ref/left-and-right-brackets
-                         {:backward-pos 2
-                          :check-fn (fn [_ _ _]
-                                      (let [input (state/get-input)
-                                            new-pos (cursor/get-caret-pos input)]
-                                        (state/set-editor-action-data! {:pos new-pos})
-                                        (commands/handle-step [:editor/search-page])))})))))))
+  (when (state/get-edit-input-id)
+    (let [input (state/get-input)]
+      (state/clear-editor-action!)
+      (let [selection (editor-handler/get-selection-and-format)
+            {:keys [selection-start selection-end selection]} selection]
+        (if (and input selection)
+          (do
+            (editor-handler/delete-and-update input selection-start selection-end)
+            (editor-handler/insert (page-ref/->page-ref selection)))
+          (insert-text page-ref/left-and-right-brackets
+                       {:backward-pos 2
+                        :check-fn (fn [_ _ _]
+                                    (let [input (state/get-input)
+                                          new-pos (cursor/get-caret-pos input)]
+                                      (state/set-editor-action-data! {:pos new-pos})
+                                      (commands/handle-step [:editor/search-page])))}))))))
 
 (defn- indent-outdent-action
   [indent?]
@@ -151,19 +150,24 @@
 
 (defn- toolbar-actions
   []
-  (let [keyboard (keyboard-action)
-        main-actions [(undo-action)
-                      (todo-action)
-                      (indent-outdent-action false)
-                      (indent-outdent-action true)
-                      (tag-action)
-                      (camera-action)
-                      (page-ref-action)
-                      (audio-action)
-                      (slash-action)
-                      (redo-action)]]
-    {:main main-actions
-     :trailing keyboard}))
+  (if (:comment-editor? (last (state/get-editor-args)))
+    {:main [(page-ref-action)
+            (camera-action)
+            (audio-action)]
+     :trailing nil}
+    (let [keyboard (keyboard-action)
+          main-actions [(undo-action)
+                        (todo-action)
+                        (indent-outdent-action false)
+                        (indent-outdent-action true)
+                        (tag-action)
+                        (camera-action)
+                        (page-ref-action)
+                        (audio-action)
+                        (slash-action)
+                        (redo-action)]]
+      {:main main-actions
+       :trailing keyboard})))
 
 (defn- action->native
   [{:keys [id title system-icon]}]

--- a/src/main/mobile/components/editor_toolbar.cljs
+++ b/src/main/mobile/components/editor_toolbar.cljs
@@ -39,22 +39,21 @@
 
 (defn- insert-page-ref!
   []
-  (when (state/get-edit-input-id)
-    (let [input (state/get-input)]
-      (state/clear-editor-action!)
-      (let [selection (editor-handler/get-selection-and-format)
-            {:keys [selection-start selection-end selection]} selection]
-        (if (and input selection)
-          (do
-            (editor-handler/delete-and-update input selection-start selection-end)
-            (editor-handler/insert (page-ref/->page-ref selection)))
-          (insert-text page-ref/left-and-right-brackets
-                       {:backward-pos 2
-                        :check-fn (fn [_ _ _]
-                                    (let [input (state/get-input)
-                                          new-pos (cursor/get-caret-pos input)]
-                                      (state/set-editor-action-data! {:pos new-pos})
-                                      (commands/handle-step [:editor/search-page])))}))))))
+  (when-let [input (state/get-input)]
+    (state/clear-editor-action!)
+    (let [selection (editor-handler/get-selection-and-format)
+          {:keys [selection-start selection-end selection]} selection]
+      (if selection
+        (do
+          (editor-handler/delete-and-update input selection-start selection-end)
+          (editor-handler/insert (page-ref/->page-ref selection)))
+        (insert-text page-ref/left-and-right-brackets
+                     {:backward-pos 2
+                      :check-fn (fn [_ _ _]
+                                  (let [input (state/get-input)
+                                        new-pos (cursor/get-caret-pos input)]
+                                    (state/set-editor-action-data! {:pos new-pos})
+                                    (commands/handle-step [:editor/search-page])))})))))
 
 (defn- indent-outdent-action
   [indent?]

--- a/src/test/mobile/editor_toolbar_test.cljs
+++ b/src/test/mobile/editor_toolbar_test.cljs
@@ -1,0 +1,37 @@
+(ns mobile.editor-toolbar-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [frontend.commands :as commands]
+            [frontend.handler.editor :as editor-handler]
+            [frontend.state :as state]
+            [frontend.util.cursor :as cursor]
+            [goog.dom :as gdom]
+            [logseq.common.util.page-ref :as page-ref]
+            [mobile.components.editor-toolbar :as editor-toolbar]))
+
+(deftest comment-toolbar-actions-are-limited
+  (testing "comment editing only exposes reference, photo, and audio"
+    (with-redefs [state/get-editor-args (constantly [{} "edit-block-comment" {:comment-editor? true}])]
+      (let [{:keys [main trailing]} (#'editor-toolbar/toolbar-actions)]
+        (is (= ["page-ref" "camera" "audio"]
+               (mapv :id main)))
+        (is (nil? trailing))))))
+
+(deftest comment-reference-action-inserts-page-ref
+  (testing "comment reference action works without regular block editor state"
+    (let [input-id "edit-block-comment"
+          input #js {:value ""}
+          insertions (atom [])]
+      (with-redefs [editor-handler/get-state (constantly nil)
+                    editor-handler/get-selection-and-format (constantly nil)
+                    state/get-edit-input-id (constantly input-id)
+                    state/get-input (constantly input)
+                    gdom/getElement (fn [id]
+                                      (when (= id input-id)
+                                        input))
+                    cursor/pos (constantly 0)
+                    commands/simple-insert! (fn [id value opts]
+                                              (swap! insertions conj
+                                                     [id value (:backward-pos opts) (fn? (:check-fn opts))]))]
+        ((:handler (#'editor-toolbar/page-ref-action)))
+        (is (= [[input-id page-ref/left-and-right-brackets 2 true]]
+               @insertions))))))


### PR DESCRIPTION
## Summary
- Limit the native mobile editor toolbar to node reference, photo, and audio while adding or editing comments.
- Allow the node reference toolbar action to insert `[[ ]]` from comment editors without depending on regular block editor state.
- Add focused mobile toolbar tests for the comment action set and reference insertion path.

## Verification
- `clj-kondo --lint src/main/mobile/components/editor_toolbar.cljs src/test/mobile/editor_toolbar_test.cljs`
- `git diff --check -- src/main/mobile/components/editor_toolbar.cljs src/test/mobile/editor_toolbar_test.cljs`

## Blocked checks
- `bb dev:test -v mobile.editor-toolbar-test` in the original worktree is blocked by an existing CLJS test compile error in `src/main/frontend/components/lazy_editor.cljs`: `Could not find module for ns: frontend.extensions.code`. The same error occurs for existing `mobile.tabs-test`.
- `bb dev:test -v mobile.editor-toolbar-test` in the clean PR worktree is blocked because that worktree has no `node_modules`, causing `bignumber.js` to be unavailable.