### PR TITLE
fix: smooth iOS tab webview transitions

### DIFF
--- a/ios/App/App/LiquidTabsRootView.swift
+++ b/ios/App/App/LiquidTabsRootView.swift
@@ -283,7 +283,7 @@ private struct LiquidTabs26View: View {
 
     private func waitForWebBackedTab(_ selection: LiquidTabsTabSelection) {
         if let id = webBackedTabId(for: selection) {
-            store.waitForWebTab(id)
+            store.beginWebTabTransitionIfNeeded(id)
         }
     }
 
@@ -450,7 +450,6 @@ private struct LiquidTabs26View: View {
                 }
 
                 if newSelection != selectedTab {
-                    prepareForSelectionChange(to: newSelection)
                     selectedTab = newSelection
                 }
             }
@@ -877,6 +876,8 @@ private struct LiquidTabs16View: View {
                             guard let id = newValue else { return }
 
                             if id != store.selectedId {
+                                store.beginWebTabTransitionIfNeeded(id)
+
                                 if id == "search" {
                                     store.suppressSearchNotifications = true
                                     resetSearchState()
@@ -941,6 +942,12 @@ private struct LiquidTabs16View: View {
                             store.selectedId ?? store.firstTab?.id
                         })
                         .frame(width: 0, height: 0)
+                    }
+                    .overlay {
+                        if store.pendingWebTabId != nil {
+                            Color.logseqBackground
+                                .ignoresSafeArea()
+                        }
                     }
                 }
                 .onAppear {

--- a/ios/App/App/LiquidTabsRootView.swift
+++ b/ios/App/App/LiquidTabsRootView.swift
@@ -450,6 +450,10 @@ private struct LiquidTabs26View: View {
                 }
 
                 if newSelection != selectedTab {
+                    let isExternalSelectionChange = store.tabId(for: selectedTab) != id
+                    if isExternalSelectionChange {
+                        prepareForSelectionChange(to: newSelection)
+                    }
                     selectedTab = newSelection
                 }
             }

--- a/ios/App/App/LiquidTabsStore.swift
+++ b/ios/App/App/LiquidTabsStore.swift
@@ -123,25 +123,33 @@ final class LiquidTabsStore: ObservableObject {
         }
     }
 
-    func waitForWebTab(_ id: String) {
-        DispatchQueue.main.async {
-            self.pendingWebTabRequestId += 1
-            let requestId = self.pendingWebTabRequestId
-            self.pendingWebTabId = id
-
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
-                guard self.pendingWebTabRequestId == requestId,
-                      self.pendingWebTabId == id else {
-                    return
-                }
-
-                self.pendingWebTabId = nil
+    private func updateOnMain(_ update: @escaping () -> Void) {
+        if Thread.isMainThread {
+            update()
+        } else {
+            DispatchQueue.main.async {
+                update()
             }
         }
     }
 
+    func beginWebTabTransitionIfNeeded(_ id: String?) {
+        guard let id, id != "graphs", id != "search" else {
+            return
+        }
+
+        waitForWebTab(id)
+    }
+
+    private func waitForWebTab(_ id: String) {
+        updateOnMain {
+            self.pendingWebTabRequestId += 1
+            self.pendingWebTabId = id
+        }
+    }
+
     func markWebTabReady(_ id: String) {
-        DispatchQueue.main.async {
+        updateOnMain {
             guard self.pendingWebTabId == id else { return }
             self.pendingWebTabRequestId += 1
             self.pendingWebTabId = nil


### PR DESCRIPTION
## Summary

- keep the native WebView transition cover active until JS explicitly marks the selected tab ready
- apply the pending WebView cover to the iOS 16-25 tab implementation as well as the iOS 26 path
- avoid re-running tab preparation when native selection is already driven through the selection binding

## Root cause

The shared iOS WebView could be exposed before the newly selected tab finished rendering because native code cleared the transition cover on a fixed timeout. iOS 16-25 also did not arm the cover before changing the selected tab, so the previous tab view could briefly show during tab switches.

## Validation

- `xcodebuild -workspace ios/App/App.xcworkspace -scheme Logseq -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`\n