### PR TITLE
fix(ios): smooth tab search transitions

### DIFF
--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -426,12 +426,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UINavigationControllerDel
                 return
             }
 
-            // Fast-path: leave SwiftUI search for the Home tab. During this
-            // transition SwiftUI is already moving the shared nav controller
-            // back into the Home tab, so rebuilding it here causes UIKit
-            // transition conflicts.
+            // Fast-path: leave SwiftUI search for the Home tab while Search is
+            // still at its root. During this transition SwiftUI is already
+            // moving the shared nav controller back into the Home tab, so
+            // rebuilding it here causes UIKit transition conflicts. If Search
+            // is showing a result detail, use the normal stack switch below so
+            // Home gets a visible web view again.
             if previousStackId == "search",
-               stackId == "home" {
+               stackId == "home",
+               self.pathStack == [self.rootPath(for: "search")] {
 
                 self.setPaths(["/__stack__/search"], for: "search")
                 self.activeStackId = "home"

--- a/ios/App/App/LiquidTabsRootView.swift
+++ b/ios/App/App/LiquidTabsRootView.swift
@@ -226,6 +226,7 @@ private struct LiquidTabs26View: View {
 
     @State private var selectedTab: LiquidTabsTabSelection = .content(0)
     @State private var searchPath = NavigationPath()
+    @State private var pendingSelectionRequestId = 0
 
     private let maxMainTabs = 6
 
@@ -234,8 +235,7 @@ private struct LiquidTabs26View: View {
             get: { selectedTab },
             set: { newValue in
                 if newValue != selectedTab {
-                    prepareForSelectionChange(to: newValue)
-                    selectedTab = newValue
+                    selectTab(newValue)
                 }
             }
         )
@@ -287,18 +287,35 @@ private struct LiquidTabs26View: View {
         }
     }
 
+    private func selectTab(_ selection: LiquidTabsTabSelection) {
+        pendingSelectionRequestId += 1
+        let requestId = pendingSelectionRequestId
+        let deferred = webBackedTabId(for: selection) != nil
+
+        prepareForSelectionChange(to: selection)
+
+        let applySelection = {
+            guard pendingSelectionRequestId == requestId else { return }
+            selectedTab = selection
+        }
+
+        if deferred {
+            DispatchQueue.main.async(execute: applySelection)
+        } else {
+            applySelection()
+        }
+    }
+
     private func prepareForSelectionChange(to selection: LiquidTabsTabSelection) {
         waitForWebBackedTab(selection)
 
         switch selection {
         case .search:
             store.suppressSearchNotifications = true
-            resetSearchState()
             isSearchFocused = true
         case .content:
             if selectedTab == .search {
                 store.suppressSearchNotifications = true
-                searchPath = NavigationPath()
                 isSearchFocused = false
             }
         }
@@ -391,13 +408,13 @@ private struct LiquidTabs26View: View {
                     })
                     .frame(width: 0, height: 0)
                 }
-                .overlay {
-                    if store.pendingWebTabId != nil {
-                        Color.logseqBackground
-                            .ignoresSafeArea()
-                    }
-                }
 
+                if store.pendingWebTabId != nil {
+                    Color.logseqBackground
+                        .ignoresSafeArea()
+                        .allowsHitTesting(false)
+                        .zIndex(1)
+                }
             }
             .onAppear {
                 let initial = initialSelection()
@@ -439,7 +456,6 @@ private struct LiquidTabs26View: View {
 
                 case .content:
                     store.suppressSearchNotifications = true
-                    searchPath = NavigationPath()
                     isSearchFocused = false
                 }
             }
@@ -452,9 +468,10 @@ private struct LiquidTabs26View: View {
                 if newSelection != selectedTab {
                     let isExternalSelectionChange = store.tabId(for: selectedTab) != id
                     if isExternalSelectionChange {
-                        prepareForSelectionChange(to: newSelection)
+                        selectTab(newSelection)
+                    } else {
+                        selectedTab = newSelection
                     }
-                    selectedTab = newSelection
                 }
             }
             .animation(nil, value: selectedTab)
