### PR TITLE
fix(desktop): stage release runtime dependencies

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -366,6 +366,9 @@ const prepareElectronMaker = async () => {
   cp.execSync('pnpm webpack-app-build', {
     stdio: 'inherit',
   })
+  cp.execSync('pnpm cli:release', {
+    stdio: 'inherit',
+  })
   cp.execSync('pnpm desktop:prepare-runtime-js', {
     stdio: 'inherit',
   })

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,7 +83,7 @@ const staticCleanKeep = new Set([
   'package.json',
   'pnpm-lock.yaml',
 ])
-const staticInstallCommand = 'pnpm install --ignore-workspace --frozen-lockfile'
+const staticInstallCommand = 'pnpm install --frozen-lockfile'
 
 const css = {
   watchCSS () {
@@ -389,12 +389,10 @@ const prepareElectronMaker = async () => {
 
   await common.pruneDesktopPackageFiles()
 
-  if (!fs.existsSync(path.join(outputPath, 'node_modules'))) {
-    cp.execSync(staticInstallCommand, {
-      cwd: outputPath,
-      stdio: 'inherit',
-    })
-  }
+  cp.execSync(staticInstallCommand, {
+    cwd: outputPath,
+    stdio: 'inherit',
+  })
 }
 
 const runStaticScript = (script) => {

--- a/resources/pnpm-workspace.yaml
+++ b/resources/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+overrides:
+  '@electron/asar': 3.4.1
+  node-abi: 4.28.0
+
+allowBuilds:
+  '@zvec/zvec': true
+  electron: true
+  electron-winstaller: true
+  keytar: true

--- a/scripts/test-cli-release-config.mjs
+++ b/scripts/test-cli-release-config.mjs
@@ -151,10 +151,30 @@ for (const [scriptName, command] of Object.entries(rootPackage.scripts ?? {})) {
 }
 
 const gulpfile = readText("gulpfile.js");
+assert.match(
+  gulpfile,
+  /const staticInstallCommand = 'pnpm install --frozen-lockfile'/,
+  "local electronMaker should use the static package pnpm workspace config",
+);
+assertNotContains(
+  gulpfile,
+  "pnpm install --ignore-workspace --frozen-lockfile",
+  "local electronMaker static install command",
+);
 assert.ok(
   gulpfile.indexOf("pnpm cli:release") <
     gulpfile.indexOf("pnpm desktop:prepare-runtime-js"),
   "local electronMaker should stage the CLI before preparing desktop runtime scripts",
+);
+assert.equal(
+  fs.existsSync(path.join(repoRoot, "resources", "pnpm-workspace.yaml")),
+  true,
+  "desktop static package should provide pnpm 11 workspace settings",
+);
+assert.match(
+  gulpfile,
+  /await common\.pruneDesktopPackageFiles\(\)\s+cp\.execSync\(staticInstallCommand,/,
+  "local electronMaker should refresh static node_modules after pruning package files",
 );
 
 const stageScriptPath = path.join(repoRoot, "scripts", "stage-cli-runtime.mjs");

--- a/scripts/test-cli-release-config.mjs
+++ b/scripts/test-cli-release-config.mjs
@@ -150,6 +150,13 @@ for (const [scriptName, command] of Object.entries(rootPackage.scripts ?? {})) {
   assertRootScriptDoesNotBuildShadowCli(scriptName, command);
 }
 
+const gulpfile = readText("gulpfile.js");
+assert.ok(
+  gulpfile.indexOf("pnpm cli:release") <
+    gulpfile.indexOf("pnpm desktop:prepare-runtime-js"),
+  "local electronMaker should stage the CLI before preparing desktop runtime scripts",
+);
+
 const stageScriptPath = path.join(repoRoot, "scripts", "stage-cli-runtime.mjs");
 assert.equal(
   fs.existsSync(stageScriptPath),


### PR DESCRIPTION
## Summary
- run the CLI release step before preparing desktop runtime scripts
- refresh static package dependencies after pruning package files

## Verification
- node scripts/test-cli-release-config.mjs (blocked locally: cli/_build/default/dist/logseq-cli.js is missing after local cleanup, and CI=true pnpm cli:release could not run because no OPAM switch is currently selected)
