### PR TITLE
fix: prefetch sync assets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,9 @@
 ## Commit & Pull Request Guidelines
 - Commit subjects are short and imperative; optional scope prefixes appear (e.g., `fix:` or `enhance(rtc):`).
 - PRs should describe the behavior change, link relevant issues, and note any test coverage added or skipped.
+- Never include the word "Codex" or any agent name in commit subjects, commit bodies, trailers, branch names, PR titles, or PR descriptions.
+- PR titles must describe the code change only.
+- Before creating or updating commits or PRs, verify that the generated metadata does not contain "Codex" or any agent name in any casing.
 
 ## Agent-Specific Notes
 - Use repo-local skills discovered under `.agents/skills/`; load the matching `SKILL.md` before editing files or proposing changes.

--- a/src/main/frontend/handler/db_based/sync.cljs
+++ b/src/main/frontend/handler/db_based/sync.cljs
@@ -301,7 +301,10 @@
                        graph (str config/db-version-prefix graph-name)
                        _ (<ensure-download-runtime-bound! graph)
                        _ (state/<invoke-db-worker :thread-api/db-sync-download-graph-by-id
-                                                  graph graph-uuid graph-e2ee?)]
+                                                  graph graph-uuid graph-e2ee?)
+                       _ (when (util/electron?)
+                           (state/<invoke-db-worker :thread-api/db-sync-download-missing-assets
+                                                    graph graph-uuid))]
                  true)
                (p/rejected (ex-info "db-sync missing graph info"
                                     {:type :db-sync/invalid-graph

--- a/src/main/frontend/worker/db_core.cljs
+++ b/src/main/frontend/worker/db_core.cljs
@@ -755,6 +755,10 @@
   [repo asset-uuid]
   (db-sync/request-asset-download! repo asset-uuid))
 
+(def-thread-api :thread-api/db-sync-download-missing-assets
+  [repo graph-id]
+  (db-sync/download-missing-assets! repo graph-id))
+
 (def-thread-api :thread-api/db-sync-retry-asset-upload
   [repo]
   (db-sync/retry-asset-upload! repo))

--- a/src/main/frontend/worker/sync.cljs
+++ b/src/main/frontend/worker/sync.cljs
@@ -412,6 +412,10 @@
   [repo asset-uuid]
   (sync-apply/request-asset-download! repo asset-uuid))
 
+(defn download-missing-assets!
+  [repo graph-id]
+  (sync-assets/download-missing-remote-assets! repo graph-id))
+
 (defn retry-asset-upload!
   [repo]
   (when-let [client (current-client repo)]

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -1479,7 +1479,8 @@
                                   (mapcat :repair-block-uuids)
                                   (remove (set prefetched-repair-block-uuids))
                                   distinct
-                                  vec)})
+                                  vec)
+         :remote-asset-tx-data (mapcat (comp :tx-data :report) @*remote-tx-results)})
 
       (catch :default e
         (js/console.error e)
@@ -1504,7 +1505,8 @@
     {:repair-block-uuids (->> @remote-tx-results
                               (mapcat :repair-block-uuids)
                               distinct
-                              vec)}))
+                              vec)
+     :remote-asset-tx-data (mapcat (comp :tx-data :report) @remote-tx-results)}))
 
 (defn- report-apply-remote-txs-error!
   [error {:keys [has-local-changes? remote-txs local-txs]}]
@@ -1524,17 +1526,37 @@
       (log/error :db-sync/report-apply-remote-txs-error-failed
                  {:error report-error}))))
 
-(defn- finish-apply-remote-txs!
+(defn- eager-remote-asset-download-owner?
+  []
+  (contains? #{:cli :electron}
+             (try
+               (platform/env-flag (platform/current) :owner-source)
+               (catch :default _
+                 nil))))
+
+(defn- download-missing-remote-assets-for-owner!
   [repo client remote-tx-data]
+  (when (and (:graph-id client)
+             (eager-remote-asset-download-owner?))
+    (let [candidates (some-> (worker-state/get-datascript-conn repo)
+                             deref
+                             (sync-assets/remote-asset-download-candidates-in-tx remote-tx-data))]
+      (when (seq candidates)
+        (sync-assets/download-remote-assets-if-missing! repo (:graph-id client) candidates)))))
+
+(defn- finish-apply-remote-txs!
+  [repo client remote-tx-data remote-asset-tx-data]
   (when-let [*inflight (:inflight client)]
     (reset! *inflight []))
 
-  (when-let [result (rehydrate-large-titles! repo {:tx-data remote-tx-data
-                                                   :graph-id (:graph-id client)})]
-    (p/catch result
-             (fn [error]
-               (log/error :db-sync/large-title-rehydrate-failed
-                          {:repo repo :error error})))))
+  (p/let [_ (when-let [result (rehydrate-large-titles! repo {:tx-data remote-tx-data
+                                                             :graph-id (:graph-id client)})]
+              (p/catch result
+                       (fn [error]
+                         (log/error :db-sync/large-title-rehydrate-failed
+                                    {:repo repo :error error}))))
+          _ (download-missing-remote-assets-for-owner! repo client remote-asset-tx-data)]
+    nil))
 
 (defn- after-repair-result
   [repair-result f]
@@ -1594,14 +1616,15 @@
                                :local-txs local-txs})
                              (throw error)))))
         finish-apply-result (fn [apply-result*]
-                              (let [repair-block-uuids (:repair-block-uuids apply-result*)]
+                              (let [repair-block-uuids (:repair-block-uuids apply-result*)
+                                    remote-asset-tx-data (:remote-asset-tx-data apply-result*)]
                                 (if (seq repair-block-uuids)
                                   (let [repair-result (<apply-server-repair-blocks!
                                                        repo client (:conn apply-context) repair-block-uuids)]
                                     (after-repair-result
                                      repair-result
-                                     #(finish-apply-remote-txs! repo client remote-tx-data)))
-                                  (finish-apply-remote-txs! repo client remote-tx-data))))]
+                                     #(finish-apply-remote-txs! repo client remote-tx-data remote-asset-tx-data)))
+                                  (finish-apply-remote-txs! repo client remote-tx-data remote-asset-tx-data))))]
     (if (contains? apply-result ::retry-result)
       (::retry-result apply-result)
       (finish-apply-result apply-result))))

