### PR TITLE
fix(outliner): exclude query property from refs

### DIFF
--- a/deps/outliner/src/logseq/outliner/pipeline.cljs
+++ b/deps/outliner/src/logseq/outliner/pipeline.cljs
@@ -7,7 +7,8 @@
             [logseq.db.common.entity-plus :as entity-plus]
             [logseq.db.frontend.content :as db-content]
             [logseq.db.frontend.property :as db-property]
-            [logseq.outliner.datascript-report :as ds-report]))
+            [logseq.outliner.datascript-report :as ds-report]
+            [clojure.set :as set]))
 
 (defn filter-deleted-blocks
   [datoms]
@@ -91,19 +92,25 @@
        ;; and look weirdly recursive - https://github.com/logseq/db-test/issues/36
        (not (:logseq.property/created-from-property block))))
 
+(defonce non-ref-properties
+  (set/union private-built-in-props
+             #{:logseq.property/query :logseq.property.publish/published-url :logseq.property/exclude-from-graph-view}))
+
 (defn db-rebuild-block-refs
   "Rebuild block refs for DB graphs, should returns ids"
   [db block & {:keys [page-or-object?-memoized]}]
   (let [block-db-id (:db/id block)
         ;; explicit lookup in order to be nbb compatible
-        properties (->
+        properties (->>
                     (->> (entity-plus/lookup-kv-then-entity (d/entity db block-db-id) :block/properties)
                          (into {}))
-                    ;; both page and parent shouldn't be counted as refs
-                    (dissoc :block/parent :block/page :logseq.property/created-by-ref
-                            :logseq.property.history/block :logseq.property.history/property :logseq.property.history/ref-value))
+                    (remove (fn [[k _v]]
+                              (and (non-ref-properties k)
+                                   ;; query value refs still count
+                                   (not= k :logseq.property/query))))
+                    (into {}))
         property-key-refs (->> (keys properties)
-                               (remove private-built-in-props)
+                               (remove non-ref-properties)
                                (keep (fn [ident]
                                        (:db/id (d/entity db ident)))))
         page-or-object? (or page-or-object?-memoized page-or-object?-helper)

--- a/deps/outliner/src/logseq/outliner/pipeline.cljs
+++ b/deps/outliner/src/logseq/outliner/pipeline.cljs
@@ -102,15 +102,11 @@
   (let [block-db-id (:db/id block)
         ;; explicit lookup in order to be nbb compatible
         properties (->>
-                    (->> (entity-plus/lookup-kv-then-entity (d/entity db block-db-id) :block/properties)
-                         (into {}))
+                    (entity-plus/lookup-kv-then-entity (d/entity db block-db-id) :block/properties)
                     (remove (fn [[k _v]]
-                              (and (non-ref-properties k)
-                                   ;; query value refs still count
-                                   (not= k :logseq.property/query))))
+                              (non-ref-properties k)))
                     (into {}))
         property-key-refs (->> (keys properties)
-                               (remove non-ref-properties)
                                (keep (fn [ident]
                                        (:db/id (d/entity db ident)))))
         page-or-object? (or page-or-object?-memoized page-or-object?-helper)

--- a/deps/outliner/src/logseq/outliner/pipeline.cljs
+++ b/deps/outliner/src/logseq/outliner/pipeline.cljs
@@ -92,7 +92,7 @@
        ;; and look weirdly recursive - https://github.com/logseq/db-test/issues/36
        (not (:logseq.property/created-from-property block))))
 
-(defonce non-ref-properties
+(defonce ^:private non-ref-properties
   (set/union private-built-in-props
              #{:logseq.property/query :logseq.property.publish/published-url :logseq.property/exclude-from-graph-view}))
 

--- a/deps/outliner/test/logseq/outliner/pipeline_test.cljs
+++ b/deps/outliner/test/logseq/outliner/pipeline_test.cljs
@@ -1,5 +1,6 @@
 (ns logseq.outliner.pipeline-test
   (:require [cljs.test :refer [deftest is]]
+            [datascript.core :as d]
             [logseq.common.util.page-ref :as page-ref]
             [logseq.db.test.helper :as db-test]
             [logseq.outliner.pipeline :as outliner-pipeline]))
@@ -12,3 +13,22 @@
     (is (= [(:db/id block)]
            (outliner-pipeline/block-content-refs @conn
                                                  {:block/title (str "ref to " (page-ref/->page-ref (:block/uuid block)))})))))
+
+(deftest db-rebuild-block-refs-for-query-block
+  (let [conn (db-test/create-conn-with-blocks
+              {:pages-and-blocks
+               [{:page {:block/title "page1"}
+                 :blocks [{:block/title "Todo query"
+                           :build/tags [:logseq.class/Query]
+                           :build/properties
+                           {:logseq.property/query
+                            {:build/property-value :block
+                             :block/title "(task Todo)"}}}]}]})
+        block (db-test/find-block-by-content @conn "Todo query")
+        refs (set (outliner-pipeline/db-rebuild-block-refs @conn block))
+        query-property-id (:db/id (d/entity @conn :logseq.property/query))
+        query-class-id (:db/id (d/entity @conn :logseq.class/Query))]
+    (is (contains? refs query-class-id)
+        "#Query class tag is included in :block/refs")
+    (is (not (contains? refs query-property-id))
+        "#Query block does not reference logseq.property/query through :block/refs")))

--- a/deps/outliner/test/logseq/outliner/pipeline_test.cljs
+++ b/deps/outliner/test/logseq/outliner/pipeline_test.cljs
@@ -28,7 +28,10 @@
         refs (set (outliner-pipeline/db-rebuild-block-refs @conn block))
         query-property-id (:db/id (d/entity @conn :logseq.property/query))
         query-class-id (:db/id (d/entity @conn :logseq.class/Query))]
+    (is (some? query-property-id)
+        "Sanity: :logseq.property/query entity exists")
     (is (contains? refs query-class-id)
         "#Query class tag is included in :block/refs")
     (is (not (contains? refs query-property-id))
+        "#Query block does not reference logseq.property/query through :block/refs"))
         "#Query block does not reference logseq.property/query through :block/refs")))


### PR DESCRIPTION
This pr excludes `:logseq.property/query，:logseq.property.publish/published-url :logseq.property/exclude-from-graph-view` when building block refs.

Related to https://github.com/logseq/logseq/pull/12767