### PR TITLE
Fix local HTTP server documentation inconsistent API call

### DIFF
--- a/resources/docs/api_server.html
+++ b/resources/docs/api_server.html
@@ -1103,7 +1103,7 @@ body .markdown-body
 <span class="l l-Scalar l-Scalar-Plain">Authorization</span><span class="p p-Indicator">:</span> <span class="l l-Scalar l-Scalar-Plain">Bearer your-valid-token-xxx</span>
 
 <span class="p p-Indicator">{</span>
-  <span class="s">&quot;method&quot;</span><span class="p p-Indicator">:</span> <span class="s">&quot;logseq.UI.showMsg&quot;</span><span class="p p-Indicator">,</span>
+  <span class="s">&quot;method&quot;</span><span class="p p-Indicator">:</span> <span class="s">&quot;logseq.IUI.showMsg&quot;</span><span class="p p-Indicator">,</span>
   <span class="s">&quot;args&quot;</span><span class="p p-Indicator">:</span> <span class="p p-Indicator">[</span>
     <span class="s">&quot;Hello</span><span class="nv"> </span><span class="s">Logseq</span><span class="nv"> </span><span class="s">:)&quot;</span>
   <span class="p p-Indicator">]</span>
@@ -1114,6 +1114,7 @@ body .markdown-body
   </ul>
   <h2 id="helps">Helps<a class="headerlink" href="#helps" title="Permanent link"></a></h2>
   <ul>
+    <li>Local HTTP server configuration guide <a href="https://docs.logseq.com/#/page/local%20http%20server">https://docs.logseq.com/#/page/local%20http%20server</a></li>
     <li>Discord community <a href="https://discord.com/invite/KpN4eHY">https://discord.com/invite/KpN4eHY</a></li>
     <li>Logseq forum <a href="https://discuss.logseq.com/c/questions-and-help/8">https://discuss.logseq.com/c/questions-and-help/8</a></li>
     <li>Plugin docs <a href="https://plugins-doc.logseq.com">https://plugins-doc.logseq.com</a></li>


### PR DESCRIPTION
# Description

While trying the local HTTP server functionality on Logseq, I was misguided by the documentation. As `method: logseq.UI.showMsg` didn't work. Yet, checking the proxy parts of the codebase it should be working. For now this small change to the documentation should make it easier for people to get started with the feature.

I assumed code was the source, and all the methods supported in that file are prefixed by `I*`.

Behaviour observed on MacOs Sonoma Logseq Build 0.10.15 (90).

# Changelog

- 📜  Replace method `logseq.UI.showMsg` with correct `logseq.IUI.showMsg`
- 📜 Add reference to Local HTTP server configuration guide from Logseq docs