### PR TITLE
fix: persist template date refs

### DIFF
--- a/deps/outliner/src/logseq/outliner/op.cljs
+++ b/deps/outliner/src/logseq/outliner/op.cljs
@@ -253,13 +253,7 @@
   [conn blocks]
   (doseq [journal-day (outliner-template/dynamic-template-journal-days blocks)]
     (when-not (ldb/get-journal-page-by-day @conn journal-day)
-      (let [title (journal-title @conn journal-day)
-            [_ page-uuid] (outliner-page/create! conn title {:journal? true})
-            page (d/entity @conn [:block/uuid page-uuid])
-            page-name (common-util/page-name-sanity-lc title)]
-        (when (and page (not= page-name (:block/name page)))
-          (ldb/transact! conn [{:db/id (:db/id page)
-                                :block/name page-name}] {}))))))
+      (outliner-page/create! conn (journal-title @conn journal-day) {:journal? true}))))
 
 (defn- apply-template-op!
   [conn *result [template-id target-block-id opts]]

--- a/deps/outliner/src/logseq/outliner/op.cljs
+++ b/deps/outliner/src/logseq/outliner/op.cljs
@@ -3,6 +3,7 @@
   (:require [clojure.string :as string]
             [datascript.core :as d]
             [logseq.common.util :as common-util]
+            [logseq.common.util.date-time :as date-time-util]
             [logseq.db :as ldb]
             [logseq.db.sqlite.export :as sqlite-export]
             [logseq.outliner.core :as outliner-core]
@@ -242,11 +243,30 @@
                      (assoc (into {} block) :db/id (:db/id block)))
                    (rest template-blocks)))))))
 
+(defn- journal-title
+  [db journal-day]
+  (date-time-util/int->journal-title
+   journal-day
+   (:logseq.property.journal/title-format (d/entity db :logseq.class/Journal))))
+
+(defn- ensure-template-journal-pages!
+  [conn blocks]
+  (doseq [journal-day (outliner-template/dynamic-template-journal-days blocks)]
+    (when-not (ldb/get-journal-page-by-day @conn journal-day)
+      (let [title (journal-title @conn journal-day)
+            [_ page-uuid] (outliner-page/create! conn title {:journal? true})
+            page (d/entity @conn [:block/uuid page-uuid])
+            page-name (common-util/page-name-sanity-lc title)]
+        (when (and page (not= page-name (:block/name page)))
+          (ldb/transact! conn [{:db/id (:db/id page)
+                                :block/name page-name}] {}))))))
+
 (defn- apply-template-op!
   [conn *result [template-id target-block-id opts]]
   (when-let [target (d/entity @conn [:block/uuid target-block-id])]
     (let [blocks (or (some-> (:template-blocks opts) seq vec)
                      (template-children-blocks @conn [:block/uuid template-id]))
+          _ (ensure-template-journal-pages! conn blocks)
           blocks (outliner-template/resolve-dynamic-template-blocks @conn target blocks)]
       (when (seq blocks)
         (let [sibling? (:sibling? opts)

--- a/deps/outliner/src/logseq/outliner/template.cljs
+++ b/deps/outliner/src/logseq/outliner/template.cljs
@@ -31,6 +31,11 @@
         day' (if (< day 10) (str "0" day) (str day))]
     (js/parseInt (str year month' day') 10)))
 
+(def ^:private journal-variable-offsets
+  {"today" 0
+   "yesterday" -1
+   "tomorrow" 1})
+
 (defn- journal-title
   [db offset-days]
   (let [journal-day (date->journal-day (date-with-day-offset offset-days))]
@@ -42,24 +47,69 @@
              db journal-day)
         (str journal-day))))
 
-(defn- target-page-title
+(defn- journal-page
+  [db offset-days]
+  (let [journal-day (date->journal-day (date-with-day-offset offset-days))]
+    (when-let [page-id (d/q '[:find ?p .
+                              :in $ ?journal-day
+                              :where
+                              [?p :block/journal-day ?journal-day]]
+                            db journal-day)]
+      (d/entity db page-id))))
+
+(defn- journal-page-or-title
+  [db offset-days]
+  (or (journal-page db offset-days)
+      (journal-title db offset-days)))
+
+(defn- target-page
   [target]
   (cond
     (ldb/page? target)
-    (:block/title target)
+    target
 
     :else
-    (get-in target [:block/page :block/title])))
+    (:block/page target)))
+
+(defn- page-ref-for
+  [page-or-title]
+  (page-ref/->page-ref
+   (if-let [page-uuid (:block/uuid page-or-title)]
+     page-uuid
+     page-or-title)))
+
+(defn- dynamic-template-matches
+  [content]
+  (when (string? content)
+    (map (comp string/lower-case string/trim second)
+         (re-seq template-re content))))
+
+(defn- block-template-contents
+  [block]
+  (concat
+   [(:block/title block) (:block/raw-title block)]
+   (when (map? (:block/properties-text-values block))
+     (vals (:block/properties-text-values block)))))
+
+(defn dynamic-template-journal-days
+  [blocks]
+  (->> blocks
+       (mapcat block-template-contents)
+       (mapcat dynamic-template-matches)
+       (keep journal-variable-offsets)
+       (map #(date->journal-day (date-with-day-offset %)))
+       distinct
+       vec))
 
 (defn- variable-rules
   [db target]
-  (let [today (journal-title db 0)
-        current-page (or (target-page-title target) today)]
-    {"today" (page-ref/->page-ref today)
-     "yesterday" (page-ref/->page-ref (journal-title db -1))
-     "tomorrow" (page-ref/->page-ref (journal-title db 1))
+  (let [today (journal-page-or-title db 0)
+        current-page (or (target-page target) today)]
+    {"today" (page-ref-for today)
+     "yesterday" (page-ref-for (journal-page-or-title db -1))
+     "tomorrow" (page-ref-for (journal-page-or-title db 1))
      "time" (current-time)
-     "current page" (page-ref/->page-ref current-page)}))
+     "current page" (page-ref-for current-page)}))
 
 (defn- resolve-string
   [content rules]

--- a/deps/outliner/test/logseq/outliner/op_test.cljs
+++ b/deps/outliner/test/logseq/outliner/op_test.cljs
@@ -2,6 +2,7 @@
   (:require [clojure.string :as string]
             [cljs.test :refer [deftest is testing]]
             [datascript.core :as d]
+            [logseq.common.util.page-ref :as page-ref]
             [logseq.db :as ldb]
             [logseq.db.test.helper :as db-test]
             [logseq.outliner.op :as outliner-op]
@@ -150,6 +151,7 @@
                                               {:block/title "time block"
                                                :build/properties {:log-time "<%time%>"}}]}]}]
                  :properties {:log-time {:logseq.property/type :default}}})
