### PR TITLE
fix: Route recycle restore through outliner ops

### DIFF
--- a/deps/outliner/src/logseq/outliner/op.cljs
+++ b/deps/outliner/src/logseq/outliner/op.cljs
@@ -131,6 +131,11 @@
      [:op :keyword]
      [:args [:tuple ::uuid ::option]]]]
 
+   [:restore-recycled
+    [:catn
+     [:op :keyword]
+     [:args [:tuple ::uuid]]]]
+
    [:recycle-delete-permanently
     [:catn
      [:op :keyword]
@@ -365,6 +370,10 @@
     :delete-page
     (let [[page-uuid opts] args]
       (reset! *result (outliner-page/delete! conn page-uuid (merge opts opts'))))
+
+    :restore-recycled
+    (let [[root-uuid] args]
+      (outliner-recycle/restore! conn root-uuid))
 
     :recycle-delete-permanently
     (let [[root-uuid] args]

--- a/deps/outliner/test/logseq/outliner/recycle_test.cljs
+++ b/deps/outliner/test/logseq/outliner/recycle_test.cljs
@@ -20,6 +20,20 @@
       (is (nil? (:logseq.property/deleted-at page')))
       (is (nil? (:logseq.property.recycle/original-parent page'))))))
 
+(deftest apply-ops-restore-recycled-page-removes-recycle-parent
+  (let [conn (db-test/create-conn-with-blocks
+              [{:page {:block/title "page1"}
+                :blocks [{:block/title "b1"}]}])
+        page (ldb/get-page @conn "page1")
+        page-uuid (:block/uuid page)]
+    (ldb/transact! conn (recycle/recycle-page-tx-data @conn page {}) {:outliner-op :delete-page})
+    (is (true? (ldb/recycled? (d/entity @conn [:block/uuid page-uuid]))))
+    (outliner-op/apply-ops! conn [[:restore-recycled [page-uuid]]] {})
+    (let [page' (ldb/get-page @conn "page1")]
+      (is (nil? (:block/parent page')))
+      (is (nil? (:logseq.property/deleted-at page')))
+      (is (nil? (:logseq.property.recycle/original-parent page'))))))
+
 (deftest permanently-delete-recycled-page-removes-page-and-descendants
   (let [conn (db-test/create-conn-with-blocks
               [{:page {:block/title "page1"}

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -33,7 +33,6 @@
             [logseq.common.util.page-ref :as page-ref]
             [logseq.db :as ldb]
             [logseq.graph-parser.text :as text]
-            [logseq.outliner.recycle :as outliner-recycle]
             [promesa.core :as p]))
 
 (def <create! page-common-handler/<create!)
@@ -51,23 +50,19 @@
 
 (defn restore-recycled!
   [root-uuid]
-  (when-let [root (db/entity [:block/uuid root-uuid])]
-    (when-let [tx-data (seq (outliner-recycle/restore-tx-data (db/get-db) root))]
-      (p/do!
-       (ui-outliner-tx/transact!
-        {:outliner-op :restore-recycled}
-        (outliner-op/transact! tx-data nil))
-       true))))
+  (p/do!
+   (ui-outliner-tx/transact!
+     {:outliner-op :restore-recycled}
+     (outliner-op/restore-recycled! root-uuid))
+   true))
 
 (defn delete-recycled-permanently!
   [root-uuid]
-  (when-let [root (db/entity [:block/uuid root-uuid])]
-    (when (seq (outliner-recycle/permanently-delete-tx-data (db/get-db) root))
-      (p/do!
-       (ui-outliner-tx/transact!
-        {:outliner-op :recycle-delete-permanently}
-        (outliner-op/recycle-delete-permanently! root-uuid))
-       true))))
+  (p/do!
+   (ui-outliner-tx/transact!
+     {:outliner-op :recycle-delete-permanently}
+     (outliner-op/recycle-delete-permanently! root-uuid))
+   true))
 
 (defn <unfavorite-page!
   [page-name]

--- a/src/main/frontend/modules/outliner/op.cljs
+++ b/src/main/frontend/modules/outliner/op.cljs
@@ -194,6 +194,11 @@
    (op-transact!
     [:delete-page [page-uuid (current-user-delete-opts opts)]])))
 
+(defn restore-recycled!
+  [root-uuid]
+  (op-transact!
+   [:restore-recycled [root-uuid]]))
+
 (defn recycle-delete-permanently!
   [root-uuid]
   (op-transact!


### PR DESCRIPTION
## Summary
- route recycle restore and permanent delete UI handlers through semantic outliner ops
- add `:restore-recycled` to the frontend outliner op builder and outliner op executor
- cover restore execution through `apply-ops!` in recycle tests

## Validation
- `pnpm exec nbb-logseq -cp "$(clojure -Spath):test" -e "(require '[cljs.test :refer [run-tests]] '[logseq.outliner.recycle-test]) (run-tests 'logseq.outliner.recycle-test)"`\n- `bb test:load-all-namespaces-with-nbb .` from `deps/outliner`