### PR TITLE
enhance: support agent bridge workspace pool

### DIFF
--- a/docs/agent-guide/logseq-cli/011-agent-bridge-workspace-pool.md
+++ b/docs/agent-guide/logseq-cli/011-agent-bridge-workspace-pool.md
@@ -9,12 +9,12 @@ The bridge reads an optional workspace pool from `cli.edn`:
 ```clojure
 {:graph "dev"
  :agent-name "logseq-coder"
- :agent-bridge {:workspaces [{:id "copy-1" :cwd "/abs/path/logseq-1"}
-                             {:id "copy-2" :cwd "/abs/path/logseq-2"}
-                             {:id "copy-3" :cwd "/abs/path/logseq-3"}]}}
+ :workspaces {"dev" [{:id "copy-1" :cwd "/abs/path/logseq-1"}
+                     {:id "copy-2" :cwd "/abs/path/logseq-2"}
+                     {:id "copy-3" :cwd "/abs/path/logseq-3"}]}}
 ```
 
-When `:agent-bridge :workspaces` is absent or empty, the bridge keeps the existing behavior and starts Codex without an explicit working directory. In that mode Codex inherits the bridge process cwd.
+`:workspaces` is a map keyed by graph name. The bridge only uses the workspace list for the graph it is currently running against. When `:workspaces` is absent, empty, or has no entry for the current graph, the bridge keeps the existing behavior and starts Codex without an explicit working directory. In that mode Codex inherits the bridge process cwd.
 
 Each workspace entry must have:
 

