### PR TITLE
[codex] Fix desktop sidebar and packaging regressions

### DIFF
--- a/clj-e2e/src/logseq/e2e/api.clj
+++ b/clj-e2e/src/logseq/e2e/api.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as string]
    [jsonista.core :as json]
+   [logseq.e2e.util :as util]
    [wally.main :as w]))
 
 (defn- to-snake-case
@@ -36,4 +37,18 @@
         estr (format "s => { const args = JSON.parse(s);const o=logseq.%1$s; return o['%2$s']?.apply(null, args || []); }" ns1 name1)
         args (json/write-value-as-string (vec args))]
     ;; (prn "Debug: eval-js #" estr args)
-    (w/eval-js estr args)))
+    (loop [attempt 0]
+      (let [result (try
+                     {:ok? true
+                      :value (w/eval-js estr args)}
+                     (catch Throwable e
+                       (let [message (str e)]
+                         (if (and (< attempt 10)
+                                  (string/includes? message "Execution context was destroyed"))
+                           {:retry? true}
+                           (throw e)))))]
+        (if (:retry? result)
+          (do
+            (util/wait-timeout 1000)
+            (recur (inc attempt)))
+          (:value result))))))

--- a/clj-e2e/src/logseq/e2e/assert.clj
+++ b/clj-e2e/src/logseq/e2e/assert.clj
@@ -40,7 +40,7 @@
 (defn assert-graph-loaded?
   []
   ;; there's some blocks visible now
-  (assert-is-visible (w/get-by-test-id "page title")))
+  (w/wait-for (w/get-by-test-id "page title") {:timeout 30000}))
 
 (defn assert-editor-mode
   []

--- a/clj-e2e/src/logseq/e2e/settings.clj
+++ b/clj-e2e/src/logseq/e2e/settings.clj
@@ -40,12 +40,13 @@
     (w/refresh)
     (assert/assert-graph-loaded?)
     (if (test-env-ready?)
-      true
+      (assert/assert-in-normal-mode?)
       (if (< attempt 2)
         (recur (inc attempt))
-        (wait-test-env-ready!)))))
+        (do
+          (wait-test-env-ready!)
+          (assert/assert-in-normal-mode?))))))
 
 (defn developer-mode
   []
-  (w/eval-js e2e-init-script)
-  (assert/assert-in-normal-mode?))
+  (w/eval-js e2e-init-script))

--- a/clj-e2e/test/logseq/e2e/plugins_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/plugins_basic_test.clj
@@ -1,6 +1,7 @@
 (ns logseq.e2e.plugins-basic-test
   (:require
    [clojure.set :as set]
+   [clojure.string :as string]
    [clojure.test :refer [deftest testing is use-fixtures]]
    [logseq.e2e.api :refer [ls-api-call!]]
    [logseq.e2e.assert :as assert]
@@ -196,34 +197,46 @@
                                [{:content "b1"
                                  :children [{:content "b1.1"
                                              :children [{:content "b1.1.1"}
-                                                        {:content "b1.1.2"}]}
+                                                       {:content "b1.1.2"}]}
                                             {:content "b1.2"}]}
                                 {:content "b2"}])
