### PR TITLE
fix(plugin): handle missing storage reads

### DIFF
--- a/src/main/frontend/fs.cljs
+++ b/src/main/frontend/fs.cljs
@@ -123,7 +123,8 @@
             file-path (path/path-join assets-dir file-name)]
         ;; Use writeFileBytes directly instead of ipc/ipc (write-file!) because
         ;; binary data like ArrayBuffer can't be transit-serialized
-        (js/window.apis.writeFileBytes file-path data))
+        (p/let [_ (mkdir-recur! assets-dir)]
+          (js/window.apis.writeFileBytes file-path data)))
       (let [file-path (path/path-join common-config/local-assets-dir file-name)]
         (write-plain-text-file! repo repo-dir file-path data {:skip-transact? true
                                                               :skip-compare? true})))))

--- a/src/main/logseq/api/plugin.cljs
+++ b/src/main/logseq/api/plugin.cljs
@@ -198,10 +198,16 @@
 
 (def read_plugin_storage_file
   (fn [plugin-id file assets?]
-    (let [sub-root (plugin-storage-sub-root plugin-id)]
-      (if (true? assets?)
-        (read_assetsdir_file file sub-root)
-        (read_dotdir_file file sub-root)))))
+    (let [sub-root (plugin-storage-sub-root plugin-id)
+          task     (if (true? assets?)
+                      (read_assetsdir_file file sub-root)
+                      (read_dotdir_file file sub-root))]
+      (-> task
+          (p/catch
+           (fn [error]
+             (if (= "file not existed" (ex-message error))
+               nil
+               (p/rejected error))))))))
 
 (def unlink_plugin_storage_file
   (fn [plugin-id file assets?]


### PR DESCRIPTION
## Summary
- return nil for missing plugin storage reads at the plugin API boundary
- create the assets directory before binary asset writes

## Verification
- not run, split-only PR extracted from the previously verified change
