### PR TITLE
[codex] fix outdated db-worker-node cleanup trigger

### DIFF
--- a/src/main/logseq/cli/server.cljs
+++ b/src/main/logseq/cli/server.cljs
@@ -338,7 +338,7 @@
   (p/let [expected (expected-revision config)
           server (ensure-server-started-once! config repo)]
     (if-not (revision-mismatch? expected (:revision server))
-      server
+      (cleanup-additional-revision-mismatched-servers! config repo expected server)
       (p/let [stop-result (profile/time! (:profile-session config)
                                           "server.restart-version-mismatch"
                                           (fn []


### PR DESCRIPTION
## Summary

Fixes a bug found while reviewing sync/db-worker related PRs, specifically #12638.

#12638 adds cleanup for additional outdated `db-worker-node` servers, but `ensure-server-started!` only calls that cleanup after the active server had a revision mismatch and was restarted. If the active server is already on the expected revision, the function returns immediately, so stale additional servers for the same repo are left running.

This changes the no-mismatch path to also run `cleanup-additional-revision-mismatched-servers!` before returning the active server.

## Validation

- `git diff --check`
- `bb dev:test -v logseq.cli.server-test/ensure-server-stops-outdated-additional-server-for-same-repo -v logseq.cli.server-test/ensure-server-uses-daemon-stop-for-outdated-server-when-shutdown-hangs`
