### PR TITLE
[codex] fix compatibility graph web urls

### DIFF
--- a/src/main/frontend/util/url.cljs
+++ b/src/main/frontend/util/url.cljs
@@ -106,11 +106,17 @@
         hash-url (hash-route-url parsed-url)
         graph-id (or (some-> hash-url .-searchParams (.get "graph-id"))
                      (.get (.-searchParams parsed-url) "graph-id"))
+        graph-identifier (when (string/blank? graph-id)
+                           (or (some-> hash-url .-searchParams (.get "graph"))
+                               (.get (.-searchParams parsed-url) "graph")))
         route (or (some-> hash-url .-pathname path-parts route-from-path-parts)
                   (route-from-path-parts (path-parts (.-pathname parsed-url))))]
     (cond-> {}
       (not (string/blank? graph-id))
       (assoc :graph-id graph-id)
+
+      (not (string/blank? graph-identifier))
+      (assoc :graph-identifier graph-identifier)
 
       route
       (assoc :route route))))

--- a/src/test/frontend/handler/graph_test.cljs
+++ b/src/test/frontend/handler/graph_test.cljs
@@ -3,6 +3,7 @@
             [frontend.common.idb :as idb]
             [frontend.handler.graph]
             [frontend.state :as state]
+            [frontend.util.url :as url-util]
             [logseq.common.graph-registry :as graph-registry]
             [promesa.core :as p]))
 
@@ -74,6 +75,24 @@
                           :graph-id "tab-uuid"}]
                         [{:url "logseq_db_current"}]
                         {:graph-id "url-uuid"}
+                        {:repo "logseq_db_tab"
+                         :graph-id "tab-uuid"}
+                        "logseq_db_current"))))))
+
+(deftest resolve-startup-repo-prefers-compatibility-url-graph-test
+  (let [resolve-f (some-> (resolve 'frontend.handler.graph/resolve-startup-repo) deref)]
+    (is (fn? resolve-f) "Startup repo resolver should exist")
+    (when resolve-f
+      (is (= "logseq_db_work"
+             (resolve-f [{:repo "logseq_db_work"
+                          :graph-name "work"
+                          :graph-id "work-uuid"}
+                         {:repo "logseq_db_tab"
+                          :graph-name "tab"
+                          :graph-id "tab-uuid"}]
+                        [{:url "logseq_db_current"}]
+                        (url-util/parse-web-url-target
+                         "https://logseq.com/#/page/Home?graph=work")
                         {:repo "logseq_db_tab"
                          :graph-id "tab-uuid"}
                         "logseq_db_current"))))))

--- a/src/test/frontend/util/url_test.cljs
+++ b/src/test/frontend/util/url_test.cljs
@@ -36,3 +36,22 @@
               :route {:to :page
                       :page-id "00000001-2026-0520-0000-000000000000"}}
              (parse-f "http://localhost:3001/#/page/00000001-2026-0520-0000-000000000000?graph-id=dc4b7cbd-65f7-4e76-9591-dcb3d14f11cf"))))))
+
+(deftest parse-web-url-target-reads-compatibility-graph-identifier-test
+  (let [parse-f (some-> (resolve 'frontend.util.url/parse-web-url-target) deref)]
+    (is (fn? parse-f) "Web URL target parser should exist")
+    (when parse-f
+      (is (= {:graph-identifier "work"}
+             (parse-f "https://logseq.com/#/?graph=work")))
+      (is (= {:graph-identifier "work"
+              :route {:to :page
+                      :page-id "Home"}}
+             (parse-f "https://logseq.com/#/page/Home?graph=work")))
+      (is (= {:graph-identifier "work"
+              :route {:to :page
+                      :page-id "Home"}}
+             (parse-f "https://logseq.com/?graph=work#/page/Home")))
+      (is (= {:graph-id "remote-graph-uuid"
+              :route {:to :page
+                      :page-id "Home"}}
+             (parse-f "https://logseq.com/#/page/Home?graph=work&graph-id=remote-graph-uuid"))))))


### PR DESCRIPTION
## Summary
- parse legacy `graph` query parameters from hash-route and top-level web URLs into `:graph-identifier`
- keep canonical `graph-id` precedence when both URL identities are present
- add parser and startup coverage for compatibility graph URLs

## Root cause
`parse-web-url-target` only read `graph-id`, so accepted ADR 0017 compatibility URLs using `?graph=<graph-name>` did not carry graph identity into startup resolution. Startup could then fall back to the tab or current graph.

## Validation
- `bb dev:test -v frontend.util.url-test/parse-web-url-target-reads-compatibility-graph-identifier-test`
- `bb dev:test -v frontend.handler.graph-test/resolve-startup-repo-prefers-compatibility-url-graph-test`
- `bb dev:test -v frontend.util.url-test`
- `bb dev:test -v frontend.handler.graph-test`
- `bb dev:lint-and-test`
- local `logseq-review-workflow` review: no findings