### PR TITLE
fix: editor focus 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,5 +93,6 @@ deps/db-sync/data
 
 clj-e2e/.clj-kondo/imports
 /cli/_build/
+/cli/_opam
 /cli/compile_commands.json
 /cli/.eglot-root

--- a/cli/package.json
+++ b/cli/package.json
@@ -2,8 +2,8 @@
   "name": "logseq-cli",
   "private": true,
   "scripts": {
-    "bundle": "dune build @bundle",
-    "test": "dune runtest"
+    "bundle": "opam exec -- dune build @bundle",
+    "test": "opam exec -- dune runtest"
   },
   "devDependencies": {
     "vite": "^8.0.16"

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -323,7 +323,9 @@
                              (dissoc :block/page)))
                      new-block)]
     (ui-outliner-tx/transact!
-     {:outliner-op :insert-blocks}
+     (cond-> {:outliner-op :insert-blocks}
+       (:editor/edit-block-fn-id config)
+       (assoc :editor/edit-block-fn-id (:editor/edit-block-fn-id config)))
      (save-current-block! {:current-block current-block})
      (outliner-op/insert-blocks! [new-block'] current-block {:sibling? sibling?
                                                              :keep-uuid? keep-uuid?
@@ -528,6 +530,7 @@
       (when-let [state (get-state)]
         (start-pending-new-block!)
         (let [{:keys [block value config]} state
+              edit-block-fn-id (random-uuid)
               value (if (string? block-value) block-value value)
               block-id (:block/uuid block)
               block-self? (block-self-alone-when-insert? config block-id)
@@ -558,12 +561,18 @@
 
                           :else
                           insert-new-block-aux!)
-              [result-promise sibling? next-block] (insert-fn (assoc config :right-sibling right-sibling) block'' value)
+              config (assoc config
+                            :right-sibling right-sibling
+                            :editor/edit-block-fn-id edit-block-fn-id)
+              [result-promise sibling? next-block] (insert-fn config block'' value)
               edit-block-f #(edit-pending-new-block! next-block sibling?)]
-          (p/do!
-           (state/queue-edit-block-fn! edit-block-f)
-           result-promise
-           (clear-when-saved!)))))
+          (-> (p/do!
+               (state/queue-edit-block-fn! edit-block-fn-id edit-block-f)
+               result-promise
+               (clear-when-saved!))
+              (p/catch (fn [e]
+                         (state/remove-edit-block-fn! edit-block-fn-id)
+                         (throw e)))))))
     (p/catch (fn [e]
                (clear-pending-new-block!)
                (throw e))))))