+          target-page (ldb/get-page @conn "Target Page")
           template-root (db-test/find-block-by-content @conn "template root")
           target-block (db-test/find-block-by-content @conn "target block")
           template-blocks (->> (ldb/get-block-and-children @conn (:block/uuid template-root)
@@ -166,7 +168,9 @@
                                                        (:block/uuid target-block)
                                                        {:template-blocks blocks-to-insert}]]]
                                     {})
-          page-var-block (db-test/find-block-by-content @conn "page is [[Target Page]]")
+          page-var-block (db-test/find-block-by-content
+                          @conn
+                          (str "page is " (page-ref/->page-ref (:block/uuid target-page))))
           time-block (some->> (d/q '[:find [?b ...]
                                      :in $ ?title ?page-title
                                      :where

--- a/src/main/frontend/worker/pipeline.cljs
+++ b/src/main/frontend/worker/pipeline.cljs
@@ -8,6 +8,7 @@
             [frontend.worker.react :as worker-react]
             [frontend.worker.state :as worker-state]
             [logseq.common.util :as common-util]
+            [logseq.common.util.date-time :as date-time-util]
             [logseq.common.util.page-ref :as page-ref]
             [logseq.common.uuid :as common-uuid]
             [logseq.db :as ldb]
@@ -20,6 +21,7 @@
             [logseq.graph-parser.exporter :as gp-exporter]
             [logseq.outliner.core :as outliner-core]
             [logseq.outliner.datascript-report :as ds-report]
+            [logseq.outliner.page :as outliner-page]
             [logseq.outliner.template :as outliner-template]
             [logseq.outliner.pipeline :as outliner-pipeline]))
 
@@ -61,6 +63,27 @@
                         added-refs)))))
             blocks)))
 
