### PR TITLE
fix: handle stale sync tx data

### DIFF
--- a/.github/workflows/cli-sync-stress.yml
+++ b/.github/workflows/cli-sync-stress.yml
@@ -188,7 +188,7 @@ jobs:
             --sync \
             --offline \
             --no-e2ee \
-            --max-ops 1000 \
+            --max-ops 3000 \
             --timeout-ms 60000
 
           "$LOGSEQ_BIN" graph validate --graph "$GRAPH" --output json --timeout-ms 60000

--- a/cli/lib/platform/node/cli_platform.ml
+++ b/cli/lib/platform/node/cli_platform.ml
@@ -358,13 +358,12 @@ module Events = struct
             reader_ref := Some reader;
             read_loop closed (make_decoder ()) reader on_chunk
     in
-    ignore
-      (Fetch.fetchWithInit url init
-       |> Js.Promise.then_ handle_response
-       |> Js.Promise.catch (fun _ -> Js.Promise.resolve ())
-        : unit Js.Promise.t);
+    let request =
+      Fetch.fetchWithInit url init
+      |> Js.Promise.then_ handle_response
+      |> Js.Promise.catch (fun _ -> Js.Promise.resolve ())
+    in
     let close () =
-      closed := true;
       Fetch.AbortController.abort controller;
       (match !reader_ref with
       | None -> ()
@@ -372,7 +371,7 @@ module Events = struct
           ignore
             (cancel reader |> Js.Promise.catch (fun _ -> Js.Promise.resolve ())
               : unit Js.Promise.t));
-      Cli_effect.pure ()
+      Cli_effect.catch (HTTP.promise_to_effect request) (fun _ -> Cli_effect.pure ())
     in
     Cli_effect.pure { close }
 end

--- a/deps/db-sync/src/logseq/db_sync/checksum.cljs
+++ b/deps/db-sync/src/logseq/db_sync/checksum.cljs
@@ -76,6 +76,35 @@
   [db eid]
   (:block/uuid (d/entity db eid)))
 
+(defn- parse-uuid-string
+  [value]
+  (when (string? value)
+    (try
+      (uuid value)
+      (catch :default _
+        nil))))
+
+(defn- entids
+  [db-before db-after value]
+  (let [lookup-ref (fn [db value]
+                     (when value
+                       (try
+                         (d/entid db value)
+                         (catch :default _
+                           nil))))
+        uuid-value (cond
+                     (uuid? value) value
+                     (string? value) (parse-uuid-string value)
+                     :else nil)]
+    (cond-> #{}
+      (integer? value) (conj value)
+      (lookup-ref db-before value) (conj (lookup-ref db-before value))
+      (lookup-ref db-after value) (conj (lookup-ref db-after value))
+      (and uuid-value (lookup-ref db-before [:block/uuid uuid-value]))
+      (conj (lookup-ref db-before [:block/uuid uuid-value]))
+      (and uuid-value (lookup-ref db-after [:block/uuid uuid-value]))
+      (conj (lookup-ref db-after [:block/uuid uuid-value])))))
+
 (defn- normalize-checksum-value
   [db attr value]
   (case attr
@@ -149,6 +178,27 @@
                  (when (checksum-eligible-entity? db e)
                    (entity-checksum-tuples db e e2ee?))))))
 
+(defn- tx-item-eids
+  [db-before db-after tx-item]
+  (if-let [eid (:e tx-item)]
+    #{eid}
+    (if (vector? tx-item)
+      (let [[op entity attr value] tx-item
+            entity-ids (entids db-before db-after entity)]
+        (cond-> entity-ids
+          (and (= op :db/add) (= attr :block/uuid))
+          (into (entids db-before db-after value))
+          (and (= op :db/retract) (= attr :block/uuid))
+          (into (entids db-before db-after value))))
+      #{})))
+
+(defn- block-uuid-tx-item?
+  [tx-item]
+  (= :block/uuid
+     (if (vector? tx-item)
+       (nth tx-item 2 nil)
+       (:a tx-item))))
+
 (defn- touched-base-eids
   [db-before db-after tx-data]
   (let [before-eligible-cache (volatile! {})
@@ -159,18 +209,20 @@
                              (let [eligible? (boolean (checksum-eligible-entity? db eid))]
                                (vswap! cache assoc eid eligible?)
                                eligible?)))]
-    (->> tx-data
-         (reduce (fn [eids datom]
-                   (if-let [eid (:e datom)]
-                     (let [attr (:a datom)]
-                       (cond-> eids
-                         (= attr :block/uuid) (conj eid)
-                         (or (cached-eligible? db-before before-eligible-cache eid)
-                             (cached-eligible? db-after after-eligible-cache eid))
-                         (conj eid)))
-                     eids))
-                 #{})
-         set)))
+    (reduce (fn [result tx-item]
+              (let [block-uuid-change? (block-uuid-tx-item? tx-item)]
+                (reduce (fn [eids eid]
+                          (cond-> eids
+                            (or block-uuid-change?
+                                (not= (get-block-uuid db-before eid)
+                                      (get-block-uuid db-after eid))
+                                (cached-eligible? db-before before-eligible-cache eid)
+                                (cached-eligible? db-after after-eligible-cache eid))
+                            (conj eid)))
+                        result
+                        (tx-item-eids db-before db-after tx-item))))
+            #{}
+            tx-data)))
 
 (defn- touched-checksum-uuids
   [db-before db-after eids]

--- a/deps/db-sync/src/logseq/db_sync/storage.cljs
+++ b/deps/db-sync/src/logseq/db_sync/storage.cljs
@@ -74,6 +74,40 @@
 (defn set-t! [sql t]
   (set-meta! sql :t t))
 
+(defn- with-sql-transaction!
+  [sql f]
+  (if-let [db (aget sql "_db")]
+    (let [transaction (.-transaction db)]
+      (if (fn? transaction)
+        (let [tx-fn (.call transaction db f)]
+          (tx-fn))
+        (f)))
+    (f)))
+
+(defn set-initial-checksum! [sql checksum]
+  (with-sql-transaction!
+    sql
+    (fn []
+      (let [existing-checksum (get-checksum sql)
+            current-t (get-t sql)]
+        (cond
+          (and (some? existing-checksum)
+               (not= existing-checksum checksum))
+          (throw (ex-info "Cannot overwrite existing checksum with snapshot checksum"
+                          {:type :db-sync/stale-snapshot-checksum
+                           :existing-checksum existing-checksum
+                           :snapshot-checksum checksum}))
+
+          (and (nil? existing-checksum)
+               (pos? current-t))
+          (throw (ex-info "Cannot initialize checksum after tx history advanced"
+                          {:type :db-sync/snapshot-checksum-after-tx-log
+                           :t current-t
+                           :snapshot-checksum checksum}))
+
+          (nil? existing-checksum)
+          (set-checksum! sql checksum))))))
+
 (defn- outliner-op->sql [outliner-op]
   (cond
     (keyword? outliner-op) (name outliner-op)
@@ -92,16 +126,6 @@
                    tx-str
                    created-at
                    (outliner-op->sql outliner-op)))
-
-(defn- with-sql-transaction!
-  [sql f]
-  (if-let [db (aget sql "_db")]
-    (let [transaction (.-transaction db)]
-      (if (fn? transaction)
-        (let [tx-fn (.call transaction db f)]
-          (tx-fn))
-        (f)))
-    (f)))
 
 (defn fetch-tx-since [sql since-t]
   (let [rows (common/get-sql-rows
@@ -151,42 +175,20 @@
 
 (defn- append-tx-for-tx-report
   [sql {:keys [db-after db-before tx-data tx-meta] :as tx-report}]
-  (let [prev-checksum (get-checksum sql)
-        checksum (sync-checksum/update-checksum prev-checksum tx-report)]
-    ;; (when (= "true" (some-> js/process .-env .-DB_SYNC_CHECKSUM_ASSERT))
-    ;;   (let [full-checksum (sync-checksum/recompute-checksum db-after)
-    ;;         prev-full-checksum (sync-checksum/recompute-checksum db-before)]
-    ;;     (when (and prev-checksum
-    ;;                (not= checksum full-checksum))
-    ;;       (prn :debug :before-checksum-error {:prev-tx (get-t sql)
-    ;;                                           :prev-checksum prev-checksum
-    ;;                                           :prev-full-checksum prev-full-checksum
-    ;;                                           :new-checksum checksum
-    ;;                                           :recomputed-after-checksum full-checksum
-    ;;                                           :tx-meta tx-meta
-    ;;                                           :db-before (ldb/write-transit-str db-before)
-    ;;                                           :tx-data (ldb/write-transit-str tx-data)})
-    ;;       (when (not= prev-checksum prev-full-checksum)
-    ;;         (prn :debug :prev-checksum-not-match {:prev-checksum prev-checksum
-    ;;                                               :prev-full-checksum prev-full-checksum}))
-    ;;       (throw (ex-info "server checksum doesn't match"
-    ;;                       {:prev-checksum prev-checksum
-    ;;                        :recomputed-after-checksum full-checksum
-    ;;                        :tx-meta tx-meta
-    ;;                        :tx-data tx-data
-    ;;                        :prev-tx (get-t sql)})))))
-
-    (when-not (empty? tx-data)
-      (let [created-at (common/now-ms)
-            normalized-data (->> tx-data
-                                 (db-normalize/normalize-tx-data db-after db-before))
-            ;; _ (prn :debug :tx-data tx-data)
-            ;; _ (prn :debug :normalized-data normalized-data)
-            tx-str (common/write-transit normalized-data)
-            new-t (inc (get-t sql))]
-        (with-sql-transaction!
-          sql
-          (fn []
+  (when-not (empty? tx-data)
+    (let [created-at (common/now-ms)
+          normalized-data (->> tx-data
+                               (db-normalize/normalize-tx-data db-after db-before)
+                               vec)
+          tx-str (common/write-transit normalized-data)]
+      (with-sql-transaction!
+        sql
+        (fn []
+          (let [prev-checksum (get-checksum sql)
+                checksum (sync-checksum/update-checksum
+                          prev-checksum
+                          (assoc tx-report :tx-data normalized-data))
+                new-t (inc (get-t sql))]
             (append-tx! sql new-t tx-str created-at (:outliner-op tx-meta))
             (set-t! sql new-t)
             (set-checksum! sql checksum)))))))

--- a/deps/db-sync/src/logseq/db_sync/tx_sanitize.cljs
+++ b/deps/db-sync/src/logseq/db_sync/tx_sanitize.cljs
@@ -33,11 +33,6 @@
        (<= 4 (count item))
        (contains? entity-op-kinds (first item))))
 
-(defn- missing-entity-op?
-  [db item]
-  (and (entity-op? item)
-       (nil? (entity-ref->eid db (second item)))))
-
 (defn- drop-ops-targeting-retracted-entities
   [db tx-data]
   (let [retract-eids (->> tx-data
@@ -124,18 +119,16 @@
   ([db tx-data]
    (sanitize-tx db tx-data nil))
   ([db tx-data {:keys [drop-missing-retract-ops?
-                       drop-missing-entity-ops?
-                       drop-ops-targeting-retracted-entities?]
+                       drop-ops-targeting-retracted-entities?
+                       retract-touched-descendants?]
                 :or {drop-missing-retract-ops? false
-                     drop-missing-entity-ops? false
-                     drop-ops-targeting-retracted-entities? false}}]
+                     drop-ops-targeting-retracted-entities? false
+                     retract-touched-descendants? false}}]
    (let [tx-data* (cond->> (strip-migration-deleted-attrs tx-data)
                     drop-missing-retract-ops?
                     (remove (fn [item]
                               (and (retract-entity-op? item)
                                    (nil? (entity-ref->eid db (second item))))))
-                    drop-missing-entity-ops?
-                    (remove (partial missing-entity-op? db))
                     drop-ops-targeting-retracted-entities?
                     (drop-ops-targeting-retracted-entities db))
          tx-data* (drop-conflicted-encrypted-retracts tx-data*)
@@ -155,7 +148,10 @@
                                                   (when (:block/uuid entity)
                                                     (ldb/get-block-full-children-ids db eid)))))
                                       set)
-         missing-retract-eids (sort (set/difference descendant-retract-eids retract-eids touched-eids))]
+         preserved-eids (cond-> retract-eids
+                          (not retract-touched-descendants?)
+                          (set/union touched-eids))
+         missing-retract-eids (sort (set/difference descendant-retract-eids preserved-eids))]
      (cond-> tx-data*
        (seq missing-retract-eids)
        (into (map (fn [eid] [:db/retractEntity eid]) missing-retract-eids))))))

--- a/deps/db-sync/src/logseq/db_sync/tx_sanitize.cljs
+++ b/deps/db-sync/src/logseq/db_sync/tx_sanitize.cljs
@@ -27,6 +27,32 @@
 (def ^:private entity-op-kinds
   #{:db/add :db/retract :db/cas :db.fn/cas})
 
+(defn- entity-op?
+  [item]
+  (and (vector? item)
+       (<= 4 (count item))
+       (contains? entity-op-kinds (first item))))
+
+(defn- missing-entity-op?
+  [db item]
+  (and (entity-op? item)
+       (nil? (entity-ref->eid db (second item)))))
+
+(defn- drop-ops-targeting-retracted-entities
+  [db tx-data]
+  (let [retract-eids (->> tx-data
+                          (keep (fn [item]
+                                  (when (retract-entity-op? item)
+                                    (entity-ref->eid db (second item)))))
+                          set)]
+    (if (empty? retract-eids)
+      tx-data
+      (remove (fn [item]
+                (and (entity-op? item)
+                     (contains? retract-eids
+                                (entity-ref->eid db (second item)))))
+              tx-data))))
+
 (def ^:private migration-deleted-attrs
   #{:block/path-refs
     :block/pre-block?
@@ -38,7 +64,7 @@
   (keep (fn [item]
           (when-not (and (vector? item)
                          (<= 4 (count item))
-                         (contains? entity-op-kinds (first item))
+                         (entity-op? item)
                          (contains? migration-deleted-attrs (nth item 2)))
             item))
         tx-data))
@@ -97,13 +123,21 @@
 (defn sanitize-tx
   ([db tx-data]
    (sanitize-tx db tx-data nil))
-  ([db tx-data {:keys [drop-missing-retract-ops?]
-                :or {drop-missing-retract-ops? false}}]
+  ([db tx-data {:keys [drop-missing-retract-ops?
+                       drop-missing-entity-ops?
+                       drop-ops-targeting-retracted-entities?]
+                :or {drop-missing-retract-ops? false
+                     drop-missing-entity-ops? false
+                     drop-ops-targeting-retracted-entities? false}}]
    (let [tx-data* (cond->> (strip-migration-deleted-attrs tx-data)
                     drop-missing-retract-ops?
                     (remove (fn [item]
                               (and (retract-entity-op? item)
-                                   (nil? (entity-ref->eid db (second item)))))))
+                                   (nil? (entity-ref->eid db (second item))))))
+                    drop-missing-entity-ops?
+                    (remove (partial missing-entity-op? db))
+                    drop-ops-targeting-retracted-entities?
+                    (drop-ops-targeting-retracted-entities db))
          tx-data* (drop-conflicted-encrypted-retracts tx-data*)
          tx-data* (vec tx-data*)
          retract-eids (->> tx-data*

--- a/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
+++ b/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
@@ -326,6 +326,24 @@
                  missing-uuid (conj missing-uuid))))
       (-> result distinct vec))))
 
