### PR TITLE
fix: preserve file timestamps during import

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -42,14 +42,17 @@
 
 (defn- add-missing-timestamps
   "Add updated-at or created-at timestamps if they doesn't exist"
-  [block]
-  (let [updated-at (common-util/time-ms)
-        block (cond-> block
-                (nil? (:block/updated-at block))
-                (assoc :block/updated-at updated-at)
-                (nil? (:block/created-at block))
-                (assoc :block/created-at updated-at))]
-    block))
+  ([block]
+   (add-missing-timestamps block nil))
+  ([block {:keys [file-created-at file-updated-at]}]
+   (let [updated-at (or file-updated-at (common-util/time-ms))
+         created-at (or file-created-at updated-at)
+         block (cond-> block
+                 (nil? (:block/updated-at block))
+                 (assoc :block/updated-at updated-at)
+                 (nil? (:block/created-at block))
+                 (assoc :block/created-at created-at))]
+     block)))
 
 (defn- build-new-namespace-page [block]
   (let [new-title (ns-util/get-last-part (:block/title block))]
@@ -1993,7 +1996,7 @@
                      (handle-math)
                      (update-block-marker db options)
                      (update-block-priority options)
-                     add-missing-timestamps
+                     (add-missing-timestamps options)
                      (dissoc :block/format :block.temp/ast-blocks)
                   ;;  ((fn [x] (prn ::block-out x) x))
                      )]
