### PR TITLE
 fix: hide recycled sidebar pages

### DIFF
--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -95,9 +95,11 @@
   (when-let [db (conn/get-db)]
     (when-let [page (ldb/get-page db common-config/favorites-page-name)]
       (let [blocks (ldb/sort-by-order (:block/_parent page))]
-        (keep (fn [block]
-                (when-let [block-db-id (:db/id (:block/link block))]
-                  (d/entity db block-db-id))) blocks)))))
+        (->> blocks
+             (keep (fn [block]
+                     (when-let [block-db-id (:db/id (:block/link block))]
+                       (d/entity db block-db-id))))
+             (remove ldb/recycled?))))))
 
 (defn toggle-favorite! []
   ;; NOTE: in journals or settings, current-page is nil

--- a/src/test/frontend/handler/db_based/recent_test.cljs
+++ b/src/test/frontend/handler/db_based/recent_test.cljs
@@ -3,16 +3,21 @@
             [datascript.core :as d]
             [frontend.db :as db]
             [frontend.handler.db-based.recent :as db-recent-handler]
-            [frontend.test.helper :as test-helper]))
+            [frontend.handler.page :as page-handler]
+            [frontend.state :as state]
+            [frontend.test.helper :as test-helper :include-macros true :refer [deftest-async]]
+            [promesa.core :as p]))
 
-(def init-data (test-helper/initial-test-page-and-blocks))
-(defn start-and-destroy-db
-  [f]
-  (test-helper/start-and-destroy-db
-   f
-   {:init-data (fn [conn] (d/transact! conn init-data))}))
+(use-fixtures :each
+  {:before test-helper/start-test-db!
+   :after (fn []
+            (state/set-current-repo! nil)
+            (test-helper/destroy-test-db!))})
 
-(use-fixtures :each start-and-destroy-db)
+(defn- mark-page-recycled!
+  [page-title]
+  (let [conn (db/get-db test-helper/test-db false)]
+    (d/transact! conn [[:db/add (:db/id (db/get-page page-title)) :logseq.property/deleted-at 1]])))
 
 (deftest recents-test
   (testing "Add some pages to recent"
@@ -25,3 +30,29 @@
       (testing "Click existing recent item shouldn't update its position"
         (db-recent-handler/add-page-to-recent! (:db/id (db/get-page "Page 10")) true)
         (is (= (map :block/title (db-recent-handler/get-recent-pages)) (reverse pages)))))))
+
+(deftest recents-hide-recycled-pages-without-removing-history-test
+  (testing "Recycled recent pages are hidden from display without mutating recents"
+    (let [active-page "Active page"
+          recycled-page "Recycled page"]
+      (doseq [page [active-page recycled-page]]
+        (test-helper/create-page! page {:redirect? false})
+        (db-recent-handler/add-page-to-recent! (:db/id (db/get-page page)) false))
+      (let [recycled-page-id (:db/id (db/get-page recycled-page))]
+        (mark-page-recycled! recycled-page)
+        (is (= [active-page]
+               (map :block/title (db-recent-handler/get-recent-pages))))
+        (is (contains? (set (state/get-recent-pages)) recycled-page-id))))))
+
+(deftest-async favorites-hide-recycled-pages-without-unfavoriting-test
+  (let [active-page "Active favorite"
+        recycled-page "Recycled favorite"]
+    (test-helper/create-page! active-page {:redirect? false})
+    (test-helper/create-page! recycled-page {:redirect? false})
+    (p/let [_ (page-handler/<favorite-page! active-page)
+            _ (page-handler/<favorite-page! recycled-page)
+            recycled-page-uuid (:block/uuid (db/get-page recycled-page))
+            _ (mark-page-recycled! recycled-page)]
+      (is (= [active-page]
+             (map :block/title (page-handler/get-favorites))))
+      (is (true? (page-handler/favorited? (str recycled-page-uuid)))))))


### PR DESCRIPTION
## Summary

- Hide recycled pages from the visible Favorites list while keeping the favorite entry intact.
- Add regression coverage that recycled pages are hidden from Favorites and Recent without mutating the stored favorite/recent references.

## Root cause

Recent pages already hide recycled entries through the read path, but Favorites returned linked page entities directly from the hidden Favorites page and did not filter recycled entities before rendering.

Fixes logseq/db-test#954.

## Validation

- `rtk bb dev:test -v frontend.handler.db-based.recent-test`