### PR TITLE
fix: namespaces copy library filtering

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1994,6 +1994,10 @@
                              ref-matched-children-ids
                              ;; Block children will not be rendered if the filters do not match them
                              (filter (fn [b] (ref-matched-children-ids (:db/id b))))
+
+                             (and (ldb/page? block) (not (:embed? config)) (not library?))
+                             (filter (fn [b] (and (ldb/page? b) (not (or (ldb/class? b) (ldb/property? b))))))
+
                              library?
                              (filter (fn [b] (and (ldb/page? b) (not (or (ldb/class? b) (ldb/property? b))))))))))
         children-count (count children)
@@ -2060,7 +2064,9 @@
                         true
                         (assoc :block-children? true)
                         (integer? (:block-level config))
-                        (update :block-level inc))]
+                        (update :block-level inc)
+                        (and (ldb/page? block) (not (:embed? config)) (not library?))
+                        (assoc :library? true))]
           (when render-children?
             (block-list config' children')))]])))
 


### PR DESCRIPTION
This addresses my issue in https://github.com/logseq/db-test/issues/970

I tried to minimize the amount of code to add/change to make this work. So I copied the code that is already used for library. 

Ideally there would be a way to tell if something is a namespace so that this filter could be more precisely applied to that. Right now it checks if the parent block is a page, is not embedded, and is not already in library mode. Then it applies the same filter that exists for the library page. It also propagates :library? true to the children so that the same filter is applied there.

The current version of logseq would show the namespace like this
<img width="426" height="635" alt="Screenshot 2026-06-26 at 11 53 50 AM" src="https://github.com/user-attachments/assets/c6d5ec3d-7c81-45d9-bb28-c1d62cf34549" />

And with these code changes
<img width="365" height="510" alt="Screenshot 2026-06-26 at 11 52 58 AM" src="https://github.com/user-attachments/assets/15e39345-4a67-4aa1-a9ce-9d6838a485df" />

Namespace pages now show page titles only.

I am not a professional coder so any feedback/criticism is welcome! 