### PR TITLE
fix: preserve query block fields before ui hydration

### DIFF
--- a/deps/outliner/src/logseq/outliner/tree.cljs
+++ b/deps/outliner/src/logseq/outliner/tree.cljs
@@ -87,14 +87,16 @@
 
 (defn ^:api block-entity->map
   [e]
-  (cond-> {:db/id (:db/id e)
-           :block/uuid (:block/uuid e)
-           :block/parent {:db/id (:db/id (:block/parent e))}
-           :block/page (:block/page e)}
-    (:block/refs e)
-    (assoc :block/refs (:block/refs e))
-    (:block/children e)
-    (assoc :block/children (:block/children e))))
+  (if (de/entity? e)
+    (cond-> {:db/id (:db/id e)
+             :block/uuid (:block/uuid e)
+             :block/parent {:db/id (:db/id (:block/parent e))}
+             :block/page (:block/page e)}
+      (:block/refs e)
+      (assoc :block/refs (:block/refs e))
+      (:block/children e)
+      (assoc :block/children (:block/children e)))
+    e))
 
 (defn ^:api filter-top-level-blocks
   [blocks]

--- a/deps/outliner/src/logseq/outliner/tree.cljs
+++ b/deps/outliner/src/logseq/outliner/tree.cljs
@@ -96,7 +96,9 @@
       (assoc :block/refs (:block/refs e))
       (:block/children e)
       (assoc :block/children (:block/children e)))
-    e))
+    (cond-> e
+      (:db/id (:block/parent e))
+      (assoc :block/parent {:db/id (:db/id (:block/parent e))}))))
 
 (defn ^:api filter-top-level-blocks
   [blocks]

--- a/src/test/frontend/modules/outliner/core_test.cljs
+++ b/src/test/frontend/modules/outliner/core_test.cljs
@@ -1010,3 +1010,20 @@
                :block/parent #:db{:id 2333},
                :block/page #:db{:id 2313},
                :block/level 3}]}]})))))
+
+(deftest non-consecutive-blocks->vec-tree-preserves-worker-pulled-block-fields
+  (let [page-ref #:db{:id 1}
+        parent {:db/id 2
+                :block/uuid #uuid "62f49b4c-f9f0-4739-9985-8bd55e4c68d4"
+                :block/title "Visible parent task"
+                :block/page page-ref
+                :block/parent page-ref}
+        child {:db/id 3
+               :block/uuid #uuid "62f49b4c-aa84-416e-9554-b486b4e59b1b"
+               :block/title "Visible child task"
+               :block/page page-ref
+               :block/parent {:db/id 2}}
+        [result] (tree/non-consecutive-blocks->vec-tree [parent child])]
+    (is (= "Visible parent task" (:block/title result)))
+    (is (= "Visible child task"
+           (:block/title (first (:block/children result)))))))

--- a/src/test/frontend/modules/outliner/core_test.cljs
+++ b/src/test/frontend/modules/outliner/core_test.cljs
@@ -1022,7 +1022,7 @@
                :block/uuid #uuid "62f49b4c-aa84-416e-9554-b486b4e59b1b"
                :block/title "Visible child task"
                :block/page page-ref
-               :block/parent {:db/id 2}}
+               :block/parent (select-keys parent [:db/id :block/uuid :block/title])}
         [result] (tree/non-consecutive-blocks->vec-tree [parent child])]
     (is (= "Visible parent task" (:block/title result)))
     (is (= "Visible child task"


### PR DESCRIPTION
## Summary

Fix query result rendering when worker-pulled blocks are not in the UI DB yet. `non-consecutive-blocks->vec-tree` now preserves plain pulled block maps as-is and only compacts Datascript entities, so renderable fields like `:block/title` remain available before UI hydration completes.

## Root cause

Built-in DOING/TODO query results can arrive from the worker before matching block entities exist in the UI DB. The tree conversion path normalized every input through `block-entity->map`, which stripped plain map fields such as `:block/title`. That left the result count correct while the query rows could render blank.

## Validation

- `bb dev:test -v 'frontend.modules.outliner.core-test/non-consecutive-blocks->vec-tree-preserves-worker-pulled-block-fields'`
- `bb dev:test -v 'frontend.modules.outliner.core-test/test-non-consecutive-blocks->vec-tree'`
- `bb dev:test -v frontend.modules.outliner.core-test`
- `clojure -M:clj-kondo --lint src/logseq/outliner/tree.cljs --cache false` from `deps/outliner`
- `clojure -M:clj-kondo --lint src/test/frontend/modules/outliner/core_test.cljs --cache false`
- `git diff --check`

Note: `bb lint:kondo-git-changes` is blocked locally because the standalone `clj-kondo` binary is not installed, so the equivalent Clojure aliases were used for the changed files.