### PR TITLE
[codex] keep remote asset metadata after restore

### DIFF
--- a/clj-e2e/bb.edn
+++ b/clj-e2e/bb.edn
@@ -1,7 +1,8 @@
 {:deps {org.babashka/http-server {:mvn/version "0.1.14"}
         org.babashka/cli {:mvn/version "0.8.67"}}
  :tasks
- {:requires ([babashka.cli :as cli])
+ {:requires ([babashka.cli :as cli]
+             [babashka.process :as bp])
   :init (do
           (def cli-opts (cli/parse-opts *command-line-args* {:alias {:p :port :n :namespace :i :include :v :var}
                                                              :coerce {:port :int :headers :edn}}))
@@ -40,11 +41,25 @@
                         :task (do (clojure (clojure-with-port "-M:test -n logseq.e2e.rtc-extra-part2-test"))
                                   (System/exit 0))}
 
+  rtc-extra-part2-asset-test {:doc "run only the asset restore regression (fast iteration)"
+                              :task (let [env (merge (into {} (System/getenv))
+                                                     {"LOGSEQ_E2E_ONLY_ASSET_RESTORE" "1"
+                                                      "LOGSEQ_E2E_FAST" "1"
+                                                      "LOGSEQ_E2E_REUSE_RTC_GRAPH" "1"})
+                                          res (deref (bp/process ["clojure" "-M:test" "-n" "logseq.e2e.rtc-extra-part2-test"]
+                                                                 {:env env
+                                                                  :out :inherit
+                                                                  :err :inherit}))]
+                                      (System/exit (:exit res)))}
+
   -run-rtc-extra-test {:depends [serve prn rtc-extra-test]}
   run-rtc-extra-test {:task (run '-run-rtc-extra-test {:parallel true})}
 
   -run-rtc-extra-part2-test {:depends [serve prn rtc-extra-part2-test]}
   run-rtc-extra-part2-test {:task (run '-run-rtc-extra-part2-test {:parallel true})}
+
+  -run-rtc-extra-part2-asset-test {:depends [serve prn rtc-extra-part2-asset-test]}
+  run-rtc-extra-part2-asset-test {:task (run '-run-rtc-extra-part2-asset-test {:parallel true})}
 
   -dev {:depends [serve prn test]}
 

--- a/clj-e2e/src/logseq/e2e/assets.clj
+++ b/clj-e2e/src/logseq/e2e/assets.clj
@@ -1,0 +1,98 @@
+(ns logseq.e2e.assets
+  (:require [clojure.set :as set]
+            [clojure.string :as string]
+            [wally.main :as w]))
+
+(defn assets-dir
+  [graph-name]
+  (str "/" graph-name "/assets"))
+
+(defn list-assets
+  "List file names in the DB-graph assets directory.
+
+  Note: clj-e2e runs the web build, so db-graph files live in lightning-fs
+  (`window.pfs`) rather than `~/logseq/graphs/...`."
+  [graph-name]
+  (let [dir (assets-dir graph-name)]
+    (vec
+     (or
+      (w/eval-js
+       (str "(() => window.pfs.readdir(" (pr-str dir) ").catch(() => []))()"))
+      []))))
+
+(defn wait-for-asset!
+  [graph-name filename timeout-ms]
+  (let [deadline-ms (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (cond
+        (some #(= filename %) (list-assets graph-name))
+        true
+
+        (> (System/currentTimeMillis) deadline-ms)
+        false
+
+        :else
+        (do (Thread/sleep 500) (recur))))))
+
+(defn wait-for-new-asset!
+  [graph-name before-filenames timeout-ms]
+  (let [before (set before-filenames)
+        deadline-ms (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (let [after (set (list-assets graph-name))
+            new-files (set/difference after before)
+            ;; DB-graph assets always have an ext (png/jpg/pdf/etc).
+            candidate (first (sort (filter #(string/includes? % ".") new-files)))]
+        (cond
+          (string? candidate)
+          candidate
+
+          (> (System/currentTimeMillis) deadline-ms)
+          nil
+
+          :else
+          (do (Thread/sleep 250) (recur)))))))
+
+(defn last-asset-block-uuid
+  "Return the `:block/uuid` (string) for the last rendered asset block in the
+  current page, inferred from the closest `.ls-block[blockid]` wrapper."
+  []
+  (w/eval-js
+   (str
+    "(() => {"
+    "  const nodes = document.querySelectorAll('.asset-ref-wrap, .asset-transfer-shell');"
+    "  const n = nodes.length;"
+    "  if (!n) return null;"
+    "  const last = nodes[n - 1];"
+    "  const block = last.closest('.ls-block');"
+    "  return block ? block.getAttribute('blockid') : null;"
+    "})()")))
+
+(defn wait-for-last-asset-block-uuid!
+  [timeout-ms]
+  (let [deadline-ms (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (if-let [uuid (last-asset-block-uuid)]
+        uuid
+        (if (> (System/currentTimeMillis) deadline-ms)
+          nil
+          (do (Thread/sleep 250) (recur)))))))
+
+(defn clear-assets-dir!
+  "Recursively delete the graph's assets directory in lightning-fs (`window.pfs`).
+
+  Why this exists: clj-e2e runs the web build, so \"Delete local graph\" doesn't
+  necessarily clear OPFS `/<graph>/assets` the same way Electron deletes
+  `~/logseq/graphs/<graph>/assets`. For the regression we care about, we need an
+  empty assets/ dir before re-downloading the graph."
+  [graph-name]
+  (let [dir (assets-dir graph-name)]
+    (boolean
+     (w/eval-js
+      (str
+       "(() => {"
+       "  const dir = " (pr-str dir) ";"
+       "  const rimraf = window.workerThread && window.workerThread.rimraf;"
+       "  if (!rimraf) return Promise.resolve(false);"
+       "  return rimraf(dir).then(() => true).catch(() => false);"
+       "})()")))))

--- a/clj-e2e/src/logseq/e2e/config.clj
+++ b/clj-e2e/src/logseq/e2e/config.clj
@@ -10,4 +10,10 @@
 
 (defonce *port (atom (resolve-port)))
 (defonce *headless (atom true))
-(defonce *slow-mo (atom 100))                  ; Set `slow-mo` lower to find more flaky tests
+(defonce *slow-mo
+  ;; The default slow-mo is intentionally conservative to reduce flakes in CI,
+  ;; but it's painful for local iteration. Set `LOGSEQ_E2E_FAST=1` to run with
+  ;; minimal delays.
+  (atom (if (= "1" (System/getenv "LOGSEQ_E2E_FAST"))
+          0
+          100)))

--- a/clj-e2e/src/logseq/e2e/page.clj
+++ b/clj-e2e/src/logseq/e2e/page.clj
@@ -26,12 +26,19 @@
   ;; Question: what's the best way to close all the popups?
   ;; close popup, exit editing
   ;; (repl/pause)
-  (util/search title)
-  (let [create-page-item (loc/filter ".search-results > div"
-                                     :has-text (str "Create page called '" title "'"))]
-    (w/wait-for create-page-item)
-    (w/click (.first create-page-item)))
-  (util/wait-editor-visible))
+  (let [click-create (fn []
+                       (util/search title)
+                       (let [create-page-item (loc/filter ".search-results > div"
+                                                          :has-text (str "Create page called '" title "'"))]
+                         (w/wait-for create-page-item {:timeout 30000})
+                         (w/click (.first create-page-item)))
+                       (util/wait-editor-visible))]
+    (try
+      (click-create)
+      (catch TimeoutError _e
+        ;; Retry once, cmdk occasionally loses focus.
+        (k/esc)
+        (click-create)))))
 
 (defn delete-page
   [page-name]

--- a/clj-e2e/src/logseq/e2e/util.clj
+++ b/clj-e2e/src/logseq/e2e/util.clj
@@ -134,7 +134,10 @@
 (defn get-edit-content
   []
   (when-let [editor (get-editor)]
-    (get-text editor)))
+    ;; `textarea.textContent` is not the runtime value. Use `inputValue` so
+    ;; helpers like `input-command` can reliably decide when a leading space is
+    ;; needed before typing `/`.
+    (.inputValue editor)))
 
 (defn bounding-xy
   [locator]
@@ -186,14 +189,37 @@
 
 (defn input-command
   [command]
-  (let [content (get-edit-content)]
-    (when (and (not= (str (last content)) " ")
-               (not= content ""))
-      (press-seq " ")))
-  (press-seq "/" {:delay 20})
-  (w/wait-for ".ui__popover-content")
-  (press-seq command {:delay 20})
-  (w/click "a.menu-link.chosen"))
+  (loop [attempt 0]
+    ;; Ensure editor focus before typing `/...`.
+    (when (w/visible? editor-q)
+      (w/click editor-q))
+    (let [content (or (get-edit-content) "")]
+      (when (and (not= content "")
+                 (not= (str (last content)) " "))
+        (press-seq " ")))
+    (let [ok?
+          (try
+            (press-seq "/" {:delay 20})
+            (w/wait-for ".ui__popover-content" {:timeout 30000})
+            (press-seq command {:delay 20})
+            (w/click "a.menu-link.chosen")
+            true
+            (catch TimeoutError _e
+              false))]
+      (when-not ok?
+        (if (< attempt 2)
+          (do
+            ;; Sometimes the editor isn't ready (or an overlay steals focus).
+            ;; Clear any partial input, then retry.
+            (k/esc)
+            (k/esc)
+            (when (w/visible? editor-q)
+              (w/click editor-q)
+              (k/press "ControlOrMeta+a")
+              (k/backspace))
+            (recur (inc attempt)))
+          (throw (ex-info "input-command failed to open command menu"
+                          {:command command :attempt attempt})))))))
 
 (defn set-tag
   "`hidden?`: some tags may be hidden from the UI, e.g. Page"

--- a/clj-e2e/test/logseq/e2e/fixtures.clj
+++ b/clj-e2e/test/logseq/e2e/fixtures.clj
@@ -12,6 +12,9 @@
             [logseq.e2e.util :as util]
             [wally.main :as w]))
 
+(def ^:private reuse-rtc-graph?
+  (= "1" (System/getenv "LOGSEQ_E2E_REUSE_RTC_GRAPH")))
+
 ;; TODO: save trace
 ;; TODO: parallel support
 (defn open-page
@@ -92,7 +95,10 @@
 
 (defn create-page
   [& [page-name]]
-  (let [page-name (or page-name (str "page " (swap! *page-number inc)))]
+  (let [page-name (or page-name
+                      (if reuse-rtc-graph?
+                        (str "page " (System/currentTimeMillis))
+                        (str "page " (swap! *page-number inc))))]
     (page/new-page page-name)
     page-name))
 
@@ -136,7 +142,9 @@
 (defn prepare-rtc-graph-fixture
   "open 2 app instances, add a rtc graph, check this graph available on other instance"
   [graph-name-prefix f]
-  (let [graph-name (str graph-name-prefix "-" (inst-string (java.time.Instant/now)))]
+  (let [graph-name (if reuse-rtc-graph?
+                     (str graph-name-prefix "-reused")
+                     (str graph-name-prefix "-" (inst-string (java.time.Instant/now))))]
     (cp/prun!
      2
      #(w/with-page %
@@ -145,7 +153,13 @@
         (util/login-test-account))
      [@*page1 @*page2])
     (w/with-page @*page1
-      (graph/new-graph graph-name true false))
+      (if reuse-rtc-graph?
+        (try
+          (graph/wait-for-remote-graph graph-name)
+          (graph/switch-graph graph-name true true)
+          (catch Throwable _e
+            (graph/new-graph graph-name true false)))
+        (graph/new-graph graph-name true false)))
     (w/with-page @*page2
       (graph/wait-for-remote-graph graph-name)
       (graph/switch-graph graph-name true true))
@@ -154,7 +168,7 @@
               *graph-name* graph-name]
       (f)
       ;; cleanup
-      (if custom-report/*preserve-graph*
+      (if (or reuse-rtc-graph? custom-report/*preserve-graph*)
         (println "Don't remove graph: " graph-name)
         (w/with-page @*page2
           (graph/remove-remote-graph graph-name))))))

--- a/clj-e2e/test/logseq/e2e/rtc_extra_part2_test.clj
+++ b/clj-e2e/test/logseq/e2e/rtc_extra_part2_test.clj
@@ -1,11 +1,12 @@
 (ns logseq.e2e.rtc-extra-part2-test
   (:require [clojure.java.io :as io]
             [clojure.string :as string]
-            [clojure.test :refer [deftest testing is use-fixtures run-test]]
+            [clojure.test :as t :refer [deftest testing is use-fixtures run-test]]
             [jsonista.core :as json]
             [logseq.e2e.block :as b]
             [logseq.e2e.const :refer [*page1 *page2 *graph-name*]]
             [logseq.e2e.custom-report :as custom-report]
+            [logseq.e2e.assets :as e2e-assets]
             [logseq.e2e.fixtures :as fixtures]
             [logseq.e2e.graph :as graph]
             [logseq.e2e.keyboard :as k]
@@ -14,6 +15,9 @@
             [logseq.e2e.util :as util]
             [wally.main :as w]
             [wally.repl :as repl]))
+
+(def ^:private only-asset-restore-test?
+  (= "1" (System/getenv "LOGSEQ_E2E_ONLY_ASSET_RESTORE")))
 
 (use-fixtures :once
   fixtures/open-2-pages
@@ -343,6 +347,16 @@
           (assert-no-severe-sync-errors!))))))
 
 ;;; https://github.com/logseq/db-test/issues/651
+(defn test-ns-hook
+  []
+  (let [ns-obj (the-ns 'logseq.e2e.rtc-extra-part2-test)]
+    (if only-asset-restore-test?
+      (let [v (ns-resolve ns-obj 'asset-blocks-validate-after-init-downloaded-test)]
+        (when-not (var? v)
+          (throw (ex-info "missing asset restore test var" {:var v})))
+        (t/test-vars [v]))
+      (t/test-all-vars ns-obj))))
+
 (deftest issue-651-block-title-double-transit-encoded-test
   (testing "
 1. create pages named \"bbb\", \"aaa\", and turn these pages into tag
@@ -433,16 +447,47 @@ wait for 5-10 seconds, will found that \"aaa/bbb\" became \"aaa/<encrypted-strin
 - remove local graph in client2
 - re-download the remote graph in client2
 - compare asset-blocks data in both clients"
-    (let [asset-file "../assets/icon.png"
-          page-title (w/with-page @*page1 (page/get-page-name))]
+    (let [temp-asset-path (java.nio.file.Files/createTempFile
+                           "logseq-e2e-asset-"
+                           ".txt"
+                           (into-array java.nio.file.attribute.FileAttribute []))
+          _ (spit (.toFile temp-asset-path)
+                  (str "logseq e2e asset " (System/currentTimeMillis)))
+          asset-path temp-asset-path
+          page-title (w/with-page @*page1 (page/get-page-name))
+          asset-block-uuid* (atom nil)
+          asset-filename* (atom nil)]
       (w/with-page @*page1
         (let [p (w/get-page)]
-          (.onFileChooser p (reify java.util.function.Consumer
-                              (accept [_ fc]
-                                (.setFiles fc (into-array java.nio.file.Path [(java.nio.file.Paths/get asset-file (into-array String []))])))))
-          (b/new-block "asset block")
-          (util/input-command "Upload an asset")
-          (w/wait-for ".ls-block img")))
+          ;; Create a new empty block first. Asset insert behaves differently
+          ;; based on whether the current block is empty.
+          (b/open-last-block)
+          (k/enter)
+          (util/wait-editor-visible)
+          (let [before (e2e-assets/list-assets *graph-name*)
+                chooser (.waitForFileChooser
+                         p
+                         (reify Runnable
+                           (run [_]
+                             (util/input-command "Upload an asset"))))]
+            (.setFiles chooser (into-array java.nio.file.Path [asset-path]))
+            ;; Prefer inspecting lightning-fs directly. UI rendering can lag,
+            ;; and reused graphs can already contain older assets.
+            (let [filename (e2e-assets/wait-for-new-asset! *graph-name* before 60000)
+                  asset-block-uuid (some-> filename (string/replace #"\.[^.]+$" ""))]
+              (reset! asset-block-uuid* asset-block-uuid)
+              (reset! asset-filename* filename)
+              (is (string? asset-block-uuid)
+                  (pr-str {:graph *graph-name*
+                           :asset-block-uuid asset-block-uuid
+                           :assets-before (vec before)
+                           :assets (e2e-assets/list-assets *graph-name*)}))
+              ;; Local sanity: the uploader should have written bytes locally.
+              (is (true? (e2e-assets/wait-for-asset! *graph-name* filename 60000))
+                  (pr-str {:graph *graph-name*
+                           :asset-block-uuid asset-block-uuid
+                           :asset-filename filename
+                           :assets (e2e-assets/list-assets *graph-name*)}))))))
 
       (let [{:keys [remote-tx]}
             (w/with-page @*page1
@@ -452,14 +497,45 @@ wait for 5-10 seconds, will found that \"aaa/bbb\" became \"aaa/<encrypted-strin
           (rtc/wait-tx-update-to remote-tx)))
 
       (w/with-page @*page2
-        (graph/remove-local-graph *graph-name*)
-        (graph/wait-for-remote-graph *graph-name*)
-        (graph/switch-graph *graph-name* true false)
-        (page/goto-page page-title)
-        (w/wait-for ".ls-block img")
-        (is (some? (.getAttribute (w/-query ".ls-block img") "src"))))
+        (let [asset-filename @asset-filename*
+              asset-block-uuid @asset-block-uuid*]
+          (is (string? asset-filename))
+          ;; Precondition: the asset *block* is synced to client2. The bytes may
+          ;; or may not have been downloaded yet, depending on the build.
+          (page/goto-page page-title)
+          (w/wait-for (format ".ls-block[blockid='%s']" asset-block-uuid)
+                      {:timeout 60000})
 
-      (rtc/validate-graphs-in-2-pw-pages))))
+          (graph/remove-local-graph *graph-name*)
+          (e2e-assets/clear-assets-dir! *graph-name*)
+          (is (not (some #(= asset-filename %) (e2e-assets/list-assets *graph-name*)))
+              (pr-str {:graph *graph-name* :asset-filename asset-filename}))
+
+          (graph/wait-for-remote-graph *graph-name*)
+          (graph/switch-graph *graph-name* true true)
+
+          ;; Regression assertion: assets should be restored as part of the
+          ;; download flow (no "visit each asset page to trigger download").
+          (let [preloaded? (e2e-assets/wait-for-asset! *graph-name* asset-filename 120000)]
+            (when-not preloaded?
+              (page/goto-page page-title)
+              (let [demand-loaded? (e2e-assets/wait-for-asset! *graph-name* asset-filename 60000)]
+                (is (true? preloaded?)
+                    (pr-str {:graph *graph-name*
+                             :asset-block-uuid asset-block-uuid
+                             :asset-filename asset-filename
+                             :reason (if demand-loaded?
+                                       :downloaded-only-after-page-visit
+                                       :asset-never-downloaded)
+                             :assets (e2e-assets/list-assets *graph-name*)}))))
+
+            (page/goto-page page-title)
+            ;; UI sanity: the asset block is present on the page.
+            (w/wait-for (format ".ls-block[blockid='%s']" asset-block-uuid)
+                        {:timeout 60000}))))
+
+      (when-not only-asset-restore-test?
+        (rtc/validate-graphs-in-2-pw-pages)))))
 
 (deftest issue-683-paste-large-block-test
   (testing "Copying and pasting a large block of text into sync-ed graph causes sync to fail"

--- a/deps/db/src/logseq/db/frontend/malli_schema.cljs
+++ b/deps/db/src/logseq/db/frontend/malli_schema.cljs
@@ -290,6 +290,10 @@
    [:block/refs {:optional true} [:set :int]]
    [:block/tx-id {:optional true} :int]
    [:block/collapsed? {:optional true} :boolean]
+   [:logseq.property.sync/large-title-object {:optional true}
+    [:map
+     [:asset-uuid :string]
+     [:asset-type :string]]]
    [:block/warning {:optional true} [:keyword]]
    [:logseq.property/created-by-ref {:optional true} :int]])
 

--- a/deps/db/src/logseq/db/frontend/schema.cljs
+++ b/deps/db/src/logseq/db/frontend/schema.cljs
@@ -91,6 +91,7 @@
 
    ;; page's original name
    :block/title {:db/index true}
+   :logseq.property.sync/large-title-object {:db/index true}
 
    ;; page's journal day
    :block/journal-day {:db/index true}

--- a/src/main/frontend/worker/sync/assets.cljs
+++ b/src/main/frontend/worker/sync/assets.cljs
@@ -10,6 +10,7 @@
    [frontend.worker.sync.client-op :as client-op]
    [frontend.worker.sync.crypt :as sync-crypt]
    [frontend.worker.sync.large-title :as sync-large-title]
+   [frontend.worker.sync.util :as sync-util]
    [lambdaisland.glogi :as log]
    [logseq.common.util :as common-util]
    [logseq.db :as ldb]
@@ -338,36 +339,58 @@
                             :base base
                             :graph-id graph-id})))))
 
+(defn <download-remote-asset-if-missing!
+  "Downloads a remote asset when the DB references it but the local file is absent.
+
+  Returns `true` when a download ran, `false` when the asset already exists."
+  [repo {:keys [graph-id asset-uuid asset-type]}]
+  (let [graph-id (or graph-id (sync-util/get-graph-id repo))
+        asset-id (some-> asset-uuid str)
+        asset-type (some-> asset-type str)]
+    (if (and (seq graph-id) (seq asset-id) (seq asset-type))
+      (p/let [meta (platform/asset-stat (platform/current)
+                                        repo
+                                        (asset-file-name asset-id asset-type))]
+        (if meta
+          false
+          (p/let [_ (download-remote-asset! repo graph-id asset-id asset-type)]
+            true)))
+      (p/rejected (ex-info "missing asset download info"
+                           {:repo repo
+                            :asset-uuid asset-uuid
+                            :asset-type asset-type
+                            :graph-id graph-id})))))
+
 (defn request-asset-download!
   [repo asset-uuid {:keys [current-client-f enqueue-asset-task-f broadcast-rtc-state!-f]}]
-  (when-let [client (current-client-f repo)]
-    (when-let [graph-id (:graph-id client)]
-      (enqueue-asset-task-f
-       client
-       #(when-let [conn (worker-state/get-datascript-conn repo)]
-          (when-let [ent (d/entity @conn [:block/uuid asset-uuid])]
-            (let [asset-type (:logseq.property.asset/type ent)
-                  asset-id (str asset-uuid)
-                  should-download? (and (seq asset-type)
-                                        (:logseq.property.asset/remote-metadata ent))]
-              (-> (p/let [meta (when should-download?
-                                 (platform/asset-stat (platform/current)
-                                                      repo
-                                                      (asset-file-name asset-id asset-type)))
-                          missing-local? (and should-download? (nil? meta))
-                          _ (when missing-local?
-                              (download-remote-asset! repo graph-id asset-uuid asset-type))
-                          _ (when missing-local?
-                              (when-let [target-ent (d/entity @conn [:block/uuid asset-uuid])]
-                                (ldb/transact!
-                                 conn
-                                 [[:db/retract (:db/id target-ent)
-                                   :logseq.property.asset/remote-metadata]]
-                                 {:persist-op? true})))
-                          _ (when missing-local?
-                              (client-op/remove-asset-op repo asset-uuid))
-                          _ (when missing-local?
-                              (broadcast-rtc-state!-f client))]
-                    nil)
-                  (p/catch (fn [e]
-                             (js/console.error e)))))))))))
+  ;; Asset downloads are pure HTTP, so they should also work before the WS sync
+  ;; loop is connected, for example right after restoring a graph from a snapshot.
+  (let [client (current-client-f repo)
+        graph-id (or (some-> client :graph-id)
+                     (sync-util/get-graph-id repo))
+        runner (fn []
+                 (when-let [conn (worker-state/get-datascript-conn repo)]
+                   (when-let [ent (d/entity @conn [:block/uuid asset-uuid])]
+                     (let [asset-type (:logseq.property.asset/type ent)
+                           external-url (:logseq.property.asset/external-url ent)]
+                       (-> (p/let [downloaded? (when (nil? external-url)
+                                                 (<download-remote-asset-if-missing!
+                                                  repo
+                                                  {:graph-id graph-id
+                                                   :asset-uuid asset-uuid
+                                                   :asset-type asset-type}))]
+                             (when downloaded?
+                               (when (d/entity @conn [:block/uuid asset-uuid])
+                                 (ldb/transact!
+                                  conn
+                                  [{:block/uuid asset-uuid
+                                    :logseq.property.asset/remote-metadata nil}]
+                                  {:persist-op? true}))
+                               (client-op/remove-asset-op repo asset-uuid)
+                               (when client
+                                 (broadcast-rtc-state!-f client))))
+                           (p/catch (fn [error]
+                                      (js/console.error error))))))))]
+    (if client
+      (enqueue-asset-task-f client runner)
+      (runner))))

--- a/src/main/frontend/worker/sync/assets.cljs
+++ b/src/main/frontend/worker/sync/assets.cljs
@@ -380,12 +380,6 @@
                                                    :asset-uuid asset-uuid
                                                    :asset-type asset-type}))]
                              (when downloaded?
-                               (when (d/entity @conn [:block/uuid asset-uuid])
-                                 (ldb/transact!
-                                  conn
-                                  [{:block/uuid asset-uuid
-                                    :logseq.property.asset/remote-metadata nil}]
-                                  {:persist-op? true}))
                                (client-op/remove-asset-op repo asset-uuid)
                                (when client
                                  (broadcast-rtc-state!-f client))))

--- a/src/main/frontend/worker/sync/download.cljs
+++ b/src/main/frontend/worker/sync/download.cljs
@@ -9,17 +9,19 @@
    [frontend.worker.shared-service :as shared-service]
    [frontend.worker.state :as worker-state]
    [frontend.worker.sync.auth :as sync-auth]
+   [frontend.worker.sync.assets :as sync-assets]
    [frontend.worker.sync.client-op :as client-op]
    [frontend.worker.sync.crypt :as sync-crypt]
    [frontend.worker.sync.log-and-state :as rtc-log-and-state]
    [frontend.worker.sync.temp-sqlite :as sync-temp-sqlite]
    [frontend.worker.sync.util :refer [fail-fast] :as sync-util]
    [lambdaisland.glogi :as log]
+   [logseq.common.util :as common-util]
    [logseq.db-sync.snapshot :as snapshot]
    [logseq.db.common.sqlite :as common-sqlite]
    [logseq.db.frontend.schema :as db-schema]
-   [promesa.core :as p]
-   [logseq.db :as ldb]))
+   [logseq.db :as ldb]
+   [promesa.core :as p]))
 
 (defn- ->uint8 [data]
   (cond
@@ -159,6 +161,66 @@
 (defonce ^:private *import-state (atom nil))
 (def ^:private snapshot-import-datoms-batch-size 10000)
 
+(defn- restorable-assets
+  [db]
+  (->> (d/datoms db :avet :logseq.property.asset/type)
+       (keep (fn [datom]
+               (let [ent (d/entity db (:e datom))
+                     asset-uuid (:block/uuid ent)
+                     asset-type (:logseq.property.asset/type ent)
+                     external-url (:logseq.property.asset/external-url ent)]
+                 (when (and asset-uuid (seq asset-type) (nil? external-url))
+                   {:asset-uuid asset-uuid
+                    :asset-type asset-type}))))
+       (common-util/distinct-by :asset-uuid)
+       vec))
+
+(defn- <restore-missing-assets!
+  [repo graph-id]
+  (p/let [conn (worker-state/get-datascript-conn repo)
+          db (some-> conn deref)
+          assets (when db (restorable-assets db))
+          total (count assets)
+          _ (when (pos? total)
+              (rtc-log-and-state/rtc-log :rtc.asset.log/initial-download-missing-assets
+                                         {:sub-type :download-progress
+                                          :graph-uuid graph-id
+                                          :message (str "Checking " total " assets")}))]
+    (when (pos? total)
+      (p/loop [remaining assets
+               downloaded 0]
+        (if (empty? remaining)
+          (rtc-log-and-state/rtc-log :rtc.asset.log/initial-download-missing-assets
+                                     {:sub-type :download-completed
+                                      :graph-uuid graph-id
+                                      :message (str "Downloaded missing assets: " downloaded)})
+          (let [batch (take 10 remaining)
+                remaining* (drop 10 remaining)]
+            (p/let [results
+                    (p/all
+                     (mapv
+                      (fn [{:keys [asset-uuid asset-type]}]
+                        (-> (sync-assets/<download-remote-asset-if-missing!
+                             repo
+                             {:graph-id graph-id
+                              :asset-uuid asset-uuid
+                              :asset-type asset-type})
+                            (p/catch
+                             (fn [error]
+                               (js/console.error "restore asset failed"
+                                                 repo
+                                                 asset-uuid
+                                                 asset-type
+                                                 error)
+                               false))))
+                      batch))
+                    downloaded (+ downloaded (count (filter true? results)))]
+              (rtc-log-and-state/rtc-log :rtc.asset.log/initial-download-missing-assets
+                                         {:sub-type :download-progress
+                                          :graph-uuid graph-id
+                                          :message (str "Downloading missing assets: " downloaded "/" total)})
+              (p/recur (vec remaining*) downloaded))))))))
+
 (defn complete-datoms-import!
   [repo graph-id remote-tx]
   (-> (p/do!
@@ -171,6 +233,7 @@
        (if-let [rehydrate-f (@thread-api/*thread-apis :thread-api/db-sync-rehydrate-large-titles)]
          (rehydrate-f repo graph-id)
          (fail-fast :db-sync/missing-field {:field :thread-api/db-sync-rehydrate-large-titles}))
+       (<restore-missing-assets! repo graph-id)
        (rtc-log-and-state/rtc-log :rtc.log/download
                                   {:sub-type :download-completed
                                    :graph-uuid graph-id

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -17,6 +17,7 @@
    [frontend.worker.sync.auth :as sync-auth]
    [frontend.worker.sync.client-op :as client-op]
    [frontend.worker.sync.crypt :as sync-crypt]
+   [frontend.worker.sync.download :as sync-download]
    [frontend.worker.sync.handle-message :as sync-handle-message]
    [frontend.worker.sync.large-title :as sync-large-title]
    [frontend.worker.sync.log-and-state :as sync-log-state]
@@ -1582,6 +1583,26 @@
             (is (= 1 (client-op/get-unpushed-asset-ops-count test-repo)))
             (is (= asset-uuid (get-in asset-op [:update-asset 2 :block-uuid])))
             (is (= :update-asset (first (:update-asset asset-op))))))))))
+
+(deftest snapshot-restore-restorable-assets-test
+  (testing "snapshot restore only preloads local asset files for internal assets"
+    (let [conn (db-test/create-conn)
+          internal-asset-uuid (random-uuid)
+          external-asset-uuid (random-uuid)
+          duplicate-datom-uuid internal-asset-uuid]
+      (d/transact! conn
+                   [{:block/uuid internal-asset-uuid
+                     :block/title "internal.png"
+                     :logseq.property.asset/type "png"}
+                    {:block/uuid external-asset-uuid
+                     :block/title "external.png"
+                     :logseq.property.asset/type "png"
+                     :logseq.property.asset/external-url "https://example.com/external.png"}
+                    {:block/uuid duplicate-datom-uuid
+                     :logseq.property.asset/type "png"}])
+      (is (= [{:asset-uuid internal-asset-uuid
+               :asset-type "png"}]
+             (#'sync-download/restorable-assets @conn))))))
 
 (deftest apply-history-action-does-not-reuse-original-tx-id-test
   (testing "undo/redo history actions should not overwrite the original pending tx row"

--- a/src/test/frontend/worker/sync/assets_test.cljs
+++ b/src/test/frontend/worker/sync/assets_test.cljs
@@ -1,12 +1,68 @@
 (ns frontend.worker.sync.assets-test
   (:require [cljs.test :refer [async deftest is]]
+            [datascript.core :as d]
             [frontend.common.crypt :as crypt]
             [frontend.worker.platform :as platform]
             [frontend.worker.shared-service :as shared-service]
             [frontend.worker.state :as worker-state]
             [frontend.worker.sync.assets :as sync-assets]
             [logseq.db :as ldb]
+            [logseq.db.frontend.schema :as db-schema]
             [promesa.core :as p]))
+
+(defn- asset-conn
+  [asset-uuid]
+  (let [conn (d/create-conn db-schema/schema)]
+    (ldb/transact! conn [{:block/uuid asset-uuid
+                          :logseq.property.asset/type "png"
+                          :logseq.property.asset/checksum "sha-256-value"
+                          :logseq.property.asset/remote-metadata {:checksum "sha-256-value"
+                                                                  :type "png"}}])
+    conn))
+
+(defn- execute-enqueued-asset-task!
+  [task]
+  (if (fn? task)
+    (task)
+    (p/resolved nil)))
+
+(deftest request-asset-download-keeps-remote-metadata-test
+  (async done
+         (let [repo "asset-download-repo"
+               graph-id "graph-1"
+               asset-uuid (random-uuid)
+               conn (asset-conn asset-uuid)
+               metadata {:checksum "sha-256-value" :type "png"}
+               download-calls (atom [])
+               broadcast-calls (atom [])]
+           (-> (p/with-redefs [worker-state/get-datascript-conn (fn [_repo]
+                                                                  conn)
+                               platform/current (fn [] {})
+                               platform/asset-stat (fn [_platform _repo _file-name]
+                                                     (p/resolved nil))
+                               sync-assets/download-remote-asset! (fn [& args]
+                                                                    (swap! download-calls conj args)
+                                                                    (p/resolved nil))]
+                 (sync-assets/request-asset-download!
+                  repo
+                  asset-uuid
+                  {:current-client-f (fn [_repo]
+                                       {:graph-id graph-id})
+                   :enqueue-asset-task-f (fn [_client task]
+                                           (execute-enqueued-asset-task! task))
+                   :broadcast-rtc-state!-f (fn [& args]
+                                             (swap! broadcast-calls conj args))}))
+               (p/then
+                (fn [_]
+                  (is (= [[repo graph-id (str asset-uuid) "png"]] @download-calls))
+                  (is (= metadata
+                         (:logseq.property.asset/remote-metadata
+                          (d/entity @conn [:block/uuid asset-uuid]))))
+                  (is (= 1 (count @broadcast-calls)))))
+               (p/catch
+                (fn [error]
+                  (is false (str "unexpected error: " error))))
+               (p/finally done)))))
 
 (deftest upload-remote-asset-serializes-resolved-encrypted-payload-test
   (async done


### PR DESCRIPTION
## Summary

Fixes a bug found while reviewing sync-related PRs, specifically #12569.

After a client downloads missing asset bytes from remote storage, it must keep `:logseq.property.asset/remote-metadata` in the graph. That metadata is the shared signal that the asset bytes exist on the sync server and lets other clients download the same asset. Removing it from the synced DB state can leave other clients unable to discover/download the remote asset.

This change removes the local metadata retract from the restore path and adds focused worker coverage that a successful missing-asset download preserves the remote metadata while still clearing the local pending asset op and broadcasting state.

## Validation

- `git diff --check`
- `bb dev:test -v frontend.worker.sync.assets-test/request-asset-download-keeps-remote-metadata-test -v frontend.worker.db-sync-test/snapshot-restore-restorable-assets-test`

## Review context

Related sync PR reviewed: #12569. The new PR is branched from that PR state, so it includes the snapshot asset restore changes plus this correction.
