### PR TITLE
feat(tags): colored tags presentation

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -728,6 +728,7 @@
     (ui-handler/close-left-sidebar!)))
 
 (declare block-title)
+(declare tag-color-style)
 
 (hsx/defc ^:large-vars/cleanup-todo page-inner
   "The inner div of page reference component
@@ -744,6 +745,7 @@
   (let [*mouse-down? (hooks/use-memo #(atom false) [])
         [mouse-down?] (hooks/use-atom *mouse-down?)
         tag? (:tag? config)
+        show-tags-in-tag-color? (true? (:ui/show-tags-in-tag-color? (state/use-sub-config)))
         recycled? (ldb/recycled? page-entity)
         page-name (when (:block/title page-entity)
                     (util/page-name-sanity-lc (:block/title page-entity)))
@@ -760,6 +762,9 @@
                 (:property? config) (str " page-property-key block-property")
                 recycled? (str " line-through opacity-70")
                 untitled? (str " opacity-50"))
+       :style (or (:link-style config)
+                  (when (and tag? show-tags-in-tag-color?)
+                    (tag-color-style page-entity)))
        :data-ref page-name
        :title (when recycled? (t :ui/deleted))
        :draggable true
@@ -838,6 +843,13 @@
 
           :else
           (block-title (assoc config :page-ref? true) page-entity {})))]]))
+
+(defn tag-color-style
+  [tag]
+  (when-let [color (some-> (:logseq.property/icon tag) :color)]
+    (when-not (string/blank? color)
+      {:color color
+       :opacity 0.95})))
 
 (hsx/defc popup-preview-impl
   [children {:keys [*timer *timer1 visible? set-visible! render *el-popup]}]
@@ -2427,7 +2439,8 @@
     (->elem
      elem
      (merge
-      {:data-hl-type (pu/lookup block :logseq.property.pdf/hl-type)})
+      {:data-hl-type (pu/lookup block :logseq.property.pdf/hl-type)
+       :style (:title-style config)})
 
      ;; children
      (let [area? (= :area (keyword (pu/lookup block :logseq.property.pdf/hl-type)))
@@ -2749,7 +2762,10 @@
         *hover-container? (hooks/use-memo #(atom false) [])
         [hover?] (hooks/use-atom *hover?)
         [_hover-container?] (hooks/use-atom *hover-container?)
-        private-tag? (ldb/private-tags (:db/ident tag))]
+        private-tag? (ldb/private-tags (:db/ident tag))
+        show-tags-in-tag-color? (true? (:ui/show-tags-in-tag-color? (state/use-sub-config)))
+        link-style (when show-tags-in-tag-color?
+                     (tag-color-style tag))]
     [:div.block-tag
      {:key (str "tag-" (:db/id tag))
       :class (str (when private-tag? "private-tag ")
@@ -2760,7 +2776,8 @@
      (if (util/mobile?)
        (page-cp (assoc config
                        :disable-preview? true
-                       :tag? true)
+                       :tag? true
+                       :link-style link-style)
                 tag)
        [:div.flex.items-center
         {:on-mouse-over #(reset! *hover? true)
@@ -2799,10 +2816,12 @@
               (db-property-handler/delete-property-value! (:db/id block) :block/tags (:db/id tag)))}
            (ui/icon "x" {:size 13})]
           [:a.hash-symbol.select-none.flex
+           {:style link-style}
            "#"])
         (page-cp (assoc config
                         :disable-preview? true
                         :tag? true
+                        :link-style link-style
                         :hide-tag-symbol? true)
                  tag)])]))
 