--- a/src/main/frontend/worker/sync/assets.cljs
+++ b/src/main/frontend/worker/sync/assets.cljs
@@ -426,3 +426,44 @@
                   (p/catch (fn [e]
                              (log-request-asset-download-failed! repo asset-uuid e)
                              (p/rejected e)))))))))))
+
+(defn- remote-asset-download-candidates
+  [db]
+  (->> (d/q '[:find ?e ?asset-uuid ?asset-type
+              :where
+              [?asset-class :db/ident :logseq.class/Asset]
+              [?e :block/tags ?asset-class]
+              [?e :block/uuid ?asset-uuid]
+              [?e :logseq.property.asset/type ?asset-type]
+              [?e :logseq.property.asset/remote-metadata]]
+            db)
+       (keep (fn [[e asset-uuid asset-type]]
+               (let [ent (d/entity db e)]
+                 (when-not (seq (some-> (:logseq.property.asset/external-url ent) str))
+                   {:asset-uuid asset-uuid
+                    :asset-type asset-type}))))
+       (sort-by (comp str :asset-uuid))))
+
+(defn download-missing-remote-assets!
+  [repo graph-id]
+  (if-let [conn (worker-state/get-datascript-conn repo)]
+    (let [candidates (remote-asset-download-candidates @conn)
+          current-platform (platform/current)]
+      (reduce
+       (fn [result-promise {:keys [asset-uuid asset-type]}]
+         (p/let [result result-promise
+                 asset-id (str asset-uuid)
+                 meta (platform/asset-stat current-platform
+                                           repo
+                                           (asset-file-name asset-id asset-type))]
+           (if meta
+             (update result :skipped-existing inc)
+             (p/let [_ (download-remote-asset! repo graph-id asset-uuid asset-type)]
+               (update result :downloaded inc)))))
+       (p/resolved {:total (count candidates)
+                    :downloaded 0
+                    :skipped-existing 0})
+       candidates))
+    (p/rejected (ex-info "datascript connection not found"
+                         {:repo repo
+                          :graph-id graph-id}))))

--- a/src/main/frontend/worker/sync/assets.cljs
+++ b/src/main/frontend/worker/sync/assets.cljs
@@ -21,6 +21,8 @@
 (defonce *repo->missing-asset-upload-files
   (atom {}))
 
+(def ^:private remote-asset-download-parallelism 10)
+
 (defn graph-aes-key
   [repo graph-id fail-fast-f]
   (if (sync-crypt/graph-e2ee? repo)
@@ -451,72 +453,49 @@
                                   (and asset-uuid (seq asset-type))))
                         distinct
                         (sort-by (juxt (comp str :asset-uuid) :asset-type)))
-        current-platform (platform/current)]
-    (reduce
-     (fn [result-promise {:keys [asset-uuid asset-type]}]
-       (p/let [result result-promise
-               asset-id (str asset-uuid)
-               meta (platform/asset-stat current-platform
-                                         repo
-                                         (asset-file-name asset-id asset-type))]
-         (if meta
-           (update result :skipped-existing inc)
-           (p/let [_ (download-remote-asset! repo graph-id asset-uuid asset-type)]
-             (update result :downloaded inc)))))
-     (p/resolved {:total (count candidates)
-                  :downloaded 0
-                  :skipped-existing 0})
-     candidates)))
-
-(defn- tx-item-components
-  [item]
-  (cond
-    (vector? item)
-    (when (#{:db/add :db/retract} (first item))
-      {:op (first item)
-       :e (second item)
-       :a (nth item 2 nil)
-       :v (nth item 3 nil)})
-
-    :else
-    (let [a (:a item)]
-      (when a
-        {:op (if (:added item) :db/add :db/retract)
-         :e (:e item)
-         :a a
-         :v (:v item)}))))
-
-(def ^:private remote-asset-candidate-attrs
-  #{:block/tags
-    :logseq.property.asset/type
-    :logseq.property.asset/remote-metadata
-    :logseq.property.asset/external-url})
-
-(defn- asset-entity?
-  [ent]
-  (some (fn [tag]
-          (= :logseq.class/Asset (:db/ident tag)))
-        (:block/tags ent)))
+        current-platform (platform/current)
+        queue (atom (vec candidates))
+        result (atom {:total (count candidates)
+                      :downloaded 0
+                      :skipped-existing 0})
+        pop-queue! (fn []
+                     (let [selected (atom nil)]
+                       (swap! queue
+                              (fn [q]
+                                (if (seq q)
+                                  (do
+                                    (reset! selected (first q))
+                                    (subvec q 1))
+                                  q)))
+                       @selected))
+        worker (fn worker []
+                 (if-let [{:keys [asset-uuid asset-type]} (pop-queue!)]
+                   (let [asset-id (str asset-uuid)]
+                     (p/let [meta (platform/asset-stat current-platform
+                                                       repo
+                                                       (asset-file-name asset-id asset-type))
+                             _ (if meta
+                                 (do
+                                   (swap! result update :skipped-existing inc)
+                                   nil)
+                                 (p/let [_ (download-remote-asset! repo graph-id asset-uuid asset-type)]
+                                   (swap! result update :downloaded inc)))]
+                       (worker)))
+                   (p/resolved nil)))]
+    (p/let [_ (p/all (mapv (fn [_] (worker))
+                           (range (min remote-asset-download-parallelism
+                                       (count candidates)))))]
+      @result)))
 
 (defn remote-asset-download-candidates-in-tx
   [db tx-data]
   (->> tx-data
-       (keep tx-item-components)
-       (keep (fn [{:keys [e a]}]
-               (when (contains? remote-asset-candidate-attrs a)
-                 e)))
-       distinct
-       (keep (fn [e]
-               (when-let [ent (d/entity db e)]
-                 (when (and (asset-entity? ent)
-                            (:logseq.property.asset/remote-metadata ent)
-                            (not (seq (some-> (:logseq.property.asset/external-url ent) str))))
-                   {:asset-uuid (:block/uuid ent)
-                    :asset-type (:logseq.property.asset/type ent)}))))
-       (filter (fn [{:keys [asset-uuid asset-type]}]
-                 (and asset-uuid (seq asset-type))))
-       distinct
-       (sort-by (juxt (comp str :asset-uuid) :asset-type))))
+       (keep (fn [d]
+               (when (and (= (:a d) :logseq.property.asset/remote-metadata) (:added d))
+                 (when-let [asset (d/entity db (:e d))]
+                   {:asset-uuid (:block/uuid asset)
+                    :asset-type (:logseq.property.asset/type asset)}))))
+       distinct))
 
 (defn download-missing-remote-assets!
   [repo graph-id]

--- a/src/main/frontend/worker/sync/assets.cljs
+++ b/src/main/frontend/worker/sync/assets.cljs
@@ -444,26 +444,85 @@
                     :asset-type asset-type}))))
        (sort-by (comp str :asset-uuid))))
 