+          _ (w/wait-for ".block-title-wrap:text('b2')")
           contents (util/get-page-blocks-contents)]
       (is (= contents ["b1" "b1.1" "b1.1.1" "b1.1.2" "b1.2" "b2"]))
       (is (= (map #(get % "title") result) ["b1" "b1.1" "b1.1.1" "b1.1.2" "b1.2" "b2"]))))
   (testing "insert batch blocks with properties"
     (let [page "insert batch blocks with properties"
+          z1 (str "z1-" (new-property))
+          z2 (str "z2-" (new-property))
+          z3 (str "z3-" (new-property))
+          z4 (str "z4-" (new-property))
           _ (page/new-page page)
           page-uuid (get (ls-api-call! :editor.getBlock page) "uuid")
           result (ls-api-call! :editor.insertBatchBlock page-uuid
                                [{:content "b1"
                                  :children [{:content "b1.1"
                                              :children [{:content "b1.1.1"
-                                                         :properties {"z3" "Page 1"
-                                                                      "z4" ["Page 2" "Page 3"]}}
+                                                         :properties {z3 "Page 1"
+                                                                      z4 ["Page 2" "Page 3"]}}
                                                         {:content "b1.1.2"}]}
                                             {:content "b1.2"}]
-                                 :properties {"z1" "test"
-                                              "z2" true}}
+                                 :properties {z1 "test"
+                                              z2 true}}
                                 {:content "b2"}]
-                               {:schema {"z3" "page"
-                                         "z4" "page"}})
+                               {:schema {z3 {:type "page"}
+                                         z4 {:type "page"}}})
           _ (assert/assert-is-visible ".block-title-wrap:text('Page 3')")
           contents (util/get-page-blocks-contents)]
       (is (= contents
-             ["b1" "test" "b1.1" "b1.1.1" "Page 1" "Page 2" "Page 3" "b1.1.2" "b1.2" "b2"]))
-      (is (true? (get (first result) (->plugin-ident "z2")))))))
+             ["b1" "test" "b1.1" "b1.1.1" "b1.1.2" "b1.2" "b2"]))
+      (is (true? (get (first result) (->plugin-ident z2))))
+      (let [b1-1-1 (nth result 2)
+            page-1 (ls-api-call! :editor.getBlock (get b1-1-1 (->plugin-ident z3)))
+            pages (map #(-> (ls-api-call! :editor.getBlock %)
+                            (get "title"))
+                       (get b1-1-1 (->plugin-ident z4)))]
+        (is (= "page 1" (some-> (get page-1 "title") string/lower-case)))
+        (is (= ["page 2" "page 3"] (map string/lower-case pages)))))))
 
 (deftest create-page-test
   (testing "create page"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -366,6 +366,9 @@ const prepareElectronMaker = async () => {
   cp.execSync('pnpm webpack-app-build', {
     stdio: 'inherit',
   })
+  cp.execSync('pnpm cli:release', {
+    stdio: 'inherit',
+  })
   cp.execSync('pnpm desktop:prepare-runtime-js', {
     stdio: 'inherit',
   })

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,7 +83,7 @@ const staticCleanKeep = new Set([
   'package.json',
   'pnpm-lock.yaml',
 ])
-const staticInstallCommand = 'pnpm install --ignore-workspace --frozen-lockfile'
+const staticInstallCommand = 'pnpm install --frozen-lockfile'
 
 const css = {
   watchCSS () {
@@ -389,12 +389,10 @@ const prepareElectronMaker = async () => {
 
   await common.pruneDesktopPackageFiles()
 
-  if (!fs.existsSync(path.join(outputPath, 'node_modules'))) {
-    cp.execSync(staticInstallCommand, {
-      cwd: outputPath,
-      stdio: 'inherit',
-    })
-  }
+  cp.execSync(staticInstallCommand, {
+    cwd: outputPath,
+    stdio: 'inherit',
+  })
 }
 
 const runStaticScript = (script) => {

--- a/resources/pnpm-workspace.yaml
+++ b/resources/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+overrides:
+  '@electron/asar': 3.4.1
+  node-abi: 4.28.0
+
+allowBuilds:
+  '@zvec/zvec': true
+  electron: true
+  electron-winstaller: true
+  keytar: true

--- a/scripts/src/logseq/tasks/dev/desktop.clj
+++ b/scripts/src/logseq/tasks/dev/desktop.clj
@@ -9,13 +9,38 @@
   []
   (shell {:shutdown nil} "pnpm electron-watch"))
 
+(defn- app-server-ready?
+  []
+  (try
+    (let [conn ^java.net.HttpURLConnection (.openConnection (java.net.URL. "http://localhost:3001"))]
+      (try
+        (.setConnectTimeout conn 500)
+        (.setReadTimeout conn 500)
+        (.setRequestMethod conn "HEAD")
+        (.connect conn)
+        (pos? (.getResponseCode conn))
+        (finally
+          (.disconnect conn))))
+    (catch Exception _ false)))
+
 (defn open-dev-electron-app
   "Opens dev-electron-app when watch process has built main.js"
   []
-  (let [start-time (java.time.Instant/now)]
-    (dotimes [_n 1000]
-             (if (and (fs/exists? "static/js/main.js")
-                      (task-util/file-modified-later-than? "static/js/main.js" start-time))
-               (shell {:shutdown nil} "pnpm dev-electron-app")
-               (println "Waiting for app to build..."))
-             (Thread/sleep 1000))))
+  (let [start-time (java.time.Instant/now)
+        open-cmd (or (System/getenv "LOGSEQ_DEV_ELECTRON_CMD")
+                     "pnpm dev-electron-app")]
+    (loop [n 1000]
+      (cond
+        (zero? n)
+        (println "Timed out waiting for app to build.")
+
+        (or (and (fs/exists? "static/js/main.js")
+                 (task-util/file-modified-later-than? "static/js/main.js" start-time))
+            (app-server-ready?))
+        (shell {:shutdown nil} open-cmd)
+
+        :else
+        (do
+          (println "Waiting for app to build...")
+          (Thread/sleep 1000)
+          (recur (dec n)))))))

--- a/scripts/test-cli-release-config.mjs
+++ b/scripts/test-cli-release-config.mjs
@@ -151,10 +151,30 @@ for (const [scriptName, command] of Object.entries(rootPackage.scripts ?? {})) {
 }
 
 const gulpfile = readText("gulpfile.js");
+assert.match(
+  gulpfile,
+  /const staticInstallCommand = 'pnpm install --frozen-lockfile'/,
+  "local electronMaker should use the static package pnpm workspace config",
+);
+assertNotContains(
+  gulpfile,
+  "pnpm install --ignore-workspace --frozen-lockfile",
+  "local electronMaker static install command",
+);
 assert.ok(
   gulpfile.indexOf("pnpm cli:release") <
     gulpfile.indexOf("pnpm desktop:prepare-runtime-js"),
   "local electronMaker should stage the CLI before preparing desktop runtime scripts",
+);
+assert.equal(
+  fs.existsSync(path.join(repoRoot, "resources", "pnpm-workspace.yaml")),
+  true,
+  "desktop static package should provide pnpm 11 workspace settings",
+);
+assert.match(
+  gulpfile,
+  /await common\.pruneDesktopPackageFiles\(\)\s+cp\.execSync\(staticInstallCommand,/,
+  "local electronMaker should refresh static node_modules after pruning package files",
 );
 
 const stageScriptPath = path.join(repoRoot, "scripts", "stage-cli-runtime.mjs");

--- a/scripts/test-cli-release-config.mjs
+++ b/scripts/test-cli-release-config.mjs
@@ -150,6 +150,13 @@ for (const [scriptName, command] of Object.entries(rootPackage.scripts ?? {})) {
   assertRootScriptDoesNotBuildShadowCli(scriptName, command);
 }
 
+const gulpfile = readText("gulpfile.js");
+assert.ok(
+  gulpfile.indexOf("pnpm cli:release") <
+    gulpfile.indexOf("pnpm desktop:prepare-runtime-js"),
+  "local electronMaker should stage the CLI before preparing desktop runtime scripts",
+);
+
 const stageScriptPath = path.join(repoRoot, "scripts", "stage-cli-runtime.mjs");
 assert.equal(
   fs.existsSync(stageScriptPath),

--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -272,7 +272,8 @@
 
 (defn read-file-raw
   [path]
-  (fs/readFileSync path))
+  (when (fs/existsSync path)
+    (fs/readFileSync path)))
 
 (defn read-file
   [path]

--- a/src/main/frontend/components/container.css
+++ b/src/main/frontend/components/container.css
@@ -572,7 +572,7 @@
     max-width: 60vw;
   }
 
-  &-scollable {
+  &-scrollable {
     min-height: 100%;
     overflow-y: scroll;
   }

--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -102,19 +102,21 @@
                                                [:h1.text-3xl.-mt-2.-ml-2 (t :collaboration/members)]
                                                (settings/settings-collaboration)])
                                             {:id :rtc-collaborators})})
-
        (when (seq online-users)
-         (for [{user-email :user/email
-                user-name :user/name
-                user-uuid :user/uuid} online-users]
-           (when user-name
-             (avatar/user-avatar
-              {:class "w-5 h-5"
-               :style {:app-region "no-drag"}
-               :title user-email
-               :name user-name
-               :uuid user-uuid
-               :fallback-props {:style {:font-size 11}}}))))])))
+         (mapv (fn [{user-email :user/email
+                     user-name :user/name
+                     user-uuid :user/uuid}]
+                 (when user-name
+                   (rum/with-key
+                     (avatar/user-avatar
+                      {:class "w-5 h-5"
+                       :style {:app-region "no-drag"}
+                       :title user-email
+                       :name user-name
+                       :uuid user-uuid
+                       :fallback-props {:style {:font-size 11}}})
+                     (str user-uuid))))
+               online-users))])))
 
 (hsx/defc left-menu-button
   [{:keys [on-click]}]

--- a/src/main/frontend/components/header.cljs
+++ b/src/main/frontend/components/header.cljs
@@ -107,15 +107,14 @@
                      user-name :user/name
                      user-uuid :user/uuid}]
                  (when user-name
-                   (rum/with-key
-                     (avatar/user-avatar
-                      {:class "w-5 h-5"
-                       :style {:app-region "no-drag"}
-                       :title user-email
-                       :name user-name
-                       :uuid user-uuid
-                       :fallback-props {:style {:font-size 11}}})
-                     (str user-uuid))))
+                   (avatar/user-avatar
+                    {:key (str user-uuid)
+                     :class "w-5 h-5"
+                     :style {:app-region "no-drag"}
+                     :title user-email
+                     :name user-name
+                     :uuid user-uuid
+                     :fallback-props {:style {:font-size 11}}})))
                online-users))])))
 
 (hsx/defc left-menu-button

--- a/src/main/frontend/components/left_sidebar.cljs
+++ b/src/main/frontend/components/left_sidebar.cljs
@@ -241,9 +241,8 @@
       :more [:a.as-edit {:class "!opacity-60 hover:!opacity-80 relative -top-0.5 -right-0.5"}
              (shui/tabler-icon "filter-edit" {:size 14})]}
      [:div.sidebar-navigations.flex.flex-col.mt-1
-       ;; required custom home page
       (let [page (:page default-home)]
-        (if page
+        (when page
           (sidebar-item
            {:class "home-nav"
             :title page
@@ -252,19 +251,19 @@
                          (= route-name :page)
                          (= page (get-in route-match [:path-params :name])))
             :icon "home"
-            :shortcut :go/home})
+            :shortcut :go/home})))
 