@@ -2810,7 +2829,8 @@
   "Tags without inline or hidden tags"
   [config block]
   (when (:block/raw-title block)
-    (let [hidden-internal-tags (cond-> ldb/internal-tags
+    (let [show-tags-in-tag-color? (true? (:ui/show-tags-in-tag-color? (state/use-sub-config)))
+          hidden-internal-tags (cond-> ldb/internal-tags
                                  (:show-tag-and-property-classes? config)
                                  (set/difference #{:logseq.class/Tag :logseq.class/Property}))
           block-tags (->>
@@ -2846,7 +2866,10 @@
                                                          (ui/icon "X" {:size 14})))
                                                       (page-cp (assoc config
                                                                       :tag? true
-                                                                      :disable-preview? true) tag)]))
+                                                                      :disable-preview? true
+                                                                      :link-style (when show-tags-in-tag-color?
+                                                                                    (tag-color-style tag)))
+                                                               tag)]))
                                                  popup-opts))}
            (for [tag (take 2 block-tags)]
              [:div.block-tag.pl-2
@@ -2854,6 +2877,8 @@
               (page-cp (assoc config
                               :tag? true
                               :disable-preview? true
+                              :link-style (when show-tags-in-tag-color?
+                                            (tag-color-style tag))
                               :disable-click? true) tag)])
           [:div.text-sm.opacity-50.ml-1
             (str "+" (- tags-count 2))]])))))
