### PR TITLE
fix(electron): stabilize main-process hot reload lifecycle

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -413,16 +413,104 @@
       :log-info! logger/info
       :log-warn! logger/warn})))
 
+(defn- setup-devtools-extension! []
+  (when-let [^js devtoolsInstaller (and dev? (js/require "electron-devtools-installer"))]
+    (-> (.default devtoolsInstaller (.-REACT_DEVELOPER_TOOLS devtoolsInstaller))
+        (.then #(js/console.log "Added Extension:" (.-REACT_DEVELOPER_TOOLS devtoolsInstaller))))))
+
+(defn- <stop-db-workers!
+  []
+  (-> (try
+        (handler/stop-all-db-workers!)
+        (catch :default e
+          (logger/warn :electron/stop-db-workers-failed e)
+          (p/resolved nil)))
+      (p/catch
+       (fn [e]
+         (logger/warn :electron/stop-db-workers-failed e)))))
+
+(defn- register-reloadable-effects!
+  [^js app' ^js win]
+  (vreset! *setup-fn
+           (fn []
+             (let [dispose-fns (volatile! [])
+                   stop-embedding! (volatile! nil)
+                   add-dispose! (fn [f]
+                                  (when f
+                                    (vswap! dispose-fns conj f))
+                                  f)]
+               (try
+                 (add-dispose! (setup-updater! win))
+                 (add-dispose! (setup-app-manager! win))
+                 (add-dispose! (handler/set-ipc-handler! win))
+                 (add-dispose! (server/setup! win))
+                 (when (cfgs/semantic-search-enabled?)
+                   (vreset! stop-embedding! (embedding-server/setup! app')))
+                 (add-dispose! (exceptions/setup-exception-listeners!))
+
+                 (vreset! *teardown-fn
+                          (fn []
+                            (let [fns @dispose-fns
+                                  stop-embedding-fn @stop-embedding!]
+                              (vreset! dispose-fns [])
+                              (vreset! stop-embedding! nil)
+                              (-> (<stop-db-workers!)
+                                  (p/finally
+                                    (fn []
+                                      (run-dispose-fns! fns)
+                                      (when stop-embedding-fn
+                                        (stop-embedding-fn))))))))
+                 (catch :default e
+                   (run-dispose-fns! @dispose-fns)
+                   (when-let [stop-embedding! @stop-embedding!]
+                     (stop-embedding!))
+                   (vreset! *teardown-fn nil)
+                   (throw e)))))))
+
+(defn- setup-main-window-close-listener!
+  [^js win]
+  (.on win "close"
+       (fn [e]
+         (when @*quit-dirty? ;; when not updating
+           (.preventDefault e)
+           (let [windows (win/get-all-windows)
+                 window @*win
+                 multiple-windows? (> (count windows) 1)]
+             (cond
+               (or multiple-windows? (not mac?) @win/*quitting?)
+               (when window
+                 (win/close-handler win e)
+                 (reset! *win nil))
+
+               (and mac? (not multiple-windows?))
+               ;; Just hiding - don't do any actual closing operation
+               (do (.preventDefault ^js/Event e)
+                   (if (and mac? (.isFullScreen win))
+                     (do (.once win "leave-full-screen" #(.hide win))
+                         (.setFullScreen win false))
+                     (.hide win)))
+
+               :else
+               nil))))))
+
+(defn- setup-app-window-lifecycle-listeners!
+  [^js app' ^js win]
+  (setup-main-window-close-listener! win)
+  (.on app' "before-quit"
+       (fn [_e]
+         (reset! win/*quitting? true)
+         (-> (handler/stop-all-db-workers!)
+             (p/finally
+               (fn []
+                 (embedding-server/stop!))))))
+  (.on app' "activate" #(when @*win (.show win))))
+
 (defn- on-app-ready!
   [^js app']
   (.on app' "ready"
        (fn []
          (logger/info (str "Logseq App(" (.getVersion app') ") Starting... "))
-
-         ;; Add React developer tool
-         (when-let [^js devtoolsInstaller (and dev? (js/require "electron-devtools-installer"))]
-           (-> (.default devtoolsInstaller (.-REACT_DEVELOPER_TOOLS devtoolsInstaller))
-               (.then #(js/console.log "Added Extension:" (.-REACT_DEVELOPER_TOOLS devtoolsInstaller)))))
+         (setup-devtools-extension!)
 
          (let [_ (setup-interceptor! app')
                ^js win (win/create-main-window!)
@@ -439,83 +527,12 @@
            (handle-initial-deeplink! win)
            (maybe-warn-wrong-release!)
 
-           (vreset! *setup-fn
-                    (fn []
-                      (let [dispose-fns (volatile! [])
-                            stop-embedding! (volatile! nil)
-                            add-dispose! (fn [f]
-                                           (when f
-                                             (vswap! dispose-fns conj f))
-                                           f)]
-                        (try
-                          (add-dispose! (setup-updater! win))
-                          (add-dispose! (setup-app-manager! win))
-                          (add-dispose! (handler/set-ipc-handler! win))
-                          (add-dispose! (server/setup! win))
-                          (when (cfgs/semantic-search-enabled?)
-                            (vreset! stop-embedding! (embedding-server/setup! app')))
-                          (add-dispose! (exceptions/setup-exception-listeners!))
-
-                          (vreset! *teardown-fn
-                                   (fn []
-                                     (let [fns @dispose-fns
-                                           stop-embedding-fn @stop-embedding!]
-                                       (vreset! dispose-fns [])
-                                       (vreset! stop-embedding! nil)
-                                       (-> (try
-                                             (handler/stop-all-db-workers!)
-                                             (catch :default e
-                                               (logger/warn :electron/stop-db-workers-failed e)
-                                               (p/resolved nil)))
-                                           (p/catch
-                                            (fn [e]
-                                              (logger/warn :electron/stop-db-workers-failed e)))
-                                           (p/finally
-                                             (fn []
-                                               (run-dispose-fns! fns)
-                                               (when stop-embedding-fn
-                                                 (stop-embedding-fn))))))))
-                          (catch :default e
-                            (run-dispose-fns! @dispose-fns)
-                            (when-let [stop-embedding! @stop-embedding!]
-                              (stop-embedding!))
-                            (vreset! *teardown-fn nil)
-                            (throw e))))))
+           (register-reloadable-effects! app' win)
 
            ;; setup effects
            (@*setup-fn)
 
-           ;; main window events
-           (.on win "close" (fn [e]
-                              (when @*quit-dirty? ;; when not updating
-                                (.preventDefault e)
-
-                                (let [windows (win/get-all-windows)
-                                      window @*win
-                                      multiple-windows? (> (count windows) 1)]
-                                  (cond
-                                    (or multiple-windows? (not mac?) @win/*quitting?)
-                                    (when window
-                                      (win/close-handler win e)
-                                      (reset! *win nil))
-
-                                    (and mac? (not multiple-windows?))
-                                        ;; Just hiding - don't do any actual closing operation
-                                    (do (.preventDefault ^js/Event e)
-                                        (if (and mac? (.isFullScreen win))
-                                          (do (.once win "leave-full-screen" #(.hide win))
-                                              (.setFullScreen win false))
-                                          (.hide win)))
-                                    :else
-                                    nil)))))
-           (.on app' "before-quit" (fn [_e]
-                                     (reset! win/*quitting? true)
-                                     (-> (handler/stop-all-db-workers!)
-                                         (p/finally
-                                           (fn []
-                                             (embedding-server/stop!))))))
-
-           (.on app' "activate" #(when @*win (.show win)))))))
+           (setup-app-window-lifecycle-listeners! app' win)))))
 
 (defn main []
   (if-not (.requestSingleInstanceLock app)

--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -2,7 +2,6 @@
   (:require ["/electron/utils" :as js-utils]
             ["electron" :refer [BrowserWindow Menu app protocol ipcMain dialog shell] :as electron]
             ["fs-extra" :as fs]
-
             ["os" :as os]
             ["path" :as node-path]
             [cljs-bean.core :as bean]
@@ -40,7 +39,44 @@
 
 (defonce *setup-fn (volatile! nil))
 (defonce *teardown-fn (volatile! nil))
+(defonce *lifecycle-op (volatile! (p/resolved nil)))
 (defonce *quit-dirty? (volatile! true))
+
+(defn- run-dispose-fns!
+  [fns]
+  (doseq [f (reverse (remove nil? fns))]
+    (try
+      (f)
+      (catch :default e
+        (logger/warn :electron/dispose-failed e)))))
+
+(defn- <run-current-teardown!
+  []
+  (if-let [teardown! @*teardown-fn]
+    (do
+      (vreset! *teardown-fn nil)
+      (try
+        (-> (or (teardown!) (p/resolved nil))
+            (p/catch (fn [e]
+                       (logger/warn :electron/teardown-failed e))))
+        (catch :default e
+          (logger/warn :electron/teardown-failed e)
+          (p/resolved nil))))
+    (p/resolved nil)))
+
+(defn- <enqueue-lifecycle!
+  [f]
+  (let [op (-> @*lifecycle-op
+               (p/catch (fn [_] nil))
+               (p/then (fn [_] (f))))]
+    (vreset! *lifecycle-op op)
+    op))
+
+(defn- replace-ipc-handler!
+  [channel listener]
+  (.removeHandler ipcMain channel)
+  (.handle ipcMain channel listener)
+  #(.removeHandler ipcMain channel))
 
 (defn setup-updater! [^js win]
   ;; manual/auto updater
@@ -158,47 +194,51 @@
         call-win-channel "call-main-win"
         export-publish-assets "export-publish-assets"
         quit-dirty-state "set-quit-dirty-state"
-        clear-win-effects! (win/setup-window-listeners! win)]
-
-    (doto ipcMain
-      (.handle quit-dirty-state
-               (fn [_ dirty?]
-                 (vreset! *quit-dirty? (boolean dirty?))))
-
-      (.handle toggle-win-channel
-               (fn [_ toggle-min?]
-                 (when-let [active-win (.getFocusedWindow BrowserWindow)]
-                   (if toggle-min?
-                     (if (.isMinimized active-win)
-                       (.restore active-win)
-                       (.minimize active-win))
-                     (if (.isMaximized active-win)
-                       (.unmaximize active-win)
-                       (.maximize active-win))))))
-
-      (.handle export-publish-assets handle-export-publish-assets)
-
-      (.handle call-app-channel
-               (fn [_ type & args]
-                 (try
-                   (js-invoke app type args)
-                   (catch :default e
-                     (logger/error (str call-app-channel " " e))))))
-
-      (.handle call-win-channel
-               (fn [^js e type & args]
-                 (let [win (get-win-from-sender e)]
-                   (try
-                     (js-invoke win type args)
-                     (catch :default e
-                       (logger/error (str call-win-channel " " e))))))))
-
-    #(do (clear-win-effects!)
-         (.removeHandler ipcMain toggle-win-channel)
-         (.removeHandler ipcMain export-publish-assets)
-         (.removeHandler ipcMain quit-dirty-state)
-         (.removeHandler ipcMain call-app-channel)
-         (.removeHandler ipcMain call-win-channel))))
+        clear-win-effects! (win/setup-window-listeners! win)
+        dispose-fns (volatile! [])
+        add-dispose! (fn [f]
+                       (vswap! dispose-fns conj f)
+                       f)]
+    (try
+      (add-dispose!
+       (replace-ipc-handler! quit-dirty-state
+                             (fn [_ dirty?]
+                               (vreset! *quit-dirty? (boolean dirty?)))))
+      (add-dispose!
+       (replace-ipc-handler! toggle-win-channel
+                             (fn [_ toggle-min?]
+                               (when-let [active-win (.getFocusedWindow BrowserWindow)]
+                                 (if toggle-min?
+                                   (if (.isMinimized active-win)
+                                     (.restore active-win)
+                                     (.minimize active-win))
+                                   (if (.isMaximized active-win)
+                                     (.unmaximize active-win)
+                                     (.maximize active-win)))))))
+      (add-dispose!
+       (replace-ipc-handler! export-publish-assets handle-export-publish-assets))
+      (add-dispose!
+       (replace-ipc-handler! call-app-channel
+                             (fn [_ type & args]
+                               (try
+                                 (js-invoke app type args)
+                                 (catch :default e
+                                   (logger/error (str call-app-channel " " e)))))))
+      (add-dispose!
+       (replace-ipc-handler! call-win-channel
+                             (fn [^js e type & args]
+                               (let [win (get-win-from-sender e)]
+                                 (try
+                                   (js-invoke win type args)
+                                   (catch :default e
+                                     (logger/error (str call-win-channel " " e))))))))
+      #(do
+         (run-dispose-fns! @dispose-fns)
+         (clear-win-effects!))
+      (catch :default e
+        (run-dispose-fns! @dispose-fns)
+        (clear-win-effects!)
+        (throw e)))))
 
 (defn- set-app-menu! []
   (let [about-fn (fn []
@@ -384,7 +424,7 @@
            (-> (.default devtoolsInstaller (.-REACT_DEVELOPER_TOOLS devtoolsInstaller))
                (.then #(js/console.log "Added Extension:" (.-REACT_DEVELOPER_TOOLS devtoolsInstaller)))))
 
-         (let [t0 (setup-interceptor! app')
+         (let [_ (setup-interceptor! app')
                ^js win (win/create-main-window!)
                _ (reset! *win win)]
 
@@ -401,20 +441,46 @@
 
            (vreset! *setup-fn
                     (fn []
-                      (let [t1 (setup-updater! win)
-                            t2 (setup-app-manager! win)
-                            t3 (handler/set-ipc-handler! win)
-                            t4 (server/setup! win)
-                            t5 (when (cfgs/semantic-search-enabled?)
-                                 (embedding-server/setup! app'))
-                            tt (exceptions/setup-exception-listeners!)]
+                      (let [dispose-fns (volatile! [])
+                            stop-embedding! (volatile! nil)
+                            add-dispose! (fn [f]
+                                           (when f
+                                             (vswap! dispose-fns conj f))
+                                           f)]
+                        (try
+                          (add-dispose! (setup-updater! win))
+                          (add-dispose! (setup-app-manager! win))
+                          (add-dispose! (handler/set-ipc-handler! win))
+                          (add-dispose! (server/setup! win))
+                          (when (cfgs/semantic-search-enabled?)
+                            (vreset! stop-embedding! (embedding-server/setup! app')))
+                          (add-dispose! (exceptions/setup-exception-listeners!))
 
-                        (vreset! *teardown-fn
-                                 #(-> (handler/stop-all-db-workers!)
-                                      (p/finally
-                                        (fn []
-                                          (doseq [f [t0 t1 t2 t3 t4 t5 tt]]
-                                            (and f (f))))))))))
+                          (vreset! *teardown-fn
+                                   (fn []
+                                     (let [fns @dispose-fns
+                                           stop-embedding-fn @stop-embedding!]
+                                       (vreset! dispose-fns [])
+                                       (vreset! stop-embedding! nil)
+                                       (-> (try
+                                             (handler/stop-all-db-workers!)
+                                             (catch :default e
+                                               (logger/warn :electron/stop-db-workers-failed e)
+                                               (p/resolved nil)))
+                                           (p/catch
+                                            (fn [e]
+                                              (logger/warn :electron/stop-db-workers-failed e)))
+                                           (p/finally
+                                             (fn []
+                                               (run-dispose-fns! fns)
+                                               (when stop-embedding-fn
+                                                 (stop-embedding-fn))))))))
+                          (catch :default e
+                            (run-dispose-fns! @dispose-fns)
+                            (when-let [stop-embedding! @stop-embedding!]
+                              (stop-embedding!))
+                            (vreset! *teardown-fn nil)
+                            (throw e))))))
 
            ;; setup effects
            (@*setup-fn)
@@ -493,8 +559,12 @@
 
 (defn start []
   (logger/debug "Main - start")
-  (when @*setup-fn (@*setup-fn)))
+  (<enqueue-lifecycle!
+   #(p/then (<run-current-teardown!)
+            (fn [_]
+              (when @*setup-fn
+                (@*setup-fn))))))
 
 (defn stop []
   (logger/debug "Main - stop")
-  (when @*teardown-fn (@*teardown-fn)))
+  (<enqueue-lifecycle! <run-current-teardown!))

--- a/src/electron/electron/db_worker.cljs
+++ b/src/electron/electron/db_worker.cljs
@@ -7,7 +7,8 @@
 (defn- initial-state
   []
   {:repos {}
-   :window->repo {}})
+   :window->repo {}
+   :stop-all-op nil})
 
 (defn- repo-key
   [repo]
@@ -132,40 +133,42 @@
 
 (defn ensure-started!
   [{:keys [state start-daemon! stop-daemon! runtime-ready?] :as manager} repo window-id]
-  (let [key (repo-key repo)]
-    (p/let [current-repo (get-in (ensure-state @state) [:window->repo window-id])
-            _ (when (and current-repo (not= current-repo key))
-                (ensure-window-stopped! manager window-id))]
-      (if-let [entry (get-in (ensure-state @state) [:repos key])]
-        (p/let [runtime (:runtime entry)
-                ready? (runtime-ready? runtime)]
-          (if ready?
-            (do
-              (swap! state (fn [current]
-                             (-> (ensure-state current)
-                                 (update-in [:repos key :windows] (fnil conj #{}) window-id)
-                                 (assoc-in [:window->repo window-id] key))))
-              runtime)
-            (p/let [_ (when (owned-runtime? runtime)
-                        (-> (stop-daemon! runtime)
-                            (p/catch (fn [_] nil))))
-                    runtime' (start-daemon! repo)]
-              (swap! state
-                     (fn [current]
-                       (let [current' (ensure-state current)
-                             windows (get-in current' [:repos key :windows] #{})]
-                         (-> current'
-                             (assoc-in [:repos key] {:runtime runtime'
-                                                     :windows (conj windows window-id)})
-                             (assoc-in [:window->repo window-id] key)))))
-              runtime')))
-        (p/let [runtime (start-daemon! repo)]
-          (swap! state (fn [current]
-                         (-> (ensure-state current)
-                             (assoc-in [:repos key] {:runtime runtime
-                                                     :windows #{window-id}})
-                             (assoc-in [:window->repo window-id] key))))
-          runtime)))))
+  (if-let [op (:stop-all-op (ensure-state @state))]
+    (p/then op (fn [_] (ensure-started! manager repo window-id)))
+    (let [key (repo-key repo)]
+      (p/let [current-repo (get-in (ensure-state @state) [:window->repo window-id])
+              _ (when (and current-repo (not= current-repo key))
+                  (ensure-window-stopped! manager window-id))]
+        (if-let [entry (get-in (ensure-state @state) [:repos key])]
+          (p/let [runtime (:runtime entry)
+                  ready? (runtime-ready? runtime)]
+            (if ready?
+              (do
+                (swap! state (fn [current]
+                               (-> (ensure-state current)
+                                   (update-in [:repos key :windows] (fnil conj #{}) window-id)
+                                   (assoc-in [:window->repo window-id] key))))
+                runtime)
+              (p/let [_ (when (owned-runtime? runtime)
+                          (-> (stop-daemon! runtime)
+                              (p/catch (fn [_] nil))))
+                      runtime' (start-daemon! repo)]
+                (swap! state
+                       (fn [current]
+                         (let [current' (ensure-state current)
+                               windows (get-in current' [:repos key :windows] #{})]
+                           (-> current'
+                               (assoc-in [:repos key] {:runtime runtime'
+                                                       :windows (conj windows window-id)})
+                               (assoc-in [:window->repo window-id] key)))))
+                runtime')))
+          (p/let [runtime (start-daemon! repo)]
+            (swap! state (fn [current]
+                           (-> (ensure-state current)
+                               (assoc-in [:repos key] {:runtime runtime
+                                                       :windows #{window-id}})
+                               (assoc-in [:window->repo window-id] key))))
+            runtime))))))
 
 (defn- parse-runtime-lock
   [{:keys [base-url]}]
@@ -207,15 +210,29 @@
 
 (defn stop-all!
   [{:keys [state stop-daemon!]}]
-  (let [entries (vals (:repos (ensure-state @state)))]
-    (-> (p/all (map (fn [{:keys [runtime]}]
-                      (if (owned-runtime? runtime)
-                        (stop-daemon! runtime)
-                        (p/resolved true)))
-                    entries))
-        (p/then (fn [_]
-                  (reset! state (initial-state))
-                  true)))))
+  (if-let [op (:stop-all-op (ensure-state @state))]
+    op
+    (let [entries (vals (:repos (ensure-state @state)))
+          op* (atom nil)
+          op (-> (p/all (map (fn [{:keys [runtime]}]
+                               (if (owned-runtime? runtime)
+                                 (stop-daemon! runtime)
+                                 (p/resolved true)))
+                             entries))
+                 (p/then (fn [_]
+                           (reset! state (assoc (initial-state) :stop-all-op @op*))
+                           true))
+                 (p/finally
+                   (fn []
+                     (swap! state
+                            (fn [current]
+                              (let [current' (ensure-state current)]
+                                (if (identical? (:stop-all-op current') @op*)
+                                  (assoc current' :stop-all-op nil)
+                                  current')))))))]
+      (reset! op* op)
+      (swap! state #(assoc (ensure-state %) :stop-all-op op))
+      op)))
 
 (defn ensure-repo-stopped!
   [{:keys [state stop-daemon!]} repo]

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -583,6 +583,7 @@
 
 (defn set-ipc-handler! [window]
   (let [main-channel "main"]
+    (.removeHandler ipcMain main-channel)
     (.handle ipcMain main-channel
              (fn [^js event args-js]
                (let [message* (volatile! nil)]

--- a/src/electron/electron/updater.cljs
+++ b/src/electron/electron/updater.cljs
@@ -1,16 +1,22 @@
 (ns electron.updater
-  (:require [cljs-bean.core :as bean]
+  (:require ["electron" :refer [ipcMain]]
+            ["electron-updater" :refer [autoUpdater]]
+            [cljs-bean.core :as bean]
             [electron.configs :as cfgs]
             [electron.logger :as logger]
             [electron.utils :refer [*win prod?]]
-            [frontend.version :refer [version]]
-            ["electron" :refer [ipcMain]]
-            ["electron-updater" :refer [autoUpdater]]))
+            [frontend.version :refer [version]]))
 
 (def *update-pending (atom nil))
 (def *downloaded-update (atom nil))
 (def debug (partial logger/debug "[updater]"))
 (def electron-version version)
+
+(defn- replace-ipc-handler!
+  [channel listener]
+  (.removeHandler ipcMain channel)
+  (.handle ipcMain channel listener)
+  #(.removeHandler ipcMain channel))
 
 (defn- updater-channel
   []
@@ -138,6 +144,17 @@
   [{:keys [^js win] :as _opts}]
   (configure-auto-updater!)
   (let [dispose-listeners! (register-auto-updater-listeners! win)
+        dispose-ipc-fns (volatile! [])
+        add-dispose! (fn [f]
+                       (vswap! dispose-ipc-fns conj f)
+                       f)
+        cleanup! (fn []
+                   (let [fns @dispose-ipc-fns]
+                     (vreset! dispose-ipc-fns [])
+                     (dispose-listeners!)
+                     (doseq [dispose! (reverse fns)]
+                       (dispose!))
+                     (reset! *update-pending nil)))
         check-channel "check-for-updates"
         install-channel "install-updates"
         get-downloaded-channel "get-downloaded-update"
@@ -151,13 +168,12 @@
                            (.quitAndInstall autoUpdater false true))
         get-downloaded-listener (fn [_e]
                                   (some-> @*downloaded-update bean/->js))]
-    (init-auto-updater! win)
-    (.handle ipcMain check-channel check-listener)
-    (.handle ipcMain install-channel install-listener)
-    (.handle ipcMain get-downloaded-channel get-downloaded-listener)
-    #(do
-       (dispose-listeners!)
-       (.removeHandler ipcMain install-channel)
-       (.removeHandler ipcMain check-channel)
-       (.removeHandler ipcMain get-downloaded-channel)
-       (reset! *update-pending nil))))
+    (try
+      (init-auto-updater! win)
+      (add-dispose! (replace-ipc-handler! check-channel check-listener))
+      (add-dispose! (replace-ipc-handler! install-channel install-listener))
+      (add-dispose! (replace-ipc-handler! get-downloaded-channel get-downloaded-listener))
+      cleanup!
+      (catch :default e
+        (cleanup!)
+        (throw e)))))

--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -143,7 +143,7 @@
 
 (defn setup-window-listeners!
   [^js win]
-  (when win
+  (if win
     (let [web-contents (. win -webContents)
           open-external!
           (fn [url]

--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -162,6 +162,30 @@
             (.preventDefault e)
             (open-default-app! url open))
 
+          persist-zoom-level-handler
+          (fn []
+            (.send web-contents "persist-zoom-level" (.getZoomLevel web-contents)))
+
+          restore-zoom-level-handler
+          (fn []
+            (.send web-contents "restore-zoom-level"))
+
+          enter-full-screen-handler
+          (fn []
+            (.send web-contents "full-screen" "enter"))
+
+          leave-full-screen-handler
+          (fn []
+            (.send web-contents "full-screen" "leave"))
+
+          maximize-handler
+          (fn []
+            (.send web-contents "maximize" true))
+
+          unmaximize-handler
+          (fn []
+            (.send web-contents "maximize" false))
+
           context-menu-handler
           (context-menu/setup-context-menu! win)
 
@@ -196,22 +220,27 @@
 
       (doto web-contents
         (.on "will-navigate" will-navigate-handler)
-        (.on "did-start-navigation" #(.send web-contents "persist-zoom-level" (.getZoomLevel web-contents)))
-        (.on "page-title-updated" #(.send web-contents "restore-zoom-level"))
+        (.on "did-start-navigation" persist-zoom-level-handler)
+        (.on "page-title-updated" restore-zoom-level-handler)
         (.setWindowOpenHandler window-open-handler))
 
       (doto win
-        (.on "enter-full-screen" #(.send web-contents "full-screen" "enter"))
-        (.on "leave-full-screen" #(.send web-contents "full-screen" "leave"))
-        (.on "maximize" #(.send web-contents "maximize" true))
-        (.on "unmaximize" #(.send web-contents "maximize" false)))
+        (.on "enter-full-screen" enter-full-screen-handler)
+        (.on "leave-full-screen" leave-full-screen-handler)
+        (.on "maximize" maximize-handler)
+        (.on "unmaximize" unmaximize-handler))
 
       ;; clear
       (fn []
         (doto web-contents
           (.off "context-menu" context-menu-handler)
-          (.off "will-navigate" will-navigate-handler))
+          (.off "will-navigate" will-navigate-handler)
+          (.off "did-start-navigation" persist-zoom-level-handler)
+          (.off "page-title-updated" restore-zoom-level-handler))
 
-        (.off win "enter-full-screen")
-        (.off win "leave-full-screen")))
+        (doto win
+          (.off "enter-full-screen" enter-full-screen-handler)
+          (.off "leave-full-screen" leave-full-screen-handler)
+          (.off "maximize" maximize-handler)
+          (.off "unmaximize" unmaximize-handler))))
     #()))

--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -141,6 +141,87 @@
           (when (= res 1)
             (default-open url)))))))
 
+(defn- window-open-handler
+  [^js win open-external!]
+  (fn [^js details]
+    (let [url         (.-url details)
+          fullscreen? (.isFullScreen win)
+          features    (string/split (.-features details) ",")
+          features    (when (seq features)
+                        (reduce (fn [a b]
+                                  (let [[k v] (string/split b "=")]
+                                    (if (string? v)
+                                      (assoc a (keyword k) (parse-long (string/trim v)))
+                                      a))) {} features))]
+      (-> (if (= url "about:blank")
+            (merge {:action "allow"
+                    :overrideBrowserWindowOptions
+                    {:frame true
+                     :titleBarStyle "default"
+                     :trafficLightPosition {:x 16 :y 16}
+                     :autoHideMenuBar (not mac?)
+                     :fullscreenable (not fullscreen?)
+                     :webPreferences
+                     {:plugins true
+                      :nodeIntegration false
+                      :webSecurity (not dev?)
+                      :preload (node-path/join js/__dirname "js/preload.js")
+                      :nativeWindowOpen true}}}
+                   features)
+            (do (open-external! url) {:action "deny"}))
+          (bean/->js)))))
+
+(defn- setup-web-contents-listeners!
+  [^js web-contents]
+  (let [will-navigate-handler
+        (fn [e url]
+          (.preventDefault e)
+          (open-default-app! url open))
+
+        persist-zoom-level-handler
+        (fn []
+          (.send web-contents "persist-zoom-level" (.getZoomLevel web-contents)))
+
+        restore-zoom-level-handler
+        (fn []
+          (.send web-contents "restore-zoom-level"))]
+    (doto web-contents
+      (.on "will-navigate" will-navigate-handler)
+      (.on "did-start-navigation" persist-zoom-level-handler)
+      (.on "page-title-updated" restore-zoom-level-handler))
+    #(doto web-contents
+       (.off "will-navigate" will-navigate-handler)
+       (.off "did-start-navigation" persist-zoom-level-handler)
+       (.off "page-title-updated" restore-zoom-level-handler))))
+
+(defn- setup-browser-window-listeners!
+  [^js win ^js web-contents]
+  (let [enter-full-screen-handler
+        (fn []
+          (.send web-contents "full-screen" "enter"))
+
+        leave-full-screen-handler
+        (fn []
+          (.send web-contents "full-screen" "leave"))
+
+        maximize-handler
+        (fn []
+          (.send web-contents "maximize" true))
+
+        unmaximize-handler
+        (fn []
+          (.send web-contents "maximize" false))]
+    (doto win
+      (.on "enter-full-screen" enter-full-screen-handler)
+      (.on "leave-full-screen" leave-full-screen-handler)
+      (.on "maximize" maximize-handler)
+      (.on "unmaximize" unmaximize-handler))
+    #(doto win
+       (.off "enter-full-screen" enter-full-screen-handler)
+       (.off "leave-full-screen" leave-full-screen-handler)
+       (.off "maximize" maximize-handler)
+       (.off "unmaximize" unmaximize-handler))))
+
 (defn setup-window-listeners!
   [^js win]
   (if win
@@ -156,91 +237,16 @@
                    (.join node-path (. app getAppPath) "index.html"))
                 (logger/info "pass-window" url)
                 (open-default-app! url open))))
-
-          will-navigate-handler
-          (fn [e url]
-            (.preventDefault e)
-            (open-default-app! url open))
-
-          persist-zoom-level-handler
-          (fn []
-            (.send web-contents "persist-zoom-level" (.getZoomLevel web-contents)))
-
-          restore-zoom-level-handler
-          (fn []
-            (.send web-contents "restore-zoom-level"))
-
-          enter-full-screen-handler
-          (fn []
-            (.send web-contents "full-screen" "enter"))
-
-          leave-full-screen-handler
-          (fn []
-            (.send web-contents "full-screen" "leave"))
-
-          maximize-handler
-          (fn []
-            (.send web-contents "maximize" true))
-
-          unmaximize-handler
-          (fn []
-            (.send web-contents "maximize" false))
-
           context-menu-handler
           (context-menu/setup-context-menu! win)
+          clear-web-contents! (setup-web-contents-listeners! web-contents)
+          clear-window! (setup-browser-window-listeners! win web-contents)]
 
-          window-open-handler
-          (fn [^js details]
-            (let [url         (.-url details)
-                  fullscreen? (.isFullScreen win)
-                  features    (string/split (.-features details) ",")
-                  features    (when (seq features)
-                                (reduce (fn [a b]
-                                          (let [[k v] (string/split b "=")]
-                                            (if (string? v)
-                                              (assoc a (keyword k) (parse-long (string/trim v)))
-                                              a))) {} features))]
-              (-> (if (= url "about:blank")
-                    (merge {:action "allow"
-                            :overrideBrowserWindowOptions
-                            {:frame true
-                             :titleBarStyle "default"
-                             :trafficLightPosition {:x 16 :y 16}
-                             :autoHideMenuBar (not mac?)
-                             :fullscreenable (not fullscreen?)
-                             :webPreferences
-                             {:plugins true
-                              :nodeIntegration false
-                              :webSecurity (not dev?)
-                              :preload (node-path/join js/__dirname "js/preload.js")
-                              :nativeWindowOpen true}}}
-                           features)
-                    (do (open-external! url) {:action "deny"}))
-                  (bean/->js))))]
-
-      (doto web-contents
-        (.on "will-navigate" will-navigate-handler)
-        (.on "did-start-navigation" persist-zoom-level-handler)
-        (.on "page-title-updated" restore-zoom-level-handler)
-        (.setWindowOpenHandler window-open-handler))
-
-      (doto win
-        (.on "enter-full-screen" enter-full-screen-handler)
-        (.on "leave-full-screen" leave-full-screen-handler)
-        (.on "maximize" maximize-handler)
-        (.on "unmaximize" unmaximize-handler))
+      (.setWindowOpenHandler web-contents (window-open-handler win open-external!))
 
       ;; clear
       (fn []
-        (doto web-contents
-          (.off "context-menu" context-menu-handler)
-          (.off "will-navigate" will-navigate-handler)
-          (.off "did-start-navigation" persist-zoom-level-handler)
-          (.off "page-title-updated" restore-zoom-level-handler))
-
-        (doto win
-          (.off "enter-full-screen" enter-full-screen-handler)
-          (.off "leave-full-screen" leave-full-screen-handler)
-          (.off "maximize" maximize-handler)
-          (.off "unmaximize" unmaximize-handler))))
+        (.off web-contents "context-menu" context-menu-handler)
+        (clear-web-contents!)
+        (clear-window!)))
     #()))

--- a/src/test/electron/db_worker_manager_test.cljs
+++ b/src/test/electron/db_worker_manager_test.cljs
@@ -199,6 +199,35 @@
                      (is false (str "unexpected error: " e))))
           (p/finally (fn [] (done)))))))
 
+(deftest ensure-started-waits-for-stop-all-before-starting-new-runtime
+  (async done
+    (let [start-calls (atom [])
+          stop-calls (atom [])
+          stop-deferred (p/deferred)
+          manager (db-worker/create-manager
+                   {:start-daemon! (fn [repo]
+                                     (swap! start-calls conj repo)
+                                     (p/resolved (runtime repo)))
+                    :stop-daemon! (fn [rt]
+                                    (swap! stop-calls conj (:repo rt))
+                                    stop-deferred)})]
+      (-> (p/let [_ (db-worker/ensure-started! manager "graph-a" :window-1)
+                  _ (let [stop-all-promise (db-worker/stop-all! manager)
+                          ensure-new-promise (db-worker/ensure-started! manager "graph-b" :window-2)]
+                      (p/let [_ (p/delay 0)
+                              _ (do
+                                  (is (= ["graph-a"] @stop-calls))
+                                  (is (= ["graph-a"] @start-calls)))
+                              _ (p/resolve! stop-deferred true)]
+                        (p/all [stop-all-promise ensure-new-promise])))
+                  manager-state @(:state manager)]
+            (is (= ["graph-a" "graph-b"] @start-calls))
+            (is (= "graph-b" (get-in manager-state [:window->repo :window-2])))
+            (is (= #{:window-2} (get-in manager-state [:repos "graph-b" :windows]))))
+          (p/catch (fn [e]
+                     (is false (str "unexpected error: " e))))
+          (p/finally (fn [] (done)))))))
+
 (deftest stop-all-skips-external-runtimes
   (async done
     (let [stop-calls (atom [])


### PR DESCRIPTION
## Summary

This PR makes Electron main-process hot reload more stable during development.

It makes IPC setup idempotent across Shadow CLJS reloads, cleans up window listeners with stable handler references, serializes Electron lifecycle teardown/setup, and prevents db-worker runtimes from being restarted while `stop-all!` is still in progress.

The goal is to reduce development-only hot reload failures such as duplicate `ipcMain.handle` registration and inconsistent db-worker runtime state after repeated watcher reloads.

## Validation

- `bb dev:test -v electron.db-worker-manager-test/ensure-started-waits-for-stop-all-before-starting-new-runtime`
- `bb dev:test -n electron.db-worker-manager-test`
- `clj-kondo --lint src/electron/electron/core.cljs src/electron/electron/db_worker.cljs src/electron/electron/handler.cljs src/electron/electron/updater.cljs src/electron/electron/window.cljs src/test/electron/db_worker_manager_test.cljs`
- `git diff --check`
- `clojure -M:cljs compile electron`
- `clojure -M:cljs compile app`

## Notes

This is primarily a development workflow stability fix. Packaged builds do not use Shadow CLJS Electron main hot reload hooks, but the underlying lifecycle cleanup is now safer and easier to reason about.