### PR TITLE
fix: group sorting broken for number properties

### DIFF
--- a/deps/db/src/logseq/db/common/view.cljs
+++ b/deps/db/src/logseq/db/common/view.cljs
@@ -613,7 +613,12 @@
                                           group-by-closed-values?
                                           (:block/order by-value)
                                           ref-property?
-                                          (db-property/property-value-content by-value)
+                                          ;; For value-ref types (e.g. :number), group-values has already
+                                          ;; extracted the scalar content, so by-value is no longer an entity.
+                                          ;; Only re-extract for entity group keys (e.g. :node/:class).
+                                          (if (de/entity? by-value)
+                                            (db-property/property-value-content by-value)
+                                            by-value)
                                           :else
                                           by-value)))]
                           (sort (common-util/by-sorting

--- a/deps/db/test/logseq/db/common/view_test.cljs
+++ b/deps/db/test/logseq/db/common/view_test.cljs
@@ -184,3 +184,29 @@
     (is (= #{"Obj B"} is-not-titles))
     (is (= #{obj-a-id} (set (:data is-result))))
     (is (= #{obj-b-id} (set (:data is-not-result))))))
+
+(deftest get-view-data-class-objects-groups-by-number-property-sorts-numerically-test
+  (let [conn (db-test/create-conn-with-blocks
+              {:classes {:Topic {:block/title "Topic"}}
+               :properties {:user.property/score {:logseq.property/type :number}}
+               :pages-and-blocks
+               [{:page {:block/title "A" :build/tags [:Topic]
+                        :build/properties {:user.property/score 2}}}
+                {:page {:block/title "B" :build/tags [:Topic]
+                        :build/properties {:user.property/score 10}}}
+                {:page {:block/title "C" :build/tags [:Topic]
+                        :build/properties {:user.property/score 1}}}]})
+        class-id (:db/id (d/entity @conn :user.class/Topic))
+        view-id (create-view-id conn :class-objects :view-for-id class-id)
+        _ (d/transact! conn [[:db/add view-id :logseq.property.view/group-by-property :user.property/score]])
+        asc-groups (map first (:data (db-view/get-view-data @conn view-id
+                                                            {:view-feature-type :class-objects
+                                                             :view-for-id class-id})))
+        _ (d/transact! conn [[:db/add view-id :logseq.property.view/sort-groups-desc? true]])
+        desc-groups (map first (:data (db-view/get-view-data @conn view-id
+                                                             {:view-feature-type :class-objects
+                                                              :view-for-id class-id})))]
+    ;; Number groups must sort numerically (1 2 10), not lexicographically (1 10 2)
+    (is (= [1 2 10] asc-groups))
+    ;; "Sort groups order" (desc?) must reverse the numeric order
+    (is (= [10 2 1] desc-groups))))


### PR DESCRIPTION
## Problem

When grouping a view/query by a **Number** property, both **Sort groups by** and **Sort groups order** have no effect — groups stay in an arbitrary, unsortable order.

## Root cause

`:number` is a *value-ref* property type (`db.type/ref`, value stored on a referenced entity under `:logseq.property/value`). This causes a double-extraction in `get-view-data` (`deps/db/src/logseq/db/common/view.cljs`):

1. `group-values` reads the property, sees a ref entity, and (since numbers aren't matched as entities) extracts the scalar via `property-value-content`. So the **group key is already a bare number** (e.g. `5`).
2. The group sort `keyfn`'s `ref-property?` branch (true for numbers) then calls `property-value-content` **again** on that bare number.
3. `property-value-content` does `(or (:block/title ent) (:logseq.property/value ent))` — both keyword lookups on a plain number return `nil`.

Every group's sort key becomes `nil`. With all keys equal, `compare` returns `0` for every pair, so no ordering is applied and reversing (desc?) is a no-op — explaining why *both* controls appear dead.

## Fix

In the `ref-property?` branch, only re-extract when the group key is still an entity (the node/class grouping case); for value-ref scalars like numbers, pass the value through unchanged.

## Tests

Added `get-view-data-class-objects-groups-by-number-property-sorts-numerically-test` using scores `2, 10, 1`:
- ascending → `[1 2 10]` (numeric, not lexicographic `[1 10 2]`)
- descending → `[10 2 1]`

Without the fix both orders produce the unsorted `(2 10 1)`, confirming the regression is caught. Full `logseq.db.common.view-test` namespace passes (9 tests / 18 assertions), and the `deps-db` lint job (clj-kondo, carve, large-vars, rules, ns-docstrings) passes locally.