+(def ^:private delete-outliner-ops
+  #{:delete-blocks
+    :delete-page})
+
+(def ^:private stale-target-noop-outliner-ops
+  #{:move-blocks
+    :move-blocks-up-down
+    :indent-outdent-blocks
+    :indent-blocks
+    :outdent-blocks})
+
+(defn- request-context->tx-meta
+  [{:keys [graph-id client-revision username]}]
+  (cond-> {}
+    graph-id (assoc :graph-id graph-id)
+    client-revision (assoc :client-revision client-revision)
+    username (assoc :username username)))
+
 (defn- import-snapshot! [^js self rows reset?]
   (let [sql (.-sql self)]
     (ensure-schema! self)
@@ -335,13 +353,19 @@
     (import-snapshot-rows! sql "kvs" rows)))
 
 (defn- apply-tx-entry!
-  [conn {:keys [tx outliner-op]}]
+  [conn {:keys [tx outliner-op]} request-context]
   (let [tx-data (tx-sanitize/sanitize-tx @conn
                                          (protocol/transit->tx tx)
-                                         {:drop-missing-retract-ops? (= outliner-op :fix)})]
+                                         {:drop-missing-retract-ops? (or (= outliner-op :fix)
+                                                                         (contains? delete-outliner-ops outliner-op))
+                                          :drop-missing-entity-ops? (contains? stale-target-noop-outliner-ops
+                                                                               outliner-op)
+                                          :drop-ops-targeting-retracted-entities? (contains? delete-outliner-ops
+                                                                                             outliner-op)})]
     (if (seq tx-data)
       (try
-        (ldb/transact! conn tx-data (cond-> {:op :apply-client-tx}
+        (ldb/transact! conn tx-data (cond-> (merge {:op :apply-client-tx}
+                                                   (request-context->tx-meta request-context))
                                       outliner-op
                                       (assoc :outliner-op outliner-op)
                                       (= outliner-op :db-migrate)
@@ -363,7 +387,7 @@
             (throw e))))
       false)))
 
-(defn- apply-tx! [^js self tx-entries]
+(defn- apply-tx! [^js self tx-entries request-context]
   (let [sql (.-sql self)]
     (ensure-conn! self)
     (let [conn (.-conn self)]
@@ -373,7 +397,7 @@
         (if-let [tx-entry (first remaining)]
           (let [tx-id (:tx-id tx-entry)
                 applied-entry? (try
-                                 (boolean (apply-tx-entry! conn tx-entry))
+                                 (boolean (apply-tx-entry! conn tx-entry request-context))
                                  (catch :default e
                                    (log/error :db-sync/transact-failed e)
                                    (let [missing-block-uuids (missing-block-uuids-from-error e)]
@@ -384,11 +408,6 @@
                                                        (seq missing-block-uuids)
                                                        (assoc :missing-block-uuids missing-block-uuids))
                                                      e)))))
-                _ (when (and tx-id (not applied-entry?))
-                    (throw (ex-info "tx entry was not applied"
-                                    {:type :db-sync/tx-entry-not-applied
-                                     :successful-tx-ids successful-tx-ids
-                                     :failed-tx-id tx-id})))
                 next-successful-tx-ids (cond-> successful-tx-ids
                                          tx-id (conj tx-id))]
             (recur (next remaining)
@@ -400,13 +419,15 @@
              :successful-tx-ids successful-tx-ids}))))))
 
 (defn handle-tx-batch!
-  [^js self sender txs t-before]
-  (let [current-t (t-now self)]
-    (cond
-      (not (snapshot-upload-finished? self))
-      {:type "tx/reject"
-       :reason "snapshot upload in progress"
-       :t current-t}
+  ([^js self sender txs t-before]
+   (handle-tx-batch! self sender txs t-before nil))
+  ([^js self sender txs t-before request-context]
+   (let [current-t (t-now self)]
+     (cond
+       (not (snapshot-upload-finished? self))
+       {:type "tx/reject"
+        :reason "snapshot upload in progress"
+        :t current-t}
 
        (or (not (number? t-before)) (neg? t-before))
        {:type "tx/reject"
@@ -420,7 +441,7 @@
        :else
        (if (seq txs)
          (try
-           (let [{:keys [t applied?]} (apply-tx! self txs)
+           (let [{:keys [t applied?]} (apply-tx! self txs request-context)
                  checksum (current-checksum self)]
              (when applied?
                ;; Broadcast once per processed batch after tx-log/checksum settle.
@@ -446,7 +467,7 @@
                  (seq missing-block-uuids) (assoc :missing-block-uuids missing-block-uuids)
                  (string? checksum) (assoc :checksum checksum)))))
          {:type "tx/reject"
-          :reason "empty tx data"}))))
+          :reason "empty tx data"})))))
 
 (defn- handle-sync-pull
   [^js self ^js url]
@@ -585,14 +606,16 @@
                    graph-id (graph-id-from-request request)]
                (if (nil? body)
                  (http/bad-request "invalid tx")
-                 (let [{:keys [txs t-before]} body
+                 (let [{:keys [client-revision txs t-before]} body
                        t-before (parse-int t-before)]
                    (if (sequential? txs)
                      (p/let [ready-for-sync? (<ready-for-sync? self graph-id)]
                        (if-not ready-for-sync?
                          (http/error-response "graph not ready" 409)
                          (http/json-response :sync/tx-batch
-                                             (handle-tx-batch! self nil txs t-before))))
+                                             (handle-tx-batch! self nil txs t-before
+                                                               {:graph-id graph-id
+                                                                :client-revision client-revision}))))
                      (http/bad-request "invalid tx")))))))))
 
 (defn- parse-reset-param

--- a/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
+++ b/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
@@ -664,7 +664,7 @@
                        (storage/set-meta! (.-sql self) snapshot-uploading-meta-key false))
                    _ (when finished?
                        (when (seq checksum-param)
-                         (storage/set-checksum! (.-sql self) checksum-param)))
+                         (storage/set-initial-checksum! (.-sql self) checksum-param)))
                    _ (when finished?
                        (<set-graph-ready-for-use! self graph-id true))]
              (http/json-response :sync/snapshot-upload {:ok true

--- a/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
+++ b/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
@@ -330,13 +330,6 @@
   #{:delete-blocks
     :delete-page})
 