+(defn download-remote-assets-if-missing!
+  [repo graph-id candidates]
+  (let [candidates (->> candidates
+                        (filter (fn [{:keys [asset-uuid asset-type]}]
+                                  (and asset-uuid (seq asset-type))))
+                        distinct
+                        (sort-by (juxt (comp str :asset-uuid) :asset-type)))
+        current-platform (platform/current)]
+    (reduce
+     (fn [result-promise {:keys [asset-uuid asset-type]}]
+       (p/let [result result-promise
+               asset-id (str asset-uuid)
+               meta (platform/asset-stat current-platform
+                                         repo
+                                         (asset-file-name asset-id asset-type))]
+         (if meta
+           (update result :skipped-existing inc)
+           (p/let [_ (download-remote-asset! repo graph-id asset-uuid asset-type)]
+             (update result :downloaded inc)))))
+     (p/resolved {:total (count candidates)
+                  :downloaded 0
+                  :skipped-existing 0})
+     candidates)))
+
+(defn- tx-item-components
+  [item]
+  (cond
+    (vector? item)
+    (when (#{:db/add :db/retract} (first item))
+      {:op (first item)
+       :e (second item)
+       :a (nth item 2 nil)
+       :v (nth item 3 nil)})
+
+    :else
+    (let [a (:a item)]
+      (when a
+        {:op (if (:added item) :db/add :db/retract)
+         :e (:e item)
+         :a a
+         :v (:v item)}))))
+
+(def ^:private remote-asset-candidate-attrs
+  #{:block/tags
+    :logseq.property.asset/type
+    :logseq.property.asset/remote-metadata
+    :logseq.property.asset/external-url})
+
+(defn- asset-entity?
+  [ent]
+  (some (fn [tag]
+          (= :logseq.class/Asset (:db/ident tag)))
+        (:block/tags ent)))
+
+(defn remote-asset-download-candidates-in-tx
+  [db tx-data]
+  (->> tx-data
+       (keep tx-item-components)
+       (keep (fn [{:keys [e a]}]
+               (when (contains? remote-asset-candidate-attrs a)
+                 e)))
+       distinct
+       (keep (fn [e]
+               (when-let [ent (d/entity db e)]
+                 (when (and (asset-entity? ent)
+                            (:logseq.property.asset/remote-metadata ent)
+                            (not (seq (some-> (:logseq.property.asset/external-url ent) str))))
+                   {:asset-uuid (:block/uuid ent)
+                    :asset-type (:logseq.property.asset/type ent)}))))
+       (filter (fn [{:keys [asset-uuid asset-type]}]
+                 (and asset-uuid (seq asset-type))))
+       distinct
+       (sort-by (juxt (comp str :asset-uuid) :asset-type))))
+
 (defn download-missing-remote-assets!
   [repo graph-id]
   (if-let [conn (worker-state/get-datascript-conn repo)]
-    (let [candidates (remote-asset-download-candidates @conn)
-          current-platform (platform/current)]
-      (reduce
-       (fn [result-promise {:keys [asset-uuid asset-type]}]
-         (p/let [result result-promise
-                 asset-id (str asset-uuid)
-                 meta (platform/asset-stat current-platform
-                                           repo
-                                           (asset-file-name asset-id asset-type))]
-           (if meta
-             (update result :skipped-existing inc)
-             (p/let [_ (download-remote-asset! repo graph-id asset-uuid asset-type)]
-               (update result :downloaded inc)))))
-       (p/resolved {:total (count candidates)
-                    :downloaded 0
-                    :skipped-existing 0})
-       candidates))
+    (download-remote-assets-if-missing!
+     repo graph-id (remote-asset-download-candidates @conn))
     (p/rejected (ex-info "datascript connection not found"
                          {:repo repo
                           :graph-id graph-id}))))

--- a/src/main/logseq/cli/command/sync.cljs
+++ b/src/main/logseq/cli/command/sync.cljs
@@ -897,7 +897,7 @@
                                  (p/finally (fn []
                                               (when-let [close! (:close! events-sub)]
                                                 (close!)))))
-                      assets-result (transport/invoke download-cfg :thread-api/db-sync-download-missing-assets
+                      assets-result (transport/invoke cfg :thread-api/db-sync-download-missing-assets
                                                       [(:repo action) graph-id])]
                 {:status :ok
                  :data (if (map? result)

--- a/src/main/logseq/cli/command/sync.cljs
+++ b/src/main/logseq/cli/command/sync.cljs
@@ -896,11 +896,14 @@
                                                    [(:repo action) graph-id (:graph-e2ee? remote-graph)])
                                  (p/finally (fn []
                                               (when-let [close! (:close! events-sub)]
-                                                (close!)))))]
+                                                (close!)))))
+                      assets-result (transport/invoke download-cfg :thread-api/db-sync-download-missing-assets
+                                                      [(:repo action) graph-id])]
                 {:status :ok
                  :data (if (map? result)
-                         result
-                         {:result result})})))
+                         (assoc result :assets assets-result)
+                         {:result result
+                          :assets assets-result})})))
           (p/then (fn [result]
                     (if (and (not graph-existed-before?)
                              (= :error (:status result)))

--- a/src/test/frontend/handler/db_based/sync_test.cljs
+++ b/src/test/frontend/handler/db_based/sync_test.cljs
@@ -633,6 +633,34 @@
                           (is false (str error))
                           (done)))))))
 
