### PR TITLE
[codex] fix worker config state sync

### DIFF
--- a/src/main/frontend/persist_db/browser.cljs
+++ b/src/main/frontend/persist_db/browser.cljs
@@ -27,7 +27,7 @@
 (defn- get-worker-state-context
   [state]
   (let [config (:config state)]
-    {:state (select-keys state [:git/current-repo config])
+    {:state (select-keys state [:git/current-repo :config])
      :context {:dev? config/dev?
                :node-test? util/node-test?
                :validate-db-options (:dev/validate-db-options config)


### PR DESCRIPTION
## Summary

Fixes a bug found while reviewing sync/db worker related PRs, specifically #11827.

`get-worker-state-context` intended to send both `:git/current-repo` and `:config` to the db worker, but the `select-keys` key vector uses the local `config` map value instead of the `:config` keyword. That means the worker receives `:git/current-repo` but not `:config` in the synced app state.

This changes the key vector to `[:git/current-repo :config]`.

## Validation

- `git diff --check`

I did not run the full old #11827 test suite because this is a one-line fixup on an old branch and the existing PR already has unrelated WIP/CI state.
