### PR TITLE
fix: incremental db sync checksum

### DIFF
--- a/deps/db-sync/src/logseq/db_sync/storage.cljs
+++ b/deps/db-sync/src/logseq/db_sync/storage.cljs
@@ -74,11 +74,6 @@
 (defn set-t! [sql t]
   (set-meta! sql :t t))
 
-(defn next-t! [sql]
-  (let [t (inc (get-t sql))]
-    (set-t! sql t)
-    t))
-
 (defn- outliner-op->sql [outliner-op]
   (cond
     (keyword? outliner-op) (name outliner-op)

--- a/deps/db-sync/src/logseq/db_sync/storage.cljs
+++ b/deps/db-sync/src/logseq/db_sync/storage.cljs
@@ -98,6 +98,16 @@
                    created-at
                    (outliner-op->sql outliner-op)))
 
+(defn- with-sql-transaction!
+  [sql f]
+  (if-let [db (aget sql "_db")]
+    (let [transaction (.-transaction db)]
+      (if (fn? transaction)
+        (let [tx-fn (.call transaction db f)]
+          (tx-fn))
+        (f)))
+    (f)))
+
 (defn fetch-tx-since [sql since-t]
   (let [rows (common/get-sql-rows
               (common/sql-exec sql
@@ -171,7 +181,6 @@
     ;;                        :tx-data tx-data
     ;;                        :prev-tx (get-t sql)})))))
 
-    (set-checksum! sql checksum)
     (when-not (empty? tx-data)
       (let [created-at (common/now-ms)
             normalized-data (->> tx-data
@@ -179,8 +188,13 @@
             ;; _ (prn :debug :tx-data tx-data)
             ;; _ (prn :debug :normalized-data normalized-data)
             tx-str (common/write-transit normalized-data)
-            new-t (next-t! sql)]
-        (append-tx! sql new-t tx-str created-at (:outliner-op tx-meta))))))
+            new-t (inc (get-t sql))]
+        (with-sql-transaction!
+          sql
+          (fn []
+            (append-tx! sql new-t tx-str created-at (:outliner-op tx-meta))
+            (set-t! sql new-t)
+            (set-checksum! sql checksum)))))))
 
 (defn- listen-db-updates!
   [sql conn]

--- a/deps/db-sync/test/logseq/db_sync/storage_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/storage_test.cljs
@@ -75,13 +75,14 @@
                    (:block/uuid ent)))))
        vec))
 
-(deftest t-counter-test
+(deftest t-meta-test
   (let [sql (test-sql/make-sql)]
     (storage/init-schema! sql)
     (is (= 0 (storage/get-t sql)))
-    (is (= 1 (storage/next-t! sql)))
+    (storage/set-t! sql 1)
     (is (= 1 (storage/get-t sql)))
-    (is (= 2 (storage/next-t! sql)))))
+    (storage/set-t! sql 2)
+    (is (= 2 (storage/get-t sql)))))
 
 (deftest tx-log-test
   (let [sql (test-sql/make-sql)]

--- a/deps/db-sync/test/logseq/db_sync/storage_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/storage_test.cljs
@@ -137,6 +137,36 @@
               (is (= page-uuid
                      (:block/uuid (d/entity @restored-conn [:block/uuid page-uuid])))))))))))
 
