### PR TITLE
fix: prefetch sync assets

### DIFF
--- a/src/main/frontend/handler/db_based/sync.cljs
+++ b/src/main/frontend/handler/db_based/sync.cljs
@@ -301,7 +301,10 @@
                        graph (str config/db-version-prefix graph-name)
                        _ (<ensure-download-runtime-bound! graph)
                        _ (state/<invoke-db-worker :thread-api/db-sync-download-graph-by-id
-                                                  graph graph-uuid graph-e2ee?)]
+                                                  graph graph-uuid graph-e2ee?)
+                       _ (when (util/electron?)
+                           (state/<invoke-db-worker :thread-api/db-sync-download-missing-assets
+                                                    graph graph-uuid))]
                  true)
                (p/rejected (ex-info "db-sync missing graph info"
                                     {:type :db-sync/invalid-graph

--- a/src/main/frontend/worker/db_core.cljs
+++ b/src/main/frontend/worker/db_core.cljs
@@ -755,6 +755,10 @@
   [repo asset-uuid]
   (db-sync/request-asset-download! repo asset-uuid))
 
+(def-thread-api :thread-api/db-sync-download-missing-assets
+  [repo graph-id]
+  (db-sync/download-missing-assets! repo graph-id))
+
 (def-thread-api :thread-api/db-sync-retry-asset-upload
   [repo]
   (db-sync/retry-asset-upload! repo))

--- a/src/main/frontend/worker/sync.cljs
+++ b/src/main/frontend/worker/sync.cljs
@@ -412,6 +412,10 @@
   [repo asset-uuid]
   (sync-apply/request-asset-download! repo asset-uuid))
 
+(defn download-missing-assets!
+  [repo graph-id]
+  (sync-assets/download-missing-remote-assets! repo graph-id))
+
 (defn retry-asset-upload!
   [repo]
   (when-let [client (current-client repo)]

--- a/src/main/frontend/worker/sync/assets.cljs
+++ b/src/main/frontend/worker/sync/assets.cljs
@@ -426,3 +426,44 @@
                   (p/catch (fn [e]
                              (log-request-asset-download-failed! repo asset-uuid e)
                              (p/rejected e)))))))))))
+
+(defn- remote-asset-download-candidates
+  [db]
+  (->> (d/q '[:find ?e ?asset-uuid ?asset-type
+              :where
+              [?asset-class :db/ident :logseq.class/Asset]
+              [?e :block/tags ?asset-class]
+              [?e :block/uuid ?asset-uuid]
+              [?e :logseq.property.asset/type ?asset-type]
+              [?e :logseq.property.asset/remote-metadata]]
+            db)
+       (keep (fn [[e asset-uuid asset-type]]
+               (let [ent (d/entity db e)]
+                 (when-not (seq (some-> (:logseq.property.asset/external-url ent) str))
+                   {:asset-uuid asset-uuid
+                    :asset-type asset-type}))))
+       (sort-by (comp str :asset-uuid))))
+
+(defn download-missing-remote-assets!
+  [repo graph-id]
+  (if-let [conn (worker-state/get-datascript-conn repo)]
+    (let [candidates (remote-asset-download-candidates @conn)
+          current-platform (platform/current)]
+      (reduce
+       (fn [result-promise {:keys [asset-uuid asset-type]}]
+         (p/let [result result-promise
+                 asset-id (str asset-uuid)
+                 meta (platform/asset-stat current-platform
+                                           repo
+                                           (asset-file-name asset-id asset-type))]
+           (if meta
+             (update result :skipped-existing inc)
+             (p/let [_ (download-remote-asset! repo graph-id asset-uuid asset-type)]
+               (update result :downloaded inc)))))
+       (p/resolved {:total (count candidates)
+                    :downloaded 0
+                    :skipped-existing 0})
+       candidates))
+    (p/rejected (ex-info "datascript connection not found"
+                         {:repo repo
+                          :graph-id graph-id}))))