@@ -2008,7 +2011,7 @@
                                 aliases))))
 
 (defn- build-new-page-or-class
-  [m db per-file-state all-idents {:keys [user-options journal-created-ats]}]
+  [m db per-file-state all-idents {:keys [user-options journal-created-ats] :as options}]
   (-> (cond-> m
         ;; Fix pages missing :block/title. Shouldn't happen
         (not (:block/title m))
@@ -2017,7 +2020,7 @@
         (update-page-alias (:page-names-to-uuids per-file-state))
         (journal-created-ats (:block/name m))
         (assoc :block/created-at (journal-created-ats (:block/name m))))
-      add-missing-timestamps
+      (add-missing-timestamps options)
       (update-page-tags db user-options per-file-state all-idents)))
 
 (defn- get-page-parents
@@ -2476,8 +2479,12 @@
 
 (defn- extract-pages-and-blocks
   "Main fn which calls graph-parser to convert markdown into data"
-  [db file content {:keys [extract-options import-state]}]
+  [db file content {:keys [extract-options import-state file-created-at file-updated-at]}]
   (let [format (common-util/get-format file)
+        with-file-timestamps (fn [node]
+                               (cond-> node
+                                 file-created-at (assoc :block/created-at file-created-at)
+                                 file-updated-at (assoc :block/updated-at file-updated-at)))
         extract-options' (merge {:block-pattern (get-block-pattern format)
                                  :date-formatter "MMM do, yyyy"
                                  :uri-encoded? false
@@ -2490,8 +2497,13 @@
         (cond (contains? #{:org :markdown :md} format)
               (-> (extract/extract file content extract-options')
                   (update :pages (fn [pages]
-                                   (map #(dissoc % :block.temp/original-page-name) pages)))
-                  (update :blocks fix-extracted-block-tags-and-refs))
+                                   (map #(-> %
+                                             (dissoc :block.temp/original-page-name)
+                                             with-file-timestamps)
+                                        pages)))
+                  (update :blocks (fn [blocks]
+                                    (fix-extracted-block-tags-and-refs
+                                     (map with-file-timestamps blocks)))))
 
               :else
               (when-not (re-find #"whiteboards/.*\.edn$" (str file))
@@ -2640,7 +2652,7 @@
 
 (defn- export-doc-file
   [{:keys [path idx] :as file} conn <read-file
-   {:keys [notify-user set-ui-state <export-file]
+   {:keys [notify-user set-ui-state <export-file <get-file-stat]
     :or {set-ui-state (constantly nil)
          <export-file (fn <export-file [conn m opts]
                         (<add-file-to-db-graph conn (:file/path m) (:file/content m) opts))}
@@ -2649,8 +2661,15 @@
   (-> (p/let [_ (set-ui-state [:graph/importing-state :current-idx] (inc idx))
               _ (set-ui-state [:graph/importing-state :current-page] path)
               content (<read-file file)
+              stat (when (fn? <get-file-stat)
+                     (<get-file-stat (or (:fs-path file) path)))
+              created-at (or (:birthtime stat) (some-> stat .-birthtime))
+              modified-at (or (:mtime stat) (some-> stat .-mtime) (:last-modified-at file))
               m {:file/path path :file/content content}
-              _ (<export-file conn m (dissoc options :set-ui-state :<export-file))]
+              export-options (cond-> (dissoc options :set-ui-state :<export-file)
+                               created-at (assoc :file-created-at (.getTime created-at))
+                               modified-at (assoc :file-updated-at (.getTime modified-at)))
+              _ (<export-file conn m export-options)]
         ;; returning val results in smoother ui updates
         m)
       (p/catch (fn [error]

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -737,6 +737,29 @@ abc
       (is (nil? (d/entity @conn [:block/uuid missing-uuid]))
           "Missing OG block ref placeholder is removed"))))
 
+(deftest-async export-doc-files-preserves-filesystem-timestamps
+  (let [created-at (js/Date. "2020-01-02T03:04:05.000Z")
+        modified-at (js/Date. "2021-06-07T08:09:10.000Z")]
+    (p/let [file (write-temp-graph-file "pages/timestamps.md" "- timestamped\n")
+            conn (db-test/create-conn)
+            _ (db-pipeline/add-listener conn)
+            doc-options (gp-exporter/build-doc-options
+                         {:macros {} :file/name-format :triple-lowbar}
+                         (merge default-export-options
+                                {:user-options {:convert-all-tags? false}
+                                 :<get-file-stat (fn [_]
+                                                   {:birthtime created-at
+                                                    :mtime modified-at})
+                                 :<export-file (fn [conn' file-map opts]
+                                                 (gp-exporter/<add-file-to-db-graph
+                                                  conn' (:file/path file-map) (:file/content file-map) opts))}))
+            _ (gp-exporter/export-doc-files conn [{:path file}] <read-file doc-options)
+            page (ldb/get-page @conn "timestamps")
+            block (db-test/find-block-by-content @conn "timestamped")]
+      (is (= (.getTime created-at) (:block/created-at page) (:block/created-at block)))
+      (is (= (.getTime modified-at) (:block/updated-at page) (:block/updated-at block)))
+      (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
+
 (deftest update-asset-links-in-block-title
   (are [x y]
        (= y (@#'gp-exporter/update-asset-links-in-block-title (first x) {(second x) "UUID"} (atom {})))

--- a/resources/js/preload.js
+++ b/resources/js/preload.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 const os = require('os')
-const { ipcRenderer, contextBridge, shell, clipboard, webFrame } = require('electron')
+const { ipcRenderer, contextBridge, shell, clipboard, webFrame, webUtils } = require('electron')
 
 const IS_MAC = process.platform === 'darwin'
 const IS_WIN32 = process.platform === 'win32'
@@ -34,6 +34,8 @@ function getClipboardData (format) {
 }
 
 contextBridge.exposeInMainWorld('apis', {
+  getFilePath: (file) => webUtils.getPathForFile(file),
+
   doAction: async (arg) => {
     return await ipcRenderer.invoke('main', arg)
   },

--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -353,5 +353,6 @@
   [path]
   (let [stat (fs/statSync path)]
     {:size (.-size stat)
+     :birthtime (.-birthtime stat)
      :mtime (.-mtime stat)
      :ctime (.-ctime stat)}))

--- a/src/main/frontend/components/imports.cljs
+++ b/src/main/frontend/components/imports.cljs
@@ -416,8 +416,11 @@
         import-graph-fn (or (:import-graph-fn opts)
                             (fn [user-inputs]
                               (let [files (->> file-objs
-                                               (map #(hash-map :file-object %
-                                                               :path (path/trim-dir-prefix original-graph-name (.-webkitRelativePath %))))
+                                              (map #(hash-map :file-object %
+                                                               :path (path/trim-dir-prefix original-graph-name (.-webkitRelativePath %))
+                                                               :fs-path (when (util/electron?)
+                                                                          (js/window.apis.getFilePath %))
+                                                               :last-modified-at (some-> (.-lastModified %) js/Date.)))
                                                (remove #(and (not (string/starts-with? (:path %) "assets/"))
                                                          ;; TODO: Update this when supporting more formats as this aggressively excludes most formats
                                                              (ignored-path? original-graph-name (.-webkitRelativePath (:file-object %))))))]


### PR DESCRIPTION
## What changed

- read creation and modification times for imported Markdown and Org files
- preserve those times on imported pages and blocks instead of using import time
- use Electron's supported file-path bridge and browser `lastModified` fallback

## Why

File graph import previously discarded filesystem timestamps, which replaced historical metadata with the time of import.

## Validation

- graph-parser exporter suite excluding integration tests: 37 tests, 332 assertions
- imported timestamp regression verifies `validate-local-db!` returns no errors
- clj-kondo on touched ClojureScript files: 0 errors, 0 warnings
- preload JavaScript syntax check
- `git diff --check`
