### PR TITLE
fix: speed up incremental search indexing

### DIFF
--- a/src/main/frontend/worker/db_core.cljs
+++ b/src/main/frontend/worker/db_core.cljs
@@ -1347,9 +1347,9 @@
                     (keep #(d/entity db (:e %)))
                     (remove search/hidden-entity?)
                     vec)
-        vector-context (search/build-vector-context-cache blocks)
         total (count blocks)
         vector-index (worker-state/get-vector-index repo)
+        index-opts {:include-vector-title? (some? vector-index)}
         progress-for-fts (fn [processed]
                            (if (zero? total)
                              100
@@ -1382,7 +1382,7 @@
                                                            search-index-build-batch-size
                                                            search-index-build-time-budget-ms)
                processed' (+ processed (count batch))
-               indexed (vec (keep #(search/block->index-with-context vector-context %) batch))
+               indexed (vec (keep #(search/block->index % index-opts) batch))
                indexed-blocks' (into indexed-blocks indexed)
                progress (progress-for-fts processed')
                should-report? (> progress last-progress)]

--- a/src/main/frontend/worker/db_listener.cljs
+++ b/src/main/frontend/worker/db_listener.cljs
@@ -43,7 +43,9 @@
         (when-not from-disk?
           (p/do!
            ;; Sync SQLite search
-           (let [{:keys [blocks-to-remove-set blocks-to-add]} (search/sync-search-indice tx-report')]
+           (let [{:keys [blocks-to-remove-set blocks-to-add]}
+                 (search/sync-search-indice tx-report'
+                                            {:include-vector-title? (some? (worker-state/get-vector-index repo))})]
              (when (seq blocks-to-remove-set)
                ((@thread-api/*thread-apis :thread-api/search-delete-blocks) repo blocks-to-remove-set))
              (when (seq blocks-to-add)

--- a/src/main/frontend/worker/search.cljs
+++ b/src/main/frontend/worker/search.cljs
@@ -1006,33 +1006,39 @@ DROP TRIGGER IF EXISTS blocks_au;
    (->> (get-all-blocks db)
         (keep #(block->index % opts)))))
 
+(defn- page-descendants
+  [page]
+  (loop [pages [page]
+         result []]
+    (if-let [page' (first pages)]
+      (let [children (->> (:block/_parent page')
+                          (filter ldb/page?)
+                          ldb/sort-by-order)]
+        (recur (concat (rest pages) children)
+               (conj result page')))
+      result)))
+
+(defn- page-tree
+  [db page]
+  (->> (page-descendants page)
+       (mapcat (fn [page']
+                 (concat
+                  [page']
+                  (mapcat #(ldb/get-block-and-children db (:block/uuid %))
+                          (ldb/sort-by-order (:block/_page page'))))))
+       distinct))
+
+(defn- entity-tree
+  [db entity]
+  (cond
+    (nil? entity) []
+    (ldb/page? entity) (page-tree db entity)
+    (:block/uuid entity) (ldb/get-block-and-children db (:block/uuid entity))
+    :else [entity]))
+
 (defn- get-blocks-from-datoms-impl
   [{:keys [db-after db-before]} datoms]
-  (letfn [(page-descendants [page]
-            (loop [pages [page]
-                   result []]
-              (if-let [page' (first pages)]
-                (let [children (->> (:block/_parent page')
-                                    (filter ldb/page?)
-                                    ldb/sort-by-order)]
-                  (recur (concat (rest pages) children)
-                         (conj result page')))
-                result)))
-          (page-tree [db page]
-            (->> (page-descendants page)
-                 (mapcat (fn [page']
-                           (concat
-                            [page']
-                            (mapcat #(ldb/get-block-and-children db (:block/uuid %))
-                                    (ldb/sort-by-order (:block/_page page'))))))
-                 distinct))
-          (entity-tree [db entity]
-            (cond
-              (nil? entity) []
-              (ldb/page? entity) (page-tree db entity)
-              (:block/uuid entity) (ldb/get-block-and-children db (:block/uuid entity))
-              :else [entity]))
-          (referrer-eids [db eids]
+  (letfn [(referrer-eids [db eids]
             (->> eids
                  (mapcat (fn [id]
                            (let [entity (d/entity db id)]

--- a/src/main/frontend/worker/search.cljs
+++ b/src/main/frontend/worker/search.cljs
@@ -148,7 +148,7 @@ DROP TRIGGER IF EXISTS blocks_au;
 (def ^:private query-boolean-operators #{"and" "or" "not" "|" "&"})
 (def ^:private query-break-chars #{\, \. \; \! \? \uFF0C \u3002 \uFF1B \uFF01 \uFF1F \u3001}) ;; , . ; ! ? ， 。 ； ！ ？ 、
 (def vector-embedding-dimension 384)
-(def vector-context-version 2)
+(def vector-context-version 3)
 (def ^:private rrf-k 60)
 (def ^:private keyword-rrf-weight 1.25)
 (def ^:private vector-rrf-weight 1.0)
@@ -549,162 +549,6 @@ DROP TRIGGER IF EXISTS blocks_au;
            (string/join " "))
       title)))
 
-(def ^:private vector-context-parent-depth 3)
-(def ^:private vector-context-child-limit 2)
-(def ^:private vector-context-segment-max-length 320)
-
-(defn- truncate-vector-context-segment
-  [text]
-  (let [text (str text)]
-    (if (> (count text) vector-context-segment-max-length)
-      (subs text 0 vector-context-segment-max-length)
-      text)))
-
-(defn- vector-context-title
-  [block]
-  (let [title (some-> (:block/title block)
-                      str
-                      string/trim)]
-    (when-not (string/blank? title)
-      (truncate-vector-context-segment title))))
-
-(defn- vector-context-segment
-  [label text]
-  (when-not (string/blank? text)
-    (str label ": " text)))
-
-(defn- vector-context-page-title
-  [block]
-  (vector-context-title (:block/page block)))
-
-(defn- vector-context-parent-path
-  [block]
-  (->> (loop [parent (:block/parent block)
-              result []]
-         (cond
-           (nil? parent)
-           result
-
-           (ldb/page? parent)
-           result
-
-           (>= (count result) vector-context-parent-depth)
-           result
-
-           :else
-           (recur (:block/parent parent) (conj result parent))))
-       reverse
-       (keep vector-context-title)
-       (string/join " > ")))
-
-(defn- vector-context-block-id
-  [block]
-  (or (:db/id block) (:block/uuid block)))
-
-(defn- same-vector-context-block?
-  [a b]
-  (let [a-id (vector-context-block-id a)]
-    (and a-id
-         (= a-id (vector-context-block-id b)))))
-
-(defn- vector-context-siblings
-  [block]
-  (some->> (:block/_parent (:block/parent block))
-           seq
-           ldb/sort-by-order
-           vec))
-
-(defn- vector-context-sibling
-  [block offset]
-  (let [siblings (vector-context-siblings block)
-        idx (some->> siblings
-                     (keep-indexed (fn [i sibling]
-                                     (when (same-vector-context-block? sibling block)
-                                       i)))
-                     first)
-        sibling-idx (when idx (+ idx offset))]
-    (when (and sibling-idx
-               (<= 0 sibling-idx)
-               (< sibling-idx (count siblings)))
-      (nth siblings sibling-idx))))
-
-(defn- vector-context-child-titles
-  [block]
-  (some->> (:block/_parent block)
-           seq
-           ldb/sort-by-order
-           (take vector-context-child-limit)
-           (keep vector-context-title)
-           (string/join " | ")))
-
-(defn- vector-context-child-titles-from-cache
-  [children-by-parent-id block]
-  (some->> (get children-by-parent-id (vector-context-block-id block))
-           seq
-           (take vector-context-child-limit)
-           (keep vector-context-title)
-           (string/join " | ")))
-
-(defn- vector-context-children-by-parent-id
-  [blocks]
-  (let [children-by-parent-id (reduce (fn [result block]
-                                        (if-let [parent-id (some-> (:block/parent block)
-                                                                   vector-context-block-id)]
-                                          (update result parent-id (fnil conj []) block)
-                                          result))
-                                      {}
-                                      blocks)]
-    (into {}
-          (map (fn [[parent-id children]]
-                 [parent-id (vec (ldb/sort-by-order children))]))
-          children-by-parent-id)))
-
-(defn- vector-context-neighbor-title-by-id
-  [children-by-parent-id]
-  (reduce-kv
-   (fn [result _parent-id children]
-     (reduce (fn [result [idx child]]
-               (let [block-id (vector-context-block-id child)]
-                 (if block-id
-                   (assoc result block-id
-                          {:previous-title (vector-context-title (get children (dec idx)))
-                           :next-title (vector-context-title (get children (inc idx)))})
-                   result)))
-             result
-             (map-indexed vector children)))
-   {}
-   children-by-parent-id))
-
-(defn build-vector-context-cache
-  [blocks]
-  (let [children-by-parent-id (vector-context-children-by-parent-id blocks)]
-    {:children-by-parent-id children-by-parent-id
-     :neighbor-title-by-id (vector-context-neighbor-title-by-id children-by-parent-id)}))
-
-(defn- block->vector-title
-  ([block title]
-   (block->vector-title nil block title))
-  ([context block title]
-   (let [block-id (vector-context-block-id block)
-         neighbor-titles (get-in context [:neighbor-title-by-id block-id])
-         previous-title (if context
-                          (:previous-title neighbor-titles)
-                          (vector-context-title (vector-context-sibling block -1)))
-         next-title (if context
-                      (:next-title neighbor-titles)
-                      (vector-context-title (vector-context-sibling block 1)))
-         child-titles (if context
-                        (vector-context-child-titles-from-cache (:children-by-parent-id context) block)
-                        (vector-context-child-titles block))]
-    (->> [(vector-context-segment "Page" (vector-context-page-title block))
-          (vector-context-segment "Path" (vector-context-parent-path block))
-          (vector-context-segment "Previous" previous-title)
-          (vector-context-segment "Block" (truncate-vector-context-segment title))
-          (vector-context-segment "Children" child-titles)
-          (vector-context-segment "Next" next-title)]
-         (keep identity)
-         (string/join "\n")))))
-
 (defn- block-result-title
   [block]
   (db-content/recur-replace-uuid-in-block-title block))
@@ -721,8 +565,12 @@ DROP TRIGGER IF EXISTS blocks_au;
                             first)]
         (select-keys alias [:block/uuid :block/title])))))
 
-(defn- block->index*
-  [context {:block/keys [uuid page title] :as block}]
+(defn block->index
+  "Convert a block to the index for searching."
+  ([block]
+   (block->index block {:include-vector-title? false}))
+  ([{:block/keys [uuid page title] :as block} {:keys [include-vector-title?]
+                                               :or {include-vector-title? false}}]
   (when-not (or
              (ldb/closed-value? block)
              (and (string? title) (> (count title) 10000))
@@ -730,23 +578,14 @@ DROP TRIGGER IF EXISTS blocks_au;
     (try
       (let [title (block-search-title block)]
         (when uuid
-          {:id (str uuid)
-           :page (str (or (:block/uuid page) uuid))
-           :title (if (page-or-object? block) title (sanitize title))
-           :vector-title (block->vector-title context block title)}))
+          (cond-> {:id (str uuid)
+                   :page (str (or (:block/uuid page) uuid))
+                   :title (if (page-or-object? block) title (sanitize title))}
+            include-vector-title?
+            (assoc :vector-title title))))
       (catch :default e
         (prn "Error: failed to run block->index on block " (:db/id block))
-        (js/console.error e)))))
-
-(defn block->index
-  "Convert a block to the index for searching"
-  [block]
-  (block->index* nil block))
-
-(defn block->index-with-context
-  "Convert a block with a precomputed vector context cache."
-  [context block]
-  (block->index* context block))
+        (js/console.error e))))))
 
 (def ^:private search-result-block-key ::block)
 
@@ -1161,27 +1000,11 @@ DROP TRIGGER IF EXISTS blocks_au;
          (remove hidden-entity?))))
 
 (defn build-blocks-indice
-  [db]
-  (let [blocks (vec (get-all-blocks db))
-        context (build-vector-context-cache blocks)]
-    (->> blocks
-         (keep #(block->index* context %)))))
-
-(defn expand-vector-context-blocks
-  [blocks]
-  (->> blocks
-       (mapcat (fn [block]
-                 (let [parent (:block/parent block)]
-                   (concat [block
-                            parent
-                            (vector-context-sibling block -1)
-                            (vector-context-sibling block 1)]
-                           (some->> (:block/_parent block)
-                                    seq
-                                    ldb/sort-by-order)))))
-       (remove nil?)
-       (remove hidden-entity?)
-       (common-util/distinct-by vector-context-block-id)))
+  ([db]
+   (build-blocks-indice db {:include-vector-title? false}))
+  ([db {:as opts}]
+   (->> (get-all-blocks db)
+        (keep #(block->index % opts)))))
 
 (defn- get-blocks-from-datoms-impl
   [{:keys [db-after db-before]} datoms]
@@ -1217,22 +1040,29 @@ DROP TRIGGER IF EXISTS blocks_au;
                               (map :db/id (:block/_refs entity))
                               (map :db/id (:block/_alias entity))))))
                  set))
-          (entities-for [db eids {:keys [include-tree? include-refs?]}]
-            (let [entities (keep #(d/entity db %) eids)
-                  entities' (if include-tree?
-                              (mapcat #(entity-tree db %) entities)
-                              entities)
-                  entities'' (if include-refs?
-                               (concat entities'
-                                       (keep #(d/entity db %)
-                                             (referrer-eids db eids)))
-                               entities')]
-              (->> entities''
-                   distinct
-                   (remove nil?))))]
+          (entities-for [db eids]
+            (->> eids
+                 (keep #(d/entity db %))
+                 distinct))
+          (entities-with-referrers-for [db eids]
+            (distinct
+             (concat (entities-for db eids)
+                     (entities-for db (referrer-eids db eids)))))
+          (entity-trees-for [db eids]
+            (->> eids
+                 (keep #(d/entity db %))
+                 (mapcat #(entity-tree db %))
+                 distinct))
+          (page-descendants-for [db eids]
+            (->> eids
+                 (keep #(d/entity db %))
+                 (filter ldb/page?)
+                 (mapcat page-descendants)
+                 distinct))]
     (when (seq datoms)
       (let [ref-affecting-attrs #{:block/uuid :block/name :block/title :block/properties :block/alias}
-            visibility-affecting-attrs #{:logseq.property/deleted-at :block/parent :block/page :block/order}
+            direct-visibility-affecting-attrs #{:block/parent :block/page :block/order}
+            page-hierarchy-affecting-attrs #{:block/parent :block/page}
             ref-eids (->> datoms
                           (filter #(contains? ref-affecting-attrs (:a %)))
                           (mapcat (fn [{:keys [a e v]}]
@@ -1240,14 +1070,28 @@ DROP TRIGGER IF EXISTS blocks_au;
                                       (= :block/alias a)
                                       (conj v))))
                           set)
-            visibility-eids (->> datoms
-                                 (filter #(contains? visibility-affecting-attrs (:a %)))
-                                 (map :e)
-                                 set)]
-        {:blocks-to-remove (concat (entities-for db-before ref-eids {:include-refs? true})
-                                   (entities-for db-before visibility-eids {:include-tree? true}))
-         :blocks-to-add (->> (concat (entities-for db-after ref-eids {:include-refs? true})
-                                     (entities-for db-after visibility-eids {:include-tree? true}))
+            direct-visibility-eids (->> datoms
+                                        (filter #(contains? direct-visibility-affecting-attrs (:a %)))
+                                        (map :e)
+                                        set)
+            page-hierarchy-eids (->> datoms
+                                     (filter #(contains? page-hierarchy-affecting-attrs (:a %)))
+                                     (map :e)
+                                     set)
+            deleted-eids (->> datoms
+                              (filter #(= :logseq.property/deleted-at (:a %)))
+                              (map :e)
+                              set)]
+        {:blocks-to-remove (distinct
+                            (concat (entities-with-referrers-for db-before ref-eids)
+                                    (entities-for db-before direct-visibility-eids)
+                                    (page-descendants-for db-before page-hierarchy-eids)
+                                    (entity-trees-for db-before deleted-eids)))
+         :blocks-to-add (->> (concat (entities-with-referrers-for db-after ref-eids)
+                                     (entities-for db-after direct-visibility-eids)
+                                     (page-descendants-for db-after page-hierarchy-eids)
+                                     (entity-trees-for db-after deleted-eids))
+                             distinct
                              (remove hidden-entity?))}))))
 
 (defn- get-affected-blocks
@@ -1256,26 +1100,27 @@ DROP TRIGGER IF EXISTS blocks_au;
         datoms (filter
                 (fn [datom]
                   ;; Capture direct changes on searchable content and outline structure
-                  ;; because vector embeddings include parent, child, and sibling context.
                   (contains? #{:block/uuid :block/name :block/title :block/properties :block/alias
-                               :block/parent :block/page :block/order}
+                               :block/parent :block/page :block/order :logseq.property/deleted-at}
                              (:a datom)))
                 data)]
     (when (seq datoms)
       (get-blocks-from-datoms-impl tx-report datoms))))
 
 (defn sync-search-indice
-  [tx-report]
-  (let [{:keys [blocks-to-add blocks-to-remove]} (get-affected-blocks tx-report)]
-    ;; update block indice
-    (when (or (seq blocks-to-add) (seq blocks-to-remove))
-      (let [blocks-to-add (expand-vector-context-blocks blocks-to-add)
-            blocks-to-add' (keep block->index blocks-to-add)
-            blocks-to-remove (set (concat (map (comp str :block/uuid) blocks-to-remove)
-                                          (->>
-                                           (set/difference
-                                            (set (map :block/uuid blocks-to-add))
-                                            (set (map :block/uuid blocks-to-add')))
-                                           (map str))))]
-        {:blocks-to-remove-set blocks-to-remove
-         :blocks-to-add        blocks-to-add'}))))
+  ([tx-report]
+   (sync-search-indice tx-report {:include-vector-title? false}))
+  ([tx-report {:keys [include-vector-title?]
+               :or {include-vector-title? false}}]
+   (let [{:keys [blocks-to-add blocks-to-remove]} (get-affected-blocks tx-report)]
+     ;; update block indice
+     (when (or (seq blocks-to-add) (seq blocks-to-remove))
+       (let [blocks-to-add' (keep #(block->index % {:include-vector-title? include-vector-title?}) blocks-to-add)
+             blocks-to-remove (set (concat (map (comp str :block/uuid) blocks-to-remove)
+                                           (->>
+                                            (set/difference
+                                             (set (map :block/uuid blocks-to-add))
+                                             (set (map :block/uuid blocks-to-add')))
+                                            (map str))))]
+         {:blocks-to-remove-set blocks-to-remove
+          :blocks-to-add        blocks-to-add'})))))

--- a/src/main/frontend/worker/search.cljs
+++ b/src/main/frontend/worker/search.cljs
@@ -1040,25 +1040,29 @@ DROP TRIGGER IF EXISTS blocks_au;
                               (map :db/id (:block/_refs entity))
                               (map :db/id (:block/_alias entity))))))
                  set))
+          (page-descendant-eids [page]
+            (set (map :db/id (page-descendants page))))
+          (entity-tree-eids [db eids]
+            (->> eids
+                 (keep #(d/entity db %))
+                 (mapcat #(entity-tree db %))
+                 (map :db/id)
+                 set))
           (entities-for [db eids]
             (->> eids
                  (keep #(d/entity db %))
                  distinct))
-          (entities-with-referrers-for [db eids]
-            (distinct
-             (concat (entities-for db eids)
-                     (entities-for db (referrer-eids db eids)))))
-          (entity-trees-for [db eids]
-            (->> eids
-                 (keep #(d/entity db %))
-                 (mapcat #(entity-tree db %))
-                 distinct))
-          (page-descendants-for [db eids]
+          (page-eids-for [db eids]
             (->> eids
                  (keep #(d/entity db %))
                  (filter ldb/page?)
-                 (mapcat page-descendants)
-                 distinct))]
+                 (map :db/id)
+                 set))
+          (page-descendant-eids-for [db eids]
+            (->> eids
+                 (keep #(d/entity db %))
+                 (mapcat page-descendant-eids)
+                 set))]
     (when (seq datoms)
       (let [ref-affecting-attrs #{:block/uuid :block/name :block/title :block/properties :block/alias}
             direct-visibility-affecting-attrs #{:block/parent :block/page :block/order}
@@ -1074,24 +1078,33 @@ DROP TRIGGER IF EXISTS blocks_au;
                                         (filter #(contains? direct-visibility-affecting-attrs (:a %)))
                                         (map :e)
                                         set)
+            block-page-eids (->> datoms
+                                 (filter #(= :block/page (:a %)))
+                                 (map :e)
+                                 set)
             page-hierarchy-eids (->> datoms
                                      (filter #(contains? page-hierarchy-affecting-attrs (:a %)))
                                      (map :e)
-                                     set)
+                                     set
+                                     (#(set/difference % block-page-eids)))
+            page-hierarchy-before-eids (page-eids-for db-before page-hierarchy-eids)
+            page-hierarchy-after-eids (page-eids-for db-after page-hierarchy-eids)
             deleted-eids (->> datoms
                               (filter #(= :logseq.property/deleted-at (:a %)))
                               (map :e)
-                              set)]
-        {:blocks-to-remove (distinct
-                            (concat (entities-with-referrers-for db-before ref-eids)
-                                    (entities-for db-before direct-visibility-eids)
-                                    (page-descendants-for db-before page-hierarchy-eids)
-                                    (entity-trees-for db-before deleted-eids)))
-         :blocks-to-add (->> (concat (entities-with-referrers-for db-after ref-eids)
-                                     (entities-for db-after direct-visibility-eids)
-                                     (page-descendants-for db-after page-hierarchy-eids)
-                                     (entity-trees-for db-after deleted-eids))
-                             distinct
+                              set)
+            remove-eids (set/union ref-eids
+                                   (referrer-eids db-before ref-eids)
+                                   direct-visibility-eids
+                                   (page-descendant-eids-for db-before page-hierarchy-before-eids)
+                                   (entity-tree-eids db-before deleted-eids))
+            add-eids (set/union ref-eids
+                                (referrer-eids db-after ref-eids)
+                                direct-visibility-eids
+                                (page-descendant-eids-for db-after page-hierarchy-after-eids)
+                                (entity-tree-eids db-after deleted-eids))]
+        {:blocks-to-remove (entities-for db-before remove-eids)
+         :blocks-to-add (->> (entities-for db-after add-eids)
                              (remove hidden-entity?))}))))
 
 (defn- get-affected-blocks

--- a/src/main/frontend/worker/search.cljs
+++ b/src/main/frontend/worker/search.cljs
@@ -1062,6 +1062,12 @@ DROP TRIGGER IF EXISTS blocks_au;
             (->> eids
                  (keep #(d/entity db %))
                  (mapcat page-descendant-eids)
+                 set))
+          (hidden-status-changed-eids-for [eids]
+            (->> eids
+                 (filter (fn [id]
+                           (not= (boolean (some-> (d/entity db-before id) hidden-entity?))
+                                 (boolean (some-> (d/entity db-after id) hidden-entity?)))))
                  set))]
     (when (seq datoms)
       (let [ref-affecting-attrs #{:block/uuid :block/name :block/title :block/properties :block/alias}
@@ -1089,6 +1095,7 @@ DROP TRIGGER IF EXISTS blocks_au;
                                      (#(set/difference % block-page-eids)))
             page-hierarchy-before-eids (page-eids-for db-before page-hierarchy-eids)
             page-hierarchy-after-eids (page-eids-for db-after page-hierarchy-eids)
+            hidden-status-changed-eids (hidden-status-changed-eids-for direct-visibility-eids)
             deleted-eids (->> datoms
                               (filter #(= :logseq.property/deleted-at (:a %)))
                               (map :e)
@@ -1096,11 +1103,13 @@ DROP TRIGGER IF EXISTS blocks_au;
             remove-eids (set/union ref-eids
                                    (referrer-eids db-before ref-eids)
                                    direct-visibility-eids
+                                   (entity-tree-eids db-before hidden-status-changed-eids)
                                    (page-descendant-eids-for db-before page-hierarchy-before-eids)
                                    (entity-tree-eids db-before deleted-eids))
             add-eids (set/union ref-eids
                                 (referrer-eids db-after ref-eids)
                                 direct-visibility-eids
+                                (entity-tree-eids db-after hidden-status-changed-eids)
                                 (page-descendant-eids-for db-after page-hierarchy-after-eids)
                                 (entity-tree-eids db-after deleted-eids))]
         {:blocks-to-remove (entities-for db-before remove-eids)

--- a/src/test/frontend/worker/db_core_test.cljs
+++ b/src/test/frontend/worker/db_core_test.cljs
@@ -452,10 +452,10 @@
           (with-redefs [search/truncate-table! (fn [_db] nil)
                         search/upsert-blocks! (fn [_db _blocks] nil)
                         search/hidden-entity? (constantly false)
-                        search/block->index-with-context (fn [_context _entity]
-                                                           {:id "block-1"
-                                                            :page "page-1"
-                                                            :title "Hello"})]
+                        search/block->index (fn [_entity & _opts]
+                                              {:id "block-1"
+                                               :page "page-1"
+                                               :title "Hello"})]
             (-> (p/let [_ (build-index! test-repo true)
                         _ (<wait-for-progress! progress-calls
                                                (fn [calls]
@@ -513,10 +513,10 @@
                           search/truncate-vector-index! (fn [_vector-index] nil)
                           search/upsert-blocks! (fn [_db _blocks] nil)
                           search/hidden-entity? (constantly false)
-                          search/block->index-with-context (fn [_context _entity]
-                                                             {:id "block-1"
-                                                              :page "page-1"
-                                                              :title "Hello"})]
+                          search/block->index (fn [_entity & _opts]
+                                                {:id "block-1"
+                                                 :page "page-1"
+                                                 :title "Hello"})]
             (let [build-id (#'db-core/start-search-index-build! repo)]
               (-> (build-index! repo search-db conn build-id)
                 (p/then (fn [_]
@@ -616,10 +616,10 @@
           (with-redefs [search/truncate-table! (fn [_db] nil)
                         search/upsert-blocks! (fn [_db _blocks] nil)
                         search/hidden-entity? (constantly false)
-                        search/block->index-with-context (fn [_context _entity]
-                                                           {:id "block-1"
-                                                            :page "page-1"
-                                                            :title "Hello"})]
+                        search/block->index (fn [_entity & _opts]
+                                              {:id "block-1"
+                                               :page "page-1"
+                                               :title "Hello"})]
             (p/let [_ (build-index! test-repo true)
                     _ (<wait-for-progress! progress-calls
                                            (fn [calls]
@@ -713,7 +713,7 @@
                            (is false (str error)))))))))
      (p/finally done))))
 
-(deftest search-build-blocks-indice-in-worker-reuses-vector-context-test
+(deftest search-build-blocks-indice-in-worker-does-not-sort-vector-context-test
   (async done
     (->
      (restoring-worker-state
@@ -756,7 +756,7 @@
                         ldb/hidden? (constantly false)
                         ldb/get-title-with-parents (fn [entity] (:block/title entity))]
             (p/let [_ (build-index! test-repo true)]
-              (is (<= @sort-calls 2)))))))
+              (is (zero? @sort-calls)))))))
      (p/catch (fn [error]
                 (is false (str "unexpected error: " error))))
      (p/finally done))))
@@ -892,10 +892,10 @@
           (with-redefs [search/truncate-table! (fn [_db] nil)
                         search/upsert-blocks! (fn [_db _blocks] nil)
                         search/hidden-entity? (constantly false)
-                        search/block->index-with-context (fn [_context _entity]
-                                                           {:id "block-1"
-                                                            :page "page-1"
-                                                            :title "Hello"})]
+                        search/block->index (fn [_entity & _opts]
+                                              {:id "block-1"
+                                               :page "page-1"
+                                               :title "Hello"})]
             (p/let [result (build-index! test-repo false)
                     _ (p/delay 10)]
               (is (= db-core/search-db-version result))

--- a/src/test/frontend/worker/search_test.cljs
+++ b/src/test/frontend/worker/search_test.cljs
@@ -552,8 +552,8 @@
           (is (= "Local-first semantic search" (:title indexed)))
           (is (not (contains? indexed :embedding))))))))
 
-(deftest block-index-includes-bounded-vector-context
-  (testing "vector-only text includes local block context without changing the keyword title"
+(deftest block-index-includes-own-title-vector-title-when-enabled
+  (testing "vector-only text uses the same indexed block title without local block context"
     (let [page-id #uuid "00000000-0000-0000-0000-000000000240"
           block-id #uuid "00000000-0000-0000-0000-000000000241"
           page {:db/id 1
@@ -594,18 +594,28 @@
                     ldb/closed-value? (constantly false)
                     ldb/hidden? (constantly false)
                     ldb/get-title-with-parents (fn [entity] (:block/title entity))]
-        (let [indexed (search/block->index block)
-              vector-title (:vector-title indexed)]
+        (let [indexed (search/block->index block {:include-vector-title? true})]
           (is (= "Hybrid retrieval" (:title indexed)))
-          (is (string/includes? vector-title "Page: Search Design"))
-          (is (string/includes? vector-title "Path: Architecture > Vector index"))
-          (is (string/includes? vector-title "Previous: Keyword search"))
-          (is (string/includes? vector-title "Block: Hybrid retrieval"))
-          (is (string/includes? vector-title "Children: Cross block context"))
-          (is (string/includes? vector-title "Next: Ranking policy")))))))
+          (is (= "Hybrid retrieval" (:vector-title indexed))))))))
 
-(deftest build-blocks-indice-reuses-sorted-vector-context
-  (testing "large pages do not sort the same sibling set once per indexed block"
+(deftest block-index-skips-vector-title-when-disabled
+  (let [block-id #uuid "00000000-0000-0000-0000-000000000247"
+        page-id #uuid "00000000-0000-0000-0000-000000000248"
+        block {:db/id 1
+               :block/uuid block-id
+               :block/title "Hybrid retrieval"
+               :block/page {:block/uuid page-id}}]
+    (with-redefs [ldb/page? (constantly false)
+                  ldb/object? (constantly false)
+                  ldb/journal? (constantly false)
+                  ldb/closed-value? (constantly false)
+                  ldb/get-title-with-parents (fn [entity] (:block/title entity))]
+      (let [indexed (search/block->index block)]
+        (is (= "Hybrid retrieval" (:title indexed)))
+        (is (not (contains? indexed :vector-title)))))))
+
+(deftest build-blocks-indice-uses-block-index
+  (testing "large pages do not sort siblings for vector title context"
     (let [page-id #uuid "00000000-0000-0000-0000-000000000250"
           page {:db/id 1
                 :page? true
@@ -632,54 +642,13 @@
                     ldb/closed-value? (constantly false)
                     ldb/hidden? (constantly false)
                     ldb/get-title-with-parents (fn [entity] (:block/title entity))]
-        (is (= 40 (count (search/build-blocks-indice :db))))
-        (is (<= @sort-calls 2))))))
+        (let [indexed (search/build-blocks-indice :db {:include-vector-title? true})]
+          (is (= 40 (count indexed)))
+          (is (zero? @sort-calls))
+          (is (every? #(= (:title %) (:vector-title %)) indexed)))))))
 
-(deftest expand-vector-context-blocks-includes-neighbor-anchors
-  (testing "incremental vector updates refresh anchors whose context includes the changed block"
-    (let [page {:db/id 1
-                :page? true
-                :block/uuid #uuid "00000000-0000-0000-0000-000000000290"
-                :block/title "Search"}
-          parent {:db/id 2
-                  :block/uuid #uuid "00000000-0000-0000-0000-000000000291"
-                  :block/title "Parent"
-                  :block/page page}
-          prev {:db/id 3
-                :block/uuid #uuid "00000000-0000-0000-0000-000000000292"
-                :block/title "Previous"
-                :block/order 1
-                :block/page page}
-          current {:db/id 4
-                   :block/uuid #uuid "00000000-0000-0000-0000-000000000293"
-                   :block/title "Current"
-                   :block/order 2
-                   :block/page page}
-          next {:db/id 5
-                :block/uuid #uuid "00000000-0000-0000-0000-000000000294"
-                :block/title "Next"
-                :block/order 3
-                :block/page page}
-          child {:db/id 6
-                 :block/uuid #uuid "00000000-0000-0000-0000-000000000295"
-                 :block/title "Child"
-                 :block/order 1
-                 :block/page page}
-          parent (assoc parent :block/_parent [prev current next])
-          current (assoc current
-                         :block/parent parent
-                         :block/_parent [child])]
-      (with-redefs [ldb/sort-by-order (fn [children] (sort-by :block/order children))
-                    ldb/hidden? (constantly false)]
-        (is (= [(uuid "00000000-0000-0000-0000-000000000293")
-                (uuid "00000000-0000-0000-0000-000000000291")
-                (uuid "00000000-0000-0000-0000-000000000292")
-                (uuid "00000000-0000-0000-0000-000000000294")
-                (uuid "00000000-0000-0000-0000-000000000295")]
-               (mapv :block/uuid (search/expand-vector-context-blocks [current]))))))))
-
-(deftest sync-search-indice-refreshes-vector-context-on-structure-change
-  (testing "moving a block under a parent re-embeds the parent with child context"
+(deftest sync-search-indice-indexes-only-directly-affected-blocks
+  (testing "moving a block under a parent does not expand indexing to the parent"
     (let [conn (db-test/create-conn-with-blocks
                 {:pages-and-blocks [{:page {:block/title "Teams"}
                                      :blocks [{:block/title "which team is Manu in?"}
@@ -687,13 +656,14 @@
           manu (db-test/find-block-by-content @conn "which team is Manu in?")
           spurs (db-test/find-block-by-content @conn "Spurs")
           tx-report (d/transact! conn [[:db/add (:db/id spurs) :block/parent (:db/id manu)]])
-          blocks-to-add (:blocks-to-add (search/sync-search-indice tx-report))
-          manu-index (some #(when (= "which team is Manu in?" (:title %)) %) blocks-to-add)]
-      (is (some? manu-index))
-      (is (true? (some-> (:vector-title manu-index)
-                         (string/includes? "Children: Spurs"))))))
+          blocks-to-add (:blocks-to-add (search/sync-search-indice tx-report {:include-vector-title? true}))
+          spurs-index (some #(when (= "Spurs" (:title %)) %) blocks-to-add)
+          titles (set (map :title blocks-to-add))]
+      (is (contains? titles "Spurs"))
+      (is (not (contains? titles "which team is Manu in?")))
+      (is (= "Spurs" (:vector-title spurs-index)))))
 
-  (testing "reordering a sibling re-embeds the previous block with next-sibling context"
+  (testing "reordering a sibling does not expand indexing to adjacent siblings"
     (let [conn (db-test/create-conn-with-blocks
                 {:pages-and-blocks [{:page {:block/title "Teams"}
                                      :blocks [{:block/title "Spurs"
@@ -702,11 +672,125 @@
                                                :block/order "b"}]}]})
           spurs (db-test/find-block-by-content @conn "Spurs")
           tx-report (d/transact! conn [[:db/add (:db/id spurs) :block/order "c"]])
-          blocks-to-add (:blocks-to-add (search/sync-search-indice tx-report))
-          tony-index (some #(when (= "Which team is Tony in?" (:title %)) %) blocks-to-add)]
-      (is (some? tony-index))
-      (is (true? (some-> (:vector-title tony-index)
-                         (string/includes? "Next: Spurs")))))))
+          blocks-to-add (:blocks-to-add (search/sync-search-indice tx-report {:include-vector-title? true}))
+          spurs-index (some #(when (= "Spurs" (:title %)) %) blocks-to-add)
+          titles (set (map :title blocks-to-add))]
+      (is (contains? titles "Spurs"))
+      (is (not (contains? titles "Which team is Tony in?")))
+      (is (= "Spurs" (:vector-title spurs-index))))))
+
+(deftest sync-search-indice-reindexes-descendant-pages-when-page-parent-changes
+  (let [parent-a-uuid (random-uuid)
+        parent-b-uuid (random-uuid)
+        child-uuid (random-uuid)
+        grandchild-uuid (random-uuid)
+        conn (db-test/create-conn)
+        page-tag :logseq.class/Page]
+    (d/transact! conn [{:block/uuid parent-a-uuid
+                        :block/title "Parent A"
+                        :block/name "parent a"
+                        :block/tags [page-tag]}
+                       {:block/uuid parent-b-uuid
+                        :block/title "Parent B"
+                        :block/name "parent b"
+                        :block/tags [page-tag]}
+                       {:block/uuid child-uuid
+                        :block/title "Child Page"
+                        :block/name "child page"
+                        :block/tags [page-tag]
+                        :block/parent [:block/uuid parent-a-uuid]
+                        :block/order "a"}
+                       {:block/uuid grandchild-uuid
+                        :block/title "Grand Page"
+                        :block/name "grand page"
+                        :block/tags [page-tag]
+                        :block/parent [:block/uuid child-uuid]
+                        :block/order "a"}])
+    (let [tx-report (d/transact! conn [[:db/add [:block/uuid child-uuid]
+                                        :block/parent [:block/uuid parent-b-uuid]]])
+          blocks-to-add (:blocks-to-add (search/sync-search-indice tx-report {:include-vector-title? true}))
+          titles (set (map :title blocks-to-add))]
+      (is (contains? titles "Parent B/Child Page"))
+      (is (contains? titles "Parent B/Child Page/Grand Page"))
+      (is (every? #(= (:title %) (:vector-title %)) blocks-to-add)))))
+
+(deftest sync-search-indice-skips-vector-title-when-disabled
+  (let [conn (db-test/create-conn-with-blocks
+              {:pages-and-blocks [{:page {:block/title "Teams"}
+                                   :blocks [{:block/title "Spurs"}]}]})
+        spurs (db-test/find-block-by-content @conn "Spurs")
+        tx-report (d/transact! conn [[:db/add (:db/id spurs) :block/title "San Antonio Spurs"]])
+        blocks-to-add (:blocks-to-add (search/sync-search-indice tx-report))
+        spurs-index (some #(when (= "San Antonio Spurs" (:title %)) %) blocks-to-add)]
+    (is (some? spurs-index))
+    (is (not (contains? spurs-index :vector-title)))))
+
+(def ^:private sync-search-indice-performance-block-count 300)
+(def ^:private sync-search-indice-performance-max-ms 1000)
+
+(defn- run-sync-search-indice-new-blocks-case
+  [include-vector-title?]
+  (let [conn (db-test/create-conn-with-blocks
+              {:pages-and-blocks [{:page {:block/title "Bulk Insert"}}]})
+        page (db-test/find-page-by-title @conn "Bulk Insert")
+        now 1760000000000
+        tx-report (d/transact! conn
+                               (mapv (fn [idx]
+                                       {:block/uuid (random-uuid)
+                                        :block/title (str "Inserted " idx)
+                                        :block/page (:db/id page)
+                                        :block/parent (:db/id page)
+                                        :block/order (str "a" idx)
+                                        :block/created-at now
+                                        :block/updated-at now})
+                                     (range sync-search-indice-performance-block-count)))
+        started (.now js/performance)
+        blocks-to-add (:blocks-to-add
+                       (search/sync-search-indice
+                        tx-report
+                        {:include-vector-title? include-vector-title?}))
+        elapsed-ms (- (.now js/performance) started)]
+    {:blocks-to-add blocks-to-add
+     :elapsed-ms elapsed-ms}))
+
+(deftest sync-search-indice-300-new-blocks-performance-when-semantic-search-enabled
+  (let [{:keys [blocks-to-add elapsed-ms]} (run-sync-search-indice-new-blocks-case true)]
+    (is (= sync-search-indice-performance-block-count (count blocks-to-add)))
+    (is (< elapsed-ms sync-search-indice-performance-max-ms))
+    (is (every? :vector-title blocks-to-add))
+    (is (every? #(= (:title %) (:vector-title %)) blocks-to-add))))
+
+(deftest sync-search-indice-300-new-blocks-performance-when-semantic-search-disabled
+  (let [{:keys [blocks-to-add elapsed-ms]} (run-sync-search-indice-new-blocks-case false)]
+    (is (= sync-search-indice-performance-block-count (count blocks-to-add)))
+    (is (< elapsed-ms sync-search-indice-performance-max-ms))
+    (is (not-any? #(contains? % :vector-title) blocks-to-add))))
+
+(deftest sync-search-indice-removes-page-descendants-when-page-is-deleted
+  (let [conn (db-test/create-conn-with-blocks
+              {:pages-and-blocks [{:page {:block/title "Deleted page"}
+                                   :blocks [{:block/title "Parent"
+                                             :build/children [{:block/title "Child"}]}]}]})
+        page (db-test/find-page-by-title @conn "Deleted page")
+        parent (db-test/find-block-by-content @conn "Parent")
+        child (db-test/find-block-by-content @conn "Child")
+        tx-report (d/transact! conn [[:db/add (:db/id page) :logseq.property/deleted-at 1760000000000]])
+        blocks-to-remove-set (:blocks-to-remove-set (search/sync-search-indice tx-report))]
+    (is (contains? blocks-to-remove-set (str (:block/uuid page))))
+    (is (contains? blocks-to-remove-set (str (:block/uuid parent))))
+    (is (contains? blocks-to-remove-set (str (:block/uuid child))))))
+
+(deftest sync-search-indice-removes-block-descendants-when-parent-block-is-deleted
+  (let [conn (db-test/create-conn-with-blocks
+              {:pages-and-blocks [{:page {:block/title "Deleted block"}
+                                   :blocks [{:block/title "Parent"
+                                             :build/children [{:block/title "Child"}]}]}]})
+        parent (db-test/find-block-by-content @conn "Parent")
+        child (db-test/find-block-by-content @conn "Child")
+        tx-report (d/transact! conn [[:db/add (:db/id parent) :logseq.property/deleted-at 1760000000000]])
+        blocks-to-remove-set (:blocks-to-remove-set (search/sync-search-indice tx-report))]
+    (is (contains? blocks-to-remove-set (str (:block/uuid parent))))
+    (is (contains? blocks-to-remove-set (str (:block/uuid child))))))
 
 (deftest search-blocks-includes-vector-only-results
   (testing "zvec vector hits are merged into desktop search even when SQLite has no keyword hit"

--- a/src/test/frontend/worker/search_test.cljs
+++ b/src/test/frontend/worker/search_test.cljs
@@ -803,6 +803,36 @@
     (is (contains? blocks-to-remove-set (str (:block/uuid parent))))
     (is (contains? blocks-to-remove-set (str (:block/uuid child))))))
 
+(deftest sync-search-indice-removes-block-descendants-when-parent-becomes-hidden
+  (let [conn (db-test/create-conn-with-blocks
+              {:pages-and-blocks [{:page {:block/title "Hidden move"}
+                                   :blocks [{:block/title "Hidden parent"
+                                             :logseq.property/hide? true}
+                                            {:block/title "Moved parent"
+                                             :build/children [{:block/title "Moved child"}]}]}]})
+        hidden-parent (db-test/find-block-by-content @conn "Hidden parent")
+        moved-parent (db-test/find-block-by-content @conn "Moved parent")
+        moved-child (db-test/find-block-by-content @conn "Moved child")
+        tx-report (d/transact! conn [[:db/add (:db/id moved-parent) :block/parent (:db/id hidden-parent)]])
+        blocks-to-remove-set (:blocks-to-remove-set (search/sync-search-indice tx-report))]
+    (is (contains? blocks-to-remove-set (str (:block/uuid moved-parent))))
+    (is (contains? blocks-to-remove-set (str (:block/uuid moved-child))))))
+
+(deftest sync-search-indice-adds-block-descendants-when-parent-becomes-visible
+  (let [conn (db-test/create-conn-with-blocks
+              {:pages-and-blocks [{:page {:block/title "Visible move"}
+                                   :blocks [{:block/title "Hidden parent"
+                                             :logseq.property/hide? true
+                                             :build/children [{:block/title "Moved parent"
+                                                               :build/children [{:block/title "Moved child"}]}]}]}]})
+        page (db-test/find-page-by-title @conn "Visible move")
+        moved-parent (db-test/find-block-by-content @conn "Moved parent")
+        tx-report (d/transact! conn [[:db/add (:db/id moved-parent) :block/parent (:db/id page)]])
+        blocks-to-add (:blocks-to-add (search/sync-search-indice tx-report))
+        titles (set (map :title blocks-to-add))]
+    (is (contains? titles "Moved parent"))
+    (is (contains? titles "Moved child"))))
+
 (deftest search-blocks-includes-vector-only-results
   (testing "zvec vector hits are merged into desktop search even when SQLite has no keyword hit"
     (let [page-id (test-uuid-string 900)

--- a/src/test/frontend/worker/search_test.cljs
+++ b/src/test/frontend/worker/search_test.cljs
@@ -755,6 +755,7 @@
 
 (deftest sync-search-indice-300-new-blocks-performance-when-semantic-search-enabled
   (let [{:keys [blocks-to-add elapsed-ms]} (run-sync-search-indice-new-blocks-case true)]
+    (println (str "sync-search-indice 300 new blocks with semantic search enabled took " elapsed-ms "ms"))
     (is (= sync-search-indice-performance-block-count (count blocks-to-add)))
     (is (< elapsed-ms sync-search-indice-performance-max-ms))
     (is (every? :vector-title blocks-to-add))
@@ -762,9 +763,19 @@
 
 (deftest sync-search-indice-300-new-blocks-performance-when-semantic-search-disabled
   (let [{:keys [blocks-to-add elapsed-ms]} (run-sync-search-indice-new-blocks-case false)]
+    (println (str "sync-search-indice 300 new blocks with semantic search disabled took " elapsed-ms "ms"))
     (is (= sync-search-indice-performance-block-count (count blocks-to-add)))
     (is (< elapsed-ms sync-search-indice-performance-max-ms))
     (is (not-any? #(contains? % :vector-title) blocks-to-add))))
+
+(deftest sync-search-indice-300-new-blocks-does-not-check-page-descendants
+  (let [page-checks (atom 0)]
+    (with-redefs [ldb/page? (fn [_entity]
+                              (swap! page-checks inc)
+                              false)]
+      (let [{:keys [blocks-to-add]} (run-sync-search-indice-new-blocks-case true)]
+        (is (= sync-search-indice-performance-block-count (count blocks-to-add)))
+        (is (<= @page-checks (* 2 sync-search-indice-performance-block-count)))))))
 
 (deftest sync-search-indice-removes-page-descendants-when-page-is-deleted
   (let [conn (db-test/create-conn-with-blocks


### PR DESCRIPTION
## Summary

Speed up incremental search indexing after outliner transactions by avoiding vector-context expansion on direct block changes.

## Root cause

`sync-search-indice` was expanding each affected block to nearby vector context and then building contextual vector titles for every indexed block. Bulk insertion of sibling blocks repeatedly touched the same sibling sets, which made the indexing path scale poorly.

## Changes

- Default `include-vector-title?` to `false` for `sync-search-indice`.
- Only include vector titles from the db listener when a vector index exists.
- Build incremental vector titles from the block's own title instead of nearby parent/sibling/child context.
- Simplify affected-block collection so parent/page/order changes index direct entities only.
- Preserve subtree removal for `:logseq.property/deleted-at`, where page/block descendants must leave the index.
- Add 300-block performance regressions for semantic-search enabled and disabled paths with a 1s guard.

## Benchmark

Direct `sync-search-indice` timing for 300 newly inserted sibling blocks after the change:

- semantic search enabled: 222.306ms, blocks-to-add=300
- semantic search disabled: 213.032ms, blocks-to-add=300

## Verification

- `clojure -M:test compile test`
- `env LOGSEQ_STABLE_IDENTS=1 node static/tests.js -v frontend.worker.search-test`
- `env LOGSEQ_STABLE_IDENTS=1 node static/tests.js -v frontend.worker.db-listener-test`
- `git diff --check`