--- a/docs/agent-guide/logseq-cli/011-agent-bridge-workspace-pool.md
+++ b/docs/agent-guide/logseq-cli/011-agent-bridge-workspace-pool.md
@@ -1,0 +1,109 @@
+# AgentBridge Local Workspace Pool
+
+Goal: `logseq agent bridge` should support running multiple Codex sessions for the same project by assigning each session to a pre-created local project copy. The bridge still runs on the host and starts the host `codex` command, so it can reuse the local Codex app/CLI configuration while isolating file changes by workspace directory.
+
+## Intended configuration
+
+The bridge reads an optional workspace pool from `cli.edn`:
+
+```clojure
+{:graph "dev"
+ :agent-name "logseq-coder"
+ :agent-bridge {:workspaces [{:id "copy-1" :cwd "/abs/path/logseq-1"}
+                             {:id "copy-2" :cwd "/abs/path/logseq-2"}
+                             {:id "copy-3" :cwd "/abs/path/logseq-3"}]}}
+```
+
+When `:agent-bridge :workspaces` is absent or empty, the bridge keeps the existing behavior and starts Codex without an explicit working directory. In that mode Codex inherits the bridge process cwd.
+
+Each workspace entry must have:
+
+- `:id`: a non-empty unique string.
+- `:cwd`: an absolute path to an existing git repository or worktree.
+
+The bridge must validate the pool before listening for graph changes. Invalid pool configuration is a startup error. A dirty workspace at startup is also a startup error because v1 does not clean or reset user files.
+
+## Session lifecycle
+
+For each routed task or comment session:
+
+1. Select the first idle workspace whose git status is clean.
+2. Fetch and pull the latest `master` in that workspace.
+3. Start host Codex with that workspace as `cwd`.
+4. Codex creates a new branch from `master`, choosing the branch name based on the task.
+5. Record the Codex session with `:workspace-id` and `:cwd`.
+6. Write `agent-session-id` back to the graph after Codex reports a session id.
+7. Codex commits all local changes before it exits, choosing the commit message based on the task.
+8. When Codex exits, the bridge verifies the workspace is clean, verifies the current branch is a session branch rather than `master`, and records that branch.
+9. Mark the session completed or failed based on the Codex exit code and post-session git verification.
+10. Leave the workspace on the session branch for inspection.
+
+Branch names are created by the agent, not the bridge. They should be concise and describe the work. Recommended shapes:
+
+```text
+fix/some-bug
+feat/x-feature
+enhance/xxx
+refactor/db-worker
+```
+
+Commit messages are also created by the agent. They should be concise and describe the completed change. If Codex exits successfully but leaves uncommitted changes or stays on `master`, the session should be marked failed. Do not silently discard changes.
+
+## Workspace pool behavior
+
+The pool is owned by one bridge process. It is not a cross-process lock. Do not run multiple bridge processes with the same `:agent-name` and the same graph expecting safe load balancing.
+
+Workspace states:
+
+- `:idle`: available for a new session.
+- `:running`: assigned to an active Codex process.
+- `:dirty`: not available because local changes remain outside a successfully committed session.
+
+Before assigning a workspace, check `git status --porcelain`. If it is not empty, mark the workspace dirty and skip it. If no workspace is idle, skip routing for that event or startup scan; the task remains routable and can be picked up by a later scan.
+
+v1 must not run `git reset`, `git clean`, or any destructive checkout to recover a workspace. Recovery is manual.
+
+## Comment resume behavior
+
+When a comment targets a block that already has `agent-session-id`, resume the original Codex session in the same workspace recorded for that session.
+
+If the original session has no workspace metadata, the workspace no longer exists in the configured pool, or the workspace is dirty, fail the comment route and add the existing failure reaction. Do not resume in a different workspace because that can split one Codex thread across unrelated checkouts.
+
+When there is no resumable target session, route the comment like a new session and allocate an idle workspace.
+
+## Output and session records
+
+`agent-bridge-sessions.edn` should keep the existing fields and add workspace metadata:
+
+```clojure
+{:session "thread-..."
+ :status :running
+ :backend :codex
+ :graph "dev"
+ :block "11111111-1111-1111-1111-111111111111"
+ :agent "logseq-coder"
+ :workspace-id "copy-1"
+ :cwd "/abs/path/logseq-1"
+ :branch "feat/x-feature"
+ :started-at 1779777600000
+ :updated-at 1779777600000}
+```
+
+`logseq agent bridge list` should show workspace information in human output and keep the full fields in EDN/JSON output.
+
+## Testing expectations
+
+Unit coverage should verify:
+
+- Workspace config validation rejects duplicate ids, relative paths, missing directories, non-git directories, and dirty repositories.
+- Existing no-workspace behavior is unchanged.
+- `start-codex!` passes configured `cwd` to `child_process.spawn`.
+- Multiple routable tasks use different idle workspaces.
+- Tasks beyond the number of available workspaces are not started.
+- Listener and startup scan share both routing claims and workspace busy state.
+- Session records include `:workspace-id`, `:cwd`, and branch metadata.
+- Comment resume uses the workspace recorded on the original session.
+- Codex prompts include branch and commit instructions for workspace sessions.
+- Codex exit marks dirty workspaces as failed sessions instead of committing or cleaning them.
+
+CLI/e2e coverage should create temporary git repository copies with fake Codex, run `agent bridge --process-once`, and verify that fake Codex observes the selected cwd. A dirty workspace scenario should verify that the bridge does not run reset or clean.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "files": [
     "dist/",
     "static/logseq-cli.js",
+    "static/js/db-worker-node.js",
+    "static/js/db-worker-node-assets.json",
     ".agents/skills/logseq-cli/SKILL.md"
   ],
   "engines": {
@@ -105,6 +107,7 @@
     "db-worker-node:release:bundle": "run-s db-worker-node:release db-worker-node:bundle",
     "db-worker-node:compile:bundle": "run-s db-worker-node:compile db-worker-node:bundle",
     "desktop:prepare-runtime-js": "node ./scripts/prepare-desktop-runtime-js.mjs",
+    "cli:install-local": "./scripts/install-local-cli.sh",
     "cli:e2e": "bb dev:cli-e2e",
     "cli:e2e:skip-build": "bb dev:cli-e2e --skip-build",
     "cljs:dev-release-app": "clojure -M:cljs release app db-worker db-worker-node --config-merge \"{:closure-defines {frontend.config/DEV-RELEASE true}}\"",

--- a/scripts/install-local-cli.sh
+++ b/scripts/install-local-cli.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+install_dir="${LOGSEQ_CLI_BIN_DIR:-$HOME/.local/bin}"
+pack_dir="$repo_root/tmp/logseq-cli"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+copy_file() {
+  local source_path="$1"
+  local target_path="$2"
+
+  if [[ ! -f "$source_path" ]]; then
+    echo "Missing build artifact: $source_path" >&2
+    exit 1
+  fi
+
+  mkdir -p "$(dirname "$target_path")"
+  cp "$source_path" "$target_path"
+}
+
+require_command clojure
+require_command pnpm
+require_command node
+
+cd "$repo_root"
+
+clojure -M:cljs release logseq-cli
+pnpm db-worker-node:release:bundle
+pnpm --dir deps/db-sync build:node-adapter
+
+copy_file "$repo_root/dist/db-worker-node.js" "$repo_root/static/js/db-worker-node.js"
+copy_file "$repo_root/dist/db-worker-node-assets.json" "$repo_root/static/js/db-worker-node-assets.json"
+
+mkdir -p "$pack_dir"
+rm -f "$pack_dir"/logseq-*.tgz
+
+tarball="$(pnpm pack --pack-destination "$pack_dir" | tail -n 1)"
+if [[ "$tarball" != /* ]]; then
+  tarball="$pack_dir/$tarball"
+fi
+
+mkdir -p "$install_dir"
+export PATH="$install_dir:$PATH"
+pnpm add --global --global-bin-dir "$install_dir" "$tarball"
+
+echo "Installed logseq to $install_dir/logseq"
+echo "Packed tarball kept at $tarball"

--- a/src/main/logseq/cli/command/agent.cljs
+++ b/src/main/logseq/cli/command/agent.cljs
@@ -646,7 +646,7 @@
     prompt))
 
 (defn- prepare-workspace-session!
-  [workspace-pool agent-name block]
+  [workspace-pool]
   (when workspace-pool
     (when-let [workspace (acquire-workspace! workspace-pool)]
       (let [cwd (:cwd workspace)]
@@ -1209,7 +1209,7 @@
 
 (defn- route-task!
   [cfg {:keys [repo graph agent-name prompt-templates workspace-pool]} {:keys [block tree-text]}]
-  (let [workspace-session (prepare-workspace-session! workspace-pool agent-name block)]
+  (let [workspace-session (prepare-workspace-session! workspace-pool)]
     (if (and workspace-pool (nil? workspace-session))
       (p/resolved nil)
       (let [prompt (append-workspace-prompt-instructions
@@ -1538,7 +1538,7 @@
            resume-session-id (first (keep identity target-session-ids))
            workspace-session (if resume-session-id
                                (acquire-existing-workspace-session! cfg workspace-pool resume-session-id)
-                               (prepare-workspace-session! workspace-pool agent-name comment-block))
+                               (prepare-workspace-session! workspace-pool))
            _ (when (and workspace-pool (nil? workspace-session))
                (throw (ex-info "agent bridge workspace is not available"
                                {:code :agent-workspace-unavailable

--- a/src/main/logseq/cli/command/agent.cljs
+++ b/src/main/logseq/cli/command/agent.cljs
@@ -343,12 +343,15 @@
       nil)))
 
 (defn start-codex!
-  [command {:keys [on-exit]}]
+  [command {:keys [cwd on-exit]}]
   (p/create
    (fn [resolve reject]
      (let [bin (first command)
            args (clj->js (vec (rest command)))
-           child (.spawn child-process bin args #js {:stdio #js ["ignore" "pipe" "pipe"]})
+           spawn-opts (cond-> {:stdio #js ["ignore" "pipe" "pipe"]}
+                        (seq (trim-non-empty cwd))
+                        (assoc :cwd cwd))
+           child (.spawn child-process bin args (clj->js spawn-opts))
            settled? (atom false)
            session-id* (atom nil)
            child-closed? (atom false)
@@ -483,6 +486,259 @@
    :command :agent-bridge
    :error {:code code
            :message message}})
+
+(defn- git-command
+  [cwd args]
+  (let [result (.spawnSync child-process
+                           "git"
+                           (clj->js (into ["-C" cwd] args))
+                           #js {:encoding "utf8"})
+        status (or (.-status result) 1)
+        stdout (or (.-stdout result) "")
+        stderr (or (.-stderr result) "")]
+    {:ok? (zero? status)
+     :status status
+     :stdout stdout
+     :stderr stderr}))
+
+(defn- git-command!
+  [cwd args error-code message]
+  (let [{:keys [ok? status stderr] :as result} (git-command cwd args)]
+    (when-not ok?
+      (throw (ex-info message
+                      {:code error-code
+                       :cwd cwd
+                       :git-args args
+                       :exit-code status
+                       :stderr stderr})))
+    result))
+
+(defn- workspace-clean?
+  [{:keys [cwd]}]
+  (let [{:keys [ok? stdout]} (git-command cwd ["status" "--porcelain"])]
+    (and ok? (string/blank? stdout))))
+
+(defn- validate-workspace-config!
+  [workspace]
+  (let [id (trim-non-empty (:id workspace))
+        cwd (trim-non-empty (:cwd workspace))]
+    (cond
+      (not id)
+      (throw (ex-info "agent bridge workspace id must be a non-empty string"
+                      {:code :agent-workspace-invalid}))
+
+      (not cwd)
+      (throw (ex-info "agent bridge workspace cwd must be a non-empty string"
+                      {:code :agent-workspace-invalid
+                       :workspace-id id}))
+
+      (not (node-path/isAbsolute cwd))
+      (throw (ex-info "agent bridge workspace cwd must be an absolute path"
+                      {:code :agent-workspace-invalid
+                       :workspace-id id
+                       :cwd cwd}))
+
+      (not (fs/existsSync cwd))
+      (throw (ex-info "agent bridge workspace cwd does not exist"
+                      {:code :agent-workspace-invalid
+                       :workspace-id id
+                       :cwd cwd}))
+
+      (not (.isDirectory (fs/statSync cwd)))
+      (throw (ex-info "agent bridge workspace cwd must be a directory"
+                      {:code :agent-workspace-invalid
+                       :workspace-id id
+                       :cwd cwd})))
+
+    (git-command! cwd ["rev-parse" "--is-inside-work-tree"]
+                  :agent-workspace-invalid
+                  "agent bridge workspace cwd must be a git repository")
+    (when-not (workspace-clean? {:cwd cwd})
+      (throw (ex-info "agent bridge workspace must be clean before startup"
+                      {:code :agent-workspace-invalid
+                       :workspace-id id
+                       :cwd cwd})))
+    {:id id
+     :cwd cwd
+     :status :idle}))
+
+(defn- resolve-workspaces!
+  [config]
+  (let [workspaces (vec (get-in config [:agent-bridge :workspaces]))]
+    (when (seq workspaces)
+      (let [resolved (mapv validate-workspace-config! workspaces)
+            ids (mapv :id resolved)]
+        (when-not (= (count ids) (count (set ids)))
+          (throw (ex-info "agent bridge workspace ids must be unique"
+                          {:code :agent-workspace-invalid})))
+        resolved))))
+
+(defn- make-workspace-pool
+  [workspaces]
+  (when (seq workspaces)
+    (atom workspaces)))
+
+(defn- set-workspace-status!
+  [workspace-pool workspace-id status]
+  (when (and workspace-pool workspace-id)
+    (swap! workspace-pool
+           (fn [workspaces]
+             (mapv (fn [workspace]
+                     (if (= workspace-id (:id workspace))
+                       (assoc workspace :status status)
+                       workspace))
+                   workspaces)))))
+
+(defn- acquire-workspace!
+  ([workspace-pool]
+   (acquire-workspace! workspace-pool nil))
+  ([workspace-pool workspace-id]
+   (when workspace-pool
+     (loop []
+       (let [workspaces @workspace-pool
+             workspace (first (filter (fn [workspace]
+                                        (and (= :idle (:status workspace))
+                                             (or (nil? workspace-id)
+                                                 (= workspace-id (:id workspace)))))
+                                      workspaces))]
+         (when workspace
+           (if (workspace-clean? workspace)
+             (let [claimed (mapv (fn [candidate]
+                                   (if (= (:id workspace) (:id candidate))
+                                     (assoc candidate :status :running)
+                                     candidate))
+                                 workspaces)]
+               (if (compare-and-set! workspace-pool workspaces claimed)
+                 workspace
+                 (recur)))
+             (let [dirty (mapv (fn [candidate]
+                                 (if (= (:id workspace) (:id candidate))
+                                   (assoc candidate :status :dirty)
+                                   candidate))
+                               workspaces)]
+               (if (compare-and-set! workspace-pool workspaces dirty)
+                 (recur)
+                 (recur))))))))))
+
+(defn- release-workspace!
+  [workspace-pool workspace]
+  (when workspace
+    (set-workspace-status! workspace-pool
+                           (:id workspace)
+                           (if (workspace-clean? workspace) :idle :dirty))))
+
+(defn- workspace-prompt-instructions
+  [workspace-session]
+  (when-let [cwd (:cwd workspace-session)]
+    (string/join
+     "\n"
+     [""
+      "Workspace instructions:"
+      (str "You are running in this project copy: " cwd)
+      "Before making code changes, create a new branch from the current master branch."
+      "Choose a concise branch name that matches the change, for example fix/some-bug, feat/x-feature, enhance/xxx, or refactor/db-worker."
+      "Before finishing, commit all local changes with a concise commit message you choose."])))
+
+(defn- append-workspace-prompt-instructions
+  [prompt workspace-session]
+  (if-let [instructions (workspace-prompt-instructions workspace-session)]
+    (str prompt "\n" instructions)
+    prompt))
+
+(defn- prepare-workspace-session!
+  [workspace-pool agent-name block]
+  (when workspace-pool
+    (when-let [workspace (acquire-workspace! workspace-pool)]
+      (let [cwd (:cwd workspace)]
+        (try
+          (git-command! cwd ["checkout" "master"]
+                        :agent-workspace-git-failed
+                        "failed to checkout master")
+          (git-command! cwd ["pull" "--ff-only" "origin" "master"]
+                        :agent-workspace-git-failed
+                        "failed to pull latest master")
+          {:workspace workspace
+           :workspace-id (:id workspace)
+           :cwd cwd}
+          (catch :default e
+            (set-workspace-status! workspace-pool (:id workspace) :dirty)
+            (throw e)))))))
+
+(defn- session-by-id
+  [config session-id]
+  (first (filter #(= session-id (:session %))
+                 (list-sessions config {:all? true}))))
+
+(defn- current-workspace-branch
+  [workspace]
+  (when workspace
+    (let [{:keys [stdout]} (git-command! (:cwd workspace)
+                                         ["branch" "--show-current"]
+                                         :agent-workspace-git-failed
+                                         "failed to read current branch")]
+      (trim-non-empty stdout))))
+
+(defn- acquire-existing-workspace-session!
+  [config workspace-pool session-id]
+  (when workspace-pool
+    (let [session (session-by-id config session-id)
+          workspace-id (:workspace-id session)
+          branch (trim-non-empty (:branch session))]
+      (when-not session
+        (throw (ex-info "agent bridge session workspace metadata is missing"
+                        {:code :agent-workspace-session-missing
+                         :session session-id})))
+      (when-not workspace-id
+        (throw (ex-info "agent bridge session workspace id is missing"
+                        {:code :agent-workspace-session-missing
+                         :session session-id})))
+      (when-not branch
+        (throw (ex-info "agent bridge session workspace branch is missing"
+                        {:code :agent-workspace-session-missing
+                         :session session-id
+                         :workspace-id workspace-id})))
+      (let [workspace (acquire-workspace! workspace-pool workspace-id)]
+        (when-not workspace
+          (throw (ex-info "agent bridge session workspace is not available"
+                          {:code :agent-workspace-unavailable
+                           :session session-id
+                           :workspace-id workspace-id})))
+        (try
+          (git-command! (:cwd workspace)
+                        ["checkout" branch]
+                        :agent-workspace-git-failed
+                        "failed to checkout agent bridge session branch")
+          (let [current-branch (current-workspace-branch workspace)]
+            (when-not (= branch current-branch)
+              (throw (ex-info "agent bridge session workspace branch mismatch"
+                              {:code :agent-workspace-git-failed
+                               :session session-id
+                               :workspace-id workspace-id
+                               :expected-branch branch
+                               :actual-branch current-branch})))
+            {:workspace workspace
+             :workspace-id workspace-id
+             :cwd (:cwd workspace)
+             :branch branch})
+          (catch :default e
+            (release-workspace! workspace-pool workspace)
+            (throw e)))))))
+
+(defn- complete-workspace-session!
+  [cfg workspace-pool workspace session-id status]
+  (if workspace
+    (let [branch (current-workspace-branch workspace)
+          clean? (workspace-clean? workspace)
+          session-branch? (and branch
+                               (not= "master" branch))
+          success? (and clean? session-branch?)
+          final-status (if success? status :failed)]
+      (record-session! cfg (cond-> {:session session-id
+                                    :status final-status
+                                    :updated-at (js/Date.now)}
+                             branch (assoc :branch branch)))
+      (set-workspace-status! workspace-pool (:id workspace) (if success? :idle :dirty)))
+    (update-session-status! cfg session-id status)))
 
 (defn- log-bridge-exit!
   [{:keys [repo graph agent-name reason exit-code error]}]
@@ -931,45 +1187,74 @@
     (.write (.-stdout js/process) (str line "\n"))))
 
 (defn- session-record
-  [graph agent-name block session-id status]
-  {:session session-id
-   :status status
-   :backend :codex
-   :graph graph
-   :block (block-uuid-str block)
-   :agent agent-name
-   :started-at (js/Date.now)
-   :updated-at (js/Date.now)})
+  ([graph agent-name block session-id status]
+   (session-record graph agent-name block session-id status nil))
+  ([graph agent-name block session-id status workspace-session]
+   (cond-> {:session session-id
+            :status status
+            :backend :codex
+            :graph graph
+            :block (block-uuid-str block)
+            :agent agent-name
+            :started-at (js/Date.now)
+            :updated-at (js/Date.now)}
+     (:workspace-id workspace-session)
+     (assoc :workspace-id (:workspace-id workspace-session))
+
+     (:cwd workspace-session)
+     (assoc :cwd (:cwd workspace-session))
+
+     (:branch workspace-session)
+     (assoc :branch (:branch workspace-session)))))
 
 (defn- route-task!
-  [cfg {:keys [repo graph agent-name prompt-templates]} {:keys [block tree-text]}]
-  (let [prompt (build-codex-prompt {:graph graph
-                                    :agent-name agent-name
-                                    :block block
-                                    :tree-text tree-text
-                                    :prompt-template (:task prompt-templates)})
-        command (build-codex-command prompt {})
-        preview (command-preview command)]
-    (emit-log! cfg (log-line (str "Codex command prepared for " (block-uuid-str block) ": " preview)))
-    (p/let [{:keys [session]} (start-codex! command
-                                            {:on-exit (fn [code session-id]
-                                                        (when session-id
-                                                          (update-session-status! cfg session-id
-                                                                                  (if (zero? (or code 1))
-                                                                                    :completed
-                                                                                    :failed))))})
-            _ (when-not (seq session)
-                (throw (ex-info "codex session id missing"
-                                {:code :codex-session-id-missing})))
-            cfg* (cli-server/ensure-server! cfg repo)
-            _ (record-session! cfg* (session-record graph agent-name block session :running))
-            _ (write-agent-session-id! cfg* repo (:block/uuid block) session)
-            _ (mark-agent-bridge-task-started! cfg* repo block)]
-      (emit-log! cfg (log-line (str "agent-session-id written for " (block-uuid-str block))))
-      {:block (block-uuid-str block)
-       :session session
-       :backend :codex
-       :preview preview})))
+  [cfg {:keys [repo graph agent-name prompt-templates workspace-pool]} {:keys [block tree-text]}]
+  (let [workspace-session (prepare-workspace-session! workspace-pool agent-name block)]
+    (if (and workspace-pool (nil? workspace-session))
+      (p/resolved nil)
+      (let [prompt (append-workspace-prompt-instructions
+                    (build-codex-prompt {:graph graph
+                                         :agent-name agent-name
+                                         :block block
+                                         :tree-text tree-text
+                                         :prompt-template (:task prompt-templates)})
+                    workspace-session)
+            command (build-codex-command prompt {})
+            preview (command-preview command)
+            workspace (:workspace workspace-session)]
+        (emit-log! cfg (log-line (str "Codex command prepared for " (block-uuid-str block) ": " preview)))
+        (p/catch
+         (p/let [{:keys [session]} (start-codex! command
+                                                 {:cwd (:cwd workspace-session)
+                                                  :on-exit (fn [code session-id]
+                                                             (when session-id
+                                                               (let [status (if (zero? (or code 1))
+                                                                              :completed
+                                                                              :failed)]
+                                                                 (try
+                                                                   (complete-workspace-session! cfg workspace-pool workspace session-id status)
+                                                                   (catch :default e
+                                                                     (log/error :agent-bridge-workspace-complete-failed e)
+                                                                     (update-session-status! cfg session-id :failed)
+                                                                     (set-workspace-status! workspace-pool (:id workspace) :dirty))))))})
+                 _ (when-not (seq session)
+                     (throw (ex-info "codex session id missing"
+                                     {:code :codex-session-id-missing})))
+                 cfg* (cli-server/ensure-server! cfg repo)
+                 _ (record-session! cfg* (session-record graph agent-name block session :running workspace-session))
+                 _ (write-agent-session-id! cfg* repo (:block/uuid block) session)
+                 _ (mark-agent-bridge-task-started! cfg* repo block)]
+           (emit-log! cfg (log-line (str "agent-session-id written for " (block-uuid-str block))))
+           (cond-> {:block (block-uuid-str block)
+                    :session session
+                    :backend :codex
+                    :preview preview}
+             (:workspace-id workspace-session)
+             (assoc :workspace-id (:workspace-id workspace-session)
+                    :cwd (:cwd workspace-session))))
+         (fn [e]
+           (release-workspace! workspace-pool workspace)
+           (throw e)))))))
 
 (defn- claim-routing-block!
   [routing-blocks* block-id]
@@ -1008,16 +1293,18 @@
           (partition-all limit coll)))
 
 (defn- process-tasks!
-  [cfg {:keys [repo graph agent-name prompt-templates routing-blocks*]}]
+  [cfg {:keys [repo graph agent-name prompt-templates routing-blocks* workspace-pool]}]
   (p/let [tasks (list-routable-tasks cfg repo agent-name)]
-    (p-map-batched max-concurrent-routes
-                   #(route-task-once! cfg {:repo repo
-                                           :graph graph
-                                           :agent-name agent-name
-                                           :prompt-templates prompt-templates
-                                           :routing-blocks* routing-blocks*}
-                                      %)
-                   tasks)))
+    (p/let [routed (p-map-batched max-concurrent-routes
+                                  #(route-task-once! cfg {:repo repo
+                                                          :graph graph
+                                                          :agent-name agent-name
+                                                          :prompt-templates prompt-templates
+                                                          :routing-blocks* routing-blocks*
+                                                          :workspace-pool workspace-pool}
+                                                     %)
+                                  tasks)]
+      (filterv some? routed))))
 
 (def ^:private assignee-property-ident :logseq.property/assignee)
 
@@ -1110,7 +1397,7 @@
 (defn- resolve-routability-datoms
   [cfg repo tx-data]
   (let [candidates (filter #(and (true? (:added %))
-                                  (task-routability-attr? (:a %)))
+                                 (task-routability-attr? (:a %)))
                            tx-data)]
     (p/let [resolved (p/all
                       (mapv (fn [datom]
@@ -1209,9 +1496,11 @@
   (ensure-reaction! cfg repo target-uuid emoji-id))
 
 (defn- comment-session-record
-  [graph agent-name comment-block session-id status]
-  (assoc (session-record graph agent-name comment-block session-id status)
-         :request :comment))
+  ([graph agent-name comment-block session-id status]
+   (comment-session-record graph agent-name comment-block session-id status nil))
+  ([graph agent-name comment-block session-id status workspace-session]
+   (assoc (session-record graph agent-name comment-block session-id status workspace-session)
+          :request :comment)))
 
 (defn- comment-target-session-id
   [agent-name block]
@@ -1220,7 +1509,7 @@
     (p/resolved nil)))
 
 (defn- route-comment!
-  [cfg {:keys [repo graph agent-name prompt-templates]} comment-block]
+  [cfg {:keys [repo graph agent-name prompt-templates workspace-pool]} comment-block]
   (p/catch
    (p/let [comment-uuid (:block/uuid comment-block)
            _ (when-not comment-uuid
@@ -1247,18 +1536,33 @@
            target-session-ids (p/all (mapv #(comment-target-session-id agent-name %)
                                            target-blocks))
            resume-session-id (first (keep identity target-session-ids))
+           workspace-session (if resume-session-id
+                               (acquire-existing-workspace-session! cfg workspace-pool resume-session-id)
+                               (prepare-workspace-session! workspace-pool agent-name comment-block))
+           _ (when (and workspace-pool (nil? workspace-session))
+               (throw (ex-info "agent bridge workspace is not available"
+                               {:code :agent-workspace-unavailable
+                                :block (block-uuid-str comment-block)})))
+           workspace (:workspace workspace-session)
+           prompt (append-workspace-prompt-instructions prompt workspace-session)
            command (if resume-session-id
                      (build-codex-resume-command resume-session-id prompt {})
                      (build-codex-command prompt {}))
            preview (command-preview command)
            _ (emit-log! cfg (log-line (str "Codex command prepared for comment " (block-uuid-str comment-block) ": " preview)))
            {:keys [session]} (start-codex! command
-                                           {:on-exit (fn [code session-id]
+                                           {:cwd (:cwd workspace-session)
+                                            :on-exit (fn [code session-id]
                                                        (when session-id
-                                                         (update-session-status! cfg session-id
-                                                                                 (if (zero? (or code 1))
-                                                                                   :completed
-                                                                                   :failed)))
+                                                         (let [status (if (zero? (or code 1))
+                                                                        :completed
+                                                                        :failed)]
+                                                           (try
+                                                             (complete-workspace-session! cfg workspace-pool workspace session-id status)
+                                                             (catch :default e
+                                                               (log/error :agent-bridge-workspace-complete-failed e)
+                                                               (update-session-status! cfg session-id :failed)
+                                                               (set-workspace-status! workspace-pool (:id workspace) :dirty)))))
                                                        (-> (ensure-comment-reaction! cfg repo comment-uuid
                                                                                      (if (zero? (or code 1))
                                                                                        comment-complete-reaction
@@ -1269,12 +1573,14 @@
                (throw (ex-info "codex session id missing"
                                {:code :codex-session-id-missing})))
            cfg* (cli-server/ensure-server! cfg repo)
-           _ (record-session! cfg* (comment-session-record graph agent-name comment-block session :running))]
+           _ (record-session! cfg* (comment-session-record graph agent-name comment-block session :running workspace-session))]
      {:block (block-uuid-str comment-block)
       :session session
       :backend :codex
       :preview preview
-      :request :comment})
+      :request :comment
+      :workspace-id (:workspace-id workspace-session)
+      :cwd (:cwd workspace-session)})
    (fn [e]
      (if-let [comment-uuid (:block/uuid comment-block)]
        (p/let [_ (ensure-comment-reaction! cfg repo comment-uuid comment-failed-reaction)]
@@ -1333,7 +1639,7 @@
         (p/all routing)))))
 
 (defn- listen-forever!
-  [cfg {:keys [repo graph agent-name prompt-templates routing-blocks*]}]
+  [cfg {:keys [repo graph agent-name prompt-templates routing-blocks* workspace-pool]}]
   (let [routing-blocks* (or routing-blocks* (atom #{}))
         handle-error! (fn [e]
                         (emit-log! cfg (log-line (str "Codex invocation failed: "
@@ -1352,7 +1658,8 @@
                                                           :graph graph
                                                           :agent-name agent-name
                                                           :prompt-templates prompt-templates
-                                                          :routing-blocks* routing-blocks*}
+                                                          :routing-blocks* routing-blocks*
+                                                          :workspace-pool workspace-pool}
                                                          payload)
                          (p/catch handle-error!))
                      (catch :default e
@@ -1378,54 +1685,67 @@
               logs (conj logs
                          (log-line (str "using agent name: " agent-name))
                          (log-line "checking codex cli ..."))]
-          (if-not (codex-available? nil)
-            (bridge-error :codex-not-found "codex executable is not available")
-            (p/let [cfg (cli-server/ensure-server! config repo)
-                    logs (conj logs (log-line "checking prompt templates ..."))
-                    prompt-templates (ensure-agent-bridge-prompt-templates! cfg repo)
-                    logs (conj logs (log-line "registering agent bridge ..."))
-                    _ (register-agent-bridge! cfg repo agent-name)]
-              (if (:dry-run? action)
-                (p/let [tasks (list-routable-tasks cfg repo agent-name)
-                        commands (dry-run-commands graph agent-name prompt-templates tasks)
-                        logs (into (conj logs (log-line "listening graph changes ..."))
-                                   (map (fn [{:keys [block preview]}]
-                                          (log-line (str "would run Codex command for " block ": " preview)))
-                                        commands))]
-                  {:status :ok
-                   :command :agent-bridge
-                   :data {:mode :dry-run
-                          :graph graph
-                          :agent-name agent-name
-                          :logs logs
-                          :commands commands}})
-                (if (:process-once? action)
-                  (do
-                    (doseq [line (conj logs (log-line "listening graph changes ..."))]
-                      (emit-log! cfg line))
-                    (let [routing-blocks* (atom #{})]
-                      (p/let [routed (process-tasks! cfg {:repo repo
-                                                          :graph graph
-                                                          :agent-name agent-name
-                                                          :prompt-templates prompt-templates
-                                                          :routing-blocks* routing-blocks*})]
-                        {:status :ok
-                         :command :agent-bridge
-                         :data {:mode :processed-once
-                                :graph graph
-                                :agent-name agent-name
-                                :routed routed}})))
-                  (let [routing-blocks* (atom #{})
-                        listen-promise (listen-forever! cfg {:repo repo
-                                                             :graph graph
-                                                             :agent-name agent-name
-                                                             :prompt-templates prompt-templates
-                                                             :routing-blocks* routing-blocks*})]
-                    (doseq [line (conj logs (log-line "listening graph changes ..."))]
-                      (emit-log! cfg line))
-                    (p/let [_ (process-tasks! cfg {:repo repo
-                                                   :graph graph
-                                                   :agent-name agent-name
-                                                   :prompt-templates prompt-templates
-                                                   :routing-blocks* routing-blocks*})]
-                      listen-promise)))))))))))
+          (try
+            (let [workspaces (resolve-workspaces! config)
+                  workspace-pool (make-workspace-pool workspaces)
+                  logs (cond-> logs
+                         (seq workspaces)
+                         (conj (log-line (str "using workspaces: " (count workspaces)))))]
+              (if-not (codex-available? nil)
+                (bridge-error :codex-not-found "codex executable is not available")
+                (p/let [cfg (cli-server/ensure-server! config repo)
+                        logs (conj logs (log-line "checking prompt templates ..."))
+                        prompt-templates (ensure-agent-bridge-prompt-templates! cfg repo)
+                        logs (conj logs (log-line "registering agent bridge ..."))
+                        _ (register-agent-bridge! cfg repo agent-name)]
+                  (if (:dry-run? action)
+                    (p/let [tasks (list-routable-tasks cfg repo agent-name)
+                            commands (dry-run-commands graph agent-name prompt-templates tasks)
+                            logs (into (conj logs (log-line "listening graph changes ..."))
+                                       (map (fn [{:keys [block preview]}]
+                                              (log-line (str "would run Codex command for " block ": " preview)))
+                                            commands))]
+                      {:status :ok
+                       :command :agent-bridge
+                       :data {:mode :dry-run
+                              :graph graph
+                              :agent-name agent-name
+                              :logs logs
+                              :commands commands}})
+                    (if (:process-once? action)
+                      (do
+                        (doseq [line (conj logs (log-line "listening graph changes ..."))]
+                          (emit-log! cfg line))
+                        (let [routing-blocks* (atom #{})]
+                          (p/let [routed (process-tasks! cfg {:repo repo
+                                                              :graph graph
+                                                              :agent-name agent-name
+                                                              :prompt-templates prompt-templates
+                                                              :routing-blocks* routing-blocks*
+                                                              :workspace-pool workspace-pool})]
+                            {:status :ok
+                             :command :agent-bridge
+                             :data {:mode :processed-once
+                                    :graph graph
+                                    :agent-name agent-name
+                                    :routed routed}})))
+                      (let [routing-blocks* (atom #{})
+                            listen-promise (listen-forever! cfg {:repo repo
+                                                                 :graph graph
+                                                                 :agent-name agent-name
+                                                                 :prompt-templates prompt-templates
+                                                                 :routing-blocks* routing-blocks*
+                                                                 :workspace-pool workspace-pool})]
+                        (doseq [line (conj logs (log-line "listening graph changes ..."))]
+                          (emit-log! cfg line))
+                        (p/let [_ (process-tasks! cfg {:repo repo
+                                                       :graph graph
+                                                       :agent-name agent-name
+                                                       :prompt-templates prompt-templates
+                                                       :routing-blocks* routing-blocks*
+                                                       :workspace-pool workspace-pool})]
+                          listen-promise)))))))
+            (catch :default e
+              (let [data (ex-data e)]
+                (bridge-error (or (:code data) :agent-workspace-invalid)
+                              (or (ex-message e) (str e)))))))))))

--- a/src/main/logseq/cli/command/agent.cljs
+++ b/src/main/logseq/cli/command/agent.cljs
@@ -535,15 +535,20 @@
      :status :idle}))
 
 (defn- resolve-workspaces!
-  [config]
-  (let [workspaces (vec (get-in config [:agent-bridge :workspaces]))]
-    (when (seq workspaces)
-      (let [resolved (mapv validate-workspace-config! workspaces)
-            ids (mapv :id resolved)]
-        (when-not (= (count ids) (count (set ids)))
-          (throw (ex-info "agent bridge workspace ids must be unique"
-                          {:code :agent-workspace-invalid})))
-        resolved))))
+  [config graph]
+  (when-let [workspaces-by-graph (:workspaces config)]
+    (when-not (map? workspaces-by-graph)
+      (throw (ex-info "agent bridge workspaces must be a map keyed by graph name"
+                      {:code :agent-workspace-invalid})))
+    (let [workspaces (vec (get workspaces-by-graph graph))]
+      (when (seq workspaces)
+        (let [resolved (mapv validate-workspace-config! workspaces)
+              ids (mapv :id resolved)]
+          (when-not (= (count ids) (count (set ids)))
+            (throw (ex-info "agent bridge workspace ids must be unique"
+                            {:code :agent-workspace-invalid
+                             :graph graph})))
+          resolved)))))
 
 (defn- make-workspace-pool
   [workspaces]
@@ -1711,7 +1716,7 @@
                          (log-line (str "using agent name: " agent-name))
                          (log-line "checking codex cli ..."))]
           (try
-            (let [workspaces (resolve-workspaces! config)
+            (let [workspaces (resolve-workspaces! config graph)
                   workspace-pool (make-workspace-pool workspaces)
                   logs (cond-> logs
                          (seq workspaces)

--- a/src/main/logseq/cli/format.cljs
+++ b/src/main/logseq/cli/format.cljs
@@ -584,7 +584,7 @@
                           (nil? value) nil
                           :else (str value)))]
     (format-counted-table
-     ["SESSION" "STATUS" "BACKEND" "GRAPH" "BLOCK" "AGENT" "STARTED" "UPDATED"]
+     ["SESSION" "STATUS" "BACKEND" "GRAPH" "BLOCK" "AGENT" "WORKSPACE" "BRANCH" "STARTED" "UPDATED"]
      (mapv (fn [session]
              [(session-field (:session session))
               (session-field (:status session))
@@ -592,6 +592,8 @@
               (session-field (:graph session))
               (session-field (:block session))
               (session-field (:agent session))
+              (session-field (:workspace-id session))
+              (session-field (:branch session))
               (human-ago (:started-at session) now-ms)
               (human-ago (:updated-at session) now-ms)])
            (or sessions [])))))

--- a/src/test/logseq/cli/command/agent_test.cljs
+++ b/src/test/logseq/cli/command/agent_test.cljs
@@ -21,6 +21,14 @@
   []
   (.mkdtempSync fs (node-path/join (.tmpdir os) "logseq-agent-bridge-test-")))
 
+(defn- spawn-result
+  ([status]
+   (spawn-result status "" ""))
+  ([status stdout stderr]
+   #js {:status status
+        :stdout stdout
+        :stderr stderr}))
+
 (defn- read-dict
   [filename]
   (reader/read-string
@@ -1068,6 +1076,35 @@
                (p/catch (fn [e]
                           (is false (str "unexpected error: " e))))
                (p/finally (fn []
+	                            (set! (.-spawn child-process) original-spawn)
+	                            (done)))))))
+
+(deftest test-start-codex-uses-configured-cwd
+  (async done
+         (let [original-spawn (.-spawn child-process)
+               spawn-opts* (atom nil)]
+           (set! (.-spawn child-process)
+                 (fn [_bin _args opts]
+                   (reset! spawn-opts* opts)
+                   (let [child (events/EventEmitter.)
+                         stdout (events/EventEmitter.)
+                         stderr (events/EventEmitter.)]
+                     (set! (.-stdout child) stdout)
+                     (set! (.-stderr child) stderr)
+                     (js/setTimeout (fn []
+                                      (.emit stdout "data" "{\"type\":\"thread.started\",\"thread_id\":\"thread-cwd\"}\n")
+                                      (.emit stdout "close")
+                                      (.emit child "close" 0 nil))
+                                    0)
+                     child)))
+           (-> (agent-command/start-codex! ["codex" "exec" "--json" "prompt"]
+                                           {:cwd "/tmp/logseq-copy-1"})
+               (p/then (fn [result]
+                         (is (= "thread-cwd" (:session result)))
+                         (is (= "/tmp/logseq-copy-1" (unchecked-get @spawn-opts* "cwd")))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
                             (set! (.-spawn child-process) original-spawn)
                             (done)))))))
 
@@ -1423,8 +1460,72 @@
         (is (= "build-host" (:agent session)))
         (is (= 1000 (:started-at session)))
         (is (= 2000 (:updated-at session))))
-      (finally
-        (fs/rmSync root #js {:recursive true :force true})))))
+	      (finally
+	        (fs/rmSync root #js {:recursive true :force true})))))
+
+(deftest test-agent-bridge-workspace-pool-validation
+  (async done
+         (let [root (temp-root)
+               workspace-a (node-path/join root "copy-a")
+               workspace-b (node-path/join root "copy-b")
+               original-spawn-sync (.-spawnSync child-process)]
+           (fs/mkdirSync workspace-a #js {:recursive true})
+           (fs/mkdirSync workspace-b #js {:recursive true})
+           (set! (.-spawnSync child-process)
+                 (fn [_bin _args _opts]
+                   (spawn-result 0 "" "")))
+           (-> (p/with-redefs [agent-command/codex-available? (fn [_] true)
+                                cli-server/ensure-server! (fn [cfg _repo] cfg)
+                                agent-command/register-agent-bridge! (fn [_cfg _repo _agent-name]
+                                                                       (p/resolved true))
+                                agent-command/ensure-agent-bridge-prompt-templates!
+                                (fn [_cfg _repo]
+                                  (p/resolved {:task "Task {{graph}} {{block-uuid}} {{agent-name}}\n{{task-block-tree}}"
+                                               :comment "Comment {{graph}} {{comment-uuid}} {{agent-name}}\n{{comment-target-context}}\n{{comment-thread-context}}\n{{requesting-comment}}"}))
+                                agent-command/list-routable-tasks (fn [_cfg _repo _agent-name]
+                                                                    (p/resolved []))]
+                 (p/let [valid (agent-command/execute-bridge
+                                {:type :agent-bridge
+                                 :repo "logseq_db_demo"
+                                 :graph "demo"
+                                 :dry-run? true}
+                                {:root-dir root
+                                 :agent-name "build-host"
+                                 :agent-bridge {:workspaces [{:id "copy-a"
+                                                              :cwd workspace-a}
+                                                             {:id "copy-b"
+                                                              :cwd workspace-b}]}})
+                         duplicate (agent-command/execute-bridge
+                                    {:type :agent-bridge
+                                     :repo "logseq_db_demo"
+                                     :graph "demo"
+                                     :dry-run? true}
+                                    {:root-dir root
+                                     :agent-name "build-host"
+                                     :agent-bridge {:workspaces [{:id "copy-a"
+                                                                  :cwd workspace-a}
+                                                                 {:id "copy-a"
+                                                                  :cwd workspace-b}]}})
+                         relative (agent-command/execute-bridge
+                                   {:type :agent-bridge
+                                    :repo "logseq_db_demo"
+                                    :graph "demo"
+                                    :dry-run? true}
+                                   {:root-dir root
+                                    :agent-name "build-host"
+                                    :agent-bridge {:workspaces [{:id "copy-a"
+                                                                 :cwd "relative-copy"}]}})]
+                   (is (= :ok (:status valid)))
+                   (is (= :error (:status duplicate)))
+                   (is (= :agent-workspace-invalid (get-in duplicate [:error :code])))
+                   (is (= :error (:status relative)))
+                   (is (= :agent-workspace-invalid (get-in relative [:error :code])))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (set! (.-spawnSync child-process) original-spawn-sync)
+                            (fs/rmSync root #js {:recursive true :force true})
+                            (done)))))))
 
 (deftest test-execute-agent-bridge-list-and-format
   (let [root (temp-root)]
@@ -1432,21 +1533,27 @@
       (agent-command/record-session! {:root-dir root}
                                      {:session "codex-running"
                                       :status :running
-                                      :backend :codex
-                                      :graph "demo"
-                                      :block "11111111-1111-1111-1111-111111111111"
-                                      :agent "build-host"
-                                      :started-at 1000
-                                      :updated-at 2000})
-      (let [result (agent-command/execute-list {:type :agent-bridge-list} {:root-dir root})
-            output (cli-format/format-result result {:output-format :human :now-ms 3000})]
+	                                      :backend :codex
+	                                      :graph "demo"
+	                                      :block "11111111-1111-1111-1111-111111111111"
+	                                      :agent "build-host"
+	                                      :workspace-id "copy-a"
+	                                      :cwd "/tmp/logseq-copy-a"
+	                                      :branch "feat/x-feature"
+	                                      :started-at 1000
+	                                      :updated-at 2000})
+	      (let [result (agent-command/execute-list {:type :agent-bridge-list} {:root-dir root})
+	            output (cli-format/format-result result {:output-format :human :now-ms 3000})]
         (is (= :ok (:status result)))
-        (is (string/includes? output "SESSION"))
-        (is (string/includes? output "STATUS"))
-        (is (string/includes? output "BACKEND"))
-        (is (string/includes? output "codex-running"))
-        (is (string/includes? output "running"))
-        (is (not (string/includes? output ":running")))
+	        (is (string/includes? output "SESSION"))
+	        (is (string/includes? output "STATUS"))
+	        (is (string/includes? output "BACKEND"))
+	        (is (string/includes? output "WORKSPACE"))
+	        (is (string/includes? output "codex-running"))
+	        (is (string/includes? output "running"))
+	        (is (string/includes? output "copy-a"))
+	        (is (string/includes? output "feat/x-feature"))
+	        (is (not (string/includes? output ":running")))
         (is (not (string/includes? output ":codex")))
         (is (string/includes? output "Count: 1")))
       (finally
@@ -1589,9 +1696,166 @@
                  (fs/rmSync root #js {:recursive true :force true})
                  (done)))
              (catch :default e
-               (fs/rmSync root #js {:recursive true :force true})
-               (is false (str "unexpected setup error: " e))
-               (done))))))
+	               (fs/rmSync root #js {:recursive true :force true})
+	               (is false (str "unexpected setup error: " e))
+	               (done))))))
+
+(deftest test-execute-agent-bridge-routes-tasks-through-workspace-pool
+  (async done
+         (let [root (temp-root)
+               workspace-a (node-path/join root "copy-a")
+               workspace-b (node-path/join root "copy-b")
+               blocks [(task-block {:db/id 42
+                                     :block/uuid #uuid "11111111-1111-1111-1111-111111111111"})
+                       (task-block {:db/id 43
+                                     :block/uuid #uuid "22222222-2222-2222-2222-222222222222"})
+                       (task-block {:db/id 44
+                                     :block/uuid #uuid "33333333-3333-3333-3333-333333333333"})]
+               codex-starts* (atom [])
+               git-calls* (atom [])
+               original-spawn-sync (.-spawnSync child-process)]
+           (fs/mkdirSync workspace-a #js {:recursive true})
+           (fs/mkdirSync workspace-b #js {:recursive true})
+           (set! (.-spawnSync child-process)
+                 (fn [bin args _opts]
+                   (let [argv (js->clj args)]
+                     (swap! git-calls* conj [bin argv])
+                     (spawn-result 0 "" ""))))
+           (-> (p/with-redefs [agent-command/codex-available? (fn [_] true)
+                                cli-server/ensure-server! (fn [cfg _repo]
+                                                            (assoc cfg :base-url "http://127.0.0.1:1234"))
+                                agent-command/register-agent-bridge! (fn [_cfg _repo _agent-name]
+                                                                       (p/resolved true))
+                                agent-command/ensure-agent-bridge-prompt-templates!
+                                (fn [_cfg _repo]
+                                  (p/resolved {:task "Task {{graph}} {{block-uuid}} {{agent-name}}\n{{task-block-tree}}"
+                                               :comment "Comment {{graph}} {{comment-uuid}} {{agent-name}}\n{{comment-target-context}}\n{{comment-thread-context}}\n{{requesting-comment}}"}))
+                                agent-command/list-routable-tasks
+                                (fn [_cfg _repo _agent-name]
+                                  (p/resolved (mapv (fn [block]
+                                                      {:block block
+                                                       :tree-text (:block/title block)})
+                                                    blocks)))
+                                transport/invoke
+                                (fn [_cfg method _args]
+                                  (case method
+                                    :thread-api/q (p/resolved :logseq.property/status.todo)
+                                    :thread-api/apply-outliner-ops (p/resolved {:ok true})
+                                    (p/rejected (ex-info "unexpected invoke"
+                                                         {:method method}))))
+                                agent-command/start-codex!
+                                (fn [command opts]
+                                  (let [session-id (str "session-" (inc (count @codex-starts*)))]
+                                    (swap! codex-starts* conj {:session session-id
+                                                               :cwd (:cwd opts)
+                                                               :prompt (last command)})
+                                    (p/resolved {:session session-id
+                                                 :status :running})))]
+                 (p/let [result (agent-command/execute-bridge
+                                 {:type :agent-bridge
+                                  :repo "logseq_db_demo"
+                                  :graph "demo"
+                                  :dry-run? false
+                                  :process-once? true}
+                                 {:root-dir root
+                                  :agent-name "build-host"
+                                  :agent-bridge {:workspaces [{:id "copy-a"
+                                                               :cwd workspace-a}
+                                                              {:id "copy-b"
+                                                               :cwd workspace-b}]}
+                                  :log-fn (fn [_] nil)})]
+                   (is (= :ok (:status result)))
+                   (is (= [workspace-a workspace-b] (mapv :cwd @codex-starts*)))
+                   (is (= 2 (count (get-in result [:data :routed]))))
+                   (is (= 2 (count @codex-starts*)))
+                   (is (every? #(string/includes? (:prompt %) "create a new branch from the current master branch")
+                               @codex-starts*))
+                   (is (every? #(string/includes? (:prompt %) "fix/some-bug, feat/x-feature, enhance/xxx, or refactor/db-worker")
+                               @codex-starts*))
+                   (is (some #(= ["git" ["-C" workspace-a "checkout" "master"]] %) @git-calls*))
+                   (is (some #(= ["git" ["-C" workspace-a "pull" "--ff-only" "origin" "master"]] %) @git-calls*))
+                   (is (not-any? #(= ["git" ["-C" workspace-a "checkout" "-b"]] %) @git-calls*))
+                   (is (not-any? #(= ["git" ["-C" workspace-a "commit"]] %) @git-calls*))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (set! (.-spawnSync child-process) original-spawn-sync)
+                            (fs/rmSync root #js {:recursive true :force true})
+                            (done)))))))
+
+(deftest test-agent-bridge-workspace-complete-rejects-master-branch
+  (let [root (temp-root)
+        workspace-a (node-path/join root "copy-a")
+        workspace-pool (atom [{:id "copy-a"
+                               :cwd workspace-a
+                               :status :running}])
+        original-spawn-sync (.-spawnSync child-process)]
+    (fs/mkdirSync workspace-a #js {:recursive true})
+    (try
+      (set! (.-spawnSync child-process)
+            (fn [_bin args _opts]
+              (let [argv (js->clj args)
+                    git-args (subvec (vec argv) 2)]
+                (case (pr-str git-args)
+                  "[\"branch\" \"--show-current\"]" (spawn-result 0 "master\n" "")
+                  "[\"status\" \"--porcelain\"]" (spawn-result 0 "" "")
+                  (spawn-result 0 "" "")))))
+      (#'agent-command/complete-workspace-session! {:root-dir root}
+                                                  workspace-pool
+                                                  {:id "copy-a"
+                                                   :cwd workspace-a}
+                                                  "session-master"
+                                                  :completed)
+      (let [session (first (agent-command/list-sessions {:root-dir root} {:all? true}))
+            workspace (first @workspace-pool)]
+        (is (= :failed (:status session)))
+        (is (= "master" (:branch session)))
+        (is (= :dirty (:status workspace))))
+      (finally
+        (set! (.-spawnSync child-process) original-spawn-sync)
+        (fs/rmSync root #js {:recursive true :force true})))))
+
+(deftest test-agent-bridge-comment-resume-checks-out-recorded-workspace-branch
+  (let [root (temp-root)
+        workspace-a (node-path/join root "copy-a")
+        workspace-pool (atom [{:id "copy-a"
+                               :cwd workspace-a
+                               :status :idle}])
+        git-calls* (atom [])
+        original-spawn-sync (.-spawnSync child-process)]
+    (fs/mkdirSync workspace-a #js {:recursive true})
+    (try
+      (agent-command/record-session! {:root-dir root}
+                                     {:session "existing-session-123"
+                                      :status :completed
+                                      :backend :codex
+                                      :graph "demo"
+                                      :block "11111111-1111-1111-1111-111111111111"
+                                      :agent "build-host"
+                                      :workspace-id "copy-a"
+                                      :cwd workspace-a
+                                      :branch "feat/x-feature"
+                                      :started-at 1000
+                                      :updated-at 2000})
+      (set! (.-spawnSync child-process)
+            (fn [bin args _opts]
+              (let [argv (js->clj args)]
+                (swap! git-calls* conj [bin argv])
+                (case (pr-str (subvec (vec argv) 2))
+                  "[\"branch\" \"--show-current\"]" (spawn-result 0 "feat/x-feature\n" "")
+                  (spawn-result 0 "" "")))))
+      (let [workspace-session (#'agent-command/acquire-existing-workspace-session!
+                               {:root-dir root}
+                               workspace-pool
+                               "existing-session-123")]
+        (is (= "copy-a" (:workspace-id workspace-session)))
+        (is (= workspace-a (:cwd workspace-session)))
+        (is (= "feat/x-feature" (:branch workspace-session)))
+        (is (some #(= ["git" ["-C" workspace-a "checkout" "feat/x-feature"]] %)
+                  @git-calls*)))
+      (finally
+        (set! (.-spawnSync child-process) original-spawn-sync)
+        (fs/rmSync root #js {:recursive true :force true})))))
 
 (deftest test-execute-agent-bridge-connects-listener-before-ready-log-and-initial-scan
   (async done

--- a/src/test/logseq/cli/command/agent_test.cljs
+++ b/src/test/logseq/cli/command/agent_test.cljs
@@ -1560,10 +1560,10 @@
                                  :dry-run? true}
                                 {:root-dir root
                                  :agent-name "build-host"
-                                 :agent-bridge {:workspaces [{:id "copy-a"
-                                                              :cwd workspace-a}
-                                                             {:id "copy-b"
-                                                              :cwd workspace-b}]}})
+                                 :workspaces {"demo" [{:id "copy-a"
+                                                       :cwd workspace-a}
+                                                      {:id "copy-b"
+                                                       :cwd workspace-b}]}})
                          duplicate (agent-command/execute-bridge
                                     {:type :agent-bridge
                                      :repo "logseq_db_demo"
@@ -1571,10 +1571,10 @@
                                      :dry-run? true}
                                     {:root-dir root
                                      :agent-name "build-host"
-                                     :agent-bridge {:workspaces [{:id "copy-a"
-                                                                  :cwd workspace-a}
-                                                                 {:id "copy-a"
-                                                                  :cwd workspace-b}]}})
+                                     :workspaces {"demo" [{:id "copy-a"
+                                                           :cwd workspace-a}
+                                                          {:id "copy-a"
+                                                           :cwd workspace-b}]}})
                          relative (agent-command/execute-bridge
                                    {:type :agent-bridge
                                     :repo "logseq_db_demo"
@@ -1582,13 +1582,27 @@
                                     :dry-run? true}
                                    {:root-dir root
                                     :agent-name "build-host"
-                                    :agent-bridge {:workspaces [{:id "copy-a"
-                                                                 :cwd "relative-copy"}]}})]
+                                    :workspaces {"demo" [{:id "copy-a"
+                                                          :cwd "relative-copy"}]}})
+                         other-graph (agent-command/execute-bridge
+                                      {:type :agent-bridge
+                                       :repo "logseq_db_demo"
+                                       :graph "demo"
+                                       :dry-run? true}
+                                      {:root-dir root
+                                       :agent-name "build-host"
+                                       :workspaces {"other graph" [{:id "copy-a"
+                                                                    :cwd "relative-copy"}]}})]
                    (is (= :ok (:status valid)))
+                   (is (some #(string/includes? % "using workspaces: 2")
+                             (get-in valid [:data :logs])))
                    (is (= :error (:status duplicate)))
                    (is (= :agent-workspace-invalid (get-in duplicate [:error :code])))
                    (is (= :error (:status relative)))
-                   (is (= :agent-workspace-invalid (get-in relative [:error :code])))))
+                   (is (= :agent-workspace-invalid (get-in relative [:error :code])))
+                   (is (= :ok (:status other-graph)))
+                   (is (not-any? #(string/includes? % "using workspaces")
+                                 (get-in other-graph [:data :logs])))))
                (p/catch (fn [e]
                           (is false (str "unexpected error: " e))))
                (p/finally (fn []
@@ -1797,10 +1811,10 @@
                                   :process-once? true}
                                  {:root-dir root
                                   :agent-name "build-host"
-                                  :agent-bridge {:workspaces [{:id "copy-a"
-                                                               :cwd workspace-a}
-                                                              {:id "copy-b"
-                                                               :cwd workspace-b}]}
+                                  :workspaces {"demo" [{:id "copy-a"
+                                                        :cwd workspace-a}
+                                                       {:id "copy-b"
+                                                        :cwd workspace-b}]}
                                   :log-fn (fn [_] nil)})]
                    (is (= :ok (:status result)))
                    (is (= [workspace-a workspace-b] (mapv :cwd @codex-starts*)))


### PR DESCRIPTION
## Summary

Adds a local workspace pool for `logseq agent bridge` so one bridge process can route sessions across pre-created project copies while still running the host `codex` CLI.

## Changes

- Add `:agent-bridge :workspaces` config validation and workspace state tracking.
- Start Codex with an explicit workspace `cwd` when a pool is configured.
- Route tasks to idle clean workspaces and leave excess tasks pending when the pool is full.
- Resume comments in the original session workspace and checkout the recorded session branch first.
- Verify completed workspace sessions are clean and on a non-`master` session branch before reusing the workspace.
- Record and display workspace id, cwd, and branch metadata for bridge sessions.
- Document the workspace pool lifecycle in `docs/agent-guide/logseq-cli`.

## Validation

- `rtk bb dev:test -v logseq.cli.command.agent-test`
- `rtk bb lint:large-vars`
- `rtk git diff --check`
