### PR TITLE
[codex] Harden file graph import

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -1640,8 +1640,7 @@
                   :size (or (:size stat) (some-> stat .-size) 0)
                   :external-url (or asset-link-or-name path)
                   :external-file-name asset-path}))
-        (p/catch (fn [error]
-                   (js/console.error error))))))
+        (p/catch (constantly nil)))))
 
 (defn- build-asset-tx
   [asset-data asset-name asset-link-or-name asset-link pdf-annotation-pages opts assets zotero-asset?]

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -585,8 +585,8 @@
                 :logseq.property/default-value :logseq.property.repeat/repeat-type.double-plus}})
 
 (defn- missing-repeat-type-property-tx
-  [db repeat-properties]
-  (when (and (:logseq.property.repeat/repeat-type repeat-properties)
+  [db repeat-property-values]
+  (when (and (:logseq.property.repeat/repeat-type repeat-property-values)
              (nil? (d/entity db :logseq.property.repeat/repeat-type)))
     (->> (or (not-empty (select-keys db-property/built-in-properties [:logseq.property.repeat/repeat-type]))
              {:logseq.property.repeat/repeat-type fallback-repeat-type-property})

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -32,6 +32,7 @@
             [logseq.db.frontend.property.build :as db-property-build]
             [logseq.db.frontend.property.type :as db-property-type]
             [logseq.db.frontend.rules :as rules]
+            [logseq.db.sqlite.create-graph :as sqlite-create-graph]
             [logseq.db.sqlite.util :as sqlite-util]
             [logseq.graph-parser.block :as gp-block]
             [logseq.graph-parser.extract :as extract]
@@ -567,6 +568,31 @@
                               (db-property-build/build-properties-with-ref-values pvalue-tx-m))
      :properties-tx pvalues-tx}))
 
+(def ^:private fallback-repeat-type-property
+  {:title "Repeating type"
+   :schema {:type :default
+            :public? false}
+   :closed-values [{:db-ident :logseq.property.repeat/repeat-type.dotted-plus
+                    :value "Advance from completion"
+                    :uuid (common-uuid/gen-uuid :db-ident-block-uuid :logseq.property.repeat/repeat-type.dotted-plus)}
+                   {:db-ident :logseq.property.repeat/repeat-type.plus
+                    :value "Advance from scheduled"
+                    :uuid (common-uuid/gen-uuid :db-ident-block-uuid :logseq.property.repeat/repeat-type.plus)}
+                   {:db-ident :logseq.property.repeat/repeat-type.double-plus
+                    :value "Advance from scheduled, skip to future"
+                    :uuid (common-uuid/gen-uuid :db-ident-block-uuid :logseq.property.repeat/repeat-type.double-plus)}]
+   :properties {:logseq.property/hide-empty-value true
+                :logseq.property/default-value :logseq.property.repeat/repeat-type.double-plus}})
+
+(defn- missing-repeat-type-property-tx
+  [db repeat-properties]
+  (when (and (:logseq.property.repeat/repeat-type repeat-properties)
+             (nil? (d/entity db :logseq.property.repeat/repeat-type)))
+    (->> (or (not-empty (select-keys db-property/built-in-properties [:logseq.property.repeat/repeat-type]))
+             {:logseq.property.repeat/repeat-type fallback-repeat-type-property})
+         sqlite-create-graph/build-properties
+         (map #(assoc % :logseq.property/built-in? true)))))
+
 (defn- find-or-create-deadline-scheduled-value
   "Given a :block/scheduled or :block/deadline value, creates the datetime property value
    and any optional journal tx associated with that value"
@@ -589,7 +615,7 @@
 
 (defn- update-block-deadline-and-scheduled
   "Converts :block/deadline and :block/scheduled to their new logseq properties."
-  [block page-names-to-uuids {:keys [user-config]}]
+  [db block page-names-to-uuids {:keys [user-config]}]
   (let [deadline (:block/deadline block)
         scheduled (:block/scheduled block)
         {deadline-value :property-value deadline-tx :journal-tx}
@@ -610,7 +636,8 @@
        (assoc :logseq.property/scheduled scheduled-value)
        (seq repeat-block-properties)
        (merge repeat-block-properties))
-     :properties-tx (distinct (concat deadline-tx scheduled-tx repeat-properties-tx))}))
+     :properties-tx (distinct (concat (missing-repeat-type-property-tx db repeat-properties')
+                                      deadline-tx scheduled-tx repeat-properties-tx))}))
 
 (defn- text-with-refs?
   "Detects if a property value has text with refs e.g. `#Logseq is #awesome`
@@ -1189,6 +1216,18 @@
            :path (path/path-join zotero-data-dir "storage" id label)
            :base label})))))
 
+(defn- file-link-map->url
+  [m]
+  (when (and (map? m) (= "file" (:protocol m)) (string? (:link m)))
+    (str "file://" (:link m))))
+
+(defn- file-url->path
+  [file-url]
+  (try
+    (js/decodeURI (path/url-to-path file-url))
+    (catch :default _
+      (path/url-to-path file-url))))
+
 (defn- walk-ast-blocks
   "Walks each ast block in order to its full depth. Saves multiple ast types for
   use in build-block-tx. This walk is only done once for perf reasons"
@@ -1211,6 +1250,8 @@
                       (string/ends-with? path-or-map ".pdf"))
                   (and (map? path-or-map) (= "zotero" (:protocol path-or-map)) (string? (:link path-or-map)))
                   (:link (get-zotero-local-pdf-path config (second x)))
+                  (file-link-map->url path-or-map)
+                  (= "pdf" (path/file-ext (file-link-map->url path-or-map)))
                   :else
                   nil)))
          (swap! results update :asset-links conj x)
@@ -1484,8 +1525,9 @@
           :logseq.property.asset/checksum (:checksum asset-data)
           :logseq.property.asset/size (:size asset-data)}
          (when-let [external-url (:external-url asset-data)]
-           {:logseq.property.asset/external-url external-url
-            :logseq.property.asset/external-file-name (:external-file-name asset-data)})))
+           (cond-> {:logseq.property.asset/external-url external-url}
+             (:external-file-name asset-data)
+             (assoc :logseq.property.asset/external-file-name (:external-file-name asset-data))))))
 
 (defn- get-asset-block-id
   [assets path]
@@ -1539,6 +1581,7 @@
   [asset-link user-config linked-files linked-base-dir zotero-imported-files]
   (let [link-map (second asset-link)
         path* (-> link-map :url second)
+        file-url (file-link-map->url path*)
         zotero-path-data (when (map? path*)
                            (get-zotero-local-pdf-path user-config link-map))
         zotero-asset? (some? zotero-path-data)
@@ -1557,6 +1600,9 @@
                                                 :link (:link zotero-path-data)
                                                 :base linked-base}
                                    zotero-asset? zotero-path-data
+                                   file-url {:path (file-url->path file-url)
+                                             :link file-url
+                                             :base (path/filename file-url)}
                                    :else {:path path*})
         asset-name (cond
                      linked-path base
@@ -1604,7 +1650,10 @@
                           :block/uuid (get-asset-block-id assets asset-link-or-name)}
                          (when-let [metadata (not-empty (common-util/safe-read-map-string (:metadata (second asset-link))))]
                            {:logseq.property.asset/resize-metadata metadata}))