-(def ^:private stale-target-noop-outliner-ops
-  #{:move-blocks
-    :move-blocks-up-down
-    :indent-outdent-blocks
-    :indent-blocks
-    :outdent-blocks})
-
 (defn- request-context->tx-meta
   [{:keys [graph-id client-revision username]}]
   (cond-> {}
@@ -358,10 +351,9 @@
                                          (protocol/transit->tx tx)
                                          {:drop-missing-retract-ops? (or (= outliner-op :fix)
                                                                          (contains? delete-outliner-ops outliner-op))
-                                          :drop-missing-entity-ops? (contains? stale-target-noop-outliner-ops
-                                                                               outliner-op)
                                           :drop-ops-targeting-retracted-entities? (contains? delete-outliner-ops
-                                                                                             outliner-op)})]
+                                                                                             outliner-op)
+                                          :retract-touched-descendants? (contains? delete-outliner-ops outliner-op)})]
     (if (seq tx-data)
       (try
         (ldb/transact! conn tx-data (cond-> (merge {:op :apply-client-tx}

--- a/deps/db-sync/src/logseq/db_sync/worker/handler/ws.cljs
+++ b/deps/db-sync/src/logseq/db_sync/worker/handler/ws.cljs
@@ -41,9 +41,19 @@
 
         "tx/batch"
         (let [txs (:txs message)
+              user (presence/get-user self ws)
               t-before (sync-handler/parse-int (:t-before message))]
           (if (sequential? txs)
-            (ws/send! ws (sync-handler/handle-tx-batch! self ws txs t-before))
+            (ws/send! ws (sync-handler/handle-tx-batch!
+                          self
+                          ws
+                          txs
+                          t-before
+                          (cond-> {:graph-id (aget self "graph-id")}
+                            (:client-revision message)
+                            (assoc :client-revision (:client-revision message))
+                            (:username user)
+                            (assoc :username (:username user)))))
             (ws/send! ws {:type "tx/reject" :reason "invalid tx"})))
 
         (ws/send! ws {:type "error" :message "unknown type"})))))
@@ -57,6 +67,7 @@
               client (aget pair 0)
               server (aget pair 1)
               state (.-state self)]
+          (aset self "graph-id" graph-id)
           (.acceptWebSocket state server)
           (let [token (auth/token-from-request request)
                 claims (auth/unsafe-jwt-claims token)

--- a/deps/db-sync/test/logseq/db_sync/checksum_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/checksum_test.cljs
@@ -210,6 +210,33 @@
       (is (not= before-checksum full))
       (is (= full incremental)))))
 
+(deftest incremental-checksum-matches-recompute-when-ineligible-referenced-entity-is-retracted-test
+  (testing "incremental checksum tracks children when normalized tx data retracts a referenced non-checksum-eligible entity"
+    (let [parent-uuid (random-uuid)
+          child-uuid (random-uuid)
+          page-uuid (random-uuid)
+          db-before (-> (d/empty-db db-schema/schema)
+                        (d/db-with [{:db/id 1
+                                     :block/uuid page-uuid
+                                     :block/name "page-a"
+                                     :block/title "Page A"}
+                                    {:db/id 2
+                                     :block/uuid parent-uuid
+                                     :block/title "Orphan parent"}
+                                    {:db/id 3
+                                     :block/uuid child-uuid
+                                     :block/title "Child"
+                                     :block/parent 2
+                                     :block/page 1}]))
+          before-checksum (checksum/recompute-checksum db-before)
+          tx-report* (d/with db-before [[:db/retractEntity [:block/uuid parent-uuid]]])
+          tx-report (assoc tx-report*
+                           :tx-data [[:db/retractEntity [:block/uuid parent-uuid]]])
+          full (checksum/recompute-checksum (:db-after tx-report))
+          incremental (checksum/update-checksum before-checksum tx-report)]
+      (is (not= before-checksum full))
+      (is (= full incremental)))))
+
 (deftest incremental-checksum-matches-recompute-when-block-is-readded-test
   (testing "incremental checksum remains equal to recompute when a block is deleted and re-added with the same UUID"
     (let [db0 (sample-db)
@@ -223,6 +250,51 @@
                                               :block/title "Child"
                                               :block/parent [:block/uuid parent-uuid]
                                               :block/page [:block/uuid page-uuid]}]))))
+
+(deftest incremental-checksum-matches-recompute-when-block-is-readded-with-uuid-tempid-test
+  (testing "server rebase txs can delete and recreate the same block using a UUID string tempid"
+    (let [db0 (sample-db)
+          checksum0 (checksum/recompute-checksum db0)
+          block-uuid (random-uuid)
+          block-tempid (str block-uuid)
+          page-uuid (:block/uuid (d/entity db0 1))
+          parent-uuid (:block/uuid (d/entity db0 3))
+          tx-data [[:db/add block-tempid :block/uuid block-uuid 536871536]
+                   [:db/add block-tempid :block/title "undo redo block" 536871536]
+                   [:db/add block-tempid :block/parent [:block/uuid parent-uuid] 536871536]
+                   [:db/add block-tempid :block/order "a0" 536871536]
+                   [:db/add block-tempid :block/page [:block/uuid page-uuid] 536871536]]
+          {:keys [db checksum]} (assert-incremental=full! db0 checksum0 tx-data)
+          {:keys [db checksum]} (assert-incremental=full! db checksum [[:db/retractEntity [:block/uuid block-uuid]]])]
+      (assert-incremental=full!
+       db
+       checksum
+       [[:db/add block-tempid :block/uuid block-uuid 536871538]
+        [:db/add block-tempid :block/title "undo redo block" 536871538]
+        [:db/add block-tempid :block/parent [:block/uuid parent-uuid] 536871538]
+        [:db/add block-tempid :block/order "a0" 536871538]
+        [:db/add block-tempid :block/page [:block/uuid page-uuid] 536871538]]))))
+
+(deftest incremental-checksum-matches-recompute-with-normalized-vector-tx-data-test
+  (testing "incremental checksum tracks normalized tx vectors persisted in server tx_log"
+    (let [db-before (sample-db)
+          checksum-before (checksum/recompute-checksum db-before)
+          block-uuid (random-uuid)
+          block-tempid (str block-uuid)
+          parent-uuid (:block/uuid (d/entity db-before 3))
+          page-uuid (:block/uuid (d/entity db-before 1))
+          normalized-tx-data [[:db/add block-tempid :block/uuid block-uuid 536871538]
+                              [:db/add block-tempid :block/title "normalized block" 536871538]
+                              [:db/add block-tempid :block/parent [:block/uuid parent-uuid] 536871538]
+                              [:db/add block-tempid :block/order "a0" 536871538]
+                              [:db/add block-tempid :block/page [:block/uuid page-uuid] 536871538]]
+          tx-report (d/with db-before normalized-tx-data)
+          full (checksum/recompute-checksum (:db-after tx-report))
+          incremental (checksum/update-checksum
+                       checksum-before
+                       (assoc tx-report :tx-data normalized-tx-data))]
+      (is (not= checksum-before full))
+      (is (= full incremental)))))
 
 (deftest incremental-checksum-matches-recompute-when-delete-tree-undo-and-delete-again-test
   (testing "incremental checksum matches recompute across delete-tree, undo-all, then delete-tree-again"

--- a/deps/db-sync/test/logseq/db_sync/storage_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/storage_test.cljs
@@ -114,6 +114,36 @@
             (is (= stale-checksum
                    (storage/get-checksum sql)))))))))
 
+(deftest initial-checksum-does-not-overwrite-existing-checksum-test
+  (testing "snapshot checksum initialization must not replace an existing incremental checksum"
+    (let [sql (test-sql/make-sql)
+          existing-checksum "aaaaaaaaaaaaaaaa"
+          snapshot-checksum "bbbbbbbbbbbbbbbb"]
+      (storage/init-schema! sql)
+      (storage/set-initial-checksum! sql existing-checksum)
+      (let [result (try
+                     (storage/set-initial-checksum! sql snapshot-checksum)
+                     :ok
+                     (catch :default error
+                       error))]
+        (is (not= :ok result))
+        (is (= existing-checksum (storage/get-checksum sql)))))))
+
+(deftest initial-checksum-rejects-non-empty-tx-log-test
+  (testing "snapshot checksum initialization must not run after tx history already advanced"
+    (let [sql (test-sql/make-sql)
+          snapshot-checksum "bbbbbbbbbbbbbbbb"]
+      (storage/init-schema! sql)
+      (storage/append-tx! sql 1 "tx-1" 100 :save-block)
+      (storage/set-t! sql 1)
+      (let [result (try
+                     (storage/set-initial-checksum! sql snapshot-checksum)
+                     :ok
+                     (catch :default error
+                       error))]
+        (is (not= :ok result))
+        (is (nil? (storage/get-checksum sql)))))))
+
 (deftest stale-checksum-transact-keeps-kvs-and-tx-log-consistent-test
   (testing "stale checksum should not fail transact; kvs and tx_log/t should advance together"
     (with-memory-sql

--- a/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
@@ -563,6 +563,144 @@
         (is (= "pull/ok" (:type pull-response)))
         (is (empty? (:txs pull-response)))))))
 
