### PR TITLE
fix: db-sync missing data repair

### DIFF
--- a/deps/db-sync/src/logseq/db_sync/malli_schema.cljs
+++ b/deps/db-sync/src/logseq/db_sync/malli_schema.cljs
@@ -52,6 +52,7 @@
    [:t {:optional true} :int]
    [:success-tx-ids {:optional true} [:sequential :uuid]]
    [:failed-tx-id {:optional true} :uuid]
+   [:missing-block-uuids {:optional true} [:sequential :uuid]]
    [:error-detail {:optional true} :string]
    [:data {:optional true} :string]])
 
@@ -79,6 +80,10 @@
    [:type [:= "tx/batch/ok"]]
    [:t :int]
    [:checksum {:optional true} :string]])
+
+(def repair-blocks-response-schema
+  [:map
+   [:tx :string]])
 
 (def ws-server-message-schema
   [:multi {:dispatch :type}
@@ -263,6 +268,7 @@
    :worker/health http-ok-response-schema
    :sync/health http-ok-response-schema
    :sync/pull pull-ok-schema
+   :sync/repair-blocks repair-blocks-response-schema
    :sync/tx-batch [:or tx-batch-ok-schema tx-reject-schema http-error-response-schema]
    :sync/snapshot-download snapshot-download-response-schema
    :sync/snapshot-upload snapshot-upload-response-schema

--- a/deps/db-sync/src/logseq/db_sync/repair.cljs
+++ b/deps/db-sync/src/logseq/db_sync/repair.cljs
@@ -8,7 +8,9 @@
 
 (defn- ref-attr?
   [db attr]
-  (= :db.type/ref (get-in (d/schema db) [attr :db/valueType])))
+  (= :db.type/ref
+     (or (get-in (d/schema db) [attr :db/valueType])
+         (:db/valueType (d/entity db attr)))))
 
 (defn- repair-ref-value
   [db repair-uuid-set attr value]
@@ -32,9 +34,37 @@
                   (:a datom)
                   (repair-ref-value db repair-uuid-set (:a datom) (:v datom))])))))
 
