### PR TITLE
fix: mobile comment toolbar

### DIFF
--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1236,6 +1236,7 @@ Similar to re-frame subscriptions"
   (when clear-editing-block?
     (set-state! :editor/editing? nil)
     (set-state! :editor/block nil))
+  (set-state! :editor/args nil)
   (when clear-editing-block?
     (let [online-users (some-> @state :rtc/state deref :online-users)]
       (when (and (coll? online-users) (> (count online-users) 1))

--- a/src/main/mobile/components/editor_toolbar.cljs
+++ b/src/main/mobile/components/editor_toolbar.cljs
@@ -174,7 +174,7 @@
             (camera-action)
             (upload-asset-action)
             (audio-action)]
-     :trailing nil}
+     :trailing (keyboard-action)}
     (let [keyboard (keyboard-action)
           main-actions [(undo-action)
                         (todo-action)


### PR DESCRIPTION
## Summary
- add the keyboard close action to the mobile comment editor toolbar
- clear stale editor args when exiting editing so the next normal block edit uses the full toolbar

## Root cause
The mobile toolbar used the last editor args to detect comment editor mode. Exiting a comment editor cleared editing state but left those args behind, so the next edit could briefly resolve to comment toolbar actions.

## Validation
- bb dev:test -v frontend.state-test

Tests added during development were removed per request.