+(deftest tx-batch-adds-request-context-to-transact-meta-test
+  (testing "graph id and client revision should be present in transact failure diagnostics"
+    (let [sql (test-sql/make-sql)
+          conn (storage/open-conn sql)
+          self #js {:sql sql
+                    :conn conn
+                    :schema-ready true}
+          tx-metas (atom [])
+          tx-entry {:tx (protocol/tx->transit [[:db/add -1 :block/title "context"]])
+                    :outliner-op :save-block}
+          response (with-redefs [ws/broadcast! (fn [& _] nil)]
+                     (d/listen! conn ::capture-request-context-tx-meta
+                                (fn [tx-report]
+                                  (swap! tx-metas conj (:tx-meta tx-report))))
+                     (try
+                       (sync-handler/handle-tx-batch!
+                        self
+                        nil
+                        [tx-entry]
+                        0
+                        {:graph-id "graph-context"
+                         :client-revision "revision-context"})
+                       (finally
+                         (d/unlisten! conn ::capture-request-context-tx-meta))))]
+      (is (= "tx/batch/ok" (:type response)))
+      (is (some #(= {:op :apply-client-tx
+                     :outliner-op :save-block
+                     :graph-id "graph-context"
+                     :client-revision "revision-context"}
+                    (select-keys % [:op :outliner-op :graph-id :client-revision]))
+                @tx-metas)))))
+
+(deftest tx-batch-ignores-stale-move-target-updates-test
+  (testing "move-blocks against a block already deleted on the server is a no-op"
+    (let [sql (test-sql/make-sql)
+          conn (storage/open-conn sql)
+          self #js {:sql sql
+                    :conn conn
+                    :schema-ready true}
+          page-uuid (random-uuid)
+          parent-uuid (random-uuid)
+          missing-block-uuid (random-uuid)
+          _ (d/transact! conn [{:block/uuid page-uuid
+                                :block/name "stale-move-page"
+                                :block/title "stale-move-page"}
+                               {:block/uuid parent-uuid
+                                :block/title "existing-parent"
+                                :block/order "a0"
+                                :block/parent [:block/uuid page-uuid]
+                                :block/page [:block/uuid page-uuid]}])
+          t-before (storage/get-t sql)
+          checksum-before (storage/get-checksum sql)
+          tx-id (random-uuid)
+          tx-entry {:tx-id tx-id
+                    :tx (protocol/tx->transit
+                         [[:db/retract [:block/uuid missing-block-uuid]
+                           :block/parent
+                           [:block/uuid page-uuid]
+                           537062408]
+                          [:db/add [:block/uuid missing-block-uuid]
+                           :block/parent
+                           [:block/uuid parent-uuid]
+                           537062408]
+                          [:db/retract [:block/uuid missing-block-uuid]
+                           :block/order
+                           "a0"
+                           537062408]
+                          [:db/add [:block/uuid missing-block-uuid]
+                           :block/order
+                           "a3"
+                           537062408]])
+                    :outliner-op :move-blocks}
+          changed-messages (atom [])
+          response (with-redefs [ws/broadcast! (fn [_self _sender payload]
+                                                 (swap! changed-messages conj payload))]
+                     (sync-handler/handle-tx-batch! self nil [tx-entry] t-before))]
+      (is (= "tx/batch/ok" (:type response)))
+      (is (= t-before (:t response)))
+      (is (= checksum-before (storage/get-checksum sql)))
+      (is (empty? (storage/fetch-tx-since sql t-before)))
+      (is (empty? @changed-messages)))))
+
+(deftest tx-batch-delete-blocks-ignores-redundant-updates-and-deletes-descendants-test
+  (testing "delete-blocks should retract current descendants even when tx-data omits them"
+    (let [sql (test-sql/make-sql)
+          conn (storage/open-conn sql)
+          self #js {:sql sql
+                    :conn conn
+                    :schema-ready true}
+          page-uuid (random-uuid)
+          parent-uuid (random-uuid)
+          child-uuid (random-uuid)
+          property-value-uuid (random-uuid)
+          now 1783043128375
+          _ (d/transact! conn [{:db/ident :user.property/sync-report}
+                               {:block/uuid page-uuid
+                                :block/name "delete-descendants-page"
+                                :block/title "delete-descendants-page"
+                                :block/created-at now
+                                :block/updated-at now}
+                               {:block/uuid parent-uuid
+                                :block/title "parent"
+                                :block/parent [:block/uuid page-uuid]
+                                :block/page [:block/uuid page-uuid]
+                                :block/order "a0"
+                                :block/created-at now
+                                :block/updated-at now}
+                               {:block/uuid child-uuid
+                                :block/title "child"
+                                :block/parent [:block/uuid parent-uuid]
+                                :block/page [:block/uuid page-uuid]
+                                :block/order "a1"
+                                :block/created-at now
+                                :block/updated-at now}
+                               {:block/uuid property-value-uuid
+                                :block/title "property value"
+                                :block/parent [:block/uuid child-uuid]
+                                :block/page [:block/uuid page-uuid]
+                                :block/order "a4"
+                                :logseq.property/created-from-property :user.property/sync-report
+                                :block/created-at now
+                                :block/updated-at now}])
+          t-before (storage/get-t sql)
+          tx-entry {:tx (protocol/tx->transit
+                         [[:db/add [:block/uuid child-uuid]
+                           :block/parent
+                           [:block/uuid page-uuid]
+                           537866038]
+                          [:db/retractEntity [:block/uuid parent-uuid]]
+                          [:db/retractEntity [:block/uuid child-uuid]]])
+                    :outliner-op :delete-blocks}
+          response (with-redefs [ws/broadcast! (fn [& _] nil)]
+                     (sync-handler/handle-tx-batch! self nil [tx-entry] t-before))]
+      (is (= "tx/batch/ok" (:type response)))
+      (is (nil? (d/entity @conn [:block/uuid parent-uuid])))
+      (is (nil? (d/entity @conn [:block/uuid child-uuid])))
+      (is (nil? (d/entity @conn [:block/uuid property-value-uuid]))))))
+
 (deftest repair-blocks-response-returns-server-block-data-test
   (testing "repair block response returns transactable datoms with lookup refs"
     (let [{:keys [conn self]} (make-server-self)
@@ -1035,8 +1173,8 @@
       (is (empty? (storage/fetch-tx-since sql t-before)))
       (is (empty? @changed-messages)))))
 
-(deftest tx-batch-rejects-unapplied-stale-rebase-with-tx-id-test
-  (testing "a client tx id should not be acknowledged when its stale rebase was not applied"
+(deftest tx-batch-acknowledges-noop-stale-rebase-with-tx-id-test
+  (testing "an accepted no-op should acknowledge its client tx id"
     (let [sql (test-sql/make-sql)
           conn (storage/open-conn sql)
           self #js {:sql sql
@@ -1071,10 +1209,9 @@
           response (with-redefs [ws/broadcast! (fn [_self _sender payload]
                                                  (swap! changed-messages conj payload))]
                      (sync-handler/handle-tx-batch! self nil [tx-entry] t-before))]
-      (is (= "tx/reject" (:type response)))
-      (is (= "db transact failed" (:reason response)))
+      (is (= "tx/batch/ok" (:type response)))
       (is (= t-before (:t response)))
-      (is (= tx-id (:failed-tx-id response)))
+      (is (nil? (:failed-tx-id response)))
       (is (= checksum-before (storage/get-checksum sql)))
       (is (empty? (storage/fetch-tx-since sql t-before)))
       (is (empty? @changed-messages)))))

--- a/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
@@ -595,8 +595,8 @@
                     (select-keys % [:op :outliner-op :graph-id :client-revision]))
                 @tx-metas)))))
 
-(deftest tx-batch-ignores-stale-move-target-updates-test
-  (testing "move-blocks against a block already deleted on the server is a no-op"
+(deftest tx-batch-rejects-move-blocks-when-target-is-missing-test
+  (testing "move-blocks against a block missing on the server should request client repair"
     (let [sql (test-sql/make-sql)
           conn (storage/open-conn sql)
           self #js {:sql sql
@@ -639,8 +639,11 @@
           response (with-redefs [ws/broadcast! (fn [_self _sender payload]
                                                  (swap! changed-messages conj payload))]
                      (sync-handler/handle-tx-batch! self nil [tx-entry] t-before))]
-      (is (= "tx/batch/ok" (:type response)))
+      (is (= "tx/reject" (:type response)))
+      (is (= "db transact failed" (:reason response)))
       (is (= t-before (:t response)))
+      (is (= tx-id (:failed-tx-id response)))
+      (is (= [missing-block-uuid] (:missing-block-uuids response)))
       (is (= checksum-before (storage/get-checksum sql)))
       (is (empty? (storage/fetch-tx-since sql t-before)))
       (is (empty? @changed-messages)))))
@@ -690,6 +693,10 @@
                          [[:db/add [:block/uuid child-uuid]
                            :block/parent
                            [:block/uuid page-uuid]
+                           537866038]
+                          [:db/add [:block/uuid property-value-uuid]
+                           :block/updated-at
+                           (inc now)
                            537866038]
                           [:db/retractEntity [:block/uuid parent-uuid]]
                           [:db/retractEntity [:block/uuid child-uuid]]])

--- a/deps/db-sync/test/logseq/db_sync/worker_handler_ws_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/worker_handler_ws_test.cljs
@@ -67,6 +67,44 @@
     (is (= "hello" (:type @sent)))
     (is (false? (contains? @sent :checksum)))))
 
+(deftest tx-batch-message-adds-graph-and-user-context-to-transact-meta-test
+  (let [sql (test-sql/make-sql)
+        conn (storage/open-conn sql)
+        ws #js {:readyState 1}
+        sent (atom nil)
+        tx-metas (atom [])
+        self #js {:conn conn
+                  :graph-id "graph-ws"
+                  :schema-ready true
+                  :sql sql}
+        raw (protocol/encode-message
+             {:type "tx/batch"
+              :client-revision "revision-ws"
+              :t-before 0
+              :txs [{:tx (protocol/tx->transit [[:db/add -1 :block/title "ws context"]])
+                     :outliner-op :save-block}]})]
+    (with-redefs [presence/get-user (fn [_self _ws]
+                                      {:user-id "user-1"
+                                       :username "alice"})
+                  ws/broadcast! (fn [& _] nil)
+                  ws/send! (fn [_target msg]
+                             (reset! sent msg))]
+      (d/listen! conn ::capture-ws-context-tx-meta
+                 (fn [tx-report]
+                   (swap! tx-metas conj (:tx-meta tx-report))))
+      (try
+        (ws-handler/handle-ws-message! self ws raw)
+        (finally
+          (d/unlisten! conn ::capture-ws-context-tx-meta))))
+    (is (= "tx/batch/ok" (:type @sent)))
+    (is (some #(= {:op :apply-client-tx
+                   :outliner-op :save-block
+                   :graph-id "graph-ws"
+                   :client-revision "revision-ws"
+                   :username "alice"}
+                  (select-keys % [:op :outliner-op :graph-id :client-revision :username]))
+              @tx-metas))))
+
 (deftest ws-send-serializes-tx-reject-uuids-as-strings-test
   (let [raw* (atom nil)
         ws #js {:readyState 1

--- a/deps/db/src/logseq/db.cljs
+++ b/deps/db/src/logseq/db.cljs
@@ -35,6 +35,7 @@
 (defonce *transact-invalid-callback (atom nil))
 (defonce *transact-pipeline-fn (atom nil))
 (defonce *debounce-fn (atom nil))
+(def ^:dynamic *batch-tx-report?* false)
 
 (defn register-transact-fn!
   [f]
@@ -220,9 +221,12 @@
        ;; (cljs.pprint/pprint tx-data)
        ;; (js/console.trace)
 
-       (if-let [transact-fn @*transact-fn]
-         (transact-fn repo-or-conn tx-data tx-meta)
-         (transact-sync repo-or-conn tx-data tx-meta))))))
+       (let [tx-meta (cond-> tx-meta
+                       *batch-tx-report?*
+                       (assoc :batch-tx-report? true))]
+         (if-let [transact-fn @*transact-fn]
+           (transact-fn repo-or-conn tx-data tx-meta)
+           (transact-sync repo-or-conn tx-data tx-meta)))))))
 
 (defn- make-conn [db opts]
   ;; `datascript.conn/->Conn` is not exposed in nbb runtime.
@@ -317,7 +321,8 @@
         (throw (ex-info "batch-transact! can't be nested called" {:tx-meta tx-meta})))
       (batch-transact-listen! conn *tx-data listen-db)
       (swap! conn assoc :skip-store? true :batch-tx? true)
