### PR TITLE
test: add cli sync stress workflow

### DIFF
--- a/.github/workflows/cli-sync-stress.yml
+++ b/.github/workflows/cli-sync-stress.yml
@@ -1,0 +1,200 @@
+name: CLI sync stress
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'scripts/cli-concurrent-edit-stress.mjs'
+      - 'scripts/cli-concurrent-edit-stress.test.mjs'
+      - 'scripts/cli-sync-stress-workflow.test.mjs'
+      - 'cli/**'
+      - 'cli-e2e/**'
+      - 'deps/db-sync/**'
+      - 'src/main/frontend/worker/**'
+      - 'src/test/frontend/worker/**'
+      - '.github/workflows/cli-sync-stress.yml'
+      - '!**/*.md'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'scripts/cli-concurrent-edit-stress.mjs'
+      - 'scripts/cli-concurrent-edit-stress.test.mjs'
+      - 'scripts/cli-sync-stress-workflow.test.mjs'
+      - 'cli/**'
+      - 'cli-e2e/**'
+      - 'deps/db-sync/**'
+      - 'src/main/frontend/worker/**'
+      - 'src/test/frontend/worker/**'
+      - '.github/workflows/cli-sync-stress.yml'
+      - '!**/*.md'
+  workflow_dispatch:
+
+env:
+  CLOJURE_VERSION: '1.12.4.1618'
+  JAVA_VERSION: '21'
+  NODE_VERSION: '24'
+  OCAML_VERSION: '5.4.0'
+  BABASHKA_VERSION: '1.12.215'
+
+jobs:
+  cli-sync-stress:
+    name: CLI sync/offline stress
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            cli/pnpm-lock.yaml
+            deps/db-sync/pnpm-lock.yaml
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Set up Clojure
+        uses: DeLaGuardo/setup-clojure@13.5
+        with:
+          cli: ${{ env.CLOJURE_VERSION }}
+          bb: ${{ env.BABASHKA_VERSION }}
+
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ env.OCAML_VERSION }}
+
+      - name: Install CLI Linux runtime deps
+        run: sudo apt-get update && sudo apt-get install -y libsecret-1-0
+
+      - name: Fetch OCaml deps
+        working-directory: cli
+        run: opam install . --deps-only --with-test --yes
+
+      - name: Fetch pnpm deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Fetch CLI pnpm deps
+        run: pnpm --dir cli install --frozen-lockfile --ignore-workspace
+
+      - name: Fetch db-sync pnpm deps
+        run: pnpm --dir deps/db-sync install --frozen-lockfile
+
+      - name: Build stress runtime
+        run: |
+          opam exec -- pnpm cli:release
+          pnpm db-worker-node:release:bundle
+          pnpm --dir deps/db-sync build:node-adapter
+
+      - name: Verify stress tests
+        run: |
+          node --test scripts/cli-concurrent-edit-stress.test.mjs
+          node --test scripts/cli-sync-stress-workflow.test.mjs
+
+      - name: Prepare stress auth
+        run: |
+          mkdir -p tmp/cli-sync-stress/home/logseq
+          node <<'NODE'
+          const crypto = require("node:crypto");
+          const fs = require("node:fs");
+
+          const encode = (payload) => Buffer.from(JSON.stringify(payload)).toString("base64url");
+          const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+          const publicJwk = publicKey.export({ format: "jwk" });
+          const exp = Math.floor(Date.now() / 1000) + 3600;
+          const header = encode({ alg: "RS256", kid: "cli-sync-stress", typ: "JWT" });
+          const payload = encode({
+              sub: "cli-sync-stress-user",
+              email: "cli-sync-stress@example.com",
+              iss: "http://127.0.0.1:19091",
+              aud: "logseq-cli-sync-stress",
+              client_id: "logseq-cli-sync-stress",
+              exp,
+          });
+          const signature = crypto.createSign("RSA-SHA256")
+            .update(`${header}.${payload}`)
+            .sign(privateKey)
+            .toString("base64url");
+          const token = `${header}.${payload}.${signature}`;
+
+          fs.writeFileSync(
+            "tmp/cli-sync-stress/jwks.json",
+            `${JSON.stringify({
+              keys: [{ ...publicJwk, alg: "RS256", use: "sig", kid: "cli-sync-stress" }],
+            })}\n`,
+          );
+
+          fs.writeFileSync(
+            "tmp/cli-sync-stress/home/logseq/auth.json",
+            `${JSON.stringify({
+              "refresh-token": "cli-sync-stress-refresh-token",
+              "id-token": token,
+              "access-token": token,
+            })}\n`,
+          );
+          NODE
+
+      - name: Run CLI sync stress
+        env:
+          LOGSEQ_BIN: ${{ github.workspace }}/tmp/cli-sync-stress/logseq
+          LOGSEQ_CLI_ROOT_DIR: ${{ github.workspace }}/tmp/cli-sync-stress/root
+          HOME: ${{ github.workspace }}/tmp/cli-sync-stress/home
+        run: |
+          mkdir -p tmp/cli-sync-stress
+          node <<'NODE' &
+          const fs = require("node:fs");
+          const http = require("node:http");
+          const jwks = fs.readFileSync("tmp/cli-sync-stress/jwks.json");
+
+          http.createServer((req, res) => {
+            if (req.url === "/.well-known/jwks.json") {
+              res.writeHead(200, { "content-type": "application/json" });
+              res.end(jwks);
+              return;
+            }
+            res.writeHead(404, { "content-type": "application/json" });
+            res.end(JSON.stringify({ error: "not found" }));
+          }).listen(19091, "127.0.0.1");
+          NODE
+          JWKS_PID=$!
+          trap 'kill "$JWKS_PID" 2>/dev/null || true' EXIT
+
+          printf '#!/usr/bin/env sh\nexec node "%s/static/logseq-cli.js" "$@"\n' "$GITHUB_WORKSPACE" > "$LOGSEQ_BIN"
+          chmod +x "$LOGSEQ_BIN"
+
+          GRAPH="cli-sync-stress-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          "$LOGSEQ_BIN" graph create --graph "$GRAPH" --output json --timeout-ms 20000
+
+          node scripts/cli-concurrent-edit-stress.mjs \
+            --graph "$GRAPH" \
+            --config "$GITHUB_WORKSPACE/tmp/cli-sync-stress/cli.edn" \
+            --auth-path "$GITHUB_WORKSPACE/tmp/cli-sync-stress/home/logseq/auth.json" \
+            --concurrency 8 \
+            --sync \
+            --offline \
+            --no-e2ee \
+            --max-ops 1000 \
+            --timeout-ms 60000
+
+          "$LOGSEQ_BIN" graph validate --graph "$GRAPH" --output json --timeout-ms 60000
+
+      - name: Print stress logs on failure
+        if: failure()
+        run: |
+          tail -n 200 tmp/cli-concurrent-edit-stress/events.jsonl || true
+          tail -n 200 tmp/cli-concurrent-edit-stress/db-sync-server.log || true
+          find tmp -name 'db-worker-node-*.log' -print -exec tail -n 200 {} \; || true

--- a/cli/lib/add.ml
+++ b/cli/lib/add.ml
@@ -445,6 +445,26 @@ let pull_tag_by_name config repo name selector =
       (Edn_util.vector_t
          [ query_value (tag_query selector); Edn_util.string (normalized_lookup_name name) ])
 
+let list_tags config repo =
+  Transport.thread_api_cli_list_tags config ~repo ~options:(Edn_util.map_t [])
+
+let tag_name_matches name entity =
+  let expected = normalized_lookup_name name in
+  let matches value = String.equal (normalized_lookup_name value) expected in
+  match
+    (Edn_util.get_string entity "block/title", Edn_util.get_string entity "block/name")
+  with
+  | Some title, _ when matches title -> true
+  | _, Some name when matches name -> true
+  | _ -> false
+
+let find_tag_by_name config repo name =
+  let open Cli_effect in
+  bind (list_tags config repo) (fun value ->
+      match Edn_util.as_seq value with
+      | Some tags -> pure (List.find_opt (tag_name_matches name) tags)
+      | None -> pure None)
+
 let pull_property_by_name config repo name selector =
   Transport.thread_api_q config ~repo
     ~query:
@@ -631,19 +651,21 @@ let tag_entity value =
 
 let resolve_tag_entity invoke_config repo tag =
   let open Cli_effect in
-  let pulled =
-    match tag with
-    | Selector.Tag_name name ->
-        pull_tag_by_name invoke_config repo name tag_selector
-    | _ -> pull_entity invoke_config repo tag_selector (lookup_of_tag tag)
-  in
-  bind pulled (fun entity ->
-      match first_entity entity with
-      | Some entity
-        when Option.is_some (id_of_entity entity) && tag_entity entity ->
-          pure (Entity.of_value entity)
-      | Some _ -> failwith "tag not found"
-      | None -> failwith "tag not found")
+  match tag with
+  | Selector.Tag_name name ->
+      bind (find_tag_by_name invoke_config repo name) (function
+        | Some entity when Option.is_some (id_of_entity entity) ->
+            pure (Entity.of_value entity)
+        | _ -> failwith "tag not found")
+  | _ ->
+      bind (pull_entity invoke_config repo tag_selector (lookup_of_tag tag))
+        (fun entity ->
+          match first_entity entity with
+          | Some entity
+            when Option.is_some (id_of_entity entity) && tag_entity entity ->
+              pure (Entity.of_value entity)
+          | Some _ -> failwith "tag not found"
+          | None -> failwith "tag not found")
 
 let resolve_tags config repo tags =
   match tags with
@@ -727,6 +749,24 @@ let resolve_created_ids config repo blocks insert_result =
                         "unable to resolve created ids")))
   in
   loop [] uuids
+
+let target_not_found_error () =
+  Error.make (Error.Target_not_found) "target block not found"
+
+let resolve_created_ids_or_target_error config repo target_uuid blocks
+    insert_result =
+  let open Cli_effect in
+  bind (resolve_created_ids config repo blocks insert_result) (function
+    | Ok ids -> pure (Ok ids)
+    | Error err when err.Error.code = Error.Add_id_resolution_failed ->
+        bind
+          (pull_entity config repo
+             (vector [ kw "db/id"; kw "block/uuid" ])
+             (vector [ kw "block/uuid"; Edn_util.uuid target_uuid ]))
+          (fun target ->
+            if Option.is_some (id_of_entity target) then pure (Error err)
+            else pure (Error (target_not_found_error ())))
+    | Error err -> pure (Error err))
 
 let property_key_to_value = function
   | Property.Key_ident ident -> Edn_util.any ident
@@ -873,7 +913,8 @@ let execute_add_block action config mode =
                                  metadata_ops)
                             (fun _metadata_result ->
                               bind
-                                (resolve_created_ids invoke_config action.repo
+                                (resolve_created_ids_or_target_error
+                                   invoke_config action.repo target_uuid
                                    all_blocks insert_result) (function
                                 | Error err ->
                                     pure

--- a/cli/lib/update.ml
+++ b/cli/lib/update.ml
@@ -336,51 +336,6 @@ let variable value = Edn_util.symbol value
 let list values = Edn_util.list values
 let query_value query = Edn_util.any (Cli_primitive.datascript_query_to_edn query)
 
-let tag_query selector =
-  vector
-    [
-      Edn_util.map [ (kw "title", variable "?title") ];
-      kw "where";
-      vector [ variable "?tag"; kw "block/title"; variable "?title" ];
-      vector [ variable "?tag"; kw "block/tags"; kw "logseq.class/Tag" ];
-      list
-        [
-          Edn_util.symbol "clojure.string/includes?";
-          variable "?title";
-          variable "?query";
-        ];
-      kw "in";
-      variable "$";
-      variable "?query";
-      kw "result-transform";
-      list
-        [
-          Edn_util.symbol "fn";
-          vector [ variable "result" ];
-          list
-            [
-              Edn_util.symbol "map";
-              list
-                [
-                  Edn_util.symbol "fn";
-                  vector
-                    [
-                      Edn_util.map [ (kw "keys", vector [ variable "title" ]) ];
-                    ];
-                  list
-                    [
-                      Edn_util.symbol "d/entity";
-                      variable "$";
-                      vector [ kw "block/name"; variable "title" ];
-                    ];
-                ];
-              variable "result";
-            ];
-        ];
-      kw "view";
-      selector;
-    ]
-
 let class_query selector class_ident =
   Cli_primitive.make_datascript_query
     ~find:
@@ -400,6 +355,7 @@ let class_query selector class_ident =
       ]
     ()
 
+let tag_query selector = query_value (class_query selector "logseq.class/Tag")
 let property_query selector = class_query selector "logseq.class/Property"
 
 let first_entity value =
@@ -415,6 +371,26 @@ let pull_tag_by_name invoke_config repo name =
     ~query:
       (Edn_util.vector_t
          [ tag_query tag_selector; Edn_util.string (normalized_page_name name) ])
+
+let list_tags invoke_config repo =
+  Transport.thread_api_cli_list_tags invoke_config ~repo ~options:(Edn_util.map_t [])
+
+let tag_name_matches name entity =
+  let expected = normalized_page_name name in
+  let matches value = String.equal (normalized_page_name value) expected in
+  match
+    (Edn_util.get_string entity "block/title", Edn_util.get_string entity "block/name")
+  with
+  | Some title, _ when matches title -> true
+  | _, Some name when matches name -> true
+  | _ -> false
+
+let find_tag_by_name invoke_config repo name =
+  let open Cli_effect in
+  bind (list_tags invoke_config repo) (fun value ->
+      match Edn_util.as_seq value with
+      | Some tags -> pure (List.find_opt (tag_name_matches name) tags)
+      | None -> pure None)
 
 let pull_property_by_name invoke_config repo name =
   Transport.thread_api_q invoke_config ~repo
@@ -519,15 +495,13 @@ let resolve_tag_id invoke_config repo = function
   | Selector.Tag_id id -> Cli_effect.pure (Ok id)
   | Tag_name name ->
       let open Cli_effect in
-      bind (pull_tag_by_name invoke_config repo name) (fun result ->
-          match Option.bind (first_entity result) id_of_entity with
+      bind (find_tag_by_name invoke_config repo name) (fun result ->
+          match Option.bind result id_of_entity with
           | Some id -> pure (Ok id)
           | None ->
               pure
                 (Error
-                   (Error.make
-                      (Error.Tag_not_found)
-                      "tag not found")))
+                   (Error.make (Error.Tag_not_found) "tag not found")))
   | (Tag_ident _ | Tag_uuid _) as tag ->
       let open Cli_effect in
       bind

--- a/cli/lib/upsert.ml
+++ b/cli/lib/upsert.ml
@@ -1236,6 +1236,26 @@ let pull_tag_by_name config repo name selector =
            Edn_util.string (normalized_lookup_name name);
          ])
 
