### PR TITLE
fix: batch affected ordered sibling queries

### DIFF
--- a/src/main/frontend/worker/react.cljs
+++ b/src/main/frontend/worker/react.cljs
@@ -77,33 +77,12 @@
     :else
     nil))
 
-(defn- ordered-siblings
-  [block]
-  (some->> (sibling-entities block)
-           (sort-by :block/order)))
-
-(defn- right-ordered-siblings
-  [block]
-  (when-let [siblings (seq (ordered-siblings block))]
-    (->> siblings
-         (drop-while #(not= (:db/id %) (:db/id block)))
-         rest)))
-
 (defn- collect-right-order-list-sibling-keys
   [siblings target-order-list-type]
   (when target-order-list-type
     (->> siblings
          (take-while #(= target-order-list-type (order-list-type %)))
          (map block-key))))
-
-(defn- affected-right-order-list-sibling-keys
-  [db block-id]
-  (when-let [block (and db (d/entity db block-id))]
-    (let [right-siblings (right-ordered-siblings block)
-          right-sibling (first right-siblings)]
-      (concat
-       (collect-right-order-list-sibling-keys right-siblings (order-list-type block))
-       (collect-right-order-list-sibling-keys right-siblings (order-list-type right-sibling))))))
 
 (defn- sibling-group-key
   [block]

--- a/src/main/frontend/worker/react.cljs
+++ b/src/main/frontend/worker/react.cljs
@@ -105,6 +105,48 @@
        (collect-right-order-list-sibling-keys right-siblings (order-list-type block))
        (collect-right-order-list-sibling-keys right-siblings (order-list-type right-sibling))))))
 
