### PR TITLE
fix: stabilize journals virtualization

### DIFF
--- a/clj-e2e/test/logseq/e2e/commands_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/commands_basic_test.clj
@@ -18,26 +18,31 @@
   fixtures/new-logseq-page
   fixtures/validate-graph)
 
+(def ^:private date-picker-day-selector
+  ".ui__calendar [role='gridcell'] button, .ui__calendar button[role='gridcell']")
+
 (defn- focused-date-picker-day
   []
   (json/read-value
    (w/eval-js
-    "(() => {
+    (format
+     "(() => {
        const active = document.activeElement;
-       const dayButton = active?.closest?.('.ui__calendar button[role=\"gridcell\"]');
+       const dayButton = active?.closest?.(%s);
        return JSON.stringify({
          focused: !!dayButton,
          text: dayButton?.textContent ?? null,
          label: dayButton?.getAttribute('aria-label') ?? dayButton?.textContent ?? null
        });
-     })()")
+     })()"
+     (json/write-value-as-string date-picker-day-selector)))
    json/keyword-keys-object-mapper))
 
 (defn- assert-date-picker-keyboard-navigation
   [command]
   (b/new-block (str command " keyboard test"))
   (util/input-command command)
-  (w/wait-for ".ui__calendar button[role='gridcell']")
+  (w/wait-for date-picker-day-selector)
   (let [initial (focused-date-picker-day)]
     (is (:focused initial)
         (str command " should focus a calendar day when opened."))

--- a/clj-e2e/test/logseq/e2e/commands_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/commands_basic_test.clj
@@ -24,11 +24,11 @@
    (w/eval-js
     "(() => {
        const active = document.activeElement;
-       const dayButton = active?.closest?.('.ui__calendar [role=\"gridcell\"] button');
+       const dayButton = active?.closest?.('.ui__calendar button[role=\"gridcell\"]');
        return JSON.stringify({
          focused: !!dayButton,
          text: dayButton?.textContent ?? null,
-         label: dayButton?.getAttribute('aria-label') ?? null
+         label: dayButton?.getAttribute('aria-label') ?? dayButton?.textContent ?? null
        });
      })()")
    json/keyword-keys-object-mapper))
@@ -37,7 +37,7 @@
   [command]
   (b/new-block (str command " keyboard test"))
   (util/input-command command)
-  (w/wait-for ".ui__calendar [role='gridcell'] button")
+  (w/wait-for ".ui__calendar button[role='gridcell']")
   (let [initial (focused-date-picker-day)]
     (is (:focused initial)
         (str command " should focus a calendar day when opened."))
@@ -224,10 +224,6 @@
         (util/input-command command)
         (k/enter)
         (assert/assert-editor-mode)
-        ;; FIXME: cannot exit edit by k/esc???
-        ;; (util/exit-edit)
-        (k/esc)
-        (b/new-block "temp fix")
         (util/exit-edit)
         (is (= command (util/get-text ".property-k")))
         (is (= "Today" (util/get-text ".ls-datetime a.page-ref")))))))
@@ -301,7 +297,7 @@
       (w/click btn)
       (util/input "page reference")
       (w/click "a.menu-link:has-text('page reference')")
-      (w/click "a.menu-link:has-text('foo')")
+      (w/click (first (w/query "a.menu-link:has-text('foo')")))
       (assert/assert-is-visible "div:text('Live query (2)')"))))
 
 (deftest advanced-query-test

--- a/clj-e2e/test/logseq/e2e/editor_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/editor_basic_test.clj
@@ -228,8 +228,10 @@
         throw new Error('Expected virtualized list scroller');
       }
 
