### PR TITLE
fix: expand overflowing bottom property pills

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -3031,7 +3031,7 @@
                 (if expanded?
                   "flex-wrap overflow-x-hidden"
                   "flex-nowrap overflow-x-hidden")])
-       :data-expanded (boolean expanded?)
+       :data-expanded (str expanded?)
        :data-bottom-properties-row (:block/uuid block)
        :tab-index -1
        :on-key-down handle-bottom-properties-row-key-down!}
@@ -3040,7 +3040,7 @@
                                    "flex-wrap overflow-x-hidden"
                                    "flex-nowrap overflow-x-hidden")])
         :ref #(set! (.-current *pills-el) %)}
-       (bottom-property-pill-items block properties opts)]
+       (bottom-property-pill-items block properties (assoc opts :expanded? expanded?))]
       (when (or overflow? expanded?)
         (bottom-properties-expand-button expanded? set-expanded!))
       (when show-hidden-properties-toggle?

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -1551,6 +1551,10 @@ html.is-mac {
     max-height: 24rem;
   }
 
+  .bottom-properties-row[data-expanded="false"] .bottom-property-pill {
+    max-width: none;
+  }
+
   .bottom-properties-pills-strip {
     flex: 1 1 0;
     width: 0;
@@ -1584,6 +1588,14 @@ html.is-mac {
 
   .bottom-property-pill.bottom-property-pill-wrap {
     @apply h-6;
+  }
+
+  .bottom-properties-row[data-expanded="true"] .bottom-property-pill {
+    @apply h-auto max-w-full items-start;
+  }
+
+  .bottom-properties-row[data-expanded="true"] .bottom-property-content {
+    @apply whitespace-normal overflow-visible;
   }
 
   .bottom-property-pill-line-break {

--- a/src/main/frontend/components/property.cljs
+++ b/src/main/frontend/components/property.cljs
@@ -1037,10 +1037,15 @@
                                 (remove (fn [[k _v]] (= k :logseq.property.class/properties))))
                show-properties-panel? (seq properties')
                page? (entity-util/page? block)
+               page-properties-area? (and page?
+                                          (or (:page-title? opts)
+                                              sidebar-properties?
+                                              tag-dialog?))
+               opts' (assoc opts :page-property? page-properties-area?)
                plugin-properties (->> (concat full-properties hidden-properties)
                                       (remove (fn [[k _v]] (= k :logseq.property.class/properties)))
                                       (into {}))
-               props-for-plugin (when (enable-block-properties-renderers? opts class?)
+               props-for-plugin (when (enable-block-properties-renderers? opts' class?)
                                   (clj->js {:blockId (str (:block/uuid block))
                                             :properties (into {} (map (fn [[k v]]
                                                                         [(subs (str k) 1)
@@ -1086,7 +1091,7 @@
                     [:> (:render replace-renderer) props-for-plugin])
                   (when show-properties-panel?
                     [:div.properties-panel
-                     (properties-section block properties' opts)]))
+                     (properties-section block properties' opts')]))
 
                 (when-not class?
                   [:<>
@@ -1096,11 +1101,11 @@
                    (when (and show-hidden-properties? (seq hidden-properties))
                      [:div.properties-panel
                       (hidden-properties-cp block hidden-properties
-                                            (assoc opts :show-hidden-properties? true))])])
+                                            (assoc opts' :show-hidden-properties? true))])])
 
                 (when (and page? (not class?))
                   ^{:key (str id "-add-property")}
-                  [new-property block opts])
+                  [new-property block opts'])
 
                 (mapv (fn [r]
                         (when (fn? (:render r))

--- a/src/main/frontend/components/property.css
+++ b/src/main/frontend/components/property.css
@@ -338,6 +338,20 @@
     @apply flex items-center shrink whitespace-nowrap;
   }
 
+  .multi-values-nowrap .select-item {
+    @apply shrink-0;
+    width: max-content;
+    max-width: none;
+  }
+
+  .multi-values-expanded .select-item {
+    min-width: 0;
+    width: auto;
+    max-width: 100%;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
   &[data-type] {
     @apply flex items-center;
   }
@@ -347,26 +361,32 @@
   }
 }
 
-.positioned-properties.block-below .bottom-property-content .property-value-inner[data-type=node] .multi-values.jtrigger {
+.positioned-properties.block-below .bottom-properties-row[data-expanded="false"] .bottom-property-content .property-value-inner[data-type=node] .multi-values.jtrigger {
   min-width: 0;
-  max-width: 100%;
-  width: 100%;
+  max-width: none;
+  width: max-content;
   overflow: hidden;
   white-space: nowrap;
 }
 
-.positioned-properties.block-below .bottom-property-content .property-value-inner[data-type=node] .select-item,
-.positioned-properties.block-below .bottom-property-content .property-value-inner[data-type=node] .page-ref,
-.positioned-properties.block-below .bottom-property-content .property-value-inner[data-type=node] .block-title-wrap {
+.positioned-properties.block-below .bottom-properties-row[data-expanded="false"] .bottom-property-content .property-value-inner[data-type=node] .select-item,
+.positioned-properties.block-below .bottom-properties-row[data-expanded="false"] .bottom-property-content .property-value-inner[data-type=node] .page-ref,
+.positioned-properties.block-below .bottom-properties-row[data-expanded="false"] .bottom-property-content .property-value-inner[data-type=node] .block-title-wrap {
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   min-width: 0;
-  max-width: 100%;
+  max-width: none;
 }
 
-.positioned-properties.block-below .bottom-property-content .property-value-inner[data-type=node] .select-item {
+.positioned-properties.block-below .bottom-properties-row[data-expanded="false"] .bottom-property-content .property-value-inner[data-type=node] .select-item {
   display: inline-flex;
+}
+
+.positioned-properties.block-below .bottom-properties-row[data-expanded="true"] .bottom-property-content .property-value-inner[data-type=node] .multi-values.jtrigger,
+.positioned-properties.block-below .bottom-properties-row[data-expanded="true"] .bottom-property-content .property-value-inner[data-type=node] .select-item,
+.positioned-properties.block-below .bottom-properties-row[data-expanded="true"] .bottom-property-content .property-value-inner[data-type=node] .page-ref,
+.positioned-properties.block-below .bottom-properties-row[data-expanded="true"] .bottom-property-content .property-value-inner[data-type=node] .block-title-wrap {
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .block-main-container .ls-properties-area {

--- a/src/main/frontend/components/property/value.cljs
+++ b/src/main/frontend/components/property/value.cljs
@@ -1376,15 +1376,15 @@
               (inline-text {} :markdown value'))])))))
 
 (defn multiple-values-trigger-class
-  [{:keys [expanded? page-property?]}]
+  [{:keys [expanded? other-position? page-property?]}]
   (str "flex flex-1 min-w-0 flex-row items-center gap-1 "
-       (if (or expanded? page-property?)
-         (str "flex-wrap " (when expanded? "multi-values-expanded"))
-         "flex-nowrap multi-values-nowrap")))
+       (if (and other-position? (not expanded?) (not page-property?))
+         "flex-nowrap multi-values-nowrap"
+         (str "flex-wrap " (when expanded? "multi-values-expanded")))))
 
 (defn multiple-value-item-class
-  [{:keys [expanded? page-property?]}]
-  (when-not (or expanded? page-property?)
+  [{:keys [expanded? other-position? page-property? show-popup!]}]
+  (when (and show-popup! other-position? (not expanded?) (not page-property?))
     "shrink-0"))
 
 (hsx/defc select-item

--- a/src/main/frontend/components/property/value.cljs
+++ b/src/main/frontend/components/property/value.cljs
@@ -1375,6 +1375,18 @@
                            value')]
               (inline-text {} :markdown value'))])))))
 
+(defn multiple-values-trigger-class
+  [{:keys [expanded? page-property?]}]
+  (str "flex flex-1 min-w-0 flex-row items-center gap-1 "
+       (if (or expanded? page-property?)
+         (str "flex-wrap " (when expanded? "multi-values-expanded"))
+         "flex-nowrap multi-values-nowrap")))
+
+(defn multiple-value-item-class
+  [{:keys [expanded? page-property?]}]
+  (when-not (or expanded? page-property?)
+    "shrink-0"))
+
 (hsx/defc select-item
   [property type value {:keys [page-cp inline-text other-position? property-position table-view? _icon?] :as opts}]
   (let [closed-values? (seq (:property/closed-values property))
@@ -1383,6 +1395,7 @@
                          [:div.flex.flex-row.items-center
                           (inline-text {} :markdown (macro-util/expand-value-if-macro content (state/get-macros)))])]
     [:div.select-item.cursor-pointer
+     {:class (multiple-value-item-class opts)}
      (cond
        (= value :logseq.property/empty-placeholder)
        (property-empty-btn-value property opts)
@@ -2109,7 +2122,7 @@
                            ("Backspace" "Delete")
                            (delete-block-property! block property)
                            :dune))
-          :class "flex flex-1 flex-row items-center flex-wrap gap-1"}
+          :class (multiple-values-trigger-class opts)}
          (let [not-empty-value? (not= (map :db/ident items) [:logseq.property/empty-placeholder])]
            (if (and (seq items) not-empty-value?)
              (if (= type :asset)

--- a/src/test/frontend/components/property/value_test.cljs
+++ b/src/test/frontend/components/property/value_test.cljs
@@ -101,36 +101,49 @@
          (:grid-template-columns property-value/asset-picker-items-grid-style))))
 
 (defn- class-set
-  [class]
-  (set (string/split (or class "") #"\s+")))
+  [class-str]
+  (set (string/split (or class-str "") #"\s+")))
 
 (deftest block-multiple-node-values-stay-in-one-row-test
-  (is (contains? (class-set (property-value/multiple-values-trigger-class {}))
-                 "min-w-0"))
-  (is (contains? (class-set (property-value/multiple-values-trigger-class {}))
-                 "flex-nowrap"))
-  (is (contains? (class-set (property-value/multiple-values-trigger-class {}))
-                 "multi-values-nowrap"))
-  (is (contains? (class-set (property-value/multiple-value-item-class {}))
-                 "shrink-0")))
+  (let [opts {:other-position? true
+              :show-popup! identity}]
+    (is (contains? (class-set (property-value/multiple-values-trigger-class opts))
+                   "min-w-0"))
+    (is (contains? (class-set (property-value/multiple-values-trigger-class opts))
+                   "flex-nowrap"))
+    (is (contains? (class-set (property-value/multiple-values-trigger-class opts))
+                   "multi-values-nowrap"))
+    (is (contains? (class-set (property-value/multiple-value-item-class opts))
+                   "shrink-0"))))
 
 (deftest expanded-multiple-node-values-can-wrap-test
-  (is (contains? (class-set (property-value/multiple-values-trigger-class {:expanded? true}))
-                 "flex-wrap"))
-  (is (contains? (class-set (property-value/multiple-values-trigger-class {:expanded? true}))
-                 "multi-values-expanded"))
-  (is (not (contains? (class-set (property-value/multiple-values-trigger-class {:expanded? true}))
-                      "flex-nowrap")))
-  (is (not (contains? (class-set (property-value/multiple-value-item-class {:expanded? true}))
-                      "shrink-0"))))
+  (let [opts {:expanded? true
+              :other-position? true
+              :show-popup! identity}]
+    (is (contains? (class-set (property-value/multiple-values-trigger-class opts))
+                   "flex-wrap"))
+    (is (contains? (class-set (property-value/multiple-values-trigger-class opts))
+                   "multi-values-expanded"))
+    (is (not (contains? (class-set (property-value/multiple-values-trigger-class opts))
+                        "flex-nowrap")))
+    (is (not (contains? (class-set (property-value/multiple-value-item-class opts))
+                        "shrink-0")))))
 
 (deftest page-multiple-node-values-can-wrap-test
-  (is (contains? (class-set (property-value/multiple-values-trigger-class {:page-property? true}))
+  (let [opts {:page-property? true
+              :show-popup! identity}]
+    (is (contains? (class-set (property-value/multiple-values-trigger-class opts))
+                   "flex-wrap"))
+    (is (not (contains? (class-set (property-value/multiple-values-trigger-class opts))
+                        "flex-nowrap")))
+    (is (not (contains? (class-set (property-value/multiple-value-item-class opts))
+                        "shrink-0")))))
+
+(deftest non-positioned-multiple-node-values-can-wrap-test
+  (is (contains? (class-set (property-value/multiple-values-trigger-class {}))
                  "flex-wrap"))
-  (is (not (contains? (class-set (property-value/multiple-values-trigger-class {:page-property? true}))
-                      "flex-nowrap")))
-  (is (not (contains? (class-set (property-value/multiple-value-item-class {:page-property? true}))
-                      "shrink-0"))))
+  (is (not (contains? (class-set (property-value/multiple-values-trigger-class {}))
+                      "flex-nowrap"))))
 
 (deftest asset-selected-ids-test
   (let [property {:db/ident :asset}]

--- a/src/test/frontend/components/property/value_test.cljs
+++ b/src/test/frontend/components/property/value_test.cljs
@@ -1,5 +1,6 @@
 (ns frontend.components.property.value-test
   (:require [cljs.test :refer [async deftest is]]
+            [clojure.string :as string]
             [frontend.components.property.value :as property-value]
             [frontend.db :as db]
             [frontend.db.async :as db-async]
@@ -98,6 +99,38 @@
   (is (= "100%" (:max-width property-value/asset-picker-grid-style)))
   (is (= "repeat(auto-fill, minmax(140px, 1fr))"
          (:grid-template-columns property-value/asset-picker-items-grid-style))))
+
+(defn- class-set
+  [class]
+  (set (string/split (or class "") #"\s+")))
+
+(deftest block-multiple-node-values-stay-in-one-row-test
+  (is (contains? (class-set (property-value/multiple-values-trigger-class {}))
+                 "min-w-0"))
+  (is (contains? (class-set (property-value/multiple-values-trigger-class {}))
+                 "flex-nowrap"))
+  (is (contains? (class-set (property-value/multiple-values-trigger-class {}))
+                 "multi-values-nowrap"))
+  (is (contains? (class-set (property-value/multiple-value-item-class {}))
+                 "shrink-0")))
+
+(deftest expanded-multiple-node-values-can-wrap-test
+  (is (contains? (class-set (property-value/multiple-values-trigger-class {:expanded? true}))
+                 "flex-wrap"))
+  (is (contains? (class-set (property-value/multiple-values-trigger-class {:expanded? true}))
+                 "multi-values-expanded"))
+  (is (not (contains? (class-set (property-value/multiple-values-trigger-class {:expanded? true}))
+                      "flex-nowrap")))
+  (is (not (contains? (class-set (property-value/multiple-value-item-class {:expanded? true}))
+                      "shrink-0"))))
+
+(deftest page-multiple-node-values-can-wrap-test
+  (is (contains? (class-set (property-value/multiple-values-trigger-class {:page-property? true}))
+                 "flex-wrap"))
+  (is (not (contains? (class-set (property-value/multiple-values-trigger-class {:page-property? true}))
+                      "flex-nowrap")))
+  (is (not (contains? (class-set (property-value/multiple-value-item-class {:page-property? true}))
+                      "shrink-0"))))
 
 (deftest asset-selected-ids-test
   (let [property {:db/ident :asset}]


### PR DESCRIPTION
## Summary

Fix bottom positioned property pills so clipped values can be expanded without changing page property wrapping behavior.

## Details

- Keep bottom property pills as a single clipped row by default.
- Detect overflow at the bottom row level so either one long value or many values can reveal the existing expand control.
- Pass the expanded row state into property value rendering so expanded bottom pills can wrap.
- Keep page property areas wrapping by default, while pages rendered in the outliner still use the bottom row behavior.

## Validation

- `bb dev:test -v frontend.components.property.value-test`
- `pnpm exec postcss tailwind.all.css -o /tmp/logseq-style.css --verbose --env production`
- `git diff --check && git diff --cached --check`
- Manually verified the bottom pills expand behavior in the app.

Fixes https://github.com/logseq/db-test/issues/966