-      (batch-tx-fn conn)
+      (binding [*batch-tx-report?* true]
+        (batch-tx-fn conn))
       (batch-transact-cleanup! conn)
       (when-some [_storage (storage/storage @conn)]
         (d/store @conn)

--- a/deps/db/src/logseq/db.cljs
+++ b/deps/db/src/logseq/db.cljs
@@ -91,8 +91,11 @@
   [db tx-data]
   (when (some (fn [d] (and (:added d)
                            (= :block/parent (:a d))
-                           (entity-util/page? (d/entity db (:e d)))
-                           (not (entity-util/page? (d/entity db (:v d)))))) tx-data)
+                           (let [entity (d/entity db (:e d))
+                                 parent (:block/parent entity)]
+                             (and (entity-util/page? entity)
+                                  (= (:v d) (:db/id parent))
+                                  (not (entity-util/page? (d/entity db (:v d)))))))) tx-data)
     (throw (ex-info "Page can't have block as parent"
                     {:tx-data tx-data}))))
 

--- a/scripts/cli-sync-stress-workflow.test.mjs
+++ b/scripts/cli-sync-stress-workflow.test.mjs
@@ -24,7 +24,6 @@ test("CLI sync stress workflow runs local sync/offline stress and validates the 
   assert.match(workflow, /--sync/);
   assert.match(workflow, /--offline/);
   assert.match(workflow, /--no-e2ee/);
-  assert.match(workflow, /--max-ops 1000/);
   assert.match(workflow, /graph validate --graph "\$GRAPH" --output json/);
 });
 

--- a/src/main/frontend/worker/db_listener.cljs
+++ b/src/main/frontend/worker/db_listener.cljs
@@ -80,7 +80,7 @@
                  [{:keys [tx-data tx-meta] :as tx-report}]
                  (when (seq tx-data)
                    (let [update-checksum? (or (:batch-final-tx-report? tx-meta)
-                                               (not (:batch-tx? @conn)))]
+                                               (not (:batch-tx-report? tx-meta)))]
                      (when update-checksum?
                        (db-sync/update-local-sync-checksum! repo tx-report)
                        (let [tx-report' (if sync-db-to-main-thread?

--- a/src/main/frontend/worker/db_listener.cljs
+++ b/src/main/frontend/worker/db_listener.cljs
@@ -77,14 +77,16 @@
     (d/unlisten! conn ::listen-db-changes!)
     (d/listen! conn ::listen-db-changes!
                (fn listen-db-changes!-inner
-                 [{:keys [tx-data _tx-meta] :as tx-report}]
+                 [{:keys [tx-data tx-meta] :as tx-report}]
                  (when (seq tx-data)
-                   (when-not (:batch-tx? @conn)
-                     (db-sync/update-local-sync-checksum! repo tx-report)
-                     (let [tx-report' (if sync-db-to-main-thread?
-                                        (sync-db-to-main-thread repo conn tx-report)
-                                        tx-report)
-                           opt {:repo repo}]
-                       (when tx-report'
-                         (doseq [[k handler-fn] handlers]
-                           (handler-fn k opt tx-report'))))))))))
+                   (let [update-checksum? (or (:batch-final-tx-report? tx-meta)
+                                               (not (:batch-tx? @conn)))]
+                     (when update-checksum?
+                       (db-sync/update-local-sync-checksum! repo tx-report)
+                       (let [tx-report' (if sync-db-to-main-thread?
+                                          (sync-db-to-main-thread repo conn tx-report)
+                                          tx-report)
+                             opt {:repo repo}]
+                         (when tx-report'
+                           (doseq [[k handler-fn] handlers]
+                             (handler-fn k opt tx-report')))))))))))

--- a/src/main/frontend/worker/sync.cljs
+++ b/src/main/frontend/worker/sync.cljs
@@ -54,6 +54,26 @@
   (when (worker-state/get-client-ops-conn repo)
     (let [current-checksum (client-op/get-local-checksum repo)
           new-checksum (sync-checksum/update-checksum current-checksum tx-report)]
+      (when (and (exists? js/process)
+                 (= "1" (aget (.-env js/process) "LOGSEQ_CHECKSUM_ASSERT")))
+        (let [recomputed-checksum (sync-checksum/recompute-checksum (:db-after tx-report))]
+          (when-not (= new-checksum recomputed-checksum)
+            (let [{:keys [tx-meta tx-data]} tx-report]
+              (log/error :db-sync/checksum-incremental-drift
+                         {:repo repo
+                          :current-checksum current-checksum
+                          :incremental-checksum new-checksum
+                          :recomputed-checksum recomputed-checksum
+                          :tx-meta tx-meta
+                          :tx-count (count tx-data)
+                          :tx-sample (take 30 tx-data)})
+              (throw (ex-info "Incremental checksum drift"
+                              {:repo repo
+                               :current-checksum current-checksum
+                               :incremental-checksum new-checksum
+                               :recomputed-checksum recomputed-checksum
+                               :tx-meta tx-meta
+                               :tx-count (count tx-data)}))))))
       (client-op/update-local-checksum repo new-checksum))))
 
 (defn- broadcast-rtc-state!

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -1754,7 +1754,7 @@
   [repo {:keys [tx-meta tx-data] :as tx-report}]
   (when-let [conn (worker-state/get-datascript-conn repo)]
     (when (and (persistable-local-tx-meta? tx-meta)
-               (not (and (:batch-tx? @conn) (not= :rebase (:outliner-op tx-meta))))
+               (not (and (:batch-tx-report? tx-meta) (not= :rebase (:outliner-op tx-meta))))
                (not (:reverse? tx-meta))
                (seq tx-data))
       (enqueue-local-tx-aux repo tx-report))))

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -396,7 +396,7 @@
                (nil? (d/entity db [:block/uuid block-uuid]))))
         (tx-item-ref-block-uuids item)))
 
-(defn- drop-stale-missing-block-ref-ops
+(defn- drop-stale-missing-block-ref-ops-result
   [db stale-block-uuids tx-data]
   (let [temp-id->uuid (tx-temp-id->uuid tx-data)
         stale-entity-block-uuids (->> tx-data
@@ -404,12 +404,14 @@
                                               (when (tx-item-missing-stale-block-ref?
                                                      db stale-block-uuids item)
                                                 (tx-item-entity-block-uuid db temp-id->uuid item))))
-                                      set)]
-    (remove (fn [item]
-              (or (tx-item-missing-stale-block-ref? db stale-block-uuids item)
-                  (contains? stale-entity-block-uuids
-                             (tx-item-entity-block-uuid db temp-id->uuid item))))
-            tx-data)))
+                                      set)
+        tx-data* (remove (fn [item]
+                           (or (tx-item-missing-stale-block-ref? db stale-block-uuids item)
+                               (contains? stale-entity-block-uuids
+                                          (tx-item-entity-block-uuid db temp-id->uuid item))))
+                         tx-data)]
+    {:tx-data tx-data*
+     :dropped-entity-block-uuids stale-entity-block-uuids}))
 
 (defn- repair-block-uuids-in-tx-data
   [db tx-data]
@@ -992,7 +994,8 @@
                       :or {allow-invalid-repair? true}}]
   (loop [remaining remote-txs
          index 0
-         results []]
+         results []
+         carried-stale-block-uuids #{}]
     (let [db @conn]
       (if-let [remote-tx (first remaining)]
         (let [deleted-block-uuids (remote-txs-retract-entity-block-uuids remaining)
@@ -1001,9 +1004,13 @@
               tx-data (some->> (:tx-data remote-tx)
                                (map (partial resolve-temp-id db))
                                (tx-sanitize/sanitize-tx db)
-                               (drop-stale-deleted-block-ref-ops db deleted-block-uuids)
-                               (drop-stale-missing-block-ref-ops db stale-block-uuids)
-                               seq)
+                               (drop-stale-deleted-block-ref-ops db deleted-block-uuids))
+              {:keys [tx-data dropped-entity-block-uuids]}
+              (drop-stale-missing-block-ref-ops-result
+               db
+               (set/union carried-stale-block-uuids stale-block-uuids)
+               tx-data)
+              tx-data (seq tx-data)
               tx-meta (apply-tx-meta remote-tx)
               invalid-retry? (and allow-invalid-repair?
                                   (missing-datom-repair-tx? tx-data)
@@ -1020,7 +1027,10 @@
                                 :report report
                                 :invalid-retry? invalid-retry?
                                 :repair-block-uuids repair-block-uuids}))]
-          (recur (next remaining) (inc index) results'))
+          (recur (next remaining)
+                 (inc index)
+                 results'
+                 (set/union carried-stale-block-uuids dropped-entity-block-uuids)))
         results))))
 
 (defn reverse-local-txs!

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -827,38 +827,42 @@
                     (sort-by :block/order (:block/_parent block))))]
     (collect entity)))
 
