### PR TITLE
[codex] fix: prune mobile stack on browser back

### DIFF
--- a/src/main/mobile/navigation.cljs
+++ b/src/main/mobile/navigation.cljs
@@ -158,6 +158,17 @@
                          (conj (vec (butlast history)) entry)
                          (conj history entry))
 
+                "pop" (if-let [idx (->> history
+                                         (map-indexed vector)
+                                         (keep (fn [[idx history-entry]]
+                                                 (when (= path (:path history-entry))
+                                                   idx)))
+                                         last)]
+                        (subvec history 0 (inc idx))
+                        (if (seq history)
+                          (conj (vec (butlast history)) entry)
+                          [entry]))
+
                 history)))]
       (swap! stack-history update stack
              (fn [{:keys [history]}]

--- a/src/test/mobile/navigation_test.cljs
+++ b/src/test/mobile/navigation_test.cljs
@@ -17,6 +17,11 @@
    :route {:to name :path-params {} :query-params {}}
    :route-match (route-match name)})
 
+(defn- stack-paths
+  [stack]
+  (->> (get-in @@#'mobile-nav/stack-history [stack :history])
+       (mapv :path)))
+
 (defn- reset-navigation-state! []
   (reset! @#'mobile-nav/navigation-source nil)
   (reset! @#'mobile-nav/initialised-stacks {})
@@ -102,6 +107,36 @@
         (is (empty? @payloads))
         (is (= [[:home {} {}]
                 [:page {} {}]]
+               @replace-calls))))))
+
+(deftest browser-back-prunes-active-stack-before-tab-restore
+  (testing "a page popped by Back should not be restored when switching back to the tab"
+    (let [route-matches (atom [])
+          replace-calls (atom [])]
+      (reset! mobile-state/*tab "home")
+      (reset! @#'mobile-nav/active-stack "home")
+      (reset! @#'mobile-nav/initialised-stacks {"home" true
+                                                "graphs" true})
+      (reset! @#'mobile-nav/stack-history
+              {"home" {:history [(stack-entry :home "/")
+                                  (stack-entry :page "/page/recent")]}
+               "graphs" {:history [(stack-entry :graphs "/__stack__/graphs")]}})
+      (with-redefs [mobile-nav/orig-replace-state (fn [& args] (swap! replace-calls conj args))
+                    route-handler/set-route-match! (fn [match] (swap! route-matches conj match))
+                    mobile-util/native-platform? (constantly false)]
+        (reset! @#'mobile-nav/navigation-source :pop)
+        (mobile-nav/notify-route-change!
+         {:route {:to :home
+                  :path-params {}
+                  :query-params {}}
+          :route-match (route-match :home)
+          :path "/"
+          :stack "home"})
+        (mobile-state/set-tab! "graphs")
+        (mobile-state/set-tab! "home")
+        (is (= ["/"] (stack-paths "home")))
+        (is (= :home (get-in (last @route-matches) [:data :name])))
+        (is (= [[:home {} {}]]
                @replace-calls))))))
 
 (deftest leaving-search-does-not-clear-query-during-tab-transition


### PR DESCRIPTION
## Summary
- prune the mobile navigation stack when the browser emits a pop route
- add a regression test for switching tabs after browser Back pops a page

## Root cause
Browser Back emitted a pop route, but mobile stack history ignored pop updates, so the popped page stayed on top and was restored after tab switching.

Fixes https://github.com/logseq/db-test/issues/893

## Validation
- bb dev:test -v mobile.navigation-test
