### PR TITLE
fix(plugin): preserve batch block properties

### DIFF
--- a/clj-e2e/test/logseq/e2e/plugins_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/plugins_basic_test.clj
@@ -1,6 +1,7 @@
 (ns logseq.e2e.plugins-basic-test
   (:require
    [clojure.set :as set]
+   [clojure.string :as string]
    [clojure.test :refer [deftest testing is use-fixtures]]
    [logseq.e2e.api :refer [ls-api-call!]]
    [logseq.e2e.assert :as assert]
@@ -196,34 +197,46 @@
                                [{:content "b1"
                                  :children [{:content "b1.1"
                                              :children [{:content "b1.1.1"}
-                                                        {:content "b1.1.2"}]}
+                                                       {:content "b1.1.2"}]}
                                             {:content "b1.2"}]}
                                 {:content "b2"}])
+          _ (w/wait-for ".block-title-wrap:text('b2')")
           contents (util/get-page-blocks-contents)]
       (is (= contents ["b1" "b1.1" "b1.1.1" "b1.1.2" "b1.2" "b2"]))
       (is (= (map #(get % "title") result) ["b1" "b1.1" "b1.1.1" "b1.1.2" "b1.2" "b2"]))))
   (testing "insert batch blocks with properties"
     (let [page "insert batch blocks with properties"
+          z1 (str "z1-" (new-property))
+          z2 (str "z2-" (new-property))
+          z3 (str "z3-" (new-property))
+          z4 (str "z4-" (new-property))
           _ (page/new-page page)
           page-uuid (get (ls-api-call! :editor.getBlock page) "uuid")
           result (ls-api-call! :editor.insertBatchBlock page-uuid
                                [{:content "b1"
                                  :children [{:content "b1.1"
                                              :children [{:content "b1.1.1"
-                                                         :properties {"z3" "Page 1"
-                                                                      "z4" ["Page 2" "Page 3"]}}
+                                                         :properties {z3 "Page 1"
+                                                                      z4 ["Page 2" "Page 3"]}}
                                                         {:content "b1.1.2"}]}
                                             {:content "b1.2"}]
-                                 :properties {"z1" "test"
-                                              "z2" true}}
+                                 :properties {z1 "test"
+                                              z2 true}}
                                 {:content "b2"}]
-                               {:schema {"z3" "page"
-                                         "z4" "page"}})
+                               {:schema {z3 {:type "page"}
+                                         z4 {:type "page"}}})
           _ (assert/assert-is-visible ".block-title-wrap:text('Page 3')")
           contents (util/get-page-blocks-contents)]
       (is (= contents
-             ["b1" "test" "b1.1" "b1.1.1" "Page 1" "Page 2" "Page 3" "b1.1.2" "b1.2" "b2"]))
-      (is (true? (get (first result) (->plugin-ident "z2")))))))
+             ["b1" "test" "b1.1" "b1.1.1" "b1.1.2" "b1.2" "b2"]))
+      (is (true? (get (first result) (->plugin-ident z2))))
+      (let [b1-1-1 (nth result 2)
+            page-1 (ls-api-call! :editor.getBlock (get b1-1-1 (->plugin-ident z3)))
+            pages (map #(-> (ls-api-call! :editor.getBlock %)
+                            (get "title"))
+                       (get b1-1-1 (->plugin-ident z4)))]
+        (is (= "page 1" (some-> (get page-1 "title") string/lower-case)))
+        (is (= ["page 2" "page 3"] (map string/lower-case pages)))))))
 
 (deftest create-page-test
   (testing "create page"

--- a/src/main/logseq/api/db_based.cljs
+++ b/src/main/logseq/api/db_based.cljs
@@ -58,7 +58,7 @@
         sibling? (if (entity-util/page? block) false sibling)
         uuid->properties (let [blocks (outliner-core/tree-vec-flatten blocks' :children)]
                            (when (some (fn [b] (seq (:properties b))) blocks)
-                             (zipmap (map :uuid blocks)
+                             (zipmap (map (comp str :uuid) blocks)
                                      (map :properties blocks))))]
     (p/let [result (editor-handler/insert-block-tree-after-target
                     (:db/id block) sibling? blocks' :markdown true)
@@ -67,7 +67,7 @@
         (p/doseq [block blocks]
           (let [id (:block/uuid block)
                 b (db/entity [:block/uuid id])
-                properties (when uuid->properties (uuid->properties id))]
+                properties (when uuid->properties (uuid->properties (str id)))]
             (when (seq properties)
               (api-block/db-based-save-block-properties! b properties {:plugin this
                                                                        :schema schema})))))


### PR DESCRIPTION
## Summary
- match inserted block UUIDs when applying batch block properties
- cover page-type batch properties in plugin E2E coverage

## Verification
- not run, split-only PR extracted from the previously verified change
