### PR TITLE
fix: sanitize get-blocks worker results

### DIFF
--- a/src/main/frontend/worker/db_core.cljs
+++ b/src/main/frontend/worker/db_core.cljs
@@ -872,6 +872,16 @@
                (common-initial-data/with-parent @conn)))))
 
 (def ^:private *get-blocks-cache (volatile! (cache/lru-cache-factory {} :threshold 1000)))
+
+(defn- sanitize-block-result
+  [result]
+  (cond-> result
+    (:block result)
+    (update :block common-util/remove-nils-non-nested)
+
+    (:children result)
+    (update :children common-util/fast-remove-nils)))
+
 (def ^:private get-blocks-with-cache
   (common.cache/cache-fn
    *get-blocks-cache
@@ -885,6 +895,7 @@
             (mapv (fn [{:keys [id opts]}]
                     (let [id' (if (and (string? id) (common-util/uuid-string? id)) (uuid id) id)]
                       (-> (common-initial-data/get-block-and-children db id' opts)
+                          sanitize-block-result
                           (assoc :id id)))))
             ldb/write-transit-str)))))
 

--- a/src/test/frontend/worker/db_core_test.cljs
+++ b/src/test/frontend/worker/db_core_test.cljs
@@ -1612,6 +1612,39 @@
          (is (map? result))
            (is (= "test page" (:block/title result)))))))))
 
+(deftest get-blocks-removes-nil-values-from-returned-blocks
+  (restoring-worker-state
+   (fn []
+     (let [get-blocks! (get @thread-api/*thread-apis :thread-api/get-blocks)
+           conn (d/create-conn db-schema/schema)
+           request [{:id 42 :opts {:children? true}}]]
+       (reset! worker-state/*datascript-conns {test-repo conn})
+       (with-redefs [common-initial-data/get-block-and-children
+                     (fn [_db _id _opts]
+                       {:block {:db/id 42
+                                :block/title "parent"
+                                :block/parent nil}
+                        :children [{:db/id 43
+                                    :block/title "child"
+                                    :block/parent nil}
+                                   {:db/id 44
+                                    :block/title "loaded"
+                                    :block/parent 42
+                                    :block.temp/load-status nil}]})]
+         (let [result (-> (get-blocks! test-repo (ldb/write-transit-str request))
+                          ldb/read-transit-str
+                          first)]
+           (is (= 42 (:id result)))
+           (is (= {:db/id 42
+                   :block/title "parent"}
+                  (:block result)))
+           (is (= [{:db/id 43
+                    :block/title "child"}
+                   {:db/id 44
+                    :block/title "loaded"
+                    :block/parent 42}]
+                  (:children result)))))))))
+
 ;; ---- undo-redo thread-api tests ----
 
 (deftest undo-redo-clear-history-calls-worker-fn


### PR DESCRIPTION
This partially addresses https://github.com/logseq/db-test/issues/974.

The issue reports a blank page caused by `Cannot store nil as a value` when rendering a page that contains a malformed block. The reported entity had `:block/page` set but `:block/parent nil`. That data shape is invalid for a block, and DataScript rejects re-transacting a map that contains nil-valued attributes.

This change does not try to identify or fix the original source of the malformed data. Instead, it hardens the worker `:thread-api/get-blocks` response boundary by removing nil-valued entries from returned `:block` and `:children` maps before they are serialized back to the renderer. This prevents lazy-loaded/query/table block results from carrying maps such as `{:block/parent nil}` into renderer-side `d/transact!`.

Existing graph repair remains the responsibility of graph validation, for example `logseq graph validate --graph <graph> --fix`, which already has logic to repair blocks that have `:block/page` but no `:block/parent`.
