### PR TITLE
fix: prevent sync checksum drift after tx rejection

### DIFF
--- a/deps/db-sync/src/logseq/db_sync/tx_sanitize.cljs
+++ b/deps/db-sync/src/logseq/db_sync/tx_sanitize.cljs
@@ -41,30 +41,46 @@
                   kw)))
         kv-entity/kv-entities))
 
+(defn- tx-ignored-kv-entity-refs
+  [tx-data]
+  (into ignored-kv-entities
+        (keep (fn [item]
+                (cond
+                  (and (map? item)
+                       (contains? ignored-kv-entities (:db/ident item)))
+                  (:db/id item)
+
+                  (and (entity-op? item)
+                       (= :db/ident (nth item 2))
+                       (contains? ignored-kv-entities (nth item 3)))
+                  (second item))))
+        tx-data))
+
 (defn- ignored-kv-entity-ref?
-  [db entity-ref]
-  (or (contains? ignored-kv-entities entity-ref)
+  [db ignored-entity-refs entity-ref]
+  (or (contains? ignored-entity-refs entity-ref)
       (when-let [eid (entity-ref->eid db entity-ref)]
         (contains? ignored-kv-entities (:db/ident (d/entity db eid))))))
 
 (defn- ignored-kv-entity-op?
-  [db item]
+  [db ignored-entity-refs item]
   (cond
     (and (map? item) (contains? item :db/id))
-    (ignored-kv-entity-ref? db (:db/id item))
+    (ignored-kv-entity-ref? db ignored-entity-refs (:db/id item))
 
     (retract-entity-op? item)
-    (ignored-kv-entity-ref? db (second item))
+    (ignored-kv-entity-ref? db ignored-entity-refs (second item))
 
     (entity-op? item)
-    (ignored-kv-entity-ref? db (second item))
+    (ignored-kv-entity-ref? db ignored-entity-refs (second item))
 
     :else
     false))
 
 (defn- strip-ignored-kv-entity-ops
   [db tx-data]
-  (remove (partial ignored-kv-entity-op? db) tx-data))
+  (let [ignored-entity-refs (tx-ignored-kv-entity-refs tx-data)]
+    (remove (partial ignored-kv-entity-op? db ignored-entity-refs) tx-data)))
 
 (defn- drop-ops-targeting-retracted-entities
   [db tx-data]
@@ -158,7 +174,7 @@
                      drop-ops-targeting-retracted-entities? false
                      retract-touched-descendants? false}}]
    (let [tx-data* (cond->> (strip-migration-deleted-attrs tx-data)
-                    true
+                    (seq ignored-kv-entities)
                     (strip-ignored-kv-entity-ops db)
                     drop-missing-retract-ops?
                     (remove (fn [item]

--- a/deps/db-sync/src/logseq/db_sync/tx_sanitize.cljs
+++ b/deps/db-sync/src/logseq/db_sync/tx_sanitize.cljs
@@ -1,7 +1,8 @@
 (ns logseq.db-sync.tx-sanitize
   (:require [clojure.set :as set]
             [datascript.core :as d]
-            [logseq.db :as ldb]))
+            [logseq.db :as ldb]
+            [logseq.db.frontend.kv-entity :as kv-entity]))
 
 (def ^:private retract-entity-ops
   #{:db/retractEntity :db.fn/retractEntity})
@@ -32,6 +33,38 @@
   (and (vector? item)
        (<= 4 (count item))
        (contains? entity-op-kinds (first item))))
+
+(def ^:private ignored-kv-entities
+  (into #{}
+        (keep (fn [[kw config]]
+                (when (get-in config [:rtc :rtc/ignore-entity-when-init-upload])
+                  kw)))
+        kv-entity/kv-entities))
+
+(defn- ignored-kv-entity-ref?
+  [db entity-ref]
+  (or (contains? ignored-kv-entities entity-ref)
+      (when-let [eid (entity-ref->eid db entity-ref)]
+        (contains? ignored-kv-entities (:db/ident (d/entity db eid))))))
+
+(defn- ignored-kv-entity-op?
+  [db item]
+  (cond
+    (and (map? item) (contains? item :db/id))
+    (ignored-kv-entity-ref? db (:db/id item))
+
+    (retract-entity-op? item)
+    (ignored-kv-entity-ref? db (second item))
+
+    (entity-op? item)
+    (ignored-kv-entity-ref? db (second item))
+
+    :else
+    false))
+
+(defn- strip-ignored-kv-entity-ops
+  [db tx-data]
+  (remove (partial ignored-kv-entity-op? db) tx-data))
 
 (defn- drop-ops-targeting-retracted-entities
   [db tx-data]
@@ -125,6 +158,8 @@
                      drop-ops-targeting-retracted-entities? false
                      retract-touched-descendants? false}}]
    (let [tx-data* (cond->> (strip-migration-deleted-attrs tx-data)
+                    true
+                    (strip-ignored-kv-entity-ops db)
                     drop-missing-retract-ops?
                     (remove (fn [item]
                               (and (retract-entity-op? item)

--- a/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
+++ b/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
@@ -563,7 +563,11 @@
                           :error (str e)})
                false)
              (throw e))))
-       false))))
+       (if (contains? delete-outliner-ops outliner-op)
+         (throw (ex-info "delete tx sanitized to empty"
+                         {:type :db-sync/empty-delete-tx
+                          :outliner-op outliner-op}))
+         false)))))
 
 (defn- apply-tx! [^js self tx-entries request-context]
   (let [sql (.-sql self)]

--- a/deps/db-sync/test/logseq/db_sync/tx_sanitize_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/tx_sanitize_test.cljs
@@ -1,6 +1,7 @@
 (ns logseq.db-sync.tx-sanitize-test
   (:require [cljs.test :refer [deftest is testing]]
             [clojure.set :as set]
+            [datascript.core :as d]
             [logseq.db-sync.tx-sanitize :as tx-sanitize]
             [logseq.db.test.helper :as db-test]))
 
@@ -78,3 +79,26 @@
           sanitized (tx-sanitize/sanitize-tx @conn tx-data)]
       (is (empty? (set/intersection ignored-ops (set sanitized))))
       (is (some #(= [:db/add [:block/uuid block-uuid] :block/title "remote title"] %) sanitized)))))
+
+(deftest sanitize-delete-blocks-retracts-property-value-children-test
+  (testing "delete-blocks adds retracts for generated property value children"
+    (let [conn (db-test/create-conn-with-blocks
+                {:properties {:user.property/cli-http-prop {:logseq.property/type :default}}
+                 :pages-and-blocks
+                 [{:page {:block/title "Page"}
+                   :blocks [{:block/title "Parent"
+                             :build/properties
+                             {:user.property/cli-http-prop
+                              {:build/property-value :block
+                               :block/title "Property value"}}}]}]})
+          parent (db-test/find-block-by-content @conn "Parent")
+          property-value (db-test/find-block-by-content @conn "Property value")
+          tx-data [[:db/retractEntity [:block/uuid (:block/uuid parent)]]]
+          sanitized (tx-sanitize/sanitize-tx @conn
+                                             tx-data
+                                             {:drop-missing-retract-ops? true
+                                              :drop-ops-targeting-retracted-entities? true
+                                              :retract-touched-descendants? true})]
+      (is (= (:db/id property-value)
+             (:db/id (:user.property/cli-http-prop (d/entity @conn (:db/id parent))))))
+      (is (some #(= [:db/retractEntity (:db/id property-value)] %) sanitized)))))

--- a/deps/db-sync/test/logseq/db_sync/tx_sanitize_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/tx_sanitize_test.cljs
@@ -10,6 +10,10 @@
     :logseq.property.embedding/hnsw-label
     :logseq.property.embedding/hnsw-label-updated-at})
 
+(def ^:private graph-backup-folder-ops
+  #{[:db/retractEntity :logseq.kv/graph-backup-folder]
+    [:db/add :logseq.kv/graph-backup-folder :logseq.kv/value "/tmp/backup"]})
+
 (defn- tx-item-attrs
   [item]
   (cond
@@ -34,4 +38,14 @@
           sanitized (tx-sanitize/sanitize-tx @conn tx-data)
           sanitized-attrs (set (mapcat tx-item-attrs sanitized))]
       (is (empty? (set/intersection migration-deleted-attrs sanitized-attrs)))
+      (is (some #(= [:db/add [:block/uuid block-uuid] :block/title "remote title"] %) sanitized)))))
+
+(deftest sanitize-tx-drops-ignored-kv-entity-ops-test
+  (testing "remote txs should not apply KV entities that are excluded from sync"
+    (let [block-uuid #uuid "11111111-1111-1111-1111-111111111111"
+          conn (db-test/create-conn)
+          tx-data (into [[:db/add [:block/uuid block-uuid] :block/title "remote title"]]
+                        graph-backup-folder-ops)
+          sanitized (tx-sanitize/sanitize-tx @conn tx-data)]
+      (is (empty? (set/intersection graph-backup-folder-ops (set sanitized))))
       (is (some #(= [:db/add [:block/uuid block-uuid] :block/title "remote title"] %) sanitized)))))

--- a/deps/db-sync/test/logseq/db_sync/tx_sanitize_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/tx_sanitize_test.cljs
@@ -49,3 +49,32 @@
           sanitized (tx-sanitize/sanitize-tx @conn tx-data)]
       (is (empty? (set/intersection graph-backup-folder-ops (set sanitized))))
       (is (some #(= [:db/add [:block/uuid block-uuid] :block/title "remote title"] %) sanitized)))))
+
+(deftest sanitize-tx-drops-same-tx-ignored-kv-tempid-ops-test
+  (testing "remote txs should drop all ops for tempids identified as ignored KV entities"
+    (let [block-uuid #uuid "11111111-1111-1111-1111-111111111111"
+          conn (db-test/create-conn)
+          ignored-ops #{[:db/add "kv-temp" :db/ident :logseq.kv/graph-backup-folder]
+                        [:db/add "kv-temp" :logseq.kv/value "/tmp/backup"]
+                        [:db/retractEntity "kv-temp"]}
+          tx-data (into [[:db/add [:block/uuid block-uuid] :block/title "remote title"]]
+                        ignored-ops)
+          sanitized (tx-sanitize/sanitize-tx @conn tx-data)]
+      (is (empty? (set/intersection ignored-ops (set sanitized))))
+      (is (some #(= [:db/add [:block/uuid block-uuid] :block/title "remote title"] %) sanitized)))))
+
+(deftest sanitize-tx-drops-same-tx-ignored-kv-map-ops-test
+  (testing "remote txs should drop map-form ignored KV entities and following tempid ops"
+    (let [block-uuid #uuid "11111111-1111-1111-1111-111111111111"
+          conn (db-test/create-conn)
+          ignored-map {:db/id -1
+                       :db/ident :logseq.kv/graph-backup-folder
+                       :logseq.kv/value "/tmp/backup"}
+          ignored-ops #{ignored-map
+                        [:db/add -1 :logseq.kv/value "/tmp/backup-2"]
+                        [:db/retractEntity -1]}
+          tx-data (into [[:db/add [:block/uuid block-uuid] :block/title "remote title"]]
+                        ignored-ops)
+          sanitized (tx-sanitize/sanitize-tx @conn tx-data)]
+      (is (empty? (set/intersection ignored-ops (set sanitized))))
+      (is (some #(= [:db/add [:block/uuid block-uuid] :block/title "remote title"] %) sanitized)))))

--- a/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
@@ -1340,6 +1340,37 @@
       (is (some? (d/entity @conn [:block/uuid success-block-uuid])))
       (is (nil? (d/entity @conn [:block/uuid missing-uuid]))))))
 
+(deftest tx-batch-rejects-stale-delete-before-later-failure-test
+  (testing "stale delete-blocks entries are not reported as successfully applied"
+    (let [sql (test-sql/make-sql)
+          conn (storage/open-conn sql)
+          self #js {:sql sql
+                    :conn conn
+                    :schema-ready true}
+          stale-delete-tx-id (random-uuid)
+          later-failed-tx-id (random-uuid)
+          missing-delete-uuid (random-uuid)
+          missing-update-uuid (random-uuid)
+          t-before (storage/get-t sql)
+          stale-delete-entry {:tx-id stale-delete-tx-id
+                              :tx (protocol/tx->transit
+                                   [[:db/retractEntity [:block/uuid missing-delete-uuid]]])
+                              :outliner-op :delete-blocks}
+          later-failed-entry {:tx-id later-failed-tx-id
+                              :tx (protocol/tx->transit
+                                   [[:db/add [:block/uuid missing-update-uuid] :block/title "stale" 1]])
+                              :outliner-op :save-block}
+          changed-messages (atom [])
+          response (with-redefs [ws/broadcast! (fn [_self _sender payload]
+                                                 (swap! changed-messages conj payload))]
+                     (sync-handler/handle-tx-batch! self nil [stale-delete-entry later-failed-entry] t-before))]
+      (is (= "tx/reject" (:type response)))
+      (is (= "db transact failed" (:reason response)))
+      (is (= t-before (:t response)))
+      (is (= stale-delete-tx-id (:failed-tx-id response)))
+      (is (nil? (:success-tx-ids response)))
+      (is (empty? @changed-messages)))))
+
 (deftest tx-batch-ignores-empty-rebase-entry-test
   (testing "empty rebase entry is a no-op: no t increment, no tx-log append, no changed broadcast"
     (let [sql (test-sql/make-sql)

--- a/deps/db/test/logseq/db/common/delete_blocks_test.cljs
+++ b/deps/db/test/logseq/db/common/delete_blocks_test.cljs
@@ -26,6 +26,27 @@
       (d/transact! conn (concat retracts extra))
       (is (nil? (d/entity @conn (:db/id reaction-entity)))))))
 
+(deftest delete-blocks-expands-property-value-children
+  (testing "delete-blocks retracts generated property value children"
+    (let [property-value-uuid (random-uuid)
+          conn (db-test/create-conn-with-blocks
+                {:properties {:user.property/cli-http-prop {:logseq.property/type :default}}
+                 :pages-and-blocks
+                 [{:page {:block/title "Page"}
+                   :blocks [{:block/title "Parent"
+                             :build/properties
+                             {:user.property/cli-http-prop
+                              {:build/property-value :block
+                               :block/title "Property value"
+                               :block/uuid property-value-uuid
+                               :build/keep-uuid? true}}}]}]})
+          parent (db-test/find-block-by-content @conn "Parent")
+          property-value (d/entity @conn [:block/uuid property-value-uuid])
+          txs [[:db/retractEntity (:db/id parent)]]
+          expanded (delete-blocks/expand-delete-blocks-tx @conn txs {:outliner-op :delete-blocks})]
+      (is (= (:db/id parent) (:db/id (:block/parent property-value))))
+      (is (some #(= [:db/retractEntity (:db/id property-value)] %) expanded)))))
+
 (deftest delete-blocks-removes-history-with-ref-value
   (testing "property history entries referencing a deleted block are retracted"
     (let [conn (db-test/create-conn-with-blocks

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -1652,6 +1652,59 @@
                 (is (= (sync-checksum/recompute-checksum @conn)
                        (client-op/get-local-checksum test-repo)))))))))))
 
+(deftest tx-reject-db-transact-failed-rolls-back-property-value-delete-test
+  (testing "a rejected delete restores generated property value children"
+    (let [property-value-uuid (random-uuid)
+          conn (db-test/create-conn-with-blocks
+                {:properties {:user.property/cli-http-prop {:logseq.property/type :default}}
+                 :pages-and-blocks
+                 [{:page {:block/title "page 1"}
+                   :blocks [{:block/title "parent"
+                             :build/properties
+                             {:user.property/cli-http-prop
+                              {:build/property-value :block
+                               :block/title "property value"
+                               :block/uuid property-value-uuid
+                               :build/keep-uuid? true}}}]}]})
+          client-ops-conn (new-client-ops-db)
+          parent (db-test/find-block-by-content @conn "parent")
+          parent-uuid (:block/uuid parent)]
+      (with-datascript-conns conn client-ops-conn
+        (fn []
+          (client-op/update-local-checksum test-repo (sync-checksum/recompute-checksum @conn))
+          (db-listener/listen-db-changes! test-repo conn :handler-keys [:checksum-test])
+          (outliner-core/delete-blocks! conn [parent] {})
+          (let [tx-id (:tx-id (first (#'sync-apply/pending-txs test-repo)))
+                raw-message (js/JSON.stringify
+                             (clj->js {:type "tx/reject"
+                                       :reason "db transact failed"
+                                       :t 3
+                                       :failed-tx-id (str tx-id)}))
+                client {:repo test-repo
+                        :graph-id "graph-1"
+                        :inflight (atom [tx-id])
+                        :online-users (atom [])
+                        :ws-state (atom :open)}]
+            (is (nil? (d/entity @conn [:block/uuid parent-uuid])))
+            (is (nil? (d/entity @conn [:block/uuid property-value-uuid])))
+            (with-redefs [client-op/get-local-tx (constantly 0)]
+              (let [error (try
+                            (with-silenced-console-error
+                              #(sync-handle-message/handle-message! test-repo client raw-message))
+                            nil
+                            (catch :default e
+                              e))
+                    restored-parent (d/entity @conn [:block/uuid parent-uuid])
+                    restored-property-value (d/entity @conn [:block/uuid property-value-uuid])]
+                (is (some? error))
+                (is (= :db-sync/tx-rejected
+                       (:type (ex-data error))))
+                (is (some? restored-parent))
+                (is (= (:db/id restored-parent)
+                       (:db/id (:block/parent restored-property-value))))
+                (is (= (sync-checksum/recompute-checksum @conn)
+                       (client-op/get-local-checksum test-repo)))))))))))
+
 (deftest tx-reject-db-transact-failed-rebase-keeps-checksum-aligned-test
   (testing "rollback plus rebase of later pending txs should keep the stored checksum aligned"
     (let [{:keys [conn client-ops-conn parent-a a-child-1 b-child-1]} (setup-two-parents)


### PR DESCRIPTION
## Summary

- Drop remote tx items that target RTC-ignored KV entities before applying sync txs.
- Reject delete tx entries that sanitize to empty so they cannot be reported as successfully applied.
- Add regressions for stale delete batch rejection, tx sanitization, delete expansion, and client rollback checksum alignment.

## Root Cause

The checksum mismatch came from partial sync batch reporting. Commit `a38f2a851b4667413cf1bbf931bed3c3513a9ac8` (`Batch large sync tx apply (#12879)`) introduced successful tx tracking for large batch apply, but an entry whose sanitized tx became empty could return `false` while still being accumulated in `success-tx-ids`. For stale `:delete-blocks` txs, that meant the client could mark a delete as synced even though the server never applied it. If a later tx in the same batch failed, the client and server diverged and the final checksum check failed.

The backup-folder sanitizer path also removes old remote txs targeting RTC-ignored KV entities such as `:logseq.kv/graph-backup-folder` before they reach Datascript remote apply.

## Verification

- `CI=true rtk bb dev:db-sync-test`
- `CI=true rtk bb dev:test -v frontend.worker.db-sync-test/tx-reject-db-transact-failed-rolls-back-property-value-delete-test`
- `git diff --check`
- `deps/db` package run reached and passed `delete-blocks-expands-property-value-children`; the broader package run was stopped after later hanging in an unrelated SQLite GC test.
