### PR TITLE
fix: restore cached refresh token

### DIFF
--- a/src/main/frontend/handler/user.cljs
+++ b/src/main/frontend/handler/user.cljs
@@ -236,9 +236,13 @@
   (let [refresh-token (js/localStorage.getItem "refresh-token")
         id-token (js/localStorage.getItem "id-token")
         access-token (js/localStorage.getItem "access-token")
+        refresh-token-present?
+        (and (string? refresh-token) (not (string/blank? refresh-token)))
+        _ (when refresh-token-present?
+            (state/set-auth-refresh-token refresh-token))
         restored-from-cache?
         (boolean
-         (when (and (string? refresh-token) (not (string/blank? refresh-token))
+         (when (and refresh-token-present?
                     (string? id-token) (not (string/blank? id-token))
                     (string? access-token) (not (string/blank? access-token)))
            (when-let [parsed (parse-jwt-safe id-token)]
@@ -246,8 +250,7 @@
                (set-tokens! id-token access-token refresh-token)
                true))))
         should-refresh?
-        (and (string? refresh-token)
-             (not (string/blank? refresh-token))
+        (and refresh-token-present?
              (or (not restored-from-cache?)
                  (some-> (state/get-auth-id-token)
                          parse-jwt-safe

--- a/src/test/frontend/handler/user_test.cljs
+++ b/src/test/frontend/handler/user_test.cljs
@@ -1,5 +1,6 @@
 (ns frontend.handler.user-test
-  (:require [cljs.test :refer [deftest is testing]]
+  (:require [cljs.core.async :as a]
+            [cljs.test :refer [deftest is testing]]
             [electron.ipc :as ipc]
             [frontend.handler.user :as user-handler]
             [frontend.state :as state]
@@ -7,31 +8,39 @@
             [promesa.core :as p]))
 
 (defn- with-mocked-local-storage
-  [f]
-  (let [old-storage (.-localStorage js/globalThis)
-        had-local-storage?
-        (.call (.-hasOwnProperty (.-prototype js/Object))
-               js/globalThis
-               "localStorage")
-        mocked-storage #js {:clear (fn [] nil)
-                            :setItem (fn [& _] nil)
-                            :getItem (fn [& _] nil)
-                            :removeItem (fn [& _] nil)}]
-    (js/Object.defineProperty js/globalThis
-                              "localStorage"
-                              #js {:value mocked-storage
-                                   :configurable true
-                                   :writable true})
-    (try
-      (f)
-      (finally
-        (if had-local-storage?
-          (js/Object.defineProperty js/globalThis
-                                    "localStorage"
-                                    #js {:value old-storage
-                                         :configurable true
-                                         :writable true})
-          (js/Reflect.deleteProperty js/globalThis "localStorage"))))))
+  ([f]
+   (with-mocked-local-storage {} f))
+  ([items f]
+   (let [old-storage (.-localStorage js/globalThis)
+         had-local-storage?
+         (.call (.-hasOwnProperty (.-prototype js/Object))
+                js/globalThis
+                "localStorage")
+         mocked-storage #js {:clear (fn [] nil)
+                             :setItem (fn [& _] nil)
+                             :getItem (fn [k] (get items k))
+                             :removeItem (fn [& _] nil)}]
+     (js/Object.defineProperty js/globalThis
+                               "localStorage"
+                               #js {:value mocked-storage
+                                    :configurable true
+                                    :writable true})
+     (try
+       (f)
+       (finally
+         (if had-local-storage?
+           (js/Object.defineProperty js/globalThis
+                                     "localStorage"
+                                     #js {:value old-storage
+                                          :configurable true
+                                          :writable true})
+           (js/Reflect.deleteProperty js/globalThis "localStorage")))))))
+
+(defn- jwt
+  [payload]
+  (str "header."
+       (js/btoa (js/JSON.stringify (clj->js (merge {:cognito:username ""} payload))))
+       ".sig"))
 
 (deftest set-tokens-persists-auth-json-with-latest-token-values-test
   (let [writes* (atom [])
@@ -80,6 +89,27 @@
                     :refresh-token "refresh-token-existing"}
                    (select-keys (js->clj (js/JSON.parse (:content (first @writes*))) :keywordize-keys true)
                                 [:id-token :access-token :refresh-token]))))))
+      (finally
+        (reset! state/state old-state)))))
+
+(deftest restore-tokens-preserves-refresh-token-before-refreshing-expired-id-token-test
+  (let [old-state @state/state
+        expired-id-token (jwt {:exp 0})
+        refresh-token "refresh-token-from-local-storage"]
+    (reset! state/state (assoc old-state
+                               :auth/id-token nil
+                               :auth/access-token nil
+                               :auth/refresh-token nil))
+    (try
+      (with-mocked-local-storage
+        {"id-token" expired-id-token
+         "access-token" "access-token-from-local-storage"
+         "refresh-token" refresh-token}
+        (fn []
+          (with-redefs [user-handler/<refresh-id-token&access-token (fn [] (a/go nil))
+                        state/pub-event! (fn [& _] nil)]
+            (user-handler/restore-tokens-from-localstorage)
+            (is (= refresh-token (state/get-auth-refresh-token))))))
       (finally
         (reset! state/state old-state)))))
 


### PR DESCRIPTION
## Summary
- Restore the cached refresh token into auth state before startup refresh runs.
- Cover the expired cached id-token startup case so DB sync keeps the refresh token available for worker auth and E2EE key access.

## Root cause
When the cached id token was expired, startup skipped `set-tokens!`, so the cached refresh token stayed only in localStorage. Later DB worker auth refresh and E2EE key paths could see no refresh token and fail with `missing-refresh-token`.

## Validation
- `rtk bb dev:test -v frontend.handler.user-test/restore-tokens-preserves-refresh-token-before-refreshing-expired-id-token-test`
- `rtk bb dev:test -v frontend.handler.user-test`
- `rtk git diff --check`
- `rtk clojure -M:clj-kondo --parallel --lint src/main/frontend/handler/user.cljs src/test/frontend/handler/user_test.cljs --cache false`