-        pdf-annotations-path (if (and zotero-asset? (string? asset-name))
+        external-file-asset? (and (string? asset-name)
+                                  (not= asset-name asset-link-or-name))
+        pdf-annotations-path (if (and (or zotero-asset? external-file-asset?)
+                                      (string? asset-name))
                                (path/path-join common-config/local-assets-dir asset-name)
                                (or asset-name asset-link-or-name))
         pdf-annotations-tx (when (= "pdf" (path/file-ext pdf-annotations-path))
@@ -1842,6 +1891,11 @@
         block))
     block))
 
+(defn- dissoc-nil-block-refs
+  [block]
+  (cond-> block
+    (nil? (:block/refs block)) (dissoc :block/refs)))
+
 (defn- at-least-two?
   [s substr]
   (if (empty? substr)
@@ -1900,7 +1954,7 @@
           {:keys [block properties-tx]}
           (handle-block-properties block* db page-names-to-uuids (:block/refs block*) walked-ast-blocks options)
           {block-after-built-in-props :block deadline-properties-tx :properties-tx}
-          (update-block-deadline-and-scheduled block page-names-to-uuids options)
+          (update-block-deadline-and-scheduled db block page-names-to-uuids options)
           {block-after-assets :block :keys [asset-blocks-tx]}
           (<handle-assets-in-block block-after-built-in-props walked-ast-blocks import-state (select-keys options [:log-fn :notify-user :<get-file-stat :user-config]))
           ;; :block/page should be [:block/page NAME]
@@ -1913,6 +1967,7 @@
                      (fix-pre-block-references pre-blocks page-names-to-uuids)
                      (fix-block-name-lookup-ref page-names-to-uuids)
                      (update-block-refs page-names-to-uuids)
+                     dissoc-nil-block-refs
                      (update-block-tags db (:user-options options) per-file-state (:all-idents import-state))
                      (handle-embeds page-names-to-uuids walked-ast-blocks (select-keys options [:log-fn]))
                      (handle-quotes (select-keys options [:log-fn]))
@@ -1983,6 +2038,20 @@
                    (throw (ex-info (str "No uuid for existing page " (pr-str (:block/name p)))
                                    (select-keys p [:block/name :block/tags])))))))
        (into {})))