@@ -845,6 +862,7 @@ private struct LiquidTabs16View: View {
     let navController: UINavigationController
 
     @State private var searchPath = NavigationPath()
+    @State private var pendingSelectionRequestId = 0
 
     private var searchTextBinding: Binding<String> {
         Binding(
@@ -853,10 +871,53 @@ private struct LiquidTabs16View: View {
         )
     }
 
+    private func webBackedTabId(_ id: String) -> String? {
+        guard id != "graphs",
+              id != "search" else {
+            return nil
+        }
+
+        return id
+    }
+
     private func resetSearchState() {
         searchPath = NavigationPath()
         store.searchText = ""
         store.searchResults = []
+    }
+
+    private func prepareForSelectionChange(to id: String) {
+        store.beginWebTabTransitionIfNeeded(id)
+
+        if id == "search" {
+            store.suppressSearchNotifications = true
+        }
+
+        if store.selectedId == "search" {
+            store.suppressSearchNotifications = true
+        }
+    }
+
+    private func selectTab(_ id: String) {
+        guard id != store.selectedId else { return }
+
+        pendingSelectionRequestId += 1
+        let requestId = pendingSelectionRequestId
+        let deferred = webBackedTabId(id) != nil
+
+        prepareForSelectionChange(to: id)
+
+        let applySelection = {
+            guard pendingSelectionRequestId == requestId else { return }
+            store.selectedId = id
+            LiquidTabsPlugin.shared?.notifyTabSelected(id: id)
+        }
+
+        if deferred {
+            DispatchQueue.main.async(execute: applySelection)
+        } else {
+            applySelection()
+        }
     }
 
     var body: some View {
@@ -880,18 +941,7 @@ private struct LiquidTabs16View: View {
                             guard let id = newValue else { return }
 
                             if id != store.selectedId {
-                                store.beginWebTabTransitionIfNeeded(id)
-
-                                if id == "search" {
-                                    store.suppressSearchNotifications = true
-                                    resetSearchState()
-                                }
-                                if store.selectedId == "search" {
-                                    store.suppressSearchNotifications = true
-                                    searchPath = NavigationPath()
-                                }
-                                store.selectedId = id
-                                LiquidTabsPlugin.shared?.notifyTabSelected(id: id)
+                                selectTab(id)
                             }
                         }
                     )) {
@@ -938,7 +988,6 @@ private struct LiquidTabs16View: View {
                             }
                         } else {
                             store.suppressSearchNotifications = true
-                            searchPath = NavigationPath()
                         }
                     }
                     .background {
@@ -947,11 +996,12 @@ private struct LiquidTabs16View: View {
                         })
                         .frame(width: 0, height: 0)
                     }
