### PR TITLE
fix: add Task tag when setting status

### DIFF
--- a/deps/outliner/src/logseq/outliner/property.cljs
+++ b/deps/outliner/src/logseq/outliner/property.cljs
@@ -89,6 +89,8 @@
                                :type :error}
                      :property-id property-ident}))))
 
+(declare get-block-classes-properties)
+
 (defn- validate-batch-deletion-of-property
   "Validates that the given property can be batch deleted from multiple nodes"
   [entities property-ident]
@@ -96,6 +98,19 @@
   (when (= :block/tags property-ident) (throw-error-if-removing-private-tag entities))
   (outliner-validate/disallow-editing-private-built-in-nodes entities)
   (throw-error-if-deleting-required-property property-ident))
+
+(defn- block-classes-provide-property?
+  [db block property-id]
+  (->> (:classes-properties (get-block-classes-properties db (:db/id block)))
+       (some #(= property-id (:db/ident %)))
+       boolean))
+
+(defn- should-add-task-tag-for-property?
+  [conn block property-id]
+  (and (contains? #{:logseq.property/status :logseq.property/scheduled :logseq.property/deadline} property-id)
+       (or (empty? (:block/tags block))
+           (ldb/internal-page? block)
+           (not (block-classes-provide-property? @conn block property-id)))))
 
 (defn- build-property-value-tx-data
   [conn block property-id value]
@@ -110,9 +125,7 @@
           update-block-tx (cond-> (outliner-core/block-with-updated-at {:db/id (:db/id block)})
                             true
                             (assoc property-id value)
-                            (and (contains? #{:logseq.property/status :logseq.property/scheduled :logseq.property/deadline} property-id)
-                                 (or (empty? (:block/tags block)) (ldb/internal-page? block))
-                                 (not (get (d/pull @conn [property-id] (:db/id block)) property-id)))
+                            (should-add-task-tag-for-property? conn block property-id)
                             (assoc :block/tags :logseq.class/Task)
                             (= :logseq.property/template-applied-to property-id)
                             (assoc :block/tags :logseq.class/Template))]

--- a/deps/outliner/test/logseq/outliner/property_test.cljs
+++ b/deps/outliner/test/logseq/outliner/property_test.cljs
@@ -275,7 +275,7 @@
                           {:block/title "cat task" :build/tags [:Cat]}
                           {:block/title "project task" :build/tags [:Project]}]}]})
         page1 (:block/uuid (db-test/find-page-by-title @conn "page1"))
-        [empty-task cat project]
+        [empty-task cat-task project]
         (map #(:block/uuid (db-test/find-block-by-content @conn %)) ["" "cat task" "project task"])]
 
     (outliner-property/batch-set-property! conn [empty-task] :logseq.property/status :logseq.property/status.doing)
@@ -288,9 +288,9 @@
            (set (map :db/ident (:block/tags (d/entity @conn [:block/uuid page1])))))
         "Adds Task to page without tag")
 
-    (outliner-property/batch-set-property! conn [cat] :logseq.property/status :logseq.property/status.doing)
+    (outliner-property/batch-set-property! conn [cat-task] :logseq.property/status :logseq.property/status.doing)
     (is (= #{:logseq.class/Task :user.class/Cat}
-           (set (map :db/ident (:block/tags (d/entity @conn [:block/uuid cat])))))
+           (set (map :db/ident (:block/tags (d/entity @conn [:block/uuid cat-task])))))
         "Adds Task to tagged block when its classes do not provide status")
 
     (outliner-property/batch-set-property! conn [project] :logseq.property/status :logseq.property/status.doing)

