### PR TITLE
fix: repair comment thread metadata

### DIFF
--- a/deps/db/src/logseq/db/frontend/schema.cljs
+++ b/deps/db/src/logseq/db/frontend/schema.cljs
@@ -30,7 +30,7 @@
          (map (juxt :major :minor)
               [(parse-schema-version x) (parse-schema-version y)])))
 
-(def version (parse-schema-version "65.31"))
+(def version (parse-schema-version "65.32"))
 
 (defn major-version
   "Return a number.

--- a/src/main/frontend/worker/db/migrate.cljs
+++ b/src/main/frontend/worker/db/migrate.cljs
@@ -92,6 +92,27 @@
                  (when-not (seq (:logseq.property.comments/blocks comments-area))
                    [:db/add comments-area-id :logseq.property.comments/blocks parent-id]))))))
 
+(defn- missing-class-extends?
+  [class]
+  (let [extends (:logseq.property.class/extends class)]
+    (or (nil? extends)
+        (and (coll? extends) (empty? extends)))))
+
+(defn- repair-comment-classes-and-targets
+  [db]
+  (let [root-id (:db/id (d/entity db :logseq.class/Root))]
+    (concat
+     (add-single-block-comment-targets db)
+     (mapcat
+      (fn [class-ident]
+        (when-let [class (d/entity db class-ident)]
+          (concat
+           (when (and root-id (missing-class-extends? class))
+             [[:db/add (:db/id class) :logseq.property.class/extends root-id]])
+           (when (:block/order class)
+             [[:db/retract (:db/id class) :block/order (:block/order class)]]))))
+      [:logseq.class/Comments :logseq.class/Comment]))))
+
 (def schema-version->updates
   "A vec of tuples defining datascript migrations. Each tuple consists of the
    schema version integer and a migration map. A migration map can have keys of :properties, :classes
@@ -128,7 +149,8 @@
              :fix tag-comment-blocks}]
    ["65.29" {:fix add-single-block-comment-targets}]
    ["65.30" {:properties [:logseq.property/assignee]}]
-   ["65.31" {:properties [:logseq.property.agent/session-id]}]])
+   ["65.31" {:properties [:logseq.property.agent/session-id]}]
+   ["65.32" {:fix repair-comment-classes-and-targets}]])
 
 (let [[major minor] (last (sort (map (comp (juxt :major :minor) db-schema/parse-schema-version first)
                                      schema-version->updates)))]

--- a/src/main/frontend/worker/db_core.cljs
+++ b/src/main/frontend/worker/db_core.cljs
@@ -424,16 +424,21 @@
   [:logseq.class/Comments
    :logseq.class/Comment])
 
+(def ^:private built-in-sync-repair-unordered-classes
+  #{:logseq.class/Comments
+    :logseq.class/Comment})
+
 ;; Fixed so duplicate repair txs from multiple clients converge on the same datoms.
 (def ^:private built-in-sync-repair-timestamp 0)
 
 (defn- stable-built-in-sync-repair-item
   [order item]
   (if (and (map? item) (:block/uuid item))
-    (assoc item
-           :block/created-at built-in-sync-repair-timestamp
-           :block/updated-at built-in-sync-repair-timestamp
-           :block/order order)
+    (cond-> (assoc item
+                   :block/created-at built-in-sync-repair-timestamp
+                   :block/updated-at built-in-sync-repair-timestamp)
+      (not (contains? built-in-sync-repair-unordered-classes (:db/ident item)))
+      (assoc :block/order order))
     item))
 
 (defn- built-in-sync-repair-tx-data

--- a/src/main/frontend/worker/pipeline.cljs
+++ b/src/main/frontend/worker/pipeline.cljs
@@ -327,6 +327,29 @@
                         :logseq.property/query [:block/uuid value-uuid]})]))))))
          tagged-block-ids)))))
 
