### PR TITLE
fix: initiate logseq.Net HTTP requests over postMessage so they work from sandboxed plugin iframes

### DIFF
--- a/libs/src/modules/LSPlugin.Net.ts
+++ b/libs/src/modules/LSPlugin.Net.ts
@@ -455,9 +455,8 @@ export class LSPluginNet {
     }
 
     const abortable = Boolean(options.abortable || options.signal)
-    // TODO: instead exper_request of callable apis
-    const reqId = this._ctx.Experiments.invokeExperMethod(
-      'request',
+    const reqId = await this._ctx._execCallableAPIAsync(
+      'exper_request',
       this._ctx.baseInfo.id,
       {
         url: options.url,


### PR DESCRIPTION
## Problem
Plugins run in a sandboxed iframe (`lsp://logseq.io`). `logseq.Net` started requests via `Experiments.invokeExperMethod('request', …)`, which does a synchronous `window.top.logseq` read. From the sandbox that cross-origin read throws ("Blocked a frame with origin … from accessing a cross-origin frame"), so requests never start. The abort path already avoids this by using the postMessage proxy — initiation should too.

## Change
In `libs/src/modules/LSPlugin.Net.ts`, `performProxyRequest` now initiates the request over the postMessage caller:

```diff
  -    // TODO: instead exper_request of callable apis
  -    const reqId = this._ctx.Experiments.invokeExperMethod(
  -      'request',
  -      this._ctx.baseInfo.id,
  -      {
  +    const reqId = await this._ctx._execCallableAPIAsync(
  +      'exper_request',
  +      this._ctx.baseInfo.id,
  +      {
           url: options.url,
           method,
           headers: options.headers,
           data: options.body ?? options.data,
           timeout: options.timeout,
           returnType: responseType,
           abortable,
           includeResponse: true,
         }
       )
```

The options object is unchanged. Both calls resolve to the same host function logseq.api.exper_request; the new path reaches it over postMessage (api:call) instead of a cross-origin window.top read. performProxyRequest is already async, so await is valid. The !reqId guard, the callback listener, and abortProxyRequest are untouched, and there's no race (the listener still registers before the host emits its callback).

### Host-side

api:call dispatches methods by name with no allowlist (LSPlugin.core.ts:411 → invokeHostExportedApi, common.ts:298). exper_request is exported host-side at src/main/logseq/api.cljs:169, right beside http_request_abort (already used by the abort path), so no host change is needed.