### PR TITLE
fix: normalize zero-keycode shortcuts

### DIFF
--- a/src/main/frontend/modules/shortcut/core.cljs
+++ b/src/main/frontend/modules/shortcut/core.cljs
@@ -16,11 +16,12 @@
             [lambdaisland.glogi :as log]
             [logseq.shui.ui :as shui])
   (:import [goog.events KeyCodes KeyNames]
-           [goog.ui KeyboardShortcutHandler]))
+           [goog.ui KeyboardShortcutHandler SyntheticKeyboardEvent]))
 
 (defonce *installed-handlers (atom {}))
 (defonce *pending-inited? (atom false))
 (defonce *pending-shortcuts (atom []))
+(defonce *keycode-normalizer-installed? (atom false))
 
 (def global-keys #js
                   [KeyCodes/TAB
@@ -30,7 +31,7 @@
 
 (def key-names (js->clj KeyNames))
 
-(declare register-shortcut!)
+(declare register-shortcut! ensure-keycode-normalizer!)
 
 (defn consume-pending-shortcuts!
   []
@@ -141,6 +142,8 @@
 
   (let [shortcut-map (dh/shortcuts-map-by-handler-id handler-id state)
         handler (new KeyboardShortcutHandler js/window)]
+    (ensure-keycode-normalizer!)
+
     ;; set arrows enter, tab to global
     (when set-global-keys?
       (.setGlobalKeys handler global-keys))
@@ -345,15 +348,52 @@
       :else
       (get code->key-name-map code))))
 
+(defn- event-code [e]
+  (or (gobj/getValueByKeys e "event_" "code")
+      (gobj/get e "code")))
+
 (defn- resolve-key-name
   "Resolve the key name from a KeyEvent. Tries key-names (keyCode) first,
-   then falls back to code->key-name (native KeyboardEvent.code) when a
-   modifier is held — corrects macOS Option+key corruption and AltGr on Windows."
+   then falls back to code->key-name (native KeyboardEvent.code)."
   [e]
   (or (get key-names (str (.-keyCode e)))
-      (when (or (.-altKey e) (.-ctrlKey e) (.-metaKey e))
-        (some-> (gobj/getValueByKeys e "event_" "code")
-                code->key-name))))
+      (some-> (event-code e)
+              code->key-name)))
+
+(defn- event-code->key-code
+  [e]
+  (some-> (event-code e)
+          code->key-name
+          KeyboardShortcutHandler/getKeyCode))
+
+(defn- zero-keycode? [e]
+  (zero? (or (gobj/get e "keyCode") 0)))
+
+(defn- needs-keycode-normalization?
+  [e]
+  (when (zero-keycode? e)
+    (when-let [key-name (some-> (event-code e) code->key-name)]
+      (not= (gobj/get e "key") key-name))))
+
+(defn- dispatch-normalized-keydown!
+  [e]
+  (when (needs-keycode-normalization? e)
+    (when-let [key-code (event-code->key-code e)]
+      (events/dispatchEvent
+       js/window
+       (SyntheticKeyboardEvent/createKeyDown
+        key-code
+        (boolean (gobj/get e "shiftKey"))
+        (boolean (gobj/get e "altKey"))
+        (boolean (gobj/get e "ctrlKey"))
+        (boolean (gobj/get e "metaKey"))
+        (or (gobj/get e "target") js/window)
+        #(.preventDefault e)
+        #(.stopPropagation e))))))
+
+(defn- ensure-keycode-normalizer! []
+  (when (compare-and-set! *keycode-normalizer-installed? false true)
+    (events/listen js/window "keydown" dispatch-normalized-keydown! true)))
 
 (defn- name-with-meta [e resolved-name]
   (let [ctrl (.-ctrlKey e)

--- a/src/test/frontend/modules/shortcut/core_test.cljs
+++ b/src/test/frontend/modules/shortcut/core_test.cljs
@@ -1,8 +1,10 @@
 (ns frontend.modules.shortcut.core-test
   (:require [cljs.test :refer [deftest is testing]]
             [frontend.modules.shortcut.config :as shortcut-config]
+            [frontend.modules.shortcut.core :as shortcut]
             [frontend.modules.shortcut.data-helper :as dh]
-            [frontend.util :as util]))
+            [frontend.util :as util]
+            [goog.object :as gobj]))
 
 (deftest test-core-basic
   (testing "get handler id"
@@ -152,6 +154,24 @@
   (testing "add comment shortcut appears in block-selection category"
     (is (some #{:editor/add-comment}
               (shortcut-config/get-category-shortcuts :shortcut.category/block-selection)))))
+
+(defn- shortcut-key-event
+  [{:keys [code key-code ctrl? alt? meta? shift?]}]
+  (let [event #js {:code code}
+        key-event #js {:keyCode  key-code
+                       :ctrlKey  (boolean ctrl?)
+                       :altKey   (boolean alt?)
+                       :metaKey  (boolean meta?)
+                       :shiftKey (boolean shift?)}]
+    (gobj/set key-event "event_" event)
+    key-event))
+
+(deftest zero-keycode-shortcut-keynames
+  (testing "Enter and Tab resolve from native KeyboardEvent.code when keyCode is 0"
+    (is (= " enter" (shortcut/keyname (shortcut-key-event {:key-code 0 :code "Enter"}))))
+    (is (= " tab" (shortcut/keyname (shortcut-key-event {:key-code 0 :code "Tab"})))))
+  (testing "modified letter shortcuts still resolve from native KeyboardEvent.code"
+    (is (= " ctrl+k" (shortcut/keyname (shortcut-key-event {:key-code 0 :code "KeyK" :ctrl? true}))))))
 
 (comment
   (cljs.test/run-tests))


### PR DESCRIPTION
## Summary
- normalize shortcut key resolution when native keydown reports keyCode 0
- dispatch normalized synthetic shortcut events so Enter/Tab still work in textareas
- add regression coverage for zero-keyCode Enter/Tab/Ctrl+K key names

## Root cause
Closure's shortcut handler checks textarea-global shortcuts by numeric keyCode before dispatch. On Electron/Linux, keydown can report keyCode 0, so Enter and Tab are rejected before Logseq's shortcut handlers run.

## Verification
- bb dev:test -v frontend.modules.shortcut.core-test
- bb dev:lint-and-test