+let list_tags config repo =
+  Transport.thread_api_cli_list_tags config ~repo ~options:(Edn_util.map_t [])
+
+let tag_name_matches name entity =
+  let expected = normalized_lookup_name name in
+  let matches value = String.equal (normalized_lookup_name value) expected in
+  match
+    (Edn_util.get_string entity "block/title", Edn_util.get_string entity "block/name")
+  with
+  | Some title, _ when matches title -> true
+  | _, Some name when matches name -> true
+  | _ -> false
+
+let find_tag_by_name config repo name =
+  let open Cli_effect in
+  bind (list_tags config repo) (fun value ->
+      match Edn_util.as_seq value with
+      | Some tags -> pure (List.find_opt (tag_name_matches name) tags)
+      | None -> pure None)
+
 let pull_property_by_name config repo name selector =
   Transport.thread_api_q config ~repo
     ~query:
@@ -1470,16 +1490,13 @@ let resolve_tag_id invoke_config repo tag =
   match tag with
   | Selector.Tag_id id -> pure (Ok id)
   | Tag_name name ->
-      bind (pull_tag_by_name invoke_config repo name tag_selector)
-        (fun result ->
-          match Option.bind (first_entity result) id_of_entity with
+      bind (find_tag_by_name invoke_config repo name) (fun result ->
+          match Option.bind result id_of_entity with
           | Some id -> pure (Ok id)
           | None ->
               pure
                 (Error
-                   (Error.make
-                      (Error.Tag_not_found)
-                      "tag not found")))
+                   (Error.make (Error.Tag_not_found) "tag not found")))
   | Tag_ident _ | Tag_uuid _ ->
       bind
         (pull_entity_by_lookup invoke_config repo tag_selector

--- a/cli/test/cli_parity_test_cases.ml
+++ b/cli/test/cli_parity_test_cases.ml
@@ -3729,6 +3729,65 @@ let () =
       expect_named_contains "property op" output
         ":user.property/root-answer \"root\"");
 
+  test_promise
+    "CLI parity add reports target-not-found when concurrent delete removes \
+     insert target" (fun () ->
+      let pull_count = ref 0 in
+      let server =
+        invoke_server (fun body ->
+            if Js.String.includes ~search:"thread-api/pull" body then (
+              incr pull_count;
+              match !pull_count with
+              | 1 ->
+                  "[\"^ \
+                   \",\"~:db/id\",627,\"~:block/uuid\",\"~u00000000-0000-4000-8000-000000000627\"]"
+              | _ -> "null")
+            else if
+              Js.String.includes ~search:"thread-api/apply-outliner-ops" body
+            then "null"
+            else "null")
+      in
+      with_server server (fun base_url ->
+          let cfg =
+            {
+              (config ~repo:"demo" ()) with
+              Cli_config.base_url = Some base_url;
+            }
+          in
+          let action =
+            expect_ok "add action"
+              (Add.build_add_block_action
+                 {
+                   Add.target_id = Some 627L;
+                   target_uuid = None;
+                   target_page_name = None;
+                   pos = Some Block.First_child;
+                   status = None;
+                   tags_edn = None;
+                   properties_edn = None;
+                   content = Some "Child";
+                   blocks_edn = None;
+                   blocks_file = None;
+                 }
+                 []
+                 (Cli_primitive.create_repo "demo"))
+          in
+          let* result =
+            effect_to_promise
+              (Add.execute_add_block action
+                 (config_with_output cfg Output.Mode.Human)
+                 Output.Mode.Human)
+          in
+          expect_bool "add result is error" true (Cli_result.is_error result);
+          (match result.Cli_result.error with
+          | Some err ->
+              expect_equal "add concurrent target delete code"
+                "target-not-found"
+                (Error.code_to_string err.Error.code)
+          | None -> fail_test "expected add error");
+          expect_int "target was rechecked" 3 !pull_count;
+          Js.Promise.resolve pass));
+
   test "CLI parity update build action validates property and tag edn"
     (fun () ->
       let base_opts =
@@ -3797,6 +3856,13 @@ let () =
       expect_int "update properties include status" 2
         (List.length action.update_properties);
       expect_int "remove properties" 1 (List.length action.remove_properties));
+
+  test "CLI parity update tag query uses datascript find syntax" (fun () ->
+      let query =
+        Melange_edn_melange.to_edn_string (Update.tag_query Update.tag_selector)
+      in
+      expect_named_contains "find" query ":find";
+      expect_named_contains "tag class" query "logseq.class/Tag");
 
   test "CLI parity sync config key parser accepts ws-url and http-base only"
     (fun () ->

--- a/cli/test/test_cases.ml
+++ b/cli/test/test_cases.ml
@@ -1435,6 +1435,64 @@ let () =
             fail_promise
               (Printf.sprintf "expected five invoke requests, got %d" !step)));
 
+  test_promise "upsert block update resolves tag names from tag list"
+    (fun () ->
+      let step = ref 0 in
+      let captured_apply_body = ref None in
+      let server =
+        invoke_server (fun body ->
+            incr step;
+            match !step with
+            | 1
+              when Js.String.includes ~search:"thread-api/pull" body
+                   && Js.String.includes ~search:"233" body ->
+                "[\"^ \
+                 \",\"~:db/id\",233,\"~:block/uuid\",\"~u00000000-0000-4000-8000-000000000233\"]"
+            | 2
+              when Js.String.includes ~search:"thread-api/cli-list-tags" body ->
+                "[[\"^ \",\"~:db/id\",200,\"~:block/title\",\"Tag A\"]]"
+            | 3
+              when Js.String.includes ~search:"thread-api/apply-outliner-ops"
+                     body ->
+                captured_apply_body := Some body;
+                "[]"
+            | _ ->
+                fail_test
+                  (Printf.sprintf "unexpected request at step %d: %s" !step body);
+                "")
+      in
+      with_server server (fun base_url ->
+          let* output =
+            run_cli_p
+              ~env:[| ("LOGSEQ_CLI_BASE_URL", base_url) |]
+              [
+                "--graph";
+                "alpha";
+                "--output";
+                "json";
+                "upsert";
+                "block";
+                "--id";
+                "233";
+                "--update-tags";
+                "[\"Tag A\"]";
+              ]
+          in
+          ignore (expect_cli_exit_zero "upsert block tag name" output);
+          let body =
+            match !captured_apply_body with
+            | Some body -> body
+            | None ->
+                fail_test "missing captured apply body";
+                failwith "missing captured apply body"
+          in
+          expect_named_contains "batch tag set op" body "batch-set-property";
+          expect_named_contains "resolved tag id" body "200";
+          if !step = 3 then Js.Promise.resolve pass
+          else
+            fail_promise
+              (Printf.sprintf "expected three invoke requests, got %d" !step)));
+
   test_promise "upsert block create resolves inline block uuid property refs"
     (fun () ->
       let step = ref 0 in

--- a/deps/db-sync/src/logseq/db_sync/worker/handler/index.cljs
+++ b/deps/db-sync/src/logseq/db_sync/worker/handler/index.cljs
@@ -128,7 +128,7 @@
                                   (string? (:encrypted-private-key user-rsa-key-pair)))]
                        (if name-exists?
                          (http/bad-request "duplicate graph name")
-                         (if-not has-user-rsa-key-pair?
+                         (if (and graph-e2ee? (not has-user-rsa-key-pair?))
                            (http/bad-request "missing user rsa key pair")
                            (p/let [_ (index/<index-upsert! db graph-id graph-name user-id schema-version graph-e2ee? graph-ready-for-use?)
                                    _ (index/<graph-member-upsert! db graph-id user-id "manager" user-id)]

--- a/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
+++ b/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
@@ -426,6 +426,11 @@
                                                        (seq missing-block-uuids)
                                                        (assoc :missing-block-uuids missing-block-uuids))
                                                      e)))))
+                _ (when (and tx-id (not applied-entry?))
+                    (throw (ex-info "tx entry was not applied"
+                                    {:type :db-sync/tx-entry-not-applied
+                                     :successful-tx-ids successful-tx-ids
+                                     :failed-tx-id tx-id})))
                 next-successful-tx-ids (cond-> successful-tx-ids
                                          tx-id (conj tx-id))]
             (recur (next remaining)

--- a/deps/db-sync/test/logseq/db_sync/worker_handler_index_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/worker_handler_index_test.cljs
@@ -186,7 +186,7 @@
                           (is false (str error))
                           (done)))))))
 
-(deftest graphs-create-non-e2ee-requires-user-rsa-key-pair-test
+(deftest graphs-create-non-e2ee-skips-user-rsa-key-pair-test
   (async done
          (let [request (js/Request. "http://localhost/graphs" #js {:method "POST"})
                url (js/URL. (.-url request))
@@ -217,9 +217,10 @@
                                                              :path-params {}}})
                          text (.text resp)
                          body (js->clj (js/JSON.parse text) :keywordize-keys true)]
-                   (is (= 400 (.-status resp)))
-                   (is (= "missing user rsa key pair" (:error body)))
-                   (is (zero? @index-upsert-calls*))))
+                   (is (= 200 (.-status resp)))
+                   (is (string? (:graph-id body)))
+                   (is (= false (:graph-e2ee? body)))
+                   (is (= 1 @index-upsert-calls*))))
                (p/then (fn []
                          (done)))
                (p/catch (fn [error]

--- a/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
@@ -1098,6 +1098,50 @@
       (is (empty? (storage/fetch-tx-since sql t-before)))
       (is (empty? @changed-messages)))))
 