+
+(defn- journal-file-name-uuid-entry
+  [{:keys [path]}]
+  (let [normalized-path (some-> path str (string/replace "\\" "/") string/lower-case)]
+    (when-let [[_ journal-title] (re-find #"(?:^|/)journals/(\d{4}_\d{2}_\d{2})\.(?:md|markdown|org)$"
+                                          normalized-path)]
+      (when-let [journal-day (date-time-util/journal-title->int journal-title ["yyyy_MM_dd"])]
+        [journal-title (common-uuid/gen-uuid :journal-page-uuid journal-day)]))))
+
+(defn- index-journal-file-name-uuids!
+  [doc-files import-state]
+  (swap! (:journal-file-name-uuids import-state)
+         merge
+         (into {} (keep journal-file-name-uuid-entry) doc-files)))
 
 (defn- build-existing-page
   [m db page-uuid {:keys [page-names-to-uuids] :as per-file-state} {:keys [notify-user import-state] :as options}]
@@ -2118,7 +2187,10 @@
   data for subsequent steps"
   [conn pages blocks {:keys [import-state user-options]
                       :as options}]
-  (let [all-pages* (-> (->> (extract/with-ref-pages pages blocks)
+  (let [journal-file-name-uuids @(:journal-file-name-uuids import-state)
+        all-pages* (-> (->> (extract/with-ref-pages pages blocks)
+                            (remove #(and (not (:block/file %))
+                                          (contains? journal-file-name-uuids (:block/name %))))
                             ;; remove unused property pages unless the page has content
                             (remove #(and (contains? (into (:property-classes user-options) (:property-parent-classes user-options))
                                                      (keyword (:block/name %)))
@@ -2137,7 +2209,7 @@
                                 (map (juxt (some-fn ::original-name :block/name) :block/uuid))
                                 (into {}))
         ;; Stateful because new page uuids can occur via tags
-        page-names-to-uuids (atom (merge all-existing-page-uuids all-new-page-uuids))
+        page-names-to-uuids (atom (merge all-existing-page-uuids all-new-page-uuids journal-file-name-uuids))
         per-file-state {:page-names-to-uuids page-names-to-uuids
                         :classes-tx (:classes-tx options)}
         all-pages-m (mapv #(handle-page-properties % @conn per-file-state all-pages options)
@@ -2246,6 +2318,8 @@
    :property-schemas (atom {})
    ;; Indexes all created pages by uuid. Index is used to fetch all parents of a page
    :all-existing-page-uuids (atom {})
+   ;; Map of legacy journal file titles like "2026_04_01" to their standard journal page uuids.
+   :journal-file-name-uuids (atom {})
    ;; Map of property or class names (keyword) to db-ident keywords
    :all-idents (atom {})
    ;; Set of children pages turned into classes by :property-parent-classes option
@@ -2469,7 +2543,7 @@
     (if-let [block (first blocks)]
       (p/let [block-tx-data (<build-block-tx @conn block pre-blocks per-file-state
                                              tx-options)]
-        (p/recur (concat tx-data block-tx-data) (rest blocks)))
+        (p/recur (into tx-data block-tx-data) (rest blocks)))
       tx-data)))
 
 (defn <add-file-to-db-graph
@@ -2510,21 +2584,22 @@
           classes-tx' (concat classes-tx retract-page-tags-tx)
           custom-status-tx @(:custom-status-tx tx-options)
           ;; Build indices
-          pages-index (->> (map #(select-keys % [:block/uuid]) pages-tx'')
-                           (concat (map #(select-keys % [:block/uuid]) classes-tx))
-                           distinct)
-          block-ids (map (fn [block] {:block/uuid (:block/uuid block)}) blocks-tx)
-          block-refs-ids (->> (mapcat :block/refs blocks-tx)
-                              (filter (fn [ref] (and (vector? ref)
-                                                     (= :block/uuid (first ref)))))
-                              (map (fn [ref] {:block/uuid (second ref)}))
-                              (seq))
+          pages-index (into [] (comp (map #(select-keys % [:block/uuid]))
+                                     (distinct))
+                            (concat pages-tx'' classes-tx))
+          block-ids (into [] (map (fn [block] {:block/uuid (:block/uuid block)})) blocks-tx)
+          block-refs-ids (into [] (comp (mapcat :block/refs)
+                                        (filter (fn [ref] (and (vector? ref)
+                                                               (= :block/uuid (first ref)))))
+                                        (map (fn [ref] {:block/uuid (second ref)})))
+                               blocks-tx)
           ;; To prevent "unique constraint" on datascript
           blocks-index (set/union (set block-ids) (set block-refs-ids))
           ;; Order matters. pages-index and blocks-index needs to come before their corresponding tx for
           ;; uuids to be valid. Also upstream-properties-tx comes after blocks-tx to possibly override blocks
-          tx (concat pages-index page-properties-tx property-page-properties-tx pages-tx'' classes-tx' custom-status-tx blocks-index blocks-tx)
-          tx' (common-util/fast-remove-nils tx)
+          tx' (into [] (comp cat (remove nil?))
+                    [pages-index page-properties-tx property-page-properties-tx pages-tx''
+                     classes-tx' custom-status-tx blocks-index blocks-tx])
           ;; _ (prn :tx-counts (map #(vector %1 (count %2))
           ;;                        [:pages-index :page-properties-tx :property-page-properties-tx :pages-tx' :classes-tx :blocks-index :blocks-tx]
           ;;                        [pages-index page-properties-tx property-page-properties-tx pages-tx' classes-tx blocks-index blocks-tx]))
@@ -2694,6 +2769,7 @@
                                    [(not (string/starts-with? (node-path/basename path) "hls__")) path])
                                  *doc-files)
                         (range 0 (count *doc-files)))]
+    (index-journal-file-name-uuids! doc-files (:import-state options))
     (-> (p/loop [_file-map (export-doc-file (get doc-files 0) conn <read-file options)
                  i 0]
           (when-not (>= i (dec (count doc-files)))

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -276,6 +276,14 @@
    "Generated Epsilon"
    "Generated Zeta"])
 
+(def generated-file-graph-ref-page-names
+  (into generated-file-graph-page-names
+        ["Generated/Missing Namespace"
+         "Generated Nested/Child"
+         "Missing Alias Target"
+         "Missing Tag Target"
+         "Generated PDF"]))
+
 (def generated-file-graph-task-markers
   [nil "TODO" "DOING" "DONE" "LATER" "NOW" "WAITING"])
 
@@ -286,13 +294,50 @@
    "edge-case"
    "db-test"])
 
+(def generated-file-graph-test-seeds
+  [1309 42 8675309])
+
+(defn- generated-page-preamble
+  [*seed page-name]
+  (let [alias-name (str page-name " Alias " (next-random! *seed 30))
+        tag-page (random-choice! *seed generated-file-graph-ref-page-names)]
+    (case (next-random! *seed 5)
+      0 (str "alias:: [[" alias-name "]], [[Missing Alias Target]]\n"
+             "tags:: [[" tag-page "]], #generated-page\n"
+             "generated-page-rank:: " (next-random! *seed 100) "\n\n")
+      1 (str "title:: " page-name "\n"
+             "public:: true\n\n")
+      "")))
+
+(defn- generated-title-suffix
+  [*seed]
+  (case (next-random! *seed 8)
+    0 (str " [missing asset](../assets/missing-" (next-random! *seed 50) ".pdf)")
+    1 (str " ![missing image](../assets/missing-" (next-random! *seed 50) ".png)")
+    2 (str " [[" (random-choice! *seed generated-file-graph-ref-page-names) "]]")
+    3 " #[[generated multi tag]]"
+    ""))
+
+(defn- generated-extra-lines
+  [*seed index]
+  (case (next-random! *seed 8)
+    0 (str "  collapsed:: true\n"
+           "  background-color:: yellow\n")
+    1 (str "  alias:: [[Generated Block Alias " (next-random! *seed 100) "]]\n")
+    2 (str "  | generated | table |\n"
+           "  | row | " index " |\n")
+    3 (str "  ```clojure\n"
+           "  (def generated-" index " " (next-random! *seed 100) ")\n"
+           "  ```\n")
+    ""))
+
 (defn- generated-md-block
   [*seed index]
   (let [block-id (generated-uuid (inc index))
         duplicate-id (generated-uuid 1)
         missing-ref-id (generated-uuid (+ 2000 index))
         task-marker (random-choice! *seed generated-file-graph-task-markers)
-        page-name (random-choice! *seed generated-file-graph-page-names)
+        page-name (random-choice! *seed generated-file-graph-ref-page-names)
         missing-page-name (str "Generated Missing " (next-random! *seed 1000))
         tag (random-choice! *seed generated-file-graph-tags)
         ref-id (case (next-random! *seed 5)
@@ -308,26 +353,30 @@
                    missing-page-name
                    page-name)
         title-prefix (if task-marker (str task-marker " ") "")
+        title-suffix (generated-title-suffix *seed)
         temporal-line (case (next-random! *seed 6)
                         0 "  SCHEDULED: <2026-01-05 Mon .+1w>\n"
                         1 "  DEADLINE: <2026-01-09 Fri +2d>\n"
                         "")
+        extra-lines (generated-extra-lines *seed index)
         nested-line (when (zero? (next-random! *seed 3))
                       (str "  - nested generated block " index
                            " [[Generated Nested " (next-random! *seed 30) "]]\n"))]
     (str "- " title-prefix "generated block " index
-         " [[" page-ref "]] ((" ref-id ")) #" tag "\n"
+         " [[" page-ref "]] ((" ref-id ")) #" tag title-suffix "\n"
          temporal-line
          "  id:: " id-value "\n"
          "  generated-ref:: [[" page-name "]]\n"
          "  generated-rank:: " (next-random! *seed 100) "\n"
+         extra-lines
          nested-line)))
 
 (defn- generated-md-file-content
-  [*seed file-index block-count]
-  (apply str
-         (map #(generated-md-block *seed (+ (* file-index 100) %))
-              (range block-count))))
+  [*seed file-index page-name block-count]
+  (str (generated-page-preamble *seed page-name)
+       (apply str
+              (map #(generated-md-block *seed (+ (* file-index 100) %))
+                   (range block-count)))))
 
 (defn- generated-md-file-graph
   [seed]
@@ -335,14 +384,40 @@
         pages (map-indexed
                (fn [index page-name]
                  [(str "pages/" (string/replace (string/lower-case page-name) " " "_") ".md")
-                  (generated-md-file-content *seed index (+ 8 (next-random! *seed 8)))])
+                  (generated-md-file-content *seed index page-name (+ 8 (next-random! *seed 8)))])
                generated-file-graph-page-names)
         journals [["journals/2026_01_05.md"
-                   (generated-md-file-content *seed 20 (+ 8 (next-random! *seed 8)))]
+                   (generated-md-file-content *seed 20 "2026_01_05" (+ 8 (next-random! *seed 8)))]
                   ["journals/2026_01_06.md"
-                   (generated-md-file-content *seed 21 (+ 8 (next-random! *seed 8)))]]]
+                   (generated-md-file-content *seed 21 "2026_01_06" (+ 8 (next-random! *seed 8)))]
+                  ["assets/generated.md"
+                   "Generated asset content\n"]]]
     (into {"logseq/config.edn" "{:preferred-format :markdown\n :journal/page-title-format \"yyyy_MM_dd\"}\n"}
           (concat pages journals))))
+
+(defn- assert-generated-md-file-graph-imports
+  [seed]
+  (let [graph-dir (write-temp-file-graph (generated-md-file-graph seed))]
+    (p/let [conn (db-test/create-conn)
+            _ (db-pipeline/add-listener conn)
+            _ (import-file-graph-to-db graph-dir conn {})
+            generated-block-count (->> (d/q '[:find [?title ...]
+                                              :where [?b :block/title ?title]]
+                                            @conn)
+                                       (filter #(string/includes? % "generated block"))
+                                       count)
+            validation-errors (map :entity (:errors (db-validate/validate-local-db! @conn)))]
+      (is (<= 60 generated-block-count)
+          (str "Seed " seed " imports the generated block corpus"))
+      (is (empty? validation-errors)
+          (str "Seed " seed " generated Markdown file graph validates")))))
+
+(defn- assert-generated-md-file-graphs-import
+  [seeds]
+  (p/loop [remaining-seeds (seq seeds)]
+    (when remaining-seeds
+      (p/let [_ (assert-generated-md-file-graph-imports (first remaining-seeds))]
+        (p/recur (next remaining-seeds))))))
 
 ;; Tests
 ;; =====
@@ -612,19 +687,10 @@
           "Imported graph validates"))))
 
 (deftest-async import-generated-markdown-file-graph
-  (let [graph-dir (write-temp-file-graph (generated-md-file-graph 1309))]
-    (p/let [conn (db-test/create-conn)
-            _ (db-pipeline/add-listener conn)
-            _ (import-file-graph-to-db graph-dir conn {})
-            generated-block-count (->> (d/q '[:find [?title ...]
-                                              :where [?b :block/title ?title]]
-                                            @conn)
-                                       (filter #(string/includes? % "generated block"))
-                                       count)]
-      (is (<= 60 generated-block-count)
-          "Generated Markdown file graph imports the generated block corpus")
-      (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
-          "Generated Markdown file graph validates"))))
+  (assert-generated-md-file-graphs-import generated-file-graph-test-seeds))
+
+(deftest-async ^:integration import-generated-markdown-file-graph-fuzz
+  (assert-generated-md-file-graphs-import (range 1 101)))
 
 (deftest-async export-doc-files-propagates-missing-block-ref-cleanup-report
   (let [missing-uuid #uuid "55555555-5555-5555-5555-555555555555"
@@ -662,6 +728,31 @@
     ["[[FIRST UUID]] and ![dino!](assets/subdir/partydino.gif)"
      "assets/subdir/partydino.gif"]
     "[[FIRST UUID]] and [[UUID]]"))
+
+(deftest-async import-missing-local-pdf-asset-link-is-ignored-quietly
+  (let [graph-dir (write-temp-file-graph
+                   {"logseq/config.edn" "{}"
+                    "pages/missing-asset.md" "- Missing local PDF [paper](../assets/missing-paper.pdf)\n"})
+        console-errors (atom [])
+        original-stderr-write (.-write (.-stderr js/process))]
+    (set! (.-write (.-stderr js/process))
+          (fn [& args]
+            (swap! console-errors conj (first args))
+            true))
+    (-> (p/let [conn (db-test/create-conn)
+                assets (atom [])
+                {:keys [import-state]} (import-file-graph-to-db graph-dir conn {:assets assets})]
+          (is (= [{:reason "No asset data found for this asset path"
+                   :path "../assets/missing-paper.pdf"
+                   :location {:block "Missing local PDF [paper](../assets/missing-paper.pdf)"}}]
+                 @(:ignored-assets import-state))
+              "Missing local PDF asset links are reported through ignored assets")
+          (is (empty? @console-errors)
+              "Missing local PDF asset links are ignored without noisy console errors")
+          (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
+              "Imported graph validates"))
+        (p/finally (fn [_]
+                     (set! (.-write (.-stderr js/process)) original-stderr-write))))))
 
 (deftest extract-template-blocks
   (let [page-uuid (random-uuid)

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -273,20 +273,33 @@
     (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
         "Imported graph validates")))
 
+(deftest-async import-empty-journal-file
+  (p/let [file (write-temp-graph-file "journals/2025_11_11.md" "\n")
+          conn (db-test/create-conn)
+          _ (db-pipeline/add-listener conn)
+          _ (import-files-to-db [file] conn {})]
+    (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
+        "Empty imported files do not transact nil block refs")))
+
 (deftest-async import-repeated-deadline-and-scheduled
   (p/let [file (write-temp-graph-file
                  "pages/repeated-tasks.md"
                  (str "- TODO wish [[name]] a happy birthday\n"
                       "  SCHEDULED: <2025-11-01 Sat 08:00 .+1y>\n"
                       "- TODO prepare weekly report\n"
-                      "  DEADLINE: <2025-11-07 Fri +2w>\n"))
+                      "  DEADLINE: <2025-11-07 Fri +2w>\n"
+                      "- TODO plan release\n"
+                      "  DEADLINE: <2025-11-08 Sat>\n"
+                      "  SCHEDULED: <2025-11-07 Fri .+1w>\n"))
           conn (db-test/create-conn)
           _ (db-pipeline/add-listener conn)
           _ (import-files-to-db [file] conn {})]
     (let [birthday-properties (db-test/readable-properties
-                               (db-test/find-block-by-content @conn #"happy birthday"))
+                             (db-test/find-block-by-content @conn #"happy birthday"))
           report-properties (db-test/readable-properties
                              (db-test/find-block-by-content @conn #"weekly report"))
+          mixed-properties (db-test/readable-properties
+                            (db-test/find-block-by-content @conn #"plan release"))
           birthday-scheduled (:logseq.property/scheduled birthday-properties)
           birthday-date (js/Date. birthday-scheduled)]
       (is (= 20251101 (date-time-util/ms->journal-day birthday-scheduled))
@@ -320,6 +333,24 @@
                                :logseq.property.repeat/recur-frequency
                                :logseq.property.repeat/recur-unit])))
           "Repeated deadline timestamp keeps its repeat properties including the `+` cookie kind")
+      (is (= {:logseq.property/deadline 20251108
+              :logseq.property/scheduled 20251107
+              :logseq.property.repeat/repeated? true
+              :logseq.property.repeat/temporal-property :logseq.property/scheduled
+              :logseq.property.repeat/repeat-type :logseq.property.repeat/repeat-type.dotted-plus
+              :logseq.property.repeat/recur-frequency 1
+              :logseq.property.repeat/recur-unit :logseq.property.repeat/recur-unit.week}
+             (-> mixed-properties
+                 (update :logseq.property/deadline date-time-util/ms->journal-day)
+                 (update :logseq.property/scheduled date-time-util/ms->journal-day)
+                 (select-keys [:logseq.property/deadline
+                               :logseq.property/scheduled
+                               :logseq.property.repeat/repeated?
+                               :logseq.property.repeat/temporal-property
+                               :logseq.property.repeat/repeat-type
+                               :logseq.property.repeat/recur-frequency
+                               :logseq.property.repeat/recur-unit])))
+          "Mixed deadline and scheduled timestamps keep both dates and the repeated temporal property")
       (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
           "Imported graph validates"))))
 
@@ -399,6 +430,28 @@
         "Custom status closed value is shared across imported files")
     (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
         "Imported graph validates")))
