### PR TITLE
[WIP] fix: login regressions (header React #310, CLI callback loopback bind)

### DIFF
--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -395,6 +395,7 @@
   (let [electron-mac? (and util/mac? (util/electron?))
         rtc-graphs (state/use-sub :rtc/graphs)
         default-home-page (state/use-sub-default-home-page)
+        electron-server (state/use-sub :electron/server)
         left-menu (left-menu-button {:on-click (fn []
                                                  (state/set-left-sidebar-open!
                                                   (not (:ui/left-sidebar-open? @state/state))))})
@@ -470,7 +471,7 @@
           (plugins/updates-notifications)])
 
        (when (state/feature-http-server-enabled?)
-         (server/server-indicator (state/use-sub :electron/server)))
+         (server/server-indicator electron-server))
 
        (when (util/electron?)
          (back-and-forward))

--- a/src/main/logseq/cli/auth.cljs
+++ b/src/main/logseq/cli/auth.cljs
@@ -17,6 +17,7 @@
 (def ^:private logout-complete-path "/logout-complete")
 (def ^:private callback-host "localhost")
 (def ^:private callback-port 8765)
+(def ^:private callback-bind-address "127.0.0.1")
 (def ^:private auth-provider "cognito")
 (def ^:private default-scope "email openid phone")
 (def ^:private token-endpoint-path "/oauth2/token")
@@ -258,7 +259,7 @@
                               (reject (ex-info "failed to start login callback server"
                                                {:code :login-callback-server-start-failed}
                                                error))))
-       (.listen server callback-port callback-host
+       (.listen server callback-port callback-bind-address
                 (fn []
                   (let [address (.address server)
                         port (.-port address)
@@ -308,7 +309,7 @@
                               (reject (ex-info "failed to start logout callback server"
                                                {:code :logout-callback-server-start-failed}
                                                error))))
-       (.listen server callback-port callback-host
+       (.listen server callback-port callback-bind-address
                 (fn []
                   (resolve {:logout-uri (logout-complete-uri)
                             :wait! (fn []


### PR DESCRIPTION
Closes: #12771 
---

## Summary

Two login fixes, one commit each. Both bugs are documented in logseq/logseq#12771.

1. **`fix: hoist conditional use-sub out of the header server indicator`**
    - the HSX migration (logseq/logseq#12748) left `(state/use-sub :electron/server)` inside `(when (state/feature-http-server-enabled?) ...)`. The flag reads non-reactive localStorage and flips mid-session (the MCP toggle auto-sets it), so the next header re-render runs one extra hook and React error `#310` blanks the window after sign-in. The subscription moves into the component `let`; the conditional keeps using the value.

3. **`fix(cli): bind login callback servers to the IPv4 loopback literal`**
    - `logseq login` listened on the resolver's first `localhost` address (often `::1` only), unreachable for browsers that resolve `localhost` as IPv4 only, so the OAuth redirect was refused, and the CLI hung until the five-minute timeout. Both callback servers now bind `127.0.0.1` per RFC 8252 section 8.3; the redirect URI keeps the `localhost` host registered with the Cognito client.
