### PR TITLE
Fix sync UUID scalar value rebasing

### DIFF
--- a/deps/db/script/replay_sync_sqlite.cljs
+++ b/deps/db/script/replay_sync_sqlite.cljs
@@ -704,6 +704,12 @@
       v)
     v))
 
+(defn ref-attr?
+  [db attr]
+  (= :db.type/ref
+     (or (get-in (d/schema db) [attr :db/valueType])
+         (:db/valueType (d/entity db attr)))))
+
 (defn resolve-temp-id
   [db datom-v]
   (if (and (vector? datom-v)
@@ -711,7 +717,9 @@
            (= (first datom-v) :db/add))
     (let [[op e a v t] datom-v
           e' (replace-uuid-str-with-eid db e)
-          v' (replace-uuid-str-with-eid db v)]
+          v' (if (ref-attr? db a)
+               (replace-uuid-str-with-eid db v)
+               v)]
       [op e' a v' t])
     datom-v))
 

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -878,13 +878,21 @@
       v)
     v))
 
+(defn- ref-attr?
+  [db attr]
+  (= :db.type/ref
+     (or (get-in (d/schema db) [attr :db/valueType])
+         (:db/valueType (d/entity db attr)))))
+
 (defn- resolve-temp-id
   [db datom-v]
   (if (and (= (count datom-v) 5)
            (= (first datom-v) :db/add))
     (let [[op e a v t] datom-v
           e' (replace-uuid-str-with-eid db e)
-          v' (replace-uuid-str-with-eid db v)]
+          v' (if (ref-attr? db a)
+               (replace-uuid-str-with-eid db v)
+               v)]
       [op e' a v' t])
     datom-v))
 
@@ -1350,42 +1358,45 @@
 
 (defn- rebase-local-op!
   [_repo conn local-tx rebase-db-before]
-  (let [{:keys [forward-ops inverse-ops]} (rebase-history-ops local-tx)
-        tx-meta {:outliner-op :rebase
-                 :original-outliner-op (:outliner-op local-tx)
-                 :db-sync/rebased-local? true
-                 ;; Keep stable tx-id across rebases so one logical pending op
-                 ;; doesn't fan out into duplicated pending rows.
-                 :db-sync/tx-id (:tx-id local-tx)
-                 :db-sync/forward-outliner-ops forward-ops
-                 :db-sync/inverse-outliner-ops inverse-ops}
-        forward-ops' (if (seq forward-ops)
-                       forward-ops
-                       (let [tx-data (-> (:tx local-tx) normalize-tx-data-for-rebase)]
-                         [[:transact [tx-data (assoc tx-meta
-                                                     :db-sync/suppress-stale-rebase-transact-failed-log?
-                                                     true)]]]))]
-    (try
-      (let [rebase-tx-report
-            (ldb/batch-transact-with-temp-conn!
-             conn
-             tx-meta
-             (fn [conn]
-               (doseq [op forward-ops']
-                 (replay-canonical-outliner-op! conn op rebase-db-before))))
-            status (if rebase-tx-report :rebased :no-op)]
-        {:tx-id (:tx-id local-tx)
-         :status status})
-      (catch :default error
-        (let [drop-log {:tx-id (:tx-id local-tx)
-                        :outliner-op (:outliner-op local-tx)
-                        :undo? (:undo? local-tx)
-                        :redo? (:redo? local-tx)
-                        :error error}]
-          (when-not (expected-stale-rebase-error? error)
-            (log/warn :db-sync/drop-op-driven-pending-tx drop-log))
+  (if (= :fix (:outliner-op local-tx))
+    {:tx-id (:tx-id local-tx)
+     :status :kept}
+    (let [{:keys [forward-ops inverse-ops]} (rebase-history-ops local-tx)
+          tx-meta {:outliner-op :rebase
+                   :original-outliner-op (:outliner-op local-tx)
+                   :db-sync/rebased-local? true
+                   ;; Keep stable tx-id across rebases so one logical pending op
+                   ;; doesn't fan out into duplicated pending rows.
+                   :db-sync/tx-id (:tx-id local-tx)
+                   :db-sync/forward-outliner-ops forward-ops
+                   :db-sync/inverse-outliner-ops inverse-ops}
+          forward-ops' (if (seq forward-ops)
+                         forward-ops
+                         (let [tx-data (-> (:tx local-tx) normalize-tx-data-for-rebase)]
+                           [[:transact [tx-data (assoc tx-meta
+                                                       :db-sync/suppress-stale-rebase-transact-failed-log?
+                                                       true)]]]))]
+      (try
+        (let [rebase-tx-report
+              (ldb/batch-transact-with-temp-conn!
+               conn
+               tx-meta
+               (fn [conn]
+                 (doseq [op forward-ops']
+                   (replay-canonical-outliner-op! conn op rebase-db-before))))
+              status (if rebase-tx-report :rebased :no-op)]
           {:tx-id (:tx-id local-tx)
-           :status :failed})))))
+           :status status})
+        (catch :default error
+          (let [drop-log {:tx-id (:tx-id local-tx)
+                          :outliner-op (:outliner-op local-tx)
+                          :undo? (:undo? local-tx)
+                          :redo? (:redo? local-tx)
+                          :error error}]
+            (when-not (expected-stale-rebase-error? error)
+              (log/warn :db-sync/drop-op-driven-pending-tx drop-log))
+            {:tx-id (:tx-id local-tx)
+             :status :failed}))))))
 
 (defn- rebase-local-txs!
   [repo conn local-txs rebase-db-before]

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -5843,13 +5843,14 @@
             (is (= local-title (:block/title (d/entity @conn [:block/uuid block-uuid]))))
             (is (= 1 (count pending)))))))))
 