+(defn- journal-title
+  [db journal-day]
+  (date-time-util/int->journal-title
+   journal-day
+   (:logseq.property.journal/title-format (d/entity db :logseq.class/Journal))))
+
+(defn- ensure-template-journal-pages
+  [db blocks]
+  (reduce
+   (fn [{:keys [db tx-data] :as result} journal-day]
+     (if (ldb/get-journal-page-by-day db journal-day)
+       result
+       (let [{page-tx-data :tx-data} (outliner-page/create db (journal-title db journal-day) {:journal? true})]
+         (when-not (seq page-tx-data)
+           (throw (ex-info "failed to create template journal page" {:journal-day journal-day})))
+         {:db (:db-after (d/with db page-tx-data))
+          :tx-data (concat tx-data page-tx-data)})))
+   {:db db
+    :tx-data []}
+   (outliner-template/dynamic-template-journal-days blocks)))
+
 (defn- insert-tag-templates
   [tx-report]
   (let [db (:db-after tx-report)
@@ -79,47 +102,54 @@
                            (cond->> templates
                              journal-page
                              (map (fn [t] (assoc t :journal journal-page))))))
-        template->blocks (fn [object template]
-                           (let [template-children (rest (ldb/get-block-and-children db (:block/uuid template)
-                                                                                      {:include-property-block? true}))
-                                 blocks (->> (cons (assoc (first template-children)
-                                                          :logseq.property/used-template (:db/id template))
-                                                   (rest template-children))
-                                             (map (fn [block]
-                                                    (cond->
-                                                     (assoc (into {} block) :db/id (:db/id block))
-                                                      (:journal template)
-                                                      (assoc :block/uuid
-                                                             (common-uuid/gen-journal-template-block
-                                                              (:block/uuid (:journal template))
-                                                              (:block/uuid block)))))))]
-                             (outliner-template/resolve-dynamic-template-blocks db object blocks)))
+        raw-template-blocks (fn [template]
+                              (let [template-children (rest (ldb/get-block-and-children db (:block/uuid template)
+                                                                                         {:include-property-block? true}))]
+                                (->> (cons (assoc (first template-children)
+                                                  :logseq.property/used-template (:db/id template))
+                                           (rest template-children))
+                                     (map (fn [block]
+                                            (cond->
+                                             (assoc (into {} block) :db/id (:db/id block))
+                                              (:journal template)
+                                              (assoc :block/uuid
+                                                     (common-uuid/gen-journal-template-block
+                                                      (:block/uuid (:journal template))
+                                                      (:block/uuid block)))))))))
         tag-additions (->> (:tx-data tx-report)
                            (filter (fn [d] (and (= (:a d) :block/tags) (:added d))))
                            (group-by :e))
-        tx-data (mapcat
-                 (fn [[e datoms]]
-                   (let [object (d/entity db e)
-                         templates (->> (set (map :v datoms))
-                                        (mapcat tag->templates)
-                                        distinct
-                                        (sort-by :block/created-at))
-                         blocks-to-insert (mapcat (partial template->blocks object) templates)]
-                     (when (seq blocks-to-insert)
-                       (let [result (outliner-core/insert-blocks
-                                     db blocks-to-insert object
-                                     {:sibling? false
-                                      :keep-uuid? journal-template?
-                                      :outliner-op :insert-template-blocks})]
-                         (concat
-                          (:tx-data result)
-                          (mapcat (fn [block]
-                                    (when-let [refs (seq (outliner-pipeline/block-content-refs db block))]
-                                      [{:db/id (:db/id block)
-                                        :block/refs refs}]))
-                                  (:blocks result)))))))
-                 tag-additions)]
-    tx-data))
+        insertion-inputs (mapcat
+                          (fn [[e datoms]]
+                            (let [templates (->> (set (map :v datoms))
+                                                 (mapcat tag->templates)
+                                                 distinct
+                                                 (sort-by :block/created-at))]
+                              (map (fn [template]
+                                     {:object-id e
+                                      :blocks (raw-template-blocks template)})
+                                   templates)))
+                          tag-additions)
+        {db-with-pages :db page-tx-data :tx-data} (ensure-template-journal-pages db (mapcat :blocks insertion-inputs))
+        insert-tx-data (mapcat
+                        (fn [{:keys [object-id blocks]}]
+                          (let [object (d/entity db-with-pages object-id)
+                                blocks-to-insert (outliner-template/resolve-dynamic-template-blocks db-with-pages object blocks)]
+                            (when (seq blocks-to-insert)
+                              (let [result (outliner-core/insert-blocks
+                                            db-with-pages blocks-to-insert object
+                                            {:sibling? false
+                                             :keep-uuid? journal-template?
+                                             :outliner-op :insert-template-blocks})]
+                                (concat
+                                 (:tx-data result)
+                                 (mapcat (fn [block]
+                                           (when-let [refs (seq (outliner-pipeline/block-content-refs db-with-pages block))]
+                                             [{:db/id (:db/id block)
+                                               :block/refs refs}]))
+                                         (:blocks result)))))))
+                        insertion-inputs)]
+    (concat page-tx-data insert-tx-data)))
 
 (defn- fix-page-tags
   "Add missing attributes and remove #Page when inserting or updating block/title with inline tags"

--- a/src/main/frontend/worker/pipeline.cljs
+++ b/src/main/frontend/worker/pipeline.cljs
@@ -22,8 +22,8 @@
             [logseq.outliner.core :as outliner-core]
             [logseq.outliner.datascript-report :as ds-report]
             [logseq.outliner.page :as outliner-page]
-            [logseq.outliner.template :as outliner-template]
-            [logseq.outliner.pipeline :as outliner-pipeline]))
+            [logseq.outliner.pipeline :as outliner-pipeline]
+            [logseq.outliner.template :as outliner-template]))
 
 (def ^:private rtc-tx-or-download-graph?
   (let [p (some-fn :rtc-op? :rtc-tx? :rtc-download-graph? :transact-remote?)]
@@ -104,7 +104,7 @@
                              (map (fn [t] (assoc t :journal journal-page))))))
         raw-template-blocks (fn [template]
                               (let [template-children (rest (ldb/get-block-and-children db (:block/uuid template)
-                                                                                         {:include-property-block? true}))]
+                                                                                        {:include-property-block? true}))]
                                 (->> (cons (assoc (first template-children)
                                                   :logseq.property/used-template (:db/id template))
                                            (rest template-children))
@@ -519,15 +519,19 @@
                                   (rtc-tx-or-download-graph? tx-meta)
                                   (::sqlite-export/imported-data? tx-meta))
                       (commands/run-commands tx-report))
