### PR TITLE
fix: avoid repeated sync delete scans

### DIFF
--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -412,12 +412,19 @@
              (contains? #{:db/retractEntity :db.fn/retractEntity} (first item)))
     (block-uuid-lookup-ref-value (second item))))
 
-(defn- remote-txs-retract-entity-block-uuids
+(defn- remote-txs-retract-entity-block-uuid-suffixes
   [remote-txs]
-  (->> remote-txs
-       (mapcat :tx-data)
-       (keep tx-item-retract-entity-block-uuid)
-       set))
+  (-> (reduce (fn [{:keys [deleted-block-uuids suffixes]} remote-tx]
+                (let [deleted-block-uuids' (into deleted-block-uuids
+                                                  (keep tx-item-retract-entity-block-uuid)
+                                                  (:tx-data remote-tx))]
+                  {:deleted-block-uuids deleted-block-uuids'
+                   :suffixes (conj suffixes deleted-block-uuids')}))
+              {:deleted-block-uuids #{}
+               :suffixes '()}
+              (reverse remote-txs))
+      :suffixes
+      vec))
 
 (defn- tx-item-missing-deleted-block-ref?
   [db deleted-block-uuids item]
@@ -1155,12 +1162,14 @@
 
 (defn- transact-remote-txs!
   [conn remote-txs & {:keys [db-before-local-reversal]}]
-  (let [deleted-block-uuids (remote-txs-retract-entity-block-uuids remote-txs)]
+  (let [deleted-block-uuid-suffixes (remote-txs-retract-entity-block-uuid-suffixes remote-txs)]
     (loop [remaining remote-txs
+           deleted-block-uuid-suffixes deleted-block-uuid-suffixes
            results []]
       (let [db @conn]
         (if-let [remote-tx (first remaining)]
-          (let [tx-data (some->> (:tx-data remote-tx)
+          (let [deleted-block-uuids (first deleted-block-uuid-suffixes)
+                tx-data (some->> (:tx-data remote-tx)
                                  (map (partial resolve-temp-id db))
                                  (tx-sanitize/sanitize-tx db)
                                  drop-stale-adds-after-remote-entity-delete
@@ -1177,6 +1186,7 @@
                            (conj {:tx-data tx-data
                                   :report report}))]
             (recur (next remaining)
+                   (next deleted-block-uuid-suffixes)
                    results'))
           results)))))
 

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -406,6 +406,13 @@
     (keep block-uuid-lookup-ref-value
           [(second item) (nth item 3 nil)])))
 
+(defn- tx-data-has-block-uuid-ref?
+  [tx-data]
+  (boolean
+   (some (fn [item]
+           (seq (tx-item-ref-block-uuids item)))
+         tx-data)))
+
 (defn- tx-item-retract-entity-block-uuid
   [item]
   (when (and (vector? item)
@@ -1172,9 +1179,13 @@
                 tx-data (some->> (:tx-data remote-tx)
                                  (map (partial resolve-temp-id db))
                                  (tx-sanitize/sanitize-tx db)
-                                 drop-stale-adds-after-remote-entity-delete
-                                 (drop-stale-deleted-block-ref-ops db deleted-block-uuids)
-                                 (drop-missing-block-ref-ops db))
+                                 drop-stale-adds-after-remote-entity-delete)
+                tx-data (cond->> tx-data
+                          (seq deleted-block-uuids)
+                          (drop-stale-deleted-block-ref-ops db deleted-block-uuids)
+
+                          (tx-data-has-block-uuid-ref? tx-data)
+                          (drop-missing-block-ref-ops db))
                 tx-data (cond->> tx-data
                           db-before-local-reversal
                           (drop-local-reversal-stale-target-ops db-before-local-reversal db))

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -1155,30 +1155,30 @@
 
 (defn- transact-remote-txs!
   [conn remote-txs & {:keys [db-before-local-reversal]}]
-  (loop [remaining remote-txs
-         results []]
-    (let [db @conn]
-      (if-let [remote-tx (first remaining)]
-        (let [deleted-block-uuids (remote-txs-retract-entity-block-uuids remaining)
-              tx-data (some->> (:tx-data remote-tx)
-                               (map (partial resolve-temp-id db))
-                               (tx-sanitize/sanitize-tx db)
-                               drop-stale-adds-after-remote-entity-delete
-                               (drop-stale-deleted-block-ref-ops db deleted-block-uuids)
-                               (drop-missing-block-ref-ops db))
-              tx-data (cond->> tx-data
-                        db-before-local-reversal
-                        (drop-local-reversal-stale-target-ops db-before-local-reversal db))
-              tx-data (seq tx-data)
-              tx-meta (apply-tx-meta remote-tx)
-              report (ldb/transact! conn tx-data tx-meta)
-              results' (cond-> results
-                         tx-data
-                         (conj {:tx-data tx-data
-                                :report report}))]
-          (recur (next remaining)
-                 results'))
-        results))))
+  (let [deleted-block-uuids (remote-txs-retract-entity-block-uuids remote-txs)]
+    (loop [remaining remote-txs
+           results []]
+      (let [db @conn]
+        (if-let [remote-tx (first remaining)]
+          (let [tx-data (some->> (:tx-data remote-tx)
+                                 (map (partial resolve-temp-id db))
+                                 (tx-sanitize/sanitize-tx db)
+                                 drop-stale-adds-after-remote-entity-delete
+                                 (drop-stale-deleted-block-ref-ops db deleted-block-uuids)
+                                 (drop-missing-block-ref-ops db))
+                tx-data (cond->> tx-data
+                          db-before-local-reversal
+                          (drop-local-reversal-stale-target-ops db-before-local-reversal db))
+                tx-data (seq tx-data)
+                tx-meta (apply-tx-meta remote-tx)
+                report (ldb/transact! conn tx-data tx-meta)
+                results' (cond-> results
+                           tx-data
+                           (conj {:tx-data tx-data
+                                  :report report}))]
+            (recur (next remaining)
+                   results'))
+          results)))))
 
 (defn reverse-local-txs!
   [conn local-txs]

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -6565,6 +6565,35 @@
                    (:block/title (d/entity @conn parent-id))))
             (is (nil? (d/entity @conn [:block/uuid child2-uuid])))))))))
 
+(deftest apply-remote-txs-skips-block-ref-filters-when-txs-have-no-block-uuid-refs-test
+  (testing "plain remote title updates avoid block-ref filters"
+    (let [{:keys [conn parent]} (setup-parent-child)
+          parent-id (:db/id parent)
+          stale-deleted-ref-filter-computations (atom 0)
+          missing-ref-filter-computations (atom 0)
+          original-stale-deleted-ref-filter-fn (deref (var sync-apply/drop-stale-deleted-block-ref-ops))
+          original-missing-ref-filter-fn (deref (var sync-apply/drop-missing-block-ref-ops))
+          remote-txs (mapv (fn [index]
+                             {:tx-data [[:db/add parent-id
+                                         :block/title
+                                         (str "remote title " index)]]})
+                           (range 128))]
+      (with-redefs [sync-apply/drop-stale-deleted-block-ref-ops
+                    (fn [db deleted-block-uuids tx-data]
+                      (swap! stale-deleted-ref-filter-computations inc)
+                      (original-stale-deleted-ref-filter-fn db deleted-block-uuids tx-data))
+                    sync-apply/drop-missing-block-ref-ops
+                    (fn [db tx-data]
+                      (swap! missing-ref-filter-computations inc)
+                      (original-missing-ref-filter-fn db tx-data))]
+        (with-datascript-conns conn nil
+          (fn []
+            (#'sync-apply/apply-remote-txs! test-repo nil remote-txs)
+            (is (zero? @stale-deleted-ref-filter-computations))
+            (is (zero? @missing-ref-filter-computations))
+            (is (= "remote title 127"
+                   (:block/title (d/entity @conn parent-id))))))))))
+
 (deftest apply-remote-txs-keeps-refs-to-block-recreated-after-earlier-delete-test
   (testing "a later remote tx can recreate a block uuid deleted earlier in the same batch"
     (let [{:keys [conn parent child2]} (setup-parent-child)

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -6546,14 +6546,14 @@
           parent-id (:db/id parent)
           child2-uuid (:block/uuid child2)
           delete-set-computations (atom 0)
-          original-delete-set-fn (deref (var sync-apply/remote-txs-retract-entity-block-uuids))
+          original-delete-set-fn (deref (var sync-apply/remote-txs-retract-entity-block-uuid-suffixes))
           remote-txs (conj (mapv (fn [index]
                                    {:tx-data [[:db/add parent-id
                                                :block/title
                                                (str "remote title " index)]]})
                                  (range 128))
                             {:tx-data [[:db/retractEntity [:block/uuid child2-uuid]]]})]
-      (with-redefs [sync-apply/remote-txs-retract-entity-block-uuids
+      (with-redefs [sync-apply/remote-txs-retract-entity-block-uuid-suffixes
                     (fn [txs]
                       (swap! delete-set-computations inc)
                       (original-delete-set-fn txs))]
@@ -6564,6 +6564,40 @@
             (is (= "remote title 127"
                    (:block/title (d/entity @conn parent-id))))
             (is (nil? (d/entity @conn [:block/uuid child2-uuid])))))))))
+
+(deftest apply-remote-txs-keeps-refs-to-block-recreated-after-earlier-delete-test
+  (testing "a later remote tx can recreate a block uuid deleted earlier in the same batch"
+    (let [{:keys [conn parent child2]} (setup-parent-child)
+          child2-uuid (:block/uuid child2)
+          parent-uuid (:block/uuid parent)
+          page-uuid (:block/uuid (:block/page parent))
+          recreated-child-uuid (random-uuid)
+          now (.now js/Date)]
+      (with-datascript-conns conn nil
+        (fn []
+          (#'sync-apply/apply-remote-txs!
+           test-repo
+           nil
+           [{:tx-data [[:db/retractEntity [:block/uuid child2-uuid]]]}
+            {:tx-data [[:db/add -1 :block/uuid child2-uuid]
+                       [:db/add -1 :block/title "child 2 recreated"]
+                       [:db/add -1 :block/parent [:block/uuid parent-uuid]]
+                       [:db/add -1 :block/page [:block/uuid page-uuid]]
+                       [:db/add -1 :block/order "b2"]
+                       [:db/add -1 :block/created-at now]
+                       [:db/add -1 :block/updated-at now]
+                       [:db/add -2 :block/uuid recreated-child-uuid]
+                       [:db/add -2 :block/title "child 2 descendant"]
+                       [:db/add -2 :block/parent [:block/uuid child2-uuid]]
+                       [:db/add -2 :block/page [:block/uuid page-uuid]]
+                       [:db/add -2 :block/order "b2a"]
+                       [:db/add -2 :block/created-at now]
+                       [:db/add -2 :block/updated-at now]]}])
+          (let [recreated-child2 (d/entity @conn [:block/uuid child2-uuid])
+                descendant (d/entity @conn [:block/uuid recreated-child-uuid])]
+            (is (= "child 2 recreated" (:block/title recreated-child2)))
+            (is (= "child 2 descendant" (:block/title descendant)))
+            (is (= child2-uuid (:block/uuid (:block/parent descendant))))))))))
 
 (deftest apply-remote-txs-local-fallback-delete-parent-retracts-remote-child-test
   (testing "rebasing a fallback local retractEntity deletes remote children inserted while the local tx was reversed"

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -6540,6 +6540,31 @@
             (is (empty? (non-recycle-validation-entities validation))
                 (str (:errors validation)))))))))
 
+(deftest apply-remote-txs-computes-remote-deletes-once-per-batch-test
+  (testing "a large remote batch keeps delete filtering without repeatedly rescanning the pull"
+    (let [{:keys [conn parent child2]} (setup-parent-child)
+          parent-id (:db/id parent)
+          child2-uuid (:block/uuid child2)
+          delete-set-computations (atom 0)
+          original-delete-set-fn (deref (var sync-apply/remote-txs-retract-entity-block-uuids))
+          remote-txs (conj (mapv (fn [index]
+                                   {:tx-data [[:db/add parent-id
+                                               :block/title
+                                               (str "remote title " index)]]})
+                                 (range 128))
+                            {:tx-data [[:db/retractEntity [:block/uuid child2-uuid]]]})]
+      (with-redefs [sync-apply/remote-txs-retract-entity-block-uuids
+                    (fn [txs]
+                      (swap! delete-set-computations inc)
+                      (original-delete-set-fn txs))]
+        (with-datascript-conns conn nil
+          (fn []
+            (#'sync-apply/apply-remote-txs! test-repo nil remote-txs)
+            (is (= 1 @delete-set-computations))
+            (is (= "remote title 127"
+                   (:block/title (d/entity @conn parent-id))))
+            (is (nil? (d/entity @conn [:block/uuid child2-uuid])))))))))
+
 (deftest apply-remote-txs-local-fallback-delete-parent-retracts-remote-child-test
   (testing "rebasing a fallback local retractEntity deletes remote children inserted while the local tx was reversed"
     (async done


### PR DESCRIPTION
## Summary

- Compute remote deleted block UUIDs once per pulled remote transaction batch instead of once for every remaining suffix.
- Keep delete filtering behavior intact while avoiding the O(n^2) scan inside remote apply.
- Add a focused regression test that instruments the delete-set computation and verifies it runs once for the batch.

## Root Cause

`transact-remote-txs!` recomputed `remote-txs-retract-entity-block-uuids` inside the loop over remote transactions. Because that helper scans all tx data in its input, a pull of N remote txs scanned N + (N - 1) + ... + 1 tx groups before applying the batch.

## Validation

- `bb dev:test -v frontend.worker.db-sync-test/apply-remote-txs-computes-remote-deletes-once-per-batch-test`
- `bb dev:test -v frontend.worker.db-sync-test/apply-remote-txs-delete-parent-with-child-without-local-changes-test`
- `clojure -M:clj-kondo --parallel --lint src/main/frontend/worker/sync/apply_txs.cljs src/test/frontend/worker/db_sync_test.cljs --cache false`
- `git diff --cached --check`