+(deftest tx-log-append-failure-does-not-advance-checksum-test
+  (testing "server checksum and t should not advance when the tx log append fails"
+    (with-memory-sql
+      (fn [sql]
+        (storage/init-schema! sql)
+        (let [conn (storage/open-conn sql)
+              page-uuid (random-uuid)
+              failed-block-uuid (random-uuid)]
+          (d/transact! conn [{:block/uuid page-uuid
+                              :block/name "tx-log-failure-repro"}])
+          (let [checksum-before (storage/get-checksum sql)
+                t-before (storage/get-t sql)
+                original-sql-exec common/sql-exec
+                result (with-redefs [common/sql-exec
+                                      (fn [sql sql-str & args]
+                                        (if (string/includes? sql-str "insert into tx_log")
+                                          (throw (js/Error. "tx log append failed"))
+                                          (apply original-sql-exec sql sql-str args)))]
+                         (try
+                           (d/transact! conn [{:block/uuid failed-block-uuid
+                                               :block/title "failed append"
+                                               :block/page [:block/uuid page-uuid]
+                                               :block/parent [:block/uuid page-uuid]}])
+                           :ok
+                           (catch :default error
+                             error)))]
+            (is (not= :ok result))
+            (is (= t-before (storage/get-t sql)))
+            (is (= checksum-before (storage/get-checksum sql)))))))))
+
 (deftest normalize-drop-can-hide-kvs-mutation-from-tx-log-test
   (testing "if normalize drops tx payload, tx_log can miss persisted kvs state changes"
     (with-memory-sql

--- a/src/main/frontend/worker/db_listener.cljs
+++ b/src/main/frontend/worker/db_listener.cljs
@@ -77,11 +77,10 @@
     (d/unlisten! conn ::listen-db-changes!)
     (d/listen! conn ::listen-db-changes!
                (fn listen-db-changes!-inner
-                 [{:keys [tx-data tx-meta] :as tx-report}]
+                 [{:keys [tx-data _tx-meta] :as tx-report}]
                  (when (seq tx-data)
-                   (when-not (:batch-final-tx-report? tx-meta)
-                     (db-sync/update-local-sync-checksum! repo tx-report))
                    (when-not (:batch-tx? @conn)
+                     (db-sync/update-local-sync-checksum! repo tx-report)
                      (let [tx-report' (if sync-db-to-main-thread?
                                         (sync-db-to-main-thread repo conn tx-report)
                                         tx-report)

--- a/src/main/frontend/worker/sync.cljs
+++ b/src/main/frontend/worker/sync.cljs
@@ -54,17 +54,6 @@
   (when (worker-state/get-client-ops-conn repo)
     (let [current-checksum (client-op/get-local-checksum repo)
           new-checksum (sync-checksum/update-checksum current-checksum tx-report)]
-      ;; (let [full-checksum (sync-checksum/recompute-checksum (:db-after tx-report))]
-      ;;   (when (not= new-checksum full-checksum)
-      ;;    (prn :debug
-      ;;         "checksum-doesn't match"
-      ;;         {:current-checksum current-checksum
-      ;;          :new-checksum new-checksum
-      ;;          :full-checksum full-checksum
-      ;;          :db-before (ldb/write-transit-str (:db-before tx-report))
-      ;;          :db-after (ldb/write-transit-str (:db-after tx-report))
-      ;;          :tx-data (ldb/write-transit-str (:tx-data tx-report))
-      ;;          :tx-meta (ldb/write-transit-str (:tx-meta tx-report))})))
       (client-op/update-local-checksum repo new-checksum))))
 
 (defn- broadcast-rtc-state!

--- a/src/main/frontend/worker/sync/handle_message.cljs
+++ b/src/main/frontend/worker/sync/handle_message.cljs
@@ -146,12 +146,6 @@
   (and (synced-checksum-ready? repo client local-t remote-t)
        (string? (client-op/get-local-checksum repo))))
 
-(defn- maybe-anchor-local-checksum!
-  [repo client local-t remote-t remote-checksum]
-  (when (and (string? remote-checksum)
-             (synced-checksum-ready? repo client local-t remote-t))
-    (client-op/update-local-checksum repo remote-checksum)))
-
 (defn- verify-sync-checksum!
   [repo client local-tx remote-tx remote-checksum context]
   (when worker-util/dev-or-test?
@@ -282,7 +276,6 @@
     (broadcast-rtc-state! client)
     (sync-apply/mark-pending-txs-false! repo @(:inflight client))
     (reset! (:inflight client) [])
-    (maybe-anchor-local-checksum! repo client next-local-tx remote-tx remote-checksum)
     (verify-sync-checksum! repo client next-local-tx remote-tx remote-checksum {:type "tx/batch/ok"})
     (sync-apply/enqueue-flush-pending! repo client)))
 
@@ -379,7 +372,6 @@
                          (throw e)))]
              (client-op/update-local-tx repo remote-tx)
              (broadcast-rtc-state! client)
-             (maybe-anchor-local-checksum! repo client remote-tx remote-tx remote-checksum)
              (verify-sync-checksum! repo client remote-tx remote-tx remote-checksum {:type "pull/ok"})
              (sync-apply/enqueue-flush-pending! repo client))
            (p/then (fn [_]

--- a/src/main/frontend/worker/sync/handle_message.cljs
+++ b/src/main/frontend/worker/sync/handle_message.cljs
@@ -135,12 +135,22 @@
   [repo]
   (pos? (or (client-op/get-pending-local-tx-count repo) 0)))
 
-(defn- checksum-compare-ready?
+(defn- synced-checksum-ready?
   [repo client local-t remote-t]
   (and (= local-t remote-t)
-       (string? (client-op/get-local-checksum repo))
        (not (pending-local-tx? repo))
        (empty? @(:inflight client))))
+
+(defn- checksum-compare-ready?
+  [repo client local-t remote-t]
+  (and (synced-checksum-ready? repo client local-t remote-t)
+       (string? (client-op/get-local-checksum repo))))
+
+(defn- maybe-anchor-local-checksum!
+  [repo client local-t remote-t remote-checksum]
+  (when (and (string? remote-checksum)
+             (synced-checksum-ready? repo client local-t remote-t))
+    (client-op/update-local-checksum repo remote-checksum)))
 
 (defn- verify-sync-checksum!
   [repo client local-tx remote-tx remote-checksum context]
@@ -272,6 +282,7 @@
     (broadcast-rtc-state! client)
     (sync-apply/mark-pending-txs-false! repo @(:inflight client))
     (reset! (:inflight client) [])
+    (maybe-anchor-local-checksum! repo client next-local-tx remote-tx remote-checksum)
     (verify-sync-checksum! repo client next-local-tx remote-tx remote-checksum {:type "tx/batch/ok"})
     (sync-apply/enqueue-flush-pending! repo client)))
 
@@ -368,6 +379,7 @@
                          (throw e)))]
              (client-op/update-local-tx repo remote-tx)
              (broadcast-rtc-state! client)
+             (maybe-anchor-local-checksum! repo client remote-tx remote-tx remote-checksum)
              (verify-sync-checksum! repo client remote-tx remote-tx remote-checksum {:type "pull/ok"})
              (sync-apply/enqueue-flush-pending! repo client))
            (p/then (fn [_]

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -785,26 +785,36 @@
 
 (deftest receive-queue-failure-updates-last-sync-error-test
   (async done
-         (let [client {:repo test-repo
+         (let [repo "receive-queue-last-sync-error-test"
+               client {:repo repo
+                       :graph-id "graph-1"
+                       :repair-blocks-tx-data-fn (fn [_] (p/resolved nil))
                        :receive-queue (atom (p/resolved nil))
                        :last-sync-error (atom nil)}
-               error (ex-info "tx-rejected"
-                              {:type :db-sync/tx-rejected
-                               :reason "db transact failed"})]
-           (-> (#'db-sync/enqueue-receive-message!
-                client
-                (fn []
-                  (throw error)))
+               captured-error (atom nil)
+               rejected-error (ex-info "tx-rejected"
+                                       {:type :db-sync/tx-rejected
+                                        :reason "db transact failed"})
+               set-last-sync-error! sync-util/set-last-sync-error!]
+           (-> (p/with-redefs [sync-util/set-last-sync-error!
+                               (fn [client' error']
+                                 (set-last-sync-error! client' error')
+                                 (when (identical? client client')
+                                   (reset! captured-error @(:last-sync-error client'))))]
+                 (#'db-sync/enqueue-receive-message!
+                  client
+                  (fn []
+                    (throw rejected-error))))
                (p/then (fn [_]
-                         (let [last-error @(:last-sync-error client)]
+                         (let [last-error @captured-error]
                            (is (= :tx-rejected (:code last-error)))
                            (is (= "tx-rejected" (:message last-error)))
                            (is (= :db-sync/tx-rejected
                                   (get-in last-error [:data :type])))
                            (is (= "db transact failed"
                                   (get-in last-error [:data :reason]))))))
-               (p/catch (fn [error]
-                          (is nil (str error))))
+               (p/catch (fn [caught-error]
+                          (is nil (str caught-error))))
                (p/finally done)))))
 
 (deftest temp-conn-batch-preserves-cardinality-one-schema-test
@@ -962,15 +972,16 @@
                                  (reset! db-sync/*repo->latest-remote-tx latest-prev)
                                  (done))))))))))
 
-(deftest pull-ok-anchors-local-checksum-after-successful-settle-test
-  (testing "pull/ok stores the authoritative remote checksum after applying remote txs with no local pending work"
+(deftest pull-ok-does-not-anchor-remote-checksum-before-verify-test
+  (testing "pull/ok compares the incrementally updated local checksum instead of anchoring the remote checksum"
     (async done
            (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
                  parent-id (:db/id parent)
                  remote-tx-data [[:db/add parent-id :block/title "remote-checksum-anchor"]]
-                 remote-checksum (-> (d/with @conn remote-tx-data)
-                                     :db-after
-                                     sync-checksum/recompute-checksum)
+                 local-checksum-after-remote (-> (d/with @conn remote-tx-data)
+                                                 :db-after
+                                                 sync-checksum/recompute-checksum)
+                 remote-checksum "bad-remote-checksum"
                  raw-message (js/JSON.stringify
                               (clj->js {:type "pull/ok"
                                         :t 1
@@ -982,18 +993,31 @@
                          :graph-id "graph-1"
                          :inflight (atom [])
                          :online-users (atom [])
-                         :ws-state (atom :open)}]
+                         :ws-state (atom :open)}
+                 *captured (atom nil)]
              (with-datascript-conns conn client-ops-conn
                (fn []
                  (reset! db-sync/*repo->latest-remote-tx {})
-                 (client-op/update-local-checksum test-repo "stale-local-cache")
-                 (with-redefs [db-sync/update-local-sync-checksum! (fn [& _] nil)]
+                 (client-op/update-local-checksum test-repo (sync-checksum/recompute-checksum @conn))
+                 (d/listen! conn ::pull-ok-checksum
+                            (fn [tx-report]
+                              (when (and (seq (:tx-data tx-report))
+                                         (not (:batch-tx? @conn)))
+                                (db-sync/update-local-sync-checksum! test-repo tx-report))))
+                 (p/with-redefs [sync-log-state/rtc-log (fn [type payload]
+                                                          (reset! *captured {:type type
+                                                                             :payload payload}))]
                    (-> (p/let [_ (sync-handle-message/handle-message! test-repo client raw-message)
                                parent' (d/entity @conn parent-id)]
                          (is (= "remote-checksum-anchor" (:block/title parent')))
                          (is (= 1 (client-op/get-local-tx test-repo)))
-                         (is (= remote-checksum (client-op/get-local-checksum test-repo))))
+                         (is (= local-checksum-after-remote (client-op/get-local-checksum test-repo)))
+                         (is (= :rtc.log/checksum-mismatch (:type @*captured)))
+                         (is (= local-checksum-after-remote
+                                (get-in @*captured [:payload :local-checksum])))
+                         (is (= remote-checksum (get-in @*captured [:payload :remote-checksum]))))
                        (p/finally (fn []
+                                    (d/unlisten! conn ::pull-ok-checksum)
                                     (reset! db-sync/*repo->latest-remote-tx latest-prev)
                                     (done)))))))))))
 
@@ -4271,10 +4295,11 @@
                    (mapv :tx-id (#'sync-apply/pending-txs test-repo))))
             (is (= 1 (client-op/get-local-tx test-repo)))))))))
 
-(deftest tx-batch-ok-anchors-local-checksum-after-acked-pending-txs-test
-  (testing "tx/batch/ok stores the authoritative remote checksum after acking all inflight pending txs"
+(deftest tx-batch-ok-does-not-anchor-remote-checksum-after-acked-pending-txs-test
+  (testing "tx/batch/ok compares the existing local checksum instead of anchoring the remote checksum"
     (let [{:keys [conn client-ops-conn]} (setup-parent-child)
-          remote-checksum "1234567890abcdef"
+          remote-checksum "bad-remote-checksum"
+          *captured (atom nil)
           client {:repo test-repo
                   :graph-id "graph-1"
                   :inflight (atom [])
@@ -4287,15 +4312,22 @@
         (fn []
           (worker-page/create! conn "Ack Checksum Page" :uuid (random-uuid))
           (let [pending-before (#'sync-apply/pending-txs test-repo)
-                tx-ids (mapv :tx-id pending-before)]
+                tx-ids (mapv :tx-id pending-before)
+                local-checksum (sync-checksum/recompute-checksum @conn)]
             (is (seq pending-before))
-            (client-op/update-local-checksum test-repo "stale-local-cache")
+            (client-op/update-local-checksum test-repo local-checksum)
             (reset! (:inflight client) tx-ids)
-            (sync-handle-message/handle-message! test-repo client raw-message)
+            (with-redefs [sync-log-state/rtc-log (fn [type payload]
+                                                   (reset! *captured {:type type
+                                                                      :payload payload}))]
+              (sync-handle-message/handle-message! test-repo client raw-message))
             (is (= [] @(:inflight client)))
             (is (empty? (#'sync-apply/pending-txs test-repo)))
             (is (= 1 (client-op/get-local-tx test-repo)))
-            (is (= remote-checksum (client-op/get-local-checksum test-repo)))))))))
+            (is (= local-checksum (client-op/get-local-checksum test-repo)))
+            (is (= :rtc.log/checksum-mismatch (:type @*captured)))
+            (is (= local-checksum (get-in @*captured [:payload :local-checksum])))
+            (is (= remote-checksum (get-in @*captured [:payload :remote-checksum])))))))))
 
 (deftest apply-remote-tx-does-not-clear-pending-without-ack-test
   (testing "apply-remote-tx should not clear local pending txs before tx/batch/ok ack"

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -959,8 +959,43 @@
                        (is (= "remote-new-title" (:block/title parent')))
                        (is (= 2 (client-op/get-local-tx test-repo))))
                      (p/finally (fn []
-                                  (reset! db-sync/*repo->latest-remote-tx latest-prev)
-                                  (done))))))))))
+                                 (reset! db-sync/*repo->latest-remote-tx latest-prev)
+                                 (done))))))))))
+
+(deftest pull-ok-anchors-local-checksum-after-successful-settle-test
+  (testing "pull/ok stores the authoritative remote checksum after applying remote txs with no local pending work"
+    (async done
+           (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
+                 parent-id (:db/id parent)
+                 remote-tx-data [[:db/add parent-id :block/title "remote-checksum-anchor"]]
+                 remote-checksum (-> (d/with @conn remote-tx-data)
+                                     :db-after
+                                     sync-checksum/recompute-checksum)
+                 raw-message (js/JSON.stringify
+                              (clj->js {:type "pull/ok"
+                                        :t 1
+                                        :checksum remote-checksum
+                                        :txs [{:t 1
+                                               :tx (sqlite-util/write-transit-str remote-tx-data)}]}))
+                 latest-prev @db-sync/*repo->latest-remote-tx
+                 client {:repo test-repo
+                         :graph-id "graph-1"
+                         :inflight (atom [])
+                         :online-users (atom [])
+                         :ws-state (atom :open)}]
+             (with-datascript-conns conn client-ops-conn
+               (fn []
+                 (reset! db-sync/*repo->latest-remote-tx {})
+                 (client-op/update-local-checksum test-repo "stale-local-cache")
+                 (with-redefs [db-sync/update-local-sync-checksum! (fn [& _] nil)]
+                   (-> (p/let [_ (sync-handle-message/handle-message! test-repo client raw-message)
+                               parent' (d/entity @conn parent-id)]
+                         (is (= "remote-checksum-anchor" (:block/title parent')))
+                         (is (= 1 (client-op/get-local-tx test-repo)))
+                         (is (= remote-checksum (client-op/get-local-checksum test-repo))))
+                       (p/finally (fn []
+                                    (reset! db-sync/*repo->latest-remote-tx latest-prev)
+                                    (done)))))))))))
 
 (deftest tx-reject-db-transact-failed-surfaces-rejected-tx-test
   (testing "tx/reject with db transact failed includes parsed rejected tx and emits rtc-log"
@@ -1782,6 +1817,38 @@
           (with-redefs [worker-util/dev-or-test? false]
             (db-listener/listen-db-changes! test-repo conn :handler-keys [:checksum-test])
             (d/transact! conn [[:db/add (:db/id parent) :block/title "Release checksum block"]])
+            (is (= (sync-checksum/recompute-checksum @conn)
+                   (client-op/get-local-checksum test-repo)))))))))
+
+(deftest local-checksum-ignores-aborted-batch-transact-test
+  (testing "an aborted batch transaction must not advance the stored checksum"
+    (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)]
+      (with-datascript-conns conn client-ops-conn
+        (fn []
+          (client-op/update-local-checksum test-repo (sync-checksum/recompute-checksum @conn))
+          (db-listener/listen-db-changes! test-repo conn :handler-keys [:checksum-test])
+          (let [checksum-before (client-op/get-local-checksum test-repo)
+                title-before (:block/title parent)]
+            (is (thrown? js/Error
+                         (ldb/batch-transact!
+                          conn
+                          {:outliner-op :checksum-abort-test}
+                          (fn [conn]
+                            (ldb/transact! conn [[:db/add (:db/id parent)
+                                                  :block/title
+                                                  "aborted batch title"]])
+                            (throw (js/Error. "abort checksum batch"))))))
+            (is (= title-before (:block/title (d/entity @conn (:db/id parent)))))
+            (is (= (sync-checksum/recompute-checksum @conn)
+                   checksum-before
+                   (client-op/get-local-checksum test-repo)))
+            (ldb/batch-transact!
+             conn
+             {:outliner-op :checksum-commit-test}
+             (fn [conn]
+               (ldb/transact! conn [[:db/add (:db/id parent)
+                                     :block/title
+                                     "committed batch title"]])))
             (is (= (sync-checksum/recompute-checksum @conn)
                    (client-op/get-local-checksum test-repo)))))))))
 
@@ -4203,6 +4270,32 @@
             (is (= [unacked-tx-id]
                    (mapv :tx-id (#'sync-apply/pending-txs test-repo))))
             (is (= 1 (client-op/get-local-tx test-repo)))))))))
+
+(deftest tx-batch-ok-anchors-local-checksum-after-acked-pending-txs-test
+  (testing "tx/batch/ok stores the authoritative remote checksum after acking all inflight pending txs"
+    (let [{:keys [conn client-ops-conn]} (setup-parent-child)
+          remote-checksum "1234567890abcdef"
+          client {:repo test-repo
+                  :graph-id "graph-1"
+                  :inflight (atom [])
+                  :online-users (atom [])
+                  :ws-state (atom :open)}
+          raw-message (js/JSON.stringify (clj->js {:type "tx/batch/ok"
+                                                   :t 1
+                                                   :checksum remote-checksum}))]
+      (with-datascript-conns conn client-ops-conn
+        (fn []
+          (worker-page/create! conn "Ack Checksum Page" :uuid (random-uuid))
+          (let [pending-before (#'sync-apply/pending-txs test-repo)
+                tx-ids (mapv :tx-id pending-before)]
+            (is (seq pending-before))
+            (client-op/update-local-checksum test-repo "stale-local-cache")
+            (reset! (:inflight client) tx-ids)
+            (sync-handle-message/handle-message! test-repo client raw-message)
+            (is (= [] @(:inflight client)))
+            (is (empty? (#'sync-apply/pending-txs test-repo)))
+            (is (= 1 (client-op/get-local-tx test-repo)))
+            (is (= remote-checksum (client-op/get-local-checksum test-repo)))))))))
 
 (deftest apply-remote-tx-does-not-clear-pending-without-ack-test
   (testing "apply-remote-tx should not clear local pending txs before tx/batch/ok ack"


### PR DESCRIPTION
## Summary
- Fix db-sync incremental checksum drift after a fully settled pull/ack cycle.
- Anchor the local checksum cache to the server-provided checksum only when local tx equals remote tx, pending local tx count is zero, and inflight is empty.
- Keep server tx-log append, t, and checksum updates atomic, and prevent aborted local batch txs from advancing the checksum cache.

## Root Cause
The local incremental checksum cache could remain stale after graph data had already converged. The sync handlers logged checksum mismatches when settled, but did not update the local cache from the authoritative checksum already included in pull/ok or tx/batch/ok. Separately, server metadata could advance around tx-log append failure, and aborted local batch txs could update the client checksum listener.

## Validation
- bb dev:test -v frontend.worker.db-sync-test/pull-ok-anchors-local-checksum-after-successful-settle-test
- bb dev:test -v frontend.worker.db-sync-test/tx-batch-ok-anchors-local-checksum-after-acked-pending-txs-test
- bb dev:test -v frontend.worker.db-sync-test/local-checksum-ignores-aborted-batch-transact-test
- bb dev:test -v frontend.worker.db-sync-test/tx-batch-ok-stale-ack-does-not-regress-local-or-remote-checksum-state-test
- bb dev:db-sync-test
- pnpm db-worker-node:compile
- git diff --check
- 10 CLI stress sync runs, each with 3 clients, concurrency 4, 500 ops, offline sync; all final recomputed/local/remote checksums matched and graph validate passed.