+(deftest rtc-download-graph-downloads-missing-assets-on-electron-test
+  (async done
+         (let [worker-calls (atom [])]
+           (-> (p/with-redefs [db-sync/http-base (fn [] "http://base")
+                               user-handler/task--ensure-id&access-token (fn [resolve _reject]
+                                                                           (resolve true))
+                               util/electron? (fn [] true)
+                               persist-db/<fetch-init-data (fn [_repo _opts]
+                                                             (p/resolved {:schema {}
+                                                                          :initial-data []}))
+                               state/<invoke-db-worker (fn [& args]
+                                                         (swap! worker-calls conj args)
+                                                         (p/resolved :ok))
+                               state/pub-event! (fn [& _] nil)
+                               state/set-state! (fn [& _] nil)]
+                 (db-sync/<rtc-download-graph! "db1" "graph-1" false))
+               (p/then (fn [_]
+                         (is (= [:thread-api/sync-app-state
+                                 :thread-api/db-sync-download-graph-by-id
+                                 :thread-api/db-sync-download-missing-assets]
+                                (mapv first @worker-calls)))
+                         (is (= ["logseq_db_db1" "graph-1"]
+                                (rest (nth @worker-calls 2))))
+                         (done)))
+               (p/catch (fn [error]
+                          (is false (str error))
+                          (done)))))))
+
 (deftest rtc-download-graph-skips-runtime-rebind-outside-electron-test
   (async done
          (let [runtime-rebind-calls (atom [])

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -1459,6 +1459,115 @@
                                              :where [?e :block/title "remote-migration-only"]]
                                         @conn))))))))))
 