--- a/deps/outliner/test/logseq/outliner/property_test.cljs
+++ b/deps/outliner/test/logseq/outliner/property_test.cljs
@@ -267,14 +267,16 @@
 
 (deftest status-property-setting-classes
   (let [conn (db-test/create-conn-with-blocks
-              {:classes {:Project {:build/class-properties [:logseq.property/status]}}
+              {:classes {:Cat {}
+                         :Project {:build/class-properties [:logseq.property/status]}}
                :pages-and-blocks
                [{:page {:block/title "page1"}
                  :blocks [{:block/title ""}
+                          {:block/title "cat task" :build/tags [:Cat]}
                           {:block/title "project task" :build/tags [:Project]}]}]})
         page1 (:block/uuid (db-test/find-page-by-title @conn "page1"))
-        [empty-task project]
-        (map #(:block/uuid (db-test/find-block-by-content @conn %)) ["" "project task"])]
+        [empty-task cat project]
+        (map #(:block/uuid (db-test/find-block-by-content @conn %)) ["" "cat task" "project task"])]
 
     (outliner-property/batch-set-property! conn [empty-task] :logseq.property/status :logseq.property/status.doing)
     (is (= [:logseq.class/Task]
@@ -286,10 +288,15 @@
            (set (map :db/ident (:block/tags (d/entity @conn [:block/uuid page1])))))
         "Adds Task to page without tag")
 
+    (outliner-property/batch-set-property! conn [cat] :logseq.property/status :logseq.property/status.doing)
+    (is (= #{:logseq.class/Task :user.class/Cat}
+           (set (map :db/ident (:block/tags (d/entity @conn [:block/uuid cat])))))
+        "Adds Task to tagged block when its classes do not provide status")
+
     (outliner-property/batch-set-property! conn [project] :logseq.property/status :logseq.property/status.doing)
     (is (= [:user.class/Project]
            (mapv :db/ident (:block/tags (d/entity @conn [:block/uuid project]))))
-        "Doesn't add Task to block when it is already tagged")))
+        "Doesn't add Task to block when its class provides status")))
 
 (deftest batch-set-property-rejects-private-built-in-entity
   (let [conn (db-test/create-conn)

--- a/src/test/logseq/cli/command/agent_test.cljs
+++ b/src/test/logseq/cli/command/agent_test.cljs
@@ -1484,6 +1484,16 @@
                                                                   (swap! active* dec)
                                                                   {:session (str "session-" (random-uuid))
                                                                    :status :running})))
+                                 transport/invoke (fn [_cfg method _args]
+                                                    (case method
+                                                      :thread-api/q
+                                                      (p/resolved nil)
+
+                                                      :thread-api/apply-outliner-ops
+                                                      (p/resolved {:ok true})
+
+                                                      (p/rejected (ex-info "unexpected invoke"
+                                                                           {:method method}))))
                                  agent-command/write-agent-session-id! (fn [_cfg _repo block-uuid session-id]
                                                                          (swap! routed* conj [block-uuid session-id])
                                                                          (p/resolved true))]
@@ -1623,6 +1633,12 @@
                                  transport/invoke (fn [_cfg method args]
                                                     (swap! calls conj [method args])
                                                     (case method
+                                                      :thread-api/q
+                                                      (p/resolved nil)
+
+                                                      :thread-api/apply-outliner-ops
+                                                      (p/resolved {:ok true})
+
                                                       :thread-api/pull
                                                       (let [[_repo selector lookup] args]
                                                         (cond
@@ -1706,6 +1722,12 @@
                                  transport/invoke (fn [_cfg method args]
                                                     (swap! calls conj [method args])
                                                     (case method
+                                                      :thread-api/q
+                                                      (p/resolved nil)
+
+                                                      :thread-api/apply-outliner-ops
+                                                      (p/resolved {:ok true})
+
                                                       :thread-api/pull
                                                       (let [[_repo _selector lookup] args]
                                                         (cond


### PR DESCRIPTION
## Summary
- add `:logseq.class/Task` when setting task properties on tagged blocks whose classes do not provide that property
- keep class objects that define `status` from being forced into Task
- update AgentBridge listener tests to allow start reaction/status side effects

## Tests
- `bb dev:lint-and-test`
- `bb dev:cli-e2e`
- `bb dev:cli-e2e-sync --skip-build`