@@ -838,18 +847,20 @@
                   (let [children (:block/_parent (db/entity (:db/id block)))]
                     (p/do!
                      (mobile-util/mobile-focus-hidden-input)
-                     (state/queue-edit-block-fn! edit-block-f)
                      (ui-outliner-tx/transact!
                       transact-opts
                       (when (seq children)
                         (outliner-op/move-blocks! children prev-block {:sibling? false}))
                       (delete-block-aux! block)
-                      (save-block! repo prev-block new-content {}))))
+                      (save-block! repo prev-block new-content {}))
+                     (when edit-block-f
+                       (edit-block-f))))
 
                   :else
                   (p/do!
-                   (state/queue-edit-block-fn! edit-block-f)
-                   (delete-block-aux! block)))))))))))
+                   (delete-block-aux! block)
+                   (when edit-block-f
+                     (edit-block-f))))))))))))
 
 (defn move-blocks!
   [blocks target opts]
@@ -891,12 +902,10 @@
           block-parent (get uuid->dom-block (:block/uuid block))
           sibling-block (when block-parent (util/get-prev-block-non-collapsed-non-embed block-parent))
           blocks' (block-handler/get-top-level-blocks blocks)
-          mobile? (util/capacitor?)]
+          mobile? (util/capacitor?)
+          edit-block-f (when (and sibling-block (not mobile?))
+                         (:edit-block-f (move-to-prev-block repo sibling-block "")))]
       (p/do!
-       (when (and sibling-block (not mobile?))
-         (let [{:keys [edit-block-f]} (move-to-prev-block repo sibling-block
-                                                          "")]
-           (state/queue-edit-block-fn! edit-block-f)))
        (let [journals (and mobile? (filter ldb/journal? blocks'))
              blocks (remove (fn [b] (contains? (set (map :db/id journals)) (:db/id b))) blocks)]
          (when (or (seq journals) (seq blocks))
@@ -907,7 +916,9 @@
               (outliner-op/delete-blocks! blocks nil))
             (when (seq journals)
               (doseq [journal journals]
-                (outliner-op/delete-page! (:block/uuid journal)))))))))))
+                (outliner-op/delete-page! (:block/uuid journal)))))))
+       (when edit-block-f
+         (edit-block-f))))))
 
 (defn copy-block-ref!
   ([block-id]
@@ -2262,11 +2273,13 @@
         target (when e (.-target e))]
     (when (or (nil? target)
               (inside-of-editor-block target))
-      (if (or (state/doc-mode-enter-for-new-line?) (inside-of-single-block (:node state)))
-        (keydown-new-line)
-        (do
-          (when e (.preventDefault e))
-          (keydown-new-block state))))))
+      (if (pending-new-block?)
+        (when e (.preventDefault e))
+        (if (or (state/doc-mode-enter-for-new-line?) (inside-of-single-block (:node state)))
+          (keydown-new-line)
+          (do
+            (when e (.preventDefault e))
+            (keydown-new-block state)))))))
 
 (defn keydown-new-line-handler [e]
   (let [state (get-state)]

--- a/src/main/frontend/modules/outliner/pipeline.cljs
+++ b/src/main/frontend/modules/outliner/pipeline.cljs
@@ -84,7 +84,7 @@
 
             (when-not (:graph/importing @state/state)
 
-              (let [edit-block-f (state/take-edit-block-fn!)]
+              (let [edit-block-f (state/take-edit-block-fn! (:editor/edit-block-fn-id tx-meta))]
                 (when-not (:skip-refresh? tx-meta)
                   (react/refresh! repo affected-keys))
                 (when edit-block-f

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -845,23 +845,62 @@ should be done through this fn in order to get global config and config defaults
       :else      (swap! state update path f)))
   nil)
 
+(defn- edit-block-fn-entry
+  [value]
+  (cond
+    (fn? value)
+    {:f value}
+
+    (and (map? value) (fn? (:f value)))
+    value
+
+    :else
+    nil))
+
 (defn- edit-block-fn-queue
   [value]
   (cond
-    (vector? value) value
-    (fn? value) [value]
-    :else []))
+    (vector? value) (into [] (keep edit-block-fn-entry) value)
+    :else (if-let [entry (edit-block-fn-entry value)]
+            [entry]
+            [])))
+
+(defn- take-edit-block-fn-entry
+  [queue pred]
+  (let [[before [entry & after]] (split-with (complement pred) queue)]
+    (when entry
+      [entry (vec (concat before after))])))
 
 (defn queue-edit-block-fn!
-  [f]
-  (when (fn? f)
-    (update-state! :editor/edit-block-fn #(conj (edit-block-fn-queue %) f))))
+  ([f]
+   (queue-edit-block-fn! nil f))
+  ([tx-id f]
+   (when (fn? f)
+     (update-state! :editor/edit-block-fn #(conj (edit-block-fn-queue %)
+                                                 {:tx-id tx-id
+                                                  :f f})))))
+
+(defn remove-edit-block-fn!
+  [tx-id]
+  (when tx-id
+    (update-state! :editor/edit-block-fn
+                   #(->> (edit-block-fn-queue %)
+                         (remove (fn [entry] (= tx-id (:tx-id entry))))
+                         vec))))
 
 (defn take-edit-block-fn!
-  []
-  (when-let [[f & more] (seq (edit-block-fn-queue @(:editor/edit-block-fn @state)))]
-    (set-state! :editor/edit-block-fn (vec more))
-    f))
+  ([]
+   (let [queue (edit-block-fn-queue @(:editor/edit-block-fn @state))]
+     (when-let [[entry more] (take-edit-block-fn-entry queue #(nil? (:tx-id %)))]
+       (set-state! :editor/edit-block-fn more)
+       (:f entry))))
+  ([tx-id]
+   (let [queue (edit-block-fn-queue @(:editor/edit-block-fn @state))
+         match (and tx-id
+                    (take-edit-block-fn-entry queue #(= tx-id (:tx-id %))))]
+     (when-let [[entry more] match]
+       (set-state! :editor/edit-block-fn more)
+       (:f entry)))))
 
 ;; State getters and setters
 ;; =========================

--- a/src/test/frontend/handler/editor_async_test.cljs
+++ b/src/test/frontend/handler/editor_async_test.cljs
@@ -41,8 +41,10 @@
      :stopped? stopped?}))
 
 (defn- take-edit-block-fn!
-  []
-  (state/take-edit-block-fn!))
+  ([]
+   (state/take-edit-block-fn!))
+  ([tx-id]
+   (state/take-edit-block-fn! tx-id)))
 
 (defn- delete-block
   [db block {:keys [embed? on-delete edit-content on-edit schedule-immediately?]}]
@@ -110,9 +112,14 @@
                               [?p :block/name "page1"]
                               [?b :block/page ?p]]
                             @conn)