-(defn- expand-insert-blocks-reverse-retracts
+(defn- retract-entity-op?
+  [item]
+  (and (vector? item)
+       (contains? #{:db/retractEntity :db.fn/retractEntity} (first item))))
+
+(defn- expand-block-retracts-to-descendants
   [db tx-data]
   (let [explicit-retracts (->> tx-data
                                (keep (fn [item]
-                                       (when (and (vector? item)
-                                                  (= :db/retractEntity (first item))
+                                       (when (and (retract-entity-op? item)
                                                   (block-ref? (second item)))
-                                         (:db/id (block-entity db (second item))))))
+                                         (some-> (block-entity db (second item)) :db/id))))
                                set)]
     (mapcat
      (fn [item]
-       (if (and (vector? item)
-                (= :db/retractEntity (first item))
-                (block-ref? (second item)))
-         (let [root (block-entity db (second item))
-               descendant-retracts (->> (block-descendants root)
-                                        (remove #(contains? explicit-retracts (:db/id %)))
-                                        (map (fn [entity]
-                                               [:db/retractEntity (block-entity-ref entity)])))]
-           (concat descendant-retracts [item]))
+       (if (and (retract-entity-op? item)
+                (block-ref? (second item))
+                (block-entity db (second item)))
+         (let [root (block-entity db (second item))]
+           (concat (->> (block-descendants root)
+                        (remove #(contains? explicit-retracts (:db/id %)))
+                        (map (fn [entity]
+                               [:db/retractEntity (block-entity-ref entity)])))
+                   [item]))
          [item]))
      tx-data)))
 
 (defn- reverse-history-action!
   [conn local-tx]
   (if-let [tx-data (seq (:reversed-tx local-tx))]
-    (let [db @conn
-          tx-data' (cond->> (some->> tx-data
-                                      (map (partial resolve-temp-id db))
-                                      normalize-tx-data-for-rebase)
-                     (= :insert-blocks (:outliner-op local-tx))
-                     (expand-insert-blocks-reverse-retracts db))]
+	      (let [db @conn
+	            tx-data' (cond->> (some->> tx-data
+	                                      (map (partial resolve-temp-id db))
+	                                      normalize-tx-data-for-rebase)
+	                     (= :insert-blocks (:outliner-op local-tx))
+	                     (expand-block-retracts-to-descendants db))]
       (ldb/transact! conn
                      tx-data'
                      {:outliner-op (:outliner-op local-tx)
@@ -1362,7 +1366,8 @@
         (ldb/transact! conn tx-data
                        {:outliner-op :recycle-delete-permanently})))
 
-    (let [[tx-data tx-meta] args]
+    (let [[tx-data tx-meta] args
+          tx-data (expand-block-retracts-to-descendants @conn tx-data)]
       (when-let [tx-data (seq tx-data)]
         (ldb/transact! conn tx-data tx-meta)))))
 
@@ -1512,16 +1517,17 @@
         (worker-undo-redo/clear-history! repo)))))
 
 (defn- apply-remote-tx-without-local-changes!
-  [{:keys [conn remote-txs stale-repair-block-uuids]}]
+  [{:keys [repo conn local-txs remote-txs stale-repair-block-uuids]}]
   (let [remote-tx-results (atom [])
-        tx-report (ldb/batch-transact!
+        tx-report (ldb/batch-transact-with-temp-conn!
                    conn
                    {:rtc-tx? true
                     :without-local-changes? true}
                    (fn [conn]
                      (reset! remote-tx-results
                              (transact-remote-txs! conn remote-txs
-                                                   :stale-repair-block-uuids stale-repair-block-uuids))))]
+                                                   :stale-repair-block-uuids stale-repair-block-uuids)))
+                   {:before-commit #(fail-if-pending-tx-snapshot-changed! repo local-txs)})]
     (repair-applied-txs! conn tx-report)
     {:repair-block-uuids (->> @remote-tx-results
                               (mapcat :repair-block-uuids)

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -389,6 +389,10 @@
        vals
        set))
 
+(defn- remote-txs-db-migrate?
+  [remote-txs]
+  (some #(= :db-migrate (:outliner-op %)) remote-txs))
+
 (defn- tx-item-missing-stale-block-ref?
   [db stale-block-uuids item]
   (some (fn [block-uuid]
@@ -1450,9 +1454,14 @@
 
 (defn- apply-remote-tx-with-local-changes!
   [{:keys [repo conn local-txs remote-txs pre-repair-tx-data post-repair-tx-data stale-repair-block-uuids
-           prefetched-repair-block-uuids]}]
-  (let [tx-meta {:rtc-tx? true
-                 :with-local-changes? true}
+           prefetched-repair-block-uuids db-migrate? skip-final-validate?]}]
+  (let [tx-meta (cond-> {:rtc-tx? true
+                         :with-local-changes? true}
+                  db-migrate?
+                  (assoc :db-migrate? true
+                         :outliner-op :db-migrate)
+                  skip-final-validate?
+                  (assoc :skip-validate-db? true))
         *rebase-tx-reports (atom [])
         *rebase-results (atom [])
         *remote-tx-results (atom [])
@@ -1517,20 +1526,33 @@
         (worker-undo-redo/clear-history! repo)))))
 
 (defn- apply-remote-tx-without-local-changes!
-  [{:keys [repo conn local-txs remote-txs stale-repair-block-uuids]}]
+  [{:keys [repo conn local-txs remote-txs pre-repair-tx-data post-repair-tx-data stale-repair-block-uuids
+           prefetched-repair-block-uuids db-migrate? skip-final-validate?]}]
   (let [remote-tx-results (atom [])
         tx-report (ldb/batch-transact-with-temp-conn!
                    conn
-                   {:rtc-tx? true
-                    :without-local-changes? true}
+                   (cond-> {:rtc-tx? true
+                            :without-local-changes? true}
+                     db-migrate?
+                     (assoc :db-migrate? true
+                            :outliner-op :db-migrate)
+                     skip-final-validate?
+                     (assoc :skip-validate-db? true))
                    (fn [conn]
+                     (when (seq pre-repair-tx-data)
+                       (maybe-apply-repair-tx-data! conn pre-repair-tx-data))
+
                      (reset! remote-tx-results
                              (transact-remote-txs! conn remote-txs
-                                                   :stale-repair-block-uuids stale-repair-block-uuids)))
+                                                   :stale-repair-block-uuids stale-repair-block-uuids))
+
+                     (when (seq post-repair-tx-data)
+                       (maybe-apply-repair-tx-data! conn post-repair-tx-data)))
                    {:before-commit #(fail-if-pending-tx-snapshot-changed! repo local-txs)})]
     (repair-applied-txs! conn tx-report)
     {:repair-block-uuids (->> @remote-tx-results
                               (mapcat :repair-block-uuids)
+                              (remove (set prefetched-repair-block-uuids))
                               distinct
                               vec)
      :remote-asset-tx-data (mapcat (comp :tx-data :report) @remote-tx-results)}))
@@ -1689,8 +1711,11 @@
                                          (remove (set remote-created-block-uuids))
                                          distinct
                                          vec)
-                invalid-repair-block-uuids (when has-local-changes?
-                                             (remote-txs-invalid-repair-block-uuids @conn remote-txs))]
+                invalid-repair-block-uuids (remote-txs-invalid-repair-block-uuids @conn remote-txs)
+                db-migrate? (remote-txs-db-migrate? remote-txs)
+                apply-args (update apply-args :apply-context assoc
+                                   :db-migrate? db-migrate?
+                                   :skip-final-validate? db-migrate?)]
        (if has-local-changes?
          (if (or (seq missing-block-uuids)
                  (seq invalid-repair-block-uuids))
@@ -1712,12 +1737,25 @@
                  (apply-with-repair pre-repair-tx-data* post-repair-tx-data*))
                (apply-with-repair pre-repair-tx-data post-repair-tx-data)))
            (apply-remote-txs-after-server-repair! apply-args))
-         (if (seq missing-block-uuids)
-           (after-repair-result
-            (<apply-server-repair-blocks! repo client conn missing-block-uuids)
-            #(apply-remote-txs-after-server-repair!
-              (update apply-args :apply-context assoc
-                      :stale-repair-block-uuids missing-block-uuids)))
+         (if (or (seq missing-block-uuids)
+                 (seq invalid-repair-block-uuids))
+           (let [pre-repair-tx-data (<server-repair-blocks-tx-data repo client missing-block-uuids)
+                 post-repair-tx-data (<server-repair-blocks-tx-data repo client invalid-repair-block-uuids)
+                 apply-with-repair (fn [pre-repair-tx-data* post-repair-tx-data*]
+                                     (apply-remote-txs-after-server-repair!
+                                      (update apply-args :apply-context assoc
+                                              :pre-repair-tx-data pre-repair-tx-data*
+                                              :post-repair-tx-data post-repair-tx-data*
+                                              :stale-repair-block-uuids missing-block-uuids
+                                              :prefetched-repair-block-uuids
+                                              (distinct (concat missing-block-uuids
+                                                                invalid-repair-block-uuids)))))]
+             (if (or (p/promise? pre-repair-tx-data)
+                     (p/promise? post-repair-tx-data))
+               (p/let [pre-repair-tx-data* pre-repair-tx-data
+                       post-repair-tx-data* post-repair-tx-data]
+                 (apply-with-repair pre-repair-tx-data* post-repair-tx-data*))
+               (apply-with-repair pre-repair-tx-data post-repair-tx-data)))
            (apply-remote-txs-after-server-repair! apply-args))))
      (fail-fast :db-sync/missing-db {:repo repo :op :apply-remote-txs}))))
 

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -1752,7 +1752,7 @@
 
 (defn enqueue-local-tx!
   [repo {:keys [tx-meta tx-data] :as tx-report}]
-  (when-let [conn (worker-state/get-datascript-conn repo)]
+  (when (worker-state/get-datascript-conn repo)
     (when (and (persistable-local-tx-meta? tx-meta)
                (not (and (:batch-tx-report? tx-meta) (not= :rebase (:outliner-op tx-meta))))
                (not (:reverse? tx-meta))

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -1975,6 +1975,71 @@
           (is (= (sync-checksum/recompute-checksum @conn)
                  (client-op/get-local-checksum test-repo))))))))
 