-      scrollContainer.scrollTop = 0;
-      await delay(500);
+      if (!blockByTitle(blockTitles[0])) {
+        scrollContainer.scrollTop = 0;
+        await delay(500);
+      }
 
       const appWrapper = document.querySelector('#app-container-wrapper');
       appWrapper?.dispatchEvent(new PointerEvent('pointerdown', {
@@ -695,14 +697,22 @@
 
 (deftest copy-blocks-selected-while-scrolling-journals-list
   (testing "copy includes blocks selected across virtualized journals while scrolling"
-    (let [journals (mapv (fn [idx]
+    (let [later-journal-blocks (mapv #(format "journals selection prelude block %03d %s"
+                                               %
+                                               (string/join " " (repeat 30 "wrapped-content")))
+                                     (range 1 101))
+          journals (mapv (fn [idx]
                            {:date (format "2026-02-%02dT12:00:00" idx)
-                            :blocks (mapv #(format "journal-%02d-scroll-copy-block-%02d" idx %)
+                            :blocks (mapv #(format "journal %02d scroll copy block %02d" idx %)
                                           (range 1 31))})
                          (range 1 5))
           blocks (mapcat :blocks (reverse journals))]
+      (seed-journals!
+       [{:date "2026-03-21T12:00:00"
+         :blocks later-journal-blocks}])
       (seed-journals! journals)
       (w/wait-for "#journals [data-virtuoso-scroller]")
+      (scroll-journals-to-text! (first blocks))
       (is (pos? (count (select-block-titles-while-scrolling! blocks))))
       (b/copy)
       (let [clipboard (w/clipboard-text)]

--- a/clj-e2e/test/logseq/e2e/editor_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/editor_basic_test.clj
@@ -228,6 +228,9 @@
         throw new Error('Expected virtualized list scroller');
       }
 
+      scrollContainer.scrollTop = 0;
+      await delay(500);
+
       const appWrapper = document.querySelector('#app-container-wrapper');
       appWrapper?.dispatchEvent(new PointerEvent('pointerdown', {
         bubbles: true,

--- a/clj-e2e/test/logseq/e2e/editor_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/editor_basic_test.clj
@@ -228,8 +228,28 @@
         throw new Error('Expected virtualized list scroller');
       }
 
+      const appWrapper = document.querySelector('#app-container-wrapper');
+      appWrapper?.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        buttons: 1,
+        clientX: 1,
+        clientY: 1
+      }));
+      appWrapper?.dispatchEvent(new PointerEvent('pointerup', {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        buttons: 0,
+        clientX: 1,
+        clientY: 1
+      }));
+      await nextFrame();
+
       const firstBlock = await scrollToBlock(blockTitles[0]);
       const firstContent = firstBlock.querySelector('.block-content');
+      await delay(500);
       const firstRect = firstContent.getBoundingClientRect();
       const clientX = Math.floor(firstRect.left + 24);
       const clientY = Math.floor(firstRect.top + Math.min(20, firstRect.height / 2));
@@ -249,14 +269,22 @@
       for (const title of blockTitles.slice(1)) {
         const block = await scrollToBlock(title);
         const target = block.querySelector('.block-main-container');
+        const targetRect = target.getBoundingClientRect();
+        const targetX = Math.floor(targetRect.left + 24);
+        const targetY = Math.floor(targetRect.top + Math.min(20, targetRect.height / 2));
+        const targetPointer = {
+          ...pointerInit,
+          clientX: targetX,
+          clientY: targetY
+        };
         if (previousTarget.isConnected) {
           previousTarget.dispatchEvent(new MouseEvent('mouseout', {
-            ...pointerInit,
+            ...targetPointer,
             relatedTarget: target
           }));
         }
         target.dispatchEvent(new MouseEvent('mouseover', {
-          ...pointerInit,
+          ...targetPointer,
           relatedTarget: previousTarget
         }));
         previousTarget = target;

--- a/clj-e2e/test/logseq/e2e/editor_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/editor_basic_test.clj
@@ -386,8 +386,8 @@
   []
   (w/eval-js
    "(async () => {
-      const target = await window.logseq.api.create_journal_page('2026-03-01T00:00:00.000Z');
-      const source = await window.logseq.api.create_journal_page('2026-02-28T00:00:00.000Z');
+      const target = await window.logseq.api.create_journal_page('2026-03-01T12:00:00');
+      const source = await window.logseq.api.create_journal_page('2026-02-28T12:00:00');
 
       await window.logseq.api.insert_batch_block(
         target.uuid,
@@ -665,7 +665,7 @@
 (deftest copy-blocks-selected-while-scrolling-journals-list
   (testing "copy includes blocks selected across virtualized journals while scrolling"
     (let [journals (mapv (fn [idx]
-                           {:date (format "2026-02-%02dT00:00:00.000Z" idx)
+                           {:date (format "2026-02-%02dT12:00:00" idx)
                             :blocks (mapv #(format "journal-%02d-scroll-copy-block-%02d" idx %)
                                           (range 1 31))})
                          (range 1 5))
@@ -681,9 +681,9 @@
 (deftest journals-list-uses-measured-spacing-without-item-margins
   (testing "journals list spacing does not use item margins that destabilize Virtuoso measurement"
     (seed-journals!
-     [{:date "2026-03-05T00:00:00.000Z"
+     [{:date "2026-03-05T12:00:00"
        :blocks ["journals measured spacing first"]}
-      {:date "2026-03-04T00:00:00.000Z"
+      {:date "2026-03-04T12:00:00"
        :blocks ["journals measured spacing second"]}])
     (w/wait-for "#journals .journal-item")
     (let [{:keys [journal-item-margin-bottom journal-item-padding-bottom] :as metrics} (journals-layout-metrics)]
@@ -694,7 +694,7 @@
   (testing "long journals keep a single virtualized measurement owner"
     (let [blocks (mapv #(format "journals long stable block %03d" %) (range 1 81))]
       (seed-journals!
-       [{:date "2026-03-06T00:00:00.000Z"
+       [{:date "2026-03-06T12:00:00"
          :blocks blocks}])
       (enable-virtualized-rendering!)
       (w/wait-for "#journals [data-virtuoso-scroller]")
@@ -710,11 +710,11 @@
                                       (string/join " " (repeat 24 "wrapped-content")))
                             (range 1 81))
           older-journals (mapv (fn [idx]
-                                  {:date (format "2026-03-%02dT00:00:00.000Z" idx)
+                                  {:date (format "2026-03-%02dT12:00:00" idx)
                                    :blocks [(format "journals remount spacer block %02d" idx)]})
                                 (range 1 18))]
       (seed-journals!
-       (into [{:date "2026-03-20T00:00:00.000Z"
+       (into [{:date "2026-03-20T12:00:00"
                :blocks long-blocks}]
              older-journals))
       (enable-virtualized-rendering!)
@@ -732,7 +732,7 @@
 (deftest journals-list-keeps-single-scroller-with-iframe-embeds
   (testing "iframe embeds render inside journals without adding nested virtualized measurement owners"
     (seed-journals!
-     [{:date "2026-03-07T00:00:00.000Z"
+     [{:date "2026-03-07T12:00:00"
        :blocks ["{{video https://www.youtube.com/watch?v=7xTGNNLPyMI}}"]}])
     (enable-virtualized-rendering!)
     (w/wait-for "#journals iframe")

--- a/clj-e2e/test/logseq/e2e/editor_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/editor_basic_test.clj
@@ -464,6 +464,82 @@
       });
     })();"))
 
+(defn- journals-long-remount-metrics
+  [long-block-title]
+  (js-json
+   (format
+    "(async () => {
+      const longBlockTitle = %s;
+      const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+      const nextFrame = () => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      const scrollContainer = document.querySelector('#main-content-container');
+
+      const findLongJournal = () => Array.from(document.querySelectorAll('#journals .journal-item'))
+        .find((item) => item.textContent.includes(longBlockTitle));
+
+      const waitForLongJournal = async () => {
+        for (let i = 0; i < 80; i++) {
+          const journal = findLongJournal();
+          if (journal) {
+            return journal;
+          }
+          await delay(100);
+        }
+        throw new Error('Expected long journal item');
+      };
+
+      const stableLongJournalHeight = async () => {
+        let previous = null;
+        let stableCount = 0;
+        for (let i = 0; i < 80; i++) {
+          const journal = await waitForLongJournal();
+          const height = Math.round(journal.getBoundingClientRect().height);
+          if (previous !== null && Math.abs(height - previous) <= 1) {
+            stableCount += 1;
+          } else {
+            stableCount = 0;
+          }
+          previous = height;
+          if (stableCount >= 3) {
+            return height;
+          }
+          await delay(100);
+        }
+        return previous;
+      };
+
+      const snapshot = async (label) => {
+        const journal = await waitForLongJournal();
+        return {
+          label,
+          'scroll-top': Math.round(scrollContainer.scrollTop),
+          'scroll-height': Math.round(scrollContainer.scrollHeight),
+          'long-journal-height': Math.round(journal.getBoundingClientRect().height)
+        };
+      };
+
+      const initialLongJournalHeight = await stableLongJournalHeight();
+      const initial = await snapshot('initial');
+
+      scrollContainer.scrollTop = scrollContainer.scrollHeight;
+      await delay(500);
+      scrollContainer.scrollTop = 0;
+      await nextFrame();
+      const afterReturn = await snapshot('after-return');
+      await delay(800);
+      const afterSettle = await snapshot('after-settle');
+      await delay(5500);
+      const afterFallback = await snapshot('after-fallback');
+
+      return JSON.stringify({
+        'initial': { ...initial, 'long-journal-height': initialLongJournalHeight },
+        'after-return': afterReturn,
+        'after-settle': afterSettle,
+        'after-fallback': afterFallback
+      });
+    })();"
+    (json/write-value-as-string long-block-title))))
+
 (defn- multiline-heading-bullet-alignment
   [title]
   (-> (w/eval-js
@@ -589,6 +665,33 @@
       (w/wait-for (format ".ls-page-blocks .ls-block:has-text('%s')" (first blocks)))
       (let [{:keys [journals-scroller-count] :as metrics} (journals-layout-metrics)]
         (is (= 1 journals-scroller-count) metrics)))))
+
+(deftest journals-list-keeps-long-journal-height-after-remount
+  (testing "long journals do not restart progressive rendering from a low measured height after remount"
+    (let [long-block-title "journals remount stable block 001"
+          long-blocks (mapv #(format "journals remount stable block %03d %s"
+                                      %
+                                      (string/join " " (repeat 24 "wrapped-content")))
+                            (range 1 81))
+          older-journals (mapv (fn [idx]
+                                  {:date (format "2026-03-%02dT00:00:00.000Z" idx)
+                                   :blocks [(format "journals remount spacer block %02d" idx)]})
+                                (range 1 18))]
+      (seed-journals!
+       (into [{:date "2026-03-20T00:00:00.000Z"
+               :blocks long-blocks}]
+             older-journals))
+      (enable-virtualized-rendering!)
+      (w/wait-for (format ".ls-page-blocks .ls-block:has-text('%s')" long-block-title))
+      (let [{:keys [initial after-return after-settle after-fallback] :as metrics} (journals-long-remount-metrics long-block-title)
+            initial-height (:long-journal-height initial)
+            initial-scroll-height (:scroll-height initial)]
+        (is (>= (:long-journal-height after-return) (dec initial-height)) metrics)
+        (is (>= (:scroll-height after-return) (dec initial-scroll-height)) metrics)
+        (is (>= (:long-journal-height after-settle) (dec initial-height)) metrics)
+        (is (>= (:scroll-height after-settle) (dec initial-scroll-height)) metrics)
+        (is (>= (:long-journal-height after-fallback) (dec initial-height)) metrics)
+        (is (>= (:scroll-height after-fallback) (dec initial-scroll-height)) metrics)))))
 
 (deftest journals-list-keeps-single-scroller-with-iframe-embeds
   (testing "iframe embeds render inside journals without adding nested virtualized measurement owners"

--- a/clj-e2e/test/logseq/e2e/editor_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/editor_basic_test.clj
@@ -193,6 +193,10 @@
   (w/refresh)
   (assert/assert-graph-loaded?))
 
+(defn- js-json
+  [script]
+  (json/read-value (w/eval-js script) json/keyword-keys-object-mapper))
+
 (defn- select-block-titles-while-scrolling!
   [blocks]
   (w/eval-js
@@ -378,6 +382,88 @@
     })();"
     (json/write-value-as-string journals))))
 
+(defn- seed-journals-with-linked-ref!
+  []
+  (w/eval-js
+   "(async () => {
+      const target = await window.logseq.api.create_journal_page('2026-03-01T00:00:00.000Z');
+      const source = await window.logseq.api.create_journal_page('2026-02-28T00:00:00.000Z');
+
+      await window.logseq.api.insert_batch_block(
+        target.uuid,
+        [{ content: 'journals linked refs visible target' }],
+        { sibling: false }
+      );
+      await window.logseq.api.insert_batch_block(
+        source.uuid,
+        [{ content: `journals linked refs visible source [[${target.name}]]` }],
+        { sibling: false }
+      );
+
+      await window.logseq.api.exit_editing_mode(false);
+      window.logseq.api.push_state('all-journals', null, null);
+    })();"))
+
+(defn- journals-layout-metrics
+  []
+  (js-json
+   "(async () => {
+      const nextFrame = () => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+      for (let i = 0; i < 40; i++) {
+        if (document.querySelector('#journals .journal-item')) {
+          break;
+        }
+        await nextFrame();
+      }
+
+      const journalItem = document.querySelector('#journals .journal-item');
+      if (!journalItem) {
+        throw new Error('Expected a mounted journal item');
+      }
+
+      const style = getComputedStyle(journalItem);
+      return JSON.stringify({
+        'journal-item-margin-bottom': Number.parseFloat(style.marginBottom),
+        'journal-item-padding-bottom': Number.parseFloat(style.paddingBottom),
+        'journals-scroller-count': document.querySelectorAll('#journals [data-virtuoso-scroller]').length
+      });
+    })();"))
+
+(defn- journals-linked-refs-metrics
+  []
+  (js-json
+   "(async () => {
+      const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+      let references = null;
+      let foldableContent = null;
+      let viewBody = null;
+
+      for (let i = 0; i < 80; i++) {
+        references = document.querySelector('#journals .references');
+        foldableContent = references?.querySelector('.ls-foldable-content');
+        viewBody = references?.querySelector('.ls-view-body');
+        const expanded = foldableContent?.getAttribute('aria-hidden') !== 'true';
+        const bodyHeight = viewBody?.getBoundingClientRect().height || 0;
+
+        if (references && expanded && bodyHeight > 0) {
+          break;
+        }
+        await delay(100);
+      }
+
+      if (!references) {
+        throw new Error('Expected linked references in journals');
+      }
+
+      return JSON.stringify({
+        'collapsed': foldableContent?.getAttribute('aria-hidden') === 'true',
+        'body-mounted': Boolean(viewBody),
+        'body-height': viewBody?.getBoundingClientRect().height || 0
+      });
+    })();"))
+
 (defn- multiline-heading-bullet-alignment
   [title]
   (-> (w/eval-js
@@ -479,6 +565,49 @@
       (let [clipboard (w/clipboard-text)]
         (doseq [block blocks]
           (is (string/includes? clipboard block)))))))
+
+(deftest journals-list-uses-measured-spacing-without-item-margins
+  (testing "journals list spacing does not use item margins that destabilize Virtuoso measurement"
+    (seed-journals!
+     [{:date "2026-03-05T00:00:00.000Z"
+       :blocks ["journals measured spacing first"]}
+      {:date "2026-03-04T00:00:00.000Z"
+       :blocks ["journals measured spacing second"]}])
+    (w/wait-for "#journals .journal-item")
+    (let [{:keys [journal-item-margin-bottom journal-item-padding-bottom] :as metrics} (journals-layout-metrics)]
+      (is (zero? journal-item-margin-bottom) metrics)
+      (is (pos? journal-item-padding-bottom) metrics))))
+
+(deftest journals-list-does-not-nest-virtualized-scrollers-in-long-journal
+  (testing "long journals keep a single virtualized measurement owner"
+    (let [blocks (mapv #(format "journals long stable block %03d" %) (range 1 81))]
+      (seed-journals!
+       [{:date "2026-03-06T00:00:00.000Z"
+         :blocks blocks}])
+      (enable-virtualized-rendering!)
+      (w/wait-for "#journals [data-virtuoso-scroller]")
+      (w/wait-for (format ".ls-page-blocks .ls-block:has-text('%s')" (first blocks)))
+      (let [{:keys [journals-scroller-count] :as metrics} (journals-layout-metrics)]
+        (is (= 1 journals-scroller-count) metrics)))))
+
+(deftest journals-list-keeps-single-scroller-with-iframe-embeds
+  (testing "iframe embeds render inside journals without adding nested virtualized measurement owners"
+    (seed-journals!
+     [{:date "2026-03-07T00:00:00.000Z"
+       :blocks ["{{video https://www.youtube.com/watch?v=7xTGNNLPyMI}}"]}])
+    (enable-virtualized-rendering!)
+    (w/wait-for "#journals iframe")
+    (let [{:keys [journals-scroller-count] :as metrics} (journals-layout-metrics)]
+      (is (= 1 journals-scroller-count) metrics))))
+
+(deftest journals-linked-refs-remain-visible
+  (testing "journals linked refs stay visible while journals layout owns the outer measurement"
+    (seed-journals-with-linked-ref!)
+    (w/wait-for "#journals .references")
+    (let [{:keys [collapsed body-mounted body-height] :as metrics} (journals-linked-refs-metrics)]
+      (is (false? collapsed) metrics)
+      (is (true? body-mounted) metrics)
+      (is (pos? body-height) metrics))))
 
 (deftest drag-and-drop-asset-does-not-create-blank-asset
   (testing "dragging and dropping a file should keep non-empty asset title"

--- a/clj-e2e/test/logseq/e2e/editor_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/editor_basic_test.clj
@@ -404,6 +404,42 @@
       window.logseq.api.push_state('all-journals', null, null);
     })();"))
 
+(defn- scroll-journals-to-text!
+  [text]
+  (w/eval-js
+   (format
+    "(async () => {
+      const text = %s;
+      const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+      const nextFrame = () => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      const scrollContainer = document.querySelector('#main-content-container');
+
+      if (!scrollContainer) {
+        throw new Error('Expected main content scroller');
+      }
+
+      const findText = () => Array.from(document.querySelectorAll('#journals .journal-item'))
+        .find((item) => item.textContent.includes(text));
+
+      scrollContainer.scrollTop = 0;
+      await nextFrame();
+
+      for (let i = 0; i < 120; i++) {
+        const item = findText();
+        if (item) {
+          item.scrollIntoView({ block: 'center' });
+          await nextFrame();
+          return true;
+        }
+
+        scrollContainer.scrollTop += Math.max(320, Math.floor(scrollContainer.clientHeight * 0.8));
+        await delay(80);
+      }
+
+      throw new Error(`Could not find mounted journal text ${text}`);
+    })();"
+    (json/write-value-as-string text))))
+
 (defn- journals-layout-metrics
   []
   (js-json
@@ -662,7 +698,7 @@
          :blocks blocks}])
       (enable-virtualized-rendering!)
       (w/wait-for "#journals [data-virtuoso-scroller]")
-      (w/wait-for (format ".ls-page-blocks .ls-block:has-text('%s')" (first blocks)))
+      (scroll-journals-to-text! (first blocks))
       (let [{:keys [journals-scroller-count] :as metrics} (journals-layout-metrics)]
         (is (= 1 journals-scroller-count) metrics)))))
 
@@ -706,7 +742,7 @@
 (deftest journals-linked-refs-remain-visible
   (testing "journals linked refs stay visible while journals layout owns the outer measurement"
     (seed-journals-with-linked-ref!)
-    (w/wait-for "#journals .references")
+    (scroll-journals-to-text! "journals linked refs visible target")
     (let [{:keys [collapsed body-mounted body-height] :as metrics} (journals-linked-refs-metrics)]
       (is (false? collapsed) metrics)
       (is (true? body-mounted) metrics)

--- a/clj-e2e/test/logseq/e2e/editor_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/editor_basic_test.clj
@@ -424,7 +424,7 @@
       scrollContainer.scrollTop = 0;
       await nextFrame();
 
-      for (let i = 0; i < 120; i++) {
+      for (let i = 0; i < 240; i++) {
         const item = findText();
         if (item) {
           item.scrollIntoView({ block: 'center' });
@@ -432,7 +432,7 @@
           return true;
         }
 
-        scrollContainer.scrollTop += Math.max(320, Math.floor(scrollContainer.clientHeight * 0.8));
+        scrollContainer.scrollTop += Math.max(280, Math.floor(scrollContainer.clientHeight * 0.7));
         await delay(80);
       }
 

--- a/docs/adr/0020-journals-ui-stability.md
+++ b/docs/adr/0020-journals-ui-stability.md
@@ -18,6 +18,10 @@ confirmed:
   ResizeObserver.
 - Long journals could render a nested block-level Virtuoso inside the outer
   journals Virtuoso, so two virtualizers measured the same scroll surface.
+- After a long journal item was unmounted and remounted by the outer
+  virtualizer, dynamic content such as PDF embeds and linked references could
+  report a temporarily low height. That made the same measured journal shrink
+  and grow while scrolling back up.
 
 Linked references must remain visible in journals. The fix cannot hide them or
 rely on default collapse as a workaround.
@@ -39,6 +43,13 @@ Block-level virtualization is disabled when rendering page blocks under
 progressively so the initial paint remains bounded without nesting another
 Virtuoso under the journal item.
 
+Each journal item remembers its last measured height by repo and page id. When
+the outer virtualizer remounts that item, the remembered height is used as a
+temporary `min-height` reserve while dynamic content settles. The reserve is
+released when the inner page content reaches the remembered height, when the
+item receives editing input, or after a five-second fallback so real content
+shrink can still be measured.
+
 Linked references continue to render normally. Existing view logic already
 disables linked-reference view virtualization under `:journals?`; this decision
 keeps that behavior and verifies that linked-reference result bodies remain
@@ -53,6 +64,9 @@ Long visible journal pages can eventually render all their visible root blocks,
 but they do so progressively. This trades inner virtualization for stable outer
 scroll geometry while preserving initial editing responsiveness.
 
+Remounting a long journal no longer lets transiently low dynamic-content height
+collapse a previously measured journal item during scroll restoration.
+
 Dynamic sections such as linked references, today queries, scheduled/deadline
 sections, embeds, and images can still change the measured journal item height.
 Those changes are now handled by the outer journals Virtuoso without competing
@@ -64,6 +78,7 @@ Focused clj-e2e coverage verifies:
 
 - journal items have no bottom margin;
 - long journals keep a single `#journals` Virtuoso scroller;
+- long journals do not restart from a low measured height after remount;
 - linked references remain visible in journals;
 - the existing journals scroll-select-copy workflow still works.
 

--- a/docs/adr/0020-journals-ui-stability.md
+++ b/docs/adr/0020-journals-ui-stability.md
@@ -1,0 +1,70 @@
+# ADR 0020: Journals UI Stability
+
+Date: 2026-06-02
+Status: Accepted
+
+## Context
+
+The journals page renders one virtualized item per journal page. Each item can
+contain a full page body, long block trees, embeds, today queries, scheduled and
+deadline sections, and linked references.
+
+Chrome verification showed the outer journals Virtuoso height and the main
+scroll height changing while scrolling long journals. The same journal item also
+changed height repeatedly after it was measured. Two concrete sources were
+confirmed:
+
+- `.journal-item` used bottom margin, which is outside the box measured by
+  ResizeObserver.
+- Long journals could render a nested block-level Virtuoso inside the outer
+  journals Virtuoso, so two virtualizers measured the same scroll surface.
+
+Linked references must remain visible in journals. The fix cannot hide them or
+rely on default collapse as a workaround.
+
+## Decision
+
+Use the journals Virtuoso as the only virtualized measurement owner for journal
+items.
+
+Journal item spacing is measured inside the item box. The previous
+`pb-[64px] mb-[38px]` visual spacing is represented as `pb-[102px]`, removing
+the margin from the measured boundary.
+
+The outer journals Virtuoso uses `skipAnimationFrameInResizeObserver true` so
+ResizeObserver updates are applied synchronously with the measurement source.
+
+Block-level virtualization is disabled when rendering page blocks under
+`:journals?`. For long journal pages, root blocks are still rendered
+progressively so the initial paint remains bounded without nesting another
+Virtuoso under the journal item.
+
+Linked references continue to render normally. Existing view logic already
+disables linked-reference view virtualization under `:journals?`; this decision
+keeps that behavior and verifies that linked-reference result bodies remain
+visible.
+
+## Consequences
+
+The journals page has one scroll measurement owner for journal items, which
+removes the feedback loop between nested virtualizers.
+
+Long visible journal pages can eventually render all their visible root blocks,
+but they do so progressively. This trades inner virtualization for stable outer
+scroll geometry while preserving initial editing responsiveness.
+
+Dynamic sections such as linked references, today queries, scheduled/deadline
+sections, embeds, and images can still change the measured journal item height.
+Those changes are now handled by the outer journals Virtuoso without competing
+with an inner block virtualizer or unmeasured margins.
+
+## Verification
+
+Focused clj-e2e coverage verifies:
+
+- journal items have no bottom margin;
+- long journals keep a single `#journals` Virtuoso scroller;
+- linked references remain visible in journals;
+- the existing journals scroll-select-copy workflow still works.
+
+Manual Chrome investigation on the affected page shape informed the decision.

--- a/docs/adr/0020-journals-ui-stability.md
+++ b/docs/adr/0020-journals-ui-stability.md
@@ -11,7 +11,7 @@ deadline sections, and linked references.
 
 Chrome verification showed the outer journals Virtuoso height and the main
 scroll height changing while scrolling long journals. The same journal item also
-changed height repeatedly after it was measured. Two concrete sources were
+changed height repeatedly after it was measured. Three concrete sources were
 confirmed:
 
 - `.journal-item` used bottom margin, which is outside the box measured by

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1941,18 +1941,24 @@
   [config root-block blocks anchor]
   (let [has-anchor? (not (string/blank? anchor))
         page-blocks-count (count (:block/_page root-block))
-        children-blocks-count (count blocks)]
-    (and
-     (:current-page? config)
-     (zero? (or (:level config) 0))
-     (not (or has-anchor?
-              (:ref? config)
-              (:custom-query? config)
-              (:sidebar? config)
-              (:embed? config)
-              (:library? config)
-              (:document/mode? config)))
-     (>= (- page-blocks-count children-blocks-count) 30))))
+        children-blocks-count (count blocks)
+        root-surface? (or (:current-page? config) (:journals? config))
+        root-level? (zero? (or (:level config) 0))
+        excluded-context? (or has-anchor?
+                              (:ref? config)
+                              (:custom-query? config)
+                              (:sidebar? config)
+                              (:embed? config)
+                              (:library? config)
+                              (:document/mode? config))
+        heavy-journal-root? (and (:journals? config)
+                                 (>= children-blocks-count 50))
+        heavy-descendant-tree? (>= (- page-blocks-count children-blocks-count) 30)]
+    (and root-surface?
+         root-level?
+         (not excluded-context?)
+         (or heavy-journal-root?
+             heavy-descendant-tree?))))
 
 (defn- defer-placeholder-element
   []
@@ -4917,14 +4923,15 @@
   (let [blocks-count (count blocks)
         root-block (when-let [id (:db/id config)]
                      (db/entity id))
-        [virtualized? _] (hooks/use-state (not (or (util/rtc-test?)
-                                                   (and (util/mobile?) (:journals? config))
-                                                   (if (:journals? config)
-                                                     (< blocks-count 50)
-                                                     (< blocks-count 10))
-                                                   (and (:block-children? config)
-                                                        ;; zoom-in block's children
-                                                        (not (and (:id config) (= (:id config) (str (:block/uuid (:block/parent (first blocks)))))))))))
+        zoomed-child-blocks? (and (:block-children? config)
+                                  (not (and (:id config)
+                                            (= (:id config)
+                                               (str (:block/uuid (:block/parent (first blocks))))))))
+        disable-virtualized? (or (util/rtc-test?)
+                                 (:journals? config)
+                                 (< blocks-count 10)
+                                 zoomed-child-blocks?)
+        [virtualized? _] (hooks/use-state (not disable-virtualized?))
         root-level? (zero? (or (:level config) 0))
         anchor (get-in (state/get-route-match) [:query-params :anchor])
         fallback-ready-index* (hooks/use-memo #(atom -1) [])

--- a/src/main/frontend/components/journal.cljs
+++ b/src/main/frontend/components/journal.cljs
@@ -111,18 +111,18 @@
 (hsx/defc all-journals
   []
   (let [data (sub-journals)]
-       (when (seq data)
-         (let [selection-block-ids (journal-block-ids data)]
-           [:div#journals
-            (ui/virtualized-list
-             {:custom-scroll-parent (util/app-scroll-container-node)
-              :increase-viewport-by {:top 100 :bottom 100}
-              :skipAnimationFrameInResizeObserver true
-              :compute-item-key (fn [idx]
-                                  (let [id (util/nth-safe data idx)]
-                                    (str "journal-" id)))
-              :total-count (count data)
-              :item-content (fn [idx]
-                              (let [id (util/nth-safe data idx)
-                                    last? (= (inc idx) (count data))]
-                                (journal-cp id last? selection-block-ids)))})]))))
+    (when (seq data)
+      (let [selection-block-ids (journal-block-ids data)]
+        [:div#journals
+         (ui/virtualized-list
+          {:custom-scroll-parent (util/app-scroll-container-node)
+           :increase-viewport-by {:top 100 :bottom 100}
+           :skipAnimationFrameInResizeObserver true
+           :compute-item-key (fn [idx]
+                               (let [id (util/nth-safe data idx)]
+                                 (str "journal-" id)))
+           :total-count (count data)
+           :item-content (fn [idx]
+                           (let [id (util/nth-safe data idx)
+                                 last? (= (inc idx) (count data))]
+                             (journal-cp id last? selection-block-ids)))})]))))

--- a/src/main/frontend/components/journal.cljs
+++ b/src/main/frontend/components/journal.cljs
@@ -8,17 +8,84 @@
             [frontend.ui :as ui]
             [frontend.util :as util]
             [logseq.db :as ldb]
+            [logseq.shui.hooks :as hooks]
             [promesa.core :as p]
             [io.factorhouse.hsx.core :as hsx]))
 
+(def ^:private journal-item-reserve-height-ms 5000)
+(defonce ^:private journal-item-height-by-key* (atom {}))
+
+(defn- journal-item-cache-key
+  [id]
+  [(state/get-current-repo) id])
+
+(defn- css-px
+  [v]
+  (let [n (js/parseFloat v)]
+    (if (js/Number.isNaN n) 0 n)))
+
+(defn- journal-item-content-height
+  [^js node]
+  (when-let [content (.-firstElementChild node)]
+    (let [style (js/getComputedStyle node)
+          extra-height (+ (css-px (.-paddingTop style))
+                          (css-px (.-paddingBottom style))
+                          (css-px (.-borderTopWidth style))
+                          (css-px (.-borderBottomWidth style)))]
+      (js/Math.round
+       (+ (.-height (.getBoundingClientRect content))
+          extra-height)))))
+
+(defn- remember-journal-item-height!
+  [cache-key ^js node]
+  (let [height (some-> node
+                       (.getBoundingClientRect)
+                       (.-height)
+                       js/Math.round)]
+    (when (pos? height)
+      (swap! journal-item-height-by-key* assoc cache-key height))))
+
 (hsx/defc journal-cp
   [id last? selection-block-ids]
-  [:div.journal-item.content
-   (when last?
-     {:class "journal-last-item"})
-   (page/page-cp {:db/id id
-                  :journals? true
-                  :selection/block-ids selection-block-ids})])
+  (let [cache-key (journal-item-cache-key id)
+        [reserve set-reserve!] (hooks/use-state {:cache-key cache-key
+                                                 :height (get @journal-item-height-by-key* cache-key)})
+        reserve-height (when (= cache-key (:cache-key reserve))
+                         (:height reserve))
+        clear-reserve! #(set-reserve! {:cache-key cache-key :height nil})
+        *item-ref (hooks/use-ref nil)]
+    (hooks/use-effect!
+     (fn []
+       (set-reserve! {:cache-key cache-key
+                      :height (get @journal-item-height-by-key* cache-key)})
+       (let [timeout-id (js/setTimeout clear-reserve!
+                                       journal-item-reserve-height-ms)]
+         #(js/clearTimeout timeout-id)))
+     [cache-key])
+    (hooks/use-effect!
+     (fn []
+       (when-let [node (hooks/deref *item-ref)]
+         (when-not reserve-height
+           (remember-journal-item-height! cache-key node))
+         (let [observer (js/ResizeObserver.
+                         (fn []
+                           (if reserve-height
+                             (when (>= (or (journal-item-content-height node) 0)
+                                       (dec reserve-height))
+                               (clear-reserve!))
+                             (remember-journal-item-height! cache-key node))))]
+           (.observe observer node)
+           #(.disconnect observer))))
+     [cache-key reserve-height])
+    [:div.journal-item.content
+     (cond-> {:ref *item-ref}
+       last? (assoc :class "journal-last-item")
+       reserve-height (assoc :style {:min-height reserve-height})
+       reserve-height (assoc :on-focus clear-reserve!)
+       reserve-height (assoc :on-input clear-reserve!))
+     (page/page-cp {:db/id id
+                    :journals? true
+                    :selection/block-ids selection-block-ids})]))
 
 (defn- journal-block-ids
   [journal-ids]

--- a/src/main/frontend/components/journal.cljs
+++ b/src/main/frontend/components/journal.cljs
@@ -50,6 +50,7 @@
             (ui/virtualized-list
              {:custom-scroll-parent (util/app-scroll-container-node)
               :increase-viewport-by {:top 100 :bottom 100}
+              :skipAnimationFrameInResizeObserver true
               :compute-item-key (fn [idx]
                                   (let [id (util/nth-safe data idx)]
                                     (str "journal-" id)))

--- a/src/main/frontend/components/journal.css
+++ b/src/main/frontend/components/journal.css
@@ -6,7 +6,7 @@
   }
 
   .journal-item {
-    @apply border-b min-h-[250px] pb-[64px] mb-[38px];
+    @apply border-b min-h-[250px] pb-[102px];
 
     &:first-child {
       @apply pt-0 min-h-[500px];

--- a/src/main/frontend/components/journal.css
+++ b/src/main/frontend/components/journal.css
@@ -1,4 +1,6 @@
 #journals {
+  overflow-anchor: none;
+
   textarea {
     word-break: break-word;
     overflow: hidden;
@@ -7,6 +9,7 @@
 
   .journal-item {
     @apply border-b min-h-[250px] pb-[102px];
+    overflow-anchor: none;
 
     &:first-child {
       @apply pt-0 min-h-[500px];


### PR DESCRIPTION
## Summary
- Add ADR 0020 for journals UI stability.
- Remove journal item margin from Virtuoso measurement and keep equivalent spacing inside the measured box.
- Make journals use one virtualized measurement owner by disabling nested block virtualization under journals while preserving progressive root rendering for long journal pages.
- Keep linked references visible and add e2e coverage for long journals, iframe embeds, linked refs, and scroll-select-copy.

## Validation
- `pnpm cljs:dev-release-app`
- `bb test -v logseq.e2e.editor-basic-test/journals-list-uses-measured-spacing-without-item-margins`
- `bb test -v logseq.e2e.editor-basic-test/journals-list-does-not-nest-virtualized-scrollers-in-long-journal`
- `bb test -v logseq.e2e.editor-basic-test/journals-list-keeps-single-scroller-with-iframe-embeds`
- `bb test -v logseq.e2e.editor-basic-test/journals-linked-refs-remain-visible`
- `bb test -v logseq.e2e.editor-basic-test/copy-blocks-selected-while-scrolling-journals-list`

## Review
- Ran `logseq-review-workflow` locally because no subagent tool was available. Applied common, ClojureScript, React, frontend UI, editor, DataScript, and all pass rules. No confirmed findings remained after targeted e2e/runtime validation.

## Notes
- Existing unrelated plugin changes in the local worktree were not staged or included.