-(deftest rebase-replays-fix-pending-tx-with-empty-reversed-data-test
-  (testing "schema fix txs with no reverse data should not fail remote rebase"
+(deftest rebase-keeps-fix-pending-tx-with-empty-reversed-data-test
+  (testing "schema fix txs with no reverse data should not be replayed as local rebases"
     (let [{:keys [conn client-ops-conn parent child1]} (setup-parent-child)
           tx-id (random-uuid)
           parent-uuid (:block/uuid parent)
           child-uuid (:block/uuid child1)
           fix-title "local fix title"]
+      (d/transact! conn [[:db/add [:block/uuid parent-uuid] :block/title fix-title]])
       (with-datascript-conns conn client-ops-conn
         (fn []
           (seed-client-op-txs!
@@ -5870,10 +5871,10 @@
                    (:block/title (d/entity @conn [:block/uuid parent-uuid]))))
             (is (= "remote child"
                    (:block/title (d/entity @conn [:block/uuid child-uuid]))))
-            (is (= :rebase (:outliner-op pending-after)))))))))
+            (is (= :fix (:outliner-op pending-after)))))))))
 
-(deftest rebase-drops-no-op-fix-pending-tx-with-empty-reversed-data-test
-  (testing "schema fix txs with no reverse data should be dropped when remote already applied the same tx"
+(deftest rebase-keeps-no-op-fix-pending-tx-with-empty-reversed-data-test
+  (testing "schema fix txs with no reverse data should stay upload-only even when remote already applied the same tx"
     (let [{:keys [conn client-ops-conn parent]} (setup-parent-child)
           tx-id (random-uuid)
           parent-uuid (:block/uuid parent)
@@ -5895,8 +5896,32 @@
            [{:tx-data [[:db/add [:block/uuid parent-uuid] :block/title fix-title]]}])
           (is (= fix-title
                  (:block/title (d/entity @conn [:block/uuid parent-uuid]))))
-          (is (not-any? #(= tx-id (:tx-id %))
-                        (#'sync-apply/pending-txs test-repo))))))))
+          (let [pending-after (#'sync-apply/pending-tx-by-id test-repo tx-id)]
+            (is (= :fix (:outliner-op pending-after)))))))))
+
+(deftest remote-log-uuid-string-scalar-values-stay-scalar-test
+  (testing "log-shaped remote history txs should only resolve UUID strings on ref attrs"
+    (let [{:keys [conn]} (setup-parent-child)
+          title-uuid #uuid "6a4970da-145c-430f-ba25-869617b87b1d"
+          title-uuid-str (str title-uuid)
+          class-temp-id "6a4970e3-275b-4d99-bc0e-04616f55afb9"
+          history-t 536872354]
+      (d/transact! conn [{:block/uuid title-uuid
+                          :block/title "existing page with UUID title text"
+                          :block/name "existing page with UUID title text"}])
+      (let [title-entity-id (:db/id (d/entity @conn [:block/uuid title-uuid]))]
+        (is (= [:db/add class-temp-id :block/title title-uuid-str history-t]
+               (#'sync-apply/resolve-temp-id
+                @conn
+                [:db/add class-temp-id :block/title title-uuid-str history-t])))
+        (is (= [:db/add class-temp-id :block/name title-uuid-str history-t]
+               (#'sync-apply/resolve-temp-id
+                @conn
+                [:db/add class-temp-id :block/name title-uuid-str history-t])))
+        (is (= [:db/add class-temp-id :block/refs title-entity-id history-t]
+               (#'sync-apply/resolve-temp-id
+                @conn
+                [:db/add class-temp-id :block/refs title-uuid-str history-t])))))))
 
 (deftest reverse-tx-data-create-property-text-block-restores-base-db-test
   (testing "reverse-tx-data for create-property-text-block should restore the base db"


### PR DESCRIPTION
## Summary
- keep db-sync repair `:fix` txs upload-only during remote rebase
- only resolve UUID-string tx values to entity ids for ref attrs
- cover the production-log-shaped UUID title/name case and update the replay debug script

## Root cause
Remote history txs can contain UUID-looking strings as scalar `:block/title` or `:block/name` values. The temp-id resolver converted UUID-looking values for every attr, so scalar title/name values could become numeric entity ids when a page with that UUID already existed locally.

Separately, pending sync repair `:fix` rows have no reverse data and should not be replayed locally during remote rebase.

## Verification
- `bb dev:test -v frontend.worker.db-sync-test/remote-log-uuid-string-scalar-values-stay-scalar-test`
- `bb dev:test -v frontend.worker.db-sync-test`
- `git diff --check`

`bb dev:lint-and-test` was started but stopped after unrelated graph layout timing failures, per request.