### PR TITLE
enhance(ux): show/hide properties

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -3004,7 +3004,7 @@
      label)))
 
 (defn- block-below-positioned-properties-cp
-  [block properties opts show-hidden-properties-toggle? show-add-property-button?]
+  [block properties opts show-hidden-properties-pill-toggle? show-hidden-properties-control? show-add-property-button?]
   (let [*pills-el (hooks/use-ref nil)
         *overflow? (hooks/use-memo #(atom false) [(:block/uuid block) (count properties)])
         [overflow?] (hooks/use-atom *overflow?)
@@ -3023,7 +3023,7 @@
            (when observer
              (.disconnect observer))
            (.removeEventListener js/window "resize" measure!))))
-     [(:block/uuid block) properties show-hidden-properties-toggle? show-add-property-button? expanded?])
+     [(:block/uuid block) properties show-hidden-properties-pill-toggle? show-hidden-properties-control? show-add-property-button? expanded?])
     [:div.positioned-properties.block-below.flex.flex-col.gap-1.text-sm.overflow-x-hidden.w-full.min-w-0
      [:div
       {:class (util/classnames
@@ -3040,10 +3040,14 @@
                                    "flex-wrap overflow-x-hidden"
                                    "flex-nowrap overflow-x-hidden")])
         :ref #(set! (.-current *pills-el) %)}
-       (bottom-property-pill-items block properties (assoc opts :expanded? expanded?))]
+       (bottom-property-pill-items block properties (assoc opts :expanded? expanded?))
+       (when show-hidden-properties-pill-toggle?
+         (property-component/hidden-properties-toggle-button block {:bottom-pill? true
+                                                                    :bottom-row-nav? true
+                                                                    :tab-index -1}))]
       (when (or overflow? expanded?)
         (bottom-properties-expand-button expanded? set-expanded!))
-      (when show-hidden-properties-toggle?
+      (when show-hidden-properties-control?
         (property-component/hidden-properties-toggle-button block {:icon-only? true
                                                                    :bottom-row-nav? true
                                                                    :tab-index 0}))
@@ -3068,11 +3072,14 @@
                      :inline-text inline-text
                      :other-position? true
                      :property-position position})
-        show-page-hidden-properties-toggle? (and (ldb/page? block)
-                                                 (not config/publishing?))
-        show-hidden-properties-toggle? (and has-viewable-properties?
-                                            show-page-hidden-properties-toggle?
-                                            (property-component/has-hidden-properties? block config))
+        has-hidden-properties? (and has-viewable-properties?
+                                    (not config/publishing?)
+                                    (property-component/has-hidden-properties? block config))
+        page? (ldb/page? block)
+        show-hidden-properties-pill-toggle? (and has-hidden-properties?
+                                                 (not page?))
+        show-hidden-properties-control? (and has-hidden-properties?
+                                             page?)
         show-page-add-property? (and (ldb/page? block)
                                      (not (ldb/class? block))
                                      (not config/publishing?))