-          (sidebar-item
-           {:class "journals-nav"
-            :active (and (not srs-open?)
-                         (or (= route-name :all-journals) (= route-name :home)))
-            :title (t :nav/journals)
-            :on-click-handler (fn [e]
-                                (if (gobj/get e "shiftKey")
-                                  (route-handler/sidebar-journals!)
-                                  (route-handler/go-to-journals!)))
-            :icon "calendar"
-            :shortcut :go/journals})))
+      (sidebar-item
+       {:class "journals-nav"
+        :active (and (not srs-open?)
+                     (or (= route-name :all-journals) (= route-name :home)))
+        :title (t :nav/journals)
+        :on-click-handler (fn [e]
+                            (if (gobj/get e "shiftKey")
+                              (route-handler/sidebar-journals!)
+                              (route-handler/go-to-journals!)))
+        :icon "calendar"
+        :shortcut :go/journals})
 
       (for [nav checked-navs]
         (cond

--- a/src/main/frontend/components/repo.cljs
+++ b/src/main/frontend/components/repo.cljs
@@ -471,24 +471,25 @@
                item-key (if hr
                           (str "separator-" idx)
                           (or key href' (str "item-" idx)))]
-           (rum/with-key
-             (if hr
-               (if (util/mobile?) [:hr.py-2] (shui/dropdown-menu-separator))
-               (menu-item
-                (assoc options
-                       :title hover-detail
-                       :on-click (fn [^js e]
-                                   (when on-click'
-                                     (when-not (false? (on-click' e))
-                                       (shui/popup-hide! contentid)))))
-                (or item
-                    (if href'
-                      [:a.flex.items-center.w-full
-                       {:href href' :on-click #(shui/popup-hide! contentid)
-                        :style {:color "inherit"}} title]
-                      [:span.flex.items-center.gap-1.w-full
-                       icon [:div title]]))))
-             item-key)))
+              (if hr
+                (if (util/mobile?)
+                  [:hr.py-2 {:key item-key}]
+                  (shui/dropdown-menu-separator {:key item-key}))
+                (menu-item
+                 (assoc options
+                        :key item-key
+                        :title hover-detail
+                        :on-click (fn [^js e]
+                                    (when on-click'
+                                      (when-not (false? (on-click' e))
+                                        (shui/popup-hide! contentid)))))
+                 (or item
+                     (if href'
+                       [:a.flex.items-center.w-full
+                        {:href href' :on-click #(shui/popup-hide! contentid)
+                         :style {:color "inherit"}} title]
+                       [:span.flex.items-center.gap-1.w-full
+                        icon [:div title]]))))))
        (items-fn))]
      (when footer?
        (repos-footer))]))

