### PR TITLE
Report sync upload response timeouts

### DIFF
--- a/src/main/frontend/worker/sync.cljs
+++ b/src/main/frontend/worker/sync.cljs
@@ -198,6 +198,7 @@
    :asset-queue (atom (p/resolved nil))
    :pending-pull-since (atom nil)
    :inflight (atom [])
+   :upload-request (atom nil)
    :last-sync-error (atom nil)
    :reconnect (atom {:attempt 0 :timer nil})
    :stale-kill-timer (atom nil)
@@ -293,6 +294,7 @@
 (defn- stop-client!
   [client]
   (clear-stale-ws-loop-timer! client)
+  (sync-apply/clear-upload-response-timeout! client)
   (when-let [reconnect (:reconnect client)]
     (clear-reconnect-timer! reconnect))
   (when-let [ws (:ws client)]

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -153,7 +153,7 @@
         ws (:ws client)
         online? (worker-state/online?)
         ws-open-state? (ws-open? ws)]
-    (when (and online? ws-open-state?)
+    (when online?
       (let [elapsed-ms (- (common-util/time-ms) (:sent-at request))
             outliner-ops (mapv outliner-op->string (:outliner-ops request))
             outliner-op-tag (when (seq outliner-ops)
@@ -741,18 +741,19 @@
                             tx-ids (mapv :tx-id tx-entries)]
                       (when (seq tx-entries)
                         (reset! (:inflight client) tx-ids)
-                        (start-upload-response-timeout!
-                         client
-                         {:tx-ids tx-ids
-                          :outliner-ops (->> tx-entries
-                                             (keep :outliner-op)
-                                             distinct
-                                             vec)
-                          :t-before local-tx})
-                        (send! ws {:type "tx/batch"
-                                   :client-revision (build-version/revision)
-                                   :t-before local-tx
-                                   :txs payload})))
+                        (p/do!
+                         (send! ws {:type "tx/batch"
+                                    :client-revision (build-version/revision)
+                                    :t-before local-tx
+                                    :txs payload})
+                         (start-upload-response-timeout!
+                          client
+                          {:tx-ids tx-ids
+                           :outliner-ops (->> tx-entries
+                                              (keep :outliner-op)
+                                              distinct
+                                              vec)
+                           :t-before local-tx}))))
                     (p/catch (fn [error]
                                (sync-util/set-last-sync-error! client error)
                                (log/error :db-sync/flush-pending-failed

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -2,6 +2,7 @@
   "Pending tx and remote tx application helpers for db sync."
   (:require
    [clojure.set :as set]
+   [clojure.string :as string]
    [datascript.core :as d]
    [frontend.worker.platform :as platform]
    [frontend.worker.shared-service :as shared-service]
@@ -41,6 +42,7 @@
 
 (def ^:private max-remote-apply-snapshot-retries 3)
 (def ^:private remote-apply-snapshot-retry-delay-ms 50)
+(def ^:private upload-response-timeout-ms (* 2 60 1000))
 
 (defn set-upload-stopped!
   [repo stopped?]
@@ -132,6 +134,80 @@
 
 (defn- ws-open? [ws]
   (sync-transport/ws-open? ws))
+
+(defn- ws-ready-state
+  [ws]
+  (when ws
+    (.-readyState ws)))
+
+(defn- outliner-op->string
+  [op]
+  (cond
+    (keyword? op) (name op)
+    (some? op) (str op)
+    :else nil))
+
+(defn- report-upload-response-timeout!
+  [client request]
+  (let [repo (:repo client)
+        ws (:ws client)
+        online? (worker-state/online?)
+        ws-open-state? (ws-open? ws)]
+    (when (and online? ws-open-state?)
+      (let [elapsed-ms (- (common-util/time-ms) (:sent-at request))
+            outliner-ops (mapv outliner-op->string (:outliner-ops request))
+            outliner-op-tag (when (seq outliner-ops)
+                              (string/join "," outliner-ops))
+            data (cond-> {:source "db-sync"
+                          :operation "upload-tx-batch"
+                          :repo repo
+                          :graph-id (:graph-id client)
+                          :timeout-ms upload-response-timeout-ms
+                          :elapsed-ms elapsed-ms
+                          :tx-count (count (:tx-ids request))
+                          :t-before (:t-before request)
+                          :latest-remote-tx (get @*repo->latest-remote-tx repo)
+                          :current-local-tx (client-op/get-local-tx repo)
+                          :online? online?
+                          :ws-open? ws-open-state?
+                          :ws-ready-state (ws-ready-state ws)}
+                   outliner-op-tag
+                   (assoc :outliner-op outliner-op-tag))]
+        (log/error :db-sync/upload-response-timeout
+                   (assoc data :tx-ids (:tx-ids request)))
+        (try
+          (platform/post-message!
+           (platform/current)
+           :capture-error
+           {:error (ex-info "Sync upload request did not get response" data)
+            :payload data
+            :extra (cond-> {:tx-ids (mapv str (:tx-ids request))}
+                     (seq outliner-ops)
+                     (assoc :outliner-ops outliner-ops))})
+          (catch :default report-error
+            (log/error :db-sync/report-upload-response-timeout-failed
+                       {:repo repo
+                        :error report-error})))))))
+
+(defn clear-upload-response-timeout!
+  [client]
+  (when-let [*upload-request (:upload-request client)]
+    (when-let [timer (:timer @*upload-request)]
+      (js/clearTimeout timer))
+    (reset! *upload-request nil)))
+
+(defn- start-upload-response-timeout!
+  [client request]
+  (when-let [*upload-request (:upload-request client)]
+    (when-not (:timer @*upload-request)
+      (let [request' (assoc request :sent-at (common-util/time-ms))
+            timer (js/setTimeout
+                   (fn []
+                     (when (= request' (dissoc @*upload-request :timer))
+                       (reset! *upload-request nil)
+                       (report-upload-response-timeout! client request')))
+                   upload-response-timeout-ms)]
+        (reset! *upload-request (assoc request' :timer timer))))))
 
 (defn upload-large-title! [repo graph-id title aes-key]
   (sync-large-title/upload-large-title!
@@ -665,6 +741,14 @@
                             tx-ids (mapv :tx-id tx-entries)]
                       (when (seq tx-entries)
                         (reset! (:inflight client) tx-ids)
+                        (start-upload-response-timeout!
+                         client
+                         {:tx-ids tx-ids
+                          :outliner-ops (->> tx-entries
+                                             (keep :outliner-op)
+                                             distinct
+                                             vec)
+                          :t-before local-tx})
                         (send! ws {:type "tx/batch"
                                    :client-revision (build-version/revision)
                                    :t-before local-tx

--- a/src/main/frontend/worker/sync/handle_message.cljs
+++ b/src/main/frontend/worker/sync/handle_message.cljs
@@ -166,6 +166,7 @@
 
 (defn- handle-tx-reject!
   [repo client message local-tx]
+  (sync-apply/clear-upload-response-timeout! client)
   (let [reason (:reason message)
         remote-tx (:t message)
         success-tx-ids (:success-tx-ids message)
@@ -263,6 +264,7 @@
 
 (defn- handle-tx-batch-ok!
   [repo client remote-tx remote-checksum]
+  (sync-apply/clear-upload-response-timeout! client)
   (require-non-negative remote-tx {:repo repo :type "tx/batch/ok"})
   (let [current-local-tx (client-op/get-local-tx repo)
         next-local-tx (max current-local-tx remote-tx)]

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -287,6 +287,8 @@
 
 (def ^:private remote-apply-test-settle-ms 500)
 
+(declare minimal-platform)
+
 (defn- with-datascript-conns
   [db-conn ops-conn f]
   (let [db-prev @worker-state/*datascript-conns
@@ -699,6 +701,98 @@
             (is (= 1 @prepare-calls))
             (is (= 0 @send-calls)))
           (#'sync-apply/set-upload-stopped! test-repo false))))))
+
+(deftest flush-pending-reports-upload-response-timeout-test
+  (async done
+         (let [{:keys [conn client-ops-conn child1]} (setup-parent-child)
+               tx-id (random-uuid)
+               sent (atom [])
+               events (atom [])
+               timeout-callback (atom nil)
+               timeout-ms (atom nil)
+               original-set-timeout js/setTimeout
+               original-clear-timeout js/clearTimeout
+               platform-prev (try
+                               (platform/current)
+                               (catch :default _ nil))
+               client {:repo test-repo
+                       :graph-id "graph-1"
+                       :inflight (atom [])
+                       :upload-request (atom nil)
+                       :ws (doto (js-obj)
+                             (aset "readyState" 1)
+                             (aset "send" (fn [raw]
+                                            (swap! sent conj
+                                                   (js->clj (js/JSON.parse raw)
+                                                            :keywordize-keys true)))))}
+               test-platform (assoc-in (minimal-platform :browser)
+                                       [:broadcast :post-message!]
+                                       (fn [type payload]
+                                         (swap! events conj [type payload])))]
+           (set! js/setTimeout
+                 (fn [f ms]
+                   (reset! timeout-callback f)
+                   (reset! timeout-ms ms)
+                   :upload-timeout))
+           (set! js/clearTimeout (fn [& _] nil))
+           (platform/set-platform! test-platform)
+           (with-datascript-conns
+             conn
+             client-ops-conn
+             (fn []
+               (-> (p/with-redefs [worker-state/online? (constantly true)
+                                    sync-crypt/graph-e2ee? (constantly false)]
+                     (reset! sync-apply/*repo->latest-remote-tx {test-repo 0})
+                     (client-op/update-local-tx test-repo 0)
+                     (seed-client-op-txs!
+                      test-repo
+                      [{:db-sync/tx-id tx-id
+                        :db-sync/pending? true
+                        :db-sync/created-at 1
+                        :db-sync/outliner-op :save-block
+                        :db-sync/normalized-tx-data
+                        [[:db/add [:block/uuid (:block/uuid child1)]
+                          :block/title
+                          "pending upload timeout report"]]}])
+                     (p/let [_ (#'sync-apply/flush-pending! test-repo client)]
+                       (is (= "tx/batch" (:type (first @sent))))
+                       (is (= [tx-id] @(:inflight client)))
+                       (is (= (* 2 60 1000) @timeout-ms))
+                       (is (fn? @timeout-callback))
+                       (@timeout-callback)
+                       (is (= 1 (count @events)))
+                       (let [[type payload] (first @events)]
+                         (is (= :capture-error type))
+                         (is (= "db-sync" (get-in payload [:payload :source])))
+                         (is (= "upload-tx-batch" (get-in payload [:payload :operation])))
+                         (is (= test-repo (get-in payload [:payload :repo])))
+                         (is (= "graph-1" (get-in payload [:payload :graph-id])))
+                         (is (= 1 (get-in payload [:payload :tx-count])))
+                         (is (= "save-block" (get-in payload [:payload :outliner-op])))
+                         (is (= (* 2 60 1000) (get-in payload [:payload :timeout-ms])))
+                         (is (= [(str tx-id)] (get-in payload [:extra :tx-ids])))
+                         (is (= ["save-block"] (get-in payload [:extra :outliner-ops])))
+                         (is (= "Sync upload request did not get response"
+                                (ex-message (:error payload)))))
+                       (reset! events [])
+                       (aset (:ws client) "readyState" 3)
+                       (#'sync-apply/start-upload-response-timeout!
+                        client
+                        {:tx-ids [tx-id]
+                         :outliner-ops [:save-block]
+                         :t-before 0})
+                       (@timeout-callback)
+                       (is (empty? @events))))
+                   (p/catch (fn [error]
+                              (is nil (str error))))
+                   (p/finally
+                     (fn []
+                       (set! js/setTimeout original-set-timeout)
+                       (set! js/clearTimeout original-clear-timeout)
+                       (if platform-prev
+                         (platform/set-platform! platform-prev)
+                         (platform/set-platform! (minimal-platform :browser)))
+                       (done)))))))))
 
 (deftest start-active-client-flushes-pending-local-txs-test
   (async done


### PR DESCRIPTION
## Summary

Report sync upload requests to Sentry when a sent tx batch does not receive a server response within 2 minutes.

The report includes the repo, graph id, tx count, tx ids, local/remote tx positions, websocket state, and the outliner operation metadata. Timeout reporting is skipped when the worker is offline or the websocket is no longer open, so disconnects and offline transitions do not create misleading Sentry events.

## Validation

- `rtk clojure -M:clj-kondo --parallel --lint src/main/frontend/worker/sync/apply_txs.cljs src/main/frontend/worker/sync/handle_message.cljs src/main/frontend/worker/sync.cljs src/test/frontend/worker/db_sync_test.cljs --cache false`
- `rtk bb dev:test -v frontend.worker.db-sync-test/flush-pending-reports-upload-response-timeout-test`
- `rtk git diff --check`