+        before-template-tx-data (concat revert-tx-data
+                                        toggle-page-and-block-tx-data
+                                        display-blocks-tx-data
+                                        ensure-query-tx-data
+                                        ensure-comments-tx-data
+                                        commands-tx)
+        template-db (if (seq before-template-tx-data)
+                      (:db-after (d/with db-after before-template-tx-data))
+                      db-after)
         insert-templates-tx (when-not (rtc-tx-or-download-graph? tx-meta)
-                              (insert-tag-templates tx-report))
+                              (insert-tag-templates (assoc tx-report :db-after template-db)))
         created-by-tx (add-created-by-ref-hook db-before db-after tx-data tx-meta)]
-    (concat revert-tx-data
-            toggle-page-and-block-tx-data
-            display-blocks-tx-data
-            ensure-query-tx-data
-            ensure-comments-tx-data
-            commands-tx
+    (concat before-template-tx-data
             insert-templates-tx
             created-by-tx
             fix-page-tags-tx-data

--- a/src/main/frontend/worker/pipeline.cljs
+++ b/src/main/frontend/worker/pipeline.cljs
@@ -111,7 +111,13 @@
                                      {:sibling? false
                                       :keep-uuid? journal-template?
                                       :outliner-op :insert-template-blocks})]
-                         (:tx-data result)))))
+                         (concat
+                          (:tx-data result)
+                          (mapcat (fn [block]
+                                    (when-let [refs (seq (outliner-pipeline/block-content-refs db block))]
+                                      [{:db/id (:db/id block)
+                                        :block/refs refs}]))
+                                  (:blocks result)))))))
                  tag-additions)]
     tx-data))
 

--- a/src/test/frontend/worker/pipeline_test.cljs
+++ b/src/test/frontend/worker/pipeline_test.cljs
@@ -568,6 +568,52 @@
       (finally
         (ldb/register-transact-pipeline-fn! identity)))))
 
