### PR TITLE
fix: allow repeated date picker selection

### DIFF
--- a/src/main/frontend/components/datepicker.cljs
+++ b/src/main/frontend/components/datepicker.cljs
@@ -18,7 +18,7 @@
   [dom-id format]
   (let [selected-date (state/sub :date-picker/date)
         select-handler! (fn [^js d]
-                          (when-let [d (or d selected-date)]
+                          (when-let [d (or d (state/sub :date-picker/date))]
                             (let [gd (goog.date.Date. (.getFullYear d) (.getMonth d) (.getDate d))
                                   journal (date/js-date->journal-title gd)]
                               ;; similar to page reference

--- a/src/main/frontend/components/datepicker.cljs
+++ b/src/main/frontend/components/datepicker.cljs
@@ -16,10 +16,9 @@
              (state/set-state! :date-picker/date (t/today)))
            state)}
   [dom-id format]
-  (let [date (state/sub :date-picker/date)
+  (let [selected-date (state/sub :date-picker/date)
         select-handler! (fn [^js d]
-                          ;; d is nil when clicked more than once
-                          (when d
+                          (when-let [d (or d selected-date)]
                             (let [gd (goog.date.Date. (.getFullYear d) (.getMonth d) (.getDate d))
                                   journal (date/js-date->journal-title gd)]
                               ;; similar to page reference
@@ -37,7 +36,7 @@
        {:mode "single"
         :initial-focus true
         :show-week-number false
-        :selected date
+        :selected selected-date
         :on-select select-handler!
         :on-day-key-down (fn [^js d _ ^js e]
                            (when (= "Enter" (.-key e))

--- a/src/test/frontend/components/datepicker_test.cljs
+++ b/src/test/frontend/components/datepicker_test.cljs
@@ -1,0 +1,32 @@
+(ns frontend.components.datepicker-test
+  (:require ["react" :as react]
+            ["react-dom/server" :as react-dom-server]
+            [cljs.test :refer [deftest is]]
+            [frontend.commands :as commands]
+            [frontend.components.datepicker :as datepicker]
+            [frontend.date :as date]
+            [frontend.handler.editor :as editor-handler]
+            [frontend.state :as state]
+            [frontend.ui :as ui]))
+
+(deftest repeated-selected-date-click-inserts-current-date-test
+  (let [selected-date (js/Date. 2026 4 20)
+        app-state* (atom {:date-picker/date selected-date})
+        calendar-opts* (atom nil)
+        inserted* (atom [])]
+    (with-redefs [state/state app-state*
+                  state/sub (fn [k] (get @app-state* k))
+                  state/set-state! (fn [k v & _] (swap! app-state* assoc k v) nil)
+                  state/clear-editor-action! (fn [] nil)
+                  date/js-date->journal-title (constantly "May 20th, 2026")
+                  editor-handler/insert-command! (fn [& args]
+                                                   (swap! inserted* conj args))
+                  ui/nlp-calendar (fn [opts]
+                                    (reset! calendar-opts* opts)
+                                    (.createElement react "div"))]
+      (.renderToStaticMarkup react-dom-server (datepicker/date-picker "edit-block" nil))
+      (reset! commands/*current-command :date-picker)
+      ((:on-select @calendar-opts*) nil)
+      (is (= [["edit-block" "[[May 20th, 2026]]" nil {:command :page-ref}]]
+             @inserted*))
+      (is (nil? @commands/*current-command)))))


### PR DESCRIPTION
Fix https://github.com/logseq/db-test/issues/887

## Summary
- Allow /Date picker to reselect the currently selected day when DayPicker reports nil.
- Add a regression test for repeated selected-date clicks.

## Root cause
React DayPicker returns nil when clicking the currently selected day in single mode, and the Logseq date picker handler ignored nil instead of inserting the selected date.

## Test plan
- bb dev:test -n frontend.components.datepicker-test
- bb dev:lint-and-test