### PR TITLE
fix: tolerate missing comments built-ins during migration

### DIFF
--- a/src/main/frontend/worker/db/migrate.cljs
+++ b/src/main/frontend/worker/db/migrate.cljs
@@ -77,25 +77,27 @@
 
 (defn- tag-comment-blocks
   [db]
-  (->> (d/q '[:find [?comment ...]
-              :where
-              [?comments-area :block/tags :logseq.class/Comments]
-              [?comment :block/parent ?comments-area]]
-            db)
-       (map (fn [comment-id]
-              [:db/add comment-id :block/tags :logseq.class/Comment]))))
+  (when (d/entity db :logseq.class/Comments)
+    (->> (d/q '[:find [?comment ...]
+                :where
+                [?comments-area :block/tags :logseq.class/Comments]
+                [?comment :block/parent ?comments-area]]
+              db)
+         (map (fn [comment-id]
+                [:db/add comment-id :block/tags :logseq.class/Comment])))))
 
 (defn- add-single-block-comment-targets
   [db]
-  (->> (d/q '[:find ?comments-area-id ?parent-id
-              :where
-              [?comments-area-id :block/tags :logseq.class/Comments]
-              [?comments-area-id :block/parent ?parent-id]]
-            db)
-       (keep (fn [[comments-area-id parent-id]]
-               (let [comments-area (d/entity db comments-area-id)]
-                 (when-not (seq (:logseq.property.comments/blocks comments-area))
-                   [:db/add comments-area-id :logseq.property.comments/blocks parent-id]))))))
+  (when (d/entity db :logseq.class/Comments)
+    (->> (d/q '[:find ?comments-area-id ?parent-id
+                :where
+                [?comments-area-id :block/tags :logseq.class/Comments]
+                [?comments-area-id :block/parent ?parent-id]]
+              db)
+         (keep (fn [[comments-area-id parent-id]]
+                 (let [comments-area (d/entity db comments-area-id)]
+                   (when-not (seq (:logseq.property.comments/blocks comments-area))
+                     [:db/add comments-area-id :logseq.property.comments/blocks parent-id])))))))
 
 (defn- missing-class-extends?
   [class]

--- a/src/test/frontend/worker/migrate_test.cljs
+++ b/src/test/frontend/worker/migrate_test.cljs
@@ -263,6 +263,24 @@
                       (d/entity @conn [:block/uuid range-comments-uuid])))))
         "Existing range comment targets should be preserved")))
 
+(deftest migrate-65-27-with-missing-comments-built-ins-does-not-crash
+  (let [conn (d/create-conn db-schema/schema)]
+    (d/transact! conn [{:db/ident :logseq.kv/schema-version
+                        :kv/value {:major 65 :minor 27}}
+                       {:db/ident :logseq.class/Root
+                        :block/title "Root Tag"}])
+
+    (is (nil? (d/entity @conn :logseq.class/Comments)))
+    (is (nil? (d/entity @conn :logseq.property.comments/blocks)))
+
+    (db-migrate/migrate conn :target-version {:major 65 :minor 33})
+
+    (is (= {:major 65 :minor 33}
+           (:kv/value (d/entity @conn :logseq.kv/schema-version))))
+    (is (some? (d/entity @conn :logseq.class/Comments)))
+    (is (some? (d/entity @conn :logseq.class/Comment)))
+    (is (some? (d/entity @conn :logseq.property.comments/blocks)))))
+
 (deftest migrate-65-30-adds-assignee-property
   (let [conn (d/create-conn db-schema/schema)]
     (d/transact! conn [{:db/ident :logseq.kv/schema-version


### PR DESCRIPTION
fix https://github.com/logseq/db-test/issues/941