+(deftest local-checksum-updates-non-batch-report-with-stale-batch-flag-test
+  (testing "a non-batch tx report must not be skipped because conn batch state is stale"
+    (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)]
+      (with-datascript-conns conn client-ops-conn
+        (fn []
+          (client-op/update-local-checksum test-repo (sync-checksum/recompute-checksum @conn))
+          (db-listener/listen-db-changes! test-repo conn :handler-keys [:checksum-test])
+          (try
+            (swap! conn assoc :batch-tx? true)
+            (d/transact! conn
+                         [[:db/add (:db/id parent)
+                           :block/title
+                           "non-batch tx while stale batch flag is set"]]
+                         {:outliner-op :checksum-stale-batch-flag-test})
+            (finally
+              (swap! conn dissoc :batch-tx?)))
+          (is (= (sync-checksum/recompute-checksum @conn)
+                 (client-op/get-local-checksum test-repo))))))))
+
+(deftest local-checksum-updates-ldb-non-batch-report-with-stale-batch-flag-test
+  (testing "ldb/transact! must not tag non-batch reports from stale conn batch state"
+    (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)]
+      (with-datascript-conns conn client-ops-conn
+        (fn []
+          (client-op/update-local-checksum test-repo (sync-checksum/recompute-checksum @conn))
+          (db-listener/listen-db-changes! test-repo conn :handler-keys [:checksum-test])
+          (try
+            (swap! conn assoc :batch-tx? true)
+            (ldb/transact! conn
+                           [[:db/add (:db/id parent)
+                             :block/title
+                             "ldb non-batch tx while stale batch flag is set"]]
+                           {:outliner-op :checksum-ldb-stale-batch-flag-test})
+            (finally
+              (swap! conn dissoc :batch-tx?)))
+          (is (= (sync-checksum/recompute-checksum @conn)
+                 (client-op/get-local-checksum test-repo))))))))
+
+(deftest batch-transact-tags-inner-tx-reports-test
+  (testing "inner batch reports carry stable metadata independent from mutable conn state"
+    (let [{:keys [conn parent]} (setup-parent-child)
+          captured (atom [])]
+      (with-datascript-conns conn nil
+        (fn []
+          (d/listen! conn ::capture-batch-tx-meta
+                     (fn [tx-report]
+                       (swap! captured conj (:tx-meta tx-report))))
+          (try
+            (ldb/batch-transact!
+             conn
+             {:outliner-op :checksum-batch-final-test}
+             (fn [conn]
+               (ldb/transact! conn
+                              [[:db/add (:db/id parent)
+                                :block/title
+                                "inner batch report title"]]
+                              {:outliner-op :checksum-inner-batch-test})))
+            (finally
+              (d/unlisten! conn ::capture-batch-tx-meta)))
+          (let [[inner final] @captured]
+            (is (:batch-tx-report? inner))
+            (is (not (:batch-final-tx-report? inner)))
+            (is (:batch-final-tx-report? final))
+            (is (not (:batch-tx-report? final)))))))))
+
 (deftest remote-batch-drops-follow-up-ops-for-stale-created-block-test
   (testing "remote txs later in the same batch should not apply ops for an entity dropped as stale"
     (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -3,6 +3,7 @@
    [cljs.test :refer [async deftest is testing use-fixtures]]
    [clojure.set :as set]
    [clojure.string :as string]
+   [datascript.conn :as dc]
    [datascript.core :as d]
    [frontend.common.crypt :as crypt]
    [frontend.test.noise :as test-noise]
@@ -1134,6 +1135,84 @@
                 (is (= 1 (aget ent "failed")))
                 (is (= child-title (:block/title child')))))))))))
 
+(deftest tx-reject-db-transact-failed-keeps-checksum-aligned-test
+  (testing "a rejected local rollback should update the stored checksum incrementally"
+    (let [{:keys [conn client-ops-conn child1]} (setup-parent-child)
+          child-uuid (:block/uuid child1)]
+      (with-datascript-conns conn client-ops-conn
+        (fn []
+          (client-op/update-local-checksum test-repo (sync-checksum/recompute-checksum @conn))
+          (db-listener/listen-db-changes! test-repo conn :handler-keys [:checksum-test])
+          (outliner-core/delete-blocks! conn [child1] {})
+          (let [tx-id (:tx-id (first (#'sync-apply/pending-txs test-repo)))
+                checksum-after-delete (client-op/get-local-checksum test-repo)
+                raw-message (js/JSON.stringify
+                             (clj->js {:type "tx/reject"
+                                       :reason "db transact failed"
+                                       :t 3
+                                       :failed-tx-id (str tx-id)}))
+                client {:repo test-repo
+                        :graph-id "graph-1"
+                        :inflight (atom [tx-id])
+                        :online-users (atom [])
+                        :ws-state (atom :open)}]
+            (is (nil? (d/entity @conn [:block/uuid child-uuid])))
+            (is (= (sync-checksum/recompute-checksum @conn)
+                   checksum-after-delete))
+            (with-redefs [client-op/get-local-tx (constantly 0)]
+              (let [error (try
+                            (with-silenced-console-error
+                              #(sync-handle-message/handle-message! test-repo client raw-message))
+                            nil
+                            (catch :default e
+                              e))]
+                (is (some? error))
+                (is (= :db-sync/tx-rejected
+                       (:type (ex-data error))))
+                (is (= (sync-checksum/recompute-checksum @conn)
+                       (client-op/get-local-checksum test-repo)))))))))))
+
+(deftest tx-reject-db-transact-failed-rebase-keeps-checksum-aligned-test
+  (testing "rollback plus rebase of later pending txs should keep the stored checksum aligned"
+    (let [{:keys [conn client-ops-conn parent-a parent-b a-child-1 b-child-1]} (setup-two-parents)
+          deleted-uuid (:block/uuid a-child-1)]
+      (with-datascript-conns conn client-ops-conn
+        (fn []
+          (client-op/update-local-checksum test-repo (sync-checksum/recompute-checksum @conn))
+          (db-listener/listen-db-changes! test-repo conn :handler-keys [:checksum-test])
+          (outliner-core/delete-blocks! conn [a-child-1] {})
+          (outliner-core/move-blocks! conn [b-child-1] parent-a {:sibling? false})
+          (let [pending (#'sync-apply/pending-txs test-repo)
+                delete-tx-id (:tx-id (first pending))
+                raw-message (js/JSON.stringify
+                             (clj->js {:type "tx/reject"
+                                       :reason "db transact failed"
+                                       :t 3
+                                       :failed-tx-id (str delete-tx-id)}))
+                client {:repo test-repo
+                        :graph-id "graph-1"
+                        :inflight (atom (mapv :tx-id pending))
+                        :online-users (atom [])
+                        :ws-state (atom :open)}]
+            (is (nil? (d/entity @conn [:block/uuid deleted-uuid])))
+            (is (= (sync-checksum/recompute-checksum @conn)
+                   (client-op/get-local-checksum test-repo)))
+            (with-redefs [client-op/get-local-tx (constantly 0)]
+              (let [error (try
+                            (with-silenced-console-error
+                              #(sync-handle-message/handle-message! test-repo client raw-message))
+                            nil
+                            (catch :default e
+                              e))]
+                (is (some? error))
+                (is (= :db-sync/tx-rejected
+                       (:type (ex-data error))))
+                (is (= (sync-checksum/recompute-checksum @conn)
+                       (client-op/get-local-checksum test-repo)))
+                (is (= (:block/uuid parent-a)
+                       (:block/uuid (:block/parent (d/entity @conn (:db/id b-child-1))))))
+                (is (some? (d/entity @conn [:block/uuid deleted-uuid])))))))))))
+
 (deftest tx-reject-db-transact-failed-selectively-updates-inflight-ops-test
   (testing "tx/reject should mark success txs as non-pending and failed tx as failed, leaving later inflight pending"
     (let [{:keys [conn client-ops-conn]} (setup-parent-child)
@@ -1875,6 +1954,26 @@
                                      "committed batch title"]])))
             (is (= (sync-checksum/recompute-checksum @conn)
                    (client-op/get-local-checksum test-repo)))))))))
+
+(deftest local-checksum-updates-for-final-batch-report-with-batch-flag-test
+  (testing "a committed final batch tx report must update checksum even if the conn batch flag is still set"
+    (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)]
+      (with-datascript-conns conn client-ops-conn
+        (fn []
+          (client-op/update-local-checksum test-repo (sync-checksum/recompute-checksum @conn))
+          (db-listener/listen-db-changes! test-repo conn :handler-keys [:checksum-test])
+          (try
+            (swap! conn assoc :batch-tx? true)
+            (d/transact! conn
+                         [[:db/add (:db/id parent)
+                           :block/title
+                           "final batch report title"]]
+                         {:outliner-op :checksum-final-batch-test
+                          :batch-final-tx-report? true})
+            (finally
+              (swap! conn dissoc :batch-tx?)))
+          (is (= (sync-checksum/recompute-checksum @conn)
+                 (client-op/get-local-checksum test-repo))))))))
 
 (deftest remote-batch-drops-follow-up-ops-for-stale-created-block-test
   (testing "remote txs later in the same batch should not apply ops for an entity dropped as stale"
@@ -4929,6 +5028,37 @@
                 (is (= created-at-before (:block/created-at page')))
                 (is (= updated-at-before (:block/updated-at page')))))))))))
 
+(deftest temp-conn-batch-commit-ignores-transient-invalid-page-parent-test
+  (testing "temp conn batch validation should check the final page parent, not transient datoms"
+    (let [conn (db-test/create-conn-with-blocks
+                {:pages-and-blocks
+                 [{:page {:block/title "page 1"}
+                   :blocks [{:block/title "temporary parent"}]}]})
+          page (ldb/get-page @conn "page 1")
+          temporary-parent (db-test/find-block-by-content @conn "temporary parent")
+          page-tag (:db/id (d/entity @conn :logseq.class/Page))
+          page-uuid (random-uuid)
+          now 1760000000000]
+      (ldb/batch-transact-with-temp-conn!
+       conn
+       {:rtc-tx? true}
+       (fn [temp-conn]
+         (ldb/transact! temp-conn
+                        [{:db/id -1
+                          :block/uuid page-uuid
+                          :block/title "Reused UUID Page"
+                          :block/name "reused uuid page"
+                          :block/tags page-tag
+                          :block/parent (:db/id temporary-parent)
+                          :block/created-at now
+                          :block/updated-at now}])
+         (ldb/transact! temp-conn
+                        [[:db/retract [:block/uuid page-uuid] :block/parent (:db/id temporary-parent)]])))
+      (let [entity (d/entity @conn [:block/uuid page-uuid])]
+        (is (= "reused uuid page" (:block/name entity)))
+        (is (nil? (:block/parent entity)))
+        (is (true? (ldb/page? entity)))))))
+
 (deftest fix-duplicate-order-against-existing-sibling-test
   (testing "duplicate order update is fixed when it collides with an existing sibling"
     (let [{:keys [conn client-ops-conn child1 child2]} (setup-parent-child)
@@ -6481,9 +6611,51 @@
           (is (nil? (d/entity @conn [:block/uuid parent-uuid])))
           (is (nil? (d/entity @conn [:block/uuid mover-1-uuid])))
           (is (nil? (d/entity @conn [:block/uuid mover-2-uuid])))
-          (let [validation (db-validate/validate-local-db! @conn)]
-            (is (empty? (non-recycle-validation-entities validation))
-                (str (:errors validation)))))))))
+            (let [validation (db-validate/validate-local-db! @conn)]
+              (is (empty? (non-recycle-validation-entities validation))
+                  (str (:errors validation)))))))))
+
+(deftest apply-remote-txs-local-fallback-delete-parent-retracts-remote-child-test
+  (testing "rebasing a fallback local retractEntity deletes remote children inserted while the local tx was reversed"
+    (async done
+      (let [conn (db-test/create-conn-with-blocks
+                  {:pages-and-blocks
+                   [{:page {:block/title "page 1"}
+                     :blocks [{:block/title "parent"}]}]})
+            client-ops-conn (new-client-ops-db)
+            parent (db-test/find-block-by-content @conn "parent")
+            parent-uuid (:block/uuid parent)
+            page-uuid (:block/uuid (:block/page parent))
+            child-uuid (random-uuid)
+            now (.now js/Date)
+            remote-tx {:tx-data [[:db/add -1 :block/uuid child-uuid]
+                                 [:db/add -1 :block/title "remote child"]
+                                 [:db/add -1 :block/parent [:block/uuid parent-uuid]]
+                                 [:db/add -1 :block/page [:block/uuid page-uuid]]
+                                 [:db/add -1 :block/order "Zz"]
+                                 [:db/add -1 :block/created-at now]
+                                 [:db/add -1 :block/updated-at now]]}]
+        (-> (with-datascript-conns
+              conn client-ops-conn
+              (fn []
+                (ldb/transact! conn
+                               [[:db/retractEntity [:block/uuid parent-uuid]]]
+                               {:local-tx? true
+                                :outliner-op :batch-remove-property})
+                (is (= 1 (count (#'sync-apply/pending-txs test-repo))))
+                (p/let [_ (#'sync-apply/apply-remote-txs!
+                           test-repo
+                           (test-sync-client)
+                           [remote-tx])
+                        _ (p/delay remote-apply-test-settle-ms)]
+                  (is (nil? (d/entity @conn [:block/uuid parent-uuid])))
+                  (is (nil? (d/entity @conn [:block/uuid child-uuid])))
+                  (let [validation (db-validate/validate-local-db! @conn)]
+                    (is (empty? (non-recycle-validation-entities validation))
+                        (str (:errors validation)))))))
+            (.catch (fn [error]
+                      (is false (str error))))
+            (.finally done))))))
 
 (deftest apply-remote-txs-rechecks-local-txs-when-local-delete-races-temp-snapshot-test
   (testing "remote apply uses a consistent pending-tx and DB snapshot when a local delete races the temp snapshot"
@@ -6576,6 +6748,88 @@
             (.catch (fn [error]
                       (is false (str error))))
             (.finally done))))))
+
+(deftest apply-remote-txs-rechecks-local-txs-when-local-edit-races-without-local-batch-test
+  (testing "remote apply without initial local changes must not batch a racing local tx into the remote checksum"
+    (async done
+      (let [{:keys [conn client-ops-conn parent child1]} (setup-parent-child)
+            child1-uuid (:block/uuid child1)
+            local-child-uuid (random-uuid)
+            original-batch-transact! ldb/batch-transact!
+            original-batch-transact-with-temp-conn! ldb/batch-transact-with-temp-conn!
+            injected-edit? (atom false)
+            inject-local-edit! (fn []
+                                 (when-not @injected-edit?
+                                   (reset! injected-edit? true)
+                                   (outliner-core/insert-blocks!
+                                    conn
+                                    [{:block/uuid local-child-uuid
+                                      :block/title "concurrent local child"}]
+                                    parent
+                                    {:sibling? false
+                                     :bottom? true
+                                     :keep-uuid? true})))]
+        (-> (with-datascript-conns
+              conn client-ops-conn
+              (fn []
+                (client-op/update-local-checksum test-repo (sync-checksum/recompute-checksum @conn))
+                (db-listener/listen-db-changes! test-repo conn :handler-keys [:checksum-test])
+                (js/Promise.resolve
+                 (p/with-redefs [ldb/batch-transact!
+                                 (fn [conn' tx-meta batch-tx-fn & opts]
+                                   (if (:without-local-changes? tx-meta)
+                                     (let [db-before @conn'
+                                           *tx-data (atom [])]
+                                       (d/listen! conn' ::without-local-batch-race
+                                                  (fn [{:keys [tx-data]}]
+                                                    (swap! *tx-data into tx-data)))
+                                       (try
+                                         (inject-local-edit!)
+                                         (swap! conn' assoc :skip-store? true :batch-tx? true)
+                                         (batch-tx-fn conn')
+                                         (d/unlisten! conn' ::without-local-batch-race)
+                                         (swap! conn' dissoc :skip-store? :batch-tx?)
+                                         (let [tx-report {:db-before db-before
+                                                          :db-after @conn'
+                                                          :tx-meta (assoc tx-meta :batch-final-tx-report? true)
+                                                          :tx-data @*tx-data}]
+                                           (dc/run-callbacks conn' tx-report)
+                                           tx-report)
+                                         (catch :default error
+                                           (reset! conn' db-before)
+                                           (throw error))
+                                         (finally
+                                           (d/unlisten! conn' ::without-local-batch-race)
+                                           (swap! conn' dissoc :skip-store? :batch-tx?)
+                                           (reset! *tx-data nil))))
+                                     (apply original-batch-transact! conn' tx-meta batch-tx-fn opts)))
+                                 ldb/batch-transact-with-temp-conn!
+                                 (fn [conn' tx-meta batch-tx-fn & opts]
+                                   (apply original-batch-transact-with-temp-conn!
+                                          conn'
+                                          tx-meta
+                                          (fn [temp-conn & batch-args]
+                                            (when (:without-local-changes? tx-meta)
+                                              (inject-local-edit!))
+                                            (apply batch-tx-fn temp-conn batch-args))
+                                          opts))]
+                   (p/let [_ (#'sync-apply/apply-remote-txs!
+                              test-repo
+                              (test-sync-client)
+                              [{:tx-data [[:db/add [:block/uuid child1-uuid]
+                                           :block/title
+                                           "remote edit after local race"]]}])
+                           _ (p/delay remote-apply-test-settle-ms)]
+                     (is @injected-edit?)
+                     (is (= "remote edit after local race"
+                            (:block/title (d/entity @conn [:block/uuid child1-uuid]))))
+                     (is (= (sync-checksum/recompute-checksum @conn)
+                            (client-op/get-local-checksum test-repo))))))))
+            (.catch (fn [error]
+                      (is false (str error))))
+            (.finally (fn []
+                        (d/unlisten! conn :frontend.worker.db-listener/listen-db-changes!)
+                        (done))))))))
 
 (deftest apply-remote-txs-delays-retry-when-local-txs-keep-changing-test
   (testing "remote apply waits for a stable pending-tx snapshot instead of reporting failure"

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -1174,7 +1174,7 @@
 
 (deftest tx-reject-db-transact-failed-rebase-keeps-checksum-aligned-test
   (testing "rollback plus rebase of later pending txs should keep the stored checksum aligned"
-    (let [{:keys [conn client-ops-conn parent-a parent-b a-child-1 b-child-1]} (setup-two-parents)
+    (let [{:keys [conn client-ops-conn parent-a a-child-1 b-child-1]} (setup-two-parents)
           deleted-uuid (:block/uuid a-child-1)]
       (with-datascript-conns conn client-ops-conn
         (fn []
@@ -5099,7 +5099,6 @@
                 {:pages-and-blocks
                  [{:page {:block/title "page 1"}
                    :blocks [{:block/title "temporary parent"}]}]})
-          page (ldb/get-page @conn "page 1")
           temporary-parent (db-test/find-block-by-content @conn "temporary parent")
           page-tag (:db/id (d/entity @conn :logseq.class/Page))
           page-uuid (random-uuid)

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -1876,6 +1876,43 @@
             (is (= (sync-checksum/recompute-checksum @conn)
                    (client-op/get-local-checksum test-repo)))))))))
 
+(deftest remote-batch-drops-follow-up-ops-for-stale-created-block-test
+  (testing "remote txs later in the same batch should not apply ops for an entity dropped as stale"
+    (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
+          page-id (:db/id (:block/page parent))
+          missing-parent-uuid (random-uuid)
+          stale-child-uuid (random-uuid)
+          now 1783110501711
+          client (test-sync-client)
+          remote-txs [{:t 1
+                       :outliner-op :insert-blocks
+                       :tx-data [[:db/add "stale-child" :block/uuid stale-child-uuid]
+                                 [:db/add "stale-child" :block/title "stale child"]
+                                 [:db/add "stale-child" :block/parent [:block/uuid missing-parent-uuid]]
+                                 [:db/add "stale-child" :block/page page-id]
+                                 [:db/add "stale-child" :block/order "a0"]
+                                 [:db/add "stale-child" :block/created-at now]
+                                 [:db/add "stale-child" :block/updated-at now]]}
+                      {:t 2
+                       :outliner-op :save-block
+                       :tx-data [[:db/add [:block/uuid stale-child-uuid]
+                                  :block/title
+                                  "stale child update"]]}]]
+      (with-datascript-conns conn client-ops-conn
+        (fn []
+          (client-op/update-local-checksum test-repo (sync-checksum/recompute-checksum @conn))
+          (with-silenced-console-error
+            (fn []
+              (is (= :ok
+                     (try
+                       (sync-apply/apply-remote-txs! test-repo client remote-txs)
+                       :ok
+                       (catch :default _error
+                         :thrown))))))
+          (is (nil? (d/entity @conn [:block/uuid stale-child-uuid])))
+          (is (= (sync-checksum/recompute-checksum @conn)
+                 (client-op/get-local-checksum test-repo))))))))
+
 (deftest first-local-block-after-upload-keeps-server-checksum-in-sync-test
   (testing "the first local block tx after upload keeps server and client checksums equal"
     (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)


### PR DESCRIPTION
## Summary

Fix db-sync stale transaction handling and stabilize incremental checksum updates without falling back to recomputing checksums during normal operation.

- Treat stale move-like operations targeting already-missing entities as no-op batches.
- Sanitize delete operations by dropping redundant writes to entities being retracted and retracting current server descendants.
- Add request context to transaction metadata so failure diagnostics include graph id, client revision, and username where available.
- Tag inner batch tx reports with stable `:batch-tx-report?` metadata and use that metadata for checksum/local-tx decisions instead of mutable `@conn :batch-tx?` state.

## Root Cause

The server stale-tx issue came from client-materialized outliner tx data that could pass the coarse `t-before` revision check while still containing entity references that were no longer valid in the server DB. Delete batches could also leave descendant/property-value blocks in an invalid parent state, causing legitimate server `tx/reject` failures.

The incremental checksum mismatch was a separate client/server shared implementation bug: checksum and local pending-tx logic inferred whether a tx report was an inner batch report from mutable connection state. Under concurrent batch/sync activity, a non-batch tx report could be processed while `@conn :batch-tx?` was still true, so real graph changes were skipped by the incremental checksum path even though the data had changed.

## Validation

- `rtk bb dev:test -v frontend.worker.db-sync-test/local-checksum-updates-non-batch-report-with-stale-batch-flag-test -v frontend.worker.db-sync-test/local-checksum-updates-ldb-non-batch-report-with-stale-batch-flag-test -v frontend.worker.db-sync-test/batch-transact-tags-inner-tx-reports-test`
- `rtk bb dev:test -v logseq.db-sync.worker-handler-sync-test/tx-batch-delete-blocks-ignores-redundant-updates-and-deletes-descendants-test -v logseq.db-sync.worker-handler-sync-test/tx-batch-stale-retract-block-includes-current-descendants-test -v logseq.db-sync.worker-handler-sync-test/tx-batch-stale-retract-page-includes-current-page-tree-test -v logseq.db-sync.worker-handler-sync-test/tx-batch-rejects-move-blocks-when-target-is-missing-test`
- Local-worker CLI stress sync, 2000 ops, 3 clients, concurrency 4, checksum assertions enabled: all clients ended at checksum `2af3643cb98c7388`; no `tx/reject`, checksum mismatch, or sync error log matches.
- `rtk git diff --check`
