### PR TITLE
fix: import org title with middle properties

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/extract.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/extract.cljc
@@ -100,11 +100,13 @@
     (if (string/starts-with? file "pages/contents.")
       "Contents"
       (let [first-block (last (first (filter gp-block/heading-block? ast)))
-            property-name (when (contains? #{"Properties" "Property_Drawer"} (ffirst ast))
-                            (let [properties-ast (second (first ast))
-                                  properties (zipmap (map (comp keyword string/lower-case first) properties-ast)
-                                                     (map second properties-ast))]
-                              (:title properties)))
+            property-name (some (fn [ast-node]
+                                  (when (contains? #{"Properties" "Property_Drawer"} (first ast-node))
+                                    (let [properties-ast (second ast-node)
+                                          properties (zipmap (map (comp keyword string/lower-case first) properties-ast)
+                                                             (map second properties-ast))]
+                                      (:title properties))))
+                                ast)
             first-block-name (let [title (last (first (:title first-block)))]
                                (and first-block
                                     (string? title)

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -447,6 +447,32 @@
     (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
         "Imported graph validates")))
 
+(deftest-async import-org-page-title-when-property-appears-in-middle
+  (p/let [file (write-temp-graph-file
+                "pages/20230410145300-end_to_end_note.org"
+                ":PROPERTIES:
+:ID:       c537c812-1ec9-4f13-adaf-1a39fd7da967
+:END:
+#+title: end_to_end_note
+#+date: <2023-04-10 Mon 14:53>
+#+filetags: :PUBLIC:
+
+abc
+
+#+hugo: more
+
+123
+")
+          conn (db-test/create-conn)
+          _ (db-pipeline/add-listener conn)
+          _ (import-files-to-db [file] conn {})]
+    (is (some? (db-test/find-page-by-title @conn "end_to_end_note"))
+        "Org #+title is imported when another property appears in the middle of the file")
+    (is (nil? (db-test/find-page-by-title @conn "20230410145300-end_to_end_note"))
+        "Importer should not fall back to the org-roam file stem")
+    (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
+        "Imported graph validates")))
+
 (deftest-async import-empty-journal-file
   (p/let [file (write-temp-graph-file "journals/2025_11_11.md" "\n")
           conn (db-test/create-conn)


### PR DESCRIPTION
## Summary
- Fix org page title extraction when mldoc places later properties before the top property drawer
- Add a file-to-DB import regression test matching issue #9066

Fixes #9066

## Tests
- Added and ran the targeted graph-parser exporter regression test for org titles with a property in the middle of the file
- Ran the graph-parser extract test namespace to check existing extraction behavior was not regressed