### PR TITLE
ci: pin andelf/nightly-release to a full commit SHA

### DIFF
--- a/.github/workflows/build-desktop-release.yml
+++ b/.github/workflows/build-desktop-release.yml
@@ -723,7 +723,7 @@ jobs:
         run: ls -rl
 
       - name: Update Nightly Release
-        uses: andelf/nightly-release@main
+        uses: andelf/nightly-release@5834076edc55cc05975561c9722043f072ac5c26 # main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
### What
Pin `andelf/nightly-release@main` → `5834076…` in `build-desktop-release.yml` (tag kept in a trailing comment).

### Why
`@main` is a moving reference. In [`build-desktop-release.yml`](https://github.com/logseq/logseq/blob/26f6f7880b1ec894871a9ec2c03bb97b954b4cb0/.github/workflows/build-desktop-release.yml#L726-L731) this action is passed `GITHUB_TOKEN` and
publishes the nightly desktop release (`draft: false`). If the action's `main` were moved (compromise or
an accidental change), the new code would run with the release-publishing token — the class of issue
behind the 2025 `tj-actions/changed-files` incident, here with the ability to alter published release
artifacts.

### Scope / safety
- Behaviour unchanged — the SHA is the current tip of the action's `main`. Signed-off.
- Renovate/Dependabot can still bump a SHA pin (the tag comment keeps it readable).

Per GitHub's guidance to [pin actions to a full-length commit SHA](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflow, the token flow, and the pinned SHA myself.</sub>