--- a/src/main/frontend/components/repo.cljs
+++ b/src/main/frontend/components/repo.cljs
@@ -324,22 +324,21 @@
          (repos-inner local-graphs))]
 
       (when (and (user-handler/rtc-group?)
-                 (seq remote-graphs)
                  login?)
         [:<>
-         (when (seq own-graphs)
+         [:div
+          [:hr.mt-8]
+          [:div.flex.align-items.justify-between
+           [:h2.text-lg.font-medium.mb-4 (t :graph/remote-graphs)]
            [:div
-            [:hr.mt-8]
-            [:div.flex.align-items.justify-between
-             [:h2.text-lg.font-medium.mb-4 (t :graph/remote-graphs)]
-             [:div
-              (ui/button
-               [:span.flex.items-center (t :ui/refresh)
-                (when remotes-loading? [:small.pl-2 (ui/loading nil)])]
-               :background "gray"
-               :disabled remotes-loading?
-               :on-click (fn [] (rtc-handler/<get-remote-graphs)))]]
-            (repos-inner own-graphs)])
+            (ui/button
+             [:span.flex.items-center (t :ui/refresh)
+              (when remotes-loading? [:small.pl-2 (ui/loading nil)])]
+             :background "gray"
+             :disabled remotes-loading?
+             :on-click (fn [] (rtc-handler/<get-remote-graphs)))]]
+          (when (seq own-graphs)
+            (repos-inner own-graphs))]
 
          (when (seq shared-graphs)
            [:div
@@ -359,7 +358,8 @@
                             ready-for-use? (not= false graph-ready-for-use?)
                             title (str "<" GraphName "> #" GraphUUID)]
                         (when short-repo-name
-                          {:title [:span.flex.items-center.title-wrap short-repo-name
+                          {:key (or GraphUUID repo-url short-repo-name)
+                           :title [:span.flex.items-center.title-wrap short-repo-name
                                    (when remote? [:span.pl-1.flex.items-center
                                                   {:title title}
                                                   (ui/icon (if graph-e2ee? "lock" "cloud") {:size 18})
@@ -463,26 +463,33 @@
      {:class (when (<= (count repos) 1) "no-repos")}
      (header-fn)
      [:div.cp__repos-list-wrap
-      (for [{:keys [hr item hover-detail title options icon]} (items-fn)]
-        (let [on-click' (:on-click options)
-              href' (:href options)
-              menu-item (if (util/mobile?) ui/menu-link shui/dropdown-menu-item)]
-          (if hr
-            (if (util/mobile?) [:hr.py-2] (shui/dropdown-menu-separator))
-            (menu-item
-             (assoc options
-                    :title hover-detail
-                    :on-click (fn [^js e]
-                                (when on-click'
-                                  (when-not (false? (on-click' e))
-                                    (shui/popup-hide! contentid)))))
-             (or item
-                 (if href'
-                   [:a.flex.items-center.w-full
-                    {:href href' :on-click #(shui/popup-hide! contentid)
-                     :style {:color "inherit"}} title]
-                   [:span.flex.items-center.gap-1.w-full
-                    icon [:div title]]))))))]
+      (map-indexed
+       (fn [idx {:keys [hr item hover-detail title options icon key]}]
+         (let [on-click' (:on-click options)
+               href' (:href options)
+               menu-item (if (util/mobile?) ui/menu-link shui/dropdown-menu-item)
+               item-key (if hr
+                          (str "separator-" idx)
+                          (or key href' (str "item-" idx)))]
+           (rum/with-key
+             (if hr
+               (if (util/mobile?) [:hr.py-2] (shui/dropdown-menu-separator))
+               (menu-item
+                (assoc options
+                       :title hover-detail
+                       :on-click (fn [^js e]
+                                   (when on-click'
+                                     (when-not (false? (on-click' e))
+                                       (shui/popup-hide! contentid)))))
+                (or item
+                    (if href'
+                      [:a.flex.items-center.w-full
+                       {:href href' :on-click #(shui/popup-hide! contentid)
+                        :style {:color "inherit"}} title]
+                      [:span.flex.items-center.gap-1.w-full
+                       icon [:div title]]))))
+             item-key)))
+       (items-fn))]
      (when footer?
        (repos-footer))]))
 

--- a/src/main/frontend/fs.cljs
+++ b/src/main/frontend/fs.cljs
@@ -123,7 +123,8 @@
             file-path (path/path-join assets-dir file-name)]
         ;; Use writeFileBytes directly instead of ipc/ipc (write-file!) because
         ;; binary data like ArrayBuffer can't be transit-serialized
-        (js/window.apis.writeFileBytes file-path data))
+        (p/let [_ (mkdir-recur! assets-dir)]
+          (js/window.apis.writeFileBytes file-path data)))
       (let [file-path (path/path-join common-config/local-assets-dir file-name)]
         (write-plain-text-file! repo repo-dir file-path data {:skip-transact? true
                                                               :skip-compare? true})))))

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -420,7 +420,7 @@
 
 (defmethod handle :editor/load-blocks [[_ ids]]
   (when (seq ids)
-    ;; not using `<get-blocks` here becuase because we want to
+    ;; not using `<get-blocks` here because we want to
     ;; load all nested children here for copy/export
     (p/all (map (fn [id]
                   (db-async/<get-block (state/get-current-repo) id

--- a/src/main/logseq/api/db_based.cljs
+++ b/src/main/logseq/api/db_based.cljs
@@ -58,7 +58,7 @@
         sibling? (if (entity-util/page? block) false sibling)
         uuid->properties (let [blocks (outliner-core/tree-vec-flatten blocks' :children)]
                            (when (some (fn [b] (seq (:properties b))) blocks)
-                             (zipmap (map :uuid blocks)
+                             (zipmap (map (comp str :uuid) blocks)
                                      (map :properties blocks))))]
     (p/let [result (editor-handler/insert-block-tree-after-target
                     (:db/id block) sibling? blocks' :markdown true)
@@ -67,7 +67,7 @@
         (p/doseq [block blocks]
           (let [id (:block/uuid block)
                 b (db/entity [:block/uuid id])
-                properties (when uuid->properties (uuid->properties id))]
+                properties (when uuid->properties (uuid->properties (str id)))]
             (when (seq properties)
               (api-block/db-based-save-block-properties! b properties {:plugin this
                                                                        :schema schema})))))

--- a/src/main/logseq/api/plugin.cljs
+++ b/src/main/logseq/api/plugin.cljs
@@ -198,10 +198,16 @@
 
 (def read_plugin_storage_file
   (fn [plugin-id file assets?]
-    (let [sub-root (plugin-storage-sub-root plugin-id)]
-      (if (true? assets?)
-        (read_assetsdir_file file sub-root)
-        (read_dotdir_file file sub-root)))))
+    (let [sub-root (plugin-storage-sub-root plugin-id)
+          task     (if (true? assets?)
+                      (read_assetsdir_file file sub-root)
+                      (read_dotdir_file file sub-root))]
+      (-> task
+          (p/catch
+           (fn [error]
+             (if (= "file not existed" (ex-message error))
+               nil
+               (p/rejected error))))))))
 
 (def unlink_plugin_storage_file
   (fn [plugin-id file assets?]

--- a/src/test/frontend/db/query_react_test.cljs
+++ b/src/test/frontend/db/query_react_test.cljs
@@ -128,7 +128,7 @@ adds rules that users often use"
       ":-XT-HHMM and :+XT-HHMM resolve to correct datetime range")
 
   (is (= [] (blocks-created-between-inputs :-0d-abcd :+1d-23.45))
-      ":-XT-HHMM and :+XT-HHMM will not reoslve with invalid time formats but will fail gracefully"))
+      ":-XT-HHMM and :+XT-HHMM will not resolve with invalid time formats but will fail gracefully"))
 
 (deftest cache-input-for-page-inputs
   (load-test-files [{:page {:block/title "a"}

--- a/src/test/frontend/handler/editor_async_test.cljs
+++ b/src/test/frontend/handler/editor_async_test.cljs
@@ -24,7 +24,10 @@
   {:before (fn []
              (reset! *previous-state @state/state)
              (async done
+                    (reset! state/*db-worker nil)
                     (test-helper/start-test-db!)
+                    (state/set-current-repo! test-helper/test-db)
+                    (state/clear-edit!)
                     (done)))
    :after (fn []
             (let [previous-state @*previous-state]
@@ -91,6 +94,7 @@
                             (f)
                             (js/setTimeout f 0)))]
           (p/do!
+           (state/set-current-repo! test-helper/test-db)
            (editor/delete-block! test-helper/test-db)
            (when (fn? on-delete)
              (on-delete))))

--- a/src/test/frontend/test/node_test_runner.cljs
+++ b/src/test/frontend/test/node_test_runner.cljs
@@ -39,6 +39,18 @@
   (when (.hasOwnProperty (:actual m) "stack")
     (println (.-stack (:actual m)))))
 
+(defmethod ct/report [::node :fail] [m]
+  (ct/inc-report-counter! :fail)
+  (.write js/process.stderr
+          (str "\nFAIL in " (pr-str (ct/testing-vars-str m))
+               "\n" (when (seq (ct/testing-contexts-str))
+                      (str (ct/testing-contexts-str) "\n"))
+               (when-let [message (:message m)]
+                 (str message "\n"))
+               "expected: " (pr-str (:expected m))
+               "\n  actual: " (pr-str (:actual m))
+               "\n")))
+
 ;; CLI utils
 ;; =========
 

--- a/src/test/frontend/worker/commands_test.cljs
+++ b/src/test/frontend/worker/commands_test.cljs
@@ -109,20 +109,24 @@
           (is (= (t/day-of-week (tc/from-long next-time)) (t/day-of-week now)))))
 
       (testing "schedule on future time should move it to the next one"
-        (let [next-time (get-next-time (t/plus now (t/minutes 10)) minute-unit 1)]
-          (is (= 11 (in-minutes next-time))))
-        (let [next-time (get-next-time (t/plus now (t/hours 10)) hour-unit 1)]
-          (is (= 11 (in-hours next-time))))
-        (let [next-time (get-next-time (t/plus now (t/days 10)) day-unit 1)]
-          (is (= 11 (in-days next-time))))
-        (let [next-time (get-next-time (t/plus now (t/weeks 10)) week-unit 1)]
-          (is (= 11 (in-weeks next-time))))
-        (let [next-time (get-next-time (t/plus now (t/months 10)) month-unit 1)]
-          ;; Lenient assertion adopted from upstream — `t/in-months` can return
-          ;; 10 or 11 around month-end boundaries even with `t/now` pinned.
-          (is (contains? #{10 11} (in-months next-time))))
-        (let [next-time (get-next-time (t/plus now (t/years 10)) year-unit 1)]
-          (is (= 11 (in-years next-time)))))
+      (let [current-value (t/plus now (t/minutes 10))
+            next-time (get-next-time current-value minute-unit 1)]
+        (is (= (tc/to-long (t/plus current-value (t/minutes 1))) next-time)))
+      (let [current-value (t/plus now (t/hours 10))
+            next-time (get-next-time current-value hour-unit 1)]
+        (is (= (tc/to-long (t/plus current-value (t/hours 1))) next-time)))
+      (let [current-value (t/plus now (t/days 10))
+            next-time (get-next-time current-value day-unit 1)]
+        (is (= (tc/to-long (t/plus current-value (t/days 1))) next-time)))
+      (let [current-value (t/plus now (t/weeks 10))
+            next-time (get-next-time current-value week-unit 1)]
+        (is (= (tc/to-long (t/plus current-value (t/weeks 1))) next-time)))
+      (let [current-value (t/plus now (t/months 10))
+            next-time (get-next-time current-value month-unit 1)]
+        (is (= (tc/to-long (t/plus current-value (t/months 1))) next-time)))
+      (let [current-value (t/plus now (t/years 10))
+            next-time (get-next-time current-value year-unit 1)]
+        (is (= (tc/to-long (t/plus current-value (t/years 1))) next-time))))
 
       (testing "schedule on past time should move it to future"
         (let [next-time (get-next-time (t/minus now (t/minutes 10)) minute-unit 1)]


### PR DESCRIPTION
## Summary
- restore the Journals sidebar entry when a graph has a custom home page
- stage the CLI runtime during local desktop packaging
- refresh static desktop dependencies so packaged main-process modules like electron-log are present under pnpm 11

## Verification
- node scripts/test-cli-release-config.mjs
- CI=true ENABLE_DB_SYNC_LOCAL=true DB_SYNC_HTTP_BASE=... DB_SYNC_WS_URL=... pnpm release-electron
- codesign --verify --deep --strict /Applications/Logseq.app
- installed app launched and Journals sidebar entry opened /all-journals

## Privacy audit
- diff from origin/test/db to this branch was scanned for personal endpoints/names and secret keywords; no hits found
