### PR TITLE
fix(electron): build a fresh MCP server per session

### DIFF
--- a/src/electron/electron/mcp_server.cljs
+++ b/src/electron/electron/mcp_server.cljs
@@ -12,9 +12,11 @@
 (defonce ^:private transports
   (atom {}))
 
+(declare create-mcp-api-server)
+
 ;; See https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http
 ;; for how to respond to different MCP requests
-(defn handle-post-request [mcp-server {:keys [port host]} req res]
+(defn handle-post-request [api-fn {:keys [port host]} req res]
   (let [session-id (aget (.-headers req) "mcp-session-id")]
     (js/console.log "POST /mcp request" session-id (pr-str (.-body req)))
     (cond
@@ -27,7 +29,8 @@
       (let [transport (StreamableHTTPServerTransport.
                        #js {:sessionIdGenerator (comp str random-uuid)
                             :enableDnsRebindingProtection true
-                            :allowedHosts #js [(str host ":" port)]})]
+                            :allowedHosts #js [(str host ":" port)]})
+            mcp-server (create-mcp-api-server api-fn)]
         (set! (.-onclose transport)
               (fn []
                 (js/console.log "Transport closed" (.-sessionId transport))

--- a/src/electron/electron/server.cljs
+++ b/src/electron/electron/server.cljs
@@ -145,12 +145,11 @@
   (let [api-fn (fn api-fn [meth args]
                  (if-let [meth' (resolve-real-api-method meth)]
                    (invoke-logseq-api! meth' args)
-                   #js {:error (str "No method found for " (pr-str meth))}))
-        mcp-server (desktop-mcp-server/create-mcp-api-server api-fn)]
+                   #js {:error (str "No method found for " (pr-str meth))}))]
     (logger/debug "[server] MCP routes initialized")
     (.post server "/mcp"
-           #(desktop-mcp-server/handle-post-request mcp-server {:port (get-port)
-                                                                :host (get-host)} %1 %2))
+           #(desktop-mcp-server/handle-post-request api-fn {:port (get-port)
+                                                            :host (get-host)} %1 %2))
     (.get server "/mcp" desktop-mcp-server/handle-get-request)
     (.delete server "/mcp" desktop-mcp-server/handle-delete-request)))
 


### PR DESCRIPTION
## Problem

The `/mcp` endpoint only serves one client per Logseq launch. Every connection after the first hangs or errors until restart.

## Cause

`initialize-mcp-routes` builds one `McpServer` and reuses it for every session. The SDK's `Server` owns a single transport, so the second `(.connect mcp-server transport)` throws `Already connected to a transport` and wedges the endpoint.

## Fix

Create the server per session: `handle-post-request` takes `api-fn` and calls `create-mcp-api-server` in the init branch. This is what the SDK's streamable-HTTP examples do. The server is stateless (tools call `api-fn` against the live graph), so nothing is shared or lost.

## Testing

`clojure -M:cljs compile electron` compiles with 0 warnings. Driving the compiled `electron.mcp-server` with the shipped SDK (1.27.1): before, session 2 crashes at `mcp_server.cljs:35`; after, three sequential sessions connect and list tools.

Separate from logseq/logseq#12413 (a Fastify body-parser 400 on the same endpoint).