+(defn- lookup-ref-block-uuid
+  [value]
+  (when (and (vector? value)
+             (= :block/uuid (first value))
+             (uuid? (second value)))
+    (second value)))
+
+(defn- missing-dependency-uuids
+  [tx-data seen]
+  (->> tx-data
+       (keep (fn [[_op _e _attr value]]
+               (lookup-ref-block-uuid value)))
+       (remove seen)
+       distinct
+       vec))
+
+(defn- block-uuids-with-dependencies
+  [db block-uuids]
+  (loop [pending (vec (distinct block-uuids))
+         seen #{}
+         ordered []]
+    (if (seq pending)
+      (let [seen' (into seen pending)
+            tx-data (mapcat (partial block-tx-data db seen') pending)
+            deps (missing-dependency-uuids tx-data seen')]
+        (recur deps seen' (into ordered pending)))
+      ordered)))
+
 (defn tx-data
   [db block-uuids]
-  (let [block-uuids* (vec (distinct block-uuids))
+  (let [block-uuids* (block-uuids-with-dependencies db block-uuids)
         repair-uuid-set (set block-uuids*)]
     (->> block-uuids*
          (mapcat (partial block-tx-data db repair-uuid-set))

--- a/deps/db-sync/src/logseq/db_sync/repair.cljs
+++ b/deps/db-sync/src/logseq/db_sync/repair.cljs
@@ -1,0 +1,41 @@
+(ns logseq.db-sync.repair
+  "Builds db-sync repair transactions for missing block entities."
+  (:require [datascript.core :as d]))
+
+(defn- block-temp-id
+  [block-uuid]
+  (str "repair-block-" block-uuid))
+
+(defn- ref-attr?
+  [db attr]
+  (= :db.type/ref (get-in (d/schema db) [attr :db/valueType])))
+
+(defn- repair-ref-value
+  [db repair-uuid-set attr value]
+  (if-let [entity (and (ref-attr? db attr)
+                       (number? value)
+                       (d/entity db value))]
+    (if-let [block-uuid (:block/uuid entity)]
+      (if (contains? repair-uuid-set block-uuid)
+        (block-temp-id block-uuid)
+        [:block/uuid block-uuid])
+      (or (:db/ident entity) value))
+    value))
+
+(defn block-tx-data
+  [db repair-uuid-set block-uuid]
+  (when-let [eid (d/entid db [:block/uuid block-uuid])]
+    (->> (d/datoms db :eavt eid)
+         (mapv (fn [datom]
+                 [:db/add
+                  (block-temp-id block-uuid)
+                  (:a datom)
+                  (repair-ref-value db repair-uuid-set (:a datom) (:v datom))])))))
+
+(defn tx-data
+  [db block-uuids]
+  (let [block-uuids* (vec (distinct block-uuids))
+        repair-uuid-set (set block-uuids*)]
+    (->> block-uuids*
+         (mapcat (partial block-tx-data db repair-uuid-set))
+         vec)))

--- a/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
+++ b/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
@@ -8,6 +8,7 @@
             [logseq.db-sync.common :as common]
             [logseq.db-sync.index :as index]
             [logseq.db-sync.protocol :as protocol]
+            [logseq.db-sync.repair :as repair]
             [logseq.db-sync.snapshot :as snapshot]
             [logseq.db-sync.storage :as storage]
             [logseq.db-sync.tx-sanitize :as tx-sanitize]
@@ -301,47 +302,11 @@
     (catch :default _
       nil)))
 
-(defn- ref-attr?
-  [db attr]
-  (= :db.type/ref (get-in (d/schema db) [attr :db/valueType])))
-
-(defn- ref-value
-  [db attr v]
-  (if-let [entity (and (ref-attr? db attr)
-                       (number? v)
-                       (d/entity db v))]
-    (if-let [block-uuid (:block/uuid entity)]
-      [:block/uuid block-uuid]
-      (or (:db/ident entity) v))
-    v))
-
-(defn- many-attr?
-  [db attr]
-  (= :db.cardinality/many (get-in (d/schema db) [attr :db/cardinality])))
-
-(defn- assoc-repair-attr
-  [db m attr value]
-  (let [value' (ref-value db attr value)]
-    (if (many-attr? db attr)
-      (update m attr (fnil conj #{}) value')
-      (assoc m attr value'))))
-
-(defn- repair-block-map
-  [db block-uuid]
-  (when-let [eid (d/entid db [:block/uuid block-uuid])]
-    (let [datoms (d/datoms db :eavt eid)]
-      (reduce (fn [m datom]
-                (assoc-repair-attr db m (:a datom) (:v datom)))
-              {}
-              datoms))))
-
 (defn repair-blocks-response
   [^js self block-uuids]
   (ensure-conn! self)
   (let [db @(.-conn self)
-        tx-data (->> block-uuids
-                     (keep (partial repair-block-map db))
-                     vec)]
+        tx-data (repair/tx-data db block-uuids)]
     {:tx (protocol/tx->transit tx-data)}))
 
 (defn- block-uuid-lookup-ref

--- a/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
+++ b/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
@@ -1,5 +1,6 @@
 (ns logseq.db-sync.worker.handler.sync
   (:require [clojure.string :as string]
+            [datascript.core :as d]
             [lambdaisland.glogi :as log]
             [logseq.db :as ldb]
             [logseq.db-sync.batch :as batch]
@@ -292,6 +293,69 @@
              :txs txs}
       (string? checksum) (assoc :checksum checksum))))
 
+(defn- parse-uuid-param
+  [value]
+  (try
+    (when (seq value)
+      (uuid value))
+    (catch :default _
+      nil)))
+
+(defn- ref-value
+  [db v]
+  (if-let [entity (and (number? v) (d/entity db v))]
+    (if-let [block-uuid (:block/uuid entity)]
+      [:block/uuid block-uuid]
+      (or (:db/ident entity) v))
+    v))
+
+(defn- many-attr?
+  [db attr]
+  (= :db.cardinality/many (get-in (d/schema db) [attr :db/cardinality])))
+
+(defn- assoc-repair-attr
+  [db m attr value]
+  (let [value' (ref-value db value)]
+    (if (many-attr? db attr)
+      (update m attr (fnil conj #{}) value')
+      (assoc m attr value'))))
+
+(defn- repair-block-map
+  [db block-uuid]
+  (when-let [eid (d/entid db [:block/uuid block-uuid])]
+    (let [datoms (d/datoms db :eavt eid)]
+      (reduce (fn [m datom]
+                (assoc-repair-attr db m (:a datom) (:v datom)))
+              {}
+              datoms))))
+
+(defn repair-blocks-response
+  [^js self block-uuids]
+  (ensure-conn! self)
+  (let [db @(.-conn self)
+        tx-data (->> block-uuids
+                     (keep (partial repair-block-map db))
+                     vec)]
+    {:tx (protocol/tx->transit tx-data)}))
+
+(defn- block-uuid-lookup-ref
+  [entity-id]
+  (when (and (sequential? entity-id)
+             (= :block/uuid (first entity-id))
+             (uuid? (second entity-id)))
+    (second entity-id)))
+
+(defn- missing-block-uuids-from-error
+  [error]
+  (loop [e error
+         result []]
+    (if e
+      (let [missing-uuid (block-uuid-lookup-ref (:entity-id (ex-data e)))]
+        (recur (ex-cause e)
+               (cond-> result
+                 missing-uuid (conj missing-uuid))))
+      (-> result distinct vec))))
+
 (defn- import-snapshot! [^js self rows reset?]
   (let [sql (.-sql self)]
     (ensure-schema! self)
@@ -342,11 +406,14 @@
                                  (boolean (apply-tx-entry! conn tx-entry))
                                  (catch :default e
                                    (log/error :db-sync/transact-failed e)
-                                   (throw (ex-info "tx entry apply failed"
-                                                   (cond-> {:type :db-sync/tx-entry-failed
-                                                            :successful-tx-ids successful-tx-ids}
-                                                     tx-id (assoc :failed-tx-id tx-id))
-                                                   e))))
+                                   (let [missing-block-uuids (missing-block-uuids-from-error e)]
+                                     (throw (ex-info "tx entry apply failed"
+                                                     (cond-> {:type :db-sync/tx-entry-failed
+                                                              :successful-tx-ids successful-tx-ids}
+                                                       tx-id (assoc :failed-tx-id tx-id)
+                                                       (seq missing-block-uuids)
+                                                       (assoc :missing-block-uuids missing-block-uuids))
+                                                     e)))))
                 next-successful-tx-ids (cond-> successful-tx-ids
                                          tx-id (conj tx-id))]
             (recur (next remaining)
@@ -387,7 +454,7 @@
               (string? checksum) (assoc :checksum checksum)))
           (catch :default e
             (let [new-t (t-now self)
-                  {:keys [successful-tx-ids failed-tx-id]}
+                  {:keys [successful-tx-ids failed-tx-id missing-block-uuids]}
                   (ex-data e)]
               (log/error :db-sync/transact-failed e)
               (when (> new-t current-t)
@@ -398,7 +465,8 @@
                        :error-detail (str e)
                        :t new-t}
                 (seq successful-tx-ids) (assoc :success-tx-ids successful-tx-ids)
-                failed-tx-id (assoc :failed-tx-id failed-tx-id)))))
+                failed-tx-id (assoc :failed-tx-id failed-tx-id)
+                (seq missing-block-uuids) (assoc :missing-block-uuids missing-block-uuids)))))
         {:type "tx/reject"
          :reason "empty tx data"}))))
 
@@ -413,6 +481,26 @@
         (if-not ready-for-sync?
           (http/error-response "graph not ready" 409)
           (http/json-response :sync/pull (pull-response self since)))))))
+
+(defn- handle-sync-repair-blocks
+  [^js self request ^js url]
+  (let [graph-id (graph-id-from-request request)
+        block-uuids (->> (.getAll (.-searchParams url) "uuid")
+                         (map parse-uuid-param)
+                         (remove nil?)
+                         distinct
+                         vec)]
+    (p/let [ready-for-sync? (<ready-for-sync? self graph-id)]
+      (cond
+        (not ready-for-sync?)
+        (http/error-response "graph not ready" 409)
+
+        (empty? block-uuids)
+        (http/bad-request "missing block uuid")
+
+        :else
+        (http/json-response :sync/repair-blocks
+                            (repair-blocks-response self block-uuids))))))
 
 (defn- normalize-diagnostic-block
   [{:keys [block/uuid block/parent block/page block/order] :as block}]
@@ -599,6 +687,9 @@
 
     :sync/pull
     (handle-sync-pull self url)
+
+    :sync/repair-blocks
+    (handle-sync-repair-blocks self request url)
 
     :sync/checksum-diagnostics
     (handle-sync-checksum-diagnostics self request)

--- a/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
+++ b/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
@@ -1,6 +1,5 @@
 (ns logseq.db-sync.worker.handler.sync
   (:require [clojure.string :as string]
-            [datascript.core :as d]
             [lambdaisland.glogi :as log]
             [logseq.db :as ldb]
             [logseq.db-sync.batch :as batch]

--- a/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
+++ b/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
@@ -301,9 +301,15 @@
     (catch :default _
       nil)))
 
+(defn- ref-attr?
+  [db attr]
+  (= :db.type/ref (get-in (d/schema db) [attr :db/valueType])))
+
 (defn- ref-value
-  [db v]
-  (if-let [entity (and (number? v) (d/entity db v))]
+  [db attr v]
+  (if-let [entity (and (ref-attr? db attr)
+                       (number? v)
+                       (d/entity db v))]
     (if-let [block-uuid (:block/uuid entity)]
       [:block/uuid block-uuid]
       (or (:db/ident entity) v))
@@ -315,7 +321,7 @@
 
 (defn- assoc-repair-attr
   [db m attr value]
-  (let [value' (ref-value db value)]
+  (let [value' (ref-value db attr value)]
     (if (many-attr? db attr)
       (update m attr (fnil conj #{}) value')
       (assoc m attr value'))))

--- a/deps/db-sync/src/logseq/db_sync/worker/routes/sync.cljs
+++ b/deps/db-sync/src/logseq/db_sync/worker/routes/sync.cljs
@@ -4,6 +4,7 @@
 (def ^:private route-data
   [["/health" {:methods {"GET" :sync/health}}]
    ["/pull" {:methods {"GET" :sync/pull}}]
+   ["/repair/blocks" {:methods {"GET" :sync/repair-blocks}}]
    ["/checksum/diagnostics" {:methods {"GET" :sync/checksum-diagnostics}}]
    ["/snapshot/download" {:methods {"GET" :sync/snapshot-download}}]
    ["/snapshot/stream" {:methods {"GET" :sync/snapshot-stream}}]

--- a/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
@@ -567,22 +567,26 @@
     (let [{:keys [conn self]} (make-server-self)
           page-uuid (random-uuid)
           block-uuid (random-uuid)]
-      (d/transact! conn [{:db/id -1
-                          :block/uuid page-uuid
-                          :block/title "page"
-                          :block/name "page"}
-                         {:db/id -2
-                          :block/uuid block-uuid
-                          :block/title "child"
-                          :block/page [:block/uuid page-uuid]
-                          :block/parent [:block/uuid page-uuid]
-                          :block/order "a0"}])
+      (d/transact!
+       conn
+       [{:db/id -1
+         :block/uuid page-uuid
+         :block/title "page"
+         :block/name "page"}
+        {:db/id -2
+         :block/uuid block-uuid
+         :block/title "child"
+         :block/page [:block/uuid page-uuid]
+         :block/parent [:block/uuid page-uuid]
+         :block/level 1
+         :block/order "a0"}])
       (let [{:keys [tx]} (sync-handler/repair-blocks-response self [block-uuid])
             [block-map] (protocol/transit->tx tx)]
         (is (= block-uuid (:block/uuid block-map)))
         (is (= "child" (:block/title block-map)))
         (is (= [:block/uuid page-uuid] (:block/page block-map)))
         (is (= [:block/uuid page-uuid] (:block/parent block-map)))
+        (is (= 1 (:block/level block-map)))
         (is (= "a0" (:block/order block-map)))))))
 
 (deftest tx-batch-keeps-created-by-ref-lookup-payload-test

--- a/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
@@ -563,7 +563,7 @@
         (is (empty? (:txs pull-response)))))))
 
 (deftest repair-blocks-response-returns-server-block-data-test
-  (testing "repair block response returns transactable maps with lookup refs"
+  (testing "repair block response returns transactable datoms with lookup refs"
     (let [{:keys [conn self]} (make-server-self)
           page-uuid (random-uuid)
           block-uuid (random-uuid)]
@@ -580,14 +580,25 @@
          :block/parent [:block/uuid page-uuid]
          :user.property/rating 1
          :block/order "a0"}])
-      (let [{:keys [tx]} (sync-handler/repair-blocks-response self [block-uuid])
-            [block-map] (protocol/transit->tx tx)]
-        (is (= block-uuid (:block/uuid block-map)))
-        (is (= "child" (:block/title block-map)))
-        (is (= [:block/uuid page-uuid] (:block/page block-map)))
-        (is (= [:block/uuid page-uuid] (:block/parent block-map)))
-        (is (= 1 (:user.property/rating block-map)))
-        (is (= "a0" (:block/order block-map)))))))
+      (let [{:keys [tx]} (sync-handler/repair-blocks-response self [page-uuid block-uuid])
+            tx-data (protocol/transit->tx tx)
+            page-temp-id (str "repair-block-" page-uuid)
+            temp-id (str "repair-block-" block-uuid)
+            attr->value (->> tx-data
+                             (filter (fn [[_op e]] (= temp-id e)))
+                             (map (fn [[op e attr value]]
+                                    [attr {:op op :e e :value value}]))
+                             (into {}))]
+        (is (every? (fn [[op e _attr _value]]
+                      (and (= :db/add op)
+                           (contains? #{page-temp-id temp-id} e)))
+                    tx-data))
+        (is (= block-uuid (get-in attr->value [:block/uuid :value])))
+        (is (= "child" (get-in attr->value [:block/title :value])))
+        (is (= page-temp-id (get-in attr->value [:block/page :value])))
+        (is (= page-temp-id (get-in attr->value [:block/parent :value])))
+        (is (= 1 (get-in attr->value [:user.property/rating :value])))
+        (is (= "a0" (get-in attr->value [:block/order :value])))))))
 
 (deftest tx-batch-keeps-created-by-ref-lookup-payload-test
   (testing "created-by lookup payload is preserved for save-block tx"

--- a/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
@@ -578,7 +578,7 @@
          :block/title "child"
          :block/page [:block/uuid page-uuid]
          :block/parent [:block/uuid page-uuid]
-         :block/level 1
+         :user.property/rating 1
          :block/order "a0"}])
       (let [{:keys [tx]} (sync-handler/repair-blocks-response self [block-uuid])
             [block-map] (protocol/transit->tx tx)]
@@ -586,7 +586,7 @@
         (is (= "child" (:block/title block-map)))
         (is (= [:block/uuid page-uuid] (:block/page block-map)))
         (is (= [:block/uuid page-uuid] (:block/parent block-map)))
-        (is (= 1 (:block/level block-map)))
+        (is (= 1 (:user.property/rating block-map)))
         (is (= "a0" (:block/order block-map)))))))
 
 (deftest tx-batch-keeps-created-by-ref-lookup-payload-test

--- a/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
@@ -1,5 +1,6 @@
 (ns logseq.db-sync.worker-handler-sync-test
   (:require [cljs.test :refer [async deftest is testing]]
+            [clojure.set :as set]
             [datascript.core :as d]
             [logseq.db-sync.checksum :as sync-checksum]
             [logseq.db-sync.common :as common]
@@ -599,6 +600,106 @@
         (is (= page-temp-id (get-in attr->value [:block/parent :value])))
         (is (= 1 (get-in attr->value [:user.property/rating :value])))
         (is (= "a0" (get-in attr->value [:block/order :value])))))))
+
+(deftest repair-blocks-response-includes-dependent-blocks-test
+  (testing "view, history, recycled, and delete repair responses include referenced block data"
+    (let [{:keys [conn self]} (make-server-self)
+          class-uuid (random-uuid)
+          property-uuid (random-uuid)
+          view-uuid (random-uuid)
+          history-uuid (random-uuid)
+          recycled-uuid (random-uuid)]
+      (d/transact!
+       conn
+       [{:db/id -10
+         :db/ident :logseq.property/view-for
+         :db/cardinality :db.cardinality/one
+         :db/valueType :db.type/ref}
+        {:db/id -11
+         :db/ident :logseq.property.view/group-by-property
+         :db/cardinality :db.cardinality/one
+         :db/valueType :db.type/ref}
+        {:db/id -12
+         :db/ident :logseq.property.recycle/original-parent
+         :db/cardinality :db.cardinality/one
+         :db/valueType :db.type/ref}
+        {:db/id -13
+         :db/ident :logseq.property.recycle/original-page
+         :db/cardinality :db.cardinality/one
+         :db/valueType :db.type/ref}
+        {:db/id -14
+         :db/ident :logseq.property.history/block
+         :db/cardinality :db.cardinality/one
+         :db/valueType :db.type/ref}
+        {:db/id -15
+         :db/ident :logseq.property.history/property
+         :db/cardinality :db.cardinality/one
+         :db/valueType :db.type/ref}
+        {:db/id -16
+         :db/ident :logseq.property.history/ref-value
+         :db/cardinality :db.cardinality/one
+         :db/valueType :db.type/ref}
+        {:db/id -1
+         :db/ident :user.class/repair-view-target
+         :block/uuid class-uuid
+         :block/title "Repair View Target"
+         :block/name "repair view target"
+         :block/order "a0"
+         :block/created-at 1
+         :block/updated-at 1}
+        {:db/id -2
+         :db/ident :user.property/repair-property
+         :block/uuid property-uuid
+         :block/title "Repair Property"
+         :block/name "repair property"
+         :block/order "a1"
+         :block/created-at 1
+         :block/updated-at 1
+         :logseq.property/type :default
+         :db/cardinality :db.cardinality/one
+         :db/index true}
+        {:db/id -3
+         :block/uuid view-uuid
+         :block/title "Repair View"
+         :block/page -1
+         :block/parent -1
+         :block/order "a2"
+         :block/created-at 1
+         :block/updated-at 1
+         :logseq.property/view-for -1
+         :logseq.property.view/group-by-property -2}
+        {:db/id -4
+         :block/uuid recycled-uuid
+         :block/title "Repair Recycled"
+         :block/page -1
+         :block/parent -1
+         :block/order "a3"
+         :block/created-at 1
+         :block/updated-at 1
+         :logseq.property/deleted-at 2
+         :logseq.property.recycle/original-parent -1
+         :logseq.property.recycle/original-page -1}
+        {:db/id -5
+         :block/uuid history-uuid
+         :block/title "Repair History"
+         :block/page -1
+         :block/parent -1
+         :block/order "a4"
+         :block/created-at 1
+         :block/updated-at 1
+         :logseq.property.history/block -4
+         :logseq.property.history/property -2
+         :logseq.property.history/ref-value -1}])
+      (let [{:keys [tx]} (sync-handler/repair-blocks-response self [view-uuid history-uuid recycled-uuid])
+            tx-data (protocol/transit->tx tx)
+            repaired-uuids (->> tx-data
+                                (filter (fn [[op _e attr _value]]
+                                          (and (= :db/add op)
+                                               (= :block/uuid attr))))
+                                (map (fn [[_op _e _attr value]] value))
+                                set)]
+        (is (set/subset? #{class-uuid property-uuid view-uuid history-uuid recycled-uuid}
+                         repaired-uuids))))))
 
 (deftest tx-batch-keeps-created-by-ref-lookup-payload-test
   (testing "created-by lookup payload is preserved for save-block tx"

--- a/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
@@ -555,11 +555,35 @@
       (is (= "tx/reject" (:type response)))
       (is (= "db transact failed" (:reason response)))
       (is (= 0 (:t response)))
+      (is (= [missing-uuid] (:missing-block-uuids response)))
       (is (nil? (d/entity @conn [:block/uuid created-uuid])))
       (is (nil? (d/entity @conn [:block/uuid missing-uuid])))
       (let [pull-response (sync-handler/pull-response self 0)]
         (is (= "pull/ok" (:type pull-response)))
         (is (empty? (:txs pull-response)))))))
+
+(deftest repair-blocks-response-returns-server-block-data-test
+  (testing "repair block response returns transactable maps with lookup refs"
+    (let [{:keys [conn self]} (make-server-self)
+          page-uuid (random-uuid)
+          block-uuid (random-uuid)]
+      (d/transact! conn [{:db/id -1
+                          :block/uuid page-uuid
+                          :block/title "page"
+                          :block/name "page"}
+                         {:db/id -2
+                          :block/uuid block-uuid
+                          :block/title "child"
+                          :block/page [:block/uuid page-uuid]
+                          :block/parent [:block/uuid page-uuid]
+                          :block/order "a0"}])
+      (let [{:keys [tx]} (sync-handler/repair-blocks-response self [block-uuid])
+            [block-map] (protocol/transit->tx tx)]
+        (is (= block-uuid (:block/uuid block-map)))
+        (is (= "child" (:block/title block-map)))
+        (is (= [:block/uuid page-uuid] (:block/page block-map)))
+        (is (= [:block/uuid page-uuid] (:block/parent block-map)))
+        (is (= "a0" (:block/order block-map)))))))
 
 (deftest tx-batch-keeps-created-by-ref-lookup-payload-test
   (testing "created-by lookup payload is preserved for save-block tx"

--- a/deps/db-sync/test/logseq/db_sync/worker_sync_routes_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/worker_sync_routes_test.cljs
@@ -8,6 +8,8 @@
       (is (= :sync/health (:handler match))))
     (let [match (sync-routes/match-route "GET" "/pull")]
       (is (= :sync/pull (:handler match))))
+    (let [match (sync-routes/match-route "GET" "/repair/blocks")]
+      (is (= :sync/repair-blocks (:handler match))))
     (let [match (sync-routes/match-route "GET" "/snapshot/download")]
       (is (= :sync/snapshot-download (:handler match))))
     (let [match (sync-routes/match-route "GET" "/snapshot/stream")]

--- a/docs/agent-guide/db-sync/protocol.md
+++ b/docs/agent-guide/db-sync/protocol.md
@@ -94,7 +94,7 @@
   - Error response (409): `{"error":"graph not ready"}` when bootstrap upload/import has not finished.
 - `GET /sync/:graph-id/repair/blocks?uuid=<block-uuid>&uuid=<block-uuid>`
   - Fetch server-authoritative block data for client repair while applying remote txs.
-  - Response: `{"tx":"<tx-transit>"}` where `tx` is a Transit-encoded vector of transactable block maps.
+  - Response: `{"tx":"<tx-transit>"}` where `tx` is a Transit-encoded Datascript transaction vector of `[:db/add ...]` datoms. Repaired block entities use `repair-block-<uuid>` temp ids and lookup refs for referenced blocks outside the repair payload.
   - Error response (400): `{"error":"missing block uuid"}`.
   - Error response (409): `{"error":"graph not ready"}` when bootstrap upload/import has not finished.
 - `POST /sync/:graph-id/tx/batch`

--- a/docs/agent-guide/db-sync/protocol.md
+++ b/docs/agent-guide/db-sync/protocol.md
@@ -92,6 +92,11 @@
   - Same as WS pull. Response: `{"type":"pull/ok","t":<t>,"checksum":"<hex>","txs":[{"t":<t>,"tx":"<tx-transit>","outliner-op":"<keyword?>"}...]}`.
   - Error response (400): `{"error":"invalid since"}`.
   - Error response (409): `{"error":"graph not ready"}` when bootstrap upload/import has not finished.
+- `GET /sync/:graph-id/repair/blocks?uuid=<block-uuid>&uuid=<block-uuid>`
+  - Fetch server-authoritative block data for client repair while applying remote txs.
+  - Response: `{"tx":"<tx-transit>"}` where `tx` is a Transit-encoded vector of transactable block maps.
+  - Error response (400): `{"error":"missing block uuid"}`.
+  - Error response (409): `{"error":"graph not ready"}` when bootstrap upload/import has not finished.
 - `POST /sync/:graph-id/tx/batch`
   - Same as WS tx/batch. Body: `{"t-before":<t>,"txs":[{"tx":"<tx-transit>","tx-id":"<uuid?>","outliner-op":"<keyword?>"}, ...]}`.
   - Response: `{"type":"tx/batch/ok","t":<t>,"checksum":"<hex>"}` or `{"type":"tx/reject","reason":...}`.

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -275,6 +275,12 @@
         [_valid? errors] (db-validate/validate-tx-report tx-report nil)]
     errors))
 
+(defn- safe-invalid-tx-errors
+  [db tx-data tx-meta]
+  (try
+    (invalid-tx-errors db tx-data tx-meta)
+    (catch :default _ nil)))
+
 (defn- block-uuid-lookup-ref
   [db v]
   (when (and (vector? v)
@@ -420,9 +426,7 @@
                 tx-meta (apply-tx-meta remote-tx)
                 errors (when (and (seq tx-data)
                                   (missing-datom-repair-tx? tx-data))
-                         (try
-                           (invalid-tx-errors db tx-data tx-meta)
-                           (catch :default _ nil)))]
+                         (safe-invalid-tx-errors db tx-data tx-meta))]
             (when (seq errors)
               (repair-block-uuids-in-tx-data db tx-data)))))
        distinct
@@ -758,7 +762,7 @@
               tx-meta (apply-tx-meta remote-tx)
               invalid-retry? (and allow-invalid-repair?
                                   (missing-datom-repair-tx? tx-data)
-                                  (seq (invalid-tx-errors db tx-data tx-meta)))
+                                  (seq (safe-invalid-tx-errors db tx-data tx-meta)))
               repair-block-uuids (when invalid-retry?
                                    (repair-block-uuids-in-tx-data db tx-data))
               report (ldb/transact! conn tx-data

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -49,7 +49,8 @@
   (true? (get @*repo->upload-stopped? repo)))
 
 (declare enqueue-asset-task!
-         fix-tx!)
+         fix-tx!
+         resolve-temp-id)
 
 (defn- current-client [repo]
   (sync-presence/current-client worker-state/*db-sync-client repo))
@@ -306,9 +307,10 @@
 (defn- missing-block-uuids-in-tx-data
   [db tx-data]
   (->> tx-data
-       (keep (fn [item]
-               (when (vector? item)
-                 (block-uuid-lookup-ref db (second item)))))
+       (mapcat (fn [item]
+                 (when (vector? item)
+                   (keep (partial block-uuid-lookup-ref db)
+                         [(second item) (nth item 3 nil)]))))
        distinct
        vec))
 
@@ -412,7 +414,7 @@
                           {:repo repo
                            :status (.-status resp)
                            :body body})))))
-    (p/resolved nil)))
+    nil))
 
 (defn- <decrypt-repair-tx-map-entry
   [aes-key [attr value]]
@@ -433,26 +435,109 @@
   [aes-key tx-data]
   (p/all (mapv (partial <decrypt-repair-tx-item aes-key) tx-data)))
 
+(defn- <server-repair-blocks-tx-data
+  [repo client block-uuids]
+  (if (seq block-uuids)
+    (if-let [repair-tx-data-fn (:repair-blocks-tx-data-fn client)]
+      (repair-tx-data-fn block-uuids)
+      (p/let [graph-e2ee? (sync-crypt/graph-e2ee? repo)
+              aes-key (when graph-e2ee?
+                        (sync-crypt/<ensure-graph-aes-key repo (:graph-id client)))
+              _ (when (and graph-e2ee? (nil? aes-key))
+                  (fail-fast :db-sync/missing-field {:repo repo :field :aes-key}))
+              tx-data (<fetch-repair-blocks repo client block-uuids)]
+        (if (seq tx-data)
+          (if aes-key
+            (<decrypt-repair-tx-data aes-key tx-data)
+            (p/resolved tx-data))
+          (p/resolved nil))))
+    nil))
+
+(defn- repair-map-block-uuid
+  [item]
+  (when (map? item)
+    (:block/uuid item)))
+
+(defn- repair-temp-id
+  [block-uuid]
+  (str "repair-block-" block-uuid))
+
+(defn- repair-ref->temp-id
+  [uuid->temp-id v]
+  (cond
+    (and (vector? v)
+         (= :block/uuid (first v))
+         (contains? uuid->temp-id (second v)))
+    (get uuid->temp-id (second v))
+
+    (map? v)
+    (update-vals v (partial repair-ref->temp-id uuid->temp-id))
+
+    (vector? v)
+    (mapv (partial repair-ref->temp-id uuid->temp-id) v)
+
+    (set? v)
+    (set (map (partial repair-ref->temp-id uuid->temp-id) v))
+
+    (seq? v)
+    (doall (map (partial repair-ref->temp-id uuid->temp-id) v))
+
+    :else
+    v))
+
+(defn- with-repair-temp-ids
+  [tx-data]
+  (let [uuid->temp-id (->> tx-data
+                           (keep repair-map-block-uuid)
+                           distinct
+                           (map (juxt identity repair-temp-id))
+                           (into {}))]
+    (mapv (fn [item]
+            (let [item' (repair-ref->temp-id uuid->temp-id item)]
+              (if-let [block-uuid (repair-map-block-uuid item)]
+                (assoc item' :db/id (repair-temp-id block-uuid))
+                item')))
+          tx-data)))
+
+(defn- maybe-apply-repair-tx-data!
+  [conn tx-data]
+  (when (seq tx-data)
+    (ldb/transact! conn (with-repair-temp-ids tx-data) (sync-fix-tx-meta))))
+
 (defn- <apply-server-repair-blocks!
   [repo client conn block-uuids]
   (if (seq block-uuids)
-    (p/let [graph-e2ee? (sync-crypt/graph-e2ee? repo)
-            aes-key (when graph-e2ee?
-                      (sync-crypt/<ensure-graph-aes-key repo (:graph-id client)))
-            _ (when (and graph-e2ee? (nil? aes-key))
-                (fail-fast :db-sync/missing-field {:repo repo :field :aes-key}))
-            tx-data (<fetch-repair-blocks repo client block-uuids)]
-      (when (seq tx-data)
-        (p/let [tx-data* (if aes-key
-                           (<decrypt-repair-tx-data aes-key tx-data)
-                           (p/resolved tx-data))]
-          (ldb/transact! conn tx-data* (sync-fix-tx-meta)))))
-    (p/resolved nil)))
+    (let [tx-data (<server-repair-blocks-tx-data repo client block-uuids)]
+      (if (p/promise? tx-data)
+        (p/let [tx-data* tx-data]
+          (maybe-apply-repair-tx-data! conn tx-data*))
+        (maybe-apply-repair-tx-data! conn tx-data)))
+    nil))
 
 (defn- remote-txs-missing-block-uuids
   [db remote-txs]
   (->> remote-txs
        (mapcat (comp (partial missing-block-uuids-in-tx-data db) :tx-data))
+       distinct
+       vec))
+
+(defn- remote-txs-invalid-repair-block-uuids
+  [db remote-txs]
+  (->> remote-txs
+       (mapcat
+        (fn [remote-tx]
+          (let [tx-data (some->> (:tx-data remote-tx)
+                                 (map (partial resolve-temp-id db))
+                                 (tx-sanitize/sanitize-tx db)
+                                 seq)
+                tx-meta (apply-tx-meta remote-tx)
+                errors (when (and (seq tx-data)
+                                  (missing-datom-repair-tx? tx-data))
+                         (try
+                           (invalid-tx-errors db tx-data tx-meta)
+                           (catch :default _ nil)))]
+            (when (seq errors)
+              (repair-block-uuids-in-tx-data db tx-data)))))
        distinct
        vec))
 
@@ -1030,8 +1115,11 @@
         (outliner-core/delete-blocks! conn blocks opts)))
 
     :create-page
-    (let [[title opts] args]
-      (outliner-page/create! conn title opts))
+    (let [[title opts] args
+          page-uuid (:uuid opts)]
+      (when-not (and (uuid? page-uuid)
+                     (d/entity @conn [:block/uuid page-uuid]))
+        (outliner-page/create! conn title opts)))
 
     :delete-page
     (let [[page-uuid opts] args]
@@ -1141,7 +1229,8 @@
     (fix-tx! conn tx-report (sync-fix-tx-meta))))
 
 (defn- apply-remote-tx-with-local-changes!
-  [{:keys [repo conn local-txs remote-txs]}]
+  [{:keys [repo conn local-txs remote-txs pre-repair-tx-data post-repair-tx-data
+           prefetched-repair-block-uuids]}]
   (let [tx-meta {:rtc-tx? true
                  :with-local-changes? true}
         *rebase-tx-reports (atom [])
@@ -1159,9 +1248,14 @@
                        (fn [conn]
                          (reverse-local-txs! conn local-txs)
 
+                         (when (seq pre-repair-tx-data)
+                           (maybe-apply-repair-tx-data! conn pre-repair-tx-data))
+
                          (reset! *remote-tx-results
-                                 (transact-remote-txs! conn remote-txs
-                                                       :allow-invalid-repair? false))
+                                 (transact-remote-txs! conn remote-txs))
+
+                         (when (seq post-repair-tx-data)
+                           (maybe-apply-repair-tx-data! conn post-repair-tx-data))
 
                          (reset! *rebase-results
                                  (rebase-local-txs! repo conn local-txs rebase-db-before)))
@@ -1173,21 +1267,21 @@
           (handle-local-tx! repo tx-report))
 
         (repair-applied-txs! conn tx-report)
+        ;; Mark only explicitly stale rebases as non-pending.
+        ;; Do not infer stale via tx-id set-diff, which can hide still-valid
+        ;; pending txs that should wait for server ack/reject.
+        (let [stale-tx-ids (->> @*rebase-results
+                                (filter (fn [{:keys [status]}]
+                                          (contains? #{:failed :no-op} status)))
+                                (keep :tx-id)
+                                distinct
+                                vec)]
+          (mark-pending-txs-false! repo stale-tx-ids))
         {:repair-block-uuids (->> @*remote-tx-results
                                   (mapcat :repair-block-uuids)
+                                  (remove (set prefetched-repair-block-uuids))
                                   distinct
                                   vec)})
-
-      ;; Mark only explicitly stale rebases as non-pending.
-      ;; Do not infer stale via tx-id set-diff, which can hide still-valid
-      ;; pending txs that should wait for server ack/reject.
-      (let [stale-tx-ids (->> @*rebase-results
-                              (filter (fn [{:keys [status]}]
-                                        (contains? #{:failed :no-op} status)))
-                              (keep :tx-id)
-                              distinct
-                              vec)]
-        (mark-pending-txs-false! repo stale-tx-ids))
 
       (catch :default e
         (js/console.error e)
@@ -1236,11 +1330,19 @@
   (when-let [*inflight (:inflight client)]
     (reset! *inflight []))
 
-  (-> (rehydrate-large-titles! repo {:tx-data remote-tx-data
-                                     :graph-id (:graph-id client)})
-      (p/catch (fn [error]
-                 (log/error :db-sync/large-title-rehydrate-failed
-                            {:repo repo :error error})))))
+  (when-let [result (rehydrate-large-titles! repo {:tx-data remote-tx-data
+                                                   :graph-id (:graph-id client)})]
+    (p/catch result
+             (fn [error]
+               (log/error :db-sync/large-title-rehydrate-failed
+                          {:repo repo :error error})))))
+
+(defn- after-repair-result
+  [repair-result f]
+  (if (p/promise? repair-result)
+    (p/let [_ repair-result]
+      (f))
+    (f)))
 
 (defn- apply-remote-txs-after-server-repair!
   [{:keys [repo client has-local-changes? remote-txs local-txs apply-context remote-tx-data]}]
@@ -1265,9 +1367,11 @@
                          (throw error)))
         repair-block-uuids (:repair-block-uuids apply-result)]
     (if (seq repair-block-uuids)
-      (p/let [_ (<apply-server-repair-blocks!
-                 repo client (:conn apply-context) repair-block-uuids)]
-        (finish-apply-remote-txs! repo client remote-tx-data))
+      (let [repair-result (<apply-server-repair-blocks!
+                           repo client (:conn apply-context) repair-block-uuids)]
+        (after-repair-result
+         repair-result
+         #(finish-apply-remote-txs! repo client remote-tx-data)))
       (finish-apply-remote-txs! repo client remote-tx-data))))
 
 (defn apply-remote-txs!
@@ -1290,12 +1394,34 @@
                       :local-txs local-txs
                       :apply-context apply-context
                       :remote-tx-data remote-tx-data*}
-          missing-block-uuids (when-not has-local-changes?
-                                (remote-txs-missing-block-uuids @conn remote-txs))]
-      (if (seq missing-block-uuids)
-        (p/let [_ (<apply-server-repair-blocks! repo client conn missing-block-uuids)]
+          missing-block-uuids (remote-txs-missing-block-uuids @conn remote-txs)
+          invalid-repair-block-uuids (when has-local-changes?
+                                       (remote-txs-invalid-repair-block-uuids @conn remote-txs))]
+      (if has-local-changes?
+        (if (or (seq missing-block-uuids)
+                (seq invalid-repair-block-uuids))
+          (let [pre-repair-tx-data (<server-repair-blocks-tx-data repo client missing-block-uuids)
+                post-repair-tx-data (<server-repair-blocks-tx-data repo client invalid-repair-block-uuids)
+                apply-with-repair (fn [pre-repair-tx-data* post-repair-tx-data*]
+                                    (apply-remote-txs-after-server-repair!
+                                     (update apply-args :apply-context assoc
+                                             :pre-repair-tx-data pre-repair-tx-data*
+                                             :post-repair-tx-data post-repair-tx-data*
+                                             :prefetched-repair-block-uuids
+                                             (distinct (concat missing-block-uuids
+                                                               invalid-repair-block-uuids)))))]
+            (if (or (p/promise? pre-repair-tx-data)
+                    (p/promise? post-repair-tx-data))
+              (p/let [pre-repair-tx-data* pre-repair-tx-data
+                      post-repair-tx-data* post-repair-tx-data]
+                (apply-with-repair pre-repair-tx-data* post-repair-tx-data*))
+              (apply-with-repair pre-repair-tx-data post-repair-tx-data)))
           (apply-remote-txs-after-server-repair! apply-args))
-        (apply-remote-txs-after-server-repair! apply-args)))
+        (if (seq missing-block-uuids)
+          (after-repair-result
+           (<apply-server-repair-blocks! repo client conn missing-block-uuids)
+           #(apply-remote-txs-after-server-repair! apply-args))
+          (apply-remote-txs-after-server-repair! apply-args))))
     (fail-fast :db-sync/missing-db {:repo repo :op :apply-remote-txs})))
 
 (defn apply-remote-tx!

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -19,6 +19,7 @@
    [lambdaisland.glogi :as log]
    [logseq.common.util :as common-util]
    [logseq.db :as ldb]
+   [logseq.db.frontend.validate :as db-validate]
    [logseq.db-sync.order :as sync-order]
    [logseq.db-sync.tx-sanitize :as tx-sanitize]
    [logseq.db.common.normalize :as db-normalize]
@@ -47,7 +48,8 @@
   [repo]
   (true? (get @*repo->upload-stopped? repo)))
 
-(declare enqueue-asset-task!)
+(declare enqueue-asset-task!
+         fix-tx!)
 
 (defn- current-client [repo]
   (sync-presence/current-client worker-state/*db-sync-client repo))
@@ -253,6 +255,207 @@
           (broadcast-rtc-state! client)))
       tx-id)))
 
+(defn- sync-fix-tx-meta
+  []
+  {:outliner-op :fix
+   :db-sync/tx-id (random-uuid)})
+
+(def ^:private upload-repair-created-at 0)
+
+(defn- missing-datom-repair-tx?
+  [tx-data]
+  (let [required-block-attrs #{:block/uuid :block/title :block/page :block/parent :block/order
+                               :block/created-at :block/updated-at}]
+    (some (fn [item]
+            (and (vector? item)
+                 (contains? #{:db/retract :db/retractEntity :db.fn/retractEntity}
+                            (first item))
+                 (or (contains? #{:db/retractEntity :db.fn/retractEntity} (first item))
+                     (contains? required-block-attrs (nth item 2 nil)))))
+          tx-data)))
+
+(defn- invalid-tx-errors
+  [db tx-data tx-meta]
+  (let [tx-report (d/with db tx-data tx-meta)
+        [_valid? errors] (db-validate/validate-tx-report tx-report nil)]
+    errors))
+
+(defn- block-uuid-lookup-ref
+  [db v]
+  (when (and (vector? v)
+             (= :block/uuid (first v))
+             (uuid? (second v))
+             (nil? (d/entity db v)))
+    (second v)))
+
+(defn- tx-item-block-uuid
+  [db v]
+  (cond
+    (uuid? v)
+    v
+
+    (and (vector? v) (= :block/uuid (first v)) (uuid? (second v)))
+    (second v)
+
+    (number? v)
+    (some-> (d/entity db v) :block/uuid)
+
+    :else
+    nil))
+
+(defn- missing-block-uuids-in-tx-data
+  [db tx-data]
+  (->> tx-data
+       (keep (fn [item]
+               (when (vector? item)
+                 (block-uuid-lookup-ref db (second item)))))
+       distinct
+       vec))
+
+(defn- repair-block-uuids-in-tx-data
+  [db tx-data]
+  (->> tx-data
+       (keep (fn [item]
+               (when (vector? item)
+                 (or (tx-item-block-uuid db (second item))
+                     (tx-item-block-uuid db (nth item 3 nil))))))
+       distinct
+       vec))
+
+(defn- ref-attr?
+  [db attr]
+  (= :db.type/ref (get-in (d/schema db) [attr :db/valueType])))
+
+(defn- ref-value
+  [db attr v]
+  (if-let [entity (and (ref-attr? db attr)
+                       (number? v)
+                       (d/entity db v))]
+    (if-let [block-uuid (:block/uuid entity)]
+      [:block/uuid block-uuid]
+      (or (:db/ident entity) v))
+    v))
+
+(defn- many-attr?
+  [db attr]
+  (= :db.cardinality/many (get-in (d/schema db) [attr :db/cardinality])))
+
+(defn- assoc-repair-attr
+  [db m attr value]
+  (let [value' (ref-value db attr value)]
+    (if (many-attr? db attr)
+      (update m attr (fnil conj #{}) value')
+      (assoc m attr value'))))
+
+(defn- local-repair-block-map
+  [db block-uuid]
+  (when-let [eid (d/entid db [:block/uuid block-uuid])]
+    (let [datoms (d/datoms db :eavt eid)]
+      (reduce (fn [m datom]
+                (assoc-repair-attr db m (:a datom) (:v datom)))
+              {}
+              datoms))))
+
+(defn- local-repair-tx-data
+  [db block-uuids]
+  (->> block-uuids
+       distinct
+       (keep (partial local-repair-block-map db))
+       vec))
+
+(defn enqueue-upload-repair!
+  [repo block-uuids]
+  (when-let [conn (worker-state/get-datascript-conn repo)]
+    (let [tx-data (local-repair-tx-data @conn block-uuids)]
+      (when (seq tx-data)
+        (let [tx-meta (sync-fix-tx-meta)
+              {:keys [should-inc-pending?]}
+              (client-op/upsert-local-tx-entry!
+               repo
+               {:tx-id (:db-sync/tx-id tx-meta)
+                :created-at upload-repair-created-at
+                :pending? true
+                :failed? false
+                :outliner-op (:outliner-op tx-meta)
+                :normalized-tx-data tx-data
+                :reversed-tx-data []})]
+          (when should-inc-pending?
+            (client-op/adjust-pending-local-tx-count! repo 1))
+          true)))))
+
+(defn- repair-blocks-url
+  [graph-id block-uuids]
+  (when-let [base (sync-auth/http-base-url @worker-state/*db-sync-config)]
+    (let [params (js/URLSearchParams.)]
+      (doseq [block-uuid block-uuids]
+        (.append params "uuid" (str block-uuid)))
+      (str base "/sync/" graph-id "/repair/blocks?" (.toString params)))))
+
+(defn- <fetch-repair-blocks
+  [repo client block-uuids]
+  (if (seq block-uuids)
+    (let [graph-id (:graph-id client)
+          url (repair-blocks-url graph-id block-uuids)]
+      (when-not (seq graph-id)
+        (fail-fast :db-sync/missing-field {:repo repo :field :graph-id}))
+      (when-not (seq url)
+        (fail-fast :db-sync/missing-field {:repo repo :field :repair-blocks-url}))
+      (p/let [resp (js/fetch url #js {:method "GET"
+                                      :headers (clj->js (auth-headers))})
+              body (.text resp)]
+        (if (.-ok resp)
+          (let [data (js->clj (js/JSON.parse body) :keywordize-keys true)]
+            (sync-transport/parse-transit fail-fast (:tx data)
+                                          {:repo repo
+                                           :type "repair/blocks"}))
+          (throw (ex-info "fetch repair blocks failed"
+                          {:repo repo
+                           :status (.-status resp)
+                           :body body})))))
+    (p/resolved nil)))
+
+(defn- <decrypt-repair-tx-map-entry
+  [aes-key [attr value]]
+  (if (contains? rtc-const/encrypt-attr-set attr)
+    (p/let [value' (sync-crypt/<decrypt-text-value aes-key value)]
+      [attr value'])
+    (p/resolved [attr value])))
+
+(defn- <decrypt-repair-tx-item
+  [aes-key item]
+  (if (map? item)
+    (p/let [entries (p/all (mapv (partial <decrypt-repair-tx-map-entry aes-key) item))]
+      (into {} entries))
+    (p/let [[item'] (sync-crypt/<decrypt-tx-data aes-key [item])]
+      item')))
+
+(defn- <decrypt-repair-tx-data
+  [aes-key tx-data]
+  (p/all (mapv (partial <decrypt-repair-tx-item aes-key) tx-data)))
+
+(defn- <apply-server-repair-blocks!
+  [repo client conn block-uuids]
+  (if (seq block-uuids)
+    (p/let [graph-e2ee? (sync-crypt/graph-e2ee? repo)
+            aes-key (when graph-e2ee?
+                      (sync-crypt/<ensure-graph-aes-key repo (:graph-id client)))
+            _ (when (and graph-e2ee? (nil? aes-key))
+                (fail-fast :db-sync/missing-field {:repo repo :field :aes-key}))
+            tx-data (<fetch-repair-blocks repo client block-uuids)]
+      (when (seq tx-data)
+        (p/let [tx-data* (if aes-key
+                           (<decrypt-repair-tx-data aes-key tx-data)
+                           (p/resolved tx-data))]
+          (ldb/transact! conn tx-data* (sync-fix-tx-meta)))))
+    (p/resolved nil)))
+
+(defn- remote-txs-missing-block-uuids
+  [db remote-txs]
+  (->> remote-txs
+       (mapcat (comp (partial missing-block-uuids-in-tx-data db) :tx-data))
+       distinct
+       vec))
+
 (defn prepare-upload-tx-entries
   [_conn pending]
   (let [entries (mapv (fn [{:keys [tx-id tx outliner-op]}]
@@ -383,51 +586,49 @@
         local-tx (client-op/get-local-tx repo)
         remote-tx (get @*repo->latest-remote-tx repo)
         conn (worker-state/get-datascript-conn repo)]
-    (when (and conn (= local-tx remote-tx)) ; rebase
-      (when (empty? inflight)
-        (when-let [ws (:ws client)]
-          (when (and (ws-open? ws) (worker-state/online?))
-            (let [batch (pending-txs repo {:limit 50})]
-              (when (seq batch)
-                (when-not (upload-stopped? repo)
-                  (let [{:keys [tx-entries drop-tx-ids]} (prepare-upload-tx-entries conn batch)]
-                    (when (seq drop-tx-ids)
-                      (log/info :db-sync/drop-tx-ids {:tx-ids drop-tx-ids})
-                      (mark-pending-txs-false! repo drop-tx-ids))
-                    (when (seq tx-entries)
-                      (-> (p/let [aes-key (when (sync-crypt/graph-e2ee? repo)
-                                            (sync-crypt/<ensure-graph-aes-key repo (:graph-id client)))
-                                  _ (when (and (sync-crypt/graph-e2ee? repo) (nil? aes-key))
-                                      (fail-fast :db-sync/missing-field {:repo repo :field :aes-key}))
-                                  tx-entries* (p/all
-                                               (mapv (fn [{:keys [tx-data] :as tx-entry}]
-                                                       (p/let [tx-data* (offload-large-titles
-                                                                         tx-data
-                                                                         {:repo repo
-                                                                          :graph-id (:graph-id client)
-                                                                          :aes-key aes-key})
-                                                               tx-data** (if aes-key
-                                                                           (sync-crypt/<encrypt-tx-data aes-key tx-data*)
-                                                                           tx-data*)]
-                                                         (assoc tx-entry :tx-data tx-data**)))
-                                                     tx-entries))
-                                  payload (mapv (fn [{:keys [tx-id tx-data outliner-op]}]
-                                                  (cond-> {:tx (sqlite-util/write-transit-str tx-data)}
-                                                    tx-id
-                                                    (assoc :tx-id (str tx-id))
-                                                    outliner-op
-                                                    (assoc :outliner-op outliner-op)))
-                                                tx-entries*)
-                                  tx-ids (mapv :tx-id tx-entries)]
-                            (reset! (:inflight client) tx-ids)
-                            (send! ws {:type "tx/batch"
-                                       :t-before local-tx
-                                       :txs payload}))
-                          (p/catch (fn [error]
-                                     (sync-util/set-last-sync-error! client error)
-                                     (log/error :db-sync/flush-pending-failed
-                                                {:repo repo
-                                                 :error error})))))))))))))))
+    (when (and conn (= local-tx remote-tx) (empty? inflight)) ; rebase
+      (when-let [ws (:ws client)]
+        (when (and (ws-open? ws) (worker-state/online?) (not (upload-stopped? repo)))
+          (let [batch (pending-txs repo {:limit 50})]
+            (when (seq batch)
+              (let [{:keys [tx-entries drop-tx-ids]} (prepare-upload-tx-entries conn batch)]
+                (when (seq drop-tx-ids)
+                  (log/info :db-sync/drop-tx-ids {:tx-ids drop-tx-ids})
+                  (mark-pending-txs-false! repo drop-tx-ids))
+                (-> (p/let [aes-key (when (and (seq tx-entries) (sync-crypt/graph-e2ee? repo))
+                                      (sync-crypt/<ensure-graph-aes-key repo (:graph-id client)))
+                            _ (when (and (seq tx-entries) (sync-crypt/graph-e2ee? repo) (nil? aes-key))
+                                (fail-fast :db-sync/missing-field {:repo repo :field :aes-key}))
+                            tx-entries* (p/all
+                                         (mapv (fn [{:keys [tx-data] :as tx-entry}]
+                                                 (p/let [tx-data* (offload-large-titles
+                                                                   tx-data
+                                                                   {:repo repo
+                                                                    :graph-id (:graph-id client)
+                                                                    :aes-key aes-key})
+                                                         tx-data** (if aes-key
+                                                                     (sync-crypt/<encrypt-tx-data aes-key tx-data*)
+                                                                     tx-data*)]
+                                                   (assoc tx-entry :tx-data tx-data**)))
+                                               tx-entries))
+                            payload (mapv (fn [{:keys [tx-id tx-data outliner-op]}]
+                                            (cond-> {:tx (sqlite-util/write-transit-str tx-data)}
+                                              tx-id
+                                              (assoc :tx-id (str tx-id))
+                                              outliner-op
+                                              (assoc :outliner-op outliner-op)))
+                                          tx-entries*)
+                            tx-ids (mapv :tx-id tx-entries)]
+                      (when (seq tx-entries)
+                        (reset! (:inflight client) tx-ids)
+                        (send! ws {:type "tx/batch"
+                                   :t-before local-tx
+                                   :txs payload})))
+                    (p/catch (fn [error]
+                               (sync-util/set-last-sync-error! client error)
+                               (log/error :db-sync/flush-pending-failed
+                                          {:repo repo
+                                           :error error}))))))))))))
 
 (defn enqueue-flush-pending!
   [repo client]
@@ -559,7 +760,8 @@
       :conflicts (client-op/get-sync-conflicts repo block-uuid)})))
 
 (defn- transact-remote-txs!
-  [conn remote-txs]
+  [conn remote-txs & {:keys [allow-invalid-repair?]
+                      :or {allow-invalid-repair? true}}]
   (loop [remaining remote-txs
          index 0
          results []]
@@ -569,11 +771,22 @@
                                (map (partial resolve-temp-id db))
                                (tx-sanitize/sanitize-tx db)
                                seq)
-              report (ldb/transact! conn tx-data (apply-tx-meta remote-tx))
+              tx-meta (apply-tx-meta remote-tx)
+              invalid-retry? (and allow-invalid-repair?
+                                  (missing-datom-repair-tx? tx-data)
+                                  (seq (invalid-tx-errors db tx-data tx-meta)))
+              repair-block-uuids (when invalid-retry?
+                                   (repair-block-uuids-in-tx-data db tx-data))
+              report (ldb/transact! conn tx-data
+                                     (cond-> tx-meta
+                                       invalid-retry?
+                                       (assoc :skip-validate-db? true)))
               results' (cond-> results
                          tx-data
                          (conj {:tx-data tx-data
-                                :report report}))]
+                                :report report
+                                :invalid-retry? invalid-retry?
+                                :repair-block-uuids repair-block-uuids}))]
           (recur (next remaining) (inc index) results'))
         results))))
 
@@ -922,12 +1135,18 @@
                                     (:tx-data rebase-tx-report)
                                     tx-meta))
 
+(defn- repair-applied-txs!
+  [conn tx-report]
+  (when (seq (:tx-data tx-report))
+    (fix-tx! conn tx-report (sync-fix-tx-meta))))
+
 (defn- apply-remote-tx-with-local-changes!
   [{:keys [repo conn local-txs remote-txs]}]
   (let [tx-meta {:rtc-tx? true
                  :with-local-changes? true}
         *rebase-tx-reports (atom [])
         *rebase-results (atom [])
+        *remote-tx-results (atom [])
         rebase-db-before @conn
         conflicts (remote-sync-conflicts rebase-db-before local-txs remote-txs)]
     (try
@@ -940,7 +1159,9 @@
                        (fn [conn]
                          (reverse-local-txs! conn local-txs)
 
-                         (transact-remote-txs! conn remote-txs)
+                         (reset! *remote-tx-results
+                                 (transact-remote-txs! conn remote-txs
+                                                       :allow-invalid-repair? false))
 
                          (reset! *rebase-results
                                  (rebase-local-txs! repo conn local-txs rebase-db-before)))
@@ -951,7 +1172,11 @@
         (doseq [tx-report @*rebase-tx-reports]
           (handle-local-tx! repo tx-report))
 
-        (fix-tx! conn tx-report {:outliner-op :fix}))
+        (repair-applied-txs! conn tx-report)
+        {:repair-block-uuids (->> @*remote-tx-results
+                                  (mapcat :repair-block-uuids)
+                                  distinct
+                                  vec)})
 
       ;; Mark only explicitly stale rebases as non-pending.
       ;; Do not infer stale via tx-id set-diff, which can hide still-valid
@@ -974,12 +1199,19 @@
 
 (defn- apply-remote-tx-without-local-changes!
   [{:keys [conn remote-txs]}]
-  (ldb/batch-transact!
-   conn
-   {:rtc-tx? true
-    :without-local-changes? true}
-   (fn [conn]
-     (transact-remote-txs! conn remote-txs))))
+  (let [remote-tx-results (atom [])
+        tx-report (ldb/batch-transact!
+                   conn
+                   {:rtc-tx? true
+                    :without-local-changes? true}
+                   (fn [conn]
+                     (reset! remote-tx-results
+                             (transact-remote-txs! conn remote-txs))))]
+    (repair-applied-txs! conn tx-report)
+    {:repair-block-uuids (->> @remote-tx-results
+                              (mapcat :repair-block-uuids)
+                              distinct
+                              vec)}))
 
 (defn- report-apply-remote-txs-error!
   [error {:keys [has-local-changes? remote-txs local-txs]}]
@@ -999,6 +1231,45 @@
       (log/error :db-sync/report-apply-remote-txs-error-failed
                  {:error report-error}))))
 
+(defn- finish-apply-remote-txs!
+  [repo client remote-tx-data]
+  (when-let [*inflight (:inflight client)]
+    (reset! *inflight []))
+
+  (-> (rehydrate-large-titles! repo {:tx-data remote-tx-data
+                                     :graph-id (:graph-id client)})
+      (p/catch (fn [error]
+                 (log/error :db-sync/large-title-rehydrate-failed
+                            {:repo repo :error error})))))
+
+(defn- apply-remote-txs-after-server-repair!
+  [{:keys [repo client has-local-changes? remote-txs local-txs apply-context remote-tx-data]}]
+  (let [apply-result (try
+                       (if has-local-changes?
+                         (apply-remote-tx-with-local-changes! apply-context)
+                         (apply-remote-tx-without-local-changes! apply-context))
+                       (catch :default error
+                         (log/error :db-sync/apply-remote-txs-failed
+                                    {:repo repo
+                                     :has-local-changes? has-local-changes?
+                                     :remote-tx-count (count remote-txs)
+                                     :local-tx-count (count local-txs)
+                                     :remote-txs remote-txs
+                                     :local-txs local-txs
+                                     :error error})
+                         (report-apply-remote-txs-error!
+                          error
+                          {:has-local-changes? has-local-changes?
+                           :remote-txs remote-txs
+                           :local-txs local-txs})
+                         (throw error)))
+        repair-block-uuids (:repair-block-uuids apply-result)]
+    (if (seq repair-block-uuids)
+      (p/let [_ (<apply-server-repair-blocks!
+                 repo client (:conn apply-context) repair-block-uuids)]
+        (finish-apply-remote-txs! repo client remote-tx-data))
+      (finish-apply-remote-txs! repo client remote-tx-data))))
+
 (defn apply-remote-txs!
   [repo client remote-txs]
   (if-let [conn (worker-state/get-datascript-conn repo)]
@@ -1011,35 +1282,20 @@
                          :conn conn
                          :local-txs local-txs
                          :remote-txs remote-txs
-                         :temp-tx-meta temp-tx-meta}]
-      (try
-        (if has-local-changes?
-          (apply-remote-tx-with-local-changes! apply-context)
-          (apply-remote-tx-without-local-changes! apply-context))
-        (catch :default error
-          (log/error :db-sync/apply-remote-txs-failed
-                     {:repo repo
+                         :temp-tx-meta temp-tx-meta}
+          apply-args {:repo repo
+                      :client client
                       :has-local-changes? has-local-changes?
-                      :remote-tx-count (count remote-txs)
-                      :local-tx-count (count local-txs)
                       :remote-txs remote-txs
                       :local-txs local-txs
-                      :error error})
-          (report-apply-remote-txs-error!
-           error
-           {:has-local-changes? has-local-changes?
-            :remote-txs remote-txs
-            :local-txs local-txs})
-          (throw error)))
-
-      (when-let [*inflight (:inflight client)]
-        (reset! *inflight []))
-
-      (-> (rehydrate-large-titles! repo {:tx-data remote-tx-data*
-                                         :graph-id (:graph-id client)})
-          (p/catch (fn [error]
-                     (log/error :db-sync/large-title-rehydrate-failed
-                                {:repo repo :error error})))))
+                      :apply-context apply-context
+                      :remote-tx-data remote-tx-data*}
+          missing-block-uuids (when-not has-local-changes?
+                                (remote-txs-missing-block-uuids @conn remote-txs))]
+      (if (seq missing-block-uuids)
+        (p/let [_ (<apply-server-repair-blocks! repo client conn missing-block-uuids)]
+          (apply-remote-txs-after-server-repair! apply-args))
+        (apply-remote-txs-after-server-repair! apply-args)))
     (fail-fast :db-sync/missing-db {:repo repo :op :apply-remote-txs})))
 
 (defn apply-remote-tx!

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -13,6 +13,7 @@
    [frontend.worker.sync.crypt :as sync-crypt]
    [frontend.worker.sync.large-title :as sync-large-title]
    [frontend.worker.sync.presence :as sync-presence]
+   [frontend.worker.sync.repair :as sync-repair]
    [frontend.worker.sync.transport :as sync-transport]
    [frontend.worker.sync.util :as sync-util :refer [fail-fast]]
    [frontend.worker.undo-redo :as worker-undo-redo]
@@ -256,13 +257,6 @@
           (broadcast-rtc-state! client)))
       tx-id)))
 
-(defn- sync-fix-tx-meta
-  []
-  {:outliner-op :fix
-   :db-sync/tx-id (random-uuid)})
-
-(def ^:private upload-repair-created-at 0)
-
 (defn- missing-datom-repair-tx?
   [tx-data]
   (let [required-block-attrs #{:block/uuid :block/title :block/page :block/parent :block/order
@@ -324,58 +318,17 @@
        distinct
        vec))
 
-(defn- ref-attr?
-  [db attr]
-  (= :db.type/ref (get-in (d/schema db) [attr :db/valueType])))
-
-(defn- ref-value
-  [db attr v]
-  (if-let [entity (and (ref-attr? db attr)
-                       (number? v)
-                       (d/entity db v))]
-    (if-let [block-uuid (:block/uuid entity)]
-      [:block/uuid block-uuid]
-      (or (:db/ident entity) v))
-    v))
-
-(defn- many-attr?
-  [db attr]
-  (= :db.cardinality/many (get-in (d/schema db) [attr :db/cardinality])))
-
-(defn- assoc-repair-attr
-  [db m attr value]
-  (let [value' (ref-value db attr value)]
-    (if (many-attr? db attr)
-      (update m attr (fnil conj #{}) value')
-      (assoc m attr value'))))
-
-(defn- local-repair-block-map
-  [db block-uuid]
-  (when-let [eid (d/entid db [:block/uuid block-uuid])]
-    (let [datoms (d/datoms db :eavt eid)]
-      (reduce (fn [m datom]
-                (assoc-repair-attr db m (:a datom) (:v datom)))
-              {}
-              datoms))))
-
-(defn- local-repair-tx-data
-  [db block-uuids]
-  (->> block-uuids
-       distinct
-       (keep (partial local-repair-block-map db))
-       vec))
-
 (defn enqueue-upload-repair!
   [repo block-uuids]
   (when-let [conn (worker-state/get-datascript-conn repo)]
-    (let [tx-data (local-repair-tx-data @conn block-uuids)]
+    (let [tx-data (sync-repair/local-repair-tx-data @conn block-uuids)]
       (when (seq tx-data)
-        (let [tx-meta (sync-fix-tx-meta)
+        (let [tx-meta (sync-repair/sync-fix-tx-meta)
               {:keys [should-inc-pending?]}
               (client-op/upsert-local-tx-entry!
                repo
                {:tx-id (:db-sync/tx-id tx-meta)
-                :created-at upload-repair-created-at
+                :created-at sync-repair/upload-repair-created-at
                 :pending? true
                 :failed? false
                 :outliner-op (:outliner-op tx-meta)
@@ -416,25 +369,6 @@
                            :body body})))))
     nil))
 
-(defn- <decrypt-repair-tx-map-entry
-  [aes-key [attr value]]
-  (if (contains? rtc-const/encrypt-attr-set attr)
-    (p/let [value' (sync-crypt/<decrypt-text-value aes-key value)]
-      [attr value'])
-    (p/resolved [attr value])))
-
-(defn- <decrypt-repair-tx-item
-  [aes-key item]
-  (if (map? item)
-    (p/let [entries (p/all (mapv (partial <decrypt-repair-tx-map-entry aes-key) item))]
-      (into {} entries))
-    (p/let [[item'] (sync-crypt/<decrypt-tx-data aes-key [item])]
-      item')))
-
-(defn- <decrypt-repair-tx-data
-  [aes-key tx-data]
-  (p/all (mapv (partial <decrypt-repair-tx-item aes-key) tx-data)))
-
 (defn- <server-repair-blocks-tx-data
   [repo client block-uuids]
   (if (seq block-uuids)
@@ -448,61 +382,14 @@
               tx-data (<fetch-repair-blocks repo client block-uuids)]
         (if (seq tx-data)
           (if aes-key
-            (<decrypt-repair-tx-data aes-key tx-data)
+            (sync-repair/<decrypt-tx-data aes-key tx-data)
             (p/resolved tx-data))
           (p/resolved nil))))
     nil))
 
-(defn- repair-map-block-uuid
-  [item]
-  (when (map? item)
-    (:block/uuid item)))
-
-(defn- repair-temp-id
-  [block-uuid]
-  (str "repair-block-" block-uuid))
-
-(defn- repair-ref->temp-id
-  [uuid->temp-id v]
-  (cond
-    (and (vector? v)
-         (= :block/uuid (first v))
-         (contains? uuid->temp-id (second v)))
-    (get uuid->temp-id (second v))
-
-    (map? v)
-    (update-vals v (partial repair-ref->temp-id uuid->temp-id))
-
-    (vector? v)
-    (mapv (partial repair-ref->temp-id uuid->temp-id) v)
-
-    (set? v)
-    (set (map (partial repair-ref->temp-id uuid->temp-id) v))
-
-    (seq? v)
-    (doall (map (partial repair-ref->temp-id uuid->temp-id) v))
-
-    :else
-    v))
-
-(defn- with-repair-temp-ids
-  [tx-data]
-  (let [uuid->temp-id (->> tx-data
-                           (keep repair-map-block-uuid)
-                           distinct
-                           (map (juxt identity repair-temp-id))
-                           (into {}))]
-    (mapv (fn [item]
-            (let [item' (repair-ref->temp-id uuid->temp-id item)]
-              (if-let [block-uuid (repair-map-block-uuid item)]
-                (assoc item' :db/id (repair-temp-id block-uuid))
-                item')))
-          tx-data)))
-
 (defn- maybe-apply-repair-tx-data!
   [conn tx-data]
-  (when (seq tx-data)
-    (ldb/transact! conn (with-repair-temp-ids tx-data) (sync-fix-tx-meta))))
+  (sync-repair/apply-tx-data! conn tx-data))
 
 (defn- <apply-server-repair-blocks!
   [repo client conn block-uuids]
@@ -1116,9 +1003,11 @@
 
     :create-page
     (let [[title opts] args
-          page-uuid (:uuid opts)]
-      (when-not (and (uuid? page-uuid)
-                     (d/entity @conn [:block/uuid page-uuid]))
+          page-uuid (:uuid opts)
+          existing-page (when (uuid? page-uuid)
+                          (d/entity @conn [:block/uuid page-uuid]))]
+      (when-not (and existing-page
+                     (not (ldb/recycled? existing-page)))
         (outliner-page/create! conn title opts)))
 
     :delete-page
@@ -1226,7 +1115,7 @@
 (defn- repair-applied-txs!
   [conn tx-report]
   (when (seq (:tx-data tx-report))
-    (fix-tx! conn tx-report (sync-fix-tx-meta))))
+    (fix-tx! conn tx-report (sync-repair/sync-fix-tx-meta))))
 
 (defn- apply-remote-tx-with-local-changes!
   [{:keys [repo conn local-txs remote-txs pre-repair-tx-data post-repair-tx-data

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -474,6 +474,12 @@
 
 (declare history-action-error-reason)
 
+(defn- expected-history-action-error-reason?
+  [reason]
+  (contains? #{:invalid-history-action-ops
+               :invalid-history-action-tx}
+             reason))
+
 (defn- inline-history-action
   [tx-meta]
   (let [forward-outliner-ops (or (:db-sync/forward-outliner-ops tx-meta)
@@ -490,7 +496,11 @@
   (if-let [conn (worker-state/get-datascript-conn repo)]
     (if-let [action (or (pending-tx-by-id repo tx-id)
                         (inline-history-action tx-meta))]
-      (let [{:keys [tx reversed-tx forward-outliner-ops inverse-outliner-ops]} action
+      (if (= :fix (:outliner-op action))
+        {:applied? false
+         :reason :unsupported-history-action
+         :action action}
+        (let [{:keys [tx reversed-tx forward-outliner-ops inverse-outliner-ops]} action
             ops (->> (if undo? inverse-outliner-ops forward-outliner-ops)
                      (filter (fn [op-entry]
                                (and (sequential? op-entry)
@@ -540,12 +550,14 @@
             {:applied? true
              :history-tx-id history-tx-id}
             (catch :default e
-              (log/error ::undo-redo-failed e)
-              {:applied? false
-               :reason (history-action-error-reason e)
-               :action action}))
+              (let [reason (history-action-error-reason e)]
+                (when-not (expected-history-action-error-reason? reason)
+                  (log/error ::undo-redo-failed e))
+                {:applied? false
+                 :reason reason
+                 :action action})))
           {:applied? false :reason :unsupported-history-action
-           :action action}))
+           :action action})))
       {:applied? false
        :reason :missing-history-action
        :tx-id tx-id})
@@ -783,6 +795,11 @@
 (defn- invalid-rebase-op!
   [op data]
   (throw (ex-info "invalid rebase op" (assoc data :op op))))
+
+(defn- expected-stale-rebase-error?
+  [error]
+  (or (= "invalid rebase op" (ex-message error))
+      (= :entity-id/missing (:error (ex-data error)))))
 
 (defn- history-action-error-reason
   [error]
@@ -1078,7 +1095,7 @@
         forward-ops' (if (seq forward-ops)
                        forward-ops
                        (let [tx-data (-> (:tx local-tx) normalize-tx-data-for-rebase)]
-                         [[:transact [tx-data nil]]]))]
+                         [[:transact [tx-data {:db-sync/suppress-stale-rebase-transact-failed-log? true}]]]))]
     (try
       (let [rebase-tx-report
             (ldb/batch-transact-with-temp-conn!
@@ -1096,7 +1113,8 @@
                         :undo? (:undo? local-tx)
                         :redo? (:redo? local-tx)
                         :error error}]
-          (log/warn :db-sync/drop-op-driven-pending-tx drop-log)
+          (when-not (expected-stale-rebase-error? error)
+            (log/warn :db-sync/drop-op-driven-pending-tx drop-log))
           {:tx-id (:tx-id local-tx)
            :status :failed})))))
 

--- a/src/main/frontend/worker/sync/handle_message.cljs
+++ b/src/main/frontend/worker/sync/handle_message.cljs
@@ -174,7 +174,8 @@
   (let [reason (:reason message)
         remote-tx (:t message)
         success-tx-ids (:success-tx-ids message)
-        failed-tx-id (:failed-tx-id message)]
+        failed-tx-id (:failed-tx-id message)
+        missing-block-uuids (:missing-block-uuids message)]
     (when (nil? reason)
       (fail-fast :db-sync/missing-field
                  {:repo repo :type "tx/reject" :field :reason}))
@@ -186,6 +187,10 @@
         (require-uuid tx-id {:repo repo :type "tx/reject" :field :success-tx-ids})))
     (when (contains? message :failed-tx-id)
       (require-uuid failed-tx-id {:repo repo :type "tx/reject" :field :failed-tx-id}))
+    (when (contains? message :missing-block-uuids)
+      (require-seq missing-block-uuids {:repo repo :type "tx/reject" :field :missing-block-uuids})
+      (doseq [block-uuid missing-block-uuids]
+        (require-uuid block-uuid {:repo repo :type "tx/reject" :field :missing-block-uuids})))
     (case reason
       "stale"
       (request-pull! client local-tx)
@@ -197,6 +202,7 @@
                                    vec)
             failed-tx-id (when (and failed-tx-id (contains? inflight-set failed-tx-id))
                            failed-tx-id)
+            recoverable-missing? (seq missing-block-uuids)
             data (when-let [raw-data (:data message)]
                    (parse-transit raw-data
                                   {:repo repo
@@ -210,18 +216,23 @@
                             (contains? message :t) (assoc :t remote-tx)
                             (seq successful-tx-ids) (assoc :success-tx-ids successful-tx-ids)
                             (some? failed-tx-id) (assoc :failed-tx-id failed-tx-id)
+                            recoverable-missing? (assoc :missing-block-uuids (vec missing-block-uuids))
                             (some? data) (assoc :data data))]
         (if (or (contains? message :success-tx-ids)
                 (contains? message :failed-tx-id))
           (do
             (sync-apply/mark-pending-txs-false! repo successful-tx-ids)
-            (when failed-tx-id
-              (sync-apply/mark-failed-txs! repo [failed-tx-id])))
+            (if recoverable-missing?
+              (sync-apply/enqueue-upload-repair! repo missing-block-uuids)
+              (when failed-tx-id
+                (sync-apply/mark-failed-txs! repo [failed-tx-id]))))
           ;; Backward compatibility for older servers without per-tx reject metadata.
           (sync-apply/mark-failed-txs! repo inflight))
         (reset! (:inflight client) [])
         (broadcast-rtc-state! client)
         (sync-log-state/rtc-log :rtc.log/tx-rejected rejected-data)
+        (when recoverable-missing?
+          (sync-apply/enqueue-flush-pending! repo client))
         (fail-fast :db-sync/tx-rejected
                    rejected-data)))))
 
@@ -358,12 +369,12 @@
                                                 (p/let [tx-data* (sync-crypt/<decrypt-tx-data aes-key tx-data)]
                                                   (assoc remote-tx :tx-data tx-data*)))
                                               remote-txs))
-                                 (p/resolved remote-txs))]
-             (try
-               (sync-apply/apply-remote-txs! repo client remote-txs*)
-               (catch :default e
-                 (log/error ::apply-remote-tx e)
-                 (throw e)))
+                                 (p/resolved remote-txs))
+                   _ (try
+                       (sync-apply/apply-remote-txs! repo client remote-txs*)
+                       (catch :default e
+                         (log/error ::apply-remote-tx e)
+                         (throw e)))]
              (client-op/update-local-tx repo remote-tx)
              (broadcast-rtc-state! client)
              (verify-sync-checksum! repo client remote-tx remote-tx remote-checksum {:type "pull/ok"})

--- a/src/main/frontend/worker/sync/large_title.cljs
+++ b/src/main/frontend/worker/sync/large_title.cljs
@@ -43,12 +43,19 @@
        (string? (:asset-uuid value))
        (string? (:asset-type value))))
 
+(defn- large-title-object-datoms
+  [db]
+  (if (get-in (:schema db) [large-title-object-attr :db/index])
+    (d/datoms db :avet large-title-object-attr)
+    (filter #(= large-title-object-attr (:a %))
+            (d/datoms db :eavt))))
+
 (defn- find-large-title-object-eid
   [db obj]
   (some (fn [datom]
           (when (= obj (:v datom))
             (:e datom)))
-        (d/datoms db :avet large-title-object-attr)))
+        (large-title-object-datoms db)))
 
 (defn- resolve-large-title-item-eid
   [db {:keys [e obj]}]
@@ -152,7 +159,7 @@
                 fail-fast-f]}]
   (when-let [conn* (or conn (get-conn-f repo))]
     (let [graph-id* (or graph-id (get-graph-id repo))
-          items (if (seq tx-data)
+          items (if (some? tx-data)
                   (->> tx-data
                        (keep (fn [item]
                                (when (and (vector? item)
@@ -162,13 +169,12 @@
                                  {:e (nth item 1)
                                   :obj (nth item 3)})))
                        (distinct))
-                  (->> (d/datoms @conn* :eavt)
+                  (->> (large-title-object-datoms @conn*)
                        (keep (fn [datom]
-                               (when (= large-title-object-attr (:a datom))
-                                 (let [obj (:v datom)]
-                                   (when (large-title-object? obj)
-                                     {:e (:e datom)
-                                      :obj obj})))))
+                               (let [obj (:v datom)]
+                                 (when (large-title-object? obj)
+                                   {:e (:e datom)
+                                    :obj obj}))))
                        (distinct)))]
       (when (seq items)
         (p/let [aes-key* (or aes-key
@@ -256,5 +262,6 @@
   (when-let [conn (get-conn-f repo)]
     (let [tx-data (mapv (fn [datom]
                           [:db/add (:e datom) large-title-object-attr (:v datom)])
-                        (d/datoms @conn :avet large-title-object-attr))]
-      (rehydrate-large-titles!-f repo {:tx-data tx-data :graph-id graph-id}))))
+                        (large-title-object-datoms @conn))]
+      (when (seq tx-data)
+        (rehydrate-large-titles!-f repo {:tx-data tx-data :graph-id graph-id})))))

--- a/src/main/frontend/worker/sync/repair.cljs
+++ b/src/main/frontend/worker/sync/repair.cljs
@@ -1,0 +1,128 @@
+(ns frontend.worker.sync.repair
+  "Builds and applies db-sync repair transactions for missing block data.
+
+  Repair transactions are used only after the server reports missing blocks or
+  when applying remote txs needs server-provided block data."
+  (:require [datascript.core :as d]
+            [logseq.db :as ldb]
+            [frontend.worker.sync.const :as sync-const]
+            [frontend.worker.sync.crypt :as sync-crypt]
+            [promesa.core :as p]))
+
+(def upload-repair-created-at 0)
+
+(defn sync-fix-tx-meta
+  []
+  {:outliner-op :fix
+   :db-sync/tx-id (random-uuid)})
+
+(defn- ref-attr?
+  [db attr]
+  (= :db.type/ref (get-in (d/schema db) [attr :db/valueType])))
+
+(defn- ref-value
+  [db attr v]
+  (if-let [entity (and (ref-attr? db attr)
+                       (number? v)
+                       (d/entity db v))]
+    (if-let [block-uuid (:block/uuid entity)]
+      [:block/uuid block-uuid]
+      (or (:db/ident entity) v))
+    v))
+
+(defn- many-attr?
+  [db attr]
+  (= :db.cardinality/many (get-in (d/schema db) [attr :db/cardinality])))
+
+(defn- assoc-repair-attr
+  [db m attr value]
+  (let [value' (ref-value db attr value)]
+    (if (many-attr? db attr)
+      (update m attr (fnil conj #{}) value')
+      (assoc m attr value'))))
+
+(defn- local-repair-block-map
+  [db block-uuid]
+  (when-let [eid (d/entid db [:block/uuid block-uuid])]
+    (let [datoms (d/datoms db :eavt eid)]
+      (reduce (fn [m datom]
+                (assoc-repair-attr db m (:a datom) (:v datom)))
+              {}
+              datoms))))
+
+(defn local-repair-tx-data
+  [db block-uuids]
+  (->> block-uuids
+       distinct
+       (keep (partial local-repair-block-map db))
+       vec))
+
+(defn- <decrypt-map-entry
+  [aes-key [attr value]]
+  (if (contains? sync-const/encrypt-attr-set attr)
+    (p/let [value' (sync-crypt/<decrypt-text-value aes-key value)]
+      [attr value'])
+    (p/resolved [attr value])))
+
+(defn- <decrypt-item
+  [aes-key item]
+  (if (map? item)
+    (p/let [entries (p/all (mapv (partial <decrypt-map-entry aes-key) item))]
+      (into {} entries))
+    (p/let [[item'] (sync-crypt/<decrypt-tx-data aes-key [item])]
+      item')))
+
+(defn <decrypt-tx-data
+  [aes-key tx-data]
+  (p/all (mapv (partial <decrypt-item aes-key) tx-data)))
+
+(defn- repair-map-block-uuid
+  [item]
+  (when (map? item)
+    (:block/uuid item)))
+
+(defn- repair-temp-id
+  [block-uuid]
+  (str "repair-block-" block-uuid))
+
+(defn- repair-ref->temp-id
+  [uuid->temp-id v]
+  (cond
+    (and (vector? v)
+         (= :block/uuid (first v))
+         (contains? uuid->temp-id (second v)))
+    (get uuid->temp-id (second v))
+
+    (map? v)
+    (update-vals v (partial repair-ref->temp-id uuid->temp-id))
+
+    (vector? v)
+    (mapv (partial repair-ref->temp-id uuid->temp-id) v)
+
+    (set? v)
+    (set (map (partial repair-ref->temp-id uuid->temp-id) v))
+
+    (seq? v)
+    (doall (map (partial repair-ref->temp-id uuid->temp-id) v))
+
+    :else
+    v))
+
+(defn- with-repair-temp-ids
+  [tx-data]
+  (let [uuid->temp-id (->> tx-data
+                           (keep repair-map-block-uuid)
+                           distinct
+                           (map (juxt identity repair-temp-id))
+                           (into {}))]
+    (mapv (fn [item]
+            (let [item' (repair-ref->temp-id uuid->temp-id item)]
+              (if-let [block-uuid (repair-map-block-uuid item)]
+                (assoc item' :db/id (repair-temp-id block-uuid))
+                item')))
+          tx-data)))
+
+(defn apply-tx-data!
+  [conn tx-data]
+  (when (seq tx-data)
+    (ldb/transact! conn (with-repair-temp-ids tx-data) (sync-fix-tx-meta))))

--- a/src/main/frontend/worker/sync/repair.cljs
+++ b/src/main/frontend/worker/sync/repair.cljs
@@ -15,6 +15,12 @@
    :gen-undo-ops? false
    :db-sync/tx-id (random-uuid)})
 
+(defn- repair-tx-meta
+  []
+  (assoc (sync-fix-tx-meta)
+         :rtc-tx? true
+         :persist-op? false))
+
 (defn local-repair-tx-data
   [db block-uuids]
   (db-sync-repair/tx-data db block-uuids))
@@ -26,4 +32,4 @@
 (defn apply-tx-data!
   [conn tx-data]
   (when (seq tx-data)
-    (ldb/transact! conn tx-data (sync-fix-tx-meta))))
+    (ldb/transact! conn tx-data (repair-tx-meta))))

--- a/src/main/frontend/worker/sync/repair.cljs
+++ b/src/main/frontend/worker/sync/repair.cljs
@@ -3,126 +3,27 @@
 
   Repair transactions are used only after the server reports missing blocks or
   when applying remote txs needs server-provided block data."
-  (:require [datascript.core :as d]
-            [logseq.db :as ldb]
-            [frontend.worker.sync.const :as sync-const]
+  (:require [logseq.db :as ldb]
             [frontend.worker.sync.crypt :as sync-crypt]
-            [promesa.core :as p]))
+            [logseq.db-sync.repair :as db-sync-repair]))
 
 (def upload-repair-created-at 0)
 
 (defn sync-fix-tx-meta
   []
   {:outliner-op :fix
+   :gen-undo-ops? false
    :db-sync/tx-id (random-uuid)})
-
-(defn- ref-attr?
-  [db attr]
-  (= :db.type/ref (get-in (d/schema db) [attr :db/valueType])))
-
-(defn- ref-value
-  [db attr v]
-  (if-let [entity (and (ref-attr? db attr)
-                       (number? v)
-                       (d/entity db v))]
-    (if-let [block-uuid (:block/uuid entity)]
-      [:block/uuid block-uuid]
-      (or (:db/ident entity) v))
-    v))
-
-(defn- many-attr?
-  [db attr]
-  (= :db.cardinality/many (get-in (d/schema db) [attr :db/cardinality])))
-
-(defn- assoc-repair-attr
-  [db m attr value]
-  (let [value' (ref-value db attr value)]
-    (if (many-attr? db attr)
-      (update m attr (fnil conj #{}) value')
-      (assoc m attr value'))))
-
-(defn- local-repair-block-map
-  [db block-uuid]
-  (when-let [eid (d/entid db [:block/uuid block-uuid])]
-    (let [datoms (d/datoms db :eavt eid)]
-      (reduce (fn [m datom]
-                (assoc-repair-attr db m (:a datom) (:v datom)))
-              {}
-              datoms))))
 
 (defn local-repair-tx-data
   [db block-uuids]
-  (->> block-uuids
-       distinct
-       (keep (partial local-repair-block-map db))
-       vec))
-
-(defn- <decrypt-map-entry
-  [aes-key [attr value]]
-  (if (contains? sync-const/encrypt-attr-set attr)
-    (p/let [value' (sync-crypt/<decrypt-text-value aes-key value)]
-      [attr value'])
-    (p/resolved [attr value])))
-
-(defn- <decrypt-item
-  [aes-key item]
-  (if (map? item)
-    (p/let [entries (p/all (mapv (partial <decrypt-map-entry aes-key) item))]
-      (into {} entries))
-    (p/let [[item'] (sync-crypt/<decrypt-tx-data aes-key [item])]
-      item')))
+  (db-sync-repair/tx-data db block-uuids))
 
 (defn <decrypt-tx-data
   [aes-key tx-data]
-  (p/all (mapv (partial <decrypt-item aes-key) tx-data)))
-
-(defn- repair-map-block-uuid
-  [item]
-  (when (map? item)
-    (:block/uuid item)))
-
-(defn- repair-temp-id
-  [block-uuid]
-  (str "repair-block-" block-uuid))
-
-(defn- repair-ref->temp-id
-  [uuid->temp-id v]
-  (cond
-    (and (vector? v)
-         (= :block/uuid (first v))
-         (contains? uuid->temp-id (second v)))
-    (get uuid->temp-id (second v))
-
-    (map? v)
-    (update-vals v (partial repair-ref->temp-id uuid->temp-id))
-
-    (vector? v)
-    (mapv (partial repair-ref->temp-id uuid->temp-id) v)
-
-    (set? v)
-    (set (map (partial repair-ref->temp-id uuid->temp-id) v))
-
-    (seq? v)
-    (doall (map (partial repair-ref->temp-id uuid->temp-id) v))
-
-    :else
-    v))
-
-(defn- with-repair-temp-ids
-  [tx-data]
-  (let [uuid->temp-id (->> tx-data
-                           (keep repair-map-block-uuid)
-                           distinct
-                           (map (juxt identity repair-temp-id))
-                           (into {}))]
-    (mapv (fn [item]
-            (let [item' (repair-ref->temp-id uuid->temp-id item)]
-              (if-let [block-uuid (repair-map-block-uuid item)]
-                (assoc item' :db/id (repair-temp-id block-uuid))
-                item')))
-          tx-data)))
+  (sync-crypt/<decrypt-tx-data aes-key tx-data))
 
 (defn apply-tx-data!
   [conn tx-data]
   (when (seq tx-data)
-    (ldb/transact! conn (with-repair-temp-ids tx-data) (sync-fix-tx-meta))))
+    (ldb/transact! conn tx-data (sync-fix-tx-meta))))

--- a/src/main/frontend/worker/sync/transport.cljs
+++ b/src/main/frontend/worker/sync/transport.cljs
@@ -64,7 +64,10 @@
                   (contains? m :failed-tx-id) (update :failed-tx-id uuid-like->string)
                   (contains? m :success-tx-ids) (update :success-tx-ids
                                                         (fn [ids]
-                                                          (mapv uuid-like->string (or ids [])))))
+                                                          (mapv uuid-like->string (or ids []))))
+                  (contains? m :missing-block-uuids) (update :missing-block-uuids
+                                                             (fn [ids]
+                                                               (mapv uuid-like->string (or ids [])))))
                 m))]
       (let [message* (normalize-legacy-tx-reject message)
             coerced (coerce db-sync-schema/ws-server-message-coercer message* {:schema :ws/server})]

--- a/src/test/frontend/test/noise.cljs
+++ b/src/test/frontend/test/noise.cljs
@@ -1,5 +1,6 @@
 (ns frontend.test.noise
-  "Shared helpers for muting noisy console output in passing test namespaces.")
+  "Shared helpers for muting noisy console output in passing test namespaces."
+  (:require [clojure.string :as string]))
 
 (def ^:private default-console-methods
   ["error" "warn" "log" "info" "debug"])
@@ -7,16 +8,32 @@
 (defonce ^:private *console-state
   (atom {}))
 
+(defn- reporter-failure-output?
+  [args]
+  (some (fn [arg]
+          (and (string? arg)
+               (or (string/includes? arg "FAIL in (")
+                   (string/includes? arg "ERROR in ("))))
+        args))
+
 (defn- mute-console!
   [key methods*]
-  (let [originals (zipmap methods* (map #(aget js/console %) methods*))]
-    (swap! *console-state assoc key originals)
+  (let [originals (zipmap methods* (map #(aget js/console %) methods*))
+        forward? (atom false)]
+    (swap! *console-state assoc key {:originals originals})
     (doseq [method methods*]
-      (aset js/console method (fn [& _] nil)))))
+      (let [original (get originals method)]
+        (aset js/console method
+              (fn [& args]
+                (when (or @forward?
+                          (reporter-failure-output? args))
+                  (reset! forward? true)
+                  (when original
+                    (apply original args)))))))))
 
 (defn- restore-console!
   [key methods*]
-  (when-let [originals (get @*console-state key)]
+  (when-let [{:keys [originals]} (get @*console-state key)]
     (doseq [method methods*]
       (when-let [original (get originals method)]
         (aset js/console method original)))

--- a/src/test/frontend/test/noise_test.cljs
+++ b/src/test/frontend/test/noise_test.cljs
@@ -1,0 +1,24 @@
+(ns frontend.test.noise-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [frontend.test.noise :as test-noise]))
+
+(deftest mute-console-fixture-forwards-test-failures-test
+  (testing "ordinary noise is muted but cljs.test failure output is preserved"
+    (let [original-log (aget js/console "log")
+          calls (atom [])
+          fixture (test-noise/mute-console-fixture
+                   ::mute-console-fixture-forwards-test-failures-test
+                   ["log"])]
+      (aset js/console "log" (fn [& args]
+                               (swap! calls conj (vec args))))
+      ((:before fixture))
+      (try
+        (.log js/console "ordinary noise")
+        (.log js/console "FAIL in (sample-test) (sample.cljs:1)")
+        (.log js/console "expected: true")
+        (is (= [["FAIL in (sample-test) (sample.cljs:1)"]
+                ["expected: true"]]
+               @calls))
+        (finally
+          ((:after fixture))
+          (aset js/console "log" original-log))))))

--- a/src/test/frontend/worker/db_sync_sim_test.cljs
+++ b/src/test/frontend/worker/db_sync_sim_test.cljs
@@ -365,6 +365,61 @@
     (->> (filter (fn [{:keys [t]}] (> t since)) txs)
          (mapv :tx))))
 
+(defn- repair-ref-uuids [v]
+  (cond
+    (and (vector? v)
+         (= :block/uuid (first v))
+         (uuid? (second v)))
+    [(second v)]
+
+    (map? v)
+    (mapcat repair-ref-uuids (vals v))
+
+    (or (vector? v) (set? v) (seq? v))
+    (mapcat repair-ref-uuids v)
+
+    :else
+    nil))
+
+(defn- order-repair-tx-data [tx-data]
+  (let [repair-uuids (set (keep :block/uuid tx-data))]
+    (loop [remaining (vec tx-data)
+           ordered []
+           added #{}]
+      (if (seq remaining)
+        (let [ready? (fn [m]
+                       (let [deps (->> (repair-ref-uuids m)
+                                       (filter repair-uuids)
+                                       set)]
+                         (set/subset? deps added)))
+              {ready true blocked false} (group-by ready? remaining)]
+          (if (seq ready)
+            (recur (vec blocked)
+                   (into ordered ready)
+                   (into added (keep :block/uuid ready)))
+            ;; Keep the original order if the repair payload is cyclic or malformed.
+            (into ordered remaining)))
+        ordered))))
+
+(defn- server-repair-tx-data
+  [server block-uuids]
+  (let [server-db @(get @server :conn)
+        collect-deps (fn [tx-data seen]
+                       (->> tx-data
+                            (mapcat repair-ref-uuids)
+                            (remove seen)
+                            distinct
+                            vec))]
+    (loop [pending (vec block-uuids)
+           seen #{}
+           tx-data []]
+      (if (seq pending)
+        (let [repair-tx-data (#'sync-apply/local-repair-tx-data server-db pending)
+              seen' (into seen pending)
+              deps (collect-deps repair-tx-data seen')]
+          (recur deps seen' (into tx-data repair-tx-data)))
+        (order-repair-tx-data tx-data)))))
+
 (defn- server-upload! [server t-before tx-entries]
   (let [accepted? (atom false)]
     (swap! server
@@ -422,15 +477,15 @@
     (let [progress? (atom false)
           local-tx (or (client-op/get-local-tx repo) 0)
           server-t (:t @server)]
-      ;; (prn :debug :repo repo :local-tx local-tx :server-t server-t)
       (when (< local-tx server-t)
         (let [txs (server-pull server local-tx)]
-          ;; (prn :debug :apply-remote-tx :repo repo
-          ;;      :txs txs)
-          (#'sync-apply/apply-remote-txs! repo client
-                                          (mapv (fn [tx-data]
-                                                  {:tx-data tx-data})
-                                                txs))
+          (#'sync-apply/apply-remote-txs!
+           repo
+           (assoc client :repair-blocks-tx-data-fn
+                  (partial server-repair-tx-data server))
+           (mapv (fn [tx-data]
+                   {:tx-data tx-data})
+                 txs))
           (client-op/update-local-tx repo server-t)
           (reset! progress? true)))
       (let [pending (#'sync-apply/pending-txs repo)

--- a/src/test/frontend/worker/db_sync_sim_test.cljs
+++ b/src/test/frontend/worker/db_sync_sim_test.cljs
@@ -382,26 +382,6 @@
     :else
     nil))
 
-(defn- order-repair-tx-data [tx-data]
-  (let [repair-uuids (set (keep :block/uuid tx-data))]
-    (loop [remaining (vec tx-data)
-           ordered []
-           added #{}]
-      (if (seq remaining)
-        (let [ready? (fn [m]
-                       (let [deps (->> (repair-ref-uuids m)
-                                       (filter repair-uuids)
-                                       set)]
-                         (set/subset? deps added)))
-              {ready true blocked false} (group-by ready? remaining)]
-          (if (seq ready)
-            (recur (vec blocked)
-                   (into ordered ready)
-                   (into added (keep :block/uuid ready)))
-            ;; Keep the original order if the repair payload is cyclic or malformed.
-            (into ordered remaining)))
-        ordered))))
-
 (defn- server-repair-tx-data
   [server block-uuids]
   (let [server-db @(get @server :conn)
@@ -413,13 +393,13 @@
                             vec))]
     (loop [pending (vec block-uuids)
            seen #{}
-           tx-data []]
+           ordered []]
       (if (seq pending)
         (let [repair-tx-data (sync-repair/local-repair-tx-data server-db pending)
               seen' (into seen pending)
               deps (collect-deps repair-tx-data seen')]
-          (recur deps seen' (into tx-data repair-tx-data)))
-        (order-repair-tx-data tx-data)))))
+          (recur deps seen' (into ordered pending)))
+        (sync-repair/local-repair-tx-data server-db ordered)))))
 
 (defn- server-upload! [server t-before tx-entries]
   (let [accepted? (atom false)]

--- a/src/test/frontend/worker/db_sync_sim_test.cljs
+++ b/src/test/frontend/worker/db_sync_sim_test.cljs
@@ -366,40 +366,9 @@
     (->> (filter (fn [{:keys [t]}] (> t since)) txs)
          (mapv :tx))))
 
-(defn- repair-ref-uuids [v]
-  (cond
-    (and (vector? v)
-         (= :block/uuid (first v))
-         (uuid? (second v)))
-    [(second v)]
-
-    (map? v)
-    (mapcat repair-ref-uuids (vals v))
-
-    (or (vector? v) (set? v) (seq? v))
-    (mapcat repair-ref-uuids v)
-
-    :else
-    nil))
-
 (defn- server-repair-tx-data
   [server block-uuids]
-  (let [server-db @(get @server :conn)
-        collect-deps (fn [tx-data seen]
-                       (->> tx-data
-                            (mapcat repair-ref-uuids)
-                            (remove seen)
-                            distinct
-                            vec))]
-    (loop [pending (vec block-uuids)
-           seen #{}
-           ordered []]
-      (if (seq pending)
-        (let [repair-tx-data (sync-repair/local-repair-tx-data server-db pending)
-              seen' (into seen pending)
-              deps (collect-deps repair-tx-data seen')]
-          (recur deps seen' (into ordered pending)))
-        (sync-repair/local-repair-tx-data server-db ordered)))))
+  (sync-repair/local-repair-tx-data @(get @server :conn) block-uuids))
 
 (defn- server-upload! [server t-before tx-entries]
   (let [accepted? (atom false)]

--- a/src/test/frontend/worker/db_sync_sim_test.cljs
+++ b/src/test/frontend/worker/db_sync_sim_test.cljs
@@ -12,6 +12,7 @@
             [frontend.worker.sync :as db-sync]
             [frontend.worker.sync.apply-txs :as sync-apply]
             [frontend.worker.sync.client-op :as client-op]
+            [frontend.worker.sync.repair :as sync-repair]
             [frontend.worker.undo-redo :as undo-redo]
             [logseq.db :as ldb]
             [logseq.db-sync.checksum :as sync-checksum]
@@ -414,7 +415,7 @@
            seen #{}
            tx-data []]
       (if (seq pending)
-        (let [repair-tx-data (#'sync-apply/local-repair-tx-data server-db pending)
+        (let [repair-tx-data (sync-repair/local-repair-tx-data server-db pending)
               seen' (into seen pending)
               deps (collect-deps repair-tx-data seen')]
           (recur deps seen' (into tx-data repair-tx-data)))

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -22,6 +22,7 @@
    [frontend.worker.sync.large-title :as sync-large-title]
    [frontend.worker.sync.log-and-state :as sync-log-state]
    [frontend.worker.sync.presence :as sync-presence]
+   [frontend.worker.sync.repair :as sync-repair]
    [frontend.worker.sync.temp-sqlite :as sync-temp-sqlite]
    [frontend.worker.sync.transport :as sync-transport]
    [frontend.worker.sync.util :as sync-util]
@@ -66,7 +67,28 @@
       (finally
         (aset js/console "error" original-console-error)))))
 
+(def ^:private *logseq-db-hooks (atom nil))
+
+(def reset-logseq-db-hooks-fixture
+  {:before
+   (fn []
+     (reset! *logseq-db-hooks
+             {:transact-fn @ldb/*transact-fn
+              :transact-pipeline-fn @ldb/*transact-pipeline-fn
+              :transact-invalid-callback @ldb/*transact-invalid-callback})
+     (reset! ldb/*transact-fn nil)
+     (reset! ldb/*transact-pipeline-fn nil)
+     (reset! ldb/*transact-invalid-callback nil))
+   :after
+   (fn []
+     (let [{:keys [transact-fn transact-pipeline-fn transact-invalid-callback]} @*logseq-db-hooks]
+       (reset! ldb/*transact-fn transact-fn)
+       (reset! ldb/*transact-pipeline-fn transact-pipeline-fn)
+       (reset! ldb/*transact-invalid-callback transact-invalid-callback)
+       (reset! *logseq-db-hooks nil)))})
+
 (use-fixtures :once (test-noise/mute-console-fixture ::db-sync-test))
+(use-fixtures :each reset-logseq-db-hooks-fixture)
 
 (defn- js-row
   [m]
@@ -4210,7 +4232,7 @@
              (-> (p/let [aes-key (crypt/<generate-aes-key)
                          encrypted-title (sync-crypt/<encrypt-text-value aes-key title)
                          encrypted-name (sync-crypt/<encrypt-text-value aes-key name)
-                         [block-map] (#'sync-apply/<decrypt-repair-tx-data
+                         [block-map] (sync-repair/<decrypt-tx-data
                                       aes-key
                                       [{:block/uuid block-uuid
                                         :block/title encrypted-title

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -625,7 +625,7 @@
                "pending upload debug gate test"]]}])
           (with-redefs [worker-state/online? (constantly true)
                         sync-apply/prepare-upload-tx-entries
-                        (fn [_conn _pending]
+                        (fn [& _args]
                           (swap! prepare-calls inc)
                           {:tx-entries []
                            :drop-tx-ids []})]
@@ -889,6 +889,57 @@
               (is (= 1 (aget failed-ent "failed")))
               (is (= 1 (aget untouched-ent "pending")))
               (is (not= 1 (aget untouched-ent "failed"))))))))))
+
+(deftest tx-reject-missing-blocks-keeps-failed-tx-pending-and-retries-with-repair-test
+  (testing "recoverable tx/reject should keep failed tx pending and prepend a repair entry for retry"
+    (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
+          failed-tx-id (random-uuid)
+          missing-uuid (:block/uuid parent)
+          raw-message (js/JSON.stringify
+                       (clj->js {:type "tx/reject"
+                                 :reason "db transact failed"
+                                 :t 0
+                                 :failed-tx-id (str failed-tx-id)
+                                 :missing-block-uuids [(str missing-uuid)]}))
+          client {:repo test-repo
+                  :graph-id "graph-1"
+                  :inflight (atom [failed-tx-id])
+                  :online-users (atom [])
+                  :ws-state (atom :open)}]
+      (with-datascript-conns
+        conn client-ops-conn
+        (fn []
+          (seed-client-op-txs!
+           test-repo
+           [{:db-sync/tx-id failed-tx-id
+             :db-sync/created-at 1
+             :db-sync/pending? true
+             :db-sync/outliner-op :save-block
+             :db-sync/normalized-tx-data [[:db/add [:block/uuid missing-uuid] :block/title "local title"]]}])
+          (with-redefs [client-op/get-local-tx (constantly 0)]
+            (let [error (try
+                          (with-silenced-console-error
+                            #(sync-handle-message/handle-message! test-repo client raw-message))
+                          nil
+                          (catch :default e
+                            e))
+                  failed-ent (client-op-tx-row client-ops-conn failed-tx-id)
+                  {:keys [tx-entries]} (#'sync-apply/prepare-upload-tx-entries
+                                        conn
+                                        (#'sync-apply/pending-txs test-repo))
+                  repair-entry (first tx-entries)
+                  failed-entry (second tx-entries)]
+              (is (some? error))
+              (is (= :db-sync/tx-rejected (:type (ex-data error))))
+              (is (= [missing-uuid] (:missing-block-uuids (ex-data error))))
+              (is (= [] @(:inflight client)))
+              (is (= 1 (aget failed-ent "pending")))
+              (is (not= 1 (aget failed-ent "failed")))
+              (is (= :fix (:outliner-op repair-entry)))
+              (is (= failed-tx-id (:tx-id failed-entry)))
+              (is (some #(and (map? %)
+                              (= missing-uuid (:block/uuid %)))
+                        (:tx-data repair-entry))))))))))
 
 (deftest tx-reject-stale-keeps-inflight-op-pending-test
   (testing "stale tx/reject should keep inflight ops pending for retry"
@@ -3881,6 +3932,207 @@
                 child2' (d/entity @conn (:db/id child2))]
             (is (some? (:block/order child1')))
             (is (not= (:block/order child1') (:block/order child2')))))))))
+
+(defn- repair-fetch-stub
+  [fetch-calls tx-data-f]
+  (fn [url _opts]
+    (let [params (.-searchParams (js/URL. url))
+          block-uuids (->> (.getAll params "uuid")
+                           array-seq
+                           (map uuid)
+                           vec)
+          tx-data (tx-data-f block-uuids)]
+      (swap! fetch-calls conj block-uuids)
+      (p/resolved
+       #js {:ok true
+            :status 200
+            :text (fn []
+                    (p/resolved
+                     (js/JSON.stringify
+                      #js {:tx (sqlite-util/write-transit-str tx-data)})))}))))
+
+(deftest prepare-upload-tx-entries-does-not-repair-missing-block-datoms-test
+  (testing "upload preparation should not infer missing required block datoms before a server reject"
+    (let [{:keys [conn client-ops-conn child1]} (setup-parent-child)
+          child-id (:db/id child1)
+          page-id (:db/id (:block/page child1))]
+      (with-datascript-conns
+        conn client-ops-conn
+        (fn []
+          (d/transact! conn [[:db/retract child-id :block/page page-id]])
+          (let [pending-before (#'sync-apply/pending-txs test-repo)
+                {:keys [tx-entries]} (#'sync-apply/prepare-upload-tx-entries conn pending-before)
+                child1' (d/entity @conn child-id)]
+            (is (nil? (:block/page child1')))
+            (is (not-any? #(= :fix (:outliner-op %)) tx-entries))))))))
+
+(deftest prepare-upload-tx-entries-does-not-repair-missing-block-lookup-ref-test
+  (testing "upload preparation should leave missing block lookup refs for the server to reject"
+    (let [{:keys [conn parent]} (setup-parent-child)
+          page-id (:db/id (:block/page parent))
+          block-uuid (random-uuid)
+          tx-id (random-uuid)
+          now 1760000000000
+          tx-data [[:db/add [:block/uuid block-uuid] :block/title "missing block"]
+                   [:db/add [:block/uuid block-uuid] :block/page page-id]
+                   [:db/add [:block/uuid block-uuid] :block/parent page-id]
+                   [:db/add [:block/uuid block-uuid] :block/order "a0"]
+                   [:db/add [:block/uuid block-uuid] :block/created-at now]
+                   [:db/add [:block/uuid block-uuid] :block/updated-at now]]
+          pending [{:tx-id tx-id
+                    :outliner-op :save-block
+                    :tx tx-data}]
+          {:keys [tx-entries]} (#'sync-apply/prepare-upload-tx-entries conn pending)]
+      (is (= [tx-id] (mapv :tx-id tx-entries)))
+      (is (= tx-data (:tx-data (first tx-entries))))
+      (is (not-any? #(= :fix (:outliner-op %)) tx-entries)))))
+
+(deftest apply-remote-txs-without-local-changes-repairs-missing-block-datoms-test
+  (testing "remote-only tx application fetches missing required block datoms from server"
+    (async done
+           (let [{:keys [conn client-ops-conn child1]} (setup-parent-child)
+                 child-id (:db/id child1)
+                 child-uuid (:block/uuid child1)
+                 page-id (:db/id (:block/page child1))
+                 fetch-calls (atom [])
+                 client {:repo test-repo :graph-id "graph-1"}
+                 fetch-prev js/fetch
+                 config-prev @worker-state/*db-sync-config]
+             (reset! worker-state/*db-sync-config {:http-base "https://example.com"})
+             (set! js/fetch
+                   (repair-fetch-stub fetch-calls
+                                      (fn [_block-uuids]
+                                        [[:db/add child-id :block/page page-id]])))
+             (-> (with-datascript-conns
+                   conn client-ops-conn
+                   (fn []
+                     (p/let [_ (#'sync-apply/apply-remote-tx!
+                                test-repo
+                                client
+                                [[:db/retract child-id :block/page page-id]])
+                             child1' (d/entity @conn child-id)
+                             pending (#'sync-apply/pending-txs test-repo)]
+                       (is (= [[child-uuid]] @fetch-calls))
+                       (is (= page-id (:db/id (:block/page child1'))))
+                       (is (some #(= :fix (:outliner-op %)) pending)))))
+                 (p/catch (fn [e]
+                            (is false (str e))))
+                 (p/finally (fn []
+                              (set! js/fetch fetch-prev)
+                              (reset! worker-state/*db-sync-config config-prev)
+                              (done))))))))
+
+(deftest apply-remote-txs-repairs-missing-block-lookup-ref-test
+  (testing "remote tx application fetches missing block lookup refs from server"
+    (async done
+           (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
+                 page-id (:db/id (:block/page parent))
+                 block-uuid (random-uuid)
+                 now 1760000000000
+                 fetch-calls (atom [])
+                 client {:repo test-repo :graph-id "graph-1"}
+                 fetch-prev js/fetch
+                 config-prev @worker-state/*db-sync-config]
+             (reset! worker-state/*db-sync-config {:http-base "https://example.com"})
+             (set! js/fetch
+                   (repair-fetch-stub fetch-calls
+                                      (fn [_block-uuids]
+                                        [{:block/uuid block-uuid
+                                          :block/title "remote missing block"
+                                          :block/page page-id
+                                          :block/parent page-id
+                                          :block/order "a0"
+                                          :block/created-at now
+                                          :block/updated-at now}])))
+             (-> (with-datascript-conns
+                   conn client-ops-conn
+                   (fn []
+                     (p/let [_ (#'sync-apply/apply-remote-tx!
+                                test-repo
+                                client
+                                [[:db/add [:block/uuid block-uuid] :block/title "remote missing block"]
+                                 [:db/add [:block/uuid block-uuid] :block/page page-id]
+                                 [:db/add [:block/uuid block-uuid] :block/parent page-id]
+                                 [:db/add [:block/uuid block-uuid] :block/order "a0"]
+                                 [:db/add [:block/uuid block-uuid] :block/created-at now]
+                                 [:db/add [:block/uuid block-uuid] :block/updated-at now]])
+                             block (d/entity @conn [:block/uuid block-uuid])]
+                       (is (= [[block-uuid]] @fetch-calls))
+                       (is (some? block))
+                       (is (= "remote missing block" (:block/title block))))))
+                 (p/catch (fn [e]
+                            (is false (str e))))
+                 (p/finally (fn []
+                              (set! js/fetch fetch-prev)
+                              (reset! worker-state/*db-sync-config config-prev)
+                              (done))))))))
+
+(deftest apply-remote-txs-repairs-missing-block-retract-lookup-ref-test
+  (testing "remote retract tx application fetches missing block lookup refs from server"
+    (async done
+           (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
+                 page-id (:db/id (:block/page parent))
+                 block-uuid (random-uuid)
+                 now 1760000000000
+                 fetch-calls (atom [])
+                 client {:repo test-repo :graph-id "graph-1"}
+                 fetch-prev js/fetch
+                 config-prev @worker-state/*db-sync-config]
+             (reset! worker-state/*db-sync-config {:http-base "https://example.com"})
+             (set! js/fetch
+                   (repair-fetch-stub fetch-calls
+                                      (fn [_block-uuids]
+                                        [{:block/uuid block-uuid
+                                          :block/title "remote missing block"
+                                          :block/page page-id
+                                          :block/parent page-id
+                                          :block/order "a0"
+                                          :block/created-at now
+                                          :block/updated-at now
+                                          :block/collapsed? true}])))
+             (-> (with-datascript-conns
+                   conn client-ops-conn
+                   (fn []
+                     (p/let [_ (#'sync-apply/apply-remote-tx!
+                                test-repo
+                                client
+                                [[:db/retract [:block/uuid block-uuid] :block/collapsed? true]])
+                             block (d/entity @conn [:block/uuid block-uuid])]
+                       (is (= [[block-uuid]] @fetch-calls))
+                       (is (some? block))
+                       (is (= "remote missing block" (:block/title block)))
+                       (is (nil? (:block/collapsed? block))))))
+                 (p/catch (fn [e]
+                            (is false (str e))))
+                 (p/finally (fn []
+                              (set! js/fetch fetch-prev)
+                              (reset! worker-state/*db-sync-config config-prev)
+                              (done))))))))
+
+(deftest decrypt-repair-tx-data-decrypts-e2ee-block-map-test
+  (testing "repair tx data decrypts encrypted server block maps"
+    (async done
+           (let [block-uuid (random-uuid)
+                 title "encrypted repair block"
+                 name "encrypted repair page"]
+             (-> (p/let [aes-key (crypt/<generate-aes-key)
+                         encrypted-title (sync-crypt/<encrypt-text-value aes-key title)
+                         encrypted-name (sync-crypt/<encrypt-text-value aes-key name)
+                         [block-map] (#'sync-apply/<decrypt-repair-tx-data
+                                      aes-key
+                                      [{:block/uuid block-uuid
+                                        :block/title encrypted-title
+                                        :block/name encrypted-name
+                                        :block/order "a0"}])]
+                   (is (= {:block/uuid block-uuid
+                           :block/title title
+                           :block/name name
+                           :block/order "a0"}
+                          block-map)))
+                 (p/catch (fn [e]
+                            (is false (str e))))
+                 (p/finally (fn []
+                              (done))))))))
 
 (deftest two-clients-extends-cycle-test
   (testing "class extends updates from two clients can retain the cycle edges"

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -960,8 +960,11 @@
               (is (not= 1 (aget failed-ent "failed")))
               (is (= :fix (:outliner-op repair-entry)))
               (is (= failed-tx-id (:tx-id failed-entry)))
-              (is (some #(and (map? %)
-                              (= missing-uuid (:block/uuid %)))
+              (is (some #(= [:db/add
+                             (str "repair-block-" missing-uuid)
+                             :block/uuid
+                             missing-uuid]
+                            %)
                         (:tx-data repair-entry))))))))))
 
 (deftest tx-reject-stale-keeps-inflight-op-pending-test
@@ -2447,6 +2450,24 @@
             (is (= true
                    (:applied? (#'sync-apply/apply-history-action! test-repo action-tx-id true {}))))
             (is (empty? (:user.property/x7 (d/entity @conn block-ref))))))))))
+
+(deftest apply-history-action-skips-sync-fix-pending-tx-test
+  (testing "sync maintenance fix txs are not replayed through undo/redo"
+    (let [{:keys [conn client-ops-conn]} (setup-parent-child)
+          tx-id (random-uuid)
+          missing-block-ref [:block/uuid (random-uuid)]]
+      (with-datascript-conns conn client-ops-conn
+        (fn []
+          (seed-client-op-txs!
+           test-repo
+           [{:db-sync/tx-id tx-id
+             :db-sync/outliner-op :fix
+             :db-sync/pending? true
+             :db-sync/normalized-tx-data [[:db/add missing-block-ref :block/title "missing"]]
+             :db-sync/reversed-tx-data [[:db/retract missing-block-ref :block/title "missing"]]}])
+          (let [result (#'sync-apply/apply-history-action! test-repo tx-id true {})]
+            (is (false? (:applied? result)))
+            (is (= :unsupported-history-action (:reason result)))))))))
 
 (deftest replay-recycle-delete-permanently-removes-recycled-page-test
   (testing "replay should permanently delete a recycled page subtree"
@@ -4223,26 +4244,27 @@
             (is (= page-id (:db/id (:block/page child1'))))
             (is (= "local title" (:block/title child1')))))))))
 
-(deftest decrypt-repair-tx-data-decrypts-e2ee-block-map-test
-  (testing "repair tx data decrypts encrypted server block maps"
+(deftest decrypt-repair-tx-data-decrypts-e2ee-block-datoms-test
+  (testing "repair tx data decrypts encrypted server block datoms"
     (async done
            (let [block-uuid (random-uuid)
+                 temp-id (str "repair-block-" block-uuid)
                  title "encrypted repair block"
                  name "encrypted repair page"]
              (-> (p/let [aes-key (crypt/<generate-aes-key)
                          encrypted-title (sync-crypt/<encrypt-text-value aes-key title)
                          encrypted-name (sync-crypt/<encrypt-text-value aes-key name)
-                         [block-map] (sync-repair/<decrypt-tx-data
-                                      aes-key
-                                      [{:block/uuid block-uuid
-                                        :block/title encrypted-title
-                                        :block/name encrypted-name
-                                        :block/order "a0"}])]
-                   (is (= {:block/uuid block-uuid
-                           :block/title title
-                           :block/name name
-                           :block/order "a0"}
-                          block-map)))
+                         tx-data (sync-repair/<decrypt-tx-data
+                                  aes-key
+                                  [[:db/add temp-id :block/uuid block-uuid]
+                                   [:db/add temp-id :block/title encrypted-title]
+                                   [:db/add temp-id :block/name encrypted-name]
+                                   [:db/add temp-id :block/order "a0"]])]
+                   (is (= [[:db/add temp-id :block/uuid block-uuid]
+                           [:db/add temp-id :block/title title]
+                           [:db/add temp-id :block/name name]
+                           [:db/add temp-id :block/order "a0"]]
+                          tx-data)))
                  (p/catch (fn [e]
                             (is false (str e))))
                  (p/finally (fn []

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -4020,6 +4020,76 @@
                                (swap! repair-calls conj (vec block-uuids))
                                (tx-data-f block-uuids))})
 
+(defn- transact-repair-dependency-fixture!
+  [conn {:keys [class-uuid property-uuid view-uuid history-uuid recycled-uuid delete-uuid]}]
+  (d/transact!
+   conn
+   [{:db/id -1
+     :db/ident :user.class/repair-view-target
+     :block/uuid class-uuid
+     :block/title "Repair View Target"
+     :block/name "repair view target"
+     :block/tags #{:logseq.class/Tag}
+     :block/order "a0"
+     :block/created-at 1
+     :block/updated-at 1
+     :logseq.property.class/extends :logseq.class/Root}
+    {:db/id -2
+     :db/ident :user.property/repair-property
+     :block/uuid property-uuid
+     :block/title "Repair Property"
+     :block/name "repair property"
+     :block/tags #{:logseq.class/Property}
+     :block/order "a1"
+     :block/created-at 1
+     :block/updated-at 1
+     :logseq.property/type :default
+     :db/cardinality :db.cardinality/one
+     :db/index true}
+    {:db/id -3
+     :block/uuid view-uuid
+     :block/title "Repair View"
+     :block/page -1
+     :block/parent -1
+     :block/order "a2"
+     :block/created-at 1
+     :block/updated-at 1
+     :logseq.property/view-for -1
+     :logseq.property.view/group-by-property -2}
+    {:db/id -4
+     :block/uuid recycled-uuid
+     :block/title "Repair Recycled"
+     :block/page -1
+     :block/parent -1
+     :block/order "a3"
+     :block/created-at 1
+     :block/updated-at 1
+     :logseq.property/deleted-at 2
+     :logseq.property.recycle/original-parent -1
+     :logseq.property.recycle/original-page -1}
+    {:db/id -5
+     :block/uuid history-uuid
+     :block/title "Repair History"
+     :block/page -1
+     :block/parent -1
+     :block/order "a4"
+     :block/created-at 1
+     :block/updated-at 1
+     :logseq.property.history/block -4
+     :logseq.property.history/property -2
+     :logseq.property.history/ref-value -1}
+    {:db/id -6
+     :block/uuid delete-uuid
+     :block/title "Repair Delete Target"
+     :block/page -1
+     :block/parent -1
+     :block/order "a5"
+     :block/created-at 1
+     :block/updated-at 1
+     :logseq.property/deleted-at 3
+     :logseq.property.recycle/original-parent -1
+     :logseq.property.recycle/original-page -1}]))
+
 (deftest prepare-upload-tx-entries-does-not-repair-missing-block-datoms-test
   (testing "upload preparation should not infer missing required block datoms before a server reject"
     (let [{:keys [conn client-ops-conn child1]} (setup-parent-child)
@@ -4178,6 +4248,52 @@
             (is (= "remote missing parent" (:block/title parent')))
             (is (= "remote child" (:block/title child')))
             (is (= parent-uuid (:block/uuid (:block/parent child'))))))))))
+
+(deftest apply-remote-txs-repairs-view-history-recycled-and-delete-dependencies-test
+  (testing "remote tx application fetches dependent repair blocks from the server"
+    (let [ids {:class-uuid (random-uuid)
+               :property-uuid (random-uuid)
+               :view-uuid (random-uuid)
+               :history-uuid (random-uuid)
+               :recycled-uuid (random-uuid)
+               :delete-uuid (random-uuid)}
+          conn (db-test/create-conn-with-blocks
+                {:pages-and-blocks
+                 [{:page {:block/title "client page"}
+                   :blocks []}]})
+          server-conn (db-test/create-conn-with-blocks
+                       {:pages-and-blocks
+                        [{:page {:block/title "server page"}
+                          :blocks []}]})
+          client-ops-conn (new-client-ops-db)
+          repair-calls (atom [])
+          client (repair-client repair-calls
+                                (fn [block-uuids]
+                                  (sync-repair/local-repair-tx-data @server-conn block-uuids)))]
+      (transact-repair-dependency-fixture! server-conn ids)
+      (with-datascript-conns
+        conn client-ops-conn
+        (fn []
+          (#'sync-apply/apply-remote-tx!
+           test-repo
+           client
+           [[:db/add [:block/uuid (:view-uuid ids)] :block/collapsed? true]
+            [:db/add [:block/uuid (:history-uuid ids)] :block/title "Repair History Remote"]
+            [:db/retractEntity [:block/uuid (:delete-uuid ids)]]])
+          (let [view (d/entity @conn [:block/uuid (:view-uuid ids)])
+                history (d/entity @conn [:block/uuid (:history-uuid ids)])
+                property (d/entity @conn [:block/uuid (:property-uuid ids)])
+                recycled (d/entity @conn [:block/uuid (:recycled-uuid ids)])
+                deleted (d/entity @conn [:block/uuid (:delete-uuid ids)])]
+            (is (= [[(:view-uuid ids) (:history-uuid ids) (:delete-uuid ids)]]
+                   @repair-calls))
+            (is (= "Repair View Target" (:block/title (:logseq.property/view-for view))))
+            (is (= "Repair Property" (:block/title (:logseq.property.view/group-by-property view))))
+            (is (true? (:block/collapsed? view)))
+            (is (= "Repair History Remote" (:block/title history)))
+            (is (= (:db/id recycled) (:db/id (:logseq.property.history/block history))))
+            (is (= (:db/id property) (:db/id (:logseq.property.history/property history))))
+            (is (nil? deleted))))))))
 
 (deftest apply-remote-txs-with-local-changes-repairs-missing-block-lookup-ref-test
   (testing "remote tx application fetches missing block lookup refs before rebasing local changes"

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -1244,6 +1244,57 @@
                                              :where [?e :block/title "remote-migration-only"]]
                                         @conn))))))))))
 
+(deftest apply-repair-tx-data-uses-maintenance-tx-meta-test
+  (testing "server repair txs should not be treated as local user ops"
+    (let [tx-metas (atom [])]
+      (with-redefs [ldb/transact!
+                    (fn [_conn _tx-data tx-meta]
+                      (swap! tx-metas conj tx-meta)
+                      {:tx-meta tx-meta})]
+        (sync-repair/apply-tx-data!
+         (db-test/create-conn)
+         [[:db/add -1 :block/title "server repair"]]))
+      (let [tx-meta (first @tx-metas)]
+        (is (= :fix (:outliner-op tx-meta)))
+        (is (true? (:rtc-tx? tx-meta)))
+        (is (false? (:persist-op? tx-meta)))))))
+
+(deftest apply-repair-tx-data-does-not-enqueue-local-tx-test
+  (testing "server repair tx-data is applied without entering the upload queue"
+    (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)]
+      (with-datascript-conns
+        conn client-ops-conn
+        (fn []
+          (sync-repair/apply-tx-data!
+           conn
+           [[:db/add (:db/id parent) :block/title "server repair"]])
+          (is (= "server repair"
+                 (:block/title (d/entity @conn (:db/id parent)))))
+          (is (= 0 (client-op/get-local-tx test-repo))))))))
+
+(deftest transact-remote-txs-validation-probe-errors-do-not-skip-transact-test
+  (testing "invalid repair detection should not crash before transact can run"
+    (let [conn (db-test/create-conn)
+          missing-uuid (random-uuid)
+          tx-data [[:db/retractEntity [:block/uuid missing-uuid]]]
+          transact-calls (atom [])
+          result (with-redefs [sync-apply/invalid-tx-errors
+                               (fn [_db _tx-data _tx-meta]
+                                 (throw (ex-info "validation probe failed" {})))
+                               ldb/transact!
+                               (fn [_conn tx-data* tx-meta*]
+                                 (swap! transact-calls conj {:tx-data tx-data*
+                                                             :tx-meta tx-meta*})
+                                 {:tx-data tx-data*})]
+                   (try
+                     (#'sync-apply/transact-remote-txs!
+                      conn
+                      [{:tx-data tx-data}])
+                     (catch :default error
+                       error)))]
+      (is (not (instance? js/Error result)))
+      (is (= [tx-data] (mapv :tx-data @transact-calls))))))
+
 (deftest apply-remote-txs-preserves-many-page-property-values-test
   (testing "remote txs keep both values when a new page-many property is created and then assigned twice"
     (let [graph {:pages-and-blocks
@@ -4147,7 +4198,7 @@
                 pending (#'sync-apply/pending-txs test-repo)]
             (is (= [[child-uuid]] @repair-calls))
             (is (= page-id (:db/id (:block/page child1'))))
-            (is (some #(= :fix (:outliner-op %)) pending))))))))
+            (is (empty? pending))))))))
 
 (deftest apply-remote-txs-repairs-missing-block-lookup-ref-test
   (testing "remote tx application fetches missing block lookup refs from server"

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -35,6 +35,7 @@
    [logseq.db-sync.worker.handler.sync :as sync-handler]
    [logseq.db-sync.worker.ws :as ws]
    [logseq.db.common.normalize :as db-normalize]
+   [logseq.db.frontend.schema :as db-schema]
    [logseq.db.frontend.validate :as db-validate]
    [logseq.db.sqlite.util :as sqlite-util]
    [logseq.db.test.helper :as db-test]
@@ -5447,6 +5448,50 @@
                        (p/catch (fn [e]
                                   (is false (str e))))
                        (p/finally done)))))))))
+
+(deftest rehydrate-large-titles-from-db-skips-missing-object-attr-test
+  (let [conn (d/create-conn db-schema/schema)
+        calls (atom [])]
+    (with-datascript-conns conn nil
+      (fn []
+        (is (nil? (sync-large-title/rehydrate-large-titles-from-db!
+                   test-repo
+                   "graph-1"
+                   {:get-conn-f worker-state/get-datascript-conn
+                    :rehydrate-large-titles!-f (fn [& args]
+                                                (swap! calls conj args)
+                                                (p/resolved nil))})))
+        (is (empty? @calls))))))
+
+(deftest rehydrate-large-titles-from-db-reads-unindexed-object-attr-test
+  (async done
+         (let [conn (d/create-conn db-schema/schema)
+               obj {:asset-uuid "title-unindexed" :asset-type "txt"}
+               calls (atom [])]
+           (d/transact! conn [{:db/id 100
+                               :block/title ""
+                               :logseq.property.sync/large-title-object obj}])
+           (with-datascript-conns conn nil
+             (fn []
+               (-> (sync-large-title/rehydrate-large-titles-from-db!
+                    test-repo
+                    "graph-1"
+                    {:get-conn-f worker-state/get-datascript-conn
+                     :rehydrate-large-titles!-f (fn [repo opts]
+                                                 (swap! calls conj [repo opts])
+                                                 (p/resolved nil))})
+                   (p/then (fn [_]
+                             (is (= [[test-repo
+                                      {:tx-data [[:db/add
+                                                  100
+                                                  :logseq.property.sync/large-title-object
+                                                  obj]]
+                                       :graph-id "graph-1"}]]
+                                    @calls))
+                             (done)))
+                   (p/catch (fn [e]
+                              (is false (str e))
+                              (done)))))))))
 
 (defn- apply-template-to-empty-target!
   [conn template-root-uuid empty-target-uuid]

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -5,6 +5,7 @@
    [clojure.string :as string]
    [datascript.core :as d]
    [frontend.common.crypt :as crypt]
+   [frontend.test.noise :as test-noise]
    [frontend.worker-common.util :as worker-util]
    [frontend.worker.handler.page :as worker-page]
    [frontend.worker.pipeline :as worker-pipeline]
@@ -24,7 +25,6 @@
    [frontend.worker.sync.temp-sqlite :as sync-temp-sqlite]
    [frontend.worker.sync.transport :as sync-transport]
    [frontend.worker.sync.util :as sync-util]
-   [frontend.test.noise :as test-noise]
    [frontend.worker.undo-redo :as undo-redo]
    [logseq.common.config :as common-config]
    [logseq.common.util :as common-util]
@@ -1216,7 +1216,7 @@
                     @tx-metas))
           (is (= "remote-migration-only"
                  (:block/title (first (d/q '[:find [(pull ?e [:block/title]) ...]
-                                          :where [?e :block/title "remote-migration-only"]]
+                                             :where [?e :block/title "remote-migration-only"]]
                                         @conn))))))))))
 
 (deftest apply-remote-txs-preserves-many-page-property-values-test
@@ -1468,8 +1468,8 @@
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:toggle-reaction [(:block/uuid parent) "+1" nil]]]
-                                  local-tx-meta)
+                      [[:toggle-reaction [(:block/uuid parent) "+1" nil]]]
+                      local-tx-meta)
           (let [pending (#'sync-apply/pending-txs test-repo)
                 txs (mapcat :tx pending)]
             (is (seq pending))
@@ -1505,8 +1505,8 @@
         (fn []
           (worker-page/create! conn "Rename Me" :uuid page-uuid)
           (apply-ops! conn
-                                  [[:rename-page [page-uuid "Renamed"]]]
-                                  local-tx-meta)
+                      [[:rename-page [page-uuid "Renamed"]]]
+                      local-tx-meta)
           (let [{:keys [forward-outliner-ops]} (last (#'sync-apply/pending-txs test-repo))]
             (is (= :save-block (ffirst forward-outliner-ops)))
             (is (= {:block/uuid page-uuid
@@ -1519,8 +1519,8 @@
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:move-blocks-up-down [[(:db/id child2)] true]]]
-                                  local-tx-meta)
+                      [[:move-blocks-up-down [[(:db/id child2)] true]]]
+                      local-tx-meta)
           (let [{:keys [forward-outliner-ops]} (first (#'sync-apply/pending-txs test-repo))
                 [op [ids up?]] (first forward-outliner-ops)]
             (is (= :move-blocks-up-down op))
@@ -1533,8 +1533,8 @@
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:indent-outdent-blocks [[(:db/id child2)] true {}]]]
-                                  local-tx-meta)
+                      [[:indent-outdent-blocks [[(:db/id child2)] true {}]]]
+                      local-tx-meta)
           (let [{:keys [forward-outliner-ops]} (first (#'sync-apply/pending-txs test-repo))
                 [_ [_ target-id opts]] (first forward-outliner-ops)]
             (is (= :move-blocks (ffirst forward-outliner-ops)))
@@ -1549,9 +1549,9 @@
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:indent-outdent-blocks [[(:db/id child3)] false {:parent-original nil
-                                                                                     :logical-outdenting? nil}]]]
-                                  tx-meta)
+                      [[:indent-outdent-blocks [[(:db/id child3)] false {:parent-original nil
+                                                                         :logical-outdenting? nil}]]]
+                      tx-meta)
           (let [source-row (first (#'sync-apply/pending-txs test-repo))
                 forward-ops (:forward-outliner-ops source-row)
                 inverse-ops (:inverse-outliner-ops source-row)]
@@ -1575,9 +1575,9 @@
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:indent-outdent-blocks [[(:db/id child2)] false {:parent-original nil
-                                                                                     :logical-outdenting? nil}]]]
-                                  tx-meta)
+                      [[:indent-outdent-blocks [[(:db/id child2)] false {:parent-original nil
+                                                                         :logical-outdenting? nil}]]]
+                      tx-meta)
           (let [source-row (first (#'sync-apply/pending-txs test-repo))
                 forward-ops (:forward-outliner-ops source-row)
                 inverse-ops (:inverse-outliner-ops source-row)]
@@ -1603,9 +1603,9 @@
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:indent-outdent-blocks [[(:db/id child2)] false {:parent-original nil
-                                                                                     :logical-outdenting? nil}]]]
-                                  local-tx-meta)
+                      [[:indent-outdent-blocks [[(:db/id child2)] false {:parent-original nil
+                                                                         :logical-outdenting? nil}]]]
+                      local-tx-meta)
           (let [source-row (first (#'sync-apply/pending-txs test-repo))
                 source-tx-id (:tx-id source-row)
                 child3-after-outdent (d/entity @conn [:block/uuid child3-uuid])]
@@ -1633,9 +1633,9 @@
                                               :errors errors})))
           (try
             (apply-ops! conn
-                                    [[:indent-outdent-blocks [[(:db/id child2)] false {:parent-original nil
-                                                                                       :logical-outdenting? nil}]]]
-                                    local-tx-meta)
+                        [[:indent-outdent-blocks [[(:db/id child2)] false {:parent-original nil
+                                                                           :logical-outdenting? nil}]]]
+                        local-tx-meta)
             (let [source-row (first (#'sync-apply/pending-txs test-repo))
                   source-tx-id (:tx-id source-row)
                   undo-result (#'sync-apply/apply-history-action! test-repo source-tx-id true {})
@@ -1769,9 +1769,9 @@
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:save-block [{:block/uuid child-uuid
-                                                  :block/title "hello"} nil]]]
-                                  local-tx-meta)
+                      [[:save-block [{:block/uuid child-uuid
+                                      :block/title "hello"} nil]]]
+                      local-tx-meta)
           (let [{:keys [tx-id]} (first (#'sync-apply/pending-txs test-repo))]
             (let [{:keys [applied? history-tx-id]} (#'sync-apply/apply-history-action! test-repo
                                                                                        tx-id
@@ -1794,9 +1794,9 @@
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:save-block [{:block/uuid child-uuid
-                                                  :block/title "hello"} nil]]]
-                                  local-tx-meta)
+                      [[:save-block [{:block/uuid child-uuid
+                                      :block/title "hello"} nil]]]
+                      local-tx-meta)
           (let [{source-tx-id :tx-id} (first (#'sync-apply/pending-txs test-repo))]
             (let [{undo-applied? :applied?
                    undo-history-tx-id :history-tx-id}
@@ -2261,12 +2261,12 @@
           (outliner-page/create! conn "Page y" {})
           (let [page-y (db-test/find-page-by-title @conn "Page y")]
             (apply-ops! conn
-                                    [[:batch-set-property [[(:db/id block-1)
-                                                            (:db/id block-2)]
-                                                           property-id
-                                                           (:db/id page-y)
-                                                           {}]]]
-                                    {})
+                        [[:batch-set-property [[(:db/id block-1)
+                                                (:db/id block-2)]
+                                               property-id
+                                               (:db/id page-y)
+                                               {}]]]
+                        {})
             (let [pending (#'sync-apply/pending-txs test-repo)
                   property-tx (some (fn [{:keys [forward-outliner-ops]}]
                                       (when (= :batch-set-property (ffirst forward-outliner-ops))
@@ -2556,11 +2556,11 @@
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:insert-blocks [[{:block/title "history insert"
-                                                      :block/uuid requested-uuid}]
-                                                    (:db/id parent)
-                                                    {:sibling? false}]]]
-                                  local-tx-meta)
+                      [[:insert-blocks [[{:block/title "history insert"
+                                          :block/uuid requested-uuid}]
+                                        (:db/id parent)
+                                        {:sibling? false}]]]
+                      local-tx-meta)
           (let [pending (first (#'sync-apply/pending-txs test-repo))
                 inserted (db-test/find-block-by-content @conn "history insert")
                 inserted-uuid (:block/uuid inserted)
@@ -2587,9 +2587,9 @@
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:save-block [{:block/uuid child-uuid
-                                                  :block/title "child 1 inline edit"} {}]]]
-                                  local-tx-meta)
+                      [[:save-block [{:block/uuid child-uuid
+                                      :block/title "child 1 inline edit"} {}]]]
+                      local-tx-meta)
           (let [{:keys [tx-id]} (first (#'sync-apply/pending-txs test-repo))]
             (is (= true
                    (:applied? (#'sync-apply/apply-history-action! test-repo tx-id true {}))))
@@ -2715,10 +2715,10 @@
         (fn []
           (let [before-ids (property-page-ids @conn)]
             (apply-ops! conn
-                                    [[:upsert-property [nil
-                                                        {:logseq.property/type :default}
-                                                        {:property-name property-name}]]]
-                                    local-tx-meta)
+                        [[:upsert-property [nil
+                                            {:logseq.property/type :default}
+                                            {:property-name property-name}]]]
+                        local-tx-meta)
             (let [after-ids (property-page-ids @conn)
                   created-id (first (seq (set/difference after-ids before-ids)))
                   created-ident (some-> (d/entity @conn created-id) :db/ident)
@@ -2763,11 +2763,11 @@
           (try
             (d/transact! conn [[:db/add property-id :logseq.property/classes :logseq.class/Root]])
             (apply-ops! conn
-                                    [[:upsert-property [property-id
-                                                        {:logseq.property/type :node
-                                                         :db/cardinality :many}
-                                                        {}]]]
-                                    local-tx-meta)
+                        [[:upsert-property [property-id
+                                            {:logseq.property/type :node
+                                             :db/cardinality :many}
+                                            {}]]]
+                        local-tx-meta)
             (let [{:keys [inverse-outliner-ops]} (last (#'sync-apply/pending-txs test-repo))]
               (is (= :upsert-property
                      (ffirst inverse-outliner-ops)))
@@ -2799,11 +2799,11 @@
                 left-uuid (:block/uuid left)
                 right-uuid (:block/uuid right)]
             (apply-ops! conn
-                                    [[:delete-blocks [[(:db/id right)]
-                                                      {:deleted-by-uuid (random-uuid)}]]
-                                     [:save-block [{:block/uuid left-uuid
-                                                    :block/title "hellohellohello"} nil]]]
-                                    local-tx-meta)
+                        [[:delete-blocks [[(:db/id right)]
+                                          {:deleted-by-uuid (random-uuid)}]]
+                         [:save-block [{:block/uuid left-uuid
+                                        :block/title "hellohellohello"} nil]]]
+                        local-tx-meta)
             (let [{:keys [tx-id]} (first (#'sync-apply/pending-txs test-repo))]
               (is (= "hellohellohello"
                      (:block/title (d/entity @conn [:block/uuid left-uuid]))))
@@ -2828,13 +2828,13 @@
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:save-block [{:block/uuid child-uuid
-                                                  :block/title "child 1 edited"} {}]]
-                                   [:insert-blocks [[{:block/title "inserted after save"
-                                                      :block/uuid inserted-uuid}]
-                                                    child-id
-                                                    {:sibling? true}]]]
-                                  local-tx-meta)
+                      [[:save-block [{:block/uuid child-uuid
+                                      :block/title "child 1 edited"} {}]]
+                       [:insert-blocks [[{:block/title "inserted after save"
+                                          :block/uuid inserted-uuid}]
+                                        child-id
+                                        {:sibling? true}]]]
+                      local-tx-meta)
           (let [{:keys [tx-id]} (first (#'sync-apply/pending-txs test-repo))
                 inserted-id (d/q '[:find ?e .
                                    :in $ ?title
@@ -2875,12 +2875,12 @@
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:insert-blocks [copied-blocks
-                                                    (:db/id empty-target)
-                                                    {:sibling? true
-                                                     :outliner-op :paste
-                                                     :replace-empty-target? true}]]]
-                                  local-tx-meta)
+                      [[:insert-blocks [copied-blocks
+                                        (:db/id empty-target)
+                                        {:sibling? true
+                                         :outliner-op :paste
+                                         :replace-empty-target? true}]]]
+                      local-tx-meta)
           (let [pending (first (#'sync-apply/pending-txs test-repo))
                 {:keys [tx-id]} pending
                 pasted-id (d/q '[:find ?e .
@@ -2927,17 +2927,17 @@
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:insert-blocks [[{:block/title "draft"
-                                                      :block/uuid inserted-uuid}]
-                                                    (:db/id parent)
-                                                    {:sibling? false}]]]
-                                  local-tx-meta)
+                      [[:insert-blocks [[{:block/title "draft"
+                                          :block/uuid inserted-uuid}]
+                                        (:db/id parent)
+                                        {:sibling? false}]]]
+                      local-tx-meta)
           (let [inserted (db-test/find-block-by-content @conn "draft")
                 inserted-uuid' (:block/uuid inserted)]
             (apply-ops! conn
-                                    [[:save-block [{:block/uuid inserted-uuid'
-                                                    :block/title "published"} {}]]]
-                                    local-tx-meta)
+                        [[:save-block [{:block/uuid inserted-uuid'
+                                        :block/title "published"} {}]]]
+                        local-tx-meta)
             (outliner-core/delete-blocks! conn
                                           [(d/entity @conn [:block/uuid inserted-uuid'])]
                                           {})
@@ -2989,9 +2989,9 @@
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:save-block [{:block/uuid child-uuid
-                                                  :block/title "local-2"} {}]]]
-                                  local-tx-meta)
+                      [[:save-block [{:block/uuid child-uuid
+                                      :block/title "local-2"} {}]]]
+                      local-tx-meta)
           (let [{:keys [tx-id]} (first (#'sync-apply/pending-txs test-repo))]
             (#'sync-apply/apply-remote-tx!
              test-repo
@@ -3073,11 +3073,11 @@
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:move-blocks [[(:db/id a-child-1)
-                                                   (:db/id b-child-1)]
-                                                  (:db/id parent-b)
-                                                  {:sibling? false}]]]
-                                  local-tx-meta)
+                      [[:move-blocks [[(:db/id a-child-1)
+                                       (:db/id b-child-1)]
+                                      (:db/id parent-b)
+                                      {:sibling? false}]]]
+                      local-tx-meta)
           (let [move-action (->> (#'sync-apply/pending-txs test-repo)
                                  (filter #(= :move-blocks (:outliner-op %)))
                                  last)
@@ -3105,11 +3105,11 @@
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:move-blocks [[(:db/id a-child-1)
-                                                   (:db/id b-child-1)]
-                                                  (:db/id parent-b)
-                                                  {:sibling? false}]]]
-                                  local-tx-meta)
+                      [[:move-blocks [[(:db/id a-child-1)
+                                       (:db/id b-child-1)]
+                                      (:db/id parent-b)
+                                      {:sibling? false}]]]
+                      local-tx-meta)
           (let [move-action (->> (#'sync-apply/pending-txs test-repo)
                                  (filter #(= :move-blocks (:outliner-op %)))
                                  last)]
@@ -3175,10 +3175,10 @@
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:create-page [page-title {:redirect? false
-                                                              :split-namespace? true
-                                                              :tags ()}]]]
-                                  local-tx-meta)
+                      [[:create-page [page-title {:redirect? false
+                                                  :split-namespace? true
+                                                  :tags ()}]]]
+                      local-tx-meta)
           (let [page-before (db-test/find-page-by-title @conn page-title)
                 page-uuid (:block/uuid page-before)
                 pending-before (last (#'sync-apply/pending-txs test-repo))]
@@ -3196,17 +3196,52 @@
               (is (some? page-after))
               (is (= page-uuid (:block/uuid page-after))))))))))
 
+(deftest rebase-duplicate-create-page-keeps-remote-children-test
+  (testing "rebased duplicate create-page should not remove remote children"
+    (let [{:keys [conn client-ops-conn]} (setup-parent-child)
+          page-title "shared rebase page"
+          child-uuid (random-uuid)
+          now 1760000000000]
+      (with-datascript-conns conn client-ops-conn
+        (fn []
+          (apply-ops! conn
+                      [[:create-page [page-title {:redirect? false
+                                                  :split-namespace? true
+                                                  :tags ()}]]]
+                      local-tx-meta)
+          (let [page-uuid (:block/uuid (db-test/find-page-by-title @conn page-title))
+                pending-before (last (#'sync-apply/pending-txs test-repo))
+                remote-page-tx (:tx pending-before)
+                remote-child-tx [[:db/add (str child-uuid) :block/uuid child-uuid]
+                                 [:db/add (str child-uuid) :block/title "remote child"]
+                                 [:db/add (str child-uuid) :block/page [:block/uuid page-uuid]]
+                                 [:db/add (str child-uuid) :block/parent [:block/uuid page-uuid]]
+                                 [:db/add (str child-uuid) :block/order "a0"]
+                                 [:db/add (str child-uuid) :block/created-at now]
+                                 [:db/add (str child-uuid) :block/updated-at now]]]
+            (#'sync-apply/apply-remote-txs!
+             test-repo
+             nil
+             [{:tx-data remote-page-tx}
+              {:tx-data remote-child-tx}])
+            (let [page-after (db-test/find-page-by-title @conn page-title)
+                  child-after (d/entity @conn [:block/uuid child-uuid])]
+              (is (some? page-after))
+              (is (= page-uuid (:block/uuid page-after)))
+              (is (= "remote child" (:block/title child-after)))
+              (is (= page-uuid (:block/uuid (:block/page child-after)))))))))))
+
 (deftest rebase-insert-blocks-keeps-block-uuid-test
   (testing "rebased insert-blocks should preserve the original block uuid"
     (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)]
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:insert-blocks [[{:block/title "rebase uuid block"
-                                                      :block/uuid (random-uuid)}]
-                                                    (:db/id parent)
-                                                    {:sibling? false}]]]
-                                  local-tx-meta)
+                      [[:insert-blocks [[{:block/title "rebase uuid block"
+                                          :block/uuid (random-uuid)}]
+                                        (:db/id parent)
+                                        {:sibling? false}]]]
+                      local-tx-meta)
           (let [block-before (db-test/find-block-by-content @conn "rebase uuid block")
                 block-uuid (:block/uuid block-before)
                 pending-before (last (#'sync-apply/pending-txs test-repo))]
@@ -3273,29 +3308,29 @@
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:toggle-reaction [(:block/uuid parent) "+1" nil]]]
-                                  local-tx-meta)
+                      [[:toggle-reaction [(:block/uuid parent) "+1" nil]]]
+                      local-tx-meta)
           (let [reaction-eid (-> (d/datoms @conn :avet :logseq.property.reaction/target (:db/id parent))
                                  first
                                  :e)
                 before-count (count (#'sync-apply/pending-txs test-repo))]
             (is (some? reaction-eid))
             (apply-ops! conn
-                                    [[:toggle-reaction [(:block/uuid parent) "+1" nil]]]
-                                    local-tx-meta)
+                        [[:toggle-reaction [(:block/uuid parent) "+1" nil]]]
+                        local-tx-meta)
             (let [after-count (count (#'sync-apply/pending-txs test-repo))]
               (is (> after-count before-count)))))))))
 
-(deftest rebase-marks-stale-reaction-tx-non-pending-immediately-test
-  (testing "stale pending reaction tx is marked non-pending during rebase to avoid re-upload"
+(deftest rebase-keeps-pending-reaction-tx-for-server-ack-or-reject-test
+  (testing "pending reaction tx remains pending after remote rebase until server ack or reject"
     (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
           target-uuid (:block/uuid parent)
           remote-delete-tx (:tx-data (outliner-core/delete-blocks @conn [parent] {}))]
       (with-datascript-conns conn client-ops-conn
         (fn []
           (apply-ops! conn
-                                  [[:toggle-reaction [target-uuid "+1" nil]]]
-                                  local-tx-meta)
+                      [[:toggle-reaction [target-uuid "+1" nil]]]
+                      local-tx-meta)
           (let [pending-before (#'sync-apply/pending-txs test-repo)
                 tx-id-before (:tx-id (first pending-before))]
             (is (= 1 (count pending-before)))
@@ -3305,9 +3340,9 @@
              remote-delete-tx)
             (let [pending-after (#'sync-apply/pending-txs test-repo)
                   tx-ent-after (client-op-tx-row client-ops-conn tx-id-before)]
-              (is (empty? pending-after))
+              (is (= 1 (count pending-after)))
               (is (some? tx-ent-after))
-              (is (= 0 (aget tx-ent-after "pending"))))))))))
+              (is (= 1 (aget tx-ent-after "pending"))))))))))
 
 (deftest tx-batch-ok-removes-acked-pending-txs-test
   (testing "tx/batch/ok clears inflight and removes acked pending txs"
@@ -3934,23 +3969,13 @@
             (is (some? (:block/order child1')))
             (is (not= (:block/order child1') (:block/order child2')))))))))
 
-(defn- repair-fetch-stub
-  [fetch-calls tx-data-f]
-  (fn [url _opts]
-    (let [params (.-searchParams (js/URL. url))
-          block-uuids (->> (.getAll params "uuid")
-                           array-seq
-                           (map uuid)
-                           vec)
-          tx-data (tx-data-f block-uuids)]
-      (swap! fetch-calls conj block-uuids)
-      (p/resolved
-       #js {:ok true
-            :status 200
-            :text (fn []
-                    (p/resolved
-                     (js/JSON.stringify
-                      #js {:tx (sqlite-util/write-transit-str tx-data)})))}))))
+(defn- repair-client
+  [repair-calls tx-data-f]
+  {:repo test-repo
+   :graph-id "graph-1"
+   :repair-blocks-tx-data-fn (fn [block-uuids]
+                               (swap! repair-calls conj (vec block-uuids))
+                               (tx-data-f block-uuids))})
 
 (deftest prepare-upload-tx-entries-does-not-repair-missing-block-datoms-test
   (testing "upload preparation should not infer missing required block datoms before a server reject"
@@ -3990,125 +4015,191 @@
 
 (deftest apply-remote-txs-without-local-changes-repairs-missing-block-datoms-test
   (testing "remote-only tx application fetches missing required block datoms from server"
-    (async done
-           (let [{:keys [conn client-ops-conn child1]} (setup-parent-child)
-                 child-id (:db/id child1)
-                 child-uuid (:block/uuid child1)
-                 page-id (:db/id (:block/page child1))
-                 fetch-calls (atom [])
-                 client {:repo test-repo :graph-id "graph-1"}
-                 fetch-prev js/fetch
-                 config-prev @worker-state/*db-sync-config]
-             (reset! worker-state/*db-sync-config {:http-base "https://example.com"})
-             (set! js/fetch
-                   (repair-fetch-stub fetch-calls
-                                      (fn [_block-uuids]
-                                        [[:db/add child-id :block/page page-id]])))
-             (-> (with-datascript-conns
-                   conn client-ops-conn
-                   (fn []
-                     (p/let [_ (#'sync-apply/apply-remote-tx!
-                                test-repo
-                                client
-                                [[:db/retract child-id :block/page page-id]])
-                             child1' (d/entity @conn child-id)
-                             pending (#'sync-apply/pending-txs test-repo)]
-                       (is (= [[child-uuid]] @fetch-calls))
-                       (is (= page-id (:db/id (:block/page child1'))))
-                       (is (some #(= :fix (:outliner-op %)) pending)))))
-                 (p/catch (fn [e]
-                            (is false (str e))))
-                 (p/finally (fn []
-                              (set! js/fetch fetch-prev)
-                              (reset! worker-state/*db-sync-config config-prev)
-                              (done))))))))
+    (let [{:keys [conn client-ops-conn child1]} (setup-parent-child)
+          child-id (:db/id child1)
+          child-uuid (:block/uuid child1)
+          page-id (:db/id (:block/page child1))
+          repair-calls (atom [])
+          client (repair-client repair-calls
+                                (fn [_block-uuids]
+                                  [[:db/add child-id :block/page page-id]]))]
+      (with-datascript-conns
+        conn client-ops-conn
+        (fn []
+          (#'sync-apply/apply-remote-tx!
+           test-repo
+           client
+           [[:db/retract child-id :block/page page-id]])
+          (let [child1' (d/entity @conn child-id)
+                pending (#'sync-apply/pending-txs test-repo)]
+            (is (= [[child-uuid]] @repair-calls))
+            (is (= page-id (:db/id (:block/page child1'))))
+            (is (some #(= :fix (:outliner-op %)) pending))))))))
 
 (deftest apply-remote-txs-repairs-missing-block-lookup-ref-test
   (testing "remote tx application fetches missing block lookup refs from server"
-    (async done
-           (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
-                 page-id (:db/id (:block/page parent))
-                 block-uuid (random-uuid)
-                 now 1760000000000
-                 fetch-calls (atom [])
-                 client {:repo test-repo :graph-id "graph-1"}
-                 fetch-prev js/fetch
-                 config-prev @worker-state/*db-sync-config]
-             (reset! worker-state/*db-sync-config {:http-base "https://example.com"})
-             (set! js/fetch
-                   (repair-fetch-stub fetch-calls
-                                      (fn [_block-uuids]
-                                        [{:block/uuid block-uuid
-                                          :block/title "remote missing block"
-                                          :block/page page-id
-                                          :block/parent page-id
-                                          :block/order "a0"
-                                          :block/created-at now
-                                          :block/updated-at now}])))
-             (-> (with-datascript-conns
-                   conn client-ops-conn
-                   (fn []
-                     (p/let [_ (#'sync-apply/apply-remote-tx!
-                                test-repo
-                                client
-                                [[:db/add [:block/uuid block-uuid] :block/title "remote missing block"]
-                                 [:db/add [:block/uuid block-uuid] :block/page page-id]
-                                 [:db/add [:block/uuid block-uuid] :block/parent page-id]
-                                 [:db/add [:block/uuid block-uuid] :block/order "a0"]
-                                 [:db/add [:block/uuid block-uuid] :block/created-at now]
-                                 [:db/add [:block/uuid block-uuid] :block/updated-at now]])
-                             block (d/entity @conn [:block/uuid block-uuid])]
-                       (is (= [[block-uuid]] @fetch-calls))
-                       (is (some? block))
-                       (is (= "remote missing block" (:block/title block))))))
-                 (p/catch (fn [e]
-                            (is false (str e))))
-                 (p/finally (fn []
-                              (set! js/fetch fetch-prev)
-                              (reset! worker-state/*db-sync-config config-prev)
-                              (done))))))))
+    (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
+          page-id (:db/id (:block/page parent))
+          block-uuid (random-uuid)
+          now 1760000000000
+          repair-calls (atom [])
+          client (repair-client repair-calls
+                                (fn [_block-uuids]
+                                  [{:block/uuid block-uuid
+                                    :block/title "remote missing block"
+                                    :block/page page-id
+                                    :block/parent page-id
+                                    :block/order "a0"
+                                    :block/created-at now
+                                    :block/updated-at now}]))]
+      (with-datascript-conns
+        conn client-ops-conn
+        (fn []
+          (#'sync-apply/apply-remote-tx!
+           test-repo
+           client
+           [[:db/add [:block/uuid block-uuid] :block/title "remote missing block"]
+            [:db/add [:block/uuid block-uuid] :block/page page-id]
+            [:db/add [:block/uuid block-uuid] :block/parent page-id]
+            [:db/add [:block/uuid block-uuid] :block/order "a0"]
+            [:db/add [:block/uuid block-uuid] :block/created-at now]
+            [:db/add [:block/uuid block-uuid] :block/updated-at now]])
+          (let [block (d/entity @conn [:block/uuid block-uuid])]
+            (is (= [[block-uuid]] @repair-calls))
+            (is (some? block))
+            (is (= "remote missing block" (:block/title block)))))))))
 
 (deftest apply-remote-txs-repairs-missing-block-retract-lookup-ref-test
   (testing "remote retract tx application fetches missing block lookup refs from server"
-    (async done
-           (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
-                 page-id (:db/id (:block/page parent))
-                 block-uuid (random-uuid)
-                 now 1760000000000
-                 fetch-calls (atom [])
-                 client {:repo test-repo :graph-id "graph-1"}
-                 fetch-prev js/fetch
-                 config-prev @worker-state/*db-sync-config]
-             (reset! worker-state/*db-sync-config {:http-base "https://example.com"})
-             (set! js/fetch
-                   (repair-fetch-stub fetch-calls
-                                      (fn [_block-uuids]
-                                        [{:block/uuid block-uuid
-                                          :block/title "remote missing block"
-                                          :block/page page-id
-                                          :block/parent page-id
-                                          :block/order "a0"
-                                          :block/created-at now
-                                          :block/updated-at now
-                                          :block/collapsed? true}])))
-             (-> (with-datascript-conns
-                   conn client-ops-conn
-                   (fn []
-                     (p/let [_ (#'sync-apply/apply-remote-tx!
-                                test-repo
-                                client
-                                [[:db/retract [:block/uuid block-uuid] :block/collapsed? true]])
-                             block (d/entity @conn [:block/uuid block-uuid])]
-                       (is (= [[block-uuid]] @fetch-calls))
-                       (is (some? block))
-                       (is (= "remote missing block" (:block/title block)))
-                       (is (nil? (:block/collapsed? block))))))
-                 (p/catch (fn [e]
-                            (is false (str e))))
-                 (p/finally (fn []
-                              (set! js/fetch fetch-prev)
-                              (reset! worker-state/*db-sync-config config-prev)
-                              (done))))))))
+    (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
+          page-id (:db/id (:block/page parent))
+          block-uuid (random-uuid)
+          now 1760000000000
+          repair-calls (atom [])
+          client (repair-client repair-calls
+                                (fn [_block-uuids]
+                                  [{:block/uuid block-uuid
+                                    :block/title "remote missing block"
+                                    :block/page page-id
+                                    :block/parent page-id
+                                    :block/order "a0"
+                                    :block/created-at now
+                                    :block/updated-at now
+                                    :block/collapsed? true}]))]
+      (with-datascript-conns
+        conn client-ops-conn
+        (fn []
+          (#'sync-apply/apply-remote-tx!
+           test-repo
+           client
+           [[:db/retract [:block/uuid block-uuid] :block/collapsed? true]])
+          (let [block (d/entity @conn [:block/uuid block-uuid])]
+            (is (= [[block-uuid]] @repair-calls))
+            (is (some? block))
+            (is (= "remote missing block" (:block/title block)))
+            (is (nil? (:block/collapsed? block)))))))))
+
+(deftest apply-remote-txs-repairs-missing-block-ref-value-test
+  (testing "remote tx application fetches missing block lookup refs used as datom values"
+    (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
+          page-id (:db/id (:block/page parent))
+          parent-uuid (random-uuid)
+          child-uuid (random-uuid)
+          now 1760000000000
+          repair-calls (atom [])
+          client (repair-client repair-calls
+                                (fn [_block-uuids]
+                                  [{:block/uuid parent-uuid
+                                    :block/title "remote missing parent"
+                                    :block/page page-id
+                                    :block/parent page-id
+                                    :block/order "a0"
+                                    :block/created-at now
+                                    :block/updated-at now}]))]
+      (with-datascript-conns
+        conn client-ops-conn
+        (fn []
+          (#'sync-apply/apply-remote-tx!
+           test-repo
+           client
+           [[:db/add (str child-uuid) :block/uuid child-uuid]
+            [:db/add (str child-uuid) :block/title "remote child"]
+            [:db/add (str child-uuid) :block/page page-id]
+            [:db/add (str child-uuid) :block/parent [:block/uuid parent-uuid]]
+            [:db/add (str child-uuid) :block/order "a0"]
+            [:db/add (str child-uuid) :block/created-at now]
+            [:db/add (str child-uuid) :block/updated-at now]])
+          (let [parent' (d/entity @conn [:block/uuid parent-uuid])
+                child' (d/entity @conn [:block/uuid child-uuid])]
+            (is (= [[parent-uuid]] @repair-calls))
+            (is (= "remote missing parent" (:block/title parent')))
+            (is (= "remote child" (:block/title child')))
+            (is (= parent-uuid (:block/uuid (:block/parent child'))))))))))
+
+(deftest apply-remote-txs-with-local-changes-repairs-missing-block-lookup-ref-test
+  (testing "remote tx application fetches missing block lookup refs before rebasing local changes"
+    (let [{:keys [conn client-ops-conn parent child1]} (setup-parent-child)
+          page-id (:db/id (:block/page parent))
+          block-uuid (random-uuid)
+          now 1760000000000
+          repair-calls (atom [])
+          client (repair-client repair-calls
+                                (fn [_block-uuids]
+                                  [{:block/uuid block-uuid
+                                    :block/title "remote missing block"
+                                    :block/page page-id
+                                    :block/parent page-id
+                                    :block/order "a0"
+                                    :block/created-at now
+                                    :block/updated-at now}]))]
+      (with-datascript-conns
+        conn client-ops-conn
+        (fn []
+          (outliner-core/save-block! conn
+                                     {:block/uuid (:block/uuid child1)
+                                      :block/title "local title"})
+          (is (seq (#'sync-apply/pending-txs test-repo)))
+          (#'sync-apply/apply-remote-tx!
+           test-repo
+           client
+           [[:db/add [:block/uuid block-uuid] :block/title "remote missing block"]
+            [:db/add [:block/uuid block-uuid] :block/page page-id]
+            [:db/add [:block/uuid block-uuid] :block/parent page-id]
+            [:db/add [:block/uuid block-uuid] :block/order "a0"]
+            [:db/add [:block/uuid block-uuid] :block/created-at now]
+            [:db/add [:block/uuid block-uuid] :block/updated-at now]])
+          (let [block (d/entity @conn [:block/uuid block-uuid])
+                child1' (d/entity @conn (:db/id child1))]
+            (is (= [[block-uuid]] @repair-calls))
+            (is (some? block))
+            (is (= "remote missing block" (:block/title block)))
+            (is (= "local title" (:block/title child1')))))))))
+
+(deftest apply-remote-txs-with-local-changes-repairs-missing-block-datoms-test
+  (testing "remote tx application fetches missing required block datoms after rebasing local changes"
+    (let [{:keys [conn client-ops-conn child1]} (setup-parent-child)
+          child-id (:db/id child1)
+          child-uuid (:block/uuid child1)
+          page-id (:db/id (:block/page child1))
+          repair-calls (atom [])
+          client (repair-client repair-calls
+                                (fn [_block-uuids]
+                                  [[:db/add child-id :block/page page-id]]))]
+      (with-datascript-conns
+        conn client-ops-conn
+        (fn []
+          (outliner-core/save-block! conn
+                                     {:block/uuid child-uuid
+                                      :block/title "local title"})
+          (is (seq (#'sync-apply/pending-txs test-repo)))
+          (#'sync-apply/apply-remote-tx!
+           test-repo
+           client
+           [[:db/retract child-id :block/page page-id]])
+          (let [child1' (d/entity @conn child-id)]
+            (is (= [[child-uuid]] @repair-calls))
+            (is (= page-id (:db/id (:block/page child1'))))
+            (is (= "local title" (:block/title child1')))))))))
 
 (deftest decrypt-repair-tx-data-decrypts-e2ee-block-map-test
   (testing "repair tx data decrypts encrypted server block maps"
@@ -4236,10 +4327,10 @@
             (let [pending-before (#'sync-apply/pending-txs test-repo)
                   tx-ids-before (mapv :tx-id pending-before)]
               (is (= 2 (count pending-before)))
-            (#'sync-apply/apply-remote-tx!
-             test-repo
-             nil
-             [[:db/add (:db/id parent) :block/title "parent remote"]])
+              (#'sync-apply/apply-remote-tx!
+               test-repo
+               nil
+               [[:db/add (:db/id parent) :block/title "parent remote"]])
               (let [pending-after (#'sync-apply/pending-txs test-repo)
                     tx-ids-after (mapv :tx-id pending-after)]
                 (is (= 2 (count pending-after)))
@@ -4688,9 +4779,9 @@
         (with-datascript-conns conn client-ops-conn
           (fn []
             (apply-ops! conn
-                                    [[:save-block [{:block/uuid (:block/uuid block)
-                                                    :block/title "test"} nil]]]
-                                    local-tx-meta)
+                        [[:save-block [{:block/uuid (:block/uuid block)
+                                        :block/title "test"} nil]]]
+                        local-tx-meta)
             (is (= 1 (count (#'sync-apply/pending-txs test-repo))))
             (#'sync-apply/apply-remote-tx!
              test-repo
@@ -4707,7 +4798,7 @@
                               {:pages-and-blocks
                                [{:page {:block/title "page 1"}
                                  :blocks [{:block/title "target"}]}]})
-                             client-ops-conn
+        client-ops-conn
         (fn []
           (client-op/add-sync-conflicts!
            test-repo
@@ -4730,7 +4821,7 @@
                               {:pages-and-blocks
                                [{:page {:block/title "page 1"}
                                  :blocks [{:block/title "target"}]}]})
-                             client-ops-conn
+        client-ops-conn
         (fn []
           (client-op/add-sync-conflicts!
            test-repo
@@ -4769,7 +4860,7 @@
                               {:pages-and-blocks
                                [{:page {:block/title "page 1"}
                                  :blocks [{:block/title "target"}]}]})
-                             client-ops-conn
+        client-ops-conn
         (fn []
           (client-op/add-sync-conflicts!
            test-repo
@@ -4900,7 +4991,9 @@
           target-uuid (:block/uuid target)
           page-uuid (:block/uuid (:block/page target))
           page-id (:db/id (:block/page target))
+          target-order (:block/order target)
           now 1760000000000
+          repair-calls (atom [])
           remote-tx [[:db/retractEntity [:block/uuid target-uuid]]
                      [:db/add -1 :block/uuid target-uuid]
                      [:db/add -1 :block/title "remote-restored"]
@@ -4910,11 +5003,18 @@
                      [:db/add -1 :block/updated-at now]
                      [:db/add -1 :block/created-at now]
                      [:db/add -1 :logseq.property/created-by-ref page-id]]
-          client {:repo test-repo
-                  :graph-id "graph-1"
-                  :inflight (atom [])
-                  :online-users (atom [])
-                  :ws-state (atom :open)}]
+          client (merge (repair-client repair-calls
+                                       (fn [_block-uuids]
+                                         [{:block/uuid target-uuid
+                                           :block/title "target"
+                                           :block/page [:block/uuid page-uuid]
+                                           :block/parent [:block/uuid page-uuid]
+                                           :block/order target-order
+                                           :block/created-at 1
+                                           :block/updated-at 1}]))
+                        {:inflight (atom [])
+                         :online-users (atom [])
+                         :ws-state (atom :open)})]
       (with-datascript-conns conn client-ops-conn
         (fn []
           ;; Local client deletes target and has pending txs.
@@ -4922,6 +5022,7 @@
           (is (seq (#'sync-apply/pending-txs test-repo)))
           ;; Remote side deletes then recreates same uuid in one batch.
           (#'sync-apply/apply-remote-tx! test-repo client remote-tx)
+          (is (= [[target-uuid]] @repair-calls))
           (let [target' (d/entity @conn [:block/uuid target-uuid])
                 pending (#'sync-apply/pending-txs test-repo)]
             ;; Current bug: target disappears locally while pending is empty.
@@ -4974,26 +5075,36 @@
           mover-2-uuid (:block/uuid mover-2)
           mover-1-order (:block/order mover-1)
           mover-2-order (:block/order mover-2)
+          parent-order (:block/order parent)
+          repair-calls (atom [])
           remote-txs [{:tx-data [[:db/retract [:block/uuid mover-1-uuid] :block/parent [:block/uuid page-uuid]]
                                  [:db/add [:block/uuid mover-1-uuid] :block/parent [:block/uuid parent-uuid]]
                                  [:db/retract [:block/uuid mover-1-uuid] :block/order mover-1-order]
                                  [:db/add [:block/uuid mover-1-uuid] :block/order "ZxV"]]}
-                     {:tx-data [[:db/retract [:block/uuid mover-2-uuid] :block/parent [:block/uuid page-uuid]]
+                      {:tx-data [[:db/retract [:block/uuid mover-2-uuid] :block/parent [:block/uuid page-uuid]]
                                  [:db/add [:block/uuid mover-2-uuid] :block/parent [:block/uuid parent-uuid]]
                                  [:db/retract [:block/uuid mover-2-uuid] :block/order mover-2-order]
                                  [:db/add [:block/uuid mover-2-uuid] :block/order "ZxG"]]}
-                     {:tx-data [[:db/retractEntity [:block/uuid parent-uuid]]]}]
-          client {:repo test-repo
-                  :graph-id "graph-1"
-                  :inflight (atom [])
-                  :online-users (atom [])
-                  :ws-state (atom :open)}]
+                      {:tx-data [[:db/retractEntity [:block/uuid parent-uuid]]]}]
+          client (merge (repair-client repair-calls
+                                       (fn [_block-uuids]
+                                         [{:block/uuid parent-uuid
+                                           :block/title "parent"
+                                           :block/page [:block/uuid page-uuid]
+                                           :block/parent [:block/uuid page-uuid]
+                                           :block/order parent-order
+                                           :block/created-at 1
+                                           :block/updated-at 1}]))
+                        {:inflight (atom [])
+                         :online-users (atom [])
+                         :ws-state (atom :open)})]
       (with-datascript-conns conn client-ops-conn
         (fn []
           ;; Local delete creates pending tx requiring reverse before remote apply.
           (outliner-core/delete-blocks! conn [parent] {})
           (is (seq (#'sync-apply/pending-txs test-repo)))
           (#'sync-apply/apply-remote-txs! test-repo client remote-txs)
+          (is (= [[parent-uuid]] @repair-calls))
           (is (nil? (d/entity @conn [:block/uuid parent-uuid])))
           (is (nil? (d/entity @conn [:block/uuid mover-1-uuid])))
           (is (nil? (d/entity @conn [:block/uuid mover-2-uuid])))
@@ -5001,8 +5112,8 @@
             (is (empty? (non-recycle-validation-entities validation))
                 (str (:errors validation)))))))))
 
-(deftest apply-remote-txs-overlap-out-of-order-parent-delete-then-move-repro-test
-  (testing "reproduces missing-parent transact-remote failure when overlapping remote slices arrive out of order"
+(deftest apply-remote-txs-overlap-out-of-order-parent-delete-then-move-repairs-test
+  (testing "repairs missing parent refs when overlapping remote slices arrive out of order"
     (let [conn (db-test/create-conn-with-blocks
                 {:pages-and-blocks
                  [{:page {:block/title "page 1"}
@@ -5015,19 +5126,28 @@
           local-delete (db-test/find-block-by-content @conn "local-pending-delete")
           page-uuid (:block/uuid (:block/page parent))
           parent-uuid (:block/uuid parent)
+          parent-order (:block/order parent)
           mover-uuid (:block/uuid mover)
           mover-order (:block/order mover)
+          repair-calls (atom [])
           tx-delete-parent {:tx-data [[:db/retractEntity [:block/uuid parent-uuid]]]}
           tx-move-under-parent
           {:tx-data [[:db/retract [:block/uuid mover-uuid] :block/parent [:block/uuid page-uuid]]
                      [:db/add [:block/uuid mover-uuid] :block/parent [:block/uuid parent-uuid]]
                      [:db/retract [:block/uuid mover-uuid] :block/order mover-order]
                      [:db/add [:block/uuid mover-uuid] :block/order "ZxV"]]}
-          client {:repo test-repo
-                  :graph-id "graph-1"
-                  :inflight (atom [])
-                  :online-users (atom [])
-                  :ws-state (atom :open)}]
+          client (merge (repair-client repair-calls
+                                       (fn [_block-uuids]
+                                         [{:block/uuid parent-uuid
+                                           :block/title "parent"
+                                           :block/page [:block/uuid page-uuid]
+                                           :block/parent [:block/uuid page-uuid]
+                                           :block/order parent-order
+                                           :block/created-at 1
+                                           :block/updated-at 1}]))
+                        {:inflight (atom [])
+                         :online-users (atom [])
+                         :ws-state (atom :open)})]
       (with-datascript-conns conn client-ops-conn
         (fn []
           ;; Keep one unrelated local pending tx so apply-remote uses reverse+rebase path.
@@ -5043,10 +5163,11 @@
                          nil
                          (catch :default e
                            e))]
-            (is (instance? js/Error result))
-            (is (string/includes? (or (ex-message result) "")
-                                  "Nothing found for entity id")
-                (str "unexpected error: " (ex-message result)))))))))
+            (is (nil? result))
+            (is (= [[parent-uuid]] @repair-calls))
+            (let [validation (db-validate/validate-local-db! @conn)]
+              (is (empty? (non-recycle-validation-entities validation))
+                  (str (:errors validation))))))))))
 
 (deftest rebase-persisted-row-contains-forward-and-inverse-outliner-ops-test
   (testing "rebased pending tx should always persist both forward and inverse outliner ops"
@@ -5459,8 +5580,8 @@
                    "graph-1"
                    {:get-conn-f worker-state/get-datascript-conn
                     :rehydrate-large-titles!-f (fn [& args]
-                                                (swap! calls conj args)
-                                                (p/resolved nil))})))
+                                                 (swap! calls conj args)
+                                                 (p/resolved nil))})))
         (is (empty? @calls))))))
 
 (deftest rehydrate-large-titles-from-db-reads-unindexed-object-attr-test
@@ -5478,8 +5599,8 @@
                     "graph-1"
                     {:get-conn-f worker-state/get-datascript-conn
                      :rehydrate-large-titles!-f (fn [repo opts]
-                                                 (swap! calls conj [repo opts])
-                                                 (p/resolved nil))})
+                                                  (swap! calls conj [repo opts])
+                                                  (p/resolved nil))})
                    (p/then (fn [_]
                              (is (= [[test-repo
                                       {:tx-data [[:db/add


### PR DESCRIPTION
## Summary

- Return missing block UUIDs when the sync server rejects a tx batch because required blocks/datoms are absent.
- Keep failed pending txs pending on recoverable rejects, enqueue an explicit client repair tx, and retry the upload batch.
- Keep upload preparation from inferring repairs locally; apply-remote repair still requests missing block data from the server.
- Document the reject/repair protocol and add server/client coverage.

## Validation

- `rtk pnpm test` in `deps/db-sync`: 120 tests, 3692 assertions, 0 failures
- `rtk bb dev:lint-and-test`: lint clean; test shards passed with 755/3950 and 1137/4484 assertions, 0 failures