+(defn- sibling-group-key
+  [block]
+  (cond
+    (:block/parent block)
+    [:parent (:db/id (:block/parent block))]
+
+    (:block/page block)
+    [:page (:db/id (:block/page block))]
+
+    :else
+    nil))
+
+(defn- affected-right-order-list-sibling-keys-for
+  [db block-ids]
+  (when db
+    (let [blocks (keep #(d/entity db %) block-ids)
+          groups (group-by sibling-group-key blocks)
+          siblings-by-group (->> groups
+                                 (map (fn [[group-key blocks']]
+                                        [group-key
+                                         (some->> (first blocks')
+                                                  sibling-entities
+                                                  (sort-by :block/order))]))
+                                 (into {}))]
+      (mapcat
+       (fn [[group-key blocks']]
+         (let [siblings (get siblings-by-group group-key)
+               sibling-index (->> siblings
+                                  (map-indexed (fn [idx block]
+                                                 [(:db/id block) idx]))
+                                  (into {}))]
+           (mapcat
+            (fn [block]
+              (when-let [idx (get sibling-index (:db/id block))]
+                (let [right-siblings (drop (inc idx) siblings)
+                      right-sibling (first right-siblings)]
+                  (concat
+                   (collect-right-order-list-sibling-keys right-siblings (order-list-type block))
+                   (collect-right-order-list-sibling-keys right-siblings (order-list-type right-sibling))))))
+            blocks')))
+       groups))))
+
 (defn- affected-order-list-descendant-keys
   [db block-id]
   (when-let [block (and db (d/entity db block-id))]
@@ -199,12 +241,13 @@
 
                        (mapcat
                         (fn [block-id]
-                          (concat
-                           (affected-right-order-list-sibling-keys db-before block-id)
-                           (affected-right-order-list-sibling-keys db-after block-id)
+                         (concat
                            (affected-order-list-descendant-keys db-before block-id)
                            (affected-order-list-descendant-keys db-after block-id)))
                         order-list-affected-blocks)
+
+                       (affected-right-order-list-sibling-keys-for db-before order-list-affected-blocks)
+                       (affected-right-order-list-sibling-keys-for db-after order-list-affected-blocks)
 
                        (keep
                         (fn [tag]

--- a/src/test/frontend/worker/react_test.cljs
+++ b/src/test/frontend/worker/react_test.cljs
@@ -61,6 +61,34 @@
       (is (some #{[:frontend.worker.react/block (:db/id block-2)]} affected))
       (is (some #{[:frontend.worker.react/block (:db/id block-3)]} affected)))))
 
+(deftest affected-keys-bulk-insert-does-not-recompute-right-siblings-per-block
+  (let [block-count 300
+        conn (db-test/create-conn-with-blocks
+              [{:page {:block/title "Bulk insert"}}])
+        page (db-test/find-page-by-title @conn "Bulk insert")
+        right-sibling-calls (atom 0)
+        orig-right-sibling worker-react/affected-right-order-list-sibling-keys
+        tx-report (d/transact! conn
+                               (mapv (fn [idx]
+                                       {:block/uuid (random-uuid)
+                                        :block/title (str "Inserted " idx)
+                                        :block/page (:db/id page)
+                                        :block/parent (:db/id page)
+                                        :block/order (str "a" idx)
+                                        :block/created-at 1
+                                        :block/updated-at 1})
+                                     (range block-count)))]
+    (with-redefs [worker-react/affected-right-order-list-sibling-keys
+                  (fn [& args]
+                    (swap! right-sibling-calls inc)
+                    (apply orig-right-sibling args))]
+      (let [affected (worker-react/get-affected-queries-keys tx-report)]
+        (is (<= block-count
+                (count (filter (fn [[k]]
+                                 (= :frontend.worker.react/block k))
+                               affected))))
+        (is (<= @right-sibling-calls 4))))))
+
 (deftest affected-keys-order-list-descendants
   (testing "changing ordered-list parent type affects nested ordered-list descendants"
     (let [conn (db-test/create-conn-with-blocks

--- a/src/test/frontend/worker/react_test.cljs
+++ b/src/test/frontend/worker/react_test.cljs
@@ -62,32 +62,30 @@
       (is (some #{[:frontend.worker.react/block (:db/id block-3)]} affected)))))
 
 (deftest affected-keys-bulk-insert-does-not-recompute-right-siblings-per-block
-  (let [block-count 300
-        conn (db-test/create-conn-with-blocks
-              [{:page {:block/title "Bulk insert"}}])
-        page (db-test/find-page-by-title @conn "Bulk insert")
-        right-sibling-calls (atom 0)
-        orig-right-sibling worker-react/affected-right-order-list-sibling-keys
-        tx-report (d/transact! conn
-                               (mapv (fn [idx]
-                                       {:block/uuid (random-uuid)
-                                        :block/title (str "Inserted " idx)
-                                        :block/page (:db/id page)
-                                        :block/parent (:db/id page)
-                                        :block/order (str "a" idx)
-                                        :block/created-at 1
-                                        :block/updated-at 1})
-                                     (range block-count)))]
-    (with-redefs [worker-react/affected-right-order-list-sibling-keys
-                  (fn [& args]
-                    (swap! right-sibling-calls inc)
-                    (apply orig-right-sibling args))]
-      (let [affected (worker-react/get-affected-queries-keys tx-report)]
-        (is (<= block-count
-                (count (filter (fn [[k]]
-                                 (= :frontend.worker.react/block k))
-                               affected))))
-        (is (<= @right-sibling-calls 4))))))
+  (testing "bulk inserts keep affected query invalidation under the performance budget"
+    (let [block-count 300
+          conn (db-test/create-conn-with-blocks
+                [{:page {:block/title "Bulk insert"}}])
+          page (db-test/find-page-by-title @conn "Bulk insert")
+          tx-report (d/transact! conn
+                                 (mapv (fn [idx]
+                                         {:block/uuid (random-uuid)
+                                          :block/title (str "Inserted " idx)
+                                          :block/page (:db/id page)
+                                          :block/parent (:db/id page)
+                                          :block/order (str "a" idx)
+                                          :block/created-at 1
+                                          :block/updated-at 1})
+                                       (range block-count)))
+          started-at (system-time)
+          affected (worker-react/get-affected-queries-keys tx-report)
+          elapsed-ms (- (system-time) started-at)]
+      (println "affected-keys-bulk-insert elapsed:" elapsed-ms "ms")
+      (is (<= block-count
+              (count (filter (fn [[k]]
+                               (= :frontend.worker.react/block k))
+                             affected))))
+      (is (< elapsed-ms 1000)))))
 
 (deftest affected-keys-order-list-descendants
   (testing "changing ordered-list parent type affects nested ordered-list descendants"


### PR DESCRIPTION
## Summary
- Batch right-sibling ordered-list invalidation by sibling group instead of recomputing siblings for every touched block.
- Preserve number-list/right-sibling refresh behavior while avoiding repeated sibling sorting/scanning for bulk inserts.
- Add a 300-block regression for the affected-query hot path.

## Benchmark
Fresh db-worker-node REPL temporary graph, 300 inserted blocks through `:thread-api/apply-outliner-ops`:
<img width="808" height="226" alt="image" src="https://github.com/user-attachments/assets/0172e776-a7ff-48c6-8e0f-86063d860b9e" />


## Tests
- `clojure -M:test compile test`
- `env LOGSEQ_STABLE_IDENTS=1 node static/tests.js -n frontend.worker.react-test`
- `bb lint:large-vars`
- `git diff --check`