--- a/src/main/logseq/cli/command/sync.cljs
+++ b/src/main/logseq/cli/command/sync.cljs
@@ -896,11 +896,14 @@
                                                    [(:repo action) graph-id (:graph-e2ee? remote-graph)])
                                  (p/finally (fn []
                                               (when-let [close! (:close! events-sub)]
-                                                (close!)))))]
+                                                (close!)))))
+                      assets-result (transport/invoke download-cfg :thread-api/db-sync-download-missing-assets
+                                                      [(:repo action) graph-id])]
                 {:status :ok
                  :data (if (map? result)
-                         result
-                         {:result result})})))
+                         (assoc result :assets assets-result)
+                         {:result result
+                          :assets assets-result})})))
           (p/then (fn [result]
                     (if (and (not graph-existed-before?)
                              (= :error (:status result)))

--- a/src/test/frontend/handler/db_based/sync_test.cljs
+++ b/src/test/frontend/handler/db_based/sync_test.cljs
@@ -633,6 +633,34 @@
                           (is false (str error))
                           (done)))))))
 
+(deftest rtc-download-graph-downloads-missing-assets-on-electron-test
+  (async done
+         (let [worker-calls (atom [])]
+           (-> (p/with-redefs [db-sync/http-base (fn [] "http://base")
+                               user-handler/task--ensure-id&access-token (fn [resolve _reject]
+                                                                           (resolve true))
+                               util/electron? (fn [] true)
+                               persist-db/<fetch-init-data (fn [_repo _opts]
+                                                             (p/resolved {:schema {}
+                                                                          :initial-data []}))
+                               state/<invoke-db-worker (fn [& args]
+                                                         (swap! worker-calls conj args)
+                                                         (p/resolved :ok))
+                               state/pub-event! (fn [& _] nil)
+                               state/set-state! (fn [& _] nil)]
+                 (db-sync/<rtc-download-graph! "db1" "graph-1" false))
+               (p/then (fn [_]
+                         (is (= [:thread-api/sync-app-state
+                                 :thread-api/db-sync-download-graph-by-id
+                                 :thread-api/db-sync-download-missing-assets]
+                                (mapv first @worker-calls)))
+                         (is (= ["logseq_db_db1" "graph-1"]
+                                (rest (nth @worker-calls 2))))
+                         (done)))
+               (p/catch (fn [error]
+                          (is false (str error))
+                          (done)))))))
+
 (deftest rtc-download-graph-skips-runtime-rebind-outside-electron-test
   (async done
          (let [runtime-rebind-calls (atom [])

--- a/src/test/frontend/worker/db_worker_test.cljs
+++ b/src/test/frontend/worker/db_worker_test.cljs
@@ -31,7 +31,8 @@
         (concat
          [:thread-api/list-db :thread-api/init :thread-api/set-db-sync-config :thread-api/get-db-sync-config
           :thread-api/db-sync-status :thread-api/db-sync-start :thread-api/db-sync-stop :thread-api/db-sync-update-presence
-          :thread-api/db-sync-request-asset-download :thread-api/db-sync-grant-graph-access :thread-api/db-sync-ensure-user-rsa-keys
+          :thread-api/db-sync-request-asset-download :thread-api/db-sync-download-missing-assets
+          :thread-api/db-sync-grant-graph-access :thread-api/db-sync-ensure-user-rsa-keys
           :thread-api/db-sync-list-remote-graphs :thread-api/db-sync-upload-graph :thread-api/db-sync-create-remote-graph
           :thread-api/db-sync-stop-upload :thread-api/db-sync-resume-upload :thread-api/db-sync-upload-stopped?
           :thread-api/db-sync-get-block-conflicts :thread-api/db-sync-clear-block-conflicts :thread-api/db-sync-download-graph-by-id
@@ -735,6 +736,7 @@
            request-graph-id "remote-graph-id"
            request-block "block-1"
            request-asset "asset-1"
+           download-missing-assets-result {:total 2 :downloaded 2 :skipped-existing 0}
            request-email "user@example.com"
            request-opts {:force? true}]
        (with-redefs [db-worker/db-sync-dbs-open? (fn [repo]
@@ -755,6 +757,9 @@
                      db-sync/request-asset-download! (fn [repo asset-uuid]
                                                        (swap! calls conj [:request-asset-download repo asset-uuid])
                                                        :asset-requested)
+                     db-sync/download-missing-assets! (fn [repo graph-id]
+                                                        (swap! calls conj [:download-missing-assets repo graph-id])
+                                                        download-missing-assets-result)
                      sync-crypt/<grant-graph-access! (fn [repo graph-id target-email]
                                                        (swap! calls conj [:grant-graph-access repo graph-id target-email])
                                                        :granted)
@@ -793,6 +798,8 @@
          (is (= :stopped ((get-thread-api :thread-api/db-sync-stop))))
          (is (= :presence-updated ((get-thread-api :thread-api/db-sync-update-presence) request-block)))
          (is (= :asset-requested ((get-thread-api :thread-api/db-sync-request-asset-download) request-repo request-asset)))
+         (is (= download-missing-assets-result
+                ((get-thread-api :thread-api/db-sync-download-missing-assets) request-repo request-graph-id)))
          (is (= :granted ((get-thread-api :thread-api/db-sync-grant-graph-access) request-repo request-graph-id request-email)))
          (is (= ensure-keys-result ((get-thread-api :thread-api/db-sync-ensure-user-rsa-keys) request-opts)))
          (is (= ensure-keys-result ((get-thread-api :thread-api/db-sync-ensure-user-rsa-keys))))

--- a/src/test/frontend/worker/sync/assets_test.cljs
+++ b/src/test/frontend/worker/sync/assets_test.cljs
@@ -234,3 +234,67 @@
                    (reset! worker-state/*db-sync-config db-sync-config)
                    (sync-assets/clear-missing-asset-upload-files! repo)
                    (done)))))))
+
+(deftest download-missing-remote-assets-downloads-only-missing-sync-assets-test
+  (async done
+         (let [repo "asset-prefetch-repo"
+               graph-id "graph-1"
+               missing-uuid (random-uuid)
+               existing-uuid (random-uuid)
+               local-uuid (random-uuid)
+               external-uuid (random-uuid)
+               conn (d/create-conn db-schema/schema)
+               stat-calls (atom [])
+               download-calls (atom [])]
+           (ldb/transact!
+            conn
+            [{:db/ident :logseq.class/Asset}
+             {:block/uuid missing-uuid
+              :block/tags #{:logseq.class/Asset}
+              :logseq.property.asset/type "png"
+              :logseq.property.asset/checksum "missing-checksum"
+              :logseq.property.asset/remote-metadata {:checksum "missing-checksum"
+                                                      :type "png"}}
+             {:block/uuid existing-uuid
+              :block/tags #{:logseq.class/Asset}
+              :logseq.property.asset/type "pdf"
+              :logseq.property.asset/checksum "existing-checksum"
+              :logseq.property.asset/remote-metadata {:checksum "existing-checksum"
+                                                      :type "pdf"}}
+             {:block/uuid local-uuid
+              :block/tags #{:logseq.class/Asset}
+              :logseq.property.asset/type "jpg"
+              :logseq.property.asset/checksum "local-checksum"}
+             {:block/uuid external-uuid
+              :block/tags #{:logseq.class/Asset}
+              :logseq.property.asset/type "gif"
+              :logseq.property.asset/checksum "external-checksum"
+              :logseq.property.asset/remote-metadata {:checksum "external-checksum"
+                                                      :type "gif"}
+              :logseq.property.asset/external-url "https://example.com/asset.gif"}])
+           (-> (p/with-redefs [worker-state/get-datascript-conn (fn [_repo]
+                                                                  conn)
+                               platform/current (fn [] {})
+                               platform/asset-stat
+                               (fn [_platform repo' file-name]
+                                 (swap! stat-calls conj [repo' file-name])
+                                 (p/resolved (when (= file-name (str existing-uuid ".pdf"))
+                                               {:size 10})))
+                               sync-assets/download-remote-asset!
+                               (fn [& args]
+                                 (swap! download-calls conj args)
+                                 (p/resolved nil))]
+                 (sync-assets/download-missing-remote-assets! repo graph-id))
+               (p/then (fn [result]
+                         (is (= {:total 2
+                                 :downloaded 1
+                                 :skipped-existing 1}
+                                result))
+                         (is (= #{[repo (str existing-uuid ".pdf")]
+                                  [repo (str missing-uuid ".png")]}
+                                (set @stat-calls)))
+                         (is (= [[repo graph-id missing-uuid "png"]]
+                                @download-calls))))
+               (p/catch (fn [error]
+                          (is false (str "unexpected error: " error))))
+               (p/finally done)))))

--- a/src/test/logseq/cli/command/sync_test.cljs
+++ b/src/test/logseq/cli/command/sync_test.cljs
@@ -1135,6 +1135,45 @@
                           (is false (str "unexpected error: " e))))
                (p/finally done)))))
 
+(deftest test-execute-sync-download-prefetches-missing-assets
+  (async done
+         (let [invoke-calls (atom [])]
+           (-> (p/with-redefs [cli-server/list-graphs (fn [_config]
+                                                        [])
+                               cli-server/ensure-server! (fn [config _repo]
+                                                           (p/resolved (assoc config :base-url "http://example")))
+                               transport/invoke (fn [_ method args]
+                                                  (swap! invoke-calls conj [method args])
+                                                  (case method
+                                                    :thread-api/db-sync-list-remote-graphs
+                                                    (p/resolved [{:graph-id "remote-graph-id"
+                                                                  :graph-name "demo"
+                                                                  :graph-e2ee? false}])
+                                                    :thread-api/q
+                                                    (p/resolved 0)
+                                                    :thread-api/db-sync-download-graph-by-id
+                                                    (p/resolved {:ok true})
+                                                    :thread-api/db-sync-download-missing-assets
+                                                    (p/resolved {:total 2
+                                                                 :downloaded 2
+                                                                 :skipped-existing 0})
+                                                    (p/resolved nil)))]
+                 (p/let [result (execute-with-runtime-auth {:type :sync-download
+                                                            :repo "logseq_db_demo"
+                                                            :graph "demo"}
+                                                           {:base-url "http://example"
+                                                            :root-dir "/tmp"})]
+                   (is (= :ok (:status result)))
+                   (is (= [:thread-api/db-sync-download-graph-by-id ["logseq_db_demo" "remote-graph-id" false]]
+                          (some #(when (= :thread-api/db-sync-download-graph-by-id (first %)) %)
+                                @invoke-calls)))
+                   (is (= [:thread-api/db-sync-download-missing-assets ["logseq_db_demo" "remote-graph-id"]]
+                          (some #(when (= :thread-api/db-sync-download-missing-assets (first %)) %)
+                                @invoke-calls)))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
 (deftest test-execute-sync-download-uses-long-timeout-only-for-download-invoke
   (async done
          (let [invoke-calls (atom [])]


### PR DESCRIPTION
## Summary

- Download missing sync-backed assets after desktop graph download completes.
- Download missing sync-backed assets after CLI `sync download` completes for CI/local automation.
- Keep web and mobile asset behavior lazy through the existing request-on-access flow.

## Why

A user can delete a remote graph before every asset has been materialized locally. Desktop and CI downloads now fully hydrate missing sync assets from the downloaded graph so local data is complete before remote deletion can cause asset loss.

## Validation

- `bb dev:test -v logseq.cli.command.sync-test`
- `bb dev:test -v frontend.handler.db-based.sync-test`
- `bb dev:test -v frontend.worker.sync.assets-test`
- `bb dev:test -v frontend.worker.db-worker-test`
- `git diff --check`