+(defn- ensure-comments-blocks-property-on-tag-additions
+  [tx-report]
+  (let [{:keys [db-after tx-data tx-meta]} tx-report
+        comments-class (d/entity db-after :logseq.class/Comments)]
+    (when (and comments-class
+               (not (rtc-tx-or-download-graph? tx-meta))
+               (not (:undo? tx-meta))
+               (not (:redo? tx-meta)))
+      (->> tx-data
+           (keep (fn [datom]
+                   (when (and (= :block/tags (:a datom))
+                              (:added datom)
+                              (= (:db/id comments-class) (:v datom)))
+                     (:e datom))))
+           distinct
+           (keep (fn [eid]
+                   (when-let [block (d/entity db-after eid)]
+                     (when (and (:block/parent block)
+                                (not (seq (:logseq.property.comments/blocks block))))
+                       (outliner-core/block-with-updated-at
+                        {:db/id eid
+                         :logseq.property.comments/blocks (:db/id (:block/parent block))})))))))))
+
 (defn- invoke-hooks-for-imported-graph [conn {:keys [tx-meta] :as tx-report}]
   (let [refs-tx-report (outliner-pipeline/transact-new-db-graph-refs conn tx-report)
         full-tx-data (concat (:tx-data tx-report) (:tx-data refs-tx-report))
@@ -454,6 +477,7 @@
                                         (toggle-page-and-block db tx-report))
         display-blocks-tx-data (add-missing-properties-to-typed-display-blocks db-after tx-data tx-meta)
         ensure-query-tx-data (ensure-query-property-on-tag-additions tx-report)
+        ensure-comments-tx-data (ensure-comments-blocks-property-on-tag-additions tx-report)
         commands-tx (when-not (or (:undo? tx-meta)
                                   (= :rebase (:outliner-op tx-meta))
                                   (rtc-tx-or-download-graph? tx-meta))
@@ -465,6 +489,7 @@
             toggle-page-and-block-tx-data
             display-blocks-tx-data
             ensure-query-tx-data
+            ensure-comments-tx-data
             commands-tx
             insert-templates-tx
             created-by-tx

--- a/src/test/frontend/worker/db_core_test.cljs
+++ b/src/test/frontend/worker/db_core_test.cljs
@@ -319,10 +319,18 @@
            (or (not (and (map? item) (:block/uuid item)))
                (and (number? (:block/created-at item))
                     (number? (:block/updated-at item))
-                    (string? (:block/order item))
-                    (db-order/validate-order-key? (:block/order item)))))
+                    (or (contains? #{:logseq.class/Comments :logseq.class/Comment} (:db/ident item))
+                        (and (string? (:block/order item))
+                             (db-order/validate-order-key? (:block/order item)))))))
          tx-data)
