### PR TITLE
fix(electron): support ESM open package interop

### DIFF
--- a/src/electron/electron/interop.cljs
+++ b/src/electron/electron/interop.cljs
@@ -1,0 +1,8 @@
+(ns electron.interop)
+
+(defn default-function-or-module
+  [module]
+  (let [default-export (.-default ^js module)]
+    (if (fn? default-export)
+      default-export
+      module)))

--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -2,11 +2,12 @@
   (:require ["electron" :refer [app BrowserWindow session]]
             ["fs-extra" :as fs]
             ["node-fetch" :default node-fetch]
-            ["open" :as open-external]
+            ["open" :as open-module]
             ["path" :as node-path]
             [cljs-bean.core :as bean]
             [clojure.string :as string]
             [electron.configs :as cfgs]
+            [electron.interop :as interop]
             [electron.logger :as logger]
             [logseq.common.config :as common-config]
             [logseq.common.graph :as common-graph]
@@ -26,6 +27,8 @@
 (defonce extract-zip (js/require "extract-zip"))
 (defonce https-proxy-agent (js/require "https-proxy-agent"))
 (defonce socks-proxy-agent (js/require "socks-proxy-agent"))
+(defonce open-external
+  (interop/default-function-or-module open-module))
 
 (declare <resolve-fetch-proxy)
 

--- a/src/test/electron/interop_test.cljs
+++ b/src/test/electron/interop_test.cljs
@@ -1,0 +1,15 @@
+(ns electron.interop-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [electron.interop :as interop]))
+
+(deftest default-function-or-module-test
+  (testing "uses native ESM default export when it is callable"
+    (let [open-fn (fn [& args] args)
+          module #js {:default open-fn}]
+      (is (identical? open-fn (interop/default-function-or-module module)))))
+  (testing "keeps CommonJS function exports callable"
+    (let [open-fn (fn [& args] args)]
+      (is (identical? open-fn (interop/default-function-or-module open-fn)))))
+  (testing "falls back to module when default is not callable"
+    (let [module #js {:default "not-callable"}]
+      (is (identical? module (interop/default-function-or-module module))))))


### PR DESCRIPTION
# fix(electron): support ESM open package interop

## Summary

- Resolve the `open` package callable from `.default` when it is available and callable.
- Keep compatibility with the previous CommonJS `open` shape by falling back to the module itself.
- Add focused unit coverage for the ESM default, CommonJS function, and non-callable default fallback cases.
- Fix custom protocol links such as `obsidian://...` failing from the Electron external-link confirmation flow with `is not a function`.

## Root Cause

The desktop runtime currently uses `open@11.0.0`, which is native ESM. In the packaged Electron app, requiring/importing `open` through the current Shadow/Node interop path can produce a module object whose callable function is exposed as `.default`.

`src/electron/electron/utils.cljs` currently imports `open` as a module namespace and later calls that value directly. That worked for the CommonJS shape handled by #12549, but it does not handle the current ESM default-export shape from `open@11`.

## Fix

Normalize the `open` package binding through a small Electron interop helper:

- use `.default` when it is a function;
- otherwise keep using the module value itself.

This keeps the #12549 CommonJS behavior while supporting the current `open@11` ESM shape.

## Test Plan

- [x] `clojure -M:clj-kondo --lint src/electron/electron/utils.cljs src/electron/electron/interop.cljs src/test/electron/interop_test.cljs --cache false`
- [x] `clojure -M:test compile test`
- [x] `node static/tests.js -n electron.interop-test`
- [x] Verified the local `open@11.0.0` package shape: `require("open")` returns an object with callable `.default`
- [x] `clojure -M:cljs release electron`
- [x] Built an unsigned macOS desktop app locally with `pnpm exec gulp electronMakerUnsigned`
- [x] Verified the packaged `app.asar/electron.js` contains the `.default` function guard
- [x] Manually verified clicking an `obsidian://` link in the rebuilt desktop app opens Obsidian successfully

## Related

- Fixes #12825
- Follow-up to #12549
- Related to dependency changes in #12460
