### PR TITLE
clean redundant class extends

### DIFF
--- a/deps/common/src/logseq/common/log.cljs
+++ b/deps/common/src/logseq/common/log.cljs
@@ -2,7 +2,5 @@
   "Minimal, logging ns that shims lambdaisland.glogi fns for nbb. Could port
   glogi to nbb later if this shim gets too big")
 
-(defn error
-  "Logs one or more values at error level."
-  [& msgs]
+(defn error [& msgs]
   (apply js/console.error (map clj->js msgs)))

--- a/deps/common/src/logseq/common/log.cljs
+++ b/deps/common/src/logseq/common/log.cljs
@@ -2,5 +2,8 @@
   "Minimal, logging ns that shims lambdaisland.glogi fns for nbb. Could port
   glogi to nbb later if this shim gets too big")
 
+(defn info [& msgs]
+  (apply js/console.info (map clj->js msgs)))
+
 (defn error [& msgs]
   (apply js/console.error (map clj->js msgs)))

--- a/deps/common/src/logseq/common/log.cljs
+++ b/deps/common/src/logseq/common/log.cljs
@@ -2,8 +2,12 @@
   "Minimal, logging ns that shims lambdaisland.glogi fns for nbb. Could port
   glogi to nbb later if this shim gets too big")
 
-(defn info [& msgs]
+(defn info
+  "Logs one or more values at info level."
+  [& msgs]
   (apply js/console.info (map clj->js msgs)))
 
-(defn error [& msgs]
+(defn error
+  "Logs one or more values at error level."
+  [& msgs]
   (apply js/console.error (map clj->js msgs)))

--- a/deps/common/src/logseq/common/log.cljs
+++ b/deps/common/src/logseq/common/log.cljs
@@ -2,11 +2,6 @@
   "Minimal, logging ns that shims lambdaisland.glogi fns for nbb. Could port
   glogi to nbb later if this shim gets too big")
 
-(defn info
-  "Logs one or more values at info level."
-  [& msgs]
-  (apply js/console.info (map clj->js msgs)))
-
 (defn error
   "Logs one or more values at error level."
   [& msgs]

--- a/deps/outliner/src/logseq/outliner/property.cljs
+++ b/deps/outliner/src/logseq/outliner/property.cljs
@@ -17,6 +17,7 @@
             [logseq.db.frontend.property.type :as db-property-type]
             [logseq.db.frontend.schema :as db-schema]
             [logseq.db.sqlite.util :as sqlite-util]
+            [logseq.common.log :as log]
             [logseq.outliner.core :as outliner-core]
             [logseq.outliner.page :as outliner-page]
             [logseq.outliner.validate :as outliner-validate]
@@ -112,6 +113,57 @@
            (ldb/internal-page? block)
            (not (block-classes-provide-property? @conn block property-id)))))
 
+(defn- ->entity-ids
+  [db value]
+  (->> (cond
+         (nil? value) []
+         (de/entity? value) [value]
+         (coll? value) value
+         :else [value])
+       (keep (fn [item]
+               (cond
+                 (de/entity? item) (:db/id item)
+                 (integer? item) item
+                 (keyword? item) (:db/id (d/entity db item)))))))
+
+(defn- class-ancestor-ids
+  [db class-id]
+  (when-let [class (d/entity db class-id)]
+    (->> (ldb/get-class-extends class)
+         (map :db/id))))
+
+(defn- direct-extends-retraction-tx-data
+  [class redundant-parent-ids reason]
+  (when (and (ldb/class? class) (seq redundant-parent-ids))
+    (let [redundant-parents (filter #(contains? redundant-parent-ids (:db/id %))
+                                    (:logseq.property.class/extends class))]
+      (when (seq redundant-parents)
+        (log/info :msg "Clean redundant class extends"
+                  :class (:block/title class)
+                  :reason reason
+                  :removed-tags (mapv :block/title redundant-parents)))
+      (map (fn [parent]
+             [:db/retract (:db/id class) :logseq.property.class/extends (:db/id parent)])
+           redundant-parents))))
+
+(defn- redundant-extends-retraction-tx-data
+  [db class value]
+  (let [parent-ids (set (->entity-ids db value))
+        ancestor-ids (set (mapcat #(class-ancestor-ids db %) parent-ids))
+        inherited-parent-ids (set/union parent-ids ancestor-ids)]
+    (concat
+     (direct-extends-retraction-tx-data
+      class
+      ancestor-ids
+      "The removed parent tag is already inherited through the new parent tag.")
+     (mapcat
+      (fn [child-id]
+        (direct-extends-retraction-tx-data
+         (d/entity db child-id)
+         inherited-parent-ids
+         "The removed parent tag is already inherited through an updated ancestor tag."))
+      (db-class/get-structured-children db (:db/id class))))))
+
 (defn- build-property-value-tx-data
   [conn block property-id value]
   (when (some? value)
@@ -122,9 +174,10 @@
           multiple-values-empty? (and (sequential? old-value)
                                       (contains? (set (map :db/ident old-value)) :logseq.property/empty-placeholder))
           extends? (= property-id :logseq.property.class/extends)
+          tx-value (if (and extends? (coll? value)) (set value) value)
           update-block-tx (cond-> (outliner-core/block-with-updated-at {:db/id (:db/id block)})
                             true
-                            (assoc property-id value)
+                            (assoc property-id tx-value)
                             (should-add-task-tag-for-property? conn block property-id)
                             (assoc :block/tags :logseq.class/Task)
                             (= :logseq.property/template-applied-to property-id)
@@ -135,9 +188,7 @@
         retract-multiple-values?
         (conj [:db/retract (:db/id update-block-tx) property-id])
         extends?
-        (concat
-         (let [extends (ldb/get-class-extends (d/entity @conn value))]
-           (map (fn [extend] [:db/retract (:db/id block) property-id (:db/id extend)]) extends)))
+        (into (redundant-extends-retraction-tx-data @conn block value))
         true
         (conj update-block-tx)))))
 
@@ -535,10 +586,11 @@
   (when (= property-id :block/tags)
     (outliner-validate/validate-tags-property @conn block-eids v))
   (when (= property-id :logseq.property.class/extends)
-    (outliner-validate/validate-extends-property
-     @conn
-     (if (number? v) (d/entity @conn v) v)
-     (map #(d/entity @conn %) block-eids))))
+    (doseq [parent-id (->entity-ids @conn v)]
+      (outliner-validate/validate-extends-property
+       @conn
+       (d/entity @conn parent-id)
+       (map #(d/entity @conn %) block-eids)))))
 
 (defn- normalize-default-url-property-value
   [conn property value]

--- a/deps/outliner/src/logseq/outliner/property.cljs
+++ b/deps/outliner/src/logseq/outliner/property.cljs
@@ -15,6 +15,7 @@
             [logseq.db.frontend.property :as db-property]
             [logseq.db.frontend.property.build :as db-property-build]
             [logseq.db.frontend.property.type :as db-property-type]
+            [logseq.db.frontend.rules :as rules]
             [logseq.db.frontend.schema :as db-schema]
             [logseq.db.sqlite.util :as sqlite-util]
             [logseq.common.log :as log]
@@ -132,37 +133,67 @@
     (->> (ldb/get-class-extends class)
          (map :db/id))))
 
-(defn- direct-extends-retraction-tx-data
-  [class redundant-parent-ids reason]
-  (when (and (ldb/class? class) (seq redundant-parent-ids))
-    (let [redundant-parents (filter #(contains? redundant-parent-ids (:db/id %))
-                                    (:logseq.property.class/extends class))]
-      (when (seq redundant-parents)
-        (log/info :msg "Clean redundant class extends"
-                  :class (:block/title class)
-                  :reason reason
-                  :removed-tags (mapv :block/title redundant-parents)))
-      (map (fn [parent]
-             [:db/retract (:db/id class) :logseq.property.class/extends (:db/id parent)])
-           redundant-parents))))
+(defn- direct-extends-retractions
+  [db class-id redundant-parent-ids reason]
+  (when (and class-id (seq redundant-parent-ids))
+    (->> (d/q '[:find ?class ?parent
+                :in $ ?class [?parent ...]
+                :where
+                [?class :logseq.property.class/extends ?parent]]
+              db class-id redundant-parent-ids)
+         (map (fn [[class-id parent-id]]
+                {:class-id class-id
+                 :parent-id parent-id
+                 :reason reason})))))
+
+(defn- descendant-extends-retractions
+  [db class-id redundant-parent-ids reason]
+  (when (and class-id (seq redundant-parent-ids))
+    (->> (d/q '[:find ?child ?parent
+                :in $ ?class [?parent ...] %
+                :where
+                (class-extends ?class ?child)
+                [?child :logseq.property.class/extends ?parent]]
+              db class-id redundant-parent-ids (:class-extends rules/rules))
+         (remove (fn [[child-id _parent-id]] (= class-id child-id)))
+         (map (fn [[child-id parent-id]]
+                {:class-id child-id
+                 :parent-id parent-id
+                 :reason reason})))))
+
+(defn- log-redundant-extends-retractions
+  [db retractions]
+  (when (seq retractions)
+    (log/info :msg "Clean redundant class extends"
+              :changes (->> retractions
+                            (group-by (fn [{:keys [class-id reason]}] [class-id reason]))
+                            (mapv (fn [[[class-id reason] retractions]]
+                                    {:class (:block/title (d/entity db class-id))
+                                     :reason reason
+                                     :removed-tags (mapv (fn [{:keys [parent-id]}]
+                                                           (:block/title (d/entity db parent-id)))
+                                                         retractions)}))))))
 
 (defn- redundant-extends-retraction-tx-data
   [db class value]
   (let [parent-ids (set (->entity-ids db value))
         ancestor-ids (set (mapcat #(class-ancestor-ids db %) parent-ids))
-        inherited-parent-ids (set/union parent-ids ancestor-ids)]
-    (concat
-     (direct-extends-retraction-tx-data
-      class
-      ancestor-ids
-      "The removed parent tag is already inherited through the new parent tag.")
-     (mapcat
-      (fn [child-id]
-        (direct-extends-retraction-tx-data
-         (d/entity db child-id)
-         inherited-parent-ids
-         "The removed parent tag is already inherited through an updated ancestor tag."))
-      (db-class/get-structured-children db (:db/id class))))))
+        inherited-parent-ids (set/union parent-ids ancestor-ids)
+        retractions (concat
+                     (direct-extends-retractions
+                      db
+                      (:db/id class)
+                      ancestor-ids
+                      "The removed parent tag is already inherited through the new parent tag.")
+                     (descendant-extends-retractions
+                      db
+                      (:db/id class)
+                      inherited-parent-ids
+                      "The removed parent tag is already inherited through an updated ancestor tag."))]
+    (log-redundant-extends-retractions db retractions)
+    (map (fn [{:keys [class-id parent-id]}]
+           [:db/retract class-id :logseq.property.class/extends parent-id])
+         retractions)))
 
 (defn- build-property-value-tx-data
   [conn block property-id value]

--- a/deps/outliner/src/logseq/outliner/property.cljs
+++ b/deps/outliner/src/logseq/outliner/property.cljs
@@ -114,18 +114,47 @@
            (ldb/internal-page? block)
            (not (block-classes-provide-property? @conn block property-id)))))
 
+(def ^:private class-lookup-ref-attrs
+  #{:db/ident :block/uuid})
+
+(defn- class-lookup-ref?
+  [value]
+  ;; Class extends accepts only entity refs that can point at class blocks.
+  ;; Keep this narrow to avoid per-value schema/entity lookups while parsing vectors.
+  (and (vector? value)
+       (= 2 (count value))
+       (contains? class-lookup-ref-attrs (first value))))
+
+(defn- single-entity-ref?
+  [value]
+  (or (de/entity? value)
+      (integer? value)
+      (keyword? value)
+      (class-lookup-ref? value)))
+
 (defn- ->entity-ids
   [db value]
-  (->> (cond
-         (nil? value) []
-         (de/entity? value) [value]
-         (coll? value) value
-         :else [value])
-       (keep (fn [item]
-               (cond
-                 (de/entity? item) (:db/id item)
-                 (integer? item) item
-                 (keyword? item) (:db/id (d/entity db item)))))))
+  (letfn [(entity-id [item]
+            (or (cond
+                  (de/entity? item) (:db/id item)
+                  (integer? item) item
+                  (keyword? item) (:db/id (d/entity db item))
+                  (class-lookup-ref? item) (:db/id (d/entity db item)))
+                (throw (ex-info "Unsupported class extends entity reference"
+                                {:value item}))))]
+    (->> (cond
+           (nil? value) []
+           (single-entity-ref? value) [value]
+           (coll? value) value
+           :else [value])
+         (map entity-id))))
+
+(defn- normalize-extends-value
+  [db value]
+  (let [ids (vec (->entity-ids db value))]
+    (if (single-entity-ref? value)
+      (first ids)
+      ids)))
 
 (defn- class-ancestor-ids
   [db class-id]
@@ -205,7 +234,10 @@
           multiple-values-empty? (and (sequential? old-value)
                                       (contains? (set (map :db/ident old-value)) :logseq.property/empty-placeholder))
           extends? (= property-id :logseq.property.class/extends)
-          tx-value (if (and extends? (coll? value)) (set value) value)
+          tx-value (if extends?
+                     (let [value' (normalize-extends-value @conn value)]
+                       (if (coll? value') (set value') value'))
+                     value)
           update-block-tx (cond-> (outliner-core/block-with-updated-at {:db/id (:db/id block)})
                             true
                             (assoc property-id tx-value)
@@ -705,12 +737,20 @@
            many? (= :db.cardinality/many (:db/cardinality property))
            entity-id? (and (:entity-id? options) (number? v))
            ref? (contains? db-property-type/all-ref-property-types property-type)
+           extends? (= property-id :logseq.property.class/extends)
            default-url-not-closed? (and (contains? #{:default :url} property-type)
+                                        (not extends?)
                                         (not (seq (entity-plus/lookup-kv-then-entity property :property/closed-values))))
-           v' (if (and ref? (not entity-id?))
+           v' (cond
+                extends?
+                (normalize-extends-value @conn v)
+
+                (and ref? (not entity-id?))
                 (if default-url-not-closed?
                   (normalize-and-validate-default-url-property-values conn property v many?)
                   (convert-ref-property-values conn property-id v property-type {:many? many?}))
+
+                :else
                 v)
            _ (when (nil? v')
                (throw (ex-info "Property value must be not nil" {:v v})))
@@ -813,8 +853,15 @@
            property (d/entity @conn property-id)
            property-type (get property :logseq.property/type :default)
            ref? (db-property-type/all-ref-property-types property-type)
-           v' (if ref?
+           extends? (= property-id :logseq.property.class/extends)
+           v' (cond
+                extends?
+                (normalize-extends-value @conn v)
+
+                ref?
                 (convert-ref-property-value conn property-id v property-type block-eid)
+
+                :else
                 v)]
        (when-not (and block property)
          (throw (ex-info "Set block property failed: block or property doesn't exist"
@@ -827,8 +874,9 @@
          (do
            (when (= property-id :block/tags)
              (outliner-validate/validate-tags-property @conn [block-eid] v'))
-           (when (= property-id :logseq.property.class/extends)
-             (outliner-validate/validate-extends-property @conn v' [block]))
+           (when extends?
+             (doseq [parent-id (->entity-ids @conn v')]
+               (outliner-validate/validate-extends-property @conn (d/entity @conn parent-id) [block])))
            (cond
              db-attribute?
              (set-block-db-attribute! conn block property property-id v v')

--- a/deps/outliner/src/logseq/outliner/property.cljs
+++ b/deps/outliner/src/logseq/outliner/property.cljs
@@ -1,6 +1,7 @@
 (ns logseq.outliner.property
   "Property related operations"
-  (:require [clojure.set :as set]
+  (:require [clojure.pprint :as pprint]
+            [clojure.set :as set]
             [clojure.string :as string]
             [datascript.core :as d]
             [datascript.impl.entity :as de]
@@ -18,7 +19,6 @@
             [logseq.db.frontend.rules :as rules]
             [logseq.db.frontend.schema :as db-schema]
             [logseq.db.sqlite.util :as sqlite-util]
-            [logseq.common.log :as log]
             [logseq.outliner.core :as outliner-core]
             [logseq.outliner.page :as outliner-page]
             [logseq.outliner.validate :as outliner-validate]
@@ -193,15 +193,15 @@
 (defn- log-redundant-extends-retractions
   [db retractions]
   (when (seq retractions)
-    (log/info :msg "Clean redundant class extends"
-              :changes (->> retractions
-                            (group-by (fn [{:keys [class-id reason]}] [class-id reason]))
-                            (mapv (fn [[[class-id reason] retractions]]
-                                    {:class (:block/title (d/entity db class-id))
-                                     :reason reason
-                                     :removed-tags (mapv (fn [{:keys [parent-id]}]
-                                                           (:block/title (d/entity db parent-id)))
-                                                         retractions)}))))))
+    (pprint/pprint {:msg "Clean redundant class extends"
+                    :changes (->> retractions
+                                  (group-by (fn [{:keys [class-id reason]}] [class-id reason]))
+                                  (mapv (fn [[[class-id reason] retractions]]
+                                          {:class (:block/title (d/entity db class-id))
+                                           :reason reason
+                                           :removed-tags (mapv (fn [{:keys [parent-id]}]
+                                                                 (:block/title (d/entity db parent-id)))
+                                                               retractions)})))})))
 
 (defn- redundant-extends-retraction-tx-data
   [db class value]
@@ -716,7 +716,7 @@
                                :i18n-key :page.validation/alias-batch-multiple-owners
                                :message "Aliases can't be batch-set on multiple pages."}}))))
 
-(defn batch-set-property!
+(defn ^:large-vars/cleanup-todo batch-set-property!
   "Sets properties for multiple blocks. Automatically handles property value refs.
    Does no validation of property values. For :many properties, passing a collection
    replaces existing values in one call, while passing a scalar preserves add-single-value behavior."

--- a/deps/outliner/src/logseq/outliner/property.cljs
+++ b/deps/outliner/src/logseq/outliner/property.cljs
@@ -1,7 +1,6 @@
 (ns logseq.outliner.property
   "Property related operations"
-  (:require [clojure.pprint :as pprint]
-            [clojure.set :as set]
+  (:require [clojure.set :as set]
             [clojure.string :as string]
             [datascript.core :as d]
             [datascript.impl.entity :as de]
@@ -16,7 +15,6 @@
             [logseq.db.frontend.property :as db-property]
             [logseq.db.frontend.property.build :as db-property-build]
             [logseq.db.frontend.property.type :as db-property-type]
-            [logseq.db.frontend.rules :as rules]
             [logseq.db.frontend.schema :as db-schema]
             [logseq.db.sqlite.util :as sqlite-util]
             [logseq.outliner.core :as outliner-core]
@@ -114,16 +112,13 @@
            (ldb/internal-page? block)
            (not (block-classes-provide-property? @conn block property-id)))))
 
-(def ^:private class-lookup-ref-attrs
-  #{:db/ident :block/uuid})
-
 (defn- class-lookup-ref?
   [value]
   ;; Class extends accepts only entity refs that can point at class blocks.
   ;; Keep this narrow to avoid per-value schema/entity lookups while parsing vectors.
   (and (vector? value)
        (= 2 (count value))
-       (contains? class-lookup-ref-attrs (first value))))
+       (contains? #{:db/ident :block/uuid} (first value))))
 
 (defn- single-entity-ref?
   [value]
@@ -149,80 +144,43 @@
            :else [value])
          (map entity-id))))
 
+(defn- class-ancestor-ids
+  [db class-ids]
+  (set (mapcat (fn [class-id]
+                 (some->> (d/entity db class-id)
+                          ldb/get-class-extends
+                          (map :db/id)))
+               class-ids)))
+
+(defn- direct-extends-retraction-tx-data
+  [class redundant-parent-ids]
+  (when (and (ldb/class? class) (seq redundant-parent-ids))
+    (keep (fn [parent]
+            (when (contains? redundant-parent-ids (:db/id parent))
+              [:db/retract (:db/id class) :logseq.property.class/extends (:db/id parent)]))
+          (:logseq.property.class/extends class))))
+
+(defn- canonical-extends-ids
+  [db value]
+  (let [parent-ids (vec (->entity-ids db value))]
+    (remove (class-ancestor-ids db parent-ids) parent-ids)))
+
 (defn- normalize-extends-value
   [db value]
-  (let [ids (vec (->entity-ids db value))]
+  (let [ids (vec (canonical-extends-ids db value))]
     (if (single-entity-ref? value)
       (first ids)
       ids)))
 
-(defn- class-ancestor-ids
-  [db class-id]
-  (when-let [class (d/entity db class-id)]
-    (->> (ldb/get-class-extends class)
-         (map :db/id))))
-
-(defn- direct-extends-retractions
-  [db class-id redundant-parent-ids reason]
-  (when (and class-id (seq redundant-parent-ids))
-    (->> (d/q '[:find ?class ?parent
-                :in $ ?class [?parent ...]
-                :where
-                [?class :logseq.property.class/extends ?parent]]
-              db class-id redundant-parent-ids)
-         (map (fn [[class-id parent-id]]
-                {:class-id class-id
-                 :parent-id parent-id
-                 :reason reason})))))
-
-(defn- descendant-extends-retractions
-  [db class-id redundant-parent-ids reason]
-  (when (and class-id (seq redundant-parent-ids))
-    (->> (d/q '[:find ?child ?parent
-                :in $ ?class [?parent ...] %
-                :where
-                (class-extends ?class ?child)
-                [?child :logseq.property.class/extends ?parent]]
-              db class-id redundant-parent-ids (:class-extends rules/rules))
-         (remove (fn [[child-id _parent-id]] (= class-id child-id)))
-         (map (fn [[child-id parent-id]]
-                {:class-id child-id
-                 :parent-id parent-id
-                 :reason reason})))))
-
-(defn- log-redundant-extends-retractions
-  [db retractions]
-  (when (seq retractions)
-    (pprint/pprint {:msg "Clean redundant class extends"
-                    :changes (->> retractions
-                                  (group-by (fn [{:keys [class-id reason]}] [class-id reason]))
-                                  (mapv (fn [[[class-id reason] retractions]]
-                                          {:class (:block/title (d/entity db class-id))
-                                           :reason reason
-                                           :removed-tags (mapv (fn [{:keys [parent-id]}]
-                                                                 (:block/title (d/entity db parent-id)))
-                                                               retractions)})))})))
-
 (defn- redundant-extends-retraction-tx-data
   [db class value]
   (let [parent-ids (set (->entity-ids db value))
-        ancestor-ids (set (mapcat #(class-ancestor-ids db %) parent-ids))
-        inherited-parent-ids (set/union parent-ids ancestor-ids)
-        retractions (concat
-                     (direct-extends-retractions
-                      db
-                      (:db/id class)
-                      ancestor-ids
-                      "The removed parent tag is already inherited through the new parent tag.")
-                     (descendant-extends-retractions
-                      db
-                      (:db/id class)
-                      inherited-parent-ids
-                      "The removed parent tag is already inherited through an updated ancestor tag."))]
-    (log-redundant-extends-retractions db retractions)
-    (map (fn [{:keys [class-id parent-id]}]
-           [:db/retract class-id :logseq.property.class/extends parent-id])
-         retractions)))
+        ancestor-ids (class-ancestor-ids db parent-ids)
+        inherited-parent-ids (set/union parent-ids ancestor-ids)]
+    (concat
+     (direct-extends-retraction-tx-data class ancestor-ids)
+     (mapcat #(direct-extends-retraction-tx-data (d/entity db %) inherited-parent-ids)
+             (db-class/get-structured-children db (:db/id class))))))
 
 (defn- build-property-value-tx-data
   [conn block property-id value]

--- a/deps/outliner/test/logseq/outliner/property_test.cljs
+++ b/deps/outliner/test/logseq/outliner/property_test.cljs
@@ -516,6 +516,47 @@
               (db-test/readable-properties (d/entity @conn :user.class/D))))
           "D removes the direct parent inherited through C"))))
 
+(deftest extends-redundant-cleanup-with-lookup-ref-parent
+  (testing "Treat lookup refs as a single parent reference"
+    (let [conn (db-test/create-conn-with-blocks
+                {:classes {:A {}
+                           :B {}
+                           :C {:build/class-extends [:B]}
+                           :D {:build/class-extends [:A :C]}}})]
+      (outliner-property/set-block-property! conn
+                                             (:db/id (d/entity @conn :user.class/B))
+                                             :logseq.property.class/extends
+                                             [:db/ident :user.class/A])
+      (is (= [:user.class/A]
+             (:logseq.property.class/extends
+              (db-test/readable-properties (d/entity @conn :user.class/B))))
+          "B uses the lookup ref as one parent")
+      (is (= [:user.class/C]
+             (:logseq.property.class/extends
+              (db-test/readable-properties (d/entity @conn :user.class/D))))
+          "D removes the direct parent inherited through C"))))
+
+(deftest extends-redundant-cleanup-with-keyword-vector-parents
+  (testing "Treat a vector of class idents as multiple parents"
+    (let [conn (db-test/create-conn-with-blocks
+                {:classes {:A {}
+                           :B {}
+                           :C {:build/class-extends [:B]}
+                           :D {:build/class-extends [:A :C]}
+                           :E {}}})]
+      (outliner-property/batch-set-property! conn
+                                             [(:db/id (d/entity @conn :user.class/B))]
+                                             :logseq.property.class/extends
+                                             [:user.class/A :user.class/E])
+      (is (= [:user.class/A :user.class/E]
+             (:logseq.property.class/extends
+              (db-test/readable-properties (d/entity @conn :user.class/B))))
+          "B uses both keyword idents as parents")
+      (is (= [:user.class/C]
+             (:logseq.property.class/extends
+              (db-test/readable-properties (d/entity @conn :user.class/D))))
+          "D removes the direct parent inherited through C"))))
+
 (deftest extends-redundant-direct-parent-cleanup-for-deep-descendants
   (testing "Clean redundant parents from deeper descendants"
     (let [conn (db-test/create-conn-with-blocks

--- a/deps/outliner/test/logseq/outliner/property_test.cljs
+++ b/deps/outliner/test/logseq/outliner/property_test.cljs
@@ -481,6 +481,86 @@
            (outliner-property/set-block-property! conn (:db/id class3) :logseq.property.class/extends (:db/id class1)))
           "Extends cycle"))))
 
+(deftest extends-redundant-direct-parent-cleanup
+  (testing "Clean redundant direct parents from descendants when a class gets a new parent"
+    (let [conn (db-test/create-conn-with-blocks
+                {:classes {:A {}
+                           :B {}
+                           :C {:build/class-extends [:B]}
+                           :D {:build/class-extends [:A :C]}}})
+          b (d/entity @conn :user.class/B)]
+      (outliner-property/set-block-property! conn
+                                             (:db/id b)
+                                             :logseq.property.class/extends
+                                             (:db/id (d/entity @conn :user.class/A)))
+      (is (= [:user.class/C]
+             (:logseq.property.class/extends
+              (db-test/readable-properties (d/entity @conn :user.class/D))))
+          "D keeps only the nearest direct parent"))))
+
+(deftest extends-redundant-direct-parent-cleanup-for-batch-vector
+  (testing "Clean descendant redundant parents when batch setting multiple parents"
+    (let [conn (db-test/create-conn-with-blocks
+                {:classes {:A {}
+                           :B {}
+                           :C {:build/class-extends [:B]}
+                           :D {:build/class-extends [:A :C]}
+                           :E {}}})]
+      (outliner-property/batch-set-property! conn
+                                             [(:db/id (d/entity @conn :user.class/B))]
+                                             :logseq.property.class/extends
+                                             [(:db/id (d/entity @conn :user.class/A))
+                                              (:db/id (d/entity @conn :user.class/E))])
+      (is (= [:user.class/C]
+             (:logseq.property.class/extends
+              (db-test/readable-properties (d/entity @conn :user.class/D))))
+          "D removes the direct parent inherited through C"))))
+
+(deftest extends-redundant-direct-parent-cleanup-for-deep-descendants
+  (testing "Clean redundant parents from deeper descendants"
+    (let [conn (db-test/create-conn-with-blocks
+                {:classes {:A {}
+                           :B {}
+                           :C {:build/class-extends [:B]}
+                           :D {:build/class-extends [:C]}
+                           :E {:build/class-extends [:A :D]}}})]
+      (outliner-property/set-block-property! conn
+                                             (:db/id (d/entity @conn :user.class/B))
+                                             :logseq.property.class/extends
+                                             (:db/id (d/entity @conn :user.class/A)))
+      (is (= [:user.class/D]
+             (:logseq.property.class/extends
+              (db-test/readable-properties (d/entity @conn :user.class/E))))
+          "E removes the direct parent inherited through D"))))
+
+(deftest extends-redundant-direct-parent-cleanup-for-root-reset
+  (testing "Clean descendant Root parents when an ancestor is reset to Root"
+    (let [conn (db-test/create-conn-with-blocks
+                {:classes {:B {}
+                           :C {:build/class-extends [:B]}
+                           :D {:build/class-extends [:logseq.class/Root :C]}}})]
+      (outliner-property/set-block-property! conn
+                                             (:db/id (d/entity @conn :user.class/B))
+                                             :logseq.property.class/extends
+                                             :logseq.class/Root)
+      (is (= [:user.class/C]
+             (:logseq.property.class/extends
+              (db-test/readable-properties (d/entity @conn :user.class/D))))
+          "D removes the direct Root parent inherited through C"))))
+
+(deftest extends-redundant-direct-parent-cleanup-without-descendants
+  (testing "Setting extends on a class without descendants does not fail"
+    (let [conn (db-test/create-conn-with-blocks
+                {:classes {:A {}
+                           :B {}}})]
+      (outliner-property/set-block-property! conn
+                                             (:db/id (d/entity @conn :user.class/B))
+                                             :logseq.property.class/extends
+                                             (:db/id (d/entity @conn :user.class/A)))
+      (is (= [:user.class/A]
+             (:logseq.property.class/extends
+              (db-test/readable-properties (d/entity @conn :user.class/B))))))))
+
 (deftest delete-property-value!
   (let [conn (db-test/create-conn-with-blocks
               {:classes {:C1 {}

--- a/deps/outliner/test/logseq/outliner/property_test.cljs
+++ b/deps/outliner/test/logseq/outliner/property_test.cljs
@@ -498,24 +498,6 @@
               (db-test/readable-properties (d/entity @conn :user.class/D))))
           "D keeps only the nearest direct parent"))))
 
-(deftest extends-redundant-direct-parent-cleanup-for-batch-vector
-  (testing "Clean descendant redundant parents when batch setting multiple parents"
-    (let [conn (db-test/create-conn-with-blocks
-                {:classes {:A {}
-                           :B {}
-                           :C {:build/class-extends [:B]}
-                           :D {:build/class-extends [:A :C]}
-                           :E {}}})]
-      (outliner-property/batch-set-property! conn
-                                             [(:db/id (d/entity @conn :user.class/B))]
-                                             :logseq.property.class/extends
-                                             [(:db/id (d/entity @conn :user.class/A))
-                                              (:db/id (d/entity @conn :user.class/E))])
-      (is (= [:user.class/C]
-             (:logseq.property.class/extends
-              (db-test/readable-properties (d/entity @conn :user.class/D))))
-          "D removes the direct parent inherited through C"))))
-
 (deftest extends-redundant-cleanup-with-lookup-ref-parent
   (testing "Treat lookup refs as a single parent reference"
     (let [conn (db-test/create-conn-with-blocks
@@ -541,38 +523,20 @@
     (let [conn (db-test/create-conn-with-blocks
                 {:classes {:A {}
                            :B {}
-                           :C {:build/class-extends [:B]}
-                           :D {:build/class-extends [:A :C]}
-                           :E {}}})]
+                           :C {:build/class-extends [:A]}
+                           :D {:build/class-extends [:A :B]}}})]
       (outliner-property/batch-set-property! conn
                                              [(:db/id (d/entity @conn :user.class/B))]
                                              :logseq.property.class/extends
-                                             [:user.class/A :user.class/E])
-      (is (= [:user.class/A :user.class/E]
-             (:logseq.property.class/extends
-              (db-test/readable-properties (d/entity @conn :user.class/B))))
-          "B uses both keyword idents as parents")
+                                             [:user.class/A :user.class/C])
       (is (= [:user.class/C]
              (:logseq.property.class/extends
-              (db-test/readable-properties (d/entity @conn :user.class/D))))
-          "D removes the direct parent inherited through C"))))
-
-(deftest extends-redundant-direct-parent-cleanup-for-deep-descendants
-  (testing "Clean redundant parents from deeper descendants"
-    (let [conn (db-test/create-conn-with-blocks
-                {:classes {:A {}
-                           :B {}
-                           :C {:build/class-extends [:B]}
-                           :D {:build/class-extends [:C]}
-                           :E {:build/class-extends [:A :D]}}})]
-      (outliner-property/set-block-property! conn
-                                             (:db/id (d/entity @conn :user.class/B))
-                                             :logseq.property.class/extends
-                                             (:db/id (d/entity @conn :user.class/A)))
-      (is (= [:user.class/D]
+              (db-test/readable-properties (d/entity @conn :user.class/B))))
+          "B keeps only the nearest parent")
+      (is (= [:user.class/B]
              (:logseq.property.class/extends
-              (db-test/readable-properties (d/entity @conn :user.class/E))))
-          "E removes the direct parent inherited through D"))))
+              (db-test/readable-properties (d/entity @conn :user.class/D))))
+          "D removes the direct parent inherited through B"))))
 
 (deftest extends-redundant-direct-parent-cleanup-for-root-reset
   (testing "Clean descendant Root parents when an ancestor is reset to Root"
@@ -588,19 +552,6 @@
              (:logseq.property.class/extends
               (db-test/readable-properties (d/entity @conn :user.class/D))))
           "D removes the direct Root parent inherited through C"))))
-
-(deftest extends-redundant-direct-parent-cleanup-without-descendants
-  (testing "Setting extends on a class without descendants does not fail"
-    (let [conn (db-test/create-conn-with-blocks
-                {:classes {:A {}
-                           :B {}}})]
-      (outliner-property/set-block-property! conn
-                                             (:db/id (d/entity @conn :user.class/B))
-                                             :logseq.property.class/extends
-                                             (:db/id (d/entity @conn :user.class/A)))
-      (is (= [:user.class/A]
-             (:logseq.property.class/extends
-              (db-test/readable-properties (d/entity @conn :user.class/B))))))))
 
 (deftest delete-property-value!
   (let [conn (db-test/create-conn-with-blocks


### PR DESCRIPTION
- Remove direct parent class edges that become redundant after updating extends, including batch vector values and descendant classes.