@@ -3084,7 +3091,8 @@
           (block-below-positioned-properties-cp block
                                                 properties
                                                 opts
-                                                show-hidden-properties-toggle?
+                                                show-hidden-properties-pill-toggle?
+                                                show-hidden-properties-control?
                                                 show-add-property-button?))
 
         (when (seq properties)

--- a/src/main/frontend/components/block.css
+++ b/src/main/frontend/components/block.css
@@ -1662,7 +1662,7 @@ html.is-mac {
   .ls-new-property .jtrigger,
   .bottom-property-control-btn {
     @apply inline-flex items-center justify-center w-6 h-6 p-0 rounded-full text-xs;
-    color: var(--ls-secondary-text-color);
+    color: var(--ls-primary-text-color);
     background-color: var(--ls-secondary-background-color);
     border: 0;
     box-shadow: inset 0 0 0 1px var(--ls-border-color);
@@ -1670,7 +1670,7 @@ html.is-mac {
 
   .ls-new-property .jtrigger:hover,
   .bottom-property-control-btn:hover {
-    color: var(--ls-secondary-text-color);
+    color: var(--ls-primary-text-color);
     background-color: var(--ls-secondary-background-color);
   }
 
@@ -1688,6 +1688,11 @@ html.is-mac {
   .bottom-property-action-icon {
     width: 16px;
     height: 16px;
+    color: var(--ls-primary-text-color);
+  }
+
+  .bottom-property-hidden-toggle-btn {
+    color: var(--ls-primary-text-color);
   }
 
   .ls-new-property .jtrigger.bottom-property-add-btn:focus,

--- a/src/main/frontend/components/property.cljs
+++ b/src/main/frontend/components/property.cljs
@@ -921,9 +921,12 @@
         full-properties (-> (concat block-own-properties'
                                     (remove property-hide-f class-property-pairs))
                             (remove-built-in-or-other-position-properties false))
-        hidden-properties (-> (concat block-hidden-properties
-                                      (filter property-hide-f class-property-pairs))
-                              (remove-built-in-or-other-position-properties true))]
+        hidden-properties (remove (fn [[property-id _]]
+                                    (= property-id :logseq.property/query))
+                                  (remove-built-in-or-other-position-properties
+                                   (concat block-hidden-properties
+                                           (filter property-hide-f class-property-pairs))
+                                   true))]
     {:full-properties full-properties
      :hidden-properties hidden-properties}))
 
@@ -940,29 +943,52 @@
     (boolean (seq hidden-properties))))
 
 (hsx/defc hidden-properties-toggle-button
-  [block {:keys [icon-only? tab-index bottom-row-nav?] :as _opts}]
+  [block {:keys [icon-only? tab-index bottom-row-nav? bottom-pill?] :as _opts}]
   (let [block-uuid (:block/uuid block)
         show-hidden-properties? (use-hidden-properties-visible block-uuid)
         label (hidden-properties-toggle-label show-hidden-properties?)]
     (when block-uuid
-      (let [button
-            (shui/button
-             {:variant :secondary
-              :size :sm
-              :class (str "bottom-property-control-btn"
-                          " hidden-properties-toggle-btn"
-                          (when icon-only? " bottom-property-add-btn"))
+      (if bottom-pill?
+        [:button.bottom-property-pill.bottom-property-pill-focusable.bottom-property-hidden-toggle-btn
+         {:type "button"
+          :data-bottom-pill-focusable true
+          :data-bottom-row-nav (when bottom-row-nav? true)
+          :tab-index (or tab-index -1)
+          :aria-label label
+          :on-click (fn [e]
+                      (util/stop e)
+                      (toggle-hidden-properties-visibility! block-uuid))}
+         (ui/icon (if show-hidden-properties? "chevron-up" "chevron-down")
+                  {:size 16 :class "bottom-property-action-icon"})
+         label]
+        (if icon-only?
+          [:div.ls-new-property
+           (shui/button
+            {:variant :secondary
+             :size :sm
+             :class "jtrigger flex bottom-property-add-btn"
+             :tab-index (or tab-index 0)
+             :data-bottom-row-nav (when bottom-row-nav? true)
+             :aria-label label
+             :on-click (fn [e]
+                         (util/stop e)
+                         (toggle-hidden-properties-visibility! block-uuid))}
+            (ui/icon (if show-hidden-properties? "chevron-up" "chevron-down")
+                     {:size 16 :class "bottom-property-action-icon"}))]
+          [:div.property-pair.property-panel-row.hidden-properties-toggle-row
+           [:div.property-key-panel
+            [:button.property-key-inner.jtrigger-view.hidden-properties-toggle-key
+             {:type "button"
               :tab-index (or tab-index 0)
-              :data-bottom-row-nav (when bottom-row-nav? true)
               :aria-label label
               :on-click (fn [e]
                           (util/stop e)
                           (toggle-hidden-properties-visibility! block-uuid))}
-             (ui/icon (if show-hidden-properties? "chevron-up" "chevron-down")
-                      {:size 16 :class "bottom-property-action-icon"})
-             (when-not icon-only?
-               label))]
-        (ui/tooltip button [:span label])))))
+             [:span.property-icon
+              (ui/icon (if show-hidden-properties? "chevron-up" "chevron-down")
+                       {:size 16})]
+             [:span.property-k label]]]
+           [:div.property-value-panel.ls-block.property-value-container]])))))
 
 (hsx/defc hidden-properties-cp
   [block hidden-properties {:keys [show-hidden-properties?] :as opts}]
@@ -1096,8 +1122,7 @@
                 (when-not class?
                   [:<>
                    (when show-hidden-properties-toggle-button?
-                     [:div.mb-1
-                      (hidden-properties-toggle-button block {})])
+                     (hidden-properties-toggle-button block {}))
                    (when (and show-hidden-properties? (seq hidden-properties))
                      [:div.properties-panel
                       (hidden-properties-cp block hidden-properties

--- a/src/main/frontend/components/property.css
+++ b/src/main/frontend/components/property.css
@@ -74,14 +74,6 @@
     @apply px-3 py-2 text-xs font-medium text-muted-foreground border-b border-gray-04;
   }
 
-  .hidden-properties-toggle-btn {
-    color: var(--ls-secondary-text-color);
-  }
-
-  .hidden-properties-toggle-btn:hover {
-    color: var(--ls-primary-text-color);
-  }
-
   .property-pair.property-panel-row {
     @apply grid items-start pr-3 gap-3 w-full;
     grid-template-columns: fit-content(260px) minmax(0, 1fr);
@@ -123,6 +115,29 @@
   .property-pair.property-panel-row[data-property-type=checkbox] .property-value-panel.ls-block.property-value-container,
   .property-pair.property-panel-row[data-property-type=checkbox] .property-value.property-value-panel-inner {
     @apply items-center;
+  }
+
+  .hidden-properties-toggle-row {
+    @apply pr-3;
+  }
+
+  .hidden-properties-toggle-key {
+    @apply w-full min-w-0 min-h-[28px] p-0 border-0 bg-transparent text-left cursor-pointer;
+    color: var(--ls-primary-text-color);
+    font: inherit;
+  }
+
+  .hidden-properties-toggle-key:hover {
+    color: var(--ls-primary-text-color);
+  }
+
+  .hidden-properties-toggle-key:focus,
+  .hidden-properties-toggle-key:focus-visible {
+    outline: none;
+  }
+
+  .hidden-properties-toggle-key .property-icon {
+    color: var(--ls-primary-text-color);
   }
 
   .property-panel-bullet {
@@ -527,7 +542,11 @@ a.control-link {
 }
 
 .ls-page-title .ls-page-properties {
-  @apply flex flex-col gap-4 mt-4;
+  @apply flex flex-col gap-0 mt-4;
+}
+
+.ls-page-title .ls-page-properties > .ls-new-property {
+  @apply mt-2;
 }
 
 .ls-property-add {


### PR DESCRIPTION
## Summary
- Move the hidden-properties toggle into the bottom property pills for non-page blocks.
- Render the page hidden-properties toggle like a property key row instead of a button.
- Keep Add property spacing separate and hide the Query property from hidden-properties listings.

## Validation
- `clojure -M:clj-kondo --lint src/main/frontend/components/property.cljs src/main/frontend/components/block.cljs --cache false`
- `bb lang:lint-hardcoded --git-changed`
- `git diff --check HEAD~1..HEAD`