### PR TITLE
fix: render full breadcrumb ancestor chain on navigation

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -3766,7 +3766,11 @@
         target-entity (when block-id (db/entity [:block/uuid block-id]))
         from-property (when block-id
                         (:logseq.property/created-from-property target-entity))
-        parents (db/get-block-parents repo block-id {:depth load-depth})
+        ;; Prefer parents loaded by the wrapper effect (authoritative worker
+        ;; chain, transacted before render). Fall back to a sync UI-db read for
+        ;; callers that don't supply them (e.g. the overflow dropdown).
+        parents (or (:parents opts)
+                    (db/get-block-parents repo block-id {:depth load-depth}))
         parents (remove nil? (concat parents [from-property]))
         segments (breadcrumb-segments target-entity parents)
         view (breadcrumb-model/build-breadcrumb-view segments (assoc vopts :show-page? show-page?))
@@ -3813,8 +3817,7 @@
 (hsx/defc breadcrumb
   [config repo block-id {:keys [_show-page? _indent? _end-separator? _navigating-block _disabled? variant header?]
                          :as opts}]
-  (let [[block set-block!] (hooks/use-state (when (uuid? block-id)
-                                              (db/entity [:block/uuid block-id])))
+  (let [[data set-data!] (hooks/use-state nil)
         effective-variant (or variant
                               (cond
                                 header? :app-header
@@ -3829,17 +3832,24 @@
                                             block-id
                                             {:children? false
                                              :skip-refresh? true})
-                 parents (when-let [id (:db/id block)]
-                           (db-async/<get-block-parents repo id load-depth))
+                 parents-data (when-let [id (:db/id block)]
+                                (db-async/<get-block-parents repo id load-depth))
+                 ;; The worker holds the complete graph and is authoritative for
+                 ;; the ancestor chain; resolve the returned ids to UI-db entities
+                 ;; now that the chain has been transacted locally.
+                 parents (mapv #(db/entity (:db/id %)) parents-data)
                  ;; Parent blocks can arrive before the UI DB has loaded page refs
                  ;; used in their titles. Hydrate only those refs before rendering.
                  _ (<hydrate-breadcrumb-ref-titles! repo (breadcrumb-segments block parents))]
-           (set-block! (or (when-let [uuid (:block/uuid block)]
-                             (db/entity [:block/uuid uuid]))
-                           block)))))
-     [])
-    (when block
-      (breadcrumb-aux config repo block-id opts))))
+           (set-data! {:block-id block-id :parents parents}))))
+     ;; Re-run on navigation (the instance is reused with a new block-id) so the
+     ;; new ancestor chain is loaded and re-hydrated.
+     [block-id load-depth])
+    ;; breadcrumb-aux is non-reactive and cannot self-heal when the parents are
+    ;; transacted, so pass the loaded chain in explicitly. Gate on block-id to
+    ;; avoid rendering a stale chain for the previous block mid-navigation.
+    (when (and data (= (:block-id data) block-id))
+      (breadcrumb-aux config repo block-id (assoc opts :parents (:parents data))))))
 
 (defn- block-drag-over
   [event uuid top? block-id *move-to']


### PR DESCRIPTION
## Problem

When navigating to / zooming into a nested block, the app-header breadcrumb sometimes shows **only the page segment** instead of the full ancestor chain (e.g. just `Media` instead of `Media / … / Cons`).

## Cause

The header passes the zoomed-in block's uuid to `breadcrumb`. Its effect loads the ancestor chain from the db-worker (the authoritative, complete graph) and transacts it into the UI DB. However, `breadcrumb-aux` is non-reactive and re-derives the parents with a **synchronous** `db/get-block-parents` read that does not reflect the just-transacted chain. Unlike the previous `rum/reactive` implementation, it never self-heals once the parents arrive, so only the always-present page segment renders.

This regressed in the breadcrumb display rewrite (#12595), which replaced the reactive `breadcrumb-aux` with a non-reactive component while keeping a one-shot mount effect.

## Fix

The effect already fetched the worker's parent chain but used it only for ref-title hydration and then discarded it. Now we:

- capture that parent chain, resolve it to UI-DB entities, and store it in component state;
- pass it directly into `breadcrumb-aux`, which prefers the supplied parents over the synchronous read;
- re-run the effect on `block-id` / `load-depth` change so navigation reloads the chain.

This guarantees both a re-render once the chain is loaded and authoritative data, independent of reactivity.

## Testing

Built a production AppImage and verified that zooming into deeply-nested blocks renders the full breadcrumb chain on every navigation, rather than collapsing to just the page name.

## Notes

The breadcrumb now waits for the async load before first paint. In dense contexts (query results / reference lists with many breadcrumbs) the breadcrumb may appear a beat later than before; the header case is unaffected visually since it loads quickly. Happy to add an immediate sync first-paint that refines on load if reviewers prefer.