### PR TITLE
fix: paste OG heading refs

### DIFF
--- a/deps/db/src/logseq/db/frontend/content.cljs
+++ b/deps/db/src/logseq/db/frontend/content.cljs
@@ -119,6 +119,13 @@
       (replace-tag-ref content' page-name id)
       content')))
 
+(defn- ref-replacement-title
+  [{:block/keys [title] original-page-name :block.temp/original-page-name}]
+  (or (when (and (string? original-page-name)
+                 (not (common-util/uuid-string? original-page-name)))
+        original-page-name)
+      title))
+
 (defn title-ref->id-ref
   "Convert ref to id refs e.g. `[[page name]] -> [[uuid]]."
   [title refs & {:keys [replace-tag?]
@@ -139,10 +146,10 @@
                         ref)))
                    sort-refs)]
     (reduce
-     (fn [content {uuid' :block/uuid :block/keys [title]}]
-       (replace-page-ref-with-id content title uuid' replace-tag?))
+     (fn [content {uuid' :block/uuid :as ref}]
+       (replace-page-ref-with-id content (ref-replacement-title ref) uuid' replace-tag?))
      title
-     (filter :block/title refs'))))
+     (filter #(and (:block/title %) (:block/uuid %)) refs'))))
 
 (defn update-block-content
   "Replace `[[internal-id]]` with `[[page name]]`"

--- a/deps/db/test/logseq/db/frontend/content_test.cljs
+++ b/deps/db/test/logseq/db/frontend/content_test.cljs
@@ -18,6 +18,21 @@
            (db-content/title-ref->id-ref "some page ref [[page1]]" [{:block/title "page1" :block/uuid page-uuid}]))
         "Replaces page ref name with uuid"))
 
+  (testing "uses original page name when journal title is normalized"
+    (let [journal-uuid #uuid "00000001-2026-0615-0000-000000000000"]
+      (is (= (str "some page ref " (page-ref/->page-ref journal-uuid))
+             (db-content/title-ref->id-ref
+              "some page ref [[2026-06-15]]"
+              [{:block/title "Jun 15th, 2026"
+                :block.temp/original-page-name "2026-06-15"
+                :block/uuid journal-uuid}])))))
+
+  (testing "ignores refs without uuid"
+    (is (= "some page ref [[2026-06-15]]"
+           (db-content/title-ref->id-ref
+            "some page ref [[2026-06-15]]"
+            [{:block/title "2026-06-15"}]))))
+
   (testing "does replace tag with :replace-tag? true"
     (is (= "some #[[5c6cd067-c602-4955-96b8-74b62e08113c]] tag"
            (db-content/title-ref->id-ref "some #test tag"

--- a/src/main/frontend/handler/paste.cljs
+++ b/src/main/frontend/handler/paste.cljs
@@ -22,10 +22,22 @@
             [logseq.graph-parser.block :as gp-block]
             [promesa.core :as p]))
 
+(defn- with-ref-ids
+  [db date-formatter refs]
+  (mapv (fn [ref]
+          (if (and (map? ref)
+                   (:block/title ref)
+                   (nil? (:block/uuid ref)))
+            (gp-block/page-name->map (:block/title ref) db true date-formatter)
+            ref))
+        refs))
+
 (defn- paste-text-parseable
   [format text]
   (when-let [editing-block (state/get-edit-block)]
     (let [page-id (:db/id (:block/page editing-block))
+          current-db (db/get-db (state/get-current-repo))
+          date-formatter (state/get-date-formatter)
           blocks (block/extract-blocks
                   (mldoc/->edn text format)
                   text format
@@ -33,9 +45,14 @@
           blocks' (cond->> (gp-block/with-parent-and-order page-id blocks)
                     true
                     (map (fn [block]
-                           (let [refs (:block/refs block)]
+                           (let [refs (some->> (:block/refs block)
+                                               (with-ref-ids current-db date-formatter))]
                              (-> block
                                  (dissoc :block/tags)
+                                 (cond-> refs
+                                   (assoc :block/refs refs))
+                                 (cond-> (:logseq.property/heading block)
+                                   (update :block/title commands/clear-markdown-heading))
                                  (update :block/title (fn [title]
                                                         (let [title' (db-content/replace-tags-with-id-refs title refs)]
                                                           (db-content/title-ref->id-ref title' refs)))))))))]

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -1,5 +1,6 @@
 (ns frontend.handler.editor-test
   (:require [clojure.test :refer [async deftest is testing use-fixtures]]
+            [datascript.core :as d]
             [frontend.commands :as commands]
             [frontend.components.editor :as editor-component]
             [frontend.db :as db]
@@ -7,6 +8,7 @@
             [frontend.db.model :as model]
             [frontend.handler.assets :as assets-handler]
             [frontend.handler.editor :as editor]
+            [frontend.handler.paste :as paste-handler]
             [frontend.handler.route :as route-handler]
             [frontend.modules.outliner.op :as outliner-op]
             [frontend.state :as state]
@@ -707,6 +709,92 @@
       (is (nil? (:logseq.property/deleted-at source')))
       (is (nil? (:logseq.property.recycle/original-page source')))
       (is (not= (:db/id recycle-page) (:db/id (:block/page source')))))))
+
+(deftest paste-og-copied-heading-page-refs-creates-journal-pages
+  (async done
+    (test-helper/load-test-files [{:page {:block/title "Paste target"}
+                                   :blocks [{:block/title "target"}]}])
+    (db/transact! [{:db/ident :logseq.class/Journal
+                    :logseq.property.journal/title-format "yyyy-MM-dd"}])
+    (let [target (test-helper/find-block-by-content "target")
+          clipboard "- ## [[2026-06-15]]\n\t- Nudeln mit Soße"]
+      (p/with-redefs [state/get-edit-block (constantly target)
+                      state/get-edit-content (constantly (:block/title target))
+                      state/get-block-op-type (constantly nil)
+                      state/set-block-op-type! (constantly nil)
+                      editor/edit-block! (constantly nil)]
+        (-> (#'paste-handler/paste-text-parseable :markdown clipboard)
+            (p/then
+             (fn [_]
+               (let [db (db/get-db)
+                     journal-id (ffirst (d/q '[:find ?e
+                                               :where
+                                               [?e :block/journal-day 20260615]]
+                                             db))
+                     journal (d/entity db journal-id)
+                     heading-block (ffirst
+                                    (d/q '[:find (pull ?b [:block/title
+                                                           :logseq.property/heading
+                                                           {:block/refs [:db/id :block/title :block/journal-day]}])
+                                           :where
+                                           [?b :logseq.property/heading 2]
+                                           [?b :block/refs ?r]
+                                           [?r :block/journal-day 20260615]]
+                                         db))]
+                 (is (= "2026-06-15" (:block/title journal)))
+                 (is (= 20260615 (:block/journal-day journal)))
+                 (is (= {:logseq.property/heading 2
+                         :block/title (str "[[" (:block/uuid journal) "]]")}
+                        (select-keys heading-block [:block/title :logseq.property/heading])))
+                 (is (= [20260615]
+                        (mapv :block/journal-day (:block/refs heading-block))))
+                 (done))))
+            (p/catch
+             (fn [e]
+               (is false (str e))
+               (done))))))))
+
+(deftest paste-og-copied-heading-page-refs-uses-default-journal-title
+  (async done
+    (test-helper/load-test-files [{:page {:block/title "Paste target"}
+                                   :blocks [{:block/title "target"}]}])
+    (let [target (test-helper/find-block-by-content "target")
+          clipboard "- ## [[2026-06-15]]\n\t- Nudeln mit Soße"]
+      (p/with-redefs [state/get-edit-block (constantly target)
+                      state/get-edit-content (constantly (:block/title target))
+                      state/get-block-op-type (constantly nil)
+                      state/set-block-op-type! (constantly nil)
+                      editor/edit-block! (constantly nil)]
+        (-> (#'paste-handler/paste-text-parseable :markdown clipboard)
+            (p/then
+             (fn [_]
+               (let [db (db/get-db)
+                     journal-id (ffirst (d/q '[:find ?e
+                                               :where
+                                               [?e :block/journal-day 20260615]]
+                                             db))
+                     journal (d/entity db journal-id)
+                     heading-block (ffirst
+                                    (d/q '[:find (pull ?b [:block/title
+                                                           :logseq.property/heading
+                                                           {:block/refs [:db/id :block/title :block/journal-day]}])
+                                           :where
+                                           [?b :logseq.property/heading 2]
+                                           [?b :block/refs ?r]
+                                           [?r :block/journal-day 20260615]]
+                                         db))]
+                 (is (= "Jun 15th, 2026" (:block/title journal)))
+                 (is (= 20260615 (:block/journal-day journal)))
+                 (is (= {:logseq.property/heading 2
+                         :block/title (str "[[" (:block/uuid journal) "]]")}
+                        (select-keys heading-block [:block/title :logseq.property/heading])))
+                 (is (= [20260615]
+                        (mapv :block/journal-day (:block/refs heading-block))))
+                 (done))))
+            (p/catch
+             (fn [e]
+               (is false (str e))
+               (done))))))))
 
 (deftest focused-root-block-operation-guards-test
   (let [root-block {:db/id 1}

--- a/src/test/frontend/handler/paste_test.cljs
+++ b/src/test/frontend/handler/paste_test.cljs
@@ -4,12 +4,14 @@
             [frontend.commands :as commands]
             [frontend.db :as db]
             [frontend.extensions.html-parser :as html-parser]
+            [frontend.format.block :as block]
             [frontend.handler.editor :as editor-handler]
             [frontend.handler.paste :as paste-handler]
             [frontend.state :as state]
             [frontend.test.helper :as test-helper :include-macros true :refer [deftest-async]]
             [frontend.util :as util]
             [frontend.util.cursor :as cursor]
+            [logseq.graph-parser.block :as gp-block]
             [promesa.core :as p]))
 
 (deftest selection-within-link-test
@@ -171,6 +173,50 @@
       (p/let [_ ((paste-handler/editor-on-paste! nil)
                  #js {:clipboardData #js {:getData (constantly clipboard)}})]
         (is (= expected-blocks @actual-blocks))))))
+
+(deftest paste-text-parseable-preserves-og-copied-heading-page-refs
+  (let [actual-blocks (atom nil)
+        date-page-uuid #uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        parsed-blocks [{:block/title "## [[2026-06-15]]"
+                        :block/uuid #uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+                        :block/refs [{:block/title "2026-06-15"
+                                      :block/uuid date-page-uuid}]
+                        :logseq.property/heading 2
+                        :block/level 1}]]
+    (with-redefs [state/get-edit-block (constantly {:block/page {:db/id 1}})
+                  db/entity (fn [id]
+                              (when (= id 1)
+                                {:block/name "paste target"}))
+                  block/extract-blocks (fn [& _] parsed-blocks)
+                  gp-block/with-parent-and-order (fn [_ blocks] blocks)
+                  editor-handler/paste-blocks (fn [blocks _opts]
+                                                (reset! actual-blocks blocks))]
+      (#'paste-handler/paste-text-parseable :markdown "- ## [[2026-06-15]]")
+      (is (= [{:block/title (str "[[" date-page-uuid "]]")
+               :logseq.property/heading 2}]
+             (mapv #(select-keys % [:block/title :logseq.property/heading])
+                   @actual-blocks))))))
+
+(deftest paste-text-parseable-does-not-create-empty-page-ref
+  (let [actual-blocks (atom nil)
+        parsed-blocks [{:block/title "## [[2026-06-15]]"
+                        :block/uuid #uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+                        :block/refs [{:block/title "2026-06-15"}]
+                        :logseq.property/heading 2
+                        :block/level 1}]]
+    (with-redefs [state/get-edit-block (constantly {:block/page {:db/id 1}})
+                  db/entity (fn [id]
+                              (when (= id 1)
+                                {:block/name "paste target"}))
+                  block/extract-blocks (fn [& _] parsed-blocks)
+                  gp-block/with-parent-and-order (fn [_ blocks] blocks)
+                  editor-handler/paste-blocks (fn [blocks _opts]
+                                                (reset! actual-blocks blocks))]
+      (#'paste-handler/paste-text-parseable :markdown "- ## [[2026-06-15]]")
+      (is (= [{:block/title "[[00000001-2026-0615-0000-000000000000]]"
+               :logseq.property/heading 2}]
+             (mapv #(select-keys % [:block/title :logseq.property/heading])
+                   @actual-blocks))))))
 
 (deftest-async editor-on-paste-prefers-blocks-from-memory-when-clipboard-custom-type-is-missing
   (let [actual-blocks (atom nil)


### PR DESCRIPTION
## Summary

Fixes logseq/db-test#955 by normalizing externally pasted OG heading blocks after markdown parsing. When the parser has already extracted `:logseq.property/heading`, the paste path now removes the markdown heading prefix from `:block/title` before page-ref/id-ref conversion.

The paste path also ensures parsed page refs have ids before title refs are converted. This prevents a malformed `[[]]` title when a parsed ref has a title but no uuid yet, and allows valid date refs such as `[[2026-06-15]]` to create/ref the journal page when the graph journal format is `yyyy-MM-dd`.

## Root cause

Pasting OG text like `- ## [[2026-06-15]]` produced a parsed block with both `:logseq.property/heading 2` and `:block/title "## [[2026-06-15]]"`. The first fix handled that title shape but did not guard the id-ref conversion against refs without ids, which can render as `[[]]`.

## Validation

- `bb dev:test -v frontend.handler.paste-test`
- `bb dev:test -v frontend.handler.editor-test/paste-og-copied-heading-page-refs-creates-journal-pages`
- `bb dev:test -v frontend.handler.graph-test/upsert-current-graph-registry-repairs-missing-local-graph-uuid-test`
