### PR TITLE
fix: keep Journals navigation with custom home

### DIFF
--- a/src/main/frontend/components/left_sidebar.cljs
+++ b/src/main/frontend/components/left_sidebar.cljs
@@ -241,9 +241,8 @@
       :more [:a.as-edit {:class "!opacity-60 hover:!opacity-80 relative -top-0.5 -right-0.5"}
              (shui/tabler-icon "filter-edit" {:size 14})]}
      [:div.sidebar-navigations.flex.flex-col.mt-1
-       ;; required custom home page
       (let [page (:page default-home)]
-        (if page
+        (when page
           (sidebar-item
            {:class "home-nav"
             :title page
@@ -252,19 +251,19 @@
                          (= route-name :page)
                          (= page (get-in route-match [:path-params :name])))
             :icon "home"
-            :shortcut :go/home})
+            :shortcut :go/home})))
 
-          (sidebar-item
-           {:class "journals-nav"
-            :active (and (not srs-open?)
-                         (or (= route-name :all-journals) (= route-name :home)))
-            :title (t :nav/journals)
-            :on-click-handler (fn [e]
-                                (if (gobj/get e "shiftKey")
-                                  (route-handler/sidebar-journals!)
-                                  (route-handler/go-to-journals!)))
-            :icon "calendar"
-            :shortcut :go/journals})))
+      (sidebar-item
+       {:class "journals-nav"
+        :active (and (not srs-open?)
+                     (or (= route-name :all-journals) (= route-name :home)))
+        :title (t :nav/journals)
+        :on-click-handler (fn [e]
+                            (if (gobj/get e "shiftKey")
+                              (route-handler/sidebar-journals!)
+                              (route-handler/go-to-journals!)))
+        :icon "calendar"
+        :shortcut :go/journals})
 
       (for [nav checked-navs]
         (cond


### PR DESCRIPTION
## Summary
- render custom Home and Journals as separate sidebar entries
- keep Journals available when a graph has a custom home page

## Verification
- not run, split-only PR extracted from the previously verified change