-        "Block-shaped repair items keep valid timestamps and order")
+        "Block-shaped repair items keep valid timestamps and order when order is allowed")
+    (is (not-any?
+         (fn [item]
+           (and (map? item)
+                (contains? #{:logseq.class/Comments :logseq.class/Comment} (:db/ident item))
+                (contains? item :block/order)))
+         tx-data)
+        "#Comments and #Comment repair class blocks should not have block order")
     (is (not-any?
          (fn [item]
            (or (and (map? item)

--- a/src/test/frontend/worker/migrate_test.cljs
+++ b/src/test/frontend/worker/migrate_test.cljs
@@ -16,6 +16,30 @@
         db
         attr)))
 
+(defn- extends-idents
+  [db entity]
+  (let [parents (:logseq.property.class/extends entity)]
+    (map (fn [parent]
+           (:db/ident (if (number? parent)
+                        (d/entity db parent)
+                        parent)))
+         (cond
+           (nil? parents) []
+           (set? parents) parents
+           (sequential? parents) parents
+           :else [parents]))))
+
+(defn- ref-ids
+  [refs]
+  (set
+   (map (fn [ref]
+          (if (number? ref) ref (:db/id ref)))
+        (cond
+          (nil? refs) []
+          (set? refs) refs
+          (sequential? refs) refs
+          :else [refs]))))
+
 (def ^:private legacy-65-24-schema
   (merge db-schema/schema
          {:block/pre-block? {:db/index true}
@@ -210,7 +234,7 @@
     (d/transact! conn [{:db/ident :logseq.kv/schema-version
                         :kv/value {:major 65 :minor 30}}])
 
-    (let [result (db-migrate/migrate conn)]
+    (let [result (db-migrate/migrate conn :target-version {:major 65 :minor 31})]
       (is (= {:major 65 :minor 31}
              (:kv/value (d/entity @conn :logseq.kv/schema-version))))
       (let [property (d/entity @conn :logseq.property.agent/session-id)]
@@ -224,3 +248,40 @@
       (is (some #(= {:properties [:logseq.property.agent/session-id]}
                     (:migrate-updates %))
                 (:upgrade-result-coll result))))))
+
+(deftest migrate-65-32-adds-root-extends-to-comment-classes
+  (let [conn (d/create-conn db-schema/schema)
+        target-uuid #uuid "11111111-1111-1111-1111-111111111111"
+        comments-area-uuid #uuid "22222222-2222-2222-2222-222222222222"]
+    (d/transact! conn [{:db/ident :logseq.kv/schema-version
+                        :kv/value {:major 65 :minor 31}}
+                       {:db/ident :logseq.class/Root
+                        :block/title "Root Tag"}
+                       {:db/ident :logseq.class/Comments
+                        :block/title "Comments"
+                        :block/order "a0"}
+                       {:db/ident :logseq.class/Comment
+                        :block/title "Comment"
+                        :block/order "a1"}
+                       {:block/uuid target-uuid
+                        :block/title "target"}
+                       {:block/uuid comments-area-uuid
+                        :block/title "Comments"
+                        :block/parent [:block/uuid target-uuid]
+                        :block/tags #{:logseq.class/Comments}}])
+
+    (let [result (db-migrate/migrate conn :target-version {:major 65 :minor 32})
+          migration-report (first (:upgrade-result-coll result))
+          migration-db (:db-after migration-report)]
+
+      (is (= {:major 65 :minor 32}
+             (:kv/value (d/entity @conn :logseq.kv/schema-version))))
+      (is (= [:logseq.class/Root]
+             (extends-idents migration-db (d/entity migration-db :logseq.class/Comments))))
+      (is (nil? (:block/order (d/entity migration-db :logseq.class/Comments))))
+      (is (= [:logseq.class/Root]
+             (extends-idents migration-db (d/entity migration-db :logseq.class/Comment))))
+      (is (nil? (:block/order (d/entity migration-db :logseq.class/Comment))))
+      (is (= #{(:db/id (d/entity migration-db [:block/uuid target-uuid]))}
+             (ref-ids (:logseq.property.comments/blocks
+                       (d/entity migration-db [:block/uuid comments-area-uuid]))))))))

--- a/src/test/frontend/worker/pipeline_test.cljs
+++ b/src/test/frontend/worker/pipeline_test.cljs
@@ -93,6 +93,24 @@
     ;; return global fn back to previous behavior
     (ldb/register-transact-pipeline-fn! identity)))
 
+(deftest ensure-comments-blocks-property-on-tag-additions-test
+  (let [conn (db-test/create-conn-with-blocks
+              {:pages-and-blocks [{:page {:block/title "page1"}
+                                   :blocks [{:block/title "target"
+                                             :build/children [{:block/title ""}]}]}]})
+        target (db-test/find-block-by-content @conn "target")
+        empty-block (first (:block/_parent target))]
+    (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
+    (try
+      (ldb/transact! conn [[:db/add (:db/id empty-block) :block/tags :logseq.class/Comments]])
+      (let [comments-area (d/entity @conn (:db/id empty-block))]
+        (is (= #{(:db/id target)}
+               (set (map :db/id (:logseq.property.comments/blocks comments-area))))
+            "Tagging an existing empty child block with #Comments should target its parent"))
+      (finally
+        ;; return global fn back to previous behavior
+        (ldb/register-transact-pipeline-fn! identity)))))
+
 (deftest code-block-tag-addition-preserves-explicit-code-lang-test
   (let [conn (db-test/create-conn-with-blocks
               {:pages-and-blocks [{:page {:block/title "page1"}}]})


### PR DESCRIPTION
## Summary

- add a 65.32 migration to repair comment thread metadata on existing graphs
- ensure #Comments and #Comment extend Root Tag without invalid block order
- set missing :logseq.property.comments/blocks when #Comments is added to an existing block
- keep built-in sync repair data aligned with the comment class validation shape

## Validation

- bb dev:test -v frontend.worker.migrate-test
- bb dev:test -v frontend.worker.pipeline-test
- bb dev:test -v frontend.worker.db-core-test/built-in-sync-repair-tx-data-covers-65-26-through-65-28-test
- bb dev:test -v frontend.worker.db-validate-test
- bb dev:test -v frontend.worker.search-test/combine-results-large-result-benchmark
- bb dev:lint-and-test

Review workflow: applied logseq-review-workflow locally. Subagent delegation was unavailable in this tool session, so the correctness, data-contract, regression, failure-mode, migration-validation, performance, test-coverage, and repository-convention passes were run locally against the required rule files.