### PR TITLE
fix: clarify today journal deletion

### DIFF
--- a/deps/outliner/src/logseq/outliner/page.cljs
+++ b/deps/outliner/src/logseq/outliner/page.cljs
@@ -104,7 +104,7 @@
   "Deletes a page. Returns true if able to delete page. If unable to delete,
   calls error-handler fn and returns false.
   Rules:
-  1. today page can't be deleted
+  1. today page content is truncated but the page itself can't be deleted
   2. properties and tags will be hard retracted
   3. other pages will be moved to Recycle"
   [conn page-uuid & {:keys [persist-op? rename? error-handler deleted-by-uuid now-ms]
@@ -130,8 +130,14 @@
             (error-handler {:msg "Built-in page cannot be deleted"})
             false)
 
-          (or (ldb/class? page) (ldb/property? page) today-page?)
-          (let [tx-data (build-page-retract-tx @conn page {:today-page? today-page?})]
+          today-page?
+          (let [tx-data (build-page-retract-tx @conn page {:today-page? true})]
+            (when (seq tx-data)
+              (ldb/transact! conn tx-data tx-meta))
+            {:truncated? true})
+
+          (or (ldb/class? page) (ldb/property? page))
+          (let [tx-data (build-page-retract-tx @conn page {})]
             (ldb/transact! conn tx-data tx-meta)
             true)
 

--- a/src/main/frontend/components/page_menu.cljs
+++ b/src/main/frontend/components/page_menu.cljs
@@ -61,10 +61,14 @@
   [page]
   (page-handler/<delete! (:block/uuid page)
                          (fn []
-                           (notification/show! (t :page.delete/success (:block/title page))
-                                               :success))
+                           (notification/show!
+                            (if (db-model/today-journal-page? page)
+                              (t :page.delete/today-journal-truncate-success)
+                              (t :page.delete/success (:block/title page)))
+                            :success))
                          {:error-handler (fn [{:keys [msg]}]
-                                           (notification/show! msg :warning))}))
+                                           (when msg
+                                             (notification/show! msg :warning)))}))
 
 (defn delete-page-confirm!
   [page]

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -1,4 +1,5 @@
-{:account/authentication "Authentication"
+{
+ :account/authentication "Authentication"
  :account/benefits-desc "With a Logseq account, you can access cloud-based services like Logseq Sync and alpha/beta features."
  :account/billing "Billing"
  :account/billing-expired-on-label "Pro plan expired on: {1}"
@@ -1135,6 +1136,7 @@
  :page.delete/confirm-title "Are you sure you want to delete this page?"
  :page.delete/permanent-confirm-title "Are you sure you want to permanently delete this page?"
  :page.delete/success "Page \"{1}\" was deleted successfully!"
+ :page.delete/today-journal-truncate-success "Today's journal page content was deleted."
  :page.delete/total "Total: {1}"
  :page.delete/warning "These pages had their content deleted but were unable to be deleted: {1}. See javascript console for more details."
 
@@ -1969,4 +1971,5 @@
  :zotero/attachments "Attachments"
  :zotero/imported-file-warning "This is a Zotero imported file, set Zotero data directory to open the file in Logseq."
  :zotero/linked-file-warning "This is a Zotero linked file, set Zotero linked attachment base directory to open the file in Logseq."
- :zotero/notes "Notes"}
+ :zotero/notes "Notes"
+}

--- a/src/resources/dicts/zh-cn.edn
+++ b/src/resources/dicts/zh-cn.edn
@@ -1132,6 +1132,7 @@
  :page.delete/confirm-title "确认要删除此页面吗？"
  :page.delete/permanent-confirm-title "确定要永久删除此页面吗？"
  :page.delete/success "页面“{1}”已成功删除！"
+ :page.delete/today-journal-truncate-success "今天的日志页面内容已删除。"
  :page.delete/total "总计: {1}"
  :page.delete/warning "这些页面的内容已删除，但无法删除：{1}。有关更多详细信息，请参阅 JavaScript 控制台。"
 


### PR DESCRIPTION
## Summary
- Keep today journal delete behavior as content truncation while preserving the page entity.
- Return a truncation result from the outliner delete path for today's journal.
- Show a dedicated success toast instead of saying the page itself was deleted.

Addresses logseq/db-test#956.

## Validation
- bb lang:validate-translations
- bb lang:lint-hardcoded --git-changed
- clojure -M:clj-kondo --lint deps/outliner/src/logseq/outliner/page.cljs src/main/frontend/components/page_menu.cljs --cache false
- git diff --check

No tests were added per request.