+
+(deftest-async import-repairs-duplicated-block-ids
+  (let [duplicated-uuid #uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]
+    (p/let [file (write-temp-graph-file
+                  "pages/duplicated-ids.md"
+                  (str "- First duplicated id\n"
+                       "  id:: " duplicated-uuid "\n"
+                       "- Second duplicated id\n"
+                       "  id:: " duplicated-uuid "\n"))
+            conn (db-test/create-conn)
+            _ (db-pipeline/add-listener conn)
+            _ (import-files-to-db [file] conn {})
+            first-block (db-test/find-block-by-content @conn "First duplicated id")
+            second-block (db-test/find-block-by-content @conn "Second duplicated id")]
+      (is (= duplicated-uuid (:block/uuid first-block))
+          "The first imported block keeps the original id")
+      (is (some? (:block/uuid second-block))
+          "The duplicate imported block gets a replacement id")
+      (is (not= duplicated-uuid (:block/uuid second-block))
+          "The duplicate imported block does not keep the conflicting id")
+      (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
+          "Imported graph validates"))))
 
 (deftest-async import-removes-pre-block-marker-and-missing-block-refs
   (let [missing-uuid #uuid "11111111-1111-1111-1111-111111111111"
@@ -600,6 +653,76 @@
                 (map first)
                 (remove #(= [{:db/ident :logseq.class/Tag}] (:block/tags %)))))
         "All classes only have :logseq.class/Tag as their tag (and don't have Page)")))
+
+(deftest-async import-linked-file-pdf-annotations
+  (let [annotation-id #uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        dir (fs/mkdtempSync (node-path/join (os/tmpdir) "logseq-graph-parser-test-"))
+        external-pdf-path (node-path/join dir "external/Linked Paper.pdf")
+        graph-dir (node-path/join dir "graph")
+        encoded-pdf-uri (str "file://" (string/replace external-pdf-path " " "%20"))]
+    (fs/mkdirSync (node-path/dirname external-pdf-path) #js {:recursive true})
+    (fs/writeFileSync external-pdf-path "pdf")
+    (doseq [[relative-path content]
+            {"logseq/config.edn" "{}"
+             "pages/source.md" (str "- ![Linked Paper.pdf](" encoded-pdf-uri ")\n")
+             "pages/hls__Linked Paper.md" (str "file:: [Linked Paper.pdf](" encoded-pdf-uri ")\n"
+                                               "file-path:: " encoded-pdf-uri "\n\n"
+                                               "- External highlight from linked pdf\n"
+                                               "  ls-type:: annotation\n"
+                                               "  hl-page:: 3\n"
+                                               "  hl-color:: yellow\n"
+                                               "  id:: " annotation-id "\n")
+             "assets/Linked Paper.edn" (str "{:highlights [{:id #uuid \"" annotation-id "\","
+                                            " :page 3,"
+                                            " :position {:bounding {:x1 1 :y1 2 :x2 3 :y2 4 :width 10 :height 20},"
+                                            "            :rects (),"
+                                            "            :page 3},"
+                                            " :content {:text \"External highlight from linked pdf\"},"
+                                            " :properties {:color \"yellow\"}}]}")}]
+      (let [file-path (node-path/join graph-dir relative-path)]
+        (fs/mkdirSync (node-path/dirname file-path) #js {:recursive true})
+        (fs/writeFileSync file-path content)))
+    (p/let [conn (db-test/create-conn)
+            assets (atom [])
+            {:keys [import-state]} (import-file-graph-to-db graph-dir conn {:assets assets})
+            asset (db-test/find-block-by-content @conn "Linked Paper")
+            annotation (db-test/find-block-by-content @conn "External highlight from linked pdf")]
+      (is (some? asset)
+          "Linked file PDF imports as an external Asset")
+      (is (= {:block/tags [:logseq.class/Asset]
+              :logseq.property.asset/type "pdf"
+              :logseq.property.asset/external-url encoded-pdf-uri}
+             (select-keys (db-test/readable-properties asset)
+                          [:block/tags
+                           :logseq.property.asset/type
+                           :logseq.property.asset/external-url]))
+          "Linked file PDF keeps the file URI as external asset metadata")
+      (is (= {:block/tags [:logseq.class/Pdf-annotation]
+              :logseq.property/asset "Linked Paper"
+              :logseq.property.pdf/hl-page 3}
+             (select-keys (db-test/readable-properties annotation)
+                          [:block/tags
+                           :logseq.property/asset
+                           :logseq.property.pdf/hl-page]))
+          "Linked file PDF annotations import and point at the external Asset")
+      (is (= 0 (count @(:ignored-assets import-state))) "No ignored assets"))))
+
+(deftest-async ^:integration import-large-flat-file-without-stack-overflow
+  (p/let [file (write-temp-graph-file
+                "pages/large.md"
+                (apply str (map #(str "- large line " % " #tag\n") (range 45000))))
+          conn (db-test/create-conn)
+          _ (db-pipeline/add-listener conn)
+          _ (import-files-to-db [file] conn {:convert-all-tags? true})]
+    (is (= 45000
+           (->> (d/q '[:find [?title ...]
+                       :where [?b :block/title ?title]]
+                     @conn)
+                (filter #(string/starts-with? % "large line "))
+                count))
+        "Large flat files import without overflowing the stack")
+    (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
+        "Imported graph validates")))
 
 (deftest-async export-basic-graph-with-convert-all-tags
   ;; This graph will contain basic examples of different features to import
@@ -1398,6 +1521,39 @@
         "Journal reference is not split into a parent namespace page")
     (is (nil? (db-test/find-page-by-title @conn "05"))
         "Journal reference is not split into a child namespace page")))
+
+(deftest-async import-legacy-journal-file-name-refs-as-journals
+  (p/let [source-file (write-temp-graph-file
+                       "journals/2026_04_01.md"
+                       "- legacy journal ref [[2026_04_02]]\n")
+          target-file (write-temp-graph-file
+                       "journals/2026_04_02.md"
+                       "- target journal\n")
+          conn (db-test/create-conn)
+          _ (import-files-to-db [source-file target-file] conn {})
+          legacy-journal (db-test/find-journal-by-journal-day @conn 20260402)
+          legacy-ref-block (db-test/find-block-by-content @conn #"legacy journal ref")]
+    (is (some? legacy-journal)
+        "Legacy yyyy_MM_dd journal page refs resolve imported journal files")
+    (is (= #{(:block/uuid legacy-journal)}
+           (set (map :block/uuid (:block/refs legacy-ref-block))))
+        "Legacy journal page ref points at the journal page")
+    (is (nil? (db-test/find-page-by-title @conn "2026_04_02"))
+        "Legacy journal page ref does not create an ordinary page")))
+
+(deftest-async import-creates-missing-ordinary-page-refs
+  (p/let [file (write-temp-graph-file
+                "pages/source.md"
+                "- missing page ref [[Missing Page]]\n")
+          conn (db-test/create-conn)
+          _ (import-files-to-db [file] conn {})
+          missing-page (db-test/find-page-by-title @conn "Missing Page")
+          source-block (db-test/find-block-by-content @conn #"missing page ref")]
+    (is (some? missing-page)
+        "Missing ordinary page refs create ordinary pages")
+    (is (= #{(:block/uuid missing-page)}
+           (set (map :block/uuid (:block/refs source-block))))
+        "Missing ordinary page ref points at the created page")))
 
 (deftest-async import-normalizes-existing-random-journal-uuid-and-text-refs
   (let [old-journal-uuid (random-uuid)

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -245,6 +245,105 @@
     (fs/writeFileSync file-path content)
     file-path))
 
+(defn- write-temp-file-graph
+  [files]
+  (let [dir (fs/mkdtempSync (node-path/join (os/tmpdir) "logseq-graph-parser-test-"))]
+    (doseq [[relative-path content] files]
+      (let [file-path (node-path/join dir relative-path)]
+        (fs/mkdirSync (node-path/dirname file-path) #js {:recursive true})
+        (fs/writeFileSync file-path content)))
+    dir))
+
+(defn- next-random!
+  [*seed n]
+  (let [next-seed (mod (* 48271 @*seed) 2147483647)]
+    (reset! *seed next-seed)
+    (mod next-seed n)))
+
+(defn- random-choice!
+  [*seed choices]
+  (nth choices (next-random! *seed (count choices))))
+
+(defn- generated-uuid
+  [n]
+  (str "10000000-0000-4000-8000-" (.padStart (.toString n 16) 12 "0")))
+
+(def generated-file-graph-page-names
+  ["Generated Alpha"
+   "Generated Beta"
+   "Generated Gamma"
+   "Generated Delta"
+   "Generated Epsilon"
+   "Generated Zeta"])
+
+(def generated-file-graph-task-markers
+  [nil "TODO" "DOING" "DONE" "LATER" "NOW" "WAITING"])
+
+(def generated-file-graph-tags
+  ["generated"
+   "import"
+   "file-graph"
+   "edge-case"
+   "db-test"])
+
+(defn- generated-md-block
+  [*seed index]
+  (let [block-id (generated-uuid (inc index))
+        duplicate-id (generated-uuid 1)
+        missing-ref-id (generated-uuid (+ 2000 index))
+        task-marker (random-choice! *seed generated-file-graph-task-markers)
+        page-name (random-choice! *seed generated-file-graph-page-names)
+        missing-page-name (str "Generated Missing " (next-random! *seed 1000))
+        tag (random-choice! *seed generated-file-graph-tags)
+        ref-id (case (next-random! *seed 5)
+                 0 block-id
+                 1 duplicate-id
+                 2 missing-ref-id
+                 (generated-uuid (inc (next-random! *seed 90))))
+        id-value (case (next-random! *seed 11)
+                   0 "broken-generated-id"
+                   1 duplicate-id
+                   block-id)
+        page-ref (if (zero? (next-random! *seed 3))
+                   missing-page-name
+                   page-name)
+        title-prefix (if task-marker (str task-marker " ") "")
+        temporal-line (case (next-random! *seed 6)
+                        0 "  SCHEDULED: <2026-01-05 Mon .+1w>\n"
+                        1 "  DEADLINE: <2026-01-09 Fri +2d>\n"
+                        "")
+        nested-line (when (zero? (next-random! *seed 3))
+                      (str "  - nested generated block " index
+                           " [[Generated Nested " (next-random! *seed 30) "]]\n"))]
+    (str "- " title-prefix "generated block " index
+         " [[" page-ref "]] ((" ref-id ")) #" tag "\n"
+         temporal-line
+         "  id:: " id-value "\n"
+         "  generated-ref:: [[" page-name "]]\n"
+         "  generated-rank:: " (next-random! *seed 100) "\n"
+         nested-line)))
+
+(defn- generated-md-file-content
+  [*seed file-index block-count]
+  (apply str
+         (map #(generated-md-block *seed (+ (* file-index 100) %))
+              (range block-count))))
+
+(defn- generated-md-file-graph
+  [seed]
+  (let [*seed (atom seed)
+        pages (map-indexed
+               (fn [index page-name]
+                 [(str "pages/" (string/replace (string/lower-case page-name) " " "_") ".md")
+                  (generated-md-file-content *seed index (+ 8 (next-random! *seed 8)))])
+               generated-file-graph-page-names)
+        journals [["journals/2026_01_05.md"
+                   (generated-md-file-content *seed 20 (+ 8 (next-random! *seed 8)))]
+                  ["journals/2026_01_06.md"
+                   (generated-md-file-content *seed 21 (+ 8 (next-random! *seed 8)))]]]
+    (into {"logseq/config.edn" "{:preferred-format :markdown\n :journal/page-title-format \"yyyy_MM_dd\"}\n"}
+          (concat pages journals))))
+
 ;; Tests
 ;; =====
 
@@ -511,6 +610,21 @@
           "Existing block refs are preserved, including forward refs from later files")
       (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
           "Imported graph validates"))))
+
+(deftest-async import-generated-markdown-file-graph
+  (let [graph-dir (write-temp-file-graph (generated-md-file-graph 1309))]
+    (p/let [conn (db-test/create-conn)
+            _ (db-pipeline/add-listener conn)
+            _ (import-file-graph-to-db graph-dir conn {})
+            generated-block-count (->> (d/q '[:find [?title ...]
+                                              :where [?b :block/title ?title]]
+                                            @conn)
+                                       (filter #(string/includes? % "generated block"))
+                                       count)]
+      (is (<= 60 generated-block-count)
+          "Generated Markdown file graph imports the generated block corpus")
+      (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
+          "Generated Markdown file graph validates"))))
 
 (deftest-async export-doc-files-propagates-missing-block-ref-cleanup-report
   (let [missing-uuid #uuid "55555555-5555-5555-5555-555555555555"

--- a/deps/outliner/test/logseq/outliner/pipeline_test.cljs
+++ b/deps/outliner/test/logseq/outliner/pipeline_test.cljs
@@ -34,3 +34,14 @@
         "#Query class tag is included in :block/refs")
     (is (not (contains? refs query-property-id))
         "#Query block does not reference logseq.property/query through :block/refs")))
+
+(deftest db-rebuild-block-refs-removes-recursive-self-ref
+  (let [conn (db-test/create-conn-with-blocks
+              [{:page {:block/title "page1"}
+                :blocks [{:block/title "self"}]}])
+        block (db-test/find-block-by-content @conn "self")
+        block' (assoc (d/pull @conn '[:db/id :block/uuid :block/title] (:db/id block))
+                      :block/title
+                      (str "self " (page-ref/->page-ref (:block/uuid block))))]
+    (is (empty? (outliner-pipeline/db-rebuild-block-refs @conn block'))
+        "A block should not rebuild a recursive ref to itself")))

--- a/docs/og_import_graph_cases.md
+++ b/docs/og_import_graph_cases.md
@@ -1,0 +1,87 @@
+# OG Import Graph Cases
+
+This file tracks file-graph-to-DB import issue classes and the regression cases fixed or covered by tests.
+
+## db-test Import Issue Classes
+
+GitHub `logseq/db-test` issues with the `import` label were audited on 2026-06-24. The file-graph importer cases fall into these classes:
+
+- Block identity and references: #213, #226, #340, #426, #525, #641, #679, #684, #748, #927, #931.
+- Journal and page references: #61, #77, #191, #192, #588, #906.
+- Legacy properties, tasks, queries, and config: #176, #193, #195, #198, #220, #250, #289, #290, #300, #318, #341, #406, #446, #521, #537, #539, #540, #601, #732, #733, #936.
+- Markdown and Org parsing fidelity: #434, #523, #582.
+- Assets, PDFs, and highlights: #196, #358, #923.
+- Tags, namespaces, aliases, and backlinks: #7, #134, #136, #197, #210, #460, #680, #724.
+- Import UX, graph lifecycle, or non-file-graph import paths: #177, #216, #827.
+
+## Fixed and Covered Cases
+
+### Legacy journal filename refs
+
+- Source issue: #906.
+- Case: an OG page links to an imported journal file by file-style names such as `[[2026_04_01]]`, including when the source file is processed before the target journal file.
+- Expected import behavior: resolve the file-style name to the DB journal page for that imported file, point `:block/refs` at the journal entity, and avoid creating an ordinary page named `2026_04_01`.
+- Regression test: `logseq.graph-parser.exporter-test/import-legacy-journal-file-name-refs-as-journals`.
+
+### Missing block refs
+
+- Source issues: #213, #340, #679, #748, #927.
+- Case: imported content contains block refs whose target block is absent from the selected file graph.
+- Expected import behavior: remove the missing block ref from imported content and `:block/refs`, preserve blocks whose title becomes empty, and do not leave placeholder entities.
+- Regression tests: `logseq.graph-parser.exporter-test/import-removes-pre-block-marker-and-missing-block-refs` and `logseq.graph-parser.exporter-test/export-doc-files-propagates-missing-block-ref-cleanup-report`.
+
+### Forward block refs
+
+- Source issues: #850, #927.
+- Case: a block references a target block that appears in a later imported file.
+- Expected import behavior: preserve the reference after all files import.
+- Regression test: `logseq.graph-parser.exporter-test/import-removes-pre-block-marker-and-missing-block-refs`.
+
+### Duplicated block ids
+
+- Generated edge case.
+- Case: two imported blocks contain the same `id::` value.
+- Expected import behavior: keep the first block id, assign a new id to later duplicates, and keep the imported graph valid.
+- Regression test: `logseq.graph-parser.exporter-test/import-repairs-duplicated-block-ids`.
+
+### Recursive block refs
+
+- Generated edge case.
+- Case: a block title references the same block id.
+- Expected import behavior: rebuild refs without adding a recursive self-reference.
+- Regression test: `logseq.outliner.pipeline-test/db-rebuild-block-refs-removes-recursive-self-ref`.
+
+### Missing pages
+
+- Generated edge case.
+- Case: imported content references a page that is not otherwise present in the selected file graph.
+- Expected import behavior: create the referenced ordinary page once and point refs at it. Legacy journal filename refs resolve to journal pages only when the corresponding journal file is part of the import set.
+- Regression tests: `logseq.graph-parser.exporter-test/import-creates-missing-ordinary-page-refs` and `logseq.graph-parser.exporter-test/import-legacy-journal-file-name-refs-as-journals`.
+
+### Mixed repeated deadline and scheduled timestamps
+
+- Source issue: #318.
+- Case: one imported task has both `DEADLINE` and `SCHEDULED`, with a repeat cookie on one of them.
+- Expected import behavior: keep both temporal dates, keep the repeat metadata attached to the repeated temporal property, and ensure the `repeat-type` built-in property exists so the imported DB validates.
+- Regression test: `logseq.graph-parser.exporter-test/import-repeated-deadline-and-scheduled`.
+
+### Linked external PDF annotations
+
+- Source issue: #923.
+- Case: an OG graph links a PDF with a `file:///...pdf` URL instead of copying the PDF under `assets/`, while the annotation EDN and `hls__*.md` files are stored under the graph by decoded filename.
+- Expected import behavior: create an external Asset node for the linked PDF, keep the `file://` URL in asset metadata, import the PDF annotations, and point annotation blocks at the external Asset.
+- Regression test: `logseq.graph-parser.exporter-test/import-linked-file-pdf-annotations`.
+
+### Large flat files
+
+- Source issue: #931.
+- Case: a large imported file has tens of thousands of top-level blocks.
+- Expected import behavior: build block txs and tx indexes eagerly enough to avoid lazy-sequence stack overflows, transact the file, and validate the imported graph.
+- Regression test: `logseq.graph-parser.exporter-test/import-large-flat-file-without-stack-overflow`.
+
+### Empty imported files
+
+- Source issue: #582.
+- Case: an Org or Markdown file graph contains an empty or one-byte journal/doc file, as in the `org-import.zip` fixture attached to #582.
+- Expected import behavior: omit absent `:block/refs` values instead of transacting nil, continue importing the rest of the graph, and keep the imported DB valid.
+- Regression test: `logseq.graph-parser.exporter-test/import-empty-journal-file`.

--- a/docs/og_import_graph_cases.md
+++ b/docs/og_import_graph_cases.md
@@ -47,9 +47,9 @@ GitHub `logseq/db-test` issues with the `import` label were audited on 2026-06-2
 ### Generated Markdown file graphs
 
 - Generated edge case.
-- Case: a deterministic random Markdown graph contains multiple pages and journals with mixed task markers, page refs, missing page refs, block refs, missing block refs, duplicated ids, broken ids, temporal markers, tags, properties, and nested blocks.
+- Case: deterministic random Markdown graphs contain multiple pages and journals with mixed task markers, page refs, missing page refs, block refs, missing block refs, duplicated ids, broken ids, temporal markers, tags, page properties, block properties, namespaces, aliases, missing asset links, tables, code fences, and nested blocks.
 - Expected import behavior: import the whole file graph without throwing, keep the generated block corpus, repair invalid identity/ref data through the normal import path, and keep the imported DB valid.
-- Regression test: `logseq.graph-parser.exporter-test/import-generated-markdown-file-graph`.
+- Regression tests: `logseq.graph-parser.exporter-test/import-generated-markdown-file-graph` and the local `^:integration` fuzz test `logseq.graph-parser.exporter-test/import-generated-markdown-file-graph-fuzz`.
 
 ### Recursive block refs
 
@@ -78,6 +78,13 @@ GitHub `logseq/db-test` issues with the `import` label were audited on 2026-06-2
 - Case: an OG graph links a PDF with a `file:///...pdf` URL instead of copying the PDF under `assets/`, while the annotation EDN and `hls__*.md` files are stored under the graph by decoded filename.
 - Expected import behavior: create an external Asset node for the linked PDF, keep the `file://` URL in asset metadata, import the PDF annotations, and point annotation blocks at the external Asset.
 - Regression test: `logseq.graph-parser.exporter-test/import-linked-file-pdf-annotations`.
+
+### Missing local PDF asset links
+
+- Generated edge case.
+- Case: imported Markdown links a local PDF under `assets/`, but the target file is absent from the selected file graph.
+- Expected import behavior: report the unresolved link through `ignored-assets`, continue importing without noisy stderr output, and keep the imported DB valid.
+- Regression test: `logseq.graph-parser.exporter-test/import-missing-local-pdf-asset-link-is-ignored-quietly`.
 
 ### Large flat files
 

--- a/docs/og_import_graph_cases.md
+++ b/docs/og_import_graph_cases.md
@@ -44,6 +44,13 @@ GitHub `logseq/db-test` issues with the `import` label were audited on 2026-06-2
 - Expected import behavior: keep the first block id, assign a new id to later duplicates, and keep the imported graph valid.
 - Regression test: `logseq.graph-parser.exporter-test/import-repairs-duplicated-block-ids`.
 
+### Generated Markdown file graphs
+
+- Generated edge case.
+- Case: a deterministic random Markdown graph contains multiple pages and journals with mixed task markers, page refs, missing page refs, block refs, missing block refs, duplicated ids, broken ids, temporal markers, tags, properties, and nested blocks.
+- Expected import behavior: import the whole file graph without throwing, keep the generated block corpus, repair invalid identity/ref data through the normal import path, and keep the imported DB valid.
+- Regression test: `logseq.graph-parser.exporter-test/import-generated-markdown-file-graph`.
+
 ### Recursive block refs
 
 - Generated edge case.


### PR DESCRIPTION
## Summary

- harden file-graph import for `logseq/db-test` import reports:
  - legacy journal filename refs: https://github.com/logseq/db-test/issues/906
  - broken/missing block refs and stuck OG import: https://github.com/logseq/db-test/issues/213, https://github.com/logseq/db-test/issues/340, https://github.com/logseq/db-test/issues/679, https://github.com/logseq/db-test/issues/748, https://github.com/logseq/db-test/issues/927
  - external linked PDF annotations: https://github.com/logseq/db-test/issues/923
  - large-file stack overflow: https://github.com/logseq/db-test/issues/931
  - Org/empty-file import abort from the attached fixture: https://github.com/logseq/db-test/issues/582
  - mixed deadline/scheduled repeat import: https://github.com/logseq/db-test/issues/318
- add generated edge-case coverage for duplicated IDs, missing pages, recursive self refs, linked external PDF annotations, empty files, and large flat files
- document the audited `logseq/db-test` import issue classes and fixed cases in `docs/og_import_graph_cases.md`

## Validation

- `rtk proxy node node_modules/@logseq/nbb-logseq/cli.js -cp src:test -m logseq.graph-parser.test-runner -n logseq.graph-parser.exporter-test --exclude :integration`
- `rtk proxy node node_modules/@logseq/nbb-logseq/cli.js -cp src:test -m nextjournal.test-runner -n logseq.outliner.pipeline-test`
- manual https://github.com/logseq/db-test/issues/931 reproduction: 45k top-level blocks imported with `:errors 0`
- manual https://github.com/logseq/db-test/issues/582 attached `org-import.zip` import: 193 blocks, `:errors 0`, no ignored files/properties
- `rtk bb lang:lint-hardcoded --git-changed`
- `git diff --check`

No CLJS recompilation was run.