+(defn- remote-asset-tx-data
+  [asset-uuid page-uuid title]
+  [[:db/add -1 :block/uuid asset-uuid]
+   [:db/add -1 :block/title title]
+   [:db/add -1 :block/parent [:block/uuid page-uuid]]
+   [:db/add -1 :block/page [:block/uuid page-uuid]]
+   [:db/add -1 :block/order "a0"]
+   [:db/add -1 :block/created-at 1760000000000]
+   [:db/add -1 :block/updated-at 1760000000000]
+   [:db/add -1 :block/tags :logseq.class/Asset]
+   [:db/add -1 :logseq.property.asset/type "png"]
+   [:db/add -1 :logseq.property.asset/size 42]
+   [:db/add -1 :logseq.property.asset/checksum "remote-checksum"]
+   [:db/add -1 :logseq.property.asset/remote-metadata {:checksum "remote-checksum"
+                                                       :type "png"}]])
+
+(defn- minimal-platform
+  [owner-source]
+  {:env {:runtime (if (= :browser owner-source) :browser :node)
+         :owner-source owner-source}
+   :storage {}
+   :kv {}
+   :broadcast {}
+   :websocket {}
+   :crypto {}
+   :timers {}
+   :sqlite {}})
+
+(defn- apply-remote-asset-tx-with-owner-source
+  [owner-source calls]
+  (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
+        page-uuid (:block/uuid (:block/page parent))
+        asset-uuid (random-uuid)
+        title (str "remote-" (name owner-source) "-asset.png")
+        client (test-sync-client)]
+    (platform/set-platform! (minimal-platform owner-source))
+    (with-datascript-conns
+      conn
+      client-ops-conn
+      (fn []
+        (p/with-redefs [sync-assets/download-missing-remote-assets!
+                        (fn [& _args]
+                          (throw (ex-info "incremental sync should not scan all assets" {})))
+                        sync-assets/download-remote-assets-if-missing!
+                        (fn [repo graph-id candidates]
+                          (swap! calls conj [owner-source repo graph-id (mapv :asset-type candidates)])
+                          (p/resolved {:total 1
+                                       :downloaded 1
+                                       :skipped-existing 0}))]
+          (p/let [_ (#'sync-apply/apply-remote-txs!
+                     test-repo client [{:tx-data (remote-asset-tx-data asset-uuid page-uuid title)}])]
+            (is (= title (:block/title (d/entity @conn [:block/uuid asset-uuid]))))))))))
+
+(deftest apply-remote-txs-downloads-missing-assets-for-cli-and-desktop-test
+  (async done
+         (let [platform-prev (try
+                               (platform/current)
+                               (catch :default _ nil))
+               calls (atom [])]
+           (-> (p/let [_ (apply-remote-asset-tx-with-owner-source :cli calls)
+                       _ (apply-remote-asset-tx-with-owner-source :electron calls)]
+                 (is (some #{[:cli test-repo "graph-1" ["png"]]} @calls))
+                 (is (some #{[:electron test-repo "graph-1" ["png"]]} @calls)))
+               (p/catch (fn [error]
+                          (is false (str "unexpected error: " error))))
+               (p/finally
+                (fn []
+                  (when platform-prev
+                    (platform/set-platform! platform-prev))
+                  (done)))))))
+
+(deftest apply-remote-txs-keeps-browser-assets-lazy-test
+  (async done
+    (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
+          page-uuid (:block/uuid (:block/page parent))
+          asset-uuid (random-uuid)
+          title "remote-browser-asset.png"
+          client (test-sync-client)
+          calls (atom [])
+          platform-prev (try
+                          (platform/current)
+                          (catch :default _ nil))]
+      (platform/set-platform! (minimal-platform :browser))
+      (-> (with-datascript-conns
+            conn
+            client-ops-conn
+            (fn []
+              (p/with-redefs [sync-assets/download-missing-remote-assets!
+                              (fn [& _args]
+                                (throw (ex-info "browser sync should not eagerly download assets" {})))
+                              sync-assets/download-remote-assets-if-missing!
+                              (fn [repo graph-id candidates]
+                                (swap! calls conj [repo graph-id candidates])
+                                (p/resolved {:total 1
+                                             :downloaded 1
+                                             :skipped-existing 0}))]
+                (p/let [_ (#'sync-apply/apply-remote-txs!
+                           test-repo client [{:tx-data (remote-asset-tx-data asset-uuid page-uuid title)}])]
+                  (is (= title (:block/title (d/entity @conn [:block/uuid asset-uuid]))))))))
+          (p/then (fn [_]
+                    (is (= [] @calls))))
+          (p/catch (fn [error]
+                     (is false (str "unexpected error: " error))))
+          (p/finally
+            (fn []
+              (when platform-prev
+                (platform/set-platform! platform-prev))
+              (done)))))))
+
 (deftest apply-repair-tx-data-uses-maintenance-tx-meta-test
   (testing "server repair txs should not be treated as local user ops"
     (let [tx-metas (atom [])]

--- a/src/test/frontend/worker/db_worker_test.cljs
+++ b/src/test/frontend/worker/db_worker_test.cljs
@@ -31,7 +31,8 @@
         (concat
          [:thread-api/list-db :thread-api/init :thread-api/set-db-sync-config :thread-api/get-db-sync-config
           :thread-api/db-sync-status :thread-api/db-sync-start :thread-api/db-sync-stop :thread-api/db-sync-update-presence
-          :thread-api/db-sync-request-asset-download :thread-api/db-sync-grant-graph-access :thread-api/db-sync-ensure-user-rsa-keys
+          :thread-api/db-sync-request-asset-download :thread-api/db-sync-download-missing-assets
+          :thread-api/db-sync-grant-graph-access :thread-api/db-sync-ensure-user-rsa-keys
           :thread-api/db-sync-list-remote-graphs :thread-api/db-sync-upload-graph :thread-api/db-sync-create-remote-graph
           :thread-api/db-sync-stop-upload :thread-api/db-sync-resume-upload :thread-api/db-sync-upload-stopped?
           :thread-api/db-sync-get-block-conflicts :thread-api/db-sync-clear-block-conflicts :thread-api/db-sync-download-graph-by-id
@@ -735,6 +736,7 @@
            request-graph-id "remote-graph-id"
            request-block "block-1"
            request-asset "asset-1"
+           download-missing-assets-result {:total 2 :downloaded 2 :skipped-existing 0}
            request-email "user@example.com"
            request-opts {:force? true}]
        (with-redefs [db-worker/db-sync-dbs-open? (fn [repo]
@@ -755,6 +757,9 @@
                      db-sync/request-asset-download! (fn [repo asset-uuid]
                                                        (swap! calls conj [:request-asset-download repo asset-uuid])
                                                        :asset-requested)
+                     db-sync/download-missing-assets! (fn [repo graph-id]
+                                                        (swap! calls conj [:download-missing-assets repo graph-id])
+                                                        download-missing-assets-result)
                      sync-crypt/<grant-graph-access! (fn [repo graph-id target-email]
                                                        (swap! calls conj [:grant-graph-access repo graph-id target-email])
                                                        :granted)
@@ -793,6 +798,8 @@
          (is (= :stopped ((get-thread-api :thread-api/db-sync-stop))))
          (is (= :presence-updated ((get-thread-api :thread-api/db-sync-update-presence) request-block)))
          (is (= :asset-requested ((get-thread-api :thread-api/db-sync-request-asset-download) request-repo request-asset)))
+         (is (= download-missing-assets-result
+                ((get-thread-api :thread-api/db-sync-download-missing-assets) request-repo request-graph-id)))
          (is (= :granted ((get-thread-api :thread-api/db-sync-grant-graph-access) request-repo request-graph-id request-email)))
          (is (= ensure-keys-result ((get-thread-api :thread-api/db-sync-ensure-user-rsa-keys) request-opts)))
          (is (= ensure-keys-result ((get-thread-api :thread-api/db-sync-ensure-user-rsa-keys))))

--- a/src/test/frontend/worker/db_worker_test.cljs
+++ b/src/test/frontend/worker/db_worker_test.cljs
@@ -723,107 +723,118 @@
     (is (empty? missing) (str "Missing thread apis: " missing))
     (is (empty? non-functions) (str "Non-function thread apis: " non-functions))))
 
+(defn- with-db-sync-core-wrapper-redefs
+  [calls f]
+  (let [results {:status {:state :connected}
+                 :ensure-keys {:ok true}
+                 :list-graphs [{:graph-id "g1"}]
+                 :upload-stopped? true
+                 :conflicts [{:op :conflict}]
+                 :download-missing-assets {:total 2 :downloaded 2 :skipped-existing 0}}]
+    (with-redefs [db-worker/db-sync-dbs-open? (fn [repo]
+                                                (swap! calls conj [:db-sync-dbs-open? repo])
+                                                true)
+                  db-sync/status (fn [repo]
+                                   (swap! calls conj [:status repo])
+                                   (:status results))
+                  db-sync/start! (fn [repo]
+                                   (swap! calls conj [:start repo])
+                                   :started)
+                  db-sync/stop! (fn []
+                                  (swap! calls conj [:stop])
+                                  :stopped)
+                  db-sync/update-presence! (fn [editing-block-uuid]
+                                             (swap! calls conj [:update-presence editing-block-uuid])
+                                             :presence-updated)
+                  db-sync/request-asset-download! (fn [repo asset-uuid]
+                                                    (swap! calls conj [:request-asset-download repo asset-uuid])
+                                                    :asset-requested)
+                  db-sync/download-missing-assets! (fn [repo graph-id]
+                                                     (swap! calls conj [:download-missing-assets repo graph-id])
+                                                     (:download-missing-assets results))
+                  sync-crypt/<grant-graph-access! (fn [repo graph-id target-email]
+                                                    (swap! calls conj [:grant-graph-access repo graph-id target-email])
+                                                    :granted)
+                  sync-crypt/ensure-user-rsa-keys! (fn [opts]
+                                                     (swap! calls conj [:ensure-user-rsa-keys opts])
+                                                     (:ensure-keys results))
+                  db-sync/list-remote-graphs! (fn []
+                                                (swap! calls conj [:list-remote-graphs])
+                                                (:list-graphs results))
+                  db-sync/upload-graph! (fn [repo]
+                                          (swap! calls conj [:upload-graph repo])
+                                          :uploading)
+                  db-sync/create-remote-graph! (fn [repo opts]
+                                                 (swap! calls conj [:create-remote-graph repo opts])
+                                                 :created)
+                  db-sync/stop-upload! (fn [repo]
+                                         (swap! calls conj [:stop-upload repo])
+                                         :stopped-upload)
+                  db-sync/resume-upload! (fn [repo]
+                                           (swap! calls conj [:resume-upload repo])
+                                           :resumed-upload)
+                  db-sync/upload-stopped? (fn [repo]
+                                            (swap! calls conj [:upload-stopped? repo])
+                                            (:upload-stopped? results))
+                  client-op/get-sync-conflicts (fn [repo block-uuid]
+                                                 (swap! calls conj [:get-sync-conflicts repo block-uuid])
+                                                 (:conflicts results))
+                  client-op/clear-sync-conflicts! (fn [repo block-uuid]
+                                                    (swap! calls conj [:clear-sync-conflicts repo block-uuid])
+                                                    nil)
+                  shared-service/broadcast-to-clients! (fn [event payload]
+                                                         (swap! calls conj [:broadcast event payload])
+                                                         nil)]
+      (f results))))
+
+(defn- assert-db-sync-core-wrapper-results!
+  [calls results request]
+  (let [{:keys [repo graph-id block asset email opts]} request]
+    (is (= (:status results) ((get-thread-api :thread-api/db-sync-status) repo)))
+    (is (= :started ((get-thread-api :thread-api/db-sync-start) repo)))
+    (is (= :stopped ((get-thread-api :thread-api/db-sync-stop))))
+    (is (= :presence-updated ((get-thread-api :thread-api/db-sync-update-presence) block)))
+    (is (= :asset-requested ((get-thread-api :thread-api/db-sync-request-asset-download) repo asset)))
+    (is (= (:download-missing-assets results)
+           ((get-thread-api :thread-api/db-sync-download-missing-assets) repo graph-id)))
+    (is (= :granted ((get-thread-api :thread-api/db-sync-grant-graph-access) repo graph-id email)))
+    (is (= (:ensure-keys results) ((get-thread-api :thread-api/db-sync-ensure-user-rsa-keys) opts)))
+    (is (= (:ensure-keys results) ((get-thread-api :thread-api/db-sync-ensure-user-rsa-keys))))
+    (is (= (:list-graphs results) ((get-thread-api :thread-api/db-sync-list-remote-graphs))))
+    (is (= :uploading ((get-thread-api :thread-api/db-sync-upload-graph) repo)))
+    (is (= :created ((get-thread-api :thread-api/db-sync-create-remote-graph) repo true false)))
+    (is (= :stopped-upload ((get-thread-api :thread-api/db-sync-stop-upload) repo)))
+    (is (= :resumed-upload ((get-thread-api :thread-api/db-sync-resume-upload) repo)))
+    (is (= (:upload-stopped? results) ((get-thread-api :thread-api/db-sync-upload-stopped?) repo)))
+    (is (= (:conflicts results) ((get-thread-api :thread-api/db-sync-get-block-conflicts) repo block)))
+    ((get-thread-api :thread-api/db-sync-clear-block-conflicts) repo block)
+    (is (some #(= [:broadcast
+                   :sync-conflicts-updated
+                   {:repo repo
+                    :block-uuid block
+                    :conflicts []}]
+                  %)
+              @calls))
+    (is (some #(= [:ensure-user-rsa-keys nil] %) @calls))
+    (is (some #(= [:create-remote-graph repo
+                   {:graph-e2ee? true
+                    :graph-ready-for-use? false}]
+                  %)
+              @calls))))
+
 (deftest thread-api-db-sync-wrappers-delegate-core-ops-test
   (restoring-worker-state
    (fn []
      (let [calls (atom [])
-           status-result {:state :connected}
-           ensure-keys-result {:ok true}
-           list-graphs-result [{:graph-id "g1"}]
-           upload-stopped-result true
-           conflicts-result [{:op :conflict}]
-           request-repo "graph-a"
-           request-graph-id "remote-graph-id"
-           request-block "block-1"
-           request-asset "asset-1"
-           download-missing-assets-result {:total 2 :downloaded 2 :skipped-existing 0}
-           request-email "user@example.com"
-           request-opts {:force? true}]
-       (with-redefs [db-worker/db-sync-dbs-open? (fn [repo]
-                                                   (swap! calls conj [:db-sync-dbs-open? repo])
-                                                   true)
-                     db-sync/status (fn [repo]
-                                      (swap! calls conj [:status repo])
-                                      status-result)
-                     db-sync/start! (fn [repo]
-                                      (swap! calls conj [:start repo])
-                                      :started)
-                     db-sync/stop! (fn []
-                                     (swap! calls conj [:stop])
-                                     :stopped)
-                     db-sync/update-presence! (fn [editing-block-uuid]
-                                                (swap! calls conj [:update-presence editing-block-uuid])
-                                                :presence-updated)
-                     db-sync/request-asset-download! (fn [repo asset-uuid]
-                                                       (swap! calls conj [:request-asset-download repo asset-uuid])
-                                                       :asset-requested)
-                     db-sync/download-missing-assets! (fn [repo graph-id]
-                                                        (swap! calls conj [:download-missing-assets repo graph-id])
-                                                        download-missing-assets-result)
-                     sync-crypt/<grant-graph-access! (fn [repo graph-id target-email]
-                                                       (swap! calls conj [:grant-graph-access repo graph-id target-email])
-                                                       :granted)
-                     sync-crypt/ensure-user-rsa-keys! (fn [opts]
-                                                        (swap! calls conj [:ensure-user-rsa-keys opts])
-                                                        ensure-keys-result)
-                     db-sync/list-remote-graphs! (fn []
-                                                   (swap! calls conj [:list-remote-graphs])
-                                                   list-graphs-result)
-                     db-sync/upload-graph! (fn [repo]
-                                             (swap! calls conj [:upload-graph repo])
-                                             :uploading)
-                     db-sync/create-remote-graph! (fn [repo opts]
-                                                    (swap! calls conj [:create-remote-graph repo opts])
-                                                    :created)
-                     db-sync/stop-upload! (fn [repo]
-                                            (swap! calls conj [:stop-upload repo])
-                                            :stopped-upload)
-                     db-sync/resume-upload! (fn [repo]
-                                              (swap! calls conj [:resume-upload repo])
-                                              :resumed-upload)
-                     db-sync/upload-stopped? (fn [repo]
-                                               (swap! calls conj [:upload-stopped? repo])
-                                               upload-stopped-result)
-                     client-op/get-sync-conflicts (fn [repo block-uuid]
-                                                    (swap! calls conj [:get-sync-conflicts repo block-uuid])
-                                                    conflicts-result)
-                     client-op/clear-sync-conflicts! (fn [repo block-uuid]
-                                                       (swap! calls conj [:clear-sync-conflicts repo block-uuid])
-                                                       nil)
-                     shared-service/broadcast-to-clients! (fn [event payload]
-                                                            (swap! calls conj [:broadcast event payload])
-                                                            nil)]
-         (is (= status-result ((get-thread-api :thread-api/db-sync-status) request-repo)))
-         (is (= :started ((get-thread-api :thread-api/db-sync-start) request-repo)))
-         (is (= :stopped ((get-thread-api :thread-api/db-sync-stop))))
-         (is (= :presence-updated ((get-thread-api :thread-api/db-sync-update-presence) request-block)))
-         (is (= :asset-requested ((get-thread-api :thread-api/db-sync-request-asset-download) request-repo request-asset)))
-         (is (= download-missing-assets-result
-                ((get-thread-api :thread-api/db-sync-download-missing-assets) request-repo request-graph-id)))
-         (is (= :granted ((get-thread-api :thread-api/db-sync-grant-graph-access) request-repo request-graph-id request-email)))
-         (is (= ensure-keys-result ((get-thread-api :thread-api/db-sync-ensure-user-rsa-keys) request-opts)))
-         (is (= ensure-keys-result ((get-thread-api :thread-api/db-sync-ensure-user-rsa-keys))))
-         (is (= list-graphs-result ((get-thread-api :thread-api/db-sync-list-remote-graphs))))
-         (is (= :uploading ((get-thread-api :thread-api/db-sync-upload-graph) request-repo)))
-         (is (= :created ((get-thread-api :thread-api/db-sync-create-remote-graph) request-repo true false)))
-         (is (= :stopped-upload ((get-thread-api :thread-api/db-sync-stop-upload) request-repo)))
-         (is (= :resumed-upload ((get-thread-api :thread-api/db-sync-resume-upload) request-repo)))
-         (is (= upload-stopped-result ((get-thread-api :thread-api/db-sync-upload-stopped?) request-repo)))
-         (is (= conflicts-result ((get-thread-api :thread-api/db-sync-get-block-conflicts) request-repo request-block)))
-         ((get-thread-api :thread-api/db-sync-clear-block-conflicts) request-repo request-block)
-         (is (some #(= [:broadcast
-                        :sync-conflicts-updated
-                        {:repo request-repo
-                         :block-uuid request-block
-                         :conflicts []}]
-                       %)
-                   @calls))
-         (is (some #(= [:ensure-user-rsa-keys nil] %) @calls))
-         (is (some #(= [:create-remote-graph request-repo
-                        {:graph-e2ee? true
-                         :graph-ready-for-use? false}]
-                       %)
-                   @calls)))))))
+           request {:repo "graph-a"
+                    :graph-id "remote-graph-id"
+                    :block "block-1"
+                    :asset "asset-1"
+                    :email "user@example.com"
+                    :opts {:force? true}}]
+       (with-db-sync-core-wrapper-redefs
+        calls
+        #(assert-db-sync-core-wrapper-results! calls % request))))))
 
 (deftest thread-api-db-sync-wrappers-delegate-import-ops-test
   (restoring-worker-state

--- a/src/test/frontend/worker/sync/assets_test.cljs
+++ b/src/test/frontend/worker/sync/assets_test.cljs
@@ -298,3 +298,39 @@
                (p/catch (fn [error]
                           (is false (str "unexpected error: " error))))
                (p/finally done)))))
+
+(deftest download-remote-assets-if-missing-bounds-download-concurrency-test
+  (async done
+         (let [repo "asset-prefetch-repo"
+               graph-id "graph-1"
+               candidates (mapv (fn [_]
+                                   {:asset-uuid (random-uuid)
+                                    :asset-type "png"})
+                                 (range 12))
+               active-downloads (atom 0)
+               max-active-downloads (atom 0)
+               download-calls (atom [])]
+           (-> (p/with-redefs [platform/current (fn [] {})
+                               platform/asset-stat
+                               (fn [_platform _repo _file-name]
+                                 (p/resolved nil))
+                               sync-assets/download-remote-asset!
+                               (fn [repo' graph-id' asset-uuid asset-type]
+                                 (swap! download-calls conj [repo' graph-id' asset-uuid asset-type])
+                                 (let [active (swap! active-downloads inc)]
+                                   (swap! max-active-downloads max active))
+                                 (p/let [_ (p/delay 20)]
+                                   (swap! active-downloads dec)
+                                   nil))]
+                 (sync-assets/download-remote-assets-if-missing!
+                  repo graph-id candidates))
+               (p/then (fn [result]
+                         (is (= {:total 12
+                                 :downloaded 12
+                                 :skipped-existing 0}
+                                result))
+                         (is (= 12 (count @download-calls)))
+                         (is (= 10 @max-active-downloads))))
+               (p/catch (fn [error]
+                          (is false (str "unexpected error: " error))))
+               (p/finally done)))))

--- a/src/test/frontend/worker/sync/assets_test.cljs
+++ b/src/test/frontend/worker/sync/assets_test.cljs
@@ -234,3 +234,67 @@
                    (reset! worker-state/*db-sync-config db-sync-config)
                    (sync-assets/clear-missing-asset-upload-files! repo)
                    (done)))))))
+
+(deftest download-missing-remote-assets-downloads-only-missing-sync-assets-test
+  (async done
+         (let [repo "asset-prefetch-repo"
+               graph-id "graph-1"
+               missing-uuid (random-uuid)
+               existing-uuid (random-uuid)
+               local-uuid (random-uuid)
+               external-uuid (random-uuid)
+               conn (d/create-conn db-schema/schema)
+               stat-calls (atom [])
+               download-calls (atom [])]
+           (ldb/transact!
+            conn
+            [{:db/ident :logseq.class/Asset}
+             {:block/uuid missing-uuid
+              :block/tags #{:logseq.class/Asset}
+              :logseq.property.asset/type "png"
+              :logseq.property.asset/checksum "missing-checksum"
+              :logseq.property.asset/remote-metadata {:checksum "missing-checksum"
+                                                      :type "png"}}
+             {:block/uuid existing-uuid
+              :block/tags #{:logseq.class/Asset}
+              :logseq.property.asset/type "pdf"
+              :logseq.property.asset/checksum "existing-checksum"
+              :logseq.property.asset/remote-metadata {:checksum "existing-checksum"
+                                                      :type "pdf"}}
+             {:block/uuid local-uuid
+              :block/tags #{:logseq.class/Asset}
+              :logseq.property.asset/type "jpg"
+              :logseq.property.asset/checksum "local-checksum"}
+             {:block/uuid external-uuid
+              :block/tags #{:logseq.class/Asset}
+              :logseq.property.asset/type "gif"
+              :logseq.property.asset/checksum "external-checksum"
+              :logseq.property.asset/remote-metadata {:checksum "external-checksum"
+                                                      :type "gif"}
+              :logseq.property.asset/external-url "https://example.com/asset.gif"}])
+           (-> (p/with-redefs [worker-state/get-datascript-conn (fn [_repo]
+                                                                  conn)
+                               platform/current (fn [] {})
+                               platform/asset-stat
+                               (fn [_platform repo' file-name]
+                                 (swap! stat-calls conj [repo' file-name])
+                                 (p/resolved (when (= file-name (str existing-uuid ".pdf"))
+                                               {:size 10})))
+                               sync-assets/download-remote-asset!
+                               (fn [& args]
+                                 (swap! download-calls conj args)
+                                 (p/resolved nil))]
+                 (sync-assets/download-missing-remote-assets! repo graph-id))
+               (p/then (fn [result]
+                         (is (= {:total 2
+                                 :downloaded 1
+                                 :skipped-existing 1}
+                                result))
+                         (is (= #{[repo (str existing-uuid ".pdf")]
+                                  [repo (str missing-uuid ".png")]}
+                                (set @stat-calls)))
+                         (is (= [[repo graph-id missing-uuid "png"]]
+                                @download-calls))))
+               (p/catch (fn [error]
+                          (is false (str "unexpected error: " error))))
+               (p/finally done)))))

--- a/src/test/logseq/cli/command/sync_test.cljs
+++ b/src/test/logseq/cli/command/sync_test.cljs
@@ -1135,6 +1135,45 @@
                           (is false (str "unexpected error: " e))))
                (p/finally done)))))
 
+(deftest test-execute-sync-download-prefetches-missing-assets
+  (async done
+         (let [invoke-calls (atom [])]
+           (-> (p/with-redefs [cli-server/list-graphs (fn [_config]
+                                                        [])
+                               cli-server/ensure-server! (fn [config _repo]
+                                                           (p/resolved (assoc config :base-url "http://example")))
+                               transport/invoke (fn [_ method args]
+                                                  (swap! invoke-calls conj [method args])
+                                                  (case method
+                                                    :thread-api/db-sync-list-remote-graphs
+                                                    (p/resolved [{:graph-id "remote-graph-id"
+                                                                  :graph-name "demo"
+                                                                  :graph-e2ee? false}])
+                                                    :thread-api/q
+                                                    (p/resolved 0)
+                                                    :thread-api/db-sync-download-graph-by-id
+                                                    (p/resolved {:ok true})
+                                                    :thread-api/db-sync-download-missing-assets
+                                                    (p/resolved {:total 2
+                                                                 :downloaded 2
+                                                                 :skipped-existing 0})
+                                                    (p/resolved nil)))]
+                 (p/let [result (execute-with-runtime-auth {:type :sync-download
+                                                            :repo "logseq_db_demo"
+                                                            :graph "demo"}
+                                                           {:base-url "http://example"
+                                                            :root-dir "/tmp"})]
+                   (is (= :ok (:status result)))
+                   (is (= [:thread-api/db-sync-download-graph-by-id ["logseq_db_demo" "remote-graph-id" false]]
+                          (some #(when (= :thread-api/db-sync-download-graph-by-id (first %)) %)
+                                @invoke-calls)))
+                   (is (= [:thread-api/db-sync-download-missing-assets ["logseq_db_demo" "remote-graph-id"]]
+                          (some #(when (= :thread-api/db-sync-download-missing-assets (first %)) %)
+                                @invoke-calls)))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
 (deftest test-execute-sync-download-uses-long-timeout-only-for-download-invoke
   (async done
          (let [invoke-calls (atom [])]

--- a/src/test/logseq/cli/command/sync_test.cljs
+++ b/src/test/logseq/cli/command/sync_test.cljs
@@ -1199,7 +1199,7 @@
                                                            {:base-url "http://example"
                                                             :root-dir "/tmp"
                                                             :timeout-ms 10000})
-                         [sync-app-state-before set-config-before list-remote-graphs sync-app-state-after set-config-after check-empty-db download]
+                         [sync-app-state-before set-config-before list-remote-graphs sync-app-state-after set-config-after check-empty-db download download-assets]
                          @invoke-calls]
                    (is (= :ok (:status result)))
                    (is (= :thread-api/sync-app-state (:method sync-app-state-before)))
@@ -1209,13 +1209,15 @@
                    (is (= :thread-api/set-db-sync-config (:method set-config-after)))
                    (is (= :thread-api/q (:method check-empty-db)))
                    (is (= :thread-api/db-sync-download-graph-by-id (:method download)))
+                   (is (= :thread-api/db-sync-download-missing-assets (:method download-assets)))
                    (is (= 10000 (:timeout-ms sync-app-state-before)))
                    (is (= 10000 (:timeout-ms set-config-before)))
                    (is (= 10000 (:timeout-ms list-remote-graphs)))
                    (is (= 10000 (:timeout-ms sync-app-state-after)))
                    (is (= 10000 (:timeout-ms set-config-after)))
                    (is (= 10000 (:timeout-ms check-empty-db)))
-                   (is (= 1800000 (:timeout-ms download)))))
+                   (is (= 1800000 (:timeout-ms download)))
+                   (is (= 10000 (:timeout-ms download-assets)))))
                (p/catch (fn [e]
                           (is false (str "unexpected error: " e))))
                (p/finally done)))))


### PR DESCRIPTION
Summary:
- Download missing remote assets after full graph downloads for desktop and CLI.
- Prefetch newly pulled remote assets immediately for desktop and CLI without scanning the whole graph.
- Keep web and mobile asset downloads lazy.

Tests:
- bb dev:test -v frontend.worker.db-sync-test/apply-remote-txs-downloads-missing-assets-for-cli-and-desktop-test -v frontend.worker.db-sync-test/apply-remote-txs-keeps-browser-assets-lazy-test
- bb dev:test -v frontend.worker.sync.assets-test -v frontend.worker.db-sync-test -v logseq.cli.command.sync-test -v frontend.handler.db-based.sync-test -v frontend.worker.db-worker-test
- git diff --check