-                       ffirst)]
+                       ffirst)
+            edit-calls (atom [])]
       (delete-block @conn block
-                    {:on-delete (fn []
+                    {:on-edit (fn [block pos opts]
+                                (swap! edit-calls conj {:block block
+                                                        :pos pos
+                                                        :opts opts}))
+                     :on-delete (fn []
                                   (let [updated-blocks (->> (d/q '[:find (pull ?b [*])
                                                                    :where
                                                                    [?p :block/name "page1"]
@@ -124,10 +131,18 @@
                                         deleted-blocks (->> (d/q '[:find (pull ?b [*])
                                                                    :where
                                                                    [?b :block/title ""]]
-                                                                 @conn)
+                                                                  @conn)
                                                             (map first))]
                                     (is (= ["b1" "b2"] updated-blocks) "Visible page blocks stay on the page")
-                                    (is (empty? deleted-blocks) "Deleted block is removed from page db")))})))
+                                    (is (empty? deleted-blocks) "Deleted block is removed from page db")
+                                    (is (= {:block "b2"
+                                            :pos 2
+                                            :opts {:custom-content "b2"
+                                                   :tail-len 0
+                                                   :container-id nil}}
+                                           (some-> (last @edit-calls)
+                                                   (update :block :block/title)))
+                                        "Deleting an empty block should focus the previous block")))})))
 
   (testing "backspace deletes empty block in embedded context"
     ;; testing embed at this layer doesn't require an embed block since
@@ -350,6 +365,7 @@
         current-block-indents (atom [])
         pending-block-indents (atom [])
         edit-calls (atom [])
+        insert-config (atom nil)
         {:keys [event stopped?]} (fake-key-event)
         previous-document (.-document js/globalThis)]
     (state/set-editing-block-id! [:unknown-container (:block/uuid current-block)])
@@ -369,7 +385,8 @@
                                                       :value "first"
                                                       :config {}
                                                       :block-container #js {}})
-                        editor/insert-new-block-aux! (fn [_config _block _value]
+                        editor/insert-new-block-aux! (fn [config _block _value]
+                                                       (reset! insert-config config)
                                                        [(p/resolved true) true next-block])
                         editor/get-new-container-id (constantly nil)
                         editor/indent-outdent (fn [indent?]
@@ -387,7 +404,8 @@
                                                                (p/resolved nil))]
           (editor/insert-new-block! nil nil)
           ((editor/keydown-tab-handler :right) event)
