### PR TITLE
fix: audio asset protocol

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -461,9 +461,8 @@
 (hsx/defc audio-cp
   ([src] (audio-cp src nil))
   ([src ext]
-   ;; Change protocol to allow media fragment uris to play
    (when src
-     (let [src (string/replace-first src common-config/asset-protocol "file://")
+     (let [src (assets-handler/asset-protocol-url->media-url src)
            opts {:controls true
                  :on-touch-start #(util/stop %)}]
        (case ext

--- a/src/main/frontend/handler/assets.cljs
+++ b/src/main/frontend/handler/assets.cljs
@@ -67,6 +67,15 @@
     (windows-drive-absolute-path? path)
     (string/replace-first #":" "/logseq__colon/")))
 
+(defn asset-protocol-url->media-url
+  [url]
+  (if (and (common-config/local-protocol-asset? url)
+           (not (util/electron?)))
+    (-> url
+        (string/replace-first common-config/asset-protocol "file://")
+        (string/replace "/logseq__colon/" ":/"))
+    url))
+
 (defn resolve-asset-real-path-url
   [repo rpath]
   (when-let [rpath (and (string? rpath)

--- a/src/main/frontend/handler/assets.cljs
+++ b/src/main/frontend/handler/assets.cljs
@@ -72,8 +72,8 @@
   (if (and (common-config/local-protocol-asset? url)
            (not (util/electron?)))
     (-> url
-        (string/replace-first common-config/asset-protocol "file://")
-        (string/replace "/logseq__colon/" ":/"))
+        (common-config/remove-asset-protocol)
+        (string/replace-first "/logseq__colon/" ":/"))
     url))
 
 (defn resolve-asset-real-path-url

--- a/src/test/frontend/handler/assets_test.cljs
+++ b/src/test/frontend/handler/assets_test.cljs
@@ -125,3 +125,9 @@
           (p/catch (fn [e]
                      (is false (str "unexpected error: " e))
                      (done)))))))
+
+(deftest asset-protocol-url->media-url-keeps-electron-assets-protocol-test
+  (with-redefs [util/electron? (constantly true)]
+    (let [url "assets:///C/logseq__colon/Users/charlie/graph/assets/test.mp3"]
+      (is (= url
+             (assets/asset-protocol-url->media-url url))))))


### PR DESCRIPTION
## Summary
- keep Electron audio asset URLs on the registered `assets://` protocol instead of rewriting them to `file://`
- add regression coverage for uploaded audio asset URLs on Electron

## Root cause
Uploaded audio assets were rendered through `audio-cp`, which rewrote `assets://` URLs to `file://`. On Electron, assets are supposed to be handled by the registered `assets://` file protocol. Rewriting bypassed that handler and could break Windows protected asset paths such as `assets:///C/logseq__colon/...`, leaving the audio player disabled.

Fixes logseq/db-test#933

## Validation
- `bb dev:test -v 'frontend.handler.assets-test/asset-protocol-url->media-url-keeps-electron-assets-protocol-test'`\n- `bb dev:test -v frontend.handler.assets-test`\n- `bb dev:test -v frontend.components.block.asset-test`\n- `git diff --check`\n\n## Notes\n- `bb lint:kondo-git-changes` was not run successfully because `clj-kondo` is not installed on PATH in this environment.