@@ -4753,6 +4778,9 @@
 (hsx/defc block-container
   [config block* & {:as opts}]
   (let [[block set-block!] (hooks/use-state block*)
+        reactive-block (when (and (:page-title? config) (:db/id block*))
+                         (db/sub-block (:db/id block*)))
+        block (or reactive-block block)
         id (or (:db/id block*) (:block/uuid block*))
         temporary-collapsed-state (state/get-block-collapsed (:block/uuid block)
                                                              (:container-id config))

--- a/src/main/frontend/components/left_sidebar.cljs
+++ b/src/main/frontend/components/left_sidebar.cljs
@@ -20,6 +20,7 @@
             [frontend.ui :as ui]
             [frontend.util :as util]
             [goog.object :as gobj]
+            [logseq.db :as ldb]
             [logseq.shui.hooks :as hooks]
             [logseq.shui.ui :as shui]
             [reitit.frontend.easy :as rfe]
@@ -37,7 +38,7 @@
         (dissoc default-home :page)))))
 
 (hsx/defc page-title-content
-  [page-id display-title tooltip-title untitled? left-sidebar-resized-at]
+  [page-id display-title tooltip-title untitled? left-sidebar-resized-at title-style]
   (let [*title-ref (hooks/use-ref nil)
         [truncated? set-truncated?!] (hooks/use-state false)
         sync-truncated! (fn []
@@ -46,7 +47,8 @@
                                                 (+ (.-clientWidth el) 1)))
                             (set-truncated?! false)))
         title-el [:span.page-title {:ref *title-ref
-                                    :class (when untitled? "opacity-50")}
+                                    :class (when untitled? "opacity-50")
+                                    :style title-style}
                   display-title]]
     (hooks/use-effect!
      (fn []
@@ -72,10 +74,14 @@
   [page recent?]
   (let [[left-sidebar-resized-at] (hooks/use-atom ui-handler/*left-sidebar-resized-at)
         id (:db/id page)
-        page (db/sub-block id)]
+        page (db/sub-block id)
+        show-tags-in-tag-color? (state/show-tags-in-tag-color?)]
     (when id
       (let [icon (icon/get-node-icon-cp page {:size 16})
             title (:block/title page)
+            tag-page? (and (ldb/class? page) (not (ldb/property? page)))
+            title-style (when (and show-tags-in-tag-color? tag-page?)
+                          (block/tag-color-style page))
             untitled? (db-model/untitled-page? title)
             display-title (cond
                             (not (db/page? page))
@@ -122,7 +128,7 @@
                                                                   :class "w-60"}})
                                (util/stop e))})
          [:span.page-icon {:key "page-icon"} icon]
-         (page-title-content id display-title tooltip-title untitled? left-sidebar-resized-at)
+         (page-title-content id display-title tooltip-title untitled? left-sidebar-resized-at title-style)
          (shui/button
            {:key "more actions"
             :size :sm

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -269,7 +269,13 @@
 
 (hsx/defc db-page-title
   [page {:keys [sidebar? journals? container-id tag-dialog? display-title]}]
-  (let [with-actions? (not config/publishing?)]
+  (let [page-id (:db/id page)
+        page (or (db/sub-block page-id) page)
+        with-actions? (not config/publishing?)
+        show-tags-in-tag-color? (state/show-tags-in-tag-color?)
+        tag-page? (and (ldb/class? page) (not (ldb/property? page)))
+        title-style (when (and show-tags-in-tag-color? tag-page?)
+                      (component-block/tag-color-style page))]
     [:div.ls-page-title.flex.flex-1.w-full.content.items-start.title
      {:class "title"
       "data-testid" "page title"
@@ -290,6 +296,7 @@
         :sidebar? sidebar?
         :tag-dialog? tag-dialog?
         :display-title display-title
+        :title-style title-style
         :hide-children? true
         :container-id container-id
         :show-tag-and-property-classes? true

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -244,8 +244,14 @@
                 true)]]
    (when (not (or (util/mobile?) (mobile-util/native-platform?)))
      [:div {:style {:text-align "right"}}
-      (ui/render-keyboard-shortcut (shortcut-helper/gen-shortcut-seq :ui/toggle-brackets)
+     (ui/render-keyboard-shortcut (shortcut-helper/gen-shortcut-seq :ui/toggle-brackets)
                                    :shortcut-id :ui/toggle-brackets)])])
+
+(defn show-tags-in-tag-color-row [t show-tags-in-tag-color?]
+  (toggle "show_tags_in_tag_color"
+          (t :settings.editor/show-tags-in-tag-color)
+          show-tags-in-tag-color?
+          config-handler/toggle-ui-show-tags-in-tag-color!))
 
 (defn toggle-wide-mode-row [t wide-mode?]
   [:div.it.sm:grid.sm:grid-cols-3.sm:gap-4.sm:items-center
@@ -874,11 +880,13 @@
         enable-tooltip? (state/enable-tooltip?)
         enable-shortcut-tooltip? (state/use-sub :ui/shortcut-tooltip?)
         show-brackets? (state/show-brackets?)
+        show-tags-in-tag-color? (state/show-tags-in-tag-color?)
         wide-mode? (state/use-sub :ui/wide-mode?)]
 
     [:div.panel-wrap.is-editor
      (date-format-row t preferred-date-format)
      (show-brackets-row t show-brackets?)
+     (show-tags-in-tag-color-row t show-tags-in-tag-color?)
      (toggle-wide-mode-row t wide-mode?)
 
      (when (util/electron?) (switch-spell-check-row t))

--- a/src/main/frontend/handler/config.cljs
+++ b/src/main/frontend/handler/config.cljs
@@ -35,6 +35,10 @@
   (let [show-brackets? (state/show-brackets?)]
     (set-config! :ui/show-brackets? (not show-brackets?))))
 
+(defn toggle-ui-show-tags-in-tag-color! []
+  (let [show-tags-in-tag-color? (state/show-tags-in-tag-color?)]
+    (set-config! :ui/show-tags-in-tag-color? (not show-tags-in-tag-color?))))
+
 (defn toggle-logical-outdenting! []
   (let [logical-outdenting? (state/logical-outdenting?)]
     (set-config! :editor/logical-outdenting? (not logical-outdenting?))))

--- a/src/main/frontend/schema/handler/common_config.cljc
+++ b/src/main/frontend/schema/handler/common_config.cljc
@@ -8,6 +8,7 @@
     [:meta/version :int]
     [:ui/enable-tooltip? :boolean]
     [:ui/show-brackets? :boolean]
+    [:ui/show-tags-in-tag-color? :boolean]
     [:feature/enable-search-remove-accents? :boolean]
     [:feature/enable-flashcards? :boolean]
     [:feature/disable-scheduled-and-deadline-query? :boolean]

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -732,6 +732,10 @@ should be done through this fn in order to get global config and config defaults
   []
   (not (false? (:ui/show-brackets? (get-config)))))
 
+(defn show-tags-in-tag-color?
+  []
+  (true? (:ui/show-tags-in-tag-color? (get-config))))
+
 (defn use-sub-default-home-page
   []
   (get-in (use-sub-config) [:default-home :page] ""))

--- a/src/resources/dicts/af.edn
+++ b/src/resources/dicts/af.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "Lêer plakken tip"
  :settings.editor/show-brackets "Wys hakies"
  :settings.editor/show-full-blocks "Wys volle blokke"
+ :settings.editor/show-tags-in-tag-color "Wys etikette in etiketkleur"
  :settings.editor/spell-checker "Speltoetser"
  :settings.editor/wide-mode "Wye modus"
 

--- a/src/resources/dicts/ar.edn
+++ b/src/resources/dicts/ar.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "عند التفعيل، سيؤدي لصق صورة من الإنترنت إلى تنزيلها وإدراجها. وعند التعطيل، سيُلصق رابط الصورة فقط."
  :settings.editor/show-brackets "عرض الأقواس"
  :settings.editor/show-full-blocks "عرض الكتل كاملة"
+ :settings.editor/show-tags-in-tag-color "إظهار الوسوم بلون الوسم"
  :settings.editor/spell-checker "المدقق الإملائي"
  :settings.editor/wide-mode "الوضع العريض"
 

--- a/src/resources/dicts/ca.edn
+++ b/src/resources/dicts/ca.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "Consell d'enganxat de fitxers"
  :settings.editor/show-brackets "Mostrar claudàtors"
  :settings.editor/show-full-blocks "Mostrar totes les línies de una referència a bloc"
+ :settings.editor/show-tags-in-tag-color "Mostra les etiquetes amb el color de l'etiqueta"
  :settings.editor/spell-checker "Corrector ortogràfic"
  :settings.editor/wide-mode "Mode ample"
 

--- a/src/resources/dicts/cs.edn
+++ b/src/resources/dicts/cs.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "Tip pro vkládání souborů"
  :settings.editor/show-brackets "Zobrazit závorky"
  :settings.editor/show-full-blocks "Zobrazení všech řádků odkazu na blok"
+ :settings.editor/show-tags-in-tag-color "Zobrazit štítky barvou štítku"
  :settings.editor/spell-checker "Kontrola pravopisu"
  :settings.editor/wide-mode "Široký režim"
 

--- a/src/resources/dicts/de.edn
+++ b/src/resources/dicts/de.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "Wenn aktiviert, werden eingefügte Bilder aus dem Internet heruntergeladen und in assets/ gespeichert. Wenn deaktiviert, wird ein Weblink zum Bild eingefügt."
  :settings.editor/show-brackets "Klammern anzeigen"
  :settings.editor/show-full-blocks "Alle Zeilen einer Blockreferenz anzeigen"
+ :settings.editor/show-tags-in-tag-color "Tags in Tag-Farbe anzeigen"
  :settings.editor/spell-checker "Rechtschreibprüfung"
  :settings.editor/wide-mode "Breitbildmodus"
 

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -1694,6 +1694,7 @@
  :settings.editor/preferred-pasting-file-hint "When enabled, pasting an image from the internet will download and insert the image. When disabled, it will paste the link to the image."
  :settings.editor/show-brackets "Show brackets"
  :settings.editor/show-full-blocks "Show all lines of a block reference"
+ :settings.editor/show-tags-in-tag-color "Show tags in tag color"
  :settings.editor/spell-checker "Spell checker"
  :settings.editor/wide-mode "Wide mode"
 

--- a/src/resources/dicts/es.edn
+++ b/src/resources/dicts/es.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "Cuando está habilitado, al pegar una imagen de internet la imagen será descargada e insertada. Cuando está deshabilitado, el enlace a la imagen será pegado."
  :settings.editor/show-brackets "Mostrar corchetes"
  :settings.editor/show-full-blocks "Mostrar todas las líneas de una referencia a bloque"
+ :settings.editor/show-tags-in-tag-color "Mostrar etiquetas con el color de la etiqueta"
  :settings.editor/spell-checker "Corrector ortográfico"
  :settings.editor/wide-mode "Modo ancho"
 

--- a/src/resources/dicts/fa.edn
+++ b/src/resources/dicts/fa.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "اگر فعال باشد، چسباندن تصویر از اینترنت آن را دانلود و درج می‌کند. اگر غیرفعال باشد، فقط پیوند تصویر چسبانده می‌شود."
  :settings.editor/show-brackets "نمایش کروشه‌ها"
  :settings.editor/show-full-blocks "نمایش کامل بلوک‌ها"
+ :settings.editor/show-tags-in-tag-color "نمایش برچسب‌ها با رنگ برچسب"
  :settings.editor/spell-checker "غلط‌یاب"
  :settings.editor/wide-mode "حالت عریض"
 

--- a/src/resources/dicts/fr.edn
+++ b/src/resources/dicts/fr.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "Lorsqu'elle est activée, coller une image depuis Internet la téléchargera et l'insérera. Sinon, seul son lien sera collé."
  :settings.editor/show-brackets "Afficher les parenthèses, crochets et accolades"
  :settings.editor/show-full-blocks "Afficher toutes les lignes d'une référence de bloc"
+ :settings.editor/show-tags-in-tag-color "Afficher les tags dans leur couleur"
  :settings.editor/spell-checker "Vérification orthographique"
  :settings.editor/wide-mode "Mode large"
 

--- a/src/resources/dicts/id.edn
+++ b/src/resources/dicts/id.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "Ketika diaktifkan, menempelkan gambar dari internet akan mengunduh dan menyisipkan gambar. Ketika dinonaktifkan, akan menempelkan tautan ke gambar."
  :settings.editor/show-brackets "Tampilkan tanda kurung"
  :settings.editor/show-full-blocks "Tampilkan semua baris referensi blok"
+ :settings.editor/show-tags-in-tag-color "Tampilkan tag dengan warna tag"
  :settings.editor/spell-checker "Pemeriksa ejaan"
  :settings.editor/wide-mode "Mode lebar"
 

--- a/src/resources/dicts/it.edn
+++ b/src/resources/dicts/it.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "Quando abilitata, incollare un'immagine da internet scaricherà e inserirà l'immagine. Quando disabilitata, incollerà il link all'immagine."
  :settings.editor/show-brackets "Mostra parentesi"
  :settings.editor/show-full-blocks "Mostra tutte le righe del riferimento ad un blocco"
+ :settings.editor/show-tags-in-tag-color "Mostra i tag nel colore del tag"
  :settings.editor/spell-checker "Correttore ortografico"
  :settings.editor/wide-mode "Modalità ampia"
 

--- a/src/resources/dicts/ja.edn
+++ b/src/resources/dicts/ja.edn
@@ -1596,6 +1596,7 @@
  :settings.editor/preferred-pasting-file-hint "このオプションが有効な場合、インターネットから画像を貼り付けたとき、画像をダウンロードして挿入します。無効な場合、画像へのリンクを挿入します。"
  :settings.editor/show-brackets "ブラケットを表示"
  :settings.editor/show-full-blocks "ブロック参照の全ての行を表示する"
+ :settings.editor/show-tags-in-tag-color "タグをタグの色で表示"
  :settings.editor/spell-checker "スペルチェッカー"
  :settings.editor/wide-mode "ワイドモード"
 

--- a/src/resources/dicts/ko.edn
+++ b/src/resources/dicts/ko.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "활성화하면, 인터넷으로부터 이미지를 붙여넣기할 때 이미지를 다운로드한 뒤 삽입합니다. 비활성화하면, 이미지의 링크를 붙여넣습니다."
  :settings.editor/show-brackets "대괄호 표시"
  :settings.editor/show-full-blocks "블록 참조의 모든 줄 표시"
+ :settings.editor/show-tags-in-tag-color "태그를 태그 색상으로 표시"
  :settings.editor/spell-checker "문법 검사"
  :settings.editor/wide-mode "와이드 모드"
 

--- a/src/resources/dicts/nb-no.edn
+++ b/src/resources/dicts/nb-no.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "Tips for filinnliming"
  :settings.editor/show-brackets "Vis klammer"
  :settings.editor/show-full-blocks "Vis hele blokker"
+ :settings.editor/show-tags-in-tag-color "Vis tagger i taggfarge"
  :settings.editor/spell-checker "Stavekontroll"
  :settings.editor/wide-mode "Bred modus"
 

--- a/src/resources/dicts/nl.edn
+++ b/src/resources/dicts/nl.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "Bestand plakken tip"
  :settings.editor/show-brackets "Toon beugels"
  :settings.editor/show-full-blocks "Volledige blokken tonen"
+ :settings.editor/show-tags-in-tag-color "Tags weergeven in tagkleur"
  :settings.editor/spell-checker "Spellingcontrole"
  :settings.editor/wide-mode "Brede modus"
 

--- a/src/resources/dicts/pl.edn
+++ b/src/resources/dicts/pl.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "Wskazówka dotycząca wklejania plików"
  :settings.editor/show-brackets "Pokaż kwadratowe nawiasy"
  :settings.editor/show-full-blocks "Pokaż wszystkie linie referencji bloku"
+ :settings.editor/show-tags-in-tag-color "Pokazuj tagi w kolorze tagu"
  :settings.editor/spell-checker "Sprawdzanie pisowni"
  :settings.editor/wide-mode "Tryb szeroki"
 

--- a/src/resources/dicts/pt-br.edn
+++ b/src/resources/dicts/pt-br.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "Quando ativado, colar uma imagem da internet fará o download e inserirá a imagem. Quando desativado, ele colará o link da imagem."
  :settings.editor/show-brackets "Mostrar colchetes"
  :settings.editor/show-full-blocks "Mostrar todas as linhas de uma referência de bloco"
+ :settings.editor/show-tags-in-tag-color "Mostrar tags na cor da tag"
  :settings.editor/spell-checker "Verificador ortografo"
  :settings.editor/wide-mode "Modo amplo"
 

--- a/src/resources/dicts/pt-pt.edn
+++ b/src/resources/dicts/pt-pt.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "Dica de colagem de ficheiros"
  :settings.editor/show-brackets "Mostrar parênteses retos"
  :settings.editor/show-full-blocks "Mostrar todas a linhas de uma referência de bloco"
+ :settings.editor/show-tags-in-tag-color "Mostrar etiquetas na cor da etiqueta"
  :settings.editor/spell-checker "Verificador ortográfico"
  :settings.editor/wide-mode "Modo amplo"
 

--- a/src/resources/dicts/ru.edn
+++ b/src/resources/dicts/ru.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "Подсказка по вставке файлов"
  :settings.editor/show-brackets "Показывать скобки"
  :settings.editor/show-full-blocks "Показать все строки в ссылке на блок"
+ :settings.editor/show-tags-in-tag-color "Показывать теги цветом тега"
  :settings.editor/spell-checker "Проверка орфографии"
  :settings.editor/wide-mode "Широкий режим"
 

--- a/src/resources/dicts/sk.edn
+++ b/src/resources/dicts/sk.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "Tip pro vkládání súborů"
  :settings.editor/show-brackets "Zobraziť zátvorky"
  :settings.editor/show-full-blocks "Zobraziť všetky riadky referencie bloku"
+ :settings.editor/show-tags-in-tag-color "Zobraziť značky farbou značky"
  :settings.editor/spell-checker "Kontrola pravopisu"
  :settings.editor/wide-mode "Široký režim"
 

--- a/src/resources/dicts/tr.edn
+++ b/src/resources/dicts/tr.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "Dosya yapıştırma ipucu"
  :settings.editor/show-brackets "Köşeli ayraçları göster"
  :settings.editor/show-full-blocks "Blok referansındaki tüm satırları göster"
+ :settings.editor/show-tags-in-tag-color "Etiketleri etiket renginde göster"
  :settings.editor/spell-checker "Yazım denetleyici"
  :settings.editor/wide-mode "Geniş mod"
 

--- a/src/resources/dicts/uk.edn
+++ b/src/resources/dicts/uk.edn
@@ -1583,6 +1583,7 @@
  :settings.editor/preferred-pasting-file-hint "Подсказка по вставке файлов"
  :settings.editor/show-brackets "Показати дужки"
  :settings.editor/show-full-blocks "Показати всі рядки посилання на блок"
+ :settings.editor/show-tags-in-tag-color "Показувати теги кольором тега"
  :settings.editor/spell-checker "Перевірка правопису"
  :settings.editor/wide-mode "Широкий режим"
 

--- a/src/resources/dicts/vi.edn
+++ b/src/resources/dicts/vi.edn
@@ -536,4 +536,6 @@
  :editor.slash/upload-asset "Tải lên tệp đính kèm"
  :editor.slash/upload-asset-desc "Tải lên các loại tệp như hình ảnh, PDF, DOCX, v.v."
  :editor.slash/yesterday-desc "Chèn ngày hôm qua"
+
+ :settings.editor/show-tags-in-tag-color "Hiển thị thẻ bằng màu của thẻ"
 }

--- a/src/resources/dicts/zh-cn.edn
+++ b/src/resources/dicts/zh-cn.edn
@@ -1694,6 +1694,7 @@
  :settings.editor/preferred-pasting-file-hint "启用后，从互联网粘贴图片将自动下载并保存到本地"
  :settings.editor/show-brackets "显示括号 [[]]"
  :settings.editor/show-full-blocks "显示块引用的所有行"
+ :settings.editor/show-tags-in-tag-color "以标签颜色显示标签"
  :settings.editor/spell-checker "单词拼写检查"
  :settings.editor/wide-mode "宽屏模式"
 

--- a/src/resources/dicts/zh-hant.edn
+++ b/src/resources/dicts/zh-hant.edn
@@ -1596,6 +1596,7 @@
  :settings.editor/preferred-pasting-file-hint "啟用後，從網際網路貼上圖片將自動下載並儲存到本機"
  :settings.editor/show-brackets "顯示括號"
  :settings.editor/show-full-blocks "顯示所有區塊引用列"
+ :settings.editor/show-tags-in-tag-color "以標籤顏色顯示標籤"
  :settings.editor/spell-checker "自動拼音核對"
  :settings.editor/wide-mode "寬屏模式"
 


### PR DESCRIPTION
## Summary

This PR adds a new setting, `Show tags in tag color`, so outline tags can render in their own tag color instead of always using the link color.

When the setting is enabled, tag coloring is now applied consistently across:

- outline tag references
- inline tag rendering
- the Recent view
- tag page titles

This feature combines well with extended tag selection colors (#12854), but both features are independent. 

## Implementation Notes

- added `:ui/show-tags-in-tag-color?` to frontend config/schema/state
- added a settings row to expose the toggle in the UI
- reused shared tag color styling in block, sidebar, and page title rendering paths
- made tag/page title rendering reactive so color changes propagate without stale text color
- added translations for `:settings.editor/show-tags-in-tag-color` to every shipped dictionary


## LLM Disclaimer

Codex/GPT 5.5 was used in this PR, I have reviewed and tested the changes myself. My Clojure is rusty, so there might be non-idiomatic constructions but the logic holds. Translations are fully LLM made.

## Example

<img width="546" height="324" alt="image" src="https://github.com/user-attachments/assets/f6d9a04b-f0c5-4ab6-830c-58ce92f0651d" />