-          (p/let [_ (when-let [edit-block-f (take-edit-block-fn!)]
+          (p/let [_ (when-let [edit-block-f (take-edit-block-fn!
+                                             (:editor/edit-block-fn-id @insert-config))]
                        (edit-block-f))]
             (is @stopped? "Tab should still be consumed while the new block is pending")
             (is (empty? @current-block-indents) "Tab must not indent the block that was split by Enter")
@@ -404,20 +422,18 @@
                 "The pending block should still enter edit mode after applying queued Tab")))
         (p/finally (fn []
                      (state/set-state! :editor/edit-block-fn nil)
-            (state/set-state! :editor/pending-new-block nil)
-            (set! (.-document js/globalThis) previous-document))))))
+                     (state/set-state! :editor/pending-new-block nil)
+                     (set! (.-document js/globalThis) previous-document))))))
 
-(deftest-async rapid-enter-keeps-new-block-focus-callbacks-in-transaction-order
+(deftest-async rapid-enter-waits-for-pending-new-block
   (let [current-block {:db/id 1
                        :block/uuid (random-uuid)
                        :block/title "first"}
         first-new-block {:db/id 2
                          :block/uuid (random-uuid)
                          :block/title ""}
-        second-new-block {:db/id 3
-                          :block/uuid (random-uuid)
-                          :block/title ""}
-        inserted-blocks (atom [first-new-block second-new-block])
+        inserted-blocks (atom [first-new-block])
+        insert-configs (atom [])
         input #js {:value "first"}
         edit-calls (atom [])
         previous-document (.-document js/globalThis)]
@@ -433,13 +449,16 @@
                                     (case lookup-ref
                                       [:block/uuid (:block/uuid current-block)] current-block
                                       [:block/uuid (:block/uuid first-new-block)] first-new-block
-                                      [:block/uuid (:block/uuid second-new-block)] second-new-block
                                       current-block))
                         editor/get-state (constantly {:block current-block
                                                       :value "first"
                                                       :config {}
+                                                      :node input
                                                       :block-container #js {}})
-                        editor/insert-new-block-aux! (fn [_config _block _value]
+                        editor/inside-of-single-block (constantly false)
+                        ldb/get-right-sibling (constantly nil)
+                        editor/insert-new-block-aux! (fn [config _block _value]
+                                                       (swap! insert-configs conj config)
                                                        (let [next-block (first @inserted-blocks)]
                                                          (swap! inserted-blocks subvec 1)
                                                          [(p/resolved true) true next-block]))
@@ -449,26 +468,91 @@
                                                                      :pos pos
                                                                      :opts opts})
                                              (p/resolved nil))]
-          (editor/insert-new-block! nil nil)
-          (editor/insert-new-block! nil nil)
-          (p/let [_ (when-let [edit-block-f (take-edit-block-fn!)]
-                       (edit-block-f))
-                  _ (when-let [edit-block-f (take-edit-block-fn!)]
-                      (edit-block-f))]
+          (editor/keydown-new-block-handler nil)
+          (editor/keydown-new-block-handler nil)
+          (p/let [_ (when-let [edit-block-f (take-edit-block-fn! (:editor/edit-block-fn-id (first @insert-configs)))]
+                       (edit-block-f))]
+            (is (= 1 (count @insert-configs))
+                "Enter should not start another insert while a new block is pending")
             (is (= [{:block first-new-block
-                     :pos 0
-                     :opts {:container-id nil
-                            :custom-content ""}}
-                    {:block second-new-block
                      :pos 0
                      :opts {:container-id nil
                             :custom-content ""}}]
                    @edit-calls)
-                "Rapid Enter should keep one focus callback per inserted block, in transaction order")))
+                "The pending block should enter edit mode once the insert transaction completes")))
         (p/finally (fn []
                      (state/set-state! :editor/edit-block-fn nil)
                      (state/set-state! :editor/pending-new-block nil)
                      (set! (.-document js/globalThis) previous-document))))))