+(deftest tag-template-journal-ref-survives-cli-upsert-property-history-tx-test
+  (let [today (date-time-util/ms->journal-day (js/Date.))
+        tomorrow (date-time-util/ms->journal-day (+ (js/Date.now) (* 24 60 60 1000)))
+        conn (db-test/create-conn-with-blocks
+              {:pages-and-blocks
+               [{:page {:build/journal today}}
+                {:page {:block/title "Templates"}
+                 :blocks [{:block/title "tag template root"
+                           :build/children [{:block/title "auto <% tomorrow %>"}]}]}]
+               :classes {:DiaryEntry {}}})
+        today-page (db-test/find-journal-by-journal-day @conn today)
+        target-block-uuid (random-uuid)
+        template-root (db-test/find-block-by-content @conn "tag template root")
+        diary-entry (ldb/get-page @conn "DiaryEntry")]
+    (ldb/transact! conn [[:db/add (:db/id template-root)
+                          :logseq.property/template-applied-to
+                          (:db/id diary-entry)]])
+    (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
+    (try
+      (outliner-op/apply-ops! conn [[:insert-blocks [[{:block/uuid target-block-uuid
+                                                        :block/title "target block"}]
+                                                      (:block/uuid today-page)
+                                                      {:outliner-op :insert-blocks
+                                                       :keep-uuid? true
+                                                       :bottom? true}]]
+                                    [:batch-set-property [[target-block-uuid]
+                                                          :logseq.property/status
+                                                          :logseq.property/status.done
+                                                          {}]]
+                                    [:batch-set-property [[target-block-uuid]
+                                                          :block/tags
+                                                          (:db/id diary-entry)
+                                                          {}]]]
+                               {})
+      (let [target-block (db-test/find-block-by-content @conn "target block")
+            tomorrow-page (db-test/find-journal-by-journal-day @conn tomorrow)
+            expected-raw-title (str "auto " (page-ref/->page-ref (:block/uuid tomorrow-page)))
+            inserted-block (db-test/find-block-by-content @conn expected-raw-title)]
+        (is (= 1 (count (:logseq.property.history/_block target-block)))
+            "The CLI-style batched outliner ops create property history before tag template tx-data")
+        (is (some? inserted-block))
+        (is (= [(:block/uuid tomorrow-page)]
+               (mapv :block/uuid (:block/refs inserted-block)))))
+      (finally
+        (ldb/register-transact-pipeline-fn! identity)))))
+
 (deftest import-tx-skips-property-history-recording-test
   (let [conn (db-test/create-conn-with-blocks
               {:pages-and-blocks [{:page {:block/title "page1"}

--- a/src/test/frontend/worker/pipeline_test.cljs
+++ b/src/test/frontend/worker/pipeline_test.cljs
@@ -4,6 +4,7 @@
             [frontend.worker.pipeline :as worker-pipeline]
             [logseq.common.util :as common-util]
             [logseq.common.util.date-time :as date-time-util]
+            [logseq.common.util.page-ref :as page-ref]
             [logseq.db :as ldb]
             [logseq.db.common.order :as db-order]
             [logseq.db.frontend.schema :as db-schema]
@@ -342,6 +343,100 @@
       (is (= expected-name (:block/name page))
           "Journal block/name keeps the default formatter for stable identity"))))
 
+(deftest apply-template-today-dynamic-variable-persists-journal-ref-test
+  (testing "apply-template stores <% today %> as a DB graph id ref to the journal page"
+    (let [today (date-time-util/ms->journal-day (js/Date.))
+          conn (db-test/create-conn-with-blocks
+                {:pages-and-blocks
+                 [{:page {:build/journal today}
+                   :blocks [{:block/title "target block"}]}
+                  {:page {:block/title "Templates"}
+                   :blocks [{:block/title "template root"
+                             :build/children [{:block/title "date <% today %>"}]}]}]})
+          today-page (db-test/find-journal-by-journal-day @conn today)
+          template-root (db-test/find-block-by-content @conn "template root")
+          target-block (db-test/find-block-by-content @conn "target block")
+          template-blocks (->> (ldb/get-block-and-children @conn (:block/uuid template-root)
+                                                           {:include-property-block? true})
+                               rest)
+          blocks-to-insert (cons (assoc (into {} (first template-blocks))
+                                        :db/id (:db/id (first template-blocks))
+                                        :logseq.property/used-template (:db/id template-root))
+                                 (map (fn [block]
+                                        (assoc (into {} block) :db/id (:db/id block)))
+                                      (rest template-blocks)))]
+      (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
+      (try
+        (outliner-op/apply-ops! conn
+                                [[:apply-template [(:block/uuid template-root)
+                                                   (:block/uuid target-block)
+                                                   {:template-blocks blocks-to-insert}]]]
+                                {})
+        (let [inserted-block (db-test/find-block-by-content
+                              @conn
+                              (str "date " (page-ref/->page-ref (:block/uuid today-page))))
+              raw-title (:v (first (d/datoms @conn :eavt (:db/id inserted-block) :block/title)))]
+          (is (some? inserted-block))
+          (is (= (str "date " (page-ref/->page-ref (:block/uuid today-page)))
+                 raw-title))
+          (is (= (str "date " (page-ref/->page-ref (:block/title today-page)))
+                 (:block/title inserted-block)))
+          (is (= [(:block/uuid today-page)]
+                 (mapv :block/uuid (:block/refs inserted-block)))))
+        (finally
+          (ldb/register-transact-pipeline-fn! identity))))))
+
+(deftest apply-template-tomorrow-dynamic-variable-creates-missing-journal-ref-test
+  (testing "apply-template creates a missing journal page before storing <% tomorrow %> as an id ref"
+    (let [today (date-time-util/ms->journal-day (js/Date.))
+          tomorrow (date-time-util/ms->journal-day (+ (js/Date.now) (* 24 60 60 1000)))
+          journal-title-format "yyyy-MM-dd"
+          expected-tomorrow-title (date-time-util/int->journal-title tomorrow journal-title-format)
+          conn (db-test/create-conn-with-blocks
+                {:pages-and-blocks
+                 [{:page {:build/journal today}
+                   :blocks [{:block/title "target block"}]}
+                  {:page {:block/title "Templates"}
+                   :blocks [{:block/title "template root"
+                             :build/children [{:block/title "date <% tomorrow %>"}]}]}]})
+          template-root (db-test/find-block-by-content @conn "template root")
+          target-block (db-test/find-block-by-content @conn "target block")
+          template-blocks (->> (ldb/get-block-and-children @conn (:block/uuid template-root)
+                                                           {:include-property-block? true})
+                               rest)
+          blocks-to-insert (cons (assoc (into {} (first template-blocks))
+                                        :db/id (:db/id (first template-blocks))
+                                        :logseq.property/used-template (:db/id template-root))
+                                 (map (fn [block]
+                                        (assoc (into {} block) :db/id (:db/id block)))
+                                      (rest template-blocks)))]
+      (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
+      (try
+        (ldb/transact! conn [[:db/add :logseq.class/Journal :logseq.property.journal/title-format journal-title-format]])
+        (is (nil? (db-test/find-journal-by-journal-day @conn tomorrow)))
+        (outliner-op/apply-ops! conn
+                                [[:apply-template [(:block/uuid template-root)
+                                                   (:block/uuid target-block)
+                                                   {:template-blocks blocks-to-insert}]]]
+                                {})
+        (let [tomorrow-page (db-test/find-journal-by-journal-day @conn tomorrow)
+              inserted-block (db-test/find-block-by-content
+                              @conn
+                              (str "date " (page-ref/->page-ref (:block/uuid tomorrow-page))))
+              raw-title (:v (first (d/datoms @conn :eavt (:db/id inserted-block) :block/title)))]
+          (is (some? tomorrow-page))
+          (is (= expected-tomorrow-title (:block/title tomorrow-page)))
+          (is (= expected-tomorrow-title (:block/name tomorrow-page)))
+          (is (some? inserted-block))
+          (is (= (str "date " (page-ref/->page-ref (:block/uuid tomorrow-page)))
+                 raw-title))
+          (is (= (str "date " (page-ref/->page-ref (:block/title tomorrow-page)))
+                 (:block/title inserted-block)))
+          (is (= [(:block/uuid tomorrow-page)]
+                 (mapv :block/uuid (:block/refs inserted-block)))))
+        (finally
+          (ldb/register-transact-pipeline-fn! identity))))))
+
 (deftest built-in-tag-must-not-convert-page-child-block-to-class-test
   (let [conn (db-test/create-conn-with-blocks
               {:pages-and-blocks [{:page {:block/title "page1"}}]})
@@ -395,6 +490,7 @@
                            :build/children [{:block/title "auto <% current page %>"}]}]}]
                :classes {:DiaryEntry {}}})
         target-block (db-test/find-block-by-content @conn "target block")
+        target-page (ldb/get-page @conn "Target Page")
         template-root (db-test/find-block-by-content @conn "tag template root")
         diary-entry (ldb/get-page @conn "DiaryEntry")]
     (ldb/transact! conn [[:db/add (:db/id template-root)
@@ -403,7 +499,16 @@
     (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
     (try
       (ldb/transact! conn [[:db/add (:db/id target-block) :block/tags (:db/id diary-entry)]])
-      (is (some? (db-test/find-block-by-content @conn "auto [[Target Page]]")))
+      (let [inserted-block (db-test/find-block-by-content
+                            @conn
+                            (str "auto " (page-ref/->page-ref (:block/uuid target-page))))
+            raw-title (:v (first (d/datoms @conn :eavt (:db/id inserted-block) :block/title)))]
+        (is (some? inserted-block))
+        (is (= (str "auto " (page-ref/->page-ref (:block/uuid target-page)))
+               raw-title))
+        (is (= "auto [[Target Page]]" (:block/title inserted-block)))
+        (is (= [(:block/uuid target-page)]
+               (mapv :block/uuid (:block/refs inserted-block)))))
       (finally
         ;; return global fn back to previous behavior
         (ldb/register-transact-pipeline-fn! identity)))))

--- a/src/test/frontend/worker/pipeline_test.cljs
+++ b/src/test/frontend/worker/pipeline_test.cljs
@@ -15,6 +15,17 @@
             [logseq.outliner.page :as outliner-page]
             [logseq.outliner.recycle :as outliner-recycle]))
 
+(defn- raw-block-title
+  [db block]
+  (when block
+    (:v (first (d/datoms db :eavt (:db/id block) :block/title)))))
+
+(defn- default-journal-page-name
+  [journal-day]
+  (-> journal-day
+      (date-time-util/int->journal-title date-time-util/default-journal-title-formatter)
+      common-util/page-name-sanity-lc))
+
 (deftest test-built-in-page-updates-that-should-be-reverted
   (let [conn (db-test/create-conn-with-blocks
               [{:page {:block/title "page1"}
@@ -375,7 +386,7 @@
         (let [inserted-block (db-test/find-block-by-content
                               @conn
                               (str "date " (page-ref/->page-ref (:block/uuid today-page))))
-              raw-title (:v (first (d/datoms @conn :eavt (:db/id inserted-block) :block/title)))]
+              raw-title (raw-block-title @conn inserted-block)]
           (is (some? inserted-block))
           (is (= (str "date " (page-ref/->page-ref (:block/uuid today-page)))
                  raw-title))
@@ -392,6 +403,7 @@
           tomorrow (date-time-util/ms->journal-day (+ (js/Date.now) (* 24 60 60 1000)))
           journal-title-format "yyyy-MM-dd"
           expected-tomorrow-title (date-time-util/int->journal-title tomorrow journal-title-format)
+          expected-tomorrow-name (default-journal-page-name tomorrow)
           conn (db-test/create-conn-with-blocks
                 {:pages-and-blocks
                  [{:page {:build/journal today}
@@ -420,16 +432,16 @@
                                                    {:template-blocks blocks-to-insert}]]]
                                 {})
         (let [tomorrow-page (db-test/find-journal-by-journal-day @conn tomorrow)
-              inserted-block (db-test/find-block-by-content
-                              @conn
-                              (str "date " (page-ref/->page-ref (:block/uuid tomorrow-page))))
-              raw-title (:v (first (d/datoms @conn :eavt (:db/id inserted-block) :block/title)))]
+              expected-raw-title (when tomorrow-page
+                                   (str "date " (page-ref/->page-ref (:block/uuid tomorrow-page))))
+              inserted-block (when expected-raw-title
+                               (db-test/find-block-by-content @conn expected-raw-title))
+              raw-title (raw-block-title @conn inserted-block)]
           (is (some? tomorrow-page))
           (is (= expected-tomorrow-title (:block/title tomorrow-page)))
-          (is (= expected-tomorrow-title (:block/name tomorrow-page)))
+          (is (= expected-tomorrow-name (:block/name tomorrow-page)))
           (is (some? inserted-block))
-          (is (= (str "date " (page-ref/->page-ref (:block/uuid tomorrow-page)))
-                 raw-title))
+          (is (= expected-raw-title raw-title))
           (is (= (str "date " (page-ref/->page-ref (:block/title tomorrow-page)))
                  (:block/title inserted-block)))
           (is (= [(:block/uuid tomorrow-page)]
@@ -502,7 +514,7 @@
       (let [inserted-block (db-test/find-block-by-content
                             @conn
                             (str "auto " (page-ref/->page-ref (:block/uuid target-page))))
-            raw-title (:v (first (d/datoms @conn :eavt (:db/id inserted-block) :block/title)))]
+            raw-title (raw-block-title @conn inserted-block)]
         (is (some? inserted-block))
         (is (= (str "auto " (page-ref/->page-ref (:block/uuid target-page)))
                raw-title))
@@ -511,6 +523,49 @@
                (mapv :block/uuid (:block/refs inserted-block)))))
       (finally
         ;; return global fn back to previous behavior
+        (ldb/register-transact-pipeline-fn! identity)))))
+
+(deftest tag-template-insertion-creates-missing-journal-ref-test
+  (let [today (date-time-util/ms->journal-day (js/Date.))
+        tomorrow (date-time-util/ms->journal-day (+ (js/Date.now) (* 24 60 60 1000)))
+        journal-title-format "yyyy-MM-dd"
+        expected-tomorrow-title (date-time-util/int->journal-title tomorrow journal-title-format)
+        expected-tomorrow-name (default-journal-page-name tomorrow)
+        conn (db-test/create-conn-with-blocks
+              {:pages-and-blocks
+               [{:page {:build/journal today}
+                 :blocks [{:block/title "target block"}]}
+                {:page {:block/title "Templates"}
+                 :blocks [{:block/title "tag template root"
+                           :build/children [{:block/title "auto <% tomorrow %>"}]}]}]
+               :classes {:DiaryEntry {}}})
+        target-block (db-test/find-block-by-content @conn "target block")
+        template-root (db-test/find-block-by-content @conn "tag template root")
+        diary-entry (ldb/get-page @conn "DiaryEntry")]
+    (ldb/transact! conn [[:db/add :logseq.class/Journal :logseq.property.journal/title-format journal-title-format]
+                         [:db/add (:db/id template-root)
+                          :logseq.property/template-applied-to
+                          (:db/id diary-entry)]])
+    (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
+    (try
+      (is (nil? (db-test/find-journal-by-journal-day @conn tomorrow)))
+      (ldb/transact! conn [[:db/add (:db/id target-block) :block/tags (:db/id diary-entry)]])
+      (let [tomorrow-page (db-test/find-journal-by-journal-day @conn tomorrow)
+            expected-raw-title (when tomorrow-page
+                                 (str "auto " (page-ref/->page-ref (:block/uuid tomorrow-page))))
+            inserted-block (when expected-raw-title
+                             (db-test/find-block-by-content @conn expected-raw-title))
+            raw-title (raw-block-title @conn inserted-block)]
+        (is (some? tomorrow-page))
+        (is (= expected-tomorrow-title (:block/title tomorrow-page)))
+        (is (= expected-tomorrow-name (:block/name tomorrow-page)))
+        (is (some? inserted-block))
+        (is (= expected-raw-title raw-title))
+        (is (= (str "auto " (page-ref/->page-ref (:block/title tomorrow-page)))
+               (:block/title inserted-block)))
+        (is (= [(:block/uuid tomorrow-page)]
+               (mapv :block/uuid (:block/refs inserted-block)))))
+      (finally
         (ldb/register-transact-pipeline-fn! identity)))))
 
 (deftest import-tx-skips-property-history-recording-test


### PR DESCRIPTION
## Summary

Fix template dynamic date variables so inserted DB graph blocks keep canonical page references instead of collapsing to empty page refs after editor normalization.

- Resolve dynamic page variables to UUID refs when the target page exists.
- Create missing journal pages referenced by template date variables before resolving template content.
- Use the graph journal title format for template-created missing journal page title and name.
- Preserve refs for tag-triggered template insertion generated inside the worker pipeline.

## Root cause

Template dynamic variables were resolved to title refs, but DB graph blocks store canonical UUID refs and derive display titles from `:block/refs`. When a journal page did not exist yet, the inserted block could not build a valid ref and later normalized to an empty page ref.

## Validation

- `bb dev:test -n frontend.worker.pipeline-test -e fix-me`