-                    .overlay {
-                        if store.pendingWebTabId != nil {
-                            Color.logseqBackground
-                                .ignoresSafeArea()
-                        }
+
+                    if store.pendingWebTabId != nil {
+                        Color.logseqBackground
+                            .ignoresSafeArea()
+                            .allowsHitTesting(false)
+                            .zIndex(1)
                     }
                 }
                 .onAppear {

--- a/ios/App/App/LiquidTabsRootView.swift
+++ b/ios/App/App/LiquidTabsRootView.swift
@@ -226,7 +226,9 @@ private struct LiquidTabs26View: View {
 
     @State private var selectedTab: LiquidTabsTabSelection = .content(0)
     @State private var searchPath = NavigationPath()
-    @State private var pendingSelectionRequestId = 0
+    @State private var deferredWebSelection: LiquidTabsTabSelection?
+    @State private var notifiedSelectionId: String?
+    @State private var suppressedSelectionId: String?
 
     private let maxMainTabs = 6
 
@@ -287,22 +289,46 @@ private struct LiquidTabs26View: View {
         }
     }
 
-    private func selectTab(_ selection: LiquidTabsTabSelection) {
-        pendingSelectionRequestId += 1
-        let requestId = pendingSelectionRequestId
-        let deferred = webBackedTabId(for: selection) != nil
-
+    private func selectTab(_ selection: LiquidTabsTabSelection, notify: Bool = true) {
         prepareForSelectionChange(to: selection)
 
-        let applySelection = {
-            guard pendingSelectionRequestId == requestId else { return }
-            selectedTab = selection
+        if let id = webBackedTabId(for: selection) {
+            deferredWebSelection = selection
+            if notify {
+                notifiedSelectionId = id
+                LiquidTabsPlugin.shared?.notifyTabSelected(id: id)
+            } else {
+                suppressedSelectionId = id
+            }
+            return
         }
 
-        if deferred {
-            DispatchQueue.main.async(execute: applySelection)
+        deferredWebSelection = nil
+        if let id = store.tabId(for: selection), !notify {
+            suppressedSelectionId = id
+        }
+        selectedTab = selection
+    }
+
+    private func applyDeferredWebSelectionIfReady() {
+        guard store.pendingWebTabId == nil,
+              let selection = deferredWebSelection else {
+            return
+        }
+
+        deferredWebSelection = nil
+        selectedTab = selection
+    }
+
+    private func notifySelectedTabIfNeeded(_ id: String) {
+        store.selectedId = id
+
+        if notifiedSelectionId == id {
+            notifiedSelectionId = nil
+        } else if suppressedSelectionId == id {
+            suppressedSelectionId = nil
         } else {
-            applySelection()
+            LiquidTabsPlugin.shared?.notifyTabSelected(id: id)
         }
     }
 
@@ -412,7 +438,6 @@ private struct LiquidTabs26View: View {
                 if store.pendingWebTabId != nil {
                     Color.logseqBackground
                         .ignoresSafeArea()
-                        .allowsHitTesting(false)
                         .zIndex(1)
                 }
             }
@@ -445,8 +470,7 @@ private struct LiquidTabs26View: View {
             }
             .onChange(of: selectedTab) { newValue in
                 if let id = store.tabId(for: newValue) {
-                    store.selectedId = id
-                    LiquidTabsPlugin.shared?.notifyTabSelected(id: id)
+                    notifySelectedTabIfNeeded(id)
                 }
 
                 switch newValue {
@@ -468,11 +492,14 @@ private struct LiquidTabs26View: View {
                 if newSelection != selectedTab {
                     let isExternalSelectionChange = store.tabId(for: selectedTab) != id
                     if isExternalSelectionChange {
-                        selectTab(newSelection)
+                        selectTab(newSelection, notify: false)
                     } else {
                         selectedTab = newSelection
                     }
                 }
+            }
+            .onChange(of: store.pendingWebTabId) { _ in
+                applyDeferredWebSelectionIfReady()
             }
             .animation(nil, value: selectedTab)
         }
@@ -862,7 +889,9 @@ private struct LiquidTabs16View: View {
     let navController: UINavigationController
 
     @State private var searchPath = NavigationPath()
-    @State private var pendingSelectionRequestId = 0
+    @State private var deferredWebTabId: String?
+    @State private var notifiedSelectionId: String?
+    @State private var suppressedSelectionId: String?
 
     private var searchTextBinding: Binding<String> {
         Binding(
@@ -898,25 +927,47 @@ private struct LiquidTabs16View: View {
         }
     }
 
-    private func selectTab(_ id: String) {
-        guard id != store.selectedId else { return }
+    private func selectTab(_ id: String, notify: Bool = true) {
+        guard id != store.selectedId || deferredWebTabId != nil else { return }
 
-        pendingSelectionRequestId += 1
-        let requestId = pendingSelectionRequestId
         let deferred = webBackedTabId(id) != nil
 
         prepareForSelectionChange(to: id)
 
-        let applySelection = {
-            guard pendingSelectionRequestId == requestId else { return }
+        if deferred {
+            deferredWebTabId = id
+            if notify {
+                notifiedSelectionId = id
+                LiquidTabsPlugin.shared?.notifyTabSelected(id: id)
+            } else {
+                suppressedSelectionId = id
+            }
+        } else {
+            deferredWebTabId = nil
+            if !notify {
+                suppressedSelectionId = id
+            }
             store.selectedId = id
-            LiquidTabsPlugin.shared?.notifyTabSelected(id: id)
+        }
+    }
+
+    private func applyDeferredWebSelectionIfReady() {
+        guard store.pendingWebTabId == nil,
+              let id = deferredWebTabId else {
+            return
         }
 
-        if deferred {
-            DispatchQueue.main.async(execute: applySelection)
+        deferredWebTabId = nil
+        store.selectedId = id
+    }
+
+    private func notifySelectedTabIfNeeded(_ id: String) {
+        if notifiedSelectionId == id {
+            notifiedSelectionId = nil
+        } else if suppressedSelectionId == id {
+            suppressedSelectionId = nil
         } else {
-            applySelection()
+            LiquidTabsPlugin.shared?.notifyTabSelected(id: id)
         }
     }
 
@@ -989,6 +1040,13 @@ private struct LiquidTabs16View: View {
                         } else {
                             store.suppressSearchNotifications = true
                         }
+
+                        if let id = newId {
+                            notifySelectedTabIfNeeded(id)
+                        }
+                    }
+                    .onChange(of: store.pendingWebTabId) { _ in
+                        applyDeferredWebSelectionIfReady()
                     }
                     .background {
                         TabReselectObserver(selectedId: {
@@ -1000,7 +1058,6 @@ private struct LiquidTabs16View: View {
                     if store.pendingWebTabId != nil {
                         Color.logseqBackground
                             .ignoresSafeArea()
-                            .allowsHitTesting(false)
                             .zIndex(1)
                     }
                 }

--- a/src/main/mobile/components/app.cljs
+++ b/src/main/mobile/components/app.cljs
@@ -303,6 +303,35 @@
      (when-not home?
        (other-page view tab route-match))]))
 
+(defn- visible-element?
+  [selector]
+  (when-let [^js element (js/document.querySelector selector)]
+    (let [^js style (.getComputedStyle js/window element)]
+      (and (not= "none" (.-display style))
+           (not= "hidden" (.-visibility style))
+           (pos? (.-offsetWidth element))
+           (pos? (.-offsetHeight element))))))
+
+(defn- tab-content-ready?
+  [tab]
+  (case tab
+    "home" (visible-element? "#app-main-home:not(.invisible)")
+    "flashcards" (visible-element? ".ls-mobile-flashcards")
+    true))
+
+(defn- mark-tab-content-ready-after-paint!
+  [tab]
+  (let [max-attempts 60]
+    (letfn [(step! [attempt]
+              (.requestAnimationFrame
+               js/window
+               (fn []
+                 (if (or (tab-content-ready? tab)
+                         (>= attempt max-attempts))
+                   (bottom-tabs/mark-tab-content-ready! tab)
+                   (step! (inc attempt))))))]
+      (step! 0))))
+
 (hsx/defc app
   [current-repo route-match]
   (let [[tab] (mobile-state/use-tab)
@@ -313,13 +342,7 @@
     (hooks/use-effect!
      (fn []
        (when (mobile-util/native-ios?)
-         (.requestAnimationFrame
-          js/window
-          (fn []
-            (.requestAnimationFrame
-             js/window
-             (fn []
-               (bottom-tabs/mark-tab-content-ready! tab))))))
+         (mark-tab-content-ready-after-paint! tab))
        nil)
      [tab route-match])
     (hooks/use-effect!

--- a/src/main/mobile/navigation.cljs
+++ b/src/main/mobile/navigation.cljs
@@ -258,17 +258,19 @@
         (let [route-match (or route-match (:route-match (stack-defaults stack)))
               path        (or path (current-path))]
           (route-handler/set-route-match! route-match)
-          (when-not (sync-browser-route! stack route route-match path)
-            (notify-route-change!
-             {:route {:to          (or (get-in route [:data :name])
-                                       (get-in route-match [:data :name]))
-                      :path-params (or (:path-params route)
-                                       (get-in route-match [:parameters :path]))
-                      :query-params (or (:query-params route)
-                                        (get-in route-match [:parameters :query]))}
-              :path  path
-              :stack stack
-              :push  false})))))))
+          (let [synced-browser-route? (sync-browser-route! stack route route-match path)]
+            (when (or (not synced-browser-route?)
+                      (= stack "search"))
+              (notify-route-change!
+               {:route {:to          (or (get-in route [:data :name])
+                                         (get-in route-match [:data :name]))
+                        :path-params (or (:path-params route)
+                                         (get-in route-match [:parameters :path]))
+                        :query-params (or (:query-params route)
+                                          (get-in route-match [:parameters :query]))}
+                :path  path
+                :stack stack
+                :push  false}))))))))
 
 (defn pop-modal!
   []

--- a/src/main/mobile/state.cljs
+++ b/src/main/mobile/state.cljs
@@ -9,15 +9,13 @@
 (defonce *tab (atom "home"))
 
 (defn set-tab! [tab]
-  (let [prev @*tab]
-    ;; When leaving the search tab, clear its stack so reopening starts fresh.
-    ;; Native search UI owns query/result clearing on each platform; doing it here
-    ;; makes the Search UI redraw during the Home tab transition on iOS.
-    (when (and (= prev "search")
-            (not= tab "search"))
-      (mobile-nav/reset-stack-history! "search"))
+  (let [prev @*tab
+        search->home? (and (= prev "search")
+                           (= tab "home"))]
     (reset! *tab tab)
-    (mobile-nav/switch-stack! tab)))
+    (if search->home?
+      (mobile-nav/pop-to-root! tab)
+      (mobile-nav/switch-stack! tab))))
 (defn use-tab [] (hooks/use-atom *tab))
 
 (defonce *popup-data (atom nil))

--- a/src/test/mobile/navigation_test.cljs
+++ b/src/test/mobile/navigation_test.cljs
@@ -155,6 +155,73 @@
         (is (= "Hello" @mobile-state/*search-input))
         (is (= [[:home {} {}]] @replace-calls))))))
 
+(deftest leaving-search-result-detail-preserves-search-stack-and-resets-home
+  (testing "Home selected from a native search result detail should not discard Search history"
+    (let [payloads (atom [])]
+      (reset! mobile-state/*tab "search")
+      (reset! @#'mobile-nav/active-stack "search")
+      (reset! @#'mobile-nav/initialised-stacks {"search" true
+                                                "home" true})
+      (reset! @#'mobile-nav/stack-history
+              {"search" {:history [(stack-entry :page "/page/jun-2nd-2026")]}
+               "home" {:history [(stack-entry :home "/")]}})
+      (with-redefs [mobile-nav/orig-replace-state (constantly nil)
+                    route-handler/set-route-match! (constantly nil)
+                    mobile-util/native-platform? (constantly true)
+                    mobile-util/ui-local #js {:routeDidChange
+                                               (fn [payload]
+                                                 (swap! payloads conj
+                                                        (js->clj payload :keywordize-keys true))
+                                                 (js/Promise.resolve nil))}]
+        (mobile-state/set-tab! "home")
+        (is (= "home" @mobile-state/*tab))
+        (is (= ["reset"] (mapv :navigationType @payloads)))
+        (is (= ["/"] (stack-paths "home")))
+        (is (= ["/page/jun-2nd-2026"] (stack-paths "search")))))))
+
+(deftest leaving-search-for-another-tab-preserves-search-stack
+  (testing "switching away from Search should keep existing results/detail state"
+    (let [stacks (atom [])]
+      (reset! mobile-state/*tab "search")
+      (reset! @#'mobile-nav/active-stack "search")
+      (reset! @#'mobile-nav/stack-history
+              {"search" {:history [(stack-entry :page "/page/jun-2nd-2026")]}
+               "flashcards" {:history [(stack-entry :flashcards "/__stack__/flashcards")]}})
+      (with-redefs [mobile-nav/switch-stack! (fn [stack] (swap! stacks conj stack))]
+        (mobile-state/set-tab! "flashcards")
+        (is (= "flashcards" @mobile-state/*tab))
+        (is (= ["flashcards"] @stacks))
+        (is (= ["/page/jun-2nd-2026"] (stack-paths "search")))))))
+
+(deftest restoring-search-result-detail-notifies-native-stack
+  (testing "returning to a preserved Search detail should reattach native web content"
+    (let [payloads (atom [])
+          replace-calls (atom [])]
+      (reset! @#'mobile-nav/active-stack "home")
+      (reset! @#'mobile-nav/initialised-stacks {"home" true
+                                                "search" true})
+      (reset! @#'mobile-nav/stack-history
+              {"home" {:history [(stack-entry :home "/")]}
+               "search" {:history [(stack-entry :page "/page/jun-2nd-2026")]}})
+      (with-redefs [mobile-nav/orig-replace-state (fn [& args] (swap! replace-calls conj args))
+                    route-handler/set-route-match! (constantly nil)
+                    mobile-util/native-platform? (constantly true)
+                    mobile-util/ui-local #js {:routeDidChange
+                                               (fn [payload]
+                                                 (swap! payloads conj
+                                                        (js->clj payload :keywordize-keys true))
+                                                 (js/Promise.resolve nil))}]
+        (mobile-nav/switch-stack! "search")
+        (is (= [[:page {} {}]] @replace-calls))
+        (is (= [{:navigationType "replace"
+                 :push false
+                 :stack "search"
+                 :route {:to "page"
+                         :path-params {}
+                         :query-params {}}
+                 :path "/page/jun-2nd-2026"}]
+               @payloads))))))
+
 (deftest selecting-flashcards-does-not-open-cards-dialog
   (testing "flashcards is a normal tab surface, not a modal shortcut"
     (let [events (atom [])


### PR DESCRIPTION
## Summary
- cover WebView-backed iOS tab switches while the selected tab content is pending, avoiding the Home journal flash before Cards renders
- preserve Search result state when switching away, while rebuilding Home correctly when selected from a Search result detail
- notify native when returning to a preserved Search detail so the shared WebView reattaches

## Verification
- bb dev:test -v mobile.navigation-test
- xcodebuild -workspace ios/App/App.xcworkspace -scheme Logseq -configuration Debug -destination 'id=6294AE55-3CA8-4995-A105-600A0FCA27CE' -derivedDataPath tmp/ios-derived build
- iOS simulator reproduced blank Home screen from Search result detail before the fix; verified Home renders after tapping Home from Search result detail on the rebuilt app

## Notes
- Final manual re-click verification for the Cards flash was blocked by the local Computer Use click bridge returning noWindowsAvailable and macOS denying osascript assistive access; the Swift build and earlier simulator checks passed, and the transition cover was moved to the outer root ZStack to cover header/content during the pending tab switch.