+(deftest tx-batch-rejects-unapplied-stale-rebase-with-tx-id-test
+  (testing "a client tx id should not be acknowledged when its stale rebase was not applied"
+    (let [sql (test-sql/make-sql)
+          conn (storage/open-conn sql)
+          self #js {:sql sql
+                    :conn conn
+                    :schema-ready true}
+          tx-id (random-uuid)
+          page-uuid (random-uuid)
+          parent-uuid (random-uuid)
+          missing-block-uuid (random-uuid)
+          _ (d/transact! conn [{:block/uuid page-uuid
+                                :block/name "rebase-stale-page-with-tx-id"
+                                :block/title "rebase-stale-page-with-tx-id"}
+                               {:block/uuid parent-uuid
+                                :block/title "existing-parent"
+                                :block/order "a0"
+                                :block/parent [:block/uuid page-uuid]
+                                :block/page [:block/uuid page-uuid]}])
+          t-before (storage/get-t sql)
+          checksum-before (storage/get-checksum sql)
+          tx-entry {:tx-id tx-id
+                    :tx (protocol/tx->transit
+                         [[:db/retract [:block/uuid missing-block-uuid]
+                           :block/parent
+                           [:block/uuid page-uuid]
+                           536882158]
+                          [:db/add [:block/uuid missing-block-uuid]
+                           :block/parent
+                           [:block/uuid parent-uuid]
+                           536882158]])
+                    :outliner-op :rebase}
+          changed-messages (atom [])
+          response (with-redefs [ws/broadcast! (fn [_self _sender payload]
+                                                 (swap! changed-messages conj payload))]
+                     (sync-handler/handle-tx-batch! self nil [tx-entry] t-before))]
+      (is (= "tx/reject" (:type response)))
+      (is (= "db transact failed" (:reason response)))
+      (is (= t-before (:t response)))
+      (is (= tx-id (:failed-tx-id response)))
+      (is (= checksum-before (storage/get-checksum sql)))
+      (is (empty? (storage/fetch-tx-since sql t-before)))
+      (is (empty? @changed-messages)))))
+
 (deftest tx-batch-ignores-stale-fix-with-missing-lookup-entity-test
   (testing "stale fix lookup refs to missing entities are treated as no-op"
     (let [sql (test-sql/make-sql)

--- a/docs/sync/failed-cases.md
+++ b/docs/sync/failed-cases.md
@@ -1,0 +1,43 @@
+# Sync Stress Failed Cases
+
+## CLI tag-name resolution failed during expanded stress
+
+- Date: 2026-07-01
+- Graph: `cli-test-5`
+- Command: `node scripts/cli-concurrent-edit-stress.mjs --graph cli-test-5 --concurrency 3 --sync --offline --offline-ms 800 --timeout-ms 20000 --max-ops 80 --extra-pages 2 --journal-pages 2 --journal-start 2026-07-01`
+- Symptom: `upsert block --update-tags '["cli-stress-tag-a"]'` failed with `Cannot parse :find, expected: (find-rel | find-coll | find-tuple | find-scalar)`.
+- Root cause: OCaml CLI tag-name resolution used a duplicated Datascript class query path for tag names. Numeric tag ids worked, but string tag names failed before the outliner mutation was applied.
+- Regression test: `cli/test/test_cases.ml` now covers `upsert block --update-tags '["Tag A"]'` resolving through `thread-api/cli-list-tags`.
+- Fix: tag-name resolution in `cli/lib/upsert.ml`, `cli/lib/add.ml`, and `cli/lib/update.ml` now uses the existing tag list endpoint instead of the broken query path.
+- Sync status after the failed stress smoke: local and remote tx both reached `71`, pending queues were zero, and checksums matched (`b18d36f60f52de7e`).
+
+## Recent db-test sync-stuck issue cluster
+
+- Date checked: 2026-07-01
+- Issues:
+  - `logseq/db-test#937`: existing browser graphs do not sync; console reports `Invalid local tx` with `local-tx nil`.
+  - `logseq/db-test#947`: browser reports `0 pending server changes` while desktop and CLI changes are already on the server.
+  - `logseq/db-test#969`: after suspend/resume, the app is online but RTC is stopped with `rtc-state :close`, `pending-local-ops 1`, and `local-tx == remote-tx`; clicking `Start Sync` resumes sync.
+  - `logseq/db-test#898`: graph stays yellow and only recovers after deleting the local graph and re-downloading.
+  - `logseq/db-test#890`: graph stays in `Preparing`; opening from remote graphs works but no sync indicator appears.
+
+### Repro path: missing client-ops `local-tx`
+
+- Target symptom: `Invalid local tx` on server `hello`, or a silent `db-sync/start-skipped` because `client-op-ready?` is false.
+- State to create: graph DB and client-ops DB are both open, but `sync_meta.local-tx` is missing from the client-ops DB.
+- Why this matches the issues: existing local graphs affected by old cache/migration state can have remote graph ids and pending local rows, while `local-tx` is absent. Missing `local-tx` must not be treated as `0`, because that would force the client to pull too many server txs from the beginning.
+- Existing fix: `:thread-api/db-sync-start` opens DBs before starting sync, and `sync/start!` skips with `:client-op-not-ready` until client-op metadata has a real integer `local-tx`.
+- Regression test: `frontend.worker.sync.restart-test/start-skips-when-client-op-local-tx-is-missing-test`.
+- Expected fixed behavior: no websocket connection is opened when `local-tx` is missing, and no code initializes missing `local-tx` to `0` outside the explicit new-remote-graph/upload paths.
+
+### Repro path: stale RTC after resume
+
+- Target symptom: online app with `rtc-state :close`, pending local changes, and no automatic retry until manual `Start Sync`.
+- State to create: current RTC client still targets the active repo/graph, but its websocket is already closed or stale after sleep/offline/resume.
+- Relevant issue evidence: `logseq/db-test#969` reports `pending-local-ops 1`, `local-tx 1244`, `remote-tx 1244`, `rtc-state :close`; `logseq/db-test#780` reports stale websocket timeout after network returns.
+- Regression tests:
+  - `frontend.handler.db-based.rtc-flows-test/resume-restart-events-do-not-depend-on-cached-rtc-lock-test`
+  - `frontend.worker.sync.restart-test/start-reconnects-closed-ws-with-stale-open-state-test`
+  - `frontend.worker.sync.restart-test/stale-loop-marks-non-open-ws-closed-test`
+  - `frontend.worker.sync.restart-test/ws-close-clears-inflight-before-reconnect-test`
+- Expected fixed behavior: network-visible/resume triggers can restart RTC, and stale/closed websockets clear inflight state, broadcast `:closed`, and schedule reconnect instead of leaving the graph permanently stopped.

--- a/scripts/cli-concurrent-edit-stress.mjs
+++ b/scripts/cli-concurrent-edit-stress.mjs
@@ -1,16 +1,25 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
 import { mkdirSync, writeFileSync, appendFileSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 
 const repoRoot = resolve(new URL("..", import.meta.url).pathname);
+const require = createRequire(import.meta.url);
+const transit = require(require.resolve("transit-js", { paths: [resolve(repoRoot, "cli")] }));
+const transitWriter = transit.writer("json");
+const transitReader = transit.reader("json");
 
 function parseArgs(argv) {
   const opts = {
     graph: "pi-memory",
     page: "CLI Concurrent Stress",
+    extraPages: 2,
+    journalPages: 2,
+    journalStart: new Date().toISOString().slice(0, 10),
+    todayDate: null,
     config: resolve(repoRoot, "tmp", "cli-concurrent-edit-stress", "cli.edn"),
     syncBase: "http://127.0.0.1:18080",
     concurrency: 8,
@@ -18,8 +27,11 @@ function parseArgs(argv) {
     timeoutMs: 20000,
     logFile: resolve(repoRoot, "tmp", "cli-concurrent-edit-stress", "events.jsonl"),
     sync: false,
+    offline: false,
+    offlineMs: 2500,
     failFast: false,
     startSyncServer: true,
+    graphE2ee: true,
     e2eePassword: "11111",
     authPath: "/Users/tiensonqin/logseq/auth.json",
     syncServerPidFile: resolve(repoRoot, "tmp", "cli-concurrent-edit-stress", "db-sync-server.pid"),
@@ -44,6 +56,18 @@ function parseArgs(argv) {
       case "--page":
         opts.page = next();
         break;
+      case "--extra-pages":
+        opts.extraPages = Number.parseInt(next(), 10);
+        break;
+      case "--journal-pages":
+        opts.journalPages = Number.parseInt(next(), 10);
+        break;
+      case "--journal-start":
+        opts.journalStart = next();
+        break;
+      case "--today-date":
+        opts.todayDate = next();
+        break;
       case "--config":
         opts.config = resolve(next());
         break;
@@ -65,8 +89,17 @@ function parseArgs(argv) {
       case "--sync":
         opts.sync = true;
         break;
+      case "--offline":
+        opts.offline = true;
+        break;
+      case "--offline-ms":
+        opts.offlineMs = Number.parseInt(next(), 10);
+        break;
       case "--no-start-sync-server":
         opts.startSyncServer = false;
+        break;
+      case "--no-e2ee":
+        opts.graphE2ee = false;
         break;
       case "--auth-path":
         opts.authPath = resolve(next());
@@ -96,6 +129,18 @@ function parseArgs(argv) {
   if (!Number.isInteger(opts.timeoutMs) || opts.timeoutMs < 1000) {
     throw new Error("--timeout-ms must be at least 1000");
   }
+  if (!Number.isInteger(opts.extraPages) || opts.extraPages < 0) {
+    throw new Error("--extra-pages must be 0 or a positive integer");
+  }
+  if (!Number.isInteger(opts.journalPages) || opts.journalPages < 0) {
+    throw new Error("--journal-pages must be 0 or a positive integer");
+  }
+  if (!Number.isInteger(opts.offlineMs) || opts.offlineMs < 100) {
+    throw new Error("--offline-ms must be at least 100");
+  }
+  if (opts.todayDate && Number.isNaN(new Date(`${opts.todayDate}T00:00:00.000Z`).getTime())) {
+    throw new Error("--today-date must be a valid YYYY-MM-DD date");
+  }
 
   opts.wsUrl = `${opts.syncBase.replace(/^http/, "ws").replace(/\/$/, "")}/sync/%s`;
   opts.httpBase = opts.syncBase.replace(/\/$/, "");
@@ -110,11 +155,18 @@ Runs parallel Logseq CLI writes against a dedicated stress page.
 Options:
   --graph NAME          Graph to mutate. Default: pi-memory
   --page NAME           Stress page. Default: CLI Concurrent Stress
+  --extra-pages N       Additional normal pages to mutate. Default: 2
+  --journal-pages N     Auto-created journal-style pages to mutate. Default: 2
+  --journal-start DATE  First journal date, YYYY-MM-DD. Default: today
+  --today-date DATE     Override today's journal date, YYYY-MM-DD
   --config PATH         Dedicated CLI config path under tmp/
   --sync-base URL       Local db-sync base URL. Default: http://127.0.0.1:18080
   --sync                Start db-sync client after verifying local /health
+  --offline             Simulate offline windows by stopping sync during writes
+  --offline-ms N        Duration of each offline window. Default: 2500
   --no-start-sync-server
                         Do not auto-start local db-sync when --sync is used
+  --no-e2ee            Initialize the stress graph as non-E2EE for local sync
   --auth-path PATH      Auth JSON for local db-sync. Default: /Users/tiensonqin/logseq/auth.json
   --e2ee-password TEXT  Password used for local sync upload initialization. Default: 11111
   --concurrency N       Parallel workers. Default: 8
@@ -186,11 +238,47 @@ function logEvent(opts, event) {
   }
 }
 
-const expectedRaceErrorCodes = new Set(["block-not-found", "source-not-found", "target-not-found"]);
+const expectedRaceErrorCodes = new Set([
+  "block-not-found",
+  "page-not-found",
+  "recycled-page",
+  "source-not-found",
+  "target-not-found",
+  "upsert-id-not-found",
+]);
 
-export function classifyCliResult(result, parsed) {
+function expectedCliRace(parsed, context = {}) {
+  return (
+    expectedRaceErrorCodes.has(parsed?.error?.code) ||
+    (context.op === "property-delete-recreate" &&
+      context.phase === "delete" &&
+      parsed?.error?.code === "property-not-found")
+  );
+}
+
+export function classifyCliResult(result, parsed, context = {}) {
   const ok = result.code === 0 && (!parsed || parsed.status === "ok");
-  const expectedRace = !ok && expectedRaceErrorCodes.has(parsed?.error?.code);
+  const expectedRace = !ok && expectedCliRace(parsed, context);
+  return {
+    ok,
+    level: ok || expectedRace ? "info" : "error",
+    outcome: ok ? "ok" : expectedRace ? "race-conflict" : "failed",
+    expectedRace,
+  };
+}
+
+function expectedHttpRace(parsed, context = {}) {
+  const message = parsed?.error?.message || "";
+  return (
+    Number.isInteger(context.id) &&
+    parsed?.error?.code === "exception" &&
+    message === "Set block property failed: block or property doesn't exist"
+  );
+}
+
+export function classifyHttpResult(result, parsed, context = {}) {
+  const ok = result.ok;
+  const expectedRace = !ok && expectedHttpRace(parsed, context);
   return {
     ok,
     level: ok || expectedRace ? "info" : "error",
@@ -294,6 +382,77 @@ async function runCli(opts, args, context = {}) {
   return { ...classification, parsed, result };
 }
 
+async function invokeThreadApi(opts, state, method, args, context = {}) {
+  const startedAt = Date.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs + 3000);
+  let response = null;
+  let text = "";
+  let parsed = null;
+  let error = null;
+  try {
+    response = await fetch(`${state.workerBaseUrl}/v1/invoke`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        method,
+        argsTransit: transitWriter.write(args),
+      }),
+      signal: controller.signal,
+    });
+    text = await response.text();
+    if (text) {
+      parsed = JSON.parse(text);
+    }
+    if (parsed?.resultTransit) {
+      parsed.result = transitReader.read(parsed.resultTransit);
+    }
+  } catch (caught) {
+    error = caught;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const classification = classifyHttpResult({ ok: !error && response?.ok, status: response?.status }, parsed, context);
+  if (classification.expectedRace) {
+    for (const id of staleIdsFromContext(context)) {
+      state.activeIds.delete(id);
+      state.activeBlockUuids.delete(id);
+      state.taskIds.delete(id);
+    }
+  }
+  logEvent(opts, {
+    event: "http",
+    level: classification.level,
+    outcome: classification.outcome,
+    context,
+    method,
+    elapsedMs: Date.now() - startedAt,
+    status: response?.status,
+    error: error ? { message: error instanceof Error ? error.message : String(error) } : parsed?.error,
+    stdout: classification.ok ? undefined : text,
+  });
+
+  if (!classification.ok && !classification.expectedRace && opts.failFast) {
+    throw new Error(`HTTP invoke failed: ${method}`);
+  }
+
+  return { ...classification, parsed, text, error };
+}
+
+async function applyOutlinerOps(opts, state, ops, options, context = {}) {
+  return invokeThreadApi(
+    opts,
+    state,
+    "thread-api/apply-outliner-ops",
+    [state.repo, ops, options || transit.map()],
+    context,
+  );
+}
+
 function resultIds(response) {
   const result = response.parsed?.data?.result;
   if (Array.isArray(result)) {
@@ -345,12 +504,28 @@ export function syncServerStartArgs(opts) {
 }
 
 export function syncUploadArgs(opts) {
-  return ["sync", "upload", "--graph", opts.graph, "--e2ee-password", opts.e2eePassword];
+  const args = ["sync", "upload", "--graph", opts.graph];
+  if (opts.graphE2ee !== false) {
+    args.push("--e2ee-password", opts.e2eePassword);
+  }
+  return args;
 }
 
-function syncStatusUninitialized(response) {
+export function syncEnsureKeysArgs(opts) {
+  return ["sync", "ensure-keys", "--upload-keys", "--e2ee-password", opts.e2eePassword];
+}
+
+export function syncNeedsEnsureKeys(opts) {
+  return opts.graphE2ee !== false;
+}
+
+export function graphValidateArgs(opts) {
+  return ["graph", "validate", "--graph", opts.graph];
+}
+
+export function syncStatusUninitialized(response) {
   const status = response.parsed?.data;
-  return response.ok && status && (status["local-tx"] == null || status["remote-tx"] == null);
+  return response.ok && status && status["graph-id"] == null;
 }
 
 async function ensureLocalSyncServer(opts) {
@@ -398,6 +573,42 @@ async function ensureLocalSyncServer(opts) {
   });
 }
 
+function graphServerRepo(opts, graphServer) {
+  return graphServer.repo || `logseq_db_${opts.graph}`;
+}
+
+async function setLocalGraphE2ee(opts, graphServer, graphE2ee) {
+  const state = {
+    workerBaseUrl: graphServer["base-url"],
+    repo: graphServerRepo(opts, graphServer),
+    activeIds: new Set(),
+    activeBlockUuids: new Map(),
+    taskIds: new Set(),
+  };
+  const response = await invokeThreadApi(
+    opts,
+    state,
+    "thread-api/transact",
+    [
+      state.repo,
+      [
+        tmap([
+          kw("db/ident"),
+          kw("logseq.kv/graph-rtc-e2ee?"),
+          kw("kv/value"),
+          graphE2ee,
+        ]),
+      ],
+      tmap([kw("outliner-op"), kw("set-kvs")]),
+      null,
+    ],
+    { op: "set-local-graph-e2ee", graphE2ee },
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to set local graph E2EE metadata for ${opts.graph}`);
+  }
+}
+
 async function ensureLocalServers(opts) {
   await runCli(opts, ["server", "start", "--graph", opts.graph], { op: "server-start" });
   const serverList = await runCli(opts, ["server", "list"], { op: "server-list" });
@@ -412,6 +623,15 @@ async function ensureLocalServers(opts) {
     await ensureLocalSyncServer(opts);
     const status = await runCli(opts, ["sync", "status", "--graph", opts.graph], { op: "sync-status-before-start" });
     if (syncStatusUninitialized(status)) {
+      if (opts.graphE2ee === false) {
+        await setLocalGraphE2ee(opts, graphServer, false);
+      }
+      if (syncNeedsEnsureKeys(opts)) {
+        const keys = await runCli(opts, syncEnsureKeysArgs(opts), { op: "sync-ensure-keys" });
+        if (!keys.ok) {
+          throw new Error(`Failed to initialize local sync keys for ${opts.graph}`);
+        }
+      }
       const upload = await runCli(opts, syncUploadArgs(opts), { op: "sync-upload-initialize" });
       if (!upload.ok) {
         throw new Error(`Failed to initialize local sync upload for ${opts.graph}`);
@@ -422,11 +642,19 @@ async function ensureLocalServers(opts) {
       throw new Error(`Failed to start local sync for ${opts.graph}`);
     }
   }
+  return graphServer;
 }
 
 function choose(set) {
   const values = Array.from(set);
   if (values.length === 0) {
+    return null;
+  }
+  return values[Math.floor(Math.random() * values.length)];
+}
+
+function chooseArray(values) {
+  if (!Array.isArray(values) || values.length === 0) {
     return null;
   }
   return values[Math.floor(Math.random() * values.length)];
@@ -442,26 +670,196 @@ function ednString(value) {
   return JSON.stringify(String(value));
 }
 
-function liveBlocksQuery(page) {
-  return `[:find [(pull ?b [:db/id]) ...] :where [?p :block/name ${ednString(page.toLowerCase())}] [?b :block/page ?p] (not [?b :block/name])]`;
+function ordinalDay(day) {
+  if (day % 100 >= 11 && day % 100 <= 13) {
+    return `${day}th`;
+  }
+  switch (day % 10) {
+    case 1:
+      return `${day}st`;
+    case 2:
+      return `${day}nd`;
+    case 3:
+      return `${day}rd`;
+    default:
+      return `${day}th`;
+  }
 }
 
-function liveIdsFromQueryResult(response) {
+function journalPageName(date) {
+  return `${date.toLocaleString("en-US", { month: "short", timeZone: "UTC" })} ${ordinalDay(date.getUTCDate())}, ${date.getUTCFullYear()}`;
+}
+
+function journalPageNameForYmd(ymd) {
+  const date = new Date(`${ymd}T00:00:00.000Z`);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid journal date: ${ymd}`);
+  }
+  return journalPageName(date);
+}
+
+function localYmd(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function todayJournalPageName(opts = {}, now = new Date()) {
+  return journalPageNameForYmd(opts.todayDate || localYmd(now));
+}
+
+export function stressPageNames(opts) {
+  const pages = [opts.page];
+  for (let index = 0; index < opts.extraPages; index += 1) {
+    pages.push(`${opts.page} page ${index + 2}`);
+  }
+
+  const start = new Date(`${opts.journalStart}T00:00:00.000Z`);
+  if (Number.isNaN(start.getTime())) {
+    throw new Error(`Invalid --journal-start date: ${opts.journalStart}`);
+  }
+  for (let index = 0; index < opts.journalPages; index += 1) {
+    const date = new Date(start.getTime() + index * 24 * 60 * 60 * 1000);
+    pages.push(journalPageName(date));
+  }
+  return pages;
+}
+
+export function bootstrapStressPageNames(opts) {
+  const pages = [opts.page];
+  for (let index = 0; index < opts.extraPages; index += 1) {
+    pages.push(`${opts.page} page ${index + 2}`);
+  }
+  return pages;
+}
+
+export function mutableStressPageNames(opts) {
+  const pages = [];
+  for (let index = 0; index < opts.extraPages; index += 1) {
+    pages.push(`${opts.page} page ${index + 2}`);
+  }
+  return pages.length > 0 ? pages : [opts.page];
+}
+
+export function operationWeights(opts = {}) {
+  const operations = [
+    ["create-root", 18],
+    ["create-child", 18],
+    ["create-tree", 10],
+    ["update", 8],
+    ["move-child", 14],
+    ["move-page", 12],
+    ["move-sibling", 12],
+    ["block-tags-add", 3],
+    ["block-tags-remove", 2],
+    ["block-properties-add", 3],
+    ["block-properties-remove", 2],
+    ["task-create", 3],
+    ["task-update", 2],
+    ["page-upsert", 2],
+    ["page-properties-add", 1],
+    ["page-properties-remove", 1],
+    ["page-delete-restore", 6],
+    ["tag-upsert", 1],
+    ["tag-delete-recreate", 1],
+    ["property-upsert", 1],
+    ["property-delete-recreate", 1],
+    ["http-insert-blocks", 12],
+    ["http-delete-blocks", 12],
+    ["http-move-blocks", 12],
+    ["http-save-block", 4],
+    ["http-move-up-down", 8],
+    ["http-indent-outdent", 8],
+    ["http-apply-template", 1],
+    ["http-create-page", 1],
+    ["http-rename-page", 1],
+    ["http-delete-restore-page", 8],
+    ["http-recycle-delete-page", 4],
+    ["http-upsert-property", 1],
+    ["http-set-block-property", 2],
+    ["http-remove-block-property", 1],
+    ["http-batch-set-property", 2],
+    ["http-batch-remove-property", 1],
+    ["http-batch-delete-property-value", 1],
+    ["http-toggle-reaction", 1],
+    ["http-insert-undo-redo", 12],
+    ["delete-single", 18],
+    ["delete-batch", 12],
+    ["delete-update-race", 8],
+  ];
+  if (opts.sync && opts.offline) {
+    operations.push(["offline-window", 2]);
+    operations.push(["offline-today-journal-race", 8]);
+  }
+  return operations;
+}
+
+export function operationNames(opts = {}) {
+  return operationWeights(opts).map(([name]) => name);
+}
+
+function liveBlocksQuery(page) {
+  return `[:find [(pull ?b [:db/id :block/uuid]) ...] :where [?p :block/name ${ednString(page.toLowerCase())}] [?b :block/page ?p] (not [?b :block/name])]`;
+}
+
+function pageByNameQuery(page) {
+  return `[:find (pull ?p [:db/id :block/uuid :block/name :block/title]) . :where [?p :block/name ${ednString(page.toLowerCase())}]]`;
+}
+
+function normalizedUuidString(value) {
+  if (typeof value === "string" && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)) {
+    return value;
+  }
+  if (value && typeof value === "object" && typeof value.value === "string") {
+    return normalizedUuidString(value.value);
+  }
+  return null;
+}
+
+function pageUuidFromQueryResult(response) {
+  return normalizedUuidString(response.parsed?.data?.result?.["block/uuid"]);
+}
+
+function liveBlocksFromQueryResult(response) {
   const rows = response.parsed?.data?.result;
   if (!Array.isArray(rows)) {
     return [];
   }
-  return rows.map((row) => row?.["db/id"]).filter((id) => Number.isInteger(id));
+  return rows
+    .map((row) => {
+      const id = row?.["db/id"];
+      const uuid = normalizedUuidString(row?.["block/uuid"]);
+      return Number.isInteger(id) && uuid ? { id, uuid } : null;
+    })
+    .filter(Boolean);
+}
+
+async function findPageUuid(opts, page, context = {}) {
+  const response = await runCli(
+    opts,
+    ["query", "--graph", opts.graph, "--query", pageByNameQuery(page)],
+    { op: "find-page-uuid", page, ...context },
+  );
+  return pageUuidFromQueryResult(response);
 }
 
 async function refreshLiveIds(opts, state, reason) {
-  const response = await runCli(
-    opts,
-    ["query", "--graph", opts.graph, "--query", liveBlocksQuery(opts.page)],
-    { op: "refresh-live-ids", reason },
-  );
-  const ids = liveIdsFromQueryResult(response);
-  state.activeIds = new Set(ids);
+  const ids = new Set();
+  const blockUuids = new Map();
+  for (const page of state.pageNames) {
+    const response = await runCli(
+      opts,
+      ["query", "--graph", opts.graph, "--query", liveBlocksQuery(page)],
+      { op: "refresh-live-ids", reason, page },
+    );
+    for (const block of liveBlocksFromQueryResult(response)) {
+      ids.add(block.id);
+      blockUuids.set(block.id, block.uuid);
+    }
+  }
+  state.activeIds = ids;
+  state.activeBlockUuids = blockUuids;
   state.lastRefreshSeq = state.nextSeq;
   logEvent(opts, {
     event: "refresh-live-ids",
@@ -495,17 +893,8 @@ function pruneStaleIds(state, response, context) {
   }
 }
 
-function weightedOperation() {
-  const operations = [
-    ["create-root", 18],
-    ["create-child", 18],
-    ["update", 18],
-    ["page-upsert", 10],
-    ["move", 8],
-    ["delete-single", 16],
-    ["delete-batch", 8],
-    ["delete-update-race", 4],
-  ];
+function weightedOperation(opts) {
+  const operations = operationWeights(opts);
   const total = operations.reduce((sum, [, weight]) => sum + weight, 0);
   let cursor = Math.random() * total;
   for (const [name, weight] of operations) {
@@ -529,13 +918,577 @@ async function createBlock(opts, state, content, targetArgs, context) {
   }
 }
 
+function randomPage(state) {
+  return chooseArray(state.pageNames) || state.pageNames[0];
+}
+
+function mutablePage(state) {
+  return chooseArray(state.mutablePageNames) || state.pageNames[0];
+}
+
+function stressTag(state) {
+  return chooseArray(state.stableTags);
+}
+
+function stressProperty(state) {
+  return chooseArray(state.stableProperties);
+}
+
+function stressTagId(state) {
+  return chooseArray(Array.from(state.stableTagIds.values()));
+}
+
+function rawPropertyIdent(state) {
+  return state.rawPropertyIdent || "user.property/cli-http-prop";
+}
+
+function propertyMap(name, value) {
+  return `{${ednString(name)} ${ednString(value)}}`;
+}
+
+function propertyVector(name) {
+  return `[${ednString(name)}]`;
+}
+
+function kw(name) {
+  return transit.keyword(name);
+}
+
+function uuid(value) {
+  return transit.uuid(value);
+}
+
+function tmap(entries = []) {
+  return transit.map(entries);
+}
+
+function blockMap(entries) {
+  return tmap(entries.flatMap(([key, value]) => [kw(key), value]));
+}
+
+function chooseActiveUuid(state) {
+  const id = choose(state.activeIds);
+  if (!id) {
+    return null;
+  }
+  const uuidValue = state.activeBlockUuids.get(id);
+  return uuidValue ? { id, uuid: uuidValue } : null;
+}
+
+function chooseDistinctActiveUuids(state) {
+  const first = chooseActiveUuid(state);
+  if (!first) {
+    return null;
+  }
+  const candidates = Array.from(state.activeBlockUuids.entries())
+    .filter(([id]) => id !== first.id)
+    .map(([id, uuidValue]) => ({ id, uuid: uuidValue }));
+  const second = chooseArray(candidates);
+  return second ? [first, second] : null;
+}
+
+async function ensureStressMetadata(opts, state) {
+  for (const page of state.bootstrapPageNames) {
+    await runCli(opts, ["upsert", "page", "--graph", opts.graph, "--page", page], {
+      op: "bootstrap-page",
+      page,
+    });
+  }
+  for (const name of [...state.stableTags, state.volatileTag]) {
+    await runCli(opts, ["upsert", "tag", "--graph", opts.graph, "--name", name], {
+      op: "bootstrap-tag",
+      name,
+    });
+  }
+  for (const name of [...state.stableProperties, state.volatileProperty]) {
+    await runCli(opts, ["upsert", "property", "--graph", opts.graph, "--name", name, "--type", "default", "--cardinality", "one", "--public", "true"], {
+      op: "bootstrap-property",
+      name,
+    });
+  }
+  await refreshStressTagIds(opts, state, "bootstrap");
+  await applyRawUpsertProperty(opts, state, { op: "bootstrap-http-upsert-property" });
+}
+
+async function refreshStressTagIds(opts, state, reason) {
+  const response = await runCli(opts, ["list", "tag", "--graph", opts.graph], {
+    op: "refresh-stress-tags",
+    reason,
+  });
+  const items = response.parsed?.data?.items || [];
+  state.stableTagIds = new Map();
+  for (const name of state.stableTags) {
+    const item = items.find((candidate) => candidate?.["block/title"] === name);
+    const id = item?.["db/id"];
+    if (Number.isInteger(id)) {
+      state.stableTagIds.set(name, id);
+    }
+  }
+}
+
+async function applyRawSaveBlock(opts, state, context, title) {
+  const block = chooseActiveUuid(state);
+  if (!block) {
+    return;
+  }
+  const response = await applyOutlinerOps(
+    opts,
+    state,
+    [
+      [
+        kw("save-block"),
+        [
+          blockMap([
+            ["block/uuid", uuid(block.uuid)],
+            ["block/title", title],
+          ]),
+          tmap(),
+        ],
+      ],
+    ],
+    tmap(),
+    { ...context, id: block.id, uuid: block.uuid },
+  );
+  if (!response.ok) {
+    state.activeIds.delete(block.id);
+    state.activeBlockUuids.delete(block.id);
+  }
+}
+
+async function applyRawInsertBlocks(opts, state, context, title) {
+  const target = chooseActiveUuid(state);
+  if (!target) {
+    return;
+  }
+  const newUuid = crypto.randomUUID();
+  const block = blockMap([
+    ["block/uuid", uuid(newUuid)],
+    ["block/title", title],
+  ]);
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("insert-blocks"), [[block], uuid(target.uuid), tmap([kw("sibling?"), false, kw("keep-uuid?"), true])]]],
+    tmap(),
+    { ...context, targetId: target.id, targetUuid: target.uuid, uuid: newUuid },
+  );
+  await refreshLiveIds(opts, state, "http-insert-blocks");
+}
+
+async function applyRawDeleteBlocks(opts, state, context) {
+  const block = chooseActiveUuid(state);
+  if (!block) {
+    return;
+  }
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("delete-blocks"), [[uuid(block.uuid)], tmap()]]],
+    tmap(),
+    { ...context, id: block.id, uuid: block.uuid },
+  );
+  state.activeIds.delete(block.id);
+  state.activeBlockUuids.delete(block.id);
+}
+
+async function applyRawMoveBlocks(opts, state, context) {
+  const pair = chooseDistinctActiveUuids(state);
+  if (!pair) {
+    return;
+  }
+  const [block, target] = pair;
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("move-blocks"), [[uuid(block.uuid)], uuid(target.uuid), tmap([kw("sibling?"), Math.random() < 0.5])]]],
+    tmap(),
+    { ...context, id: block.id, uuid: block.uuid, targetId: target.id, targetUuid: target.uuid },
+  );
+}
+
+async function applyRawMoveUpDown(opts, state, context, up) {
+  const block = chooseActiveUuid(state);
+  if (!block) {
+    return;
+  }
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("move-blocks-up-down"), [[uuid(block.uuid)], up]]],
+    tmap(),
+    { ...context, id: block.id, uuid: block.uuid, up },
+  );
+}
+
+async function applyRawIndentOutdent(opts, state, context, indent) {
+  const block = chooseActiveUuid(state);
+  if (!block) {
+    return;
+  }
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("indent-outdent-blocks"), [[uuid(block.uuid)], indent, tmap()]]],
+    tmap(),
+    { ...context, id: block.id, uuid: block.uuid, indent },
+  );
+}
+
+async function applyRawApplyTemplate(opts, state, context, title) {
+  const target = chooseActiveUuid(state);
+  if (!target) {
+    return;
+  }
+  const templateUuid = crypto.randomUUID();
+  const insertedUuid = crypto.randomUUID();
+  const templateBlock = blockMap([
+    ["block/uuid", uuid(insertedUuid)],
+    ["block/title", title],
+  ]);
+  await applyOutlinerOps(
+    opts,
+    state,
+    [
+      [
+        kw("apply-template"),
+        [
+          uuid(templateUuid),
+          uuid(target.uuid),
+          tmap([kw("template-blocks"), [templateBlock], kw("sibling?"), false]),
+        ],
+      ],
+    ],
+    tmap(),
+    { ...context, targetId: target.id, targetUuid: target.uuid, templateUuid, uuid: insertedUuid },
+  );
+  await refreshLiveIds(opts, state, "http-apply-template");
+}
+
+async function applyRawCreatePage(opts, state, context, title) {
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("create-page"), [title, tmap()]]],
+    tmap(),
+    { ...context, page: title },
+  );
+  state.pageNames.push(title);
+  state.mutablePageNames.push(title);
+}
+
+async function applyRawRenamePage(opts, state, context, title) {
+  const page = mutablePage(state);
+  const pageUuid = await findPageUuid(opts, page, context);
+  if (!pageUuid) {
+    return;
+  }
+  const temporaryTitle = `${title} ${Date.now()}`;
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("rename-page"), [uuid(pageUuid), temporaryTitle]]],
+    tmap(),
+    { ...context, page, pageUuid, phase: "rename-away", temporaryTitle },
+  );
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("rename-page"), [uuid(pageUuid), page]]],
+    tmap(),
+    { ...context, page, pageUuid, phase: "rename-back", temporaryTitle },
+  );
+}
+
+async function applyRawDeleteRestorePage(opts, state, context) {
+  const page = mutablePage(state);
+  const pageUuid = await findPageUuid(opts, page, context);
+  if (!pageUuid) {
+    return;
+  }
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("delete-page"), [uuid(pageUuid), tmap()]]],
+    tmap(),
+    { ...context, page, pageUuid, phase: "delete" },
+  );
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("restore-recycled"), [uuid(pageUuid)]]],
+    tmap(),
+    { ...context, page, pageUuid, phase: "restore" },
+  );
+  await refreshLiveIds(opts, state, "http-delete-restore-page");
+}
+
+async function applyRawRecycleDeletePage(opts, state, context, title) {
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("create-page"), [title, tmap()]]],
+    tmap(),
+    { ...context, page: title, phase: "create" },
+  );
+  const pageUuid = await findPageUuid(opts, title, context);
+  if (!pageUuid) {
+    return;
+  }
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("delete-page"), [uuid(pageUuid), tmap()]]],
+    tmap(),
+    { ...context, page: title, pageUuid, phase: "delete" },
+  );
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("recycle-delete-permanently"), [uuid(pageUuid)]]],
+    tmap(),
+    { ...context, page: title, pageUuid, phase: "permanent-delete" },
+  );
+}
+
+async function applyRawUpsertProperty(opts, state, context) {
+  await applyOutlinerOps(
+    opts,
+    state,
+    [
+      [
+        kw("upsert-property"),
+        [
+          kw(rawPropertyIdent(state)),
+          tmap([kw("logseq.property/type"), kw("default"), kw("db/cardinality"), kw("db.cardinality/one")]),
+          tmap([kw("property-name"), state.rawPropertyName || "cli-http-prop"]),
+        ],
+      ],
+    ],
+    tmap(),
+    context,
+  );
+}
+
+async function applyRawSetBlockProperty(opts, state, context, value) {
+  const block = chooseActiveUuid(state);
+  if (!block) {
+    return;
+  }
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("set-block-property"), [uuid(block.uuid), kw(rawPropertyIdent(state)), value]]],
+    tmap(),
+    { ...context, id: block.id, uuid: block.uuid },
+  );
+}
+
+async function applyRawRemoveBlockProperty(opts, state, context) {
+  const block = chooseActiveUuid(state);
+  if (!block) {
+    return;
+  }
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("remove-block-property"), [uuid(block.uuid), kw(rawPropertyIdent(state))]]],
+    tmap(),
+    { ...context, id: block.id, uuid: block.uuid },
+  );
+}
+
+async function applyRawBatchSetProperty(opts, state, context, value) {
+  const blocks = chooseMany(state.activeIds, 3)
+    .map((id) => ({ id, uuid: state.activeBlockUuids.get(id) }))
+    .filter((block) => block.uuid);
+  if (blocks.length === 0) {
+    return;
+  }
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("batch-set-property"), [blocks.map((block) => uuid(block.uuid)), kw(rawPropertyIdent(state)), value, tmap()]]],
+    tmap(),
+    { ...context, ids: blocks.map((block) => block.id) },
+  );
+}
+
+async function applyRawBatchRemoveProperty(opts, state, context) {
+  const blocks = chooseMany(state.activeIds, 3)
+    .map((id) => ({ id, uuid: state.activeBlockUuids.get(id) }))
+    .filter((block) => block.uuid);
+  if (blocks.length === 0) {
+    return;
+  }
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("batch-remove-property"), [blocks.map((block) => uuid(block.uuid)), kw(rawPropertyIdent(state))]]],
+    tmap(),
+    { ...context, ids: blocks.map((block) => block.id) },
+  );
+}
+
+async function applyRawBatchDeletePropertyValue(opts, state, context) {
+  const block = chooseActiveUuid(state);
+  const tagId = stressTagId(state);
+  if (!block || !tagId) {
+    return;
+  }
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("batch-set-property"), [[uuid(block.uuid)], kw("block/tags"), tagId, tmap()]]],
+    tmap(),
+    { ...context, id: block.id, uuid: block.uuid, tagId, phase: "set-tag" },
+  );
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("batch-delete-property-value"), [[uuid(block.uuid)], kw("block/tags"), tagId]]],
+    tmap(),
+    { ...context, id: block.id, uuid: block.uuid, tagId, phase: "delete-tag-value" },
+  );
+}
+
+async function applyRawToggleReaction(opts, state, context) {
+  const block = chooseActiveUuid(state);
+  if (!block) {
+    return;
+  }
+  await applyOutlinerOps(
+    opts,
+    state,
+    [[kw("toggle-reaction"), [uuid(block.uuid), "thumbs-up", null]]],
+    tmap(),
+    { ...context, id: block.id, uuid: block.uuid },
+  );
+}
+
+async function applyRawInsertUndoRedo(opts, state, context, title) {
+  const target = chooseActiveUuid(state);
+  if (!target) {
+    return;
+  }
+  const newUuid = crypto.randomUUID();
+  const block = blockMap([
+    ["block/uuid", uuid(newUuid)],
+    ["block/title", title],
+  ]);
+  const forward = [[kw("insert-blocks"), [[block], uuid(target.uuid), tmap([kw("sibling?"), false, kw("keep-uuid?"), true])]]];
+  const inverse = [[kw("delete-blocks"), [[uuid(newUuid)], tmap()]]];
+  await applyOutlinerOps(opts, state, forward, tmap(), {
+    ...context,
+    phase: "redo-initial",
+    targetId: target.id,
+    targetUuid: target.uuid,
+    uuid: newUuid,
+  });
+  await applyOutlinerOps(opts, state, inverse, tmap(), {
+    ...context,
+    phase: "undo",
+    targetId: target.id,
+    targetUuid: target.uuid,
+    uuid: newUuid,
+  });
+  await applyOutlinerOps(opts, state, forward, tmap(), {
+    ...context,
+    phase: "redo",
+    targetId: target.id,
+    targetUuid: target.uuid,
+    uuid: newUuid,
+  });
+  await refreshLiveIds(opts, state, "http-insert-undo-redo");
+}
+
+async function offlineWindow(opts, state, context) {
+  if (state.offlineRunning) {
+    return;
+  }
+  state.offlineRunning = true;
+  try {
+    await runCli(opts, ["sync", "stop", "--graph", opts.graph], { ...context, phase: "stop" });
+    logEvent(opts, {
+      event: "offline-window",
+      level: "warn",
+      status: "offline",
+      context,
+      durationMs: opts.offlineMs,
+    });
+    await delay(opts.offlineMs);
+    const start = await runCli(opts, ["sync", "start", "--graph", opts.graph], { ...context, phase: "start" });
+    if (!start.ok && opts.failFast) {
+      throw new Error(`Failed to restart sync after offline window for ${opts.graph}`);
+    }
+  } finally {
+    state.offlineRunning = false;
+  }
+}
+
+async function offlineTodayJournalRace(opts, state, context) {
+  if (state.offlineRunning) {
+    return;
+  }
+  state.offlineRunning = true;
+  const page = todayJournalPageName(opts);
+  if (!state.pageNames.includes(page)) {
+    state.pageNames.push(page);
+  }
+
+  const clientCount = Math.max(2, opts.concurrency);
+  try {
+    await runCli(opts, ["sync", "stop", "--graph", opts.graph], { ...context, phase: "stop", page });
+    logEvent(opts, {
+      event: "offline-today-journal-race",
+      level: "warn",
+      status: "offline",
+      context: { ...context, page, clientCount },
+      durationMs: opts.offlineMs,
+    });
+
+    const responses = await Promise.all(
+      Array.from({ length: clientCount }, (_, index) => {
+        const clientId = index + 1;
+        return runCli(
+          opts,
+          [
+            "upsert",
+            "block",
+            "--graph",
+            opts.graph,
+            "--target-page",
+            page,
+            "--content",
+            `offline today journal ${state.runId} client=${clientId} seq=${context.seq}`,
+          ],
+          { ...context, phase: "write", page, clientId, clientCount },
+        );
+      }),
+    );
+    for (const response of responses) {
+      for (const id of resultIds(response)) {
+        state.activeIds.add(id);
+      }
+    }
+
+    await delay(opts.offlineMs);
+    const start = await runCli(opts, ["sync", "start", "--graph", opts.graph], { ...context, phase: "start", page });
+    if (!start.ok && opts.failFast) {
+      throw new Error(`Failed to restart sync after offline today journal race for ${opts.graph}`);
+    }
+    await refreshLiveIds(opts, state, "offline-today-journal-race");
+  } finally {
+    state.offlineRunning = false;
+  }
+}
+
 async function runOperation(opts, state, workerId, seq) {
-  const op = weightedOperation();
+  const op = weightedOperation(opts);
   const stamp = `${state.runId} worker=${workerId} seq=${seq} op=${op}`;
   await refreshLiveIdsIfNeeded(opts, state, "operation");
 
-  if (state.activeIds.size < opts.concurrency && op !== "create-root") {
-    await createBlock(opts, state, `seed ${stamp}`, ["--target-page", opts.page], {
+  if (state.activeIds.size < opts.concurrency && !["create-root", "offline-window", "offline-today-journal-race"].includes(op)) {
+    await createBlock(opts, state, `seed ${stamp}`, ["--target-page", randomPage(state)], {
       workerId,
       seq,
       op: "seed",
@@ -545,17 +1498,40 @@ async function runOperation(opts, state, workerId, seq) {
 
   switch (op) {
     case "create-root":
-      await createBlock(opts, state, `root ${stamp}`, ["--target-page", opts.page], { workerId, seq, op });
+      await createBlock(opts, state, `root ${stamp}`, ["--target-page", randomPage(state)], { workerId, seq, op });
       return;
 
     case "create-child": {
       const parentId = choose(state.activeIds);
-      await createBlock(opts, state, `child ${stamp} parent=${parentId}`, ["--target-id", String(parentId), "--pos", "last-child"], {
-        workerId,
-        seq,
-        op,
-        parentId,
-      });
+      await createBlock(
+        opts,
+        state,
+        `child ${stamp} parent=${parentId}`,
+        ["--target-id", String(parentId), "--pos", Math.random() < 0.5 ? "first-child" : "last-child"],
+        {
+          workerId,
+          seq,
+          op,
+          parentId,
+        },
+      );
+      return;
+    }
+
+    case "create-tree": {
+      const page = randomPage(state);
+      const blocks = `[
+        {:block/title ${ednString(`tree root ${stamp}`)}
+         :block/children [{:block/title ${ednString(`tree child ${stamp}`)}}]}
+        {:block/title ${ednString(`tree sibling ${stamp}`)}}]`;
+      const response = await runCli(
+        opts,
+        ["upsert", "block", "--graph", opts.graph, "--target-page", page, "--blocks", blocks],
+        { workerId, seq, op, page },
+      );
+      for (const id of resultIds(response)) {
+        state.activeIds.add(id);
+      }
       return;
     }
 
@@ -571,16 +1547,7 @@ async function runOperation(opts, state, workerId, seq) {
       return;
     }
 
-    case "page-upsert": {
-      await runCli(opts, ["upsert", "page", "--graph", opts.graph, "--page", opts.page], {
-        workerId,
-        seq,
-        op,
-      });
-      return;
-    }
-
-    case "move": {
+    case "move-child": {
       const id = choose(state.activeIds);
       const targetId = choose(state.activeIds);
       if (!id || !targetId || id === targetId) {
@@ -595,6 +1562,336 @@ async function runOperation(opts, state, workerId, seq) {
       pruneStaleIds(state, response, context);
       return;
     }
+
+    case "move-page": {
+      const id = choose(state.activeIds);
+      const page = randomPage(state);
+      if (!id) {
+        return;
+      }
+      const context = { workerId, seq, op, id, page };
+      const response = await runCli(
+        opts,
+        ["upsert", "block", "--graph", opts.graph, "--id", String(id), "--target-page", page],
+        context,
+      );
+      pruneStaleIds(state, response, context);
+      return;
+    }
+
+    case "move-sibling": {
+      const id = choose(state.activeIds);
+      const targetId = choose(state.activeIds);
+      if (!id || !targetId || id === targetId) {
+        return;
+      }
+      const context = { workerId, seq, op, id, targetId };
+      const response = await runCli(
+        opts,
+        ["upsert", "block", "--graph", opts.graph, "--id", String(id), "--target-id", String(targetId), "--pos", "sibling"],
+        context,
+      );
+      pruneStaleIds(state, response, context);
+      return;
+    }
+
+    case "block-tags-add": {
+      const id = choose(state.activeIds);
+      const tag = stressTag(state);
+      if (!id || !tag) {
+        return;
+      }
+      const context = { workerId, seq, op, id, tag };
+      const response = await runCli(
+        opts,
+        ["upsert", "block", "--graph", opts.graph, "--id", String(id), "--update-tags", `[${ednString(tag)}]`],
+        context,
+      );
+      pruneStaleIds(state, response, context);
+      return;
+    }
+
+    case "block-tags-remove": {
+      const id = choose(state.activeIds);
+      const tag = stressTag(state);
+      if (!id || !tag) {
+        return;
+      }
+      const context = { workerId, seq, op, id, tag };
+      const response = await runCli(
+        opts,
+        ["upsert", "block", "--graph", opts.graph, "--id", String(id), "--remove-tags", `[${ednString(tag)}]`],
+        context,
+      );
+      pruneStaleIds(state, response, context);
+      return;
+    }
+
+    case "block-properties-add": {
+      const id = choose(state.activeIds);
+      const property = stressProperty(state);
+      if (!id || !property) {
+        return;
+      }
+      const context = { workerId, seq, op, id, property };
+      const response = await runCli(
+        opts,
+        ["upsert", "block", "--graph", opts.graph, "--id", String(id), "--update-properties", propertyMap(property, `value ${stamp}`)],
+        context,
+      );
+      pruneStaleIds(state, response, context);
+      return;
+    }
+
+    case "block-properties-remove": {
+      const id = choose(state.activeIds);
+      const property = stressProperty(state);
+      if (!id || !property) {
+        return;
+      }
+      const context = { workerId, seq, op, id, property };
+      const response = await runCli(
+        opts,
+        ["upsert", "block", "--graph", opts.graph, "--id", String(id), "--remove-properties", propertyVector(property)],
+        context,
+      );
+      pruneStaleIds(state, response, context);
+      return;
+    }
+
+    case "task-create": {
+      const page = randomPage(state);
+      const response = await runCli(
+        opts,
+        [
+          "upsert",
+          "task",
+          "--graph",
+          opts.graph,
+          "--target-page",
+          page,
+          "--content",
+          `task ${stamp}`,
+          "--status",
+          "todo",
+          "--priority",
+          "high",
+        ],
+        { workerId, seq, op, page },
+      );
+      for (const id of resultIds(response)) {
+        state.activeIds.add(id);
+        state.taskIds.add(id);
+      }
+      return;
+    }
+
+    case "task-update": {
+      const id = choose(state.taskIds.size > 0 ? state.taskIds : state.activeIds);
+      if (!id) {
+        return;
+      }
+      const context = { workerId, seq, op, id };
+      const response = await runCli(
+        opts,
+        ["upsert", "task", "--graph", opts.graph, "--id", String(id), "--status", "doing", "--priority", "low"],
+        context,
+      );
+      pruneStaleIds(state, response, context);
+      return;
+    }
+
+    case "page-upsert": {
+      await runCli(opts, ["upsert", "page", "--graph", opts.graph, "--page", randomPage(state)], {
+        workerId,
+        seq,
+        op,
+      });
+      return;
+    }
+
+    case "page-properties-add": {
+      const page = randomPage(state);
+      const property = stressProperty(state);
+      await runCli(
+        opts,
+        ["upsert", "page", "--graph", opts.graph, "--page", page, "--update-properties", propertyMap(property, `page ${stamp}`)],
+        { workerId, seq, op, page, property },
+      );
+      return;
+    }
+
+    case "page-properties-remove": {
+      const page = randomPage(state);
+      const property = stressProperty(state);
+      await runCli(
+        opts,
+        ["upsert", "page", "--graph", opts.graph, "--page", page, "--remove-properties", propertyVector(property)],
+        { workerId, seq, op, page, property },
+      );
+      return;
+    }
+
+    case "page-delete-restore": {
+      const page = mutablePage(state);
+      await runCli(opts, ["remove", "page", "--graph", opts.graph, "--page", page], {
+        workerId,
+        seq,
+        op,
+        page,
+        phase: "delete",
+      });
+      await runCli(opts, ["upsert", "page", "--graph", opts.graph, "--page", page, "--restore"], {
+        workerId,
+        seq,
+        op,
+        page,
+        phase: "restore",
+      });
+      await refreshLiveIds(opts, state, "page-delete-restore");
+      return;
+    }
+
+    case "tag-upsert": {
+      const tag = chooseArray([...state.stableTags, state.volatileTag]);
+      await runCli(opts, ["upsert", "tag", "--graph", opts.graph, "--name", tag], {
+        workerId,
+        seq,
+        op,
+        tag,
+      });
+      return;
+    }
+
+    case "tag-delete-recreate": {
+      const tag = state.volatileTag;
+      await runCli(opts, ["remove", "tag", "--graph", opts.graph, "--name", tag], {
+        workerId,
+        seq,
+        op,
+        tag,
+        phase: "delete",
+      });
+      await runCli(opts, ["upsert", "tag", "--graph", opts.graph, "--name", tag], {
+        workerId,
+        seq,
+        op,
+        tag,
+        phase: "recreate",
+      });
+      return;
+    }
+
+    case "property-upsert": {
+      const property = chooseArray([...state.stableProperties, state.volatileProperty]);
+      await runCli(
+        opts,
+        ["upsert", "property", "--graph", opts.graph, "--name", property, "--type", "default", "--cardinality", "one", "--public", "true"],
+        { workerId, seq, op, property },
+      );
+      return;
+    }
+
+    case "property-delete-recreate": {
+      const property = state.volatileProperty;
+      await runCli(opts, ["remove", "property", "--graph", opts.graph, "--name", property], {
+        workerId,
+        seq,
+        op,
+        property,
+        phase: "delete",
+      });
+      await runCli(
+        opts,
+        ["upsert", "property", "--graph", opts.graph, "--name", property, "--type", "default", "--cardinality", "one", "--public", "true"],
+        { workerId, seq, op, property, phase: "recreate" },
+      );
+      return;
+    }
+
+    case "http-insert-blocks":
+      await applyRawInsertBlocks(opts, state, { workerId, seq, op }, `http insert ${stamp}`);
+      return;
+
+    case "http-delete-blocks":
+      await applyRawDeleteBlocks(opts, state, { workerId, seq, op });
+      return;
+
+    case "http-move-blocks":
+      await applyRawMoveBlocks(opts, state, { workerId, seq, op });
+      return;
+
+    case "http-save-block":
+      await applyRawSaveBlock(opts, state, { workerId, seq, op }, `http save ${stamp}`);
+      return;
+
+    case "http-move-up-down":
+      await applyRawMoveUpDown(opts, state, { workerId, seq, op }, Math.random() < 0.5);
+      return;
+
+    case "http-indent-outdent":
+      await applyRawIndentOutdent(opts, state, { workerId, seq, op }, Math.random() < 0.5);
+      return;
+
+    case "http-apply-template":
+      await applyRawApplyTemplate(opts, state, { workerId, seq, op }, `http template ${stamp}`);
+      return;
+
+    case "http-create-page":
+      await applyRawCreatePage(opts, state, { workerId, seq, op }, `CLI HTTP Page ${state.runId} ${seq}`);
+      return;
+
+    case "http-rename-page":
+      await applyRawRenamePage(opts, state, { workerId, seq, op }, `CLI HTTP Rename ${state.runId} ${seq}`);
+      return;
+
+    case "http-delete-restore-page":
+      await applyRawDeleteRestorePage(opts, state, { workerId, seq, op });
+      return;
+
+    case "http-recycle-delete-page":
+      await applyRawRecycleDeletePage(opts, state, { workerId, seq, op }, `CLI HTTP Recycle ${state.runId} ${seq}`);
+      return;
+
+    case "http-upsert-property":
+      await applyRawUpsertProperty(opts, state, { workerId, seq, op });
+      return;
+
+    case "http-set-block-property":
+      await applyRawSetBlockProperty(opts, state, { workerId, seq, op }, `http property ${stamp}`);
+      return;
+
+    case "http-remove-block-property":
+      await applyRawRemoveBlockProperty(opts, state, { workerId, seq, op });
+      return;
+
+    case "http-batch-set-property":
+      await applyRawBatchSetProperty(opts, state, { workerId, seq, op }, `http batch ${stamp}`);
+      return;
+
+    case "http-batch-remove-property":
+      await applyRawBatchRemoveProperty(opts, state, { workerId, seq, op });
+      return;
+
+    case "http-batch-delete-property-value":
+      await applyRawBatchDeletePropertyValue(opts, state, { workerId, seq, op });
+      return;
+
+    case "http-toggle-reaction":
+      await applyRawToggleReaction(opts, state, { workerId, seq, op });
+      return;
+
+    case "http-insert-undo-redo":
+      await applyRawInsertUndoRedo(opts, state, { workerId, seq, op }, `http undo redo ${stamp}`);
+      return;
+
+    case "offline-window":
+      await offlineWindow(opts, state, { workerId, seq, op });
+      return;
+
+    case "offline-today-journal-race":
+      await offlineTodayJournalRace(opts, state, { workerId, seq, op });
+      return;
 
     case "delete-single": {
       const id = choose(state.activeIds);
@@ -707,12 +2004,26 @@ async function main() {
 
   const state = {
     runId: `stress-${Date.now()}`,
+    pageNames: stressPageNames(opts),
+    bootstrapPageNames: bootstrapStressPageNames(opts),
+    mutablePageNames: [],
+    stableTags: ["cli-stress-tag-a", "cli-stress-tag-b"],
+    stableTagIds: new Map(),
+    stableProperties: ["cli-stress-prop-a", "cli-stress-prop-b"],
+    volatileTag: "cli-stress-volatile-tag",
+    volatileProperty: "cli-stress-volatile-prop",
+    rawPropertyIdent: "user.property/cli-http-prop",
+    rawPropertyName: "cli-http-prop",
     activeIds: new Set(),
+    activeBlockUuids: new Map(),
+    taskIds: new Set(),
     nextSeq: 0,
     lastRefreshSeq: -Infinity,
     refreshing: false,
+    offlineRunning: false,
     stop: false,
   };
+  state.mutablePageNames = mutableStressPageNames(opts);
 
   logEvent(opts, {
     event: "start",
@@ -724,15 +2035,29 @@ async function main() {
     concurrency: opts.concurrency,
     maxOps: opts.maxOps,
     sync: opts.sync,
+    offline: opts.offline,
+    graphE2ee: opts.graphE2ee,
+    pageNames: state.pageNames,
   });
 
-  await ensureLocalServers(opts);
-  await runCli(opts, ["upsert", "page", "--graph", opts.graph, "--page", opts.page], {
-    op: "upsert-stress-page",
-  });
+  const graphServer = await ensureLocalServers(opts);
+  state.workerBaseUrl = graphServer["base-url"];
+  state.repo = graphServerRepo(opts, graphServer);
+
+  const preflightValidation = await runCli(opts, graphValidateArgs(opts), { op: "preflight-graph-validate" });
+  if (!preflightValidation.ok) {
+    throw new Error(`Preflight graph validation failed for ${opts.graph}`);
+  }
+
+  await ensureStressMetadata(opts, state);
   await refreshLiveIds(opts, state, "startup");
 
   await Promise.all(Array.from({ length: opts.concurrency }, (_, index) => worker(opts, state, index + 1)));
+
+  const validation = await runCli(opts, graphValidateArgs(opts), { op: "final-graph-validate" });
+  if (!validation.ok) {
+    throw new Error(`Final graph validation failed for ${opts.graph}`);
+  }
 
   logEvent(opts, {
     event: "stop",

--- a/scripts/cli-concurrent-edit-stress.test.mjs
+++ b/scripts/cli-concurrent-edit-stress.test.mjs
@@ -5,11 +5,22 @@ import { join } from "node:path";
 import test from "node:test";
 
 import {
+  bootstrapStressPageNames,
+  classifyHttpResult,
   classifyCliResult,
+  graphValidateArgs,
+  mutableStressPageNames,
+  operationNames,
+  operationWeights,
+  stressPageNames,
   stressConfigText,
+  syncEnsureKeysArgs,
+  syncNeedsEnsureKeys,
   syncServerStartArgs,
+  syncStatusUninitialized,
   syncUploadArgs,
   staleIdsFromContext,
+  todayJournalPageName,
 } from "./cli-concurrent-edit-stress.mjs";
 
 test("classifies stale block conflicts as race outcomes", () => {
@@ -27,6 +38,52 @@ test("classifies stale block conflicts as race outcomes", () => {
     outcome: "race-conflict",
     expectedRace: true,
   });
+});
+
+test("classifies stale task and recycled page conflicts as race outcomes", () => {
+  for (const code of ["upsert-id-not-found", "recycled-page", "page-not-found"]) {
+    assert.equal(
+      classifyCliResult(
+        { code: 1 },
+        {
+          status: "error",
+          error: { code, message: "race" },
+        },
+        { id: 42 },
+      ).outcome,
+      "race-conflict",
+    );
+  }
+});
+
+test("classifies concurrent volatile property delete as a race outcome", () => {
+  assert.equal(
+    classifyCliResult(
+      { code: 1 },
+      {
+        status: "error",
+        error: { code: "property-not-found", message: "property not found" },
+      },
+      { op: "property-delete-recreate", phase: "delete" },
+    ).outcome,
+    "race-conflict",
+  );
+});
+
+test("classifies stale raw outliner block property failures as race outcomes", () => {
+  assert.equal(
+    classifyHttpResult(
+      { ok: false, status: 500 },
+      {
+        error: {
+          code: "exception",
+          message: "Set block property failed: block or property doesn't exist",
+        },
+      },
+      { id: 525, op: "http-set-block-property" },
+    ).outcome,
+    "race-conflict",
+  );
 });
 
 test("keeps created-id resolution failures visible as errors", () => {
@@ -106,6 +163,16 @@ test("stress config includes runtime auth to avoid refresh during sync start", (
 });
 
 test("builds sync upload initialization command with e2ee password", () => {
+  assert.equal(syncNeedsEnsureKeys({ graphE2ee: true }), true);
+
+  assert.deepEqual(syncEnsureKeysArgs({ e2eePassword: "11111" }), [
+    "sync",
+    "ensure-keys",
+    "--upload-keys",
+    "--e2ee-password",
+    "11111",
+  ]);
+
   assert.deepEqual(syncUploadArgs({ graph: "pi-memory", e2eePassword: "11111" }), [
     "sync",
     "upload",
@@ -114,4 +181,190 @@ test("builds sync upload initialization command with e2ee password", () => {
     "--e2ee-password",
     "11111",
   ]);
+
+  assert.equal(syncNeedsEnsureKeys({ graphE2ee: false }), false);
+  assert.deepEqual(syncUploadArgs({ graph: "pi-memory", e2eePassword: "11111", graphE2ee: false }), [
+    "sync",
+    "upload",
+    "--graph",
+    "pi-memory",
+  ]);
+});
+
+test("builds final graph validation command", () => {
+  assert.deepEqual(graphValidateArgs({ graph: "pi-memory" }), ["graph", "validate", "--graph", "pi-memory"]);
+});
+
+test("does not re-upload when linked graph has no remote tx before websocket start", () => {
+  assert.equal(
+    syncStatusUninitialized({
+      ok: true,
+      parsed: {
+        data: {
+          "graph-id": "ea64137c-e829-49fb-98de-dc83b745377b",
+          "local-tx": 55,
+          "remote-tx": null,
+        },
+      },
+    }),
+    false,
+  );
+
+  assert.equal(
+    syncStatusUninitialized({
+      ok: true,
+      parsed: {
+        data: {
+          "graph-id": null,
+          "local-tx": 55,
+          "remote-tx": null,
+        },
+      },
+    }),
+    true,
+  );
+});
+
+test("builds a multi-page stress surface with journal pages", () => {
+  assert.deepEqual(
+    stressPageNames({
+      page: "CLI Concurrent Stress",
+      extraPages: 2,
+      journalPages: 2,
+      journalStart: "2026-07-01",
+    }),
+    [
+      "CLI Concurrent Stress",
+      "CLI Concurrent Stress page 2",
+      "CLI Concurrent Stress page 3",
+      "Jul 1st, 2026",
+      "Jul 2nd, 2026",
+    ],
+  );
+});
+
+test("mutable stress pages exclude journal pages", () => {
+  assert.deepEqual(
+    mutableStressPageNames({
+      page: "CLI Concurrent Stress",
+      extraPages: 2,
+      journalPages: 2,
+      journalStart: "2026-07-01",
+    }),
+    ["CLI Concurrent Stress page 2", "CLI Concurrent Stress page 3"],
+  );
+});
+
+test("bootstrap stress pages exclude auto-created journal pages", () => {
+  assert.deepEqual(
+    bootstrapStressPageNames({
+      page: "CLI Concurrent Stress",
+      extraPages: 2,
+      journalPages: 2,
+      journalStart: "2026-07-01",
+    }),
+    ["CLI Concurrent Stress", "CLI Concurrent Stress page 2", "CLI Concurrent Stress page 3"],
+  );
+});
+
+test("today journal page name uses the local calendar date", () => {
+  assert.equal(todayJournalPageName({}, new Date("2026-07-01T16:30:00+08:00")), "Jul 1st, 2026");
+  assert.equal(todayJournalPageName({ todayDate: "2026-07-02" }), "Jul 2nd, 2026");
+});
+
+test("operation set covers broad outliner and metadata mutations", () => {
+  const names = operationNames({ sync: true, offline: true });
+
+  for (const name of [
+    "create-root",
+    "create-child",
+    "create-tree",
+    "update",
+    "move-child",
+    "move-page",
+    "move-sibling",
+    "block-tags-add",
+    "block-tags-remove",
+    "block-properties-add",
+    "block-properties-remove",
+    "task-create",
+    "task-update",
+    "page-upsert",
+    "page-properties-add",
+    "page-properties-remove",
+    "page-delete-restore",
+    "tag-upsert",
+    "tag-delete-recreate",
+    "property-upsert",
+    "property-delete-recreate",
+    "http-insert-blocks",
+    "http-delete-blocks",
+    "http-move-blocks",
+    "http-save-block",
+    "http-move-up-down",
+    "http-indent-outdent",
+    "http-apply-template",
+    "http-create-page",
+    "http-rename-page",
+    "http-delete-restore-page",
+    "http-recycle-delete-page",
+    "http-upsert-property",
+    "http-set-block-property",
+    "http-remove-block-property",
+    "http-batch-set-property",
+    "http-batch-remove-property",
+    "http-batch-delete-property-value",
+    "http-toggle-reaction",
+    "http-insert-undo-redo",
+    "delete-single",
+    "delete-batch",
+    "delete-update-race",
+    "offline-window",
+    "offline-today-journal-race",
+  ]) {
+    assert.equal(names.includes(name), true, `${name} should be in the operation set`);
+  }
+});
+
+test("offline operation is available only when sync offline simulation is enabled", () => {
+  assert.equal(operationNames({ sync: true, offline: true }).includes("offline-window"), true);
+  assert.equal(operationNames({ sync: true, offline: false }).includes("offline-window"), false);
+  assert.equal(operationNames({ sync: false, offline: true }).includes("offline-window"), false);
+  assert.equal(operationNames({ sync: true, offline: true }).includes("offline-today-journal-race"), true);
+  assert.equal(operationNames({ sync: true, offline: false }).includes("offline-today-journal-race"), false);
+  assert.equal(operationNames({ sync: false, offline: true }).includes("offline-today-journal-race"), false);
+  assert.ok(
+    new Map(operationWeights({ sync: true, offline: true })).get("offline-today-journal-race") >= 8,
+    "offline today journal race should run often enough to catch page creation conflicts",
+  );
+});
+
+test("critical outliner mutations dominate the stress distribution", () => {
+  const weights = new Map(operationWeights({ sync: true, offline: true }));
+  const criticalOps = [
+    "create-root",
+    "create-child",
+    "create-tree",
+    "move-child",
+    "move-page",
+    "move-sibling",
+    "http-insert-blocks",
+    "http-delete-blocks",
+    "http-move-blocks",
+    "http-move-up-down",
+    "http-indent-outdent",
+    "http-delete-restore-page",
+    "http-insert-undo-redo",
+    "delete-single",
+    "delete-batch",
+    "delete-update-race",
+  ];
+  const totalWeight = [...weights.values()].reduce((sum, weight) => sum + weight, 0);
+  const criticalWeight = criticalOps.reduce((sum, name) => sum + (weights.get(name) || 0), 0);
+
+  assert.ok(criticalWeight / totalWeight >= 0.65, "insert/delete/move/undo-redo operations should dominate the run");
+  assert.ok((weights.get("http-insert-undo-redo") || 0) >= 8, "undo/redo should run often enough to catch regressions");
+  assert.ok((weights.get("http-insert-blocks") || 0) >= 8, "raw insert should run often enough to catch regressions");
+  assert.ok((weights.get("http-delete-blocks") || 0) >= 8, "raw delete should run often enough to catch regressions");
+  assert.ok((weights.get("http-move-blocks") || 0) >= 8, "raw move should run often enough to catch regressions");
 });

--- a/scripts/cli-sync-stress-workflow.test.mjs
+++ b/scripts/cli-sync-stress-workflow.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const workflowPath = new URL("../.github/workflows/cli-sync-stress.yml", import.meta.url);
+
+test("CLI sync stress workflow runs local sync/offline stress and validates the graph", () => {
+  const workflow = readFileSync(workflowPath, "utf8");
+
+  assert.match(workflow, /^name: CLI sync stress$/m);
+  assert.match(workflow, /pnpm --dir deps\/db-sync build:node-adapter/);
+  assert.match(workflow, /opam exec -- pnpm cli:release/);
+  assert.match(workflow, /pnpm db-worker-node:release:bundle/);
+  assert.match(workflow, /alg: "RS256"/);
+  assert.match(workflow, /kid: "cli-sync-stress"/);
+  assert.match(workflow, /generateKeyPairSync/);
+  assert.match(workflow, /createSign/);
+  assert.match(workflow, /http:\/\/127\.0\.0\.1:19091/);
+  assert.match(workflow, /http\.createServer/);
+  assert.match(workflow, /LOGSEQ_CLI_ROOT_DIR/);
+  assert.match(workflow, /HOME: \$\{\{ github\.workspace \}\}\/tmp\/cli-sync-stress\/home/);
+  assert.match(workflow, /node scripts\/cli-concurrent-edit-stress\.mjs/);
+  assert.match(workflow, /--sync/);
+  assert.match(workflow, /--offline/);
+  assert.match(workflow, /--no-e2ee/);
+  assert.match(workflow, /--max-ops 1000/);
+  assert.match(workflow, /graph validate --graph "\$GRAPH" --output json/);
+});

--- a/src/main/frontend/worker/sync.cljs
+++ b/src/main/frontend/worker/sync.cljs
@@ -378,6 +378,7 @@
           (active-client-for? current repo graph-id)
           (do
             (broadcast-rtc-state! current)
+            (sync-apply/enqueue-flush-pending! repo current)
             (p/resolved nil))
 
           :else

--- a/src/main/frontend/worker/sync/upload.cljs
+++ b/src/main/frontend/worker/sync/upload.cljs
@@ -270,7 +270,8 @@
       :else
       (do
         (sync-util/require-auth-token! {:repo repo :field :auth-token})
-        (p/let [_ (sync-crypt/ensure-user-rsa-keys! {:ensure-server? true})
+        (p/let [_ (when graph-e2ee?
+                    (sync-crypt/ensure-user-rsa-keys! {:ensure-server? true}))
                 body (coerce-http-request :graphs/create
                                           {:graph-name graph-name
                                            :schema-version schema-version

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -663,6 +663,88 @@
             (is (= 0 @send-calls)))
           (#'sync-apply/set-upload-stopped! test-repo false))))))
 
+(deftest start-active-client-flushes-pending-local-txs-test
+  (async done
+         (let [{:keys [conn client-ops-conn child1]} (setup-parent-child)
+               repo (str test-repo "-active-client-" (random-uuid))
+               tx-id (random-uuid)
+               sent (atom [])
+               broadcasts (atom 0)
+               latest-prev @db-sync/*repo->latest-remote-tx
+               get-datascript-conn worker-state/get-datascript-conn
+               get-client-ops-conn worker-state/get-client-ops-conn
+               client {:repo repo
+                       :graph-id "graph-1"
+                       :ws (doto (js-obj)
+                             (aset "readyState" 1)
+                             (aset "send" (fn [raw]
+                                            (swap! sent conj
+                                                   (js->clj (js/JSON.parse raw)
+                                                            :keywordize-keys true)))))
+                       :ws-state (atom :open)
+                       :inflight (atom [])
+                       :send-queue (atom (p/resolved nil))
+                       :receive-queue (atom (p/resolved nil))
+                       :asset-queue (atom (p/resolved nil))
+                       :pending-pull-since (atom nil)
+                       :online-users (atom [])
+                       :reconnect (atom {:attempt 0 :timer nil})
+                       :stale-kill-timer (atom nil)
+                       :last-ws-message-ts (atom (common-util/time-ms))
+                       :last-sync-error (atom nil)}
+               client-atom (atom client)
+               config-atom (atom {:ws-url "wss://sync.example.test/sync/%s"})]
+           (swap! client-op/*repo->pending-local-tx-count dissoc repo)
+           (undo-redo/clear-history! repo)
+           (swap! db-sync/*repo->latest-remote-tx assoc repo 0)
+           (-> (p/with-redefs [worker-state/*db-sync-client client-atom
+                                worker-state/*db-sync-config config-atom
+                                worker-state/get-datascript-conn
+                                (fn [repo']
+                                  (if (= repo repo')
+                                    conn
+                                    (get-datascript-conn repo')))
+                                worker-state/get-client-ops-conn
+                                (fn [repo']
+                                  (if (= repo repo')
+                                    client-ops-conn
+                                    (get-client-ops-conn repo')))
+                                sync-util/get-graph-id (fn [_repo] "graph-1")
+                                sync-crypt/graph-e2ee? (constantly false)
+                                worker-state/online? (constantly true)
+                                shared-service/broadcast-to-clients! (fn [& _]
+                                                                       (swap! broadcasts inc))]
+                 (client-op/update-local-tx repo 0)
+                 (seed-client-op-txs!
+                  repo
+                  [{:db-sync/tx-id tx-id
+                    :db-sync/pending? true
+                    :db-sync/created-at 1
+                    :db-sync/outliner-op :save-block
+                    :db-sync/normalized-tx-data
+                    [[:db/add [:block/uuid (:block/uuid child1)]
+                      :block/title
+                      "pending active client flush"]]}])
+                 (p/let [_ (db-sync/start! repo)
+                         _ @(:send-queue client)]
+                   (is (= 1 @broadcasts))
+                   (is (= 0 (client-op/get-local-tx repo)))
+                   (is (= 0 (get @db-sync/*repo->latest-remote-tx repo)))
+                   (is (= [tx-id]
+                          (mapv :tx-id (#'sync-apply/pending-txs repo))))
+                   (is (nil? @(:last-sync-error client)))
+                   (is (= "tx/batch" (:type (first @sent))))
+                   (is (= [(str tx-id)]
+                          (mapv :tx-id (:txs (first @sent)))))
+                   (is (= [tx-id] @(:inflight client)))))
+               (p/catch (fn [error]
+                          (is nil (str error))))
+               (p/finally (fn []
+                            (undo-redo/clear-history! repo)
+                            (swap! client-op/*repo->pending-local-tx-count dissoc repo)
+                            (reset! db-sync/*repo->latest-remote-tx latest-prev)
+                            (done)))))))
+
 (deftest prepare-upload-tx-entries-drops-empty-txs-test
   (testing "empty tx rows should be dropped from upload batch"
     (let [{:keys [conn client-ops-conn child1]} (setup-parent-child)
@@ -1465,7 +1547,7 @@
                                                      vec))
                                            :outliner-op outliner-op})))]
               (doseq [tx-entry tx-entries]
-                (#'sync-handler/apply-tx-entry! server-conn tx-entry))
+                (#'sync-handler/apply-tx-entry! server-conn {} tx-entry))
               (is (= (sync-checksum/recompute-checksum @conn)
                      (sync-checksum/recompute-checksum @server-conn))))))))))
 
@@ -1494,7 +1576,7 @@
                                                    vec))
                                          :outliner-op outliner-op})))]
             (doseq [tx-entry tx-entries]
-              (#'sync-handler/apply-tx-entry! server-conn tx-entry))
+              (#'sync-handler/apply-tx-entry! server-conn {} tx-entry))
             (is (= (sync-checksum/recompute-checksum @conn)
                    (sync-checksum/recompute-checksum @server-conn)))))))))
 

--- a/src/test/frontend/worker/db_worker_test.cljs
+++ b/src/test/frontend/worker/db_worker_test.cljs
@@ -737,7 +737,10 @@
            request-asset "asset-1"
            request-email "user@example.com"
            request-opts {:force? true}]
-       (with-redefs [db-sync/status (fn [repo]
+       (with-redefs [db-worker/db-sync-dbs-open? (fn [repo]
+                                                   (swap! calls conj [:db-sync-dbs-open? repo])
+                                                   true)
+                     db-sync/status (fn [repo]
                                       (swap! calls conj [:status repo])
                                       status-result)
                      db-sync/start! (fn [repo]

--- a/src/test/frontend/worker/sync/restart_test.cljs
+++ b/src/test/frontend/worker/sync/restart_test.cljs
@@ -4,6 +4,7 @@
             [frontend.worker.shared-service :as shared-service]
             [frontend.worker.state :as worker-state]
             [frontend.worker.sync :as sync]
+            [frontend.worker.sync.client-op :as client-op]
             [frontend.worker.sync.util :as sync-util]
             [promesa.core :as p]))
 
@@ -40,7 +41,15 @@
              :crypto {}
              :timers {}
              :sqlite {}})
-           (-> (p/with-redefs [sync-util/get-graph-id (fn [_repo] graph-id)
+           (-> (p/with-redefs [worker-state/get-client-ops-conn (fn [_repo] true)
+                               client-op/get-local-tx (fn [_repo] 0)
+                               client-op/get-pending-local-tx-count (fn [_repo] 0)
+                               client-op/get-unpushed-asset-ops-count (fn [_repo] 0)
+                               client-op/get-all-asset-ops (fn [_repo] [])
+                               client-op/get-local-checksum (fn [_repo] nil)
+                               client-op/get-graph-uuid (fn [_repo] graph-id)
+                               client-op/update-graph-uuid (fn [_repo _graph-id] nil)
+                               sync-util/get-graph-id (fn [_repo] graph-id)
                                sync/<resolve-ws-token (fn [] (p/resolved "token"))
                                shared-service/broadcast-to-clients! (fn [& _] nil)]
                  (sync/start! repo))
@@ -48,6 +57,51 @@
                 (fn [_]
                   (is (= 1 @connect-calls)
                       "start! should reconnect when the cached websocket is already closed")))
+               (p/catch
+                (fn [error]
+                  (is false (str "unexpected error: " error))))
+               (p/finally
+                (fn []
+                  (reset! worker-state/*db-sync-client prev-client)
+                  (reset! worker-state/*db-sync-config prev-config)
+                  (when prev-platform
+                    (platform/set-platform! prev-platform))
+                  (done)))))))
+
+(deftest start-skips-when-client-op-local-tx-is-missing-test
+  (async done
+         (let [repo "missing-local-tx-repo"
+               graph-id "graph-1"
+               prev-client @worker-state/*db-sync-client
+               prev-config @worker-state/*db-sync-config
+               prev-platform (try
+                               (platform/current)
+                               (catch :default _ nil))
+               connect-calls (atom 0)]
+           (reset! worker-state/*db-sync-config {:ws-url "wss://sync.example.test/sync/%s"})
+           (reset! worker-state/*db-sync-client nil)
+           (platform/set-platform!
+            {:env {:runtime :node}
+             :storage {}
+             :kv {}
+             :broadcast {}
+             :websocket {:connect (fn [_url]
+                                    (swap! connect-calls inc)
+                                    #js {:readyState 0
+                                         :close (fn [] nil)})}
+             :crypto {}
+             :timers {}
+             :sqlite {}})
+           (-> (p/with-redefs [worker-state/get-client-ops-conn (fn [_repo] true)
+                               client-op/get-local-tx (fn [_repo] nil)
+                               client-op/update-local-tx (fn [_repo _tx]
+                                                           (throw (js/Error. "must not initialize missing local-tx to 0")))
+                               sync-util/get-graph-id (fn [_repo] graph-id)]
+                 (sync/start! repo))
+               (p/then
+                (fn [_]
+                  (is (zero? @connect-calls)
+                      "start! should wait for valid client-op local-tx instead of syncing from 0")))
                (p/catch
                 (fn [error]
                   (is false (str "unexpected error: " error))))

--- a/src/test/frontend/worker/sync/upload_test.cljs
+++ b/src/test/frontend/worker/sync/upload_test.cljs
@@ -1,6 +1,7 @@
 (ns frontend.worker.sync.upload-test
   (:require [cljs.test :refer [async deftest is]]
             [frontend.worker.sync.crypt :as sync-crypt]
+            [frontend.worker.sync.util :as sync-util]
             [frontend.worker.sync.upload :as sync-upload]
             [promesa.core :as p]
             [clojure.string :as string]))
@@ -115,6 +116,49 @@
                                  [:preflight true]
                                  [:create-aux "repo-1" {:graph-e2ee? true
                                                         :graph-ready-for-use? false}]]
+                                @calls*))))
+               (p/catch (fn [error]
+                          (is false (str "unexpected error: " error))))
+               (p/finally done)))))
+
+(deftest create-remote-graph-aux-skips-rsa-keys-for-non-e2ee-graph-test
+  (async done
+         (let [calls* (atom [])]
+           (-> (p/with-redefs [sync-crypt/<preflight-upload-e2ee! (fn [_repo graph-e2ee?]
+                                                                    (swap! calls* conj [:preflight graph-e2ee?])
+                                                                    (p/resolved nil))
+                               sync-upload/list-remote-graphs! (fn []
+                                                                  (swap! calls* conj [:list-remote-graphs])
+                                                                  (p/resolved []))
+                               sync-upload/http-base-url (fn [] "https://sync.example.test")
+                               sync-util/require-auth-token! (fn [context]
+                                                               (swap! calls* conj [:require-auth context]))
+                               sync-crypt/ensure-user-rsa-keys! (fn [opts]
+                                                                  (swap! calls* conj [:ensure-rsa opts])
+                                                                  (p/resolved nil))
+                               sync-util/fetch-json (fn [url request _opts]
+                                                      (swap! calls* conj [:fetch url request])
+                                                      (p/resolved {:graph-id "new-graph-id"
+                                                                   :graph-e2ee? false}))
+                               sync-upload/persist-upload-graph-identity! (fn [repo graph-id graph-e2ee?]
+                                                                            (swap! calls* conj [:persist repo graph-id graph-e2ee?])
+                                                                            {:graph-id graph-id
+                                                                             :graph-e2ee? graph-e2ee?})]
+                 (sync-upload/create-remote-graph! "repo-1" {:graph-e2ee? false
+                                                              :graph-ready-for-use? false}))
+               (p/then (fn [identity]
+                         (is (= {:graph-id "new-graph-id"
+                                 :graph-e2ee? false}
+                                identity))
+                         (is (not-any? #(= :ensure-rsa (first %)) @calls*))
+                         (is (= [[:list-remote-graphs]
+                                 [:preflight false]
+                                 [:require-auth {:repo "repo-1" :field :auth-token}]
+                                 [:fetch "https://sync.example.test/graphs"
+                                  {:method "POST"
+                                   :headers {"content-type" "application/json"}
+                                   :body "{\"graph-name\":\"repo-1\",\"schema-version\":null,\"graph-e2ee?\":false,\"graph-ready-for-use?\":false}"}]
+                                 [:persist "repo-1" "new-graph-id" false]]
                                 @calls*))))
                (p/catch (fn [error]
                           (is false (str "unexpected error: " error))))


### PR DESCRIPTION
## Summary
- add a GitHub workflow for CLI sync/offline stress testing
- expand the CLI concurrent edit stress harness and validation coverage
- fix non-E2EE local sync graph creation paths used by the stress workflow

## Verification
- bb dev:lint-and-test
- pnpm --dir deps/db-sync test:node-adapter
- opam exec -- dune runtest test
- bb -f cli-e2e/bb.edn test --skip-build
- bb -f cli-e2e/bb.edn test-sync --skip-build
- node --test scripts/cli-concurrent-edit-stress.test.mjs scripts/cli-sync-stress-workflow.test.mjs
- local 1000-op CLI sync/offline stress plus graph validate