+
+(deftest-async rejected-new-block-insert-removes-queued-edit-callback
+  (let [current-block {:db/id 1
+                       :block/uuid (random-uuid)
+                       :block/title "first"}
+        next-block {:db/id 2
+                    :block/uuid (random-uuid)
+                    :block/title ""}
+        input #js {:value "first"}
+        expected-error (js/Error. "insert failed")
+        result-promise (p/deferred)
+        insert-config (atom nil)
+        previous-document (.-document js/globalThis)]
+    (state/set-editing-block-id! [:unknown-container (:block/uuid current-block)])
+    (set! (.-document js/globalThis)
+          #js {:activeElement input
+               :getElementById (fn [_id] input)})
+    (-> (p/with-redefs [state/get-edit-input-id (constantly "edit-block-current")
+                        gdom/getElement (constantly input)
+                        util/get-selection-start (constantly 5)
+                        util/get-selection-end (constantly 5)
+                        db/entity (fn [lookup-ref]
+                                    (case lookup-ref
+                                      [:block/uuid (:block/uuid current-block)] current-block
+                                      [:block/uuid (:block/uuid next-block)] next-block
+                                      current-block))
+                        editor/get-state (constantly {:block current-block
+                                                      :value "first"
+                                                      :config {}
+                                                      :node input
+                                                      :block-container #js {}})
+                        editor/inside-of-single-block (constantly false)
+                        ldb/get-right-sibling (constantly nil)
+                        editor/insert-new-block-aux! (fn [config _block _value]
+                                                       (reset! insert-config config)
+                                                       [result-promise true next-block])
+                        editor/get-new-container-id (constantly nil)]
+          (let [insert-result (.catch (.then (editor/insert-new-block! nil nil)
+                                            (fn [_] ::resolved))
+                                      (fn [e] e))]
+            (.catch result-promise (fn [_] nil))
+            (p/let [_ (p/delay 0)
+                    _ (do
+                        (p/reject! result-promise expected-error)
+                        nil)
+                    result insert-result]
+              (is (identical? expected-error result)
+                  "Insert failure should still reject with the original error")
+              (is (nil? (take-edit-block-fn! (:editor/edit-block-fn-id @insert-config)))
+                  "Rejected insert should remove the queued tagged edit callback"))))
+        (p/finally (fn []
+                     (state/set-state! :editor/edit-block-fn nil)
+                     (state/set-state! :editor/pending-new-block nil)
+                     (set! (.-document js/globalThis) previous-document))))))
+
+(deftest tagged-enter-callback-does-not-block-delete-focus
+  (let [enter-tx-id (random-uuid)
+        edit-calls (atom [])]
+    (try
+      (state/queue-edit-block-fn! enter-tx-id #(swap! edit-calls conj :enter))
+      (state/queue-edit-block-fn! #(swap! edit-calls conj :delete-previous))
+      (when-let [edit-block-f (take-edit-block-fn! enter-tx-id)]
+        (edit-block-f))
+      (when-let [edit-block-f (take-edit-block-fn!)]
+        (edit-block-f))
+      (is (= [:enter :delete-previous] @edit-calls)
+          "Tagged Enter focus should not consume the untagged delete focus callback")
+      (finally
+        (state/set-state! :editor/edit-block-fn nil)))))
 
 (deftest-async indent-block-does-not-move-into-comments-area
   (load-test-files


### PR DESCRIPTION
## Summary
- fix rapid Enter focus by consuming Enter while a new block is pending and tagging insert focus callbacks by transaction metadata
- fix delete focus by editing the previous block after delete transactions instead of leaving untagged callbacks queued
- fix CLI release bundling by running dune through the CLI opam switch

## Validation
- pnpm cli:release
- node static/logseq-cli.js --help
- node static/logseq-cli.js --version
- pnpm --dir cli test
- bb dev:test -v frontend.handler.editor-async-test
- live Electron renderer check on local graph `4k-movies`: rapid Enter focused the new block, delete focused the previous block, pending state was nil, queue was empty

Related to https://github.com/logseq/db-test/issues/960