### PR TITLE
feat(sync): add self-hosted deployment manager

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.shadow-cljs
+**/.shadow-cljs
+node_modules
+**/node_modules
+dist
+**/dist
+static
+tmp
+**/tmp
+cli/dist

--- a/.github/workflows/db-sync-native-release.yml
+++ b/.github/workflows/db-sync-native-release.yml
@@ -1,0 +1,72 @@
+name: db-sync native release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to create or update'
+        required: true
+        default: 'db-sync-native'
+        type: string
+  push:
+    tags:
+      - 'db-sync-native-v*'
+
+permissions:
+  contents: read
+
+jobs:
+  runtime:
+    name: Build native runtime packages
+    uses: ./.github/workflows/db-sync-native-runtime.yml
+
+  release:
+    name: Publish runtime release
+    needs: runtime
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download runtime artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: logseq-sync-runtime-linux-*
+          path: artifacts
+          merge-multiple: true
+
+      - name: Prepare manager asset
+        env:
+          DEFAULT_RELEASE_REPOSITORY: ${{ github.repository }}
+        run: |
+          sed "s|readonly default_release_repository=\"logseq/logseq\"|readonly default_release_repository=\"${DEFAULT_RELEASE_REPOSITORY}\"|" \
+            deps/db-sync/deploy/logseq-sync-native \
+            > artifacts/logseq-sync-native
+          chmod 0755 artifacts/logseq-sync-native
+          cd artifacts
+          sha256sum logseq-sync-native > logseq-sync-native.sha256
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_TAG: ${{ inputs.release_tag }}
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            release_tag="${GITHUB_REF#refs/tags/}"
+          else
+            release_tag="$REQUESTED_TAG"
+          fi
+          [[ "$release_tag" =~ ^db-sync-native(-v[0-9A-Za-z._-]+)?$ ]] || {
+            printf 'Invalid native runtime release tag: %s\n' "$release_tag" >&2
+            exit 1
+          }
+          if ! gh release view "$release_tag" >/dev/null 2>&1; then
+            gh release create "$release_tag" \
+              --target "$GITHUB_SHA" \
+              --title "Logseq Sync native runtime" \
+              --notes "Prebuilt Linux x64 and arm64 runtimes for the native self-hosted Sync installer."
+          fi
+          gh release upload "$release_tag" artifacts/* --clobber

--- a/.github/workflows/db-sync-native-release.yml
+++ b/.github/workflows/db-sync-native-release.yml
@@ -64,9 +64,14 @@ jobs:
             exit 1
           }
           if ! gh release view "$release_tag" >/dev/null 2>&1; then
+            release_flags=()
+            case "$release_tag" in
+              *-test.*|*-rc.*) release_flags+=(--prerelease) ;;
+            esac
             gh release create "$release_tag" \
               --target "$GITHUB_SHA" \
               --title "Logseq Sync native runtime" \
-              --notes "Prebuilt Linux x64 and arm64 runtimes for the native self-hosted Sync installer."
+              --notes "Prebuilt Linux x64 and arm64 runtimes for the native self-hosted Sync installer." \
+              "${release_flags[@]}"
           fi
           gh release upload "$release_tag" artifacts/* --clobber

--- a/.github/workflows/db-sync-native-runtime.yml
+++ b/.github/workflows/db-sync-native-runtime.yml
@@ -77,9 +77,9 @@ jobs:
             )"
             test -n "$highest_glibc"
             compatible_highest="$(printf '%s\n%s\n' \
-              'GLIBC_2.28' "$highest_glibc" | sort -V | tail -n 1)"
-            if [[ "$compatible_highest" != 'GLIBC_2.28' ]]; then
-              printf '%s requires %s; the runtime baseline is GLIBC_2.28.\n' \
+              'GLIBC_2.29' "$highest_glibc" | sort -V | tail -n 1)"
+            if [[ "$compatible_highest" != 'GLIBC_2.29' ]]; then
+              printf '%s requires %s; the runtime baseline is GLIBC_2.29.\n' \
                 "$binary" "$highest_glibc" >&2
               exit 1
             fi

--- a/.github/workflows/db-sync-native-runtime.yml
+++ b/.github/workflows/db-sync-native-runtime.yml
@@ -2,22 +2,7 @@ name: db-sync native runtime
 
 on:
   workflow_call:
-    inputs:
-      release_tag:
-        description: 'Release tag to create or update; empty builds artifacts only'
-        required: false
-        default: ''
-        type: string
   workflow_dispatch:
-    inputs:
-      release_tag:
-        description: 'Release tag to create or update; leave empty to build artifacts only'
-        required: false
-        default: 'db-sync-native'
-        type: string
-  push:
-    tags:
-      - 'db-sync-native-v*'
 
 permissions:
   contents: read
@@ -152,57 +137,3 @@ jobs:
             ${{ runner.temp }}/artifacts/*.tar.gz
             ${{ runner.temp }}/artifacts/*.sha256
           if-no-files-found: error
-
-  release:
-    name: Publish runtime release
-    needs: build
-    if: >-
-      startsWith(github.ref, 'refs/tags/db-sync-native-v') ||
-      (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Download runtime artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: logseq-sync-runtime-linux-*
-          path: artifacts
-          merge-multiple: true
-
-      - name: Prepare manager asset
-        env:
-          DEFAULT_RELEASE_REPOSITORY: ${{ github.repository }}
-        run: |
-          sed "s|readonly default_release_repository=\"logseq/logseq\"|readonly default_release_repository=\"${DEFAULT_RELEASE_REPOSITORY}\"|" \
-            deps/db-sync/deploy/logseq-sync-native \
-            > artifacts/logseq-sync-native
-          chmod 0755 artifacts/logseq-sync-native
-          cd artifacts
-          sha256sum logseq-sync-native > logseq-sync-native.sha256
-
-      - name: Create or update GitHub release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REQUESTED_TAG: ${{ inputs.release_tag }}
-        run: |
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            release_tag="${GITHUB_REF#refs/tags/}"
-          else
-            release_tag="$REQUESTED_TAG"
-          fi
-          [[ "$release_tag" =~ ^db-sync-native(-v[0-9A-Za-z._-]+)?$ ]] || {
-            printf 'Invalid native runtime release tag: %s\n' "$release_tag" >&2
-            exit 1
-          }
-          if ! gh release view "$release_tag" >/dev/null 2>&1; then
-            gh release create "$release_tag" \
-              --target "$GITHUB_SHA" \
-              --title "Logseq Sync native runtime" \
-              --notes "Prebuilt Linux x64 and arm64 runtimes for the native self-hosted Sync installer."
-          fi
-          gh release upload "$release_tag" artifacts/* --clobber

--- a/.github/workflows/db-sync-native-runtime.yml
+++ b/.github/workflows/db-sync-native-runtime.yml
@@ -57,7 +57,9 @@ jobs:
           cli: ${{ env.CLOJURE_VERSION }}
 
       - name: Install production dependencies
-        run: pnpm install --frozen-lockfile --prod
+        run: |
+          pnpm install --frozen-lockfile --prod --ignore-workspace
+          pnpm rebuild better-sqlite3 --ignore-workspace
 
       - name: Build Node adapter
         run: pnpm build:node-adapter

--- a/.github/workflows/db-sync-native-runtime.yml
+++ b/.github/workflows/db-sync-native-runtime.yml
@@ -1,16 +1,13 @@
 name: db-sync native runtime
 
 on:
-  pull_request:
-    branches: [master]
-    paths:
-      - 'deps/common/**'
-      - 'deps/db/**'
-      - 'deps/db-sync/**'
-      - 'deps/graph-parser/**'
-      - 'deps/outliner/**'
-      - 'resources/**'
-      - '.github/workflows/db-sync-native-runtime.yml'
+  workflow_call:
+    inputs:
+      release_tag:
+        description: 'Release tag to create or update; empty builds artifacts only'
+        required: false
+        default: ''
+        type: string
   workflow_dispatch:
     inputs:
       release_tag:

--- a/.github/workflows/db-sync-native-runtime.yml
+++ b/.github/workflows/db-sync-native-runtime.yml
@@ -1,0 +1,211 @@
+name: db-sync native runtime
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'deps/common/**'
+      - 'deps/db/**'
+      - 'deps/db-sync/**'
+      - 'deps/graph-parser/**'
+      - 'deps/outliner/**'
+      - 'resources/**'
+      - '.github/workflows/db-sync-native-runtime.yml'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to create or update; leave empty to build artifacts only'
+        required: false
+        default: 'db-sync-native'
+        type: string
+  push:
+    tags:
+      - 'db-sync-native-v*'
+
+permissions:
+  contents: read
+
+env:
+  CLOJURE_VERSION: '1.12.4.1618'
+  JAVA_VERSION: '21'
+  NODE_VERSION: '24'
+  PNPM_VERSION: '10.33.0'
+
+jobs:
+  build:
+    name: Build Linux ${{ matrix.arch }} runtime
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        working-directory: deps/db-sync
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: deps/db-sync/pnpm-lock.yaml
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Set up Clojure
+        uses: DeLaGuardo/setup-clojure@13.5
+        with:
+          cli: ${{ env.CLOJURE_VERSION }}
+
+      - name: Install production dependencies
+        run: pnpm install --frozen-lockfile --prod
+
+      - name: Build Node adapter
+        run: pnpm build:node-adapter
+
+      - name: Check Linux runtime compatibility baseline
+        run: |
+          sqlite_addon="$(find node_modules -path '*/better-sqlite3/build/Release/better_sqlite3.node' -print -quit)"
+          test -n "$sqlite_addon"
+          for binary in "$(command -v node)" "$sqlite_addon"; do
+            highest_glibc="$(
+              readelf --version-info "$binary" \
+                | sed -n 's/.*Name: \(GLIBC_[0-9.]*\).*/\1/p' \
+                | sort -Vu \
+                | tail -n 1
+            )"
+            test -n "$highest_glibc"
+            compatible_highest="$(printf '%s\n%s\n' \
+              'GLIBC_2.28' "$highest_glibc" | sort -V | tail -n 1)"
+            if [[ "$compatible_highest" != 'GLIBC_2.28' ]]; then
+              printf '%s requires %s; the runtime baseline is GLIBC_2.28.\n' \
+                "$binary" "$highest_glibc" >&2
+              exit 1
+            fi
+          done
+
+      - name: Package runtime
+        env:
+          DEFAULT_RELEASE_REPOSITORY: ${{ github.repository }}
+          RUNTIME_ARCH: ${{ matrix.arch }}
+          RUNTIME_VERSION: ${{ github.sha }}
+        run: |
+          chmod +x deploy/package-native-runtime.sh deploy/logseq-sync-native
+          deploy/package-native-runtime.sh \
+            "$RUNTIME_VERSION" "$RUNTIME_ARCH" "$RUNNER_TEMP/artifacts"
+
+      - name: Smoke test packaged runtime
+        env:
+          RUNTIME_ARCH: ${{ matrix.arch }}
+        run: |
+          runtime_test_dir="$RUNNER_TEMP/runtime-test"
+          mkdir -p "$runtime_test_dir"
+          tar -xzf \
+            "$RUNNER_TEMP/artifacts/logseq-sync-runtime-linux-${RUNTIME_ARCH}.tar.gz" \
+            -C "$runtime_test_dir"
+          runtime="$runtime_test_dir/logseq-sync-runtime"
+          test "$(cat "$runtime/ARCHITECTURE")" = "$RUNTIME_ARCH"
+          "$runtime/node/bin/node" --version
+          DB_SYNC_HOST=127.0.0.1 \
+          DB_SYNC_PORT=18080 \
+          DB_SYNC_BASE_URL=http://127.0.0.1:18080 \
+          DB_SYNC_DATA_DIR="$RUNNER_TEMP/runtime-data" \
+          DB_SYNC_STORAGE_DRIVER=sqlite \
+          DB_SYNC_ASSETS_DRIVER=filesystem \
+            "$runtime/node/bin/node" "$runtime/app/node-adapter.js" \
+              >"$RUNNER_TEMP/runtime.log" 2>&1 &
+          runtime_pid=$!
+          trap 'kill "$runtime_pid" 2>/dev/null || true' EXIT
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent http://127.0.0.1:18080/health \
+                | grep -q '"ok":true'; then
+              exit 0
+            fi
+            if ! kill -0 "$runtime_pid" 2>/dev/null; then
+              cat "$RUNNER_TEMP/runtime.log"
+              exit 1
+            fi
+            sleep 1
+          done
+          cat "$RUNNER_TEMP/runtime.log"
+          exit 1
+
+      - name: Upload runtime artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: logseq-sync-runtime-linux-${{ matrix.arch }}
+          path: |
+            ${{ runner.temp }}/artifacts/*.tar.gz
+            ${{ runner.temp }}/artifacts/*.sha256
+          if-no-files-found: error
+
+  release:
+    name: Publish runtime release
+    needs: build
+    if: >-
+      startsWith(github.ref, 'refs/tags/db-sync-native-v') ||
+      (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download runtime artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: logseq-sync-runtime-linux-*
+          path: artifacts
+          merge-multiple: true
+
+      - name: Prepare manager asset
+        env:
+          DEFAULT_RELEASE_REPOSITORY: ${{ github.repository }}
+        run: |
+          sed "s|readonly default_release_repository=\"logseq/logseq\"|readonly default_release_repository=\"${DEFAULT_RELEASE_REPOSITORY}\"|" \
+            deps/db-sync/deploy/logseq-sync-native \
+            > artifacts/logseq-sync-native
+          chmod 0755 artifacts/logseq-sync-native
+          cd artifacts
+          sha256sum logseq-sync-native > logseq-sync-native.sha256
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_TAG: ${{ inputs.release_tag }}
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            release_tag="${GITHUB_REF#refs/tags/}"
+          else
+            release_tag="$REQUESTED_TAG"
+          fi
+          [[ "$release_tag" =~ ^db-sync-native(-v[0-9A-Za-z._-]+)?$ ]] || {
+            printf 'Invalid native runtime release tag: %s\n' "$release_tag" >&2
+            exit 1
+          }
+          if ! gh release view "$release_tag" >/dev/null 2>&1; then
+            gh release create "$release_tag" \
+              --target "$GITHUB_SHA" \
+              --title "Logseq Sync native runtime" \
+              --notes "Prebuilt Linux x64 and arm64 runtimes for the native self-hosted Sync installer."
+          fi
+          gh release upload "$release_tag" artifacts/* --clobber

--- a/.github/workflows/deps-db-sync.yml
+++ b/.github/workflows/deps-db-sync.yml
@@ -146,5 +146,5 @@ jobs:
             y \
             | bash deploy/logseq-sync setup
           curl --fail --silent http://127.0.0.1:18080/health
-          docker compose --env-file "$install_dir/.env" -f "$install_dir/compose.yaml" config -q
+          docker compose --env-file "$install_dir/.env" -f "$install_dir/compose.yaml" -f "$install_dir/compose.http.yaml" config -q
           docker compose --profile https --env-file "$install_dir/.env" -f "$install_dir/compose.yaml" config -q

--- a/.github/workflows/deps-db-sync.yml
+++ b/.github/workflows/deps-db-sync.yml
@@ -1,6 +1,7 @@
 name: logseq/db-sync CI
 
 on:
+  workflow_dispatch:
   # Path filters ensure jobs only kick off if a change is made to db-sync or
   # its local dependencies
   push:

--- a/.github/workflows/deps-db-sync.yml
+++ b/.github/workflows/deps-db-sync.yml
@@ -7,6 +7,10 @@ on:
     branches: [master]
     paths:
       - 'deps/db-sync/**'
+      - 'deps/graph-parser/**'
+      - 'deps/outliner/**'
+      - 'resources/**'
+      - '.dockerignore'
       - '.github/workflows/deps-db-sync.yml'
       - '!deps/db-sync/**.md'
       # Deps that logseq/db-sync depends on should trigger this workflow
@@ -16,6 +20,10 @@ on:
     branches: [master]
     paths:
       - 'deps/db-sync/**'
+      - 'deps/graph-parser/**'
+      - 'deps/outliner/**'
+      - 'resources/**'
+      - '.dockerignore'
       - '.github/workflows/deps-db-sync.yml'
       - '!deps/db-sync/**.md'
       # Deps that logseq/db-sync depends on should trigger this workflow
@@ -99,3 +107,43 @@ jobs:
 
       - name: Lint for vars that are too large
         run: bb lint:large-vars
+
+  deployment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate shell syntax
+        run: bash -n deploy/logseq-sync
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Node adapter image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deps/db-sync/deploy/Dockerfile
+          load: true
+          tags: logseq-db-sync-node
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run deployment manager HTTP smoke test
+        run: |
+          install_dir="$RUNNER_TEMP/logseq-sync-install"
+          data_dir="$RUNNER_TEMP/logseq-sync-data"
+          printf '%s\n' \
+            "$install_dir" \
+            "$data_dir" \
+            http \
+            http://127.0.0.1:18080 \
+            I_ACCEPT_HTTP \
+            logseq-client \
+            y \
+            | bash deploy/logseq-sync setup
+          curl --fail --silent http://127.0.0.1:18080/health
+          docker compose --env-file "$install_dir/.env" -f "$install_dir/compose.yaml" config -q
+          docker compose --profile https --env-file "$install_dir/.env" -f "$install_dir/compose.yaml" config -q

--- a/.github/workflows/deps-db-sync.yml
+++ b/.github/workflows/deps-db-sync.yml
@@ -117,7 +117,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate shell syntax
-        run: bash -n deploy/logseq-sync
+        run: |
+          bash -n deploy/logseq-sync
+          bash -n deploy/logseq-sync-native
+          bash -n deploy/test.sh
+          bash -n deploy/native-test.sh
+
+      - name: Run deployment manager tests
+        run: |
+          bash deploy/test.sh
+          bash deploy/native-test.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/deps-db-sync.yml
+++ b/.github/workflows/deps-db-sync.yml
@@ -43,6 +43,10 @@ env:
   BABASHKA_VERSION: '1.12.215'
 
 jobs:
+  native-runtime:
+    name: Build native runtime packages
+    uses: ./.github/workflows/db-sync-native-runtime.yml
+
   test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deps-db-sync.yml
+++ b/.github/workflows/deps-db-sync.yml
@@ -120,6 +120,7 @@ jobs:
         run: |
           bash -n deploy/logseq-sync
           bash -n deploy/logseq-sync-native
+          bash -n deploy/package-native-runtime.sh
           bash -n deploy/test.sh
           bash -n deploy/native-test.sh
 

--- a/.github/workflows/deps-db-sync.yml
+++ b/.github/workflows/deps-db-sync.yml
@@ -12,6 +12,8 @@ on:
       - 'deps/outliner/**'
       - 'resources/**'
       - '.dockerignore'
+      - '.github/workflows/db-sync-native-runtime.yml'
+      - '.github/workflows/db-sync-native-release.yml'
       - '.github/workflows/deps-db-sync.yml'
       - '!deps/db-sync/**.md'
       # Deps that logseq/db-sync depends on should trigger this workflow
@@ -25,6 +27,8 @@ on:
       - 'deps/outliner/**'
       - 'resources/**'
       - '.dockerignore'
+      - '.github/workflows/db-sync-native-runtime.yml'
+      - '.github/workflows/db-sync-native-release.yml'
       - '.github/workflows/deps-db-sync.yml'
       - '!deps/db-sync/**.md'
       # Deps that logseq/db-sync depends on should trigger this workflow

--- a/deps/db-sync/README.md
+++ b/deps/db-sync/README.md
@@ -103,6 +103,11 @@ It requires typing `DELETE` as confirmation.
 
 ### Node.js Adapter (self-hosted)
 
+For the guided native systemd setup, including automatic HTTPS, persistent
+storage, and day-two management commands, follow the
+[deployment manager quickstart](deploy/README.md). The commands below are the
+manual developer workflow.
+
 Build the adapter:
 
 ```bash
@@ -133,6 +138,7 @@ pnpm test:node-adapter
 
 | Variable | Purpose |
 | --- | --- |
+| DB_SYNC_HOST | HTTP server bind address (defaults to `127.0.0.1`) |
 | DB_SYNC_PORT | HTTP server port |
 | DB_SYNC_BASE_URL | External base URL for asset links |
 | DB_SYNC_ADMIN_TOKEN | Admin-only token for operator graph deletion endpoints |

--- a/deps/db-sync/deploy/Caddyfile.template
+++ b/deps/db-sync/deploy/Caddyfile.template
@@ -1,0 +1,3 @@
+{DOMAIN} {
+  reverse_proxy sync:8080
+}

--- a/deps/db-sync/deploy/Caddyfile.template
+++ b/deps/db-sync/deploy/Caddyfile.template
@@ -1,4 +1,4 @@
-https://{DOMAIN}:10010 {
+{PUBLIC_URL} {
 	reverse_proxy sync:8080
 	tls {
 		issuer acme {

--- a/deps/db-sync/deploy/Caddyfile.template
+++ b/deps/db-sync/deploy/Caddyfile.template
@@ -1,3 +1,8 @@
-{DOMAIN} {
-  reverse_proxy sync:8080
+https://{DOMAIN}:10010 {
+	reverse_proxy sync:8080
+	tls {
+		issuer acme {
+			disable_tlsalpn_challenge
+		}
+	}
 }

--- a/deps/db-sync/deploy/Dockerfile
+++ b/deps/db-sync/deploy/Dockerfile
@@ -1,0 +1,53 @@
+FROM eclipse-temurin:21-jdk-jammy AS build
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates build-essential git python3 \
+ && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && curl -fsSLO https://download.clojure.org/install/linux-install-1.12.4.1618.sh \
+ && chmod +x linux-install-1.12.4.1618.sh \
+ && ./linux-install-1.12.4.1618.sh
+
+WORKDIR /workspace
+
+COPY deps/common ./deps/common
+COPY deps/db ./deps/db
+COPY deps/graph-parser ./deps/graph-parser
+COPY deps/outliner ./deps/outliner
+COPY deps/db-sync ./deps/db-sync
+COPY resources ./resources
+
+RUN npm install --global pnpm@10.33.0
+
+WORKDIR /workspace/deps/graph-parser
+
+RUN pnpm install --frozen-lockfile --prod
+
+WORKDIR /workspace/deps/db-sync
+
+# Install the Node adapter and its graph-parser runtime dependencies without
+# entering the root desktop workspace.
+RUN pnpm install --frozen-lockfile --prod \
+ && pnpm rebuild better-sqlite3 \
+ && pnpm build:node-adapter
+
+FROM node:24-bookworm-slim
+
+ENV NODE_ENV=production \
+    DB_SYNC_PORT=8080 \
+    DB_SYNC_DATA_DIR=/var/lib/logseq-sync
+
+WORKDIR /app
+
+COPY --from=build /workspace/deps/db-sync/node_modules ./node_modules
+COPY --from=build /workspace/deps/graph-parser/node_modules ./node_modules
+COPY --from=build /workspace/deps/db-sync/worker/dist/node-adapter.js ./node-adapter.js
+
+RUN mkdir -p /var/lib/logseq-sync \
+ && chown node:node /var/lib/logseq-sync
+
+USER node
+
+EXPOSE 8080
+
+CMD ["node", "node-adapter.js"]

--- a/deps/db-sync/deploy/Dockerfile
+++ b/deps/db-sync/deploy/Dockerfile
@@ -10,37 +10,40 @@ RUN apt-get update \
 
 WORKDIR /workspace
 
+RUN npm install --global pnpm@10.33.0
+
+# Keep dependency installation cached when only application source changes.
+WORKDIR /workspace/deps/db-sync
+
+COPY deps/db-sync/package.json deps/db-sync/pnpm-lock.yaml ./
+
+RUN pnpm install --frozen-lockfile --prod \
+ && pnpm rebuild better-sqlite3
+
+WORKDIR /workspace
+
 COPY deps/common ./deps/common
 COPY deps/db ./deps/db
 COPY deps/graph-parser ./deps/graph-parser
 COPY deps/outliner ./deps/outliner
-COPY deps/db-sync ./deps/db-sync
+COPY deps/db-sync/deps.edn deps/db-sync/shadow-cljs.edn ./deps/db-sync/
+COPY deps/db-sync/src ./deps/db-sync/src
 COPY resources ./resources
-
-RUN npm install --global pnpm@10.33.0
-
-WORKDIR /workspace/deps/graph-parser
-
-RUN pnpm install --frozen-lockfile --prod
 
 WORKDIR /workspace/deps/db-sync
 
-# Install the Node adapter and its graph-parser runtime dependencies without
-# entering the root desktop workspace.
-RUN pnpm install --frozen-lockfile --prod \
- && pnpm rebuild better-sqlite3 \
- && pnpm build:node-adapter
+RUN pnpm build:node-adapter
 
 FROM node:24-bookworm-slim
 
 ENV NODE_ENV=production \
+    DB_SYNC_HOST=0.0.0.0 \
     DB_SYNC_PORT=8080 \
     DB_SYNC_DATA_DIR=/var/lib/logseq-sync
 
 WORKDIR /app
 
 COPY --from=build /workspace/deps/db-sync/node_modules ./node_modules
-COPY --from=build /workspace/deps/graph-parser/node_modules ./node_modules
 COPY --from=build /workspace/deps/db-sync/worker/dist/node-adapter.js ./node-adapter.js
 
 RUN mkdir -p /var/lib/logseq-sync \

--- a/deps/db-sync/deploy/README.md
+++ b/deps/db-sync/deploy/README.md
@@ -1,0 +1,41 @@
+# Logseq Sync deployment manager
+
+`logseq-sync` deploys the experimental DB Sync Node adapter as one Docker
+Compose deployment. HTTPS also starts an optional Caddy proxy. It builds the
+adapter from this checkout, so copy or clone the full Logseq repository to the
+Linux server first.
+
+## Prerequisites
+
+- Linux host with Docker Engine and Docker Compose. Install Docker using the
+  [official Docker Engine documentation](https://docs.docker.com/engine/install/).
+- A public DNS record when selecting HTTPS.
+- `curl` when selecting HTTPS, so the manager can verify the public endpoint.
+- A Logseq account. The default setup uses the JWT issuer already configured in
+  the current Logseq client. A custom JWT issuer requires a Logseq client built
+  to issue matching tokens.
+
+## Commands
+
+```bash
+cd deps/db-sync/deploy
+./logseq-sync setup
+./logseq-sync status
+./logseq-sync logs --follow
+```
+
+The manager writes deployment files under `~/.local/share/logseq-sync` by
+default and stores graph SQLite files and assets under
+`~/.local/share/logseq-sync-data`. Existing generated files are never replaced
+without first creating a timestamped backup after confirmation.
+
+HTTPS uses Caddy and requires ports 80 and 443. HTTP is available only after an
+explicit acknowledgement because bearer tokens are sent in plaintext.
+
+## Limitations
+
+This is an experimental self-hosted adapter. Run a backup strategy for the
+persistent data directory before relying on it for important graphs. The
+deployment manager configures verified JWT authentication only; shared-token
+and anonymous modes are not exposed until the client and server support them
+end-to-end.

--- a/deps/db-sync/deploy/README.md
+++ b/deps/db-sync/deploy/README.md
@@ -2,7 +2,7 @@
 
 The recommended lightweight deployment runs a prebuilt Sync Node runtime and
 Caddy as two native systemd services. It does not require Docker or a local
-build environment. Caddy serves `HTTPS/WSS` on public port `10010` by default,
+build environment. Caddy serves `HTTPS/WSS` on public port `443` by default,
 obtains and renews the certificate, and forwards traffic to the adapter on
 `127.0.0.1:10011`.
 
@@ -20,7 +20,7 @@ You also need:
 
 - a domain whose DNS `A`/`AAAA` record already points to the server;
 - inbound TCP port `80` for certificate issuance and renewal;
-- inbound TCP port `10010` by default, or the custom HTTPS port selected during setup;
+- inbound TCP port `443` by default, or the custom HTTPS port selected during setup;
 - `sudo` access.
 
 Do not expose the private adapter port printed in the deployment plan. The
@@ -59,7 +59,7 @@ This wizard will configure a prebuilt Sync runtime, Caddy, automatic HTTPS, and 
 You only need a domain name, public HTTPS port, and private Sync port.
 
 Step 1/3 - Sync domain name: sync.example.com
-Step 2/3 - Public HTTPS port [10010]:
+Step 2/3 - Public HTTPS port [443]:
 Step 3/3 - Private Sync port [10011]:
 ```
 
@@ -96,10 +96,11 @@ After setup succeeds, enter the printed value in **Logseq → Settings → Advan
 → Sync Server URL**:
 
 ```text
-https://sync.example.com:10010
+https://sync.example.com
 ```
 
-The URL must include `https://` and the selected port.
+The URL must include `https://`. Include the selected port only when it is not
+the default HTTPS port `443`.
 
 ## Cloud firewall
 
@@ -109,12 +110,11 @@ server firewall:
 | Port | Source | Purpose |
 | --- | --- | --- |
 | TCP 80 | Internet | Automatic HTTPS certificate validation and renewal |
-| Selected HTTPS port (default TCP 10010) | Internet | Logseq HTTPS and secure WebSocket traffic |
+| Selected HTTPS port (default TCP 443) | Internet | Logseq HTTPS and secure WebSocket traffic |
 
-Port `443` is not used when the default port is selected. The adapter's internal
-port is private and must not be opened. If another process already owns port
-`80` or the selected HTTPS port, stop it or integrate the generated Caddy site
-into the existing reverse proxy before running setup.
+The adapter's internal port is private and must not be opened. If another
+process already owns port `80` or the selected HTTPS port, stop it or integrate
+the generated Caddy site into the existing reverse proxy before running setup.
 
 ## Operate and update
 
@@ -201,5 +201,5 @@ preferred:
 ./logseq-sync setup
 ```
 
-It exposes the same public `https://domain:10010` endpoint, but requires Docker
+It exposes the same public `https://domain` endpoint on port `443`, but requires Docker
 Engine and Docker Compose.

--- a/deps/db-sync/deploy/README.md
+++ b/deps/db-sync/deploy/README.md
@@ -172,11 +172,13 @@ logseq-sync-runtime/
   ARCHITECTURE
 ```
 
-Pull requests build and smoke-test both architectures. Run the workflow
-manually with release tag `db-sync-native` to update the rolling installation
-channel, or push a `db-sync-native-v*` tag for a versioned release. The workflow
-uploads the runtime archives, checksums, manager, and manager checksum as GitHub
-Release assets.
+Pull requests and the existing db-sync CI build and smoke-test both
+architectures. Run the `db-sync native release` workflow manually with release
+tag `db-sync-native` to update the rolling installation channel, or push a
+`db-sync-native-v*` tag for a versioned release. The release workflow uploads
+the runtime archives, checksums, manager, and manager checksum as GitHub Release
+assets. Runtime build jobs use read-only repository permissions; only the
+explicit release job receives permission to write release assets.
 
 ## Docker alternative
 

--- a/deps/db-sync/deploy/README.md
+++ b/deps/db-sync/deploy/README.md
@@ -1,18 +1,20 @@
 # Self-host Logseq Sync on Linux
 
-The recommended lightweight deployment runs the Sync Node adapter and Caddy as
-two native systemd services. It does not require Docker. Caddy serves
-`HTTPS/WSS` on public port `10010` by default, obtains and renews the certificate, and
-forwards traffic to the adapter on `127.0.0.1:10011`.
+The recommended lightweight deployment runs a prebuilt Sync Node runtime and
+Caddy as two native systemd services. It does not require Docker or a local
+build environment. Caddy serves `HTTPS/WSS` on public port `10010` by default,
+obtains and renews the certificate, and forwards traffic to the adapter on
+`127.0.0.1:10011`.
 
 ## Before you start
 
-Use a dedicated systemd server on `x86_64` or `arm64`. The installer supports
-Debian/Ubuntu (`apt`) and RPM-based cloud distributions (`dnf` or `yum`) whose
-enabled repositories provide Java 17 or 21, including OpenCloudOS 9, Amazon
-Linux 2023, and current RHEL-compatible distributions. On OpenCloudOS, the
-installer also recognizes the distribution's Tencent KonaJDK 17 packages.
-You need:
+Use a systemd-based Linux server on `x86_64` or `arm64`. The server does not
+need Node.js, Java, Clojure, pnpm, Python, gcc, or a Linux package manager. It
+only needs standard base utilities (`curl`, `tar`, and `sha256sum`) plus sudo.
+This keeps the same installation path for Debian, Ubuntu, OpenCloudOS,
+TencentOS, RHEL-compatible distributions, and other glibc-based Linux systems.
+
+You also need:
 
 - a domain whose DNS `A`/`AAAA` record already points to the server;
 - inbound TCP port `80` for certificate issuance and renewal;
@@ -20,25 +22,38 @@ You need:
 - `sudo` access.
 
 Do not expose the private adapter port printed in the deployment plan. The
-installer also makes the adapter bind only to the loopback interface.
+installer binds the adapter to the loopback interface only.
 
 ## Install
 
-Clone the repository and run one command:
+Download the small management command from the native runtime release and run
+the guided setup:
 
 ```bash
-git clone https://github.com/logseq/logseq.git
-cd logseq/deps/db-sync/deploy
+curl -fL \
+  https://github.com/logseq/logseq/releases/download/db-sync-native/logseq-sync-native \
+  -o /tmp/logseq-sync-native
+curl -fL \
+  https://github.com/logseq/logseq/releases/download/db-sync-native/logseq-sync-native.sha256 \
+  -o /tmp/logseq-sync-native.sha256
+cd /tmp
+sha256sum --check logseq-sync-native.sha256
+chmod +x logseq-sync-native
 sudo ./logseq-sync-native setup
 ```
 
-Setup starts a guided flow. It asks for the domain, public HTTPS port, and
-private Sync port. Press Enter to accept the port defaults, or enter other
-available ports. It then prints the complete deployment plan for confirmation.
+Setup automatically selects the Linux `x64` or `arm64` runtime, verifies its
+SHA-256 checksum, installs it under `/opt/logseq-sync`, downloads Caddy, and
+creates the two systemd services. Compilation happens only in GitHub Actions,
+not on the server.
+
+The setup wizard asks for the domain, public HTTPS port, and private Sync port.
+Press Enter to accept the port defaults, or enter other available ports. It
+prints the complete deployment plan before downloading or changing services.
 
 ```text
 Logseq Sync setup
-This wizard will configure Sync Node, Caddy, automatic HTTPS, and systemd.
+This wizard will configure a prebuilt Sync runtime, Caddy, automatic HTTPS, and systemd.
 You only need a domain name, public HTTPS port, and private Sync port.
 
 Step 1/3 - Sync domain name: sync.example.com
@@ -72,20 +87,6 @@ sudo ./logseq-sync-native setup \
   --yes
 ```
 
-On the first run, the installer prepares the required build tools, Clojure CLI,
-and Caddy. It reuses a system-wide Node.js 22.12+ or 24.x installation when the
-binary is in a stable service-accessible path. Node installations under a login
-home directory, such as root-only `nvm`, are not suitable for systemd services;
-when no suitable system Node.js is found, setup installs a private Node.js 24
-runtime. It then:
-
-1. builds the adapter from the checked-out revision;
-2. creates dedicated `logseq-sync` and `caddy` service users;
-3. stores graph data under `/var/lib/logseq-sync`;
-4. installs and starts both systemd services;
-5. waits for the private and public health checks to pass;
-6. prints the URL to enter in Logseq.
-
 No Cognito values are requested in the normal flow. The installer uses the
 verified JWT settings already used by an unmodified Logseq client.
 
@@ -110,9 +111,8 @@ server firewall:
 
 Port `443` is not used when the default port is selected. The adapter's internal
 port is private and must not be opened. If another process already owns port
-`80` or the selected HTTPS port, stop it or
-integrate the generated Caddy site into the existing reverse proxy before
-running setup.
+`80` or the selected HTTPS port, stop it or integrate the generated Caddy site
+into the existing reverse proxy before running setup.
 
 ## Operate and update
 
@@ -120,25 +120,34 @@ running setup.
 sudo logseq-sync-native status
 sudo logseq-sync-native logs --follow sync
 sudo logseq-sync-native logs --follow proxy
-```
-
-To update, move the checkout to the desired revision and rebuild atomically:
-
-```bash
-git -C ../../.. pull --ff-only
 sudo logseq-sync-native update
 ```
 
-Configuration and graph data are preserved. Each build is installed into a
-separate release directory before the `current` link is switched, so a partial
-build never replaces the running adapter. Rerunning `setup` preserves the data
-directory and creates timestamped backups of generated configuration files.
+`update` downloads the current checksum-verified runtime from the configured
+release channel. Configuration and graph data are preserved. Each runtime is
+installed into a separate release directory before the `current` link is
+switched. If either health check fails, the previous runtime is restored.
+The runtime also carries the corresponding management command, so updates do
+not require another repository checkout.
+
+For testing a fork or pinning a versioned runtime release, set the source on the
+first setup:
+
+```bash
+sudo LOGSEQ_SYNC_RELEASE_REPOSITORY=owner/logseq \
+  LOGSEQ_SYNC_RELEASE_TAG=db-sync-native-v1 \
+  ./logseq-sync-native setup
+```
+
+The selected repository and tag are persisted for later updates.
 
 ## What gets installed
 
 | Path | Contents |
 | --- | --- |
-| `/opt/logseq-sync` | Caddy, pnpm, optional private Node, and versioned adapter builds |
+| `/opt/logseq-sync/releases` | versioned, self-contained Sync runtimes |
+| `/opt/logseq-sync/current` | active runtime symlink |
+| `/opt/logseq-sync/toolchain/bin/caddy` | Caddy executable |
 | `/etc/logseq-sync` | generated environment and Caddy configuration |
 | `/var/lib/logseq-sync` | graph SQLite files and assets |
 | `/var/lib/logseq-sync-caddy` | certificates and Caddy state |
@@ -148,15 +157,35 @@ directory and creates timestamped backups of generated configuration files.
 The service is experimental. Back up `/var/lib/logseq-sync` before relying on
 it for important graphs.
 
+## Building and publishing runtimes
+
+The `db-sync native runtime` GitHub Actions workflow builds on native Linux x64
+and arm64 runners with Java 21 and Node.js 24. Each archive contains:
+
+```text
+logseq-sync-runtime/
+  node/bin/node
+  app/node-adapter.js
+  app/node_modules/
+  bin/logseq-sync-native
+  VERSION
+  ARCHITECTURE
+```
+
+Pull requests build and smoke-test both architectures. Run the workflow
+manually with release tag `db-sync-native` to update the rolling installation
+channel, or push a `db-sync-native-v*` tag for a versioned release. The workflow
+uploads the runtime archives, checksums, manager, and manager checksum as GitHub
+Release assets.
+
 ## Docker alternative
 
-The existing Docker Compose manager remains available when container isolation
-is preferred:
+The Docker Compose manager remains available when container isolation is
+preferred:
 
 ```bash
 ./logseq-sync setup
 ```
 
 It exposes the same public `https://domain:10010` endpoint, but requires Docker
-Engine and Docker Compose. Native deployment is the recommended path for small
-servers that should not carry a container runtime.
+Engine and Docker Compose.

--- a/deps/db-sync/deploy/README.md
+++ b/deps/db-sync/deploy/README.md
@@ -7,7 +7,11 @@ forwards traffic to the adapter on `127.0.0.1:10011`.
 
 ## Before you start
 
-Use a dedicated Debian or Ubuntu server with systemd on `x86_64` or `arm64`.
+Use a dedicated systemd server on `x86_64` or `arm64`. The installer supports
+Debian/Ubuntu (`apt`) and RPM-based cloud distributions (`dnf` or `yum`) whose
+enabled repositories provide Java 17 or 21, including OpenCloudOS 9, Amazon
+Linux 2023, and current RHEL-compatible distributions. On OpenCloudOS, the
+installer also recognizes the distribution's Tencent KonaJDK 17 packages.
 You need:
 
 - a domain whose DNS `A`/`AAAA` record already points to the server;

--- a/deps/db-sync/deploy/README.md
+++ b/deps/db-sync/deploy/README.md
@@ -45,9 +45,9 @@ sudo ./logseq-sync-native setup
 ```
 
 Setup automatically selects the Linux `x64` or `arm64` runtime, verifies its
-SHA-256 checksum, installs it under `/opt/logseq-sync`, downloads Caddy, and
-creates the two systemd services. Compilation happens only in GitHub Actions,
-not on the server.
+SHA-256 checksum, installs the runtime, configuration, data, and Caddy under
+one `/opt/logseq-sync` directory, and creates the two systemd services.
+Compilation happens only in GitHub Actions, not on the server.
 
 The setup wizard asks for the domain, public HTTPS port, and private Sync port.
 Press Enter to accept the port defaults, or enter other available ports. It
@@ -143,21 +143,31 @@ sudo LOGSEQ_SYNC_RELEASE_REPOSITORY=owner/logseq \
 
 The selected repository and tag are persisted for later updates.
 
+To put the complete deployment somewhere other than `/opt/logseq-sync`, set
+one home directory on the first setup. The installed management command
+remembers its home through its symlink, so later commands need no extra option:
+
+```bash
+sudo LOGSEQ_SYNC_HOME=/srv/logseq-sync ./logseq-sync-native setup
+sudo logseq-sync-native status
+```
+
 ## What gets installed
 
 | Path | Contents |
 | --- | --- |
+| `/opt/logseq-sync/bin` | Caddy and the canonical management command |
 | `/opt/logseq-sync/releases` | versioned, self-contained Sync runtimes |
 | `/opt/logseq-sync/current` | active runtime symlink |
-| `/opt/logseq-sync/toolchain/bin/caddy` | Caddy executable |
-| `/etc/logseq-sync` | generated environment and Caddy configuration |
-| `/var/lib/logseq-sync` | graph SQLite files and assets |
-| `/var/lib/logseq-sync-caddy` | certificates and Caddy state |
+| `/opt/logseq-sync/config` | generated environment and Caddy configuration |
+| `/opt/logseq-sync/data` | graph SQLite files and assets |
+| `/opt/logseq-sync/caddy-data` | certificates and Caddy state |
 | `/etc/systemd/system` | Sync and Caddy service units |
-| `/usr/local/bin/logseq-sync-native` | management command |
+| `/usr/local/bin/logseq-sync-native` | symlink to the management command |
 
-The service is experimental. Back up `/var/lib/logseq-sync` before relying on
-it for important graphs.
+The service is experimental. Back up `/opt/logseq-sync/data` before relying on
+it for important graphs. Back up the complete `/opt/logseq-sync` directory when
+you also want to preserve configuration and existing certificates.
 
 ## Building and publishing runtimes
 

--- a/deps/db-sync/deploy/README.md
+++ b/deps/db-sync/deploy/README.md
@@ -1,41 +1,154 @@
-# Logseq Sync deployment manager
+# Self-host Logseq Sync on Linux
 
-`logseq-sync` deploys the experimental DB Sync Node adapter as one Docker
-Compose deployment. HTTPS also starts an optional Caddy proxy. It builds the
-adapter from this checkout, so copy or clone the full Logseq repository to the
-Linux server first.
+The recommended lightweight deployment runs the Sync Node adapter and Caddy as
+two native systemd services. It does not require Docker. Caddy serves
+`HTTPS/WSS` on public port `10010` by default, obtains and renews the certificate, and
+forwards traffic to the adapter on `127.0.0.1:10011`.
 
-## Prerequisites
+## Before you start
 
-- Linux host with Docker Engine and Docker Compose. Install Docker using the
-  [official Docker Engine documentation](https://docs.docker.com/engine/install/).
-- A public DNS record when selecting HTTPS.
-- `curl` when selecting HTTPS, so the manager can verify the public endpoint.
-- A Logseq account. The default setup uses the JWT issuer already configured in
-  the current Logseq client. A custom JWT issuer requires a Logseq client built
-  to issue matching tokens.
+Use a dedicated Debian or Ubuntu server with systemd on `x86_64` or `arm64`.
+You need:
 
-## Commands
+- a domain whose DNS `A`/`AAAA` record already points to the server;
+- inbound TCP port `80` for certificate issuance and renewal;
+- inbound TCP port `10010` by default, or the custom HTTPS port selected during setup;
+- `sudo` access.
+
+Do not expose the private adapter port printed in the deployment plan. The
+installer also makes the adapter bind only to the loopback interface.
+
+## Install
+
+Clone the repository and run one command:
 
 ```bash
-cd deps/db-sync/deploy
-./logseq-sync setup
-./logseq-sync status
-./logseq-sync logs --follow
+git clone https://github.com/logseq/logseq.git
+cd logseq/deps/db-sync/deploy
+sudo ./logseq-sync-native setup
 ```
 
-The manager writes deployment files under `~/.local/share/logseq-sync` by
-default and stores graph SQLite files and assets under
-`~/.local/share/logseq-sync-data`. Existing generated files are never replaced
-without first creating a timestamped backup after confirmation.
+Setup starts a guided flow. It asks for the domain, public HTTPS port, and
+private Sync port. Press Enter to accept the port defaults, or enter other
+available ports. It then prints the complete deployment plan for confirmation.
 
-HTTPS uses Caddy and requires ports 80 and 443. HTTP is available only after an
-explicit acknowledgement because bearer tokens are sent in plaintext.
+```text
+Logseq Sync setup
+This wizard will configure Sync Node, Caddy, automatic HTTPS, and systemd.
+You only need a domain name, public HTTPS port, and private Sync port.
 
-## Limitations
+Step 1/3 - Sync domain name: sync.example.com
+Step 2/3 - Public HTTPS port [10010]:
+Step 3/3 - Private Sync port [10011]:
+```
 
-This is an experimental self-hosted adapter. Run a backup strategy for the
-persistent data directory before relying on it for important graphs. The
-deployment manager configures verified JWT authentication only; shared-token
-and anonymous modes are not exposed until the client and server support them
-end-to-end.
+The wizard explains each value before asking:
+
+- **Domain** — enter a hostname only, without `https://` or a path. Its public
+  `A`/`AAAA` record must have propagated and point to this server's public
+  address. Setup prints the IP addresses returned by DNS.
+- **Public HTTPS port** — Logseq clients use this port for HTTPS and secure
+  WebSockets. Allow it through the cloud security group and server firewall.
+- **Private Sync port** — Sync Node listens on `127.0.0.1` at this port and
+  Caddy forwards requests to it. Never expose it publicly.
+- **TCP 80** — Caddy uses it only to obtain and renew the HTTPS certificate.
+
+Cloud NAT and multi-address hosts make it unreliable to infer the intended
+public server address from local interfaces alone. Confirm that the displayed
+DNS addresses belong to this server; setup then verifies the final public
+`/health` endpoint before reporting success.
+
+For unattended or repeatable deployment, provide named options explicitly:
+
+```bash
+sudo ./logseq-sync-native setup \
+  --domain sync.example.com \
+  --public-port 12000 \
+  --internal-port 12001 \
+  --yes
+```
+
+On the first run, the installer prepares the required build tools, a private
+Node.js runtime, Clojure CLI, and Caddy. It then:
+
+1. builds the adapter from the checked-out revision;
+2. creates dedicated `logseq-sync` and `caddy` service users;
+3. stores graph data under `/var/lib/logseq-sync`;
+4. installs and starts both systemd services;
+5. waits for the private and public health checks to pass;
+6. prints the URL to enter in Logseq.
+
+No Cognito values are requested in the normal flow. The installer uses the
+verified JWT settings already used by an unmodified Logseq client.
+
+After setup succeeds, enter the printed value in **Logseq → Settings → Advanced
+→ Sync Server URL**:
+
+```text
+https://sync.example.com:10010
+```
+
+The URL must include `https://` and the selected port.
+
+## Cloud firewall
+
+Allow these inbound rules in the cloud provider's security group and in the
+server firewall:
+
+| Port | Source | Purpose |
+| --- | --- | --- |
+| TCP 80 | Internet | Automatic HTTPS certificate validation and renewal |
+| Selected HTTPS port (default TCP 10010) | Internet | Logseq HTTPS and secure WebSocket traffic |
+
+Port `443` is not used when the default port is selected. The adapter's internal
+port is private and must not be opened. If another process already owns port
+`80` or the selected HTTPS port, stop it or
+integrate the generated Caddy site into the existing reverse proxy before
+running setup.
+
+## Operate and update
+
+```bash
+sudo logseq-sync-native status
+sudo logseq-sync-native logs --follow sync
+sudo logseq-sync-native logs --follow proxy
+```
+
+To update, move the checkout to the desired revision and rebuild atomically:
+
+```bash
+git -C ../../.. pull --ff-only
+sudo logseq-sync-native update
+```
+
+Configuration and graph data are preserved. Each build is installed into a
+separate release directory before the `current` link is switched, so a partial
+build never replaces the running adapter. Rerunning `setup` preserves the data
+directory and creates timestamped backups of generated configuration files.
+
+## What gets installed
+
+| Path | Contents |
+| --- | --- |
+| `/opt/logseq-sync` | private Node/Caddy tools and versioned adapter builds |
+| `/etc/logseq-sync` | generated environment and Caddy configuration |
+| `/var/lib/logseq-sync` | graph SQLite files and assets |
+| `/var/lib/logseq-sync-caddy` | certificates and Caddy state |
+| `/etc/systemd/system` | Sync and Caddy service units |
+| `/usr/local/bin/logseq-sync-native` | management command |
+
+The service is experimental. Back up `/var/lib/logseq-sync` before relying on
+it for important graphs.
+
+## Docker alternative
+
+The existing Docker Compose manager remains available when container isolation
+is preferred:
+
+```bash
+./logseq-sync setup
+```
+
+It exposes the same public `https://domain:10010` endpoint, but requires Docker
+Engine and Docker Compose. Native deployment is the recommended path for small
+servers that should not carry a container runtime.

--- a/deps/db-sync/deploy/README.md
+++ b/deps/db-sync/deploy/README.md
@@ -11,8 +11,10 @@ obtains and renews the certificate, and forwards traffic to the adapter on
 Use a systemd-based Linux server on `x86_64` or `arm64`. The server does not
 need Node.js, Java, Clojure, pnpm, Python, gcc, or a Linux package manager. It
 only needs standard base utilities (`curl`, `tar`, and `sha256sum`) plus sudo.
-This keeps the same installation path for Debian, Ubuntu, OpenCloudOS,
-TencentOS, RHEL-compatible distributions, and other glibc-based Linux systems.
+The prebuilt runtime requires GLIBC 2.29 or newer, which covers current Debian,
+Ubuntu, OpenCloudOS 9, TencentOS, and RHEL 9-compatible distributions. Setup
+loads the bundled SQLite module before switching services, so an older or
+otherwise incompatible host fails before its running release is replaced.
 
 You also need:
 

--- a/deps/db-sync/deploy/README.md
+++ b/deps/db-sync/deploy/README.md
@@ -72,8 +72,12 @@ sudo ./logseq-sync-native setup \
   --yes
 ```
 
-On the first run, the installer prepares the required build tools, a private
-Node.js runtime, Clojure CLI, and Caddy. It then:
+On the first run, the installer prepares the required build tools, Clojure CLI,
+and Caddy. It reuses a system-wide Node.js 22.12+ or 24.x installation when the
+binary is in a stable service-accessible path. Node installations under a login
+home directory, such as root-only `nvm`, are not suitable for systemd services;
+when no suitable system Node.js is found, setup installs a private Node.js 24
+runtime. It then:
 
 1. builds the adapter from the checked-out revision;
 2. creates dedicated `logseq-sync` and `caddy` service users;
@@ -134,7 +138,7 @@ directory and creates timestamped backups of generated configuration files.
 
 | Path | Contents |
 | --- | --- |
-| `/opt/logseq-sync` | private Node/Caddy tools and versioned adapter builds |
+| `/opt/logseq-sync` | Caddy, pnpm, optional private Node, and versioned adapter builds |
 | `/etc/logseq-sync` | generated environment and Caddy configuration |
 | `/var/lib/logseq-sync` | graph SQLite files and assets |
 | `/var/lib/logseq-sync-caddy` | certificates and Caddy state |

--- a/deps/db-sync/deploy/compose.http.yaml
+++ b/deps/db-sync/deploy/compose.http.yaml
@@ -1,0 +1,4 @@
+services:
+  sync:
+    ports:
+      - "${DB_SYNC_BIND_ADDRESS:-127.0.0.1}:${DB_SYNC_PUBLIC_PORT:-8080}:8080"

--- a/deps/db-sync/deploy/compose.yaml
+++ b/deps/db-sync/deploy/compose.yaml
@@ -1,0 +1,52 @@
+services:
+  sync:
+    build:
+      context: ${LOGSEQ_SYNC_SOURCE_DIR:?Set by logseq-sync}
+      dockerfile: deps/db-sync/deploy/Dockerfile
+    environment:
+      DB_SYNC_PORT: "8080"
+      DB_SYNC_BASE_URL: ${DB_SYNC_BASE_URL:?Set by logseq-sync}
+      DB_SYNC_DATA_DIR: /var/lib/logseq-sync
+      DB_SYNC_STORAGE_DRIVER: sqlite
+      DB_SYNC_ASSETS_DRIVER: filesystem
+      DB_SYNC_LOG_LEVEL: ${DB_SYNC_LOG_LEVEL:-info}
+      COGNITO_ISSUER: ${COGNITO_ISSUER:?Set by logseq-sync}
+      COGNITO_CLIENT_ID: ${COGNITO_CLIENT_ID:?Set by logseq-sync}
+      COGNITO_JWKS_URL: ${COGNITO_JWKS_URL:?Set by logseq-sync}
+    user: "${LOGSEQ_SYNC_UID:?Set by logseq-sync}:${LOGSEQ_SYNC_GID:?Set by logseq-sync}"
+    volumes:
+      - ${LOGSEQ_SYNC_DATA_DIR:?Set by logseq-sync}:/var/lib/logseq-sync
+    ports:
+      - "${DB_SYNC_BIND_ADDRESS:-127.0.0.1}:${DB_SYNC_PUBLIC_PORT:-8080}:8080"
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8080/health').then((response) => { if (!response.ok) process.exit(1) }).catch(() => process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    restart: unless-stopped
+
+  caddy:
+    image: caddy:2.10-alpine
+    profiles: ["https"]
+    depends_on:
+      sync:
+        condition: service_healthy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ${LOGSEQ_SYNC_INSTALL_DIR:?Set by logseq-sync}/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:2019/config/"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    restart: unless-stopped
+
+volumes:
+  caddy-data:
+  caddy-config:

--- a/deps/db-sync/deploy/compose.yaml
+++ b/deps/db-sync/deploy/compose.yaml
@@ -16,8 +16,6 @@ services:
     user: "${LOGSEQ_SYNC_UID:?Set by logseq-sync}:${LOGSEQ_SYNC_GID:?Set by logseq-sync}"
     volumes:
       - ${LOGSEQ_SYNC_DATA_DIR:?Set by logseq-sync}:/var/lib/logseq-sync
-    ports:
-      - "${DB_SYNC_BIND_ADDRESS:-127.0.0.1}:${DB_SYNC_PUBLIC_PORT:-8080}:8080"
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8080/health').then((response) => { if (!response.ok) process.exit(1) }).catch(() => process.exit(1))"]
       interval: 10s

--- a/deps/db-sync/deploy/compose.yaml
+++ b/deps/db-sync/deploy/compose.yaml
@@ -4,6 +4,7 @@ services:
       context: ${LOGSEQ_SYNC_SOURCE_DIR:?Set by logseq-sync}
       dockerfile: deps/db-sync/deploy/Dockerfile
     environment:
+      DB_SYNC_HOST: "0.0.0.0"
       DB_SYNC_PORT: "8080"
       DB_SYNC_BASE_URL: ${DB_SYNC_BASE_URL:?Set by logseq-sync}
       DB_SYNC_DATA_DIR: /var/lib/logseq-sync
@@ -17,7 +18,7 @@ services:
     volumes:
       - ${LOGSEQ_SYNC_DATA_DIR:?Set by logseq-sync}:/var/lib/logseq-sync
     healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8080/health').then((response) => { if (!response.ok) process.exit(1) }).catch(() => process.exit(1))"]
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8080/health').then(async (response) => { const body = await response.json(); if (!response.ok || body.ok !== true) process.exit(1) }).catch(() => process.exit(1))"]
       interval: 10s
       timeout: 5s
       retries: 12
@@ -32,7 +33,7 @@ services:
         condition: service_healthy
     ports:
       - "80:80"
-      - "443:443"
+      - "10010:10010"
     volumes:
       - ${LOGSEQ_SYNC_INSTALL_DIR:?Set by logseq-sync}/Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy-data:/data

--- a/deps/db-sync/deploy/compose.yaml
+++ b/deps/db-sync/deploy/compose.yaml
@@ -33,7 +33,7 @@ services:
         condition: service_healthy
     ports:
       - "80:80"
-      - "10010:10010"
+      - "${DB_SYNC_PUBLIC_PORT:-443}:${DB_SYNC_PUBLIC_PORT:-443}"
     volumes:
       - ${LOGSEQ_SYNC_INSTALL_DIR:?Set by logseq-sync}/Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy-data:/data

--- a/deps/db-sync/deploy/logseq-sync
+++ b/deps/db-sync/deploy/logseq-sync
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly source_dir="$(cd -- "$script_dir/../../.." && pwd)"
+readonly docker_install_url="https://docs.docker.com/engine/install/"
+readonly default_install_dir="${HOME}/.local/share/logseq-sync"
+readonly default_data_dir="${HOME}/.local/share/logseq-sync-data"
+readonly default_cognito_issuer="https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8"
+readonly default_cognito_client_id="69cs1lgme7p8kbgld8n5kseii6"
+readonly default_cognito_jwks_url="${default_cognito_issuer}/.well-known/jwks.json"
+
+die() {
+  printf 'Error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_docker() {
+  if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
+    printf 'Docker Engine with Docker Compose is required. Install it first:\n%s\n' "$docker_install_url" >&2
+    exit 1
+  fi
+}
+
+require_linux() {
+  [[ "$(uname -s)" == "Linux" ]] || die "logseq-sync must run on a Linux host."
+}
+
+read_value() {
+  local prompt="$1"
+  local default_value="${2:-}"
+  local value
+  if [[ -n "$default_value" ]]; then
+    read -r -p "$prompt [$default_value]: " value
+    printf '%s' "${value:-$default_value}"
+  else
+    read -r -p "$prompt: " value
+    printf '%s' "$value"
+  fi
+}
+
+confirm() {
+  local prompt="$1"
+  local value
+  read -r -p "$prompt [y/N]: " value
+  [[ "$value" == "y" || "$value" == "Y" ]]
+}
+
+compose() {
+  local install_dir="$1"
+  shift
+  docker compose --env-file "$install_dir/.env" -f "$install_dir/compose.yaml" "$@"
+}
+
+write_file() {
+  local path="$1"
+  shift
+  umask 077
+  printf '%s' "$*" > "$path"
+}
+
+valid_env_value() {
+  [[ -n "$1" && "$1" != *$'\n'* && "$1" != *$'\r'* \
+     && "$1" != *'$'* && "$1" != *'#'* && "$1" != *[[:space:]]* ]]
+}
+
+valid_port() {
+  [[ "$1" =~ ^[0-9]+$ ]] && (( 10#$1 >= 1 && 10#$1 <= 65535 ))
+}
+
+valid_domain() {
+  [[ ${#1} -le 253 \
+     && "$1" =~ ^([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}$ ]]
+}
+
+confirm_existing() {
+  local path="$1"
+  if [[ -e "$path" ]]; then
+    if ! confirm "${path} exists. Create a timestamped backup before replacement?"; then
+      die "Existing file was not changed."
+    fi
+  fi
+}
+
+backup_existing() {
+  local path="$1"
+  local timestamp backup suffix=0
+  [[ -e "$path" ]] || return
+  timestamp="$(date +%Y%m%d%H%M%S)"
+  backup="${path}.backup-${timestamp}"
+  while [[ -e "$backup" ]]; do
+    suffix=$((suffix + 1))
+    backup="${path}.backup-${timestamp}-${suffix}"
+  done
+  cp -a -- "$path" "$backup"
+}
+
+wait_for_service_health() {
+  local install_dir="$1"
+  local service="$2"
+  local attempts=30
+  local status
+  while (( attempts > 0 )); do
+    status="$(compose "$install_dir" ps --format json "$service" 2>/dev/null || true)"
+    if grep -q 'healthy' <<<"$status"; then
+      printf '%s is healthy.\n' "$service"
+      return 0
+    fi
+    sleep 2
+    attempts=$((attempts - 1))
+  done
+  printf '%s did not become healthy. Inspect logs with:\n  %s/logseq-sync logs --follow %s\n' "$service" "$script_dir" "$install_dir" >&2
+  return 1
+}
+
+wait_for_https_endpoint() {
+  local public_url="$1"
+  local attempts=12
+  while (( attempts > 0 )); do
+    if curl --fail --silent --show-error --max-time 5 "$public_url/health" >/dev/null; then
+      printf 'Public HTTPS endpoint is reachable.\n'
+      return 0
+    fi
+    sleep 5
+    attempts=$((attempts - 1))
+  done
+  printf 'Public HTTPS endpoint did not become reachable: %s/health\n' "$public_url" >&2
+  return 1
+}
+
+setup() {
+  require_linux
+  require_docker
+  local install_dir data_dir endpoint_mode public_url bind_address public_port domain
+  local issuer client_id jwks_url auth_mode
+  local -a profile_args=()
+
+  install_dir="$(read_value 'Deployment directory' "$default_install_dir")"
+  data_dir="$(read_value 'Persistent data directory' "$default_data_dir")"
+  valid_env_value "$source_dir" && valid_env_value "$install_dir" && valid_env_value "$data_dir" \
+    || die "Paths must not be empty or contain whitespace, $, #, or newlines."
+  endpoint_mode="$(read_value 'Endpoint mode (https/http)' 'https')"
+  [[ "$endpoint_mode" == "https" || "$endpoint_mode" == "http" ]] || die "Endpoint mode must be https or http."
+
+  if [[ "$endpoint_mode" == "https" ]]; then
+    command -v curl >/dev/null 2>&1 || die "HTTPS setup requires curl to verify the public endpoint."
+    domain="$(read_value 'Public domain name')"
+    valid_domain "$domain" || die "HTTPS requires a valid DNS domain name, not an IP address."
+    public_url="https://${domain}"
+    bind_address="127.0.0.1"
+    public_port="8080"
+    profile_args=(--profile https)
+  else
+    public_url="$(read_value 'Public HTTP URL (for example http://203.0.113.10:8080)')"
+    [[ "$public_url" =~ ^http://[A-Za-z0-9.-]+:[0-9]+$ ]] || die "HTTP URL must include a hostname or IPv4 address and numeric port."
+    printf 'Warning: HTTP exposes Logseq bearer tokens in transit.\n' >&2
+    [[ "$(read_value 'Type I_ACCEPT_HTTP to continue')" == "I_ACCEPT_HTTP" ]] || die "HTTP risk acknowledgement was not accepted."
+    bind_address="0.0.0.0"
+    public_port="${public_url##*:}"
+    valid_port "$public_port" || die "HTTP URL port must be between 1 and 65535."
+  fi
+
+  auth_mode="$(read_value 'Authentication (logseq-client/custom-client)' 'logseq-client')"
+  case "$auth_mode" in
+    logseq-client)
+      issuer="$default_cognito_issuer"
+      client_id="$default_cognito_client_id"
+      jwks_url="$default_cognito_jwks_url"
+      ;;
+    custom-client)
+      printf 'Custom JWT settings require a Logseq client built to issue matching tokens.\n' >&2
+      issuer="$(read_value 'Cognito issuer URL')"
+      client_id="$(read_value 'Cognito client ID')"
+      jwks_url="$(read_value 'Cognito JWKS URL')"
+      [[ "$issuer" =~ ^https://[^[:space:]]+$ ]] || die "Cognito issuer must be an HTTPS URL."
+      [[ "$client_id" =~ ^[A-Za-z0-9._-]+$ ]] || die "Cognito client ID contains unsupported characters."
+      [[ "$jwks_url" =~ ^https://[^[:space:]]+$ ]] || die "Cognito JWKS URL must be an HTTPS URL."
+      ;;
+    *) die "Authentication must be logseq-client or custom-client." ;;
+  esac
+  valid_env_value "$issuer" && valid_env_value "$client_id" && valid_env_value "$jwks_url" \
+    || die "JWT settings must not contain newlines."
+
+  printf '\nDeployment plan:\n  URL: %s\n  Install: %s\n  Data: %s\n  Authentication: %s JWT over %s\n' "$public_url" "$install_dir" "$data_dir" "$auth_mode" "$endpoint_mode"
+  confirm 'Write deployment configuration and start Sync?' || die "Cancelled before writing configuration."
+
+  confirm_existing "$install_dir/compose.yaml"
+  confirm_existing "$install_dir/.env"
+  if [[ "$endpoint_mode" == "https" ]]; then
+    confirm_existing "$install_dir/Caddyfile"
+  fi
+
+  mkdir -p -- "$install_dir" "$data_dir"
+  backup_existing "$install_dir/compose.yaml"
+  backup_existing "$install_dir/.env"
+  if [[ "$endpoint_mode" == "https" ]]; then
+    backup_existing "$install_dir/Caddyfile"
+  fi
+
+  cp -- "$script_dir/compose.yaml" "$install_dir/compose.yaml"
+  write_file "$install_dir/.env" "LOGSEQ_SYNC_SOURCE_DIR=${source_dir}
+LOGSEQ_SYNC_INSTALL_DIR=${install_dir}
+LOGSEQ_SYNC_DATA_DIR=${data_dir}
+LOGSEQ_SYNC_UID=$(id -u)
+LOGSEQ_SYNC_GID=$(id -g)
+LOGSEQ_SYNC_ENDPOINT_MODE=${endpoint_mode}
+DB_SYNC_BASE_URL=${public_url}
+DB_SYNC_BIND_ADDRESS=${bind_address}
+DB_SYNC_PUBLIC_PORT=${public_port}
+DB_SYNC_LOG_LEVEL=info
+COGNITO_ISSUER=${issuer}
+COGNITO_CLIENT_ID=${client_id}
+COGNITO_JWKS_URL=${jwks_url}
+"
+  if [[ "$endpoint_mode" == "https" ]]; then
+    sed "s/{DOMAIN}/${domain}/g" "$script_dir/Caddyfile.template" > "$install_dir/Caddyfile"
+  fi
+
+  if ! compose "$install_dir" "${profile_args[@]}" up -d --build; then
+    printf 'Sync startup failed. Inspect logs with:\n  %s/logseq-sync logs --follow %s\n' "$script_dir" "$install_dir" >&2
+    return 1
+  fi
+  wait_for_service_health "$install_dir" sync
+  if [[ "$endpoint_mode" == "https" ]]; then
+    wait_for_service_health "$install_dir" caddy
+    wait_for_https_endpoint "$public_url"
+  fi
+  printf 'Logseq Sync is ready. In Logseq, set Sync Server URL to:\n  %s\n' "$public_url"
+  printf 'Status: %s/logseq-sync status %s\n' "$script_dir" "$install_dir"
+}
+
+status() {
+  local install_dir="${1:-$default_install_dir}"
+  [[ -f "$install_dir/.env" ]] || die "No deployment configuration at $install_dir."
+  require_docker
+  compose "$install_dir" ps
+  printf 'Sync Server URL: %s\n' "$(sed -n 's/^DB_SYNC_BASE_URL=//p' "$install_dir/.env")"
+  if wait_for_service_health "$install_dir" sync; then
+    printf 'Health endpoint: ok\n'
+  else
+    printf 'Health endpoint: unavailable\n' >&2
+    return 1
+  fi
+  if [[ "$(sed -n 's/^LOGSEQ_SYNC_ENDPOINT_MODE=//p' "$install_dir/.env")" == "https" ]]; then
+    if ! wait_for_service_health "$install_dir" caddy; then
+      printf 'HTTPS proxy health: unavailable\n' >&2
+      return 1
+    fi
+    if ! wait_for_https_endpoint "$(sed -n 's/^DB_SYNC_BASE_URL=//p' "$install_dir/.env")"; then
+      printf 'Public HTTPS endpoint: unavailable\n' >&2
+      return 1
+    fi
+  fi
+}
+
+logs() {
+  local install_dir="$default_install_dir"
+  local follow=""
+  local service=""
+  while (( $# > 0 )); do
+    case "$1" in
+      --follow) follow="--follow" ;;
+      sync|proxy) service="$1" ;;
+      *) install_dir="$1" ;;
+    esac
+    shift
+  done
+  [[ -f "$install_dir/.env" ]] || die "No deployment configuration at $install_dir."
+  require_docker
+  if [[ "$service" == "proxy" ]] \
+     && [[ "$(sed -n 's/^LOGSEQ_SYNC_ENDPOINT_MODE=//p' "$install_dir/.env")" != "https" ]]; then
+    die "Proxy logging is unavailable because this deployment uses HTTP mode."
+  fi
+  local -a args=(logs --tail 200)
+  if [[ -n "$follow" ]]; then
+    args+=(--follow)
+  fi
+  if [[ -n "$service" ]]; then
+    args+=("$service")
+  fi
+  compose "$install_dir" "${args[@]}"
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  logseq-sync setup
+  logseq-sync status [deployment-directory]
+  logseq-sync logs [--follow] [sync|proxy] [deployment-directory]
+  logseq-sync help
+EOF
+}
+
+case "${1:-help}" in
+  setup) setup ;;
+  status) shift; status "$@" ;;
+  logs) shift; logs "$@" ;;
+  help|-h|--help) usage ;;
+  *) usage; exit 1 ;;
+esac

--- a/deps/db-sync/deploy/logseq-sync
+++ b/deps/db-sync/deploy/logseq-sync
@@ -48,8 +48,16 @@ confirm() {
 
 compose() {
   local install_dir="$1"
+  local endpoint_mode
+  local -a files=(-f "$install_dir/compose.yaml")
   shift
-  docker compose --env-file "$install_dir/.env" -f "$install_dir/compose.yaml" "$@"
+  endpoint_mode="$(sed -n 's/^LOGSEQ_SYNC_ENDPOINT_MODE=//p' "$install_dir/.env")"
+  case "$endpoint_mode" in
+    http) files+=(-f "$install_dir/compose.http.yaml") ;;
+    https) ;;
+    *) die "Deployment configuration has an invalid endpoint mode." ;;
+  esac
+  docker compose --env-file "$install_dir/.env" "${files[@]}" "$@"
 }
 
 write_file() {
@@ -185,6 +193,7 @@ setup() {
   confirm 'Write deployment configuration and start Sync?' || die "Cancelled before writing configuration."
 
   confirm_existing "$install_dir/compose.yaml"
+  confirm_existing "$install_dir/compose.http.yaml"
   confirm_existing "$install_dir/.env"
   if [[ "$endpoint_mode" == "https" ]]; then
     confirm_existing "$install_dir/Caddyfile"
@@ -192,12 +201,14 @@ setup() {
 
   mkdir -p -- "$install_dir" "$data_dir"
   backup_existing "$install_dir/compose.yaml"
+  backup_existing "$install_dir/compose.http.yaml"
   backup_existing "$install_dir/.env"
   if [[ "$endpoint_mode" == "https" ]]; then
     backup_existing "$install_dir/Caddyfile"
   fi
 
   cp -- "$script_dir/compose.yaml" "$install_dir/compose.yaml"
+  cp -- "$script_dir/compose.http.yaml" "$install_dir/compose.http.yaml"
   write_file "$install_dir/.env" "LOGSEQ_SYNC_SOURCE_DIR=${source_dir}
 LOGSEQ_SYNC_INSTALL_DIR=${install_dir}
 LOGSEQ_SYNC_DATA_DIR=${data_dir}

--- a/deps/db-sync/deploy/logseq-sync
+++ b/deps/db-sync/deploy/logseq-sync
@@ -85,7 +85,7 @@ confirm_existing() {
 backup_existing() {
   local path="$1"
   local timestamp backup suffix=0
-  [[ -e "$path" ]] || return
+  [[ -e "$path" ]] || return 0
   timestamp="$(date +%Y%m%d%H%M%S)"
   backup="${path}.backup-${timestamp}"
   while [[ -e "$backup" ]]; do

--- a/deps/db-sync/deploy/logseq-sync
+++ b/deps/db-sync/deploy/logseq-sync
@@ -20,6 +20,9 @@ require_docker() {
     printf 'Docker Engine with Docker Compose is required. Install it first:\n%s\n' "$docker_install_url" >&2
     exit 1
   fi
+  if ! docker info >/dev/null 2>&1; then
+    die "Docker Engine is not reachable. Start Docker and ensure the current user can access it without sudo."
+  fi
 }
 
 require_linux() {
@@ -60,6 +63,19 @@ compose() {
   docker compose --env-file "$install_dir/.env" "${files[@]}" "$@"
 }
 
+compose_https() {
+  local install_dir="$1"
+  shift
+  docker compose --env-file "$install_dir/.env" \
+    -f "$install_dir/compose.yaml" --profile https "$@"
+}
+
+read_env_value() {
+  local path="$1"
+  local key="$2"
+  sed -n "s/^${key}=//p" "$path"
+}
+
 write_file() {
   local path="$1"
   shift
@@ -76,9 +92,66 @@ valid_port() {
   [[ "$1" =~ ^[0-9]+$ ]] && (( 10#$1 >= 1 && 10#$1 <= 65535 ))
 }
 
+valid_hostname() {
+  local hostname="$1"
+  local label
+  local -a labels=()
+  [[ -n "$hostname" && ${#hostname} -le 253 \
+     && "$hostname" != .* && "$hostname" != *. ]] || return 1
+  IFS='.' read -r -a labels <<<"$hostname"
+  for label in "${labels[@]}"; do
+    [[ "$label" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$ ]] || return 1
+  done
+}
+
+valid_ipv4() {
+  local address="$1"
+  local a b c d extra
+  IFS='.' read -r a b c d extra <<<"$address"
+  [[ -z "${extra:-}" && "$a" =~ ^[0-9]+$ && "$b" =~ ^[0-9]+$ \
+     && "$c" =~ ^[0-9]+$ && "$d" =~ ^[0-9]+$ \
+     && ${#a} -le 3 && ${#b} -le 3 && ${#c} -le 3 && ${#d} -le 3 ]] \
+    && (( 10#$a <= 255 && 10#$b <= 255 && 10#$c <= 255 && 10#$d <= 255 ))
+}
+
+valid_host() {
+  if [[ "$1" =~ ^[0-9.]+$ ]]; then
+    valid_ipv4 "$1"
+  else
+    valid_hostname "$1"
+  fi
+}
+
 valid_domain() {
   [[ ${#1} -le 253 \
      && "$1" =~ ^([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}$ ]]
+}
+
+valid_http_url() {
+  local url="$1"
+  local authority host port
+  [[ "$url" == http://* ]] || return 1
+  authority="${url#http://}"
+  [[ "$authority" != *[/?#@]* ]] || return 1
+  [[ "$authority" == *:* ]] || return 1
+  host="${authority%:*}"
+  port="${authority##*:}"
+  valid_host "$host" && valid_port "$port"
+}
+
+valid_https_url() {
+  local url="$1"
+  local remainder authority host port=""
+  [[ "$url" == https://* && "$url" != *[[:space:]?#@]* ]] || return 1
+  remainder="${url#https://}"
+  authority="${remainder%%/*}"
+  host="$authority"
+  if [[ "$authority" == *:* ]]; then
+    host="${authority%:*}"
+    port="${authority##*:}"
+    valid_port "$port" || return 1
+  fi
+  valid_host "$host"
 }
 
 confirm_existing() {
@@ -103,14 +176,20 @@ backup_existing() {
   cp -a -- "$path" "$backup"
 }
 
+service_is_healthy() {
+  local install_dir="$1"
+  local service="$2"
+  local status
+  status="$(compose "$install_dir" ps --format json "$service" 2>/dev/null || true)"
+  grep -Eq '"Health"[[:space:]]*:[[:space:]]*"healthy"' <<<"$status"
+}
+
 wait_for_service_health() {
   local install_dir="$1"
   local service="$2"
   local attempts=30
-  local status
   while (( attempts > 0 )); do
-    status="$(compose "$install_dir" ps --format json "$service" 2>/dev/null || true)"
-    if grep -q 'healthy' <<<"$status"; then
+    if service_is_healthy "$install_dir" "$service"; then
       printf '%s is healthy.\n' "$service"
       return 0
     fi
@@ -121,18 +200,25 @@ wait_for_service_health() {
   return 1
 }
 
-wait_for_https_endpoint() {
+public_endpoint_is_healthy() {
+  local public_url="$1"
+  local body
+  body="$(curl --fail --silent --max-time 5 "$public_url/health" 2>/dev/null)" || return 1
+  [[ "$body" == '{"ok":true}' ]]
+}
+
+wait_for_public_endpoint() {
   local public_url="$1"
   local attempts=12
   while (( attempts > 0 )); do
-    if curl --fail --silent --show-error --max-time 5 "$public_url/health" >/dev/null; then
-      printf 'Public HTTPS endpoint is reachable.\n'
+    if public_endpoint_is_healthy "$public_url"; then
+      printf 'Public endpoint is healthy.\n'
       return 0
     fi
     sleep 5
     attempts=$((attempts - 1))
   done
-  printf 'Public HTTPS endpoint did not become reachable: %s/health\n' "$public_url" >&2
+  printf 'Public endpoint did not return {"ok":true}: %s/health\n' "$public_url" >&2
   return 1
 }
 
@@ -140,35 +226,75 @@ setup() {
   require_linux
   require_docker
   local install_dir data_dir endpoint_mode public_url bind_address public_port domain
-  local issuer client_id jwks_url auth_mode
-  local -a profile_args=()
+  local issuer client_id jwks_url auth_mode log_level
+  local existing_env="" previous_data_dir="" previous_endpoint_mode="" previous_public_url=""
+  local previous_issuer="" previous_client_id="" previous_jwks_url="" previous_log_level=""
+  local data_default endpoint_default domain_default public_url_default auth_default exposure
+  local -a compose_args=()
 
   install_dir="$(read_value 'Deployment directory' "$default_install_dir")"
-  data_dir="$(read_value 'Persistent data directory' "$default_data_dir")"
+  if [[ -f "$install_dir/.env" ]]; then
+    existing_env="$install_dir/.env"
+    previous_data_dir="$(read_env_value "$existing_env" LOGSEQ_SYNC_DATA_DIR)"
+    previous_endpoint_mode="$(read_env_value "$existing_env" LOGSEQ_SYNC_ENDPOINT_MODE)"
+    previous_public_url="$(read_env_value "$existing_env" DB_SYNC_BASE_URL)"
+    previous_log_level="$(read_env_value "$existing_env" DB_SYNC_LOG_LEVEL)"
+    previous_issuer="$(read_env_value "$existing_env" COGNITO_ISSUER)"
+    previous_client_id="$(read_env_value "$existing_env" COGNITO_CLIENT_ID)"
+    previous_jwks_url="$(read_env_value "$existing_env" COGNITO_JWKS_URL)"
+    [[ "$previous_endpoint_mode" == "https" || "$previous_endpoint_mode" == "http" ]] \
+      || die "Existing deployment configuration has an invalid endpoint mode."
+    valid_env_value "$previous_data_dir" \
+      && valid_env_value "$previous_public_url" \
+      && valid_env_value "$previous_log_level" \
+      && valid_env_value "$previous_issuer" \
+      && valid_env_value "$previous_client_id" \
+      && valid_env_value "$previous_jwks_url" \
+      || die "Existing deployment configuration is missing required values or contains invalid values."
+  fi
+
+  data_default="${previous_data_dir:-$default_data_dir}"
+  endpoint_default="${previous_endpoint_mode:-https}"
+  data_dir="$(read_value 'Persistent data directory' "$data_default")"
   valid_env_value "$source_dir" && valid_env_value "$install_dir" && valid_env_value "$data_dir" \
     || die "Paths must not be empty or contain whitespace, $, #, or newlines."
-  endpoint_mode="$(read_value 'Endpoint mode (https/http)' 'https')"
+  endpoint_mode="$(read_value 'Endpoint mode (https/http)' "$endpoint_default")"
   [[ "$endpoint_mode" == "https" || "$endpoint_mode" == "http" ]] || die "Endpoint mode must be https or http."
+  command -v curl >/dev/null 2>&1 || die "Setup requires curl to verify the public endpoint."
 
   if [[ "$endpoint_mode" == "https" ]]; then
-    command -v curl >/dev/null 2>&1 || die "HTTPS setup requires curl to verify the public endpoint."
-    domain="$(read_value 'Public domain name')"
+    domain_default=""
+    if [[ "$previous_public_url" =~ ^https://([^:/]+):10010$ ]]; then
+      domain_default="${BASH_REMATCH[1]}"
+    fi
+    domain="$(read_value 'Public domain name' "$domain_default")"
     valid_domain "$domain" || die "HTTPS requires a valid DNS domain name, not an IP address."
-    public_url="https://${domain}"
+    public_url="https://${domain}:10010"
     bind_address="127.0.0.1"
-    public_port="8080"
-    profile_args=(--profile https)
+    public_port="10010"
+    exposure="ports 80/tcp and 10010/tcp"
   else
-    public_url="$(read_value 'Public HTTP URL (for example http://203.0.113.10:8080)')"
-    [[ "$public_url" =~ ^http://[A-Za-z0-9.-]+:[0-9]+$ ]] || die "HTTP URL must include a hostname or IPv4 address and numeric port."
+    public_url_default=""
+    if [[ "$previous_public_url" == http://* ]]; then
+      public_url_default="$previous_public_url"
+    fi
+    public_url="$(read_value 'Public HTTP URL (for example http://203.0.113.10:8080)' "$public_url_default")"
+    valid_http_url "$public_url" || die "HTTP URL must include a valid hostname or IPv4 address and port."
     printf 'Warning: HTTP exposes Logseq bearer tokens in transit.\n' >&2
     [[ "$(read_value 'Type I_ACCEPT_HTTP to continue')" == "I_ACCEPT_HTTP" ]] || die "HTTP risk acknowledgement was not accepted."
     bind_address="0.0.0.0"
     public_port="${public_url##*:}"
-    valid_port "$public_port" || die "HTTP URL port must be between 1 and 65535."
+    exposure="${bind_address}:${public_port}"
   fi
 
-  auth_mode="$(read_value 'Authentication (logseq-client/custom-client)' 'logseq-client')"
+  auth_default="logseq-client"
+  if [[ -n "$existing_env" ]] \
+     && [[ "$previous_issuer" != "$default_cognito_issuer" \
+           || "$previous_client_id" != "$default_cognito_client_id" \
+           || "$previous_jwks_url" != "$default_cognito_jwks_url" ]]; then
+    auth_default="custom-client"
+  fi
+  auth_mode="$(read_value 'Authentication (logseq-client/custom-client)' "$auth_default")"
   case "$auth_mode" in
     logseq-client)
       issuer="$default_cognito_issuer"
@@ -177,19 +303,32 @@ setup() {
       ;;
     custom-client)
       printf 'Custom JWT settings require a Logseq client built to issue matching tokens.\n' >&2
-      issuer="$(read_value 'Cognito issuer URL')"
-      client_id="$(read_value 'Cognito client ID')"
-      jwks_url="$(read_value 'Cognito JWKS URL')"
-      [[ "$issuer" =~ ^https://[^[:space:]]+$ ]] || die "Cognito issuer must be an HTTPS URL."
+      issuer="$(read_value 'Cognito issuer URL' "$previous_issuer")"
+      client_id="$(read_value 'Cognito client ID' "$previous_client_id")"
+      jwks_url="$(read_value 'Cognito JWKS URL' "$previous_jwks_url")"
+      valid_https_url "$issuer" || die "Cognito issuer must be a valid HTTPS URL."
       [[ "$client_id" =~ ^[A-Za-z0-9._-]+$ ]] || die "Cognito client ID contains unsupported characters."
-      [[ "$jwks_url" =~ ^https://[^[:space:]]+$ ]] || die "Cognito JWKS URL must be an HTTPS URL."
+      valid_https_url "$jwks_url" || die "Cognito JWKS URL must be a valid HTTPS URL."
       ;;
     *) die "Authentication must be logseq-client or custom-client." ;;
   esac
   valid_env_value "$issuer" && valid_env_value "$client_id" && valid_env_value "$jwks_url" \
-    || die "JWT settings must not contain newlines."
+    || die "JWT settings must not be empty or contain whitespace, $, #, or newlines."
+  log_level="${previous_log_level:-info}"
+  valid_env_value "$log_level" || die "The existing log level is invalid."
 
-  printf '\nDeployment plan:\n  URL: %s\n  Install: %s\n  Data: %s\n  Authentication: %s JWT over %s\n' "$public_url" "$install_dir" "$data_dir" "$auth_mode" "$endpoint_mode"
+  printf '\nDeployment plan:\n  URL: %s\n  Exposure: %s\n  Install: %s\n  Data: %s\n  Authentication: %s JWT over %s\n' "$public_url" "$exposure" "$install_dir" "$data_dir" "$auth_mode" "$endpoint_mode"
+  if [[ -n "$existing_env" && "$data_dir" != "$previous_data_dir" ]]; then
+    confirm 'The persistent data directory changed. Continue with the new directory?' \
+      || die "Cancelled before changing the persistent data directory."
+  fi
+  if [[ -n "$existing_env" ]] \
+     && [[ "$issuer" != "$previous_issuer" \
+           || "$client_id" != "$previous_client_id" \
+           || "$jwks_url" != "$previous_jwks_url" ]]; then
+    confirm 'Authentication settings changed. Existing graph identities may not match. Continue?' \
+      || die "Cancelled before changing authentication settings."
+  fi
   confirm 'Write deployment configuration and start Sync?' || die "Cancelled before writing configuration."
 
   confirm_existing "$install_dir/compose.yaml"
@@ -218,7 +357,7 @@ LOGSEQ_SYNC_ENDPOINT_MODE=${endpoint_mode}
 DB_SYNC_BASE_URL=${public_url}
 DB_SYNC_BIND_ADDRESS=${bind_address}
 DB_SYNC_PUBLIC_PORT=${public_port}
-DB_SYNC_LOG_LEVEL=info
+DB_SYNC_LOG_LEVEL=${log_level}
 COGNITO_ISSUER=${issuer}
 COGNITO_CLIENT_ID=${client_id}
 COGNITO_JWKS_URL=${jwks_url}
@@ -227,15 +366,24 @@ COGNITO_JWKS_URL=${jwks_url}
     sed "s/{DOMAIN}/${domain}/g" "$script_dir/Caddyfile.template" > "$install_dir/Caddyfile"
   fi
 
-  if ! compose "$install_dir" "${profile_args[@]}" up -d --build; then
+  if [[ "$previous_endpoint_mode" == "https" && "$endpoint_mode" == "http" ]]; then
+    compose_https "$install_dir" rm --stop --force caddy
+  fi
+
+  if [[ "$endpoint_mode" == "https" ]]; then
+    compose_args=(--profile https up -d --build --force-recreate)
+  else
+    compose_args=(up -d --build)
+  fi
+  if ! compose "$install_dir" "${compose_args[@]}"; then
     printf 'Sync startup failed. Inspect logs with:\n  %s/logseq-sync logs --follow %s\n' "$script_dir" "$install_dir" >&2
     return 1
   fi
   wait_for_service_health "$install_dir" sync
   if [[ "$endpoint_mode" == "https" ]]; then
     wait_for_service_health "$install_dir" caddy
-    wait_for_https_endpoint "$public_url"
   fi
+  wait_for_public_endpoint "$public_url"
   printf 'Logseq Sync is ready. In Logseq, set Sync Server URL to:\n  %s\n' "$public_url"
   printf 'Status: %s/logseq-sync status %s\n' "$script_dir" "$install_dir"
 }
@@ -246,21 +394,21 @@ status() {
   require_docker
   compose "$install_dir" ps
   printf 'Sync Server URL: %s\n' "$(sed -n 's/^DB_SYNC_BASE_URL=//p' "$install_dir/.env")"
-  if wait_for_service_health "$install_dir" sync; then
+  if service_is_healthy "$install_dir" sync; then
     printf 'Health endpoint: ok\n'
   else
     printf 'Health endpoint: unavailable\n' >&2
     return 1
   fi
   if [[ "$(sed -n 's/^LOGSEQ_SYNC_ENDPOINT_MODE=//p' "$install_dir/.env")" == "https" ]]; then
-    if ! wait_for_service_health "$install_dir" caddy; then
+    if ! service_is_healthy "$install_dir" caddy; then
       printf 'HTTPS proxy health: unavailable\n' >&2
       return 1
     fi
-    if ! wait_for_https_endpoint "$(sed -n 's/^DB_SYNC_BASE_URL=//p' "$install_dir/.env")"; then
-      printf 'Public HTTPS endpoint: unavailable\n' >&2
-      return 1
-    fi
+  fi
+  if ! public_endpoint_is_healthy "$(sed -n 's/^DB_SYNC_BASE_URL=//p' "$install_dir/.env")"; then
+    printf 'Public endpoint: unavailable\n' >&2
+    return 1
   fi
 }
 
@@ -287,6 +435,9 @@ logs() {
     args+=(--follow)
   fi
   if [[ -n "$service" ]]; then
+    if [[ "$service" == "proxy" ]]; then
+      service="caddy"
+    fi
     args+=("$service")
   fi
   compose "$install_dir" "${args[@]}"

--- a/deps/db-sync/deploy/logseq-sync
+++ b/deps/db-sync/deploy/logseq-sync
@@ -6,6 +6,7 @@ readonly source_dir="$(cd -- "$script_dir/../../.." && pwd)"
 readonly docker_install_url="https://docs.docker.com/engine/install/"
 readonly default_install_dir="${HOME}/.local/share/logseq-sync"
 readonly default_data_dir="${HOME}/.local/share/logseq-sync-data"
+readonly default_public_port="443"
 readonly default_cognito_issuer="https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8"
 readonly default_cognito_client_id="69cs1lgme7p8kbgld8n5kseii6"
 readonly default_cognito_jwks_url="${default_cognito_issuer}/.well-known/jwks.json"
@@ -127,6 +128,16 @@ valid_domain() {
      && "$1" =~ ^([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}$ ]]
 }
 
+https_url() {
+  local domain="$1"
+  local port="$2"
+  if [[ "$port" == "443" ]]; then
+    printf 'https://%s' "$domain"
+  else
+    printf 'https://%s:%s' "$domain" "$port"
+  fi
+}
+
 valid_http_url() {
   local url="$1"
   local authority host port
@@ -228,6 +239,7 @@ setup() {
   local install_dir data_dir endpoint_mode public_url bind_address public_port domain
   local issuer client_id jwks_url auth_mode log_level
   local existing_env="" previous_data_dir="" previous_endpoint_mode="" previous_public_url=""
+  local previous_public_port="" previous_url_port=""
   local previous_issuer="" previous_client_id="" previous_jwks_url="" previous_log_level=""
   local data_default endpoint_default domain_default public_url_default auth_default exposure
   local -a compose_args=()
@@ -238,6 +250,7 @@ setup() {
     previous_data_dir="$(read_env_value "$existing_env" LOGSEQ_SYNC_DATA_DIR)"
     previous_endpoint_mode="$(read_env_value "$existing_env" LOGSEQ_SYNC_ENDPOINT_MODE)"
     previous_public_url="$(read_env_value "$existing_env" DB_SYNC_BASE_URL)"
+    previous_public_port="$(read_env_value "$existing_env" DB_SYNC_PUBLIC_PORT)"
     previous_log_level="$(read_env_value "$existing_env" DB_SYNC_LOG_LEVEL)"
     previous_issuer="$(read_env_value "$existing_env" COGNITO_ISSUER)"
     previous_client_id="$(read_env_value "$existing_env" COGNITO_CLIENT_ID)"
@@ -264,15 +277,17 @@ setup() {
 
   if [[ "$endpoint_mode" == "https" ]]; then
     domain_default=""
-    if [[ "$previous_public_url" =~ ^https://([^:/]+):10010$ ]]; then
+    if [[ "$previous_public_url" =~ ^https://([^:/]+)(:([0-9]+))?$ ]]; then
       domain_default="${BASH_REMATCH[1]}"
+      previous_url_port="${BASH_REMATCH[3]:-443}"
     fi
     domain="$(read_value 'Public domain name' "$domain_default")"
     valid_domain "$domain" || die "HTTPS requires a valid DNS domain name, not an IP address."
-    public_url="https://${domain}:10010"
+    public_port="${previous_public_port:-${previous_url_port:-$default_public_port}}"
+    valid_port "$public_port" || die "The configured public HTTPS port is invalid."
+    public_url="$(https_url "$domain" "$public_port")"
     bind_address="127.0.0.1"
-    public_port="10010"
-    exposure="ports 80/tcp and 10010/tcp"
+    exposure="ports 80/tcp and ${public_port}/tcp"
   else
     public_url_default=""
     if [[ "$previous_public_url" == http://* ]]; then
@@ -363,7 +378,7 @@ COGNITO_CLIENT_ID=${client_id}
 COGNITO_JWKS_URL=${jwks_url}
 "
   if [[ "$endpoint_mode" == "https" ]]; then
-    sed "s/{DOMAIN}/${domain}/g" "$script_dir/Caddyfile.template" > "$install_dir/Caddyfile"
+    sed "s|{PUBLIC_URL}|${public_url}|g" "$script_dir/Caddyfile.template" > "$install_dir/Caddyfile"
   fi
 
   if [[ "$previous_endpoint_mode" == "https" && "$endpoint_mode" == "http" ]]; then

--- a/deps/db-sync/deploy/logseq-sync-native
+++ b/deps/db-sync/deploy/logseq-sync-native
@@ -1,0 +1,725 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly checkout_source_dir="$(cd -- "$script_dir/../../.." 2>/dev/null && pwd || true)"
+readonly install_root="${LOGSEQ_SYNC_INSTALL_ROOT:-/opt/logseq-sync}"
+readonly config_dir="${LOGSEQ_SYNC_CONFIG_DIR:-/etc/logseq-sync}"
+readonly data_dir="${LOGSEQ_SYNC_DATA_DIR:-/var/lib/logseq-sync}"
+readonly systemd_dir="${LOGSEQ_SYNC_SYSTEMD_DIR:-/etc/systemd/system}"
+readonly caddy_data_dir="${LOGSEQ_SYNC_CADDY_DATA_DIR:-/var/lib/logseq-sync-caddy}"
+readonly manager_path="${LOGSEQ_SYNC_MANAGER_PATH:-/usr/local/bin/logseq-sync-native}"
+readonly sync_service="logseq-sync.service"
+readonly proxy_service="logseq-sync-caddy.service"
+readonly default_public_port="10010"
+readonly default_internal_port="10011"
+readonly node_major="24"
+readonly pnpm_version="10.33.0"
+readonly clojure_version="1.12.4.1618"
+readonly default_cognito_issuer="https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8"
+readonly default_cognito_client_id="69cs1lgme7p8kbgld8n5kseii6"
+readonly default_cognito_jwks_url="${default_cognito_issuer}/.well-known/jwks.json"
+configured_source_dir="$(sed -n 's/^LOGSEQ_SYNC_SOURCE_DIR=//p' "$config_dir/sync.env" 2>/dev/null || true)"
+configured_public_port="$(sed -n 's/^LOGSEQ_SYNC_PUBLIC_PORT=//p' "$config_dir/sync.env" 2>/dev/null || true)"
+configured_internal_port="$(sed -n 's/^LOGSEQ_SYNC_INTERNAL_PORT=//p' "$config_dir/sync.env" 2>/dev/null || true)"
+public_port="${configured_public_port:-$default_public_port}"
+internal_port="${configured_internal_port:-$default_internal_port}"
+assume_yes="${LOGSEQ_SYNC_ASSUME_YES:-false}"
+if [[ -f "$checkout_source_dir/deps/db-sync/package.json" ]]; then
+  readonly source_dir="$checkout_source_dir"
+else
+  readonly source_dir="$configured_source_dir"
+fi
+temporary_paths=()
+
+register_temporary_path() {
+  temporary_paths+=("$1")
+}
+
+cleanup_temporary_paths() {
+  local path
+  for path in "${temporary_paths[@]-}"; do
+    case "$path" in
+      /tmp/logseq-sync-node.*|/tmp/logseq-sync-clojure.*|/tmp/logseq-sync-build.*)
+        [[ -d "$path" ]] && rm -rf -- "$path"
+        ;;
+      /tmp/logseq-sync-caddy.*)
+        [[ -f "$path" ]] && rm -f -- "$path"
+        ;;
+    esac
+  done
+  return 0
+}
+
+trap cleanup_temporary_paths EXIT
+
+die() {
+  printf 'Error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_linux() {
+  [[ "$(uname -s)" == "Linux" ]] || die "Native deployment requires Linux."
+}
+
+require_root() {
+  [[ "${LOGSEQ_SYNC_TEST_MODE:-false}" == "true" ]] && return 0
+  (( EUID == 0 )) || die "Run this command with sudo."
+}
+
+validate_install_paths() {
+  local path
+  for path in "$install_root" "$config_dir" "$data_dir" "$systemd_dir" \
+    "$caddy_data_dir" "$manager_path"; do
+    [[ "$path" == /* && "$path" != "/" && "$path" != "/opt" \
+       && "$path" != "/etc" && "$path" != "/var" && "$path" != "/var/lib" \
+       && "$path" != *$'\n'* && "$path" != *$'\r'* ]] \
+      || die "Unsafe deployment path: $path"
+  done
+}
+
+set_owner() {
+  [[ "${LOGSEQ_SYNC_TEST_MODE:-false}" == "true" ]] && return 0
+  chown "$@"
+}
+
+confirm() {
+  local prompt="$1"
+  local default_answer="${2:-no}"
+  local answer
+  if [[ "$assume_yes" == "true" ]]; then
+    return 0
+  fi
+  if [[ "$default_answer" == "yes" ]]; then
+    printf '%s [Y/n]: ' "$prompt" >&2
+    read -r answer || answer=""
+    [[ -z "$answer" || "$answer" == "y" || "$answer" == "Y" ]]
+  else
+    printf '%s [y/N]: ' "$prompt" >&2
+    read -r answer || answer=""
+    [[ "$answer" == "y" || "$answer" == "Y" ]]
+  fi
+}
+
+read_value() {
+  local prompt="$1"
+  local default_value="${2:-}"
+  local value
+  if [[ -n "$default_value" ]]; then
+    printf '%s [%s]: ' "$prompt" "$default_value" >&2
+    read -r value || value=""
+    printf '%s' "${value:-$default_value}"
+  else
+    printf '%s: ' "$prompt" >&2
+    read -r value || value=""
+    printf '%s' "$value"
+  fi
+}
+
+valid_port() {
+  [[ "$1" =~ ^[0-9]+$ ]] && (( 10#$1 >= 1 && 10#$1 <= 65535 ))
+}
+
+valid_domain() {
+  [[ ${#1} -le 253 \
+     && "$1" =~ ^([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}$ ]]
+}
+
+read_env_value() {
+  local key="$1"
+  [[ -f "$config_dir/sync.env" ]] || return 0
+  sed -n "s/^${key}=//p" "$config_dir/sync.env"
+}
+
+backup_file() {
+  local path="$1"
+  local timestamp backup suffix=0
+  [[ -e "$path" ]] || return 0
+  timestamp="$(date +%Y%m%d%H%M%S)"
+  backup="${path}.backup-${timestamp}"
+  while [[ -e "$backup" ]]; do
+    suffix=$((suffix + 1))
+    backup="${path}.backup-${timestamp}-${suffix}"
+  done
+  cp -a -- "$path" "$backup"
+}
+
+write_private_file() {
+  local path="$1"
+  shift
+  umask 077
+  printf '%s' "$*" > "$path"
+}
+
+architecture() {
+  case "$(uname -m)" in
+    x86_64) printf 'x64' ;;
+    aarch64|arm64) printf 'arm64' ;;
+    *) die "Only x86_64 and arm64 Linux hosts are currently supported." ;;
+  esac
+}
+
+caddy_architecture() {
+  case "$(uname -m)" in
+    x86_64) printf 'amd64' ;;
+    aarch64|arm64) printf 'arm64' ;;
+    *) die "Only x86_64 and arm64 Linux hosts are currently supported." ;;
+  esac
+}
+
+ensure_system_packages() {
+  command -v apt-get >/dev/null 2>&1 \
+    || die "Automatic dependency installation currently supports Debian and Ubuntu."
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update
+  apt-get install -y --no-install-recommends \
+    build-essential ca-certificates curl git openjdk-21-jdk-headless python3 tar util-linux xz-utils
+}
+
+install_node_toolchain() {
+  local node_arch version archive temp_dir checksum_file
+  node_arch="$(architecture)"
+  version="$(curl --fail --silent --show-error https://nodejs.org/dist/index.tab \
+    | awk -F '\t' -v major="v${node_major}." \
+        'NR > 1 && !found && index($1, major) == 1 {print $1; found = 1}')"
+  [[ -n "$version" ]] || die "Could not determine the latest Node.js ${node_major} release."
+  archive="node-${version}-linux-${node_arch}.tar.xz"
+  temp_dir="$(mktemp -d /tmp/logseq-sync-node.XXXXXX)"
+  register_temporary_path "$temp_dir"
+  curl --fail --location --show-error \
+    "https://nodejs.org/dist/${version}/${archive}" -o "$temp_dir/$archive"
+  curl --fail --location --show-error \
+    "https://nodejs.org/dist/${version}/SHASUMS256.txt" -o "$temp_dir/SHASUMS256.txt"
+  checksum_file="$(grep "  ${archive}$" "$temp_dir/SHASUMS256.txt" || true)"
+  [[ -n "$checksum_file" ]] || die "Node.js checksum entry is missing."
+  (cd "$temp_dir" && printf '%s\n' "$checksum_file" | sha256sum --check --status)
+  mkdir -p "$install_root/toolchain"
+  rm -rf -- "$install_root/toolchain/node"
+  mkdir -p "$install_root/toolchain/node"
+  tar -xJf "$temp_dir/$archive" --strip-components=1 -C "$install_root/toolchain/node"
+  rm -rf -- "$temp_dir"
+  "$install_root/toolchain/node/bin/npm" install --global \
+    --prefix "$install_root/toolchain" "pnpm@${pnpm_version}"
+}
+
+install_clojure_cli() {
+  local temp_dir installer
+  temp_dir="$(mktemp -d /tmp/logseq-sync-clojure.XXXXXX)"
+  register_temporary_path "$temp_dir"
+  installer="$temp_dir/linux-install-${clojure_version}.sh"
+  curl --fail --location --show-error \
+    "https://download.clojure.org/install/linux-install-${clojure_version}.sh" \
+    -o "$installer"
+  chmod +x "$installer"
+  "$installer"
+  rm -rf -- "$temp_dir"
+}
+
+install_caddy() {
+  local temp_file
+  temp_file="$(mktemp /tmp/logseq-sync-caddy.XXXXXX)"
+  register_temporary_path "$temp_file"
+  curl --fail --location --show-error \
+    "https://caddyserver.com/api/download?os=linux&arch=$(caddy_architecture)" \
+    -o "$temp_file"
+  mkdir -p "$install_root/toolchain/bin"
+  install -m 0755 "$temp_file" "$install_root/toolchain/bin/caddy"
+  rm -f -- "$temp_file"
+}
+
+dependencies_ready() {
+  command -v curl >/dev/null 2>&1 \
+    && command -v git >/dev/null 2>&1 \
+    && command -v java >/dev/null 2>&1 \
+    && command -v clojure >/dev/null 2>&1 \
+    && clojure -Sdescribe >/dev/null 2>&1 \
+    && [[ -x "$install_root/toolchain/node/bin/node" ]] \
+    && [[ -x "$install_root/toolchain/bin/pnpm" ]] \
+    && [[ -x "$install_root/toolchain/bin/caddy" ]]
+}
+
+bootstrap() {
+  local skip_confirmation="${1:-false}"
+  require_linux
+  require_root
+  validate_install_paths
+  command -v systemctl >/dev/null 2>&1 || die "systemd is required."
+  printf 'The installer will add build tools, a private Node.js runtime, Clojure CLI, and Caddy.\n'
+  if [[ "$skip_confirmation" != "true" ]]; then
+    confirm 'Install missing dependencies automatically?' yes || die "Dependency installation cancelled."
+  fi
+  ensure_system_packages
+  if [[ ! -x "$install_root/toolchain/node/bin/node" \
+        || ! -x "$install_root/toolchain/bin/pnpm" ]]; then
+    install_node_toolchain
+  fi
+  if ! command -v clojure >/dev/null 2>&1 || ! clojure -Sdescribe >/dev/null 2>&1; then
+    install_clojure_cli
+  fi
+  if [[ ! -x "$install_root/toolchain/bin/caddy" ]]; then
+    install_caddy
+  fi
+  dependencies_ready || die "Dependency installation did not complete successfully."
+  printf 'Dependencies are ready.\n'
+}
+
+ensure_dependencies() {
+  if dependencies_ready; then
+    return 0
+  fi
+  printf 'Some native build or runtime dependencies are missing.\n'
+  bootstrap true
+}
+
+ensure_service_users() {
+  [[ "${LOGSEQ_SYNC_TEST_MODE:-false}" == "true" ]] && return 0
+  if ! getent group logseq-sync >/dev/null; then
+    groupadd --system logseq-sync
+  fi
+  if ! id logseq-sync >/dev/null 2>&1; then
+    useradd --system --gid logseq-sync --home-dir "$data_dir" --no-create-home \
+      --shell /usr/sbin/nologin logseq-sync
+  fi
+  if ! getent group caddy >/dev/null; then
+    groupadd --system caddy
+  fi
+  if ! id caddy >/dev/null 2>&1; then
+    useradd --system --gid caddy --home-dir "$caddy_data_dir" --no-create-home \
+      --shell /usr/sbin/nologin caddy
+  fi
+}
+
+builder_identity() {
+  local candidate="${SUDO_USER:-root}"
+  if id "$candidate" >/dev/null 2>&1; then
+    printf '%s' "$candidate"
+  else
+    printf 'root'
+  fi
+}
+
+run_as_builder() {
+  local builder="$1"
+  shift
+  if [[ "$builder" == "root" ]]; then
+    "$@"
+  else
+    runuser -u "$builder" -- "$@"
+  fi
+}
+
+replace_current_release() {
+  local release_dir="$1"
+  [[ ! -e "$install_root/current" || -L "$install_root/current" ]] \
+    || die "$install_root/current must be a symbolic link."
+  ln -sfn "$release_dir" "$install_root/current.new"
+  if mv -Tf "$install_root/current.new" "$install_root/current" 2>/dev/null; then
+    return 0
+  fi
+  [[ -L "$install_root/current" ]] && unlink "$install_root/current"
+  mv -f "$install_root/current.new" "$install_root/current"
+}
+
+build_adapter() {
+  local build_root builder builder_home release_id release_dir suffix=0
+  build_root="$(mktemp -d /tmp/logseq-sync-build.XXXXXX)"
+  register_temporary_path "$build_root"
+  [[ -f "$source_dir/deps/db-sync/package.json" ]] \
+    || die "The configured Logseq source checkout is unavailable: $source_dir"
+  builder="$(builder_identity)"
+  builder_home="$(getent passwd "$builder" | cut -d: -f6)"
+  mkdir -p "$build_root/deps/db-sync"
+  cp -a "$source_dir/deps/common" "$build_root/deps/common"
+  cp -a "$source_dir/deps/db" "$build_root/deps/db"
+  cp -a "$source_dir/deps/graph-parser" "$build_root/deps/graph-parser"
+  cp -a "$source_dir/deps/outliner" "$build_root/deps/outliner"
+  cp -a "$source_dir/resources" "$build_root/resources"
+  cp -a "$source_dir/deps/db-sync/package.json" \
+    "$source_dir/deps/db-sync/pnpm-lock.yaml" \
+    "$source_dir/deps/db-sync/deps.edn" \
+    "$source_dir/deps/db-sync/shadow-cljs.edn" \
+    "$build_root/deps/db-sync/"
+  cp -a "$source_dir/deps/db-sync/src" "$build_root/deps/db-sync/src"
+  set_owner -R "$builder" "$build_root"
+  run_as_builder "$builder" env \
+    HOME="$builder_home" \
+    PATH="$install_root/toolchain/node/bin:$install_root/toolchain/bin:/usr/local/bin:/usr/bin:/bin" \
+    "$install_root/toolchain/bin/pnpm" --dir "$build_root/deps/db-sync" \
+    install --frozen-lockfile --prod
+  run_as_builder "$builder" env \
+    HOME="$builder_home" \
+    PATH="$install_root/toolchain/node/bin:$install_root/toolchain/bin:/usr/local/bin:/usr/bin:/bin" \
+    "$install_root/toolchain/bin/pnpm" --dir "$build_root/deps/db-sync" \
+    build:node-adapter
+  release_id="$(git -C "$source_dir" rev-parse --short=12 HEAD 2>/dev/null || date +%Y%m%d%H%M%S)"
+  release_dir="$install_root/releases/$release_id"
+  while [[ -e "$release_dir" ]]; do
+    suffix=$((suffix + 1))
+    release_dir="$install_root/releases/${release_id}-${suffix}"
+  done
+  mkdir -p "$release_dir"
+  cp -a "$build_root/deps/db-sync/worker/dist/node-adapter.js" "$release_dir/"
+  cp -a "$build_root/deps/db-sync/node_modules" "$release_dir/"
+  set_owner -R logseq-sync:logseq-sync "$release_dir"
+  replace_current_release "$release_dir"
+  rm -rf -- "$build_root"
+}
+
+write_configuration() {
+  local domain="$1"
+  local public_url="https://${domain}:${public_port}"
+  mkdir -p "$config_dir" "$data_dir" "$caddy_data_dir" "$systemd_dir"
+  set_owner -R logseq-sync:logseq-sync "$data_dir"
+  set_owner caddy:caddy "$caddy_data_dir"
+  set_owner root:caddy "$config_dir"
+  chmod 0750 "$config_dir" "$data_dir" "$caddy_data_dir"
+  backup_file "$config_dir/sync.env"
+  backup_file "$config_dir/Caddyfile"
+  backup_file "$systemd_dir/$sync_service"
+  backup_file "$systemd_dir/$proxy_service"
+  write_private_file "$config_dir/sync.env" "NODE_ENV=production
+LOGSEQ_SYNC_SOURCE_DIR=${source_dir}
+LOGSEQ_SYNC_PUBLIC_PORT=${public_port}
+LOGSEQ_SYNC_INTERNAL_PORT=${internal_port}
+DB_SYNC_HOST=127.0.0.1
+DB_SYNC_PORT=${internal_port}
+DB_SYNC_BASE_URL=${public_url}
+DB_SYNC_DATA_DIR=${data_dir}
+DB_SYNC_STORAGE_DRIVER=sqlite
+DB_SYNC_ASSETS_DRIVER=filesystem
+DB_SYNC_LOG_LEVEL=info
+COGNITO_ISSUER=${default_cognito_issuer}
+COGNITO_CLIENT_ID=${default_cognito_client_id}
+COGNITO_JWKS_URL=${default_cognito_jwks_url}
+"
+  set_owner root:logseq-sync "$config_dir/sync.env"
+  chmod 0640 "$config_dir/sync.env"
+  printf '%s\n' "https://${domain}:${public_port} {" \
+    $'\t'"reverse_proxy 127.0.0.1:${internal_port}" \
+    $'\ttls {' \
+    $'\t\tissuer acme {' \
+    $'\t\t\tdisable_tlsalpn_challenge' \
+    $'\t\t}' \
+    $'\t}' \
+    '}' > "$config_dir/Caddyfile"
+  set_owner root:caddy "$config_dir/Caddyfile"
+  chmod 0640 "$config_dir/Caddyfile"
+  write_private_file "$systemd_dir/$sync_service" "[Unit]
+Description=Logseq Sync Node adapter
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=logseq-sync
+Group=logseq-sync
+WorkingDirectory=${install_root}/current
+EnvironmentFile=${config_dir}/sync.env
+ExecStart=${install_root}/toolchain/node/bin/node ${install_root}/current/node-adapter.js
+Restart=on-failure
+RestartSec=5s
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=${data_dir}
+
+[Install]
+WantedBy=multi-user.target
+"
+  chmod 0644 "$systemd_dir/$sync_service"
+  write_private_file "$systemd_dir/$proxy_service" "[Unit]
+Description=Logseq Sync HTTPS proxy
+After=network-online.target ${sync_service}
+Wants=network-online.target ${sync_service}
+
+[Service]
+Type=notify
+User=caddy
+Group=caddy
+Environment=XDG_DATA_HOME=${caddy_data_dir}
+Environment=XDG_CONFIG_HOME=${caddy_data_dir}
+ExecStart=${install_root}/toolchain/bin/caddy run --environ --config ${config_dir}/Caddyfile
+ExecReload=${install_root}/toolchain/bin/caddy reload --config ${config_dir}/Caddyfile --force
+TimeoutStopSec=5s
+LimitNOFILE=1048576
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=${caddy_data_dir}
+
+[Install]
+WantedBy=multi-user.target
+"
+  chmod 0644 "$systemd_dir/$proxy_service"
+}
+
+install_manager() {
+  local manager_source="$source_dir/deps/db-sync/deploy/logseq-sync-native"
+  [[ -f "$manager_source" ]] || manager_source="${BASH_SOURCE[0]}"
+  mkdir -p "$(dirname -- "$manager_path")"
+  if [[ -e "$manager_path" ]]; then
+    if [[ "$manager_source" -ef "$manager_path" ]] || cmp -s "$manager_source" "$manager_path"; then
+      return 0
+    fi
+  fi
+  backup_file "$manager_path"
+  install -m 0755 "$manager_source" "$manager_path"
+}
+
+wait_for_url() {
+  local url="$1"
+  local attempts="$2"
+  local delay="$3"
+  local body
+  while (( attempts > 0 )); do
+    body="$(curl --fail --silent --show-error --max-time 5 "$url/health" 2>/dev/null || true)"
+    if [[ "$body" == '{"ok":true}' ]]; then
+      return 0
+    fi
+    attempts=$((attempts - 1))
+    (( attempts > 0 )) && sleep "$delay"
+  done
+  return 1
+}
+
+start_services() {
+  local public_url="$1"
+  if ! "$install_root/toolchain/bin/caddy" validate --config "$config_dir/Caddyfile"; then
+    printf 'Caddy configuration validation failed.\n' >&2
+    return 1
+  fi
+  systemctl daemon-reload
+  systemctl enable "$sync_service" "$proxy_service" >/dev/null
+  systemctl restart "$sync_service"
+  if ! wait_for_url "http://127.0.0.1:${internal_port}" 30 2; then
+    journalctl -u "$sync_service" --no-pager -n 30 >&2 || true
+    printf 'Sync did not become healthy.\n' >&2
+    return 1
+  fi
+  systemctl restart "$proxy_service"
+  if ! wait_for_url "$public_url" 24 5; then
+    journalctl -u "$proxy_service" --no-pager -n 30 >&2 || true
+    printf 'HTTPS did not become reachable. Confirm DNS and inbound TCP ports 80 and %s.\n' \
+      "$public_port" >&2
+    return 1
+  fi
+}
+
+setup() {
+  local domain=""
+  local requested_port=""
+  local requested_internal_port=""
+  local internal_port_default
+  local previous_url previous_domain="" previous_port="" public_url resolved_ips
+  while (( $# > 0 )); do
+    case "$1" in
+      --domain)
+        (( $# >= 2 )) || die "--domain requires a value."
+        domain="$2"
+        shift 2
+        ;;
+      --domain=*)
+        domain="${1#--domain=}"
+        shift
+        ;;
+      --public-port)
+        (( $# >= 2 )) || die "--public-port requires a value."
+        requested_port="$2"
+        shift 2
+        ;;
+      --public-port=*)
+        requested_port="${1#--public-port=}"
+        shift
+        ;;
+      --internal-port)
+        (( $# >= 2 )) || die "--internal-port requires a value."
+        requested_internal_port="$2"
+        shift 2
+        ;;
+      --internal-port=*)
+        requested_internal_port="${1#--internal-port=}"
+        shift
+        ;;
+      --yes|-y)
+        assume_yes="true"
+        shift
+        ;;
+      --help|-h)
+        usage
+        return 0
+        ;;
+      *)
+        die "Unknown setup option: $1. Use --domain, --public-port, --internal-port, or --yes."
+        ;;
+    esac
+  done
+  require_linux
+  require_root
+  validate_install_paths
+  command -v systemctl >/dev/null 2>&1 || die "systemd is required."
+  if [[ "$assume_yes" != "true" ]]; then
+    printf '\nLogseq Sync setup\n'
+    printf 'This wizard will configure Sync Node, Caddy, automatic HTTPS, and systemd.\n'
+    printf 'You only need a domain name, public HTTPS port, and private Sync port.\n\n'
+  fi
+  previous_url="$(read_env_value DB_SYNC_BASE_URL)"
+  if [[ "$previous_url" =~ ^https://([^:/]+):([0-9]+)$ ]]; then
+    previous_domain="${BASH_REMATCH[1]}"
+    previous_port="${BASH_REMATCH[2]}"
+  fi
+  if [[ -z "$domain" ]]; then
+    printf 'Domain requirements:\n'
+    printf '  - Enter a hostname only, for example sync.example.com (no https:// or path).\n'
+    printf '  - Its public A/AAAA record must already resolve to this server.\n'
+    printf '  - Wait for DNS propagation before continuing.\n\n'
+    domain="$(read_value 'Step 1/3 - Sync domain name' "$previous_domain")"
+  fi
+  valid_domain "$domain" || die "Enter a valid DNS domain name, not an IP address."
+  command -v getent >/dev/null 2>&1 || die "The getent command is required for DNS validation."
+  resolved_ips="$(getent ahosts "$domain" \
+    | awk '!seen[$1]++ {printf "%s%s", separator, $1; separator=", "}' || true)"
+  [[ -n "$resolved_ips" ]] \
+    || die "The domain does not currently resolve. Create its DNS record before setup."
+  if [[ -n "$requested_port" ]]; then
+    public_port="$requested_port"
+  else
+    printf '\nPublic HTTPS port:\n'
+    printf '  - Logseq clients connect here using HTTPS and secure WebSockets.\n'
+    printf '  - Allow this TCP port in the cloud security group and server firewall.\n'
+    printf '  - TCP 80 must also be reachable for automatic certificate validation.\n\n'
+    public_port="$(read_value 'Step 2/3 - Public HTTPS port' "${previous_port:-$default_public_port}")"
+  fi
+  valid_port "$public_port" || die "Public HTTPS port must be between 1 and 65535."
+  [[ "$public_port" != "80" ]] \
+    || die "Public HTTPS port 80 is reserved for automatic certificate validation."
+  internal_port_default="$internal_port"
+  if [[ "$public_port" == "$internal_port_default" ]]; then
+    if (( 10#$public_port < 65535 )); then
+      internal_port_default="$((10#$public_port + 1))"
+    else
+      internal_port_default="$((10#$public_port - 1))"
+    fi
+  fi
+  if [[ -n "$requested_internal_port" ]]; then
+    internal_port="$requested_internal_port"
+  else
+    printf '\nPrivate Sync port:\n'
+    printf '  - Sync Node listens on 127.0.0.1 only; Caddy forwards requests here.\n'
+    printf '  - Do not expose or allow this port in the public firewall.\n\n'
+    internal_port="$(read_value 'Step 3/3 - Private Sync port' "$internal_port_default")"
+  fi
+  valid_port "$internal_port" || die "Private Sync port must be between 1024 and 65535."
+  (( 10#$internal_port >= 1024 )) \
+    || die "Private Sync port must be between 1024 and 65535."
+  [[ "$public_port" != "$internal_port" ]] \
+    || die "Public HTTPS port and private Sync port must be different."
+  public_url="https://${domain}:${public_port}"
+  printf '\nDeployment plan:\n'
+  printf '  DNS: %s -> %s\n' "$domain" "$resolved_ips"
+  printf '  Public endpoint (enter in Logseq): %s\n' "$public_url"
+  printf '  Public inbound TCP: 80 (certificate), %s (HTTPS/WSS)\n' "$public_port"
+  printf '  Private adapter: 127.0.0.1:%s (local only, do not expose)\n' "$internal_port"
+  printf '  Data: %s\n' "$data_dir"
+  printf '  Services: Sync Node + Caddy (systemd)\n\n'
+  confirm 'Build and start Logseq Sync?' yes || die "Setup cancelled."
+  ensure_dependencies
+  ensure_service_users
+  build_adapter
+  write_configuration "$domain"
+  install_manager
+  start_services "$public_url" || die "Setup did not complete. Generated configuration and data were preserved."
+  printf '\nLogseq Sync is ready. Enter this URL in Logseq → Settings → Advanced → Sync Server URL:\n'
+  printf '  %s\n' "$public_url"
+  printf 'Manage it later with: sudo %s status\n' "$manager_path"
+}
+
+update() {
+  local public_url previous_release
+  require_linux
+  require_root
+  validate_install_paths
+  [[ -f "$config_dir/sync.env" ]] || die "Run setup first."
+  ensure_dependencies
+  public_url="$(read_env_value DB_SYNC_BASE_URL)"
+  previous_release="$(readlink "$install_root/current" 2>/dev/null || true)"
+  [[ -n "$previous_release" && -d "$previous_release" ]] \
+    || die "The current adapter release is missing. Run setup to repair it."
+  printf 'Building the current checkout and preserving configuration and data.\n'
+  build_adapter
+  install_manager
+  systemctl restart "$sync_service"
+  if ! wait_for_url "http://127.0.0.1:${internal_port}" 30 2; then
+    journalctl -u "$sync_service" --no-pager -n 30 >&2 || true
+    replace_current_release "$previous_release"
+    systemctl restart "$sync_service" || true
+    die "Updated Sync process did not become healthy; the previous release was restored."
+  fi
+  if ! wait_for_url "$public_url" 6 2; then
+    replace_current_release "$previous_release"
+    systemctl restart "$sync_service" || true
+    die "Updated public endpoint is unavailable; the previous release was restored."
+  fi
+  printf 'Logseq Sync was updated successfully: %s\n' "$public_url"
+}
+
+status() {
+  local public_url internal_body public_body
+  require_root
+  validate_install_paths
+  [[ -f "$config_dir/sync.env" ]] || die "No native deployment configuration found."
+  public_url="$(read_env_value DB_SYNC_BASE_URL)"
+  systemctl --no-pager --full status "$sync_service" "$proxy_service" || true
+  internal_body="$(curl --fail --silent --max-time 3 "http://127.0.0.1:${internal_port}/health" 2>/dev/null || true)"
+  public_body="$(curl --fail --silent --max-time 5 "$public_url/health" 2>/dev/null || true)"
+  printf 'Sync Server URL: %s\n' "$public_url"
+  [[ "$internal_body" == '{"ok":true}' ]] || die "The private Sync health check failed."
+  [[ "$public_body" == '{"ok":true}' ]] || die "The public HTTPS health check failed."
+  printf 'Health: ok\n'
+}
+
+logs() {
+  local follow="" unit="$sync_service"
+  require_root
+  validate_install_paths
+  while (( $# > 0 )); do
+    case "$1" in
+      --follow|-f) follow="--follow" ;;
+      sync) unit="$sync_service" ;;
+      proxy|caddy) unit="$proxy_service" ;;
+      *) die "Unknown logs option: $1" ;;
+    esac
+    shift
+  done
+  journalctl -u "$unit" --no-pager -n 200 $follow
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  sudo logseq-sync-native setup
+  sudo logseq-sync-native setup --domain <domain> --public-port <port> \
+    --internal-port <port> [--yes]
+  sudo logseq-sync-native update
+  sudo logseq-sync-native bootstrap
+  sudo logseq-sync-native status
+  sudo logseq-sync-native logs [--follow] [sync|proxy]
+
+The public HTTPS port defaults to 10010 when setup input is left blank. Port 80
+is used only for automatic certificate issuance and renewal. The Node adapter
+uses a separate loopback-only port managed by the installer.
+EOF
+}
+
+case "${1:-help}" in
+  setup) shift; setup "$@" ;;
+  update) shift; update "$@" ;;
+  bootstrap) shift; bootstrap false "$@" ;;
+  status) shift; status "$@" ;;
+  logs) shift; logs "$@" ;;
+  help|-h|--help) usage ;;
+  *) usage; exit 1 ;;
+esac

--- a/deps/db-sync/deploy/logseq-sync-native
+++ b/deps/db-sync/deploy/logseq-sync-native
@@ -496,15 +496,20 @@ wait_for_url() {
   local url="$1"
   local attempts="$2"
   local delay="$3"
+  local description="${4:-$url}"
   local body
+  printf 'Waiting for %s' "$description"
   while (( attempts > 0 )); do
     body="$(curl --fail --silent --show-error --max-time 5 "$url/health" 2>/dev/null || true)"
     if [[ "$body" == '{"ok":true}' ]]; then
+      printf ' ready.\n'
       return 0
     fi
     attempts=$((attempts - 1))
+    printf '.'
     (( attempts > 0 )) && sleep "$delay"
   done
+  printf '\n'
   return 1
 }
 
@@ -516,14 +521,19 @@ start_services() {
   fi
   systemctl daemon-reload
   systemctl enable "$sync_service" "$proxy_service" >/dev/null
+  printf 'Starting Sync Node on 127.0.0.1:%s.\n' "$internal_port"
   systemctl restart "$sync_service"
-  if ! wait_for_url "http://127.0.0.1:${internal_port}" 30 2; then
+  if ! wait_for_url "http://127.0.0.1:${internal_port}" 30 2 \
+    "the private Sync health check at 127.0.0.1:${internal_port}"; then
     journalctl -u "$sync_service" --no-pager -n 30 >&2 || true
     printf 'Sync did not become healthy.\n' >&2
     return 1
   fi
+  printf 'Starting Caddy on public HTTPS port %s.\n' "$public_port"
+  printf 'Caddy will obtain or renew the TLS certificate automatically; this can take a few minutes.\n'
   systemctl restart "$proxy_service"
-  if ! wait_for_url "$public_url" 24 5; then
+  if ! wait_for_url "$public_url" 24 5 \
+    "the public HTTPS health check at ${public_url}"; then
     journalctl -u "$proxy_service" --no-pager -n 30 >&2 || true
     printf 'HTTPS did not become reachable. Confirm DNS and inbound TCP ports 80 and %s.\n' \
       "$public_port" >&2
@@ -663,13 +673,15 @@ update() {
   verify_service_runtime
   install_manager
   systemctl restart "$sync_service"
-  if ! wait_for_url "http://127.0.0.1:${internal_port}" 30 2; then
+  if ! wait_for_url "http://127.0.0.1:${internal_port}" 30 2 \
+    "the private Sync health check at 127.0.0.1:${internal_port}"; then
     journalctl -u "$sync_service" --no-pager -n 30 >&2 || true
     replace_current_release "$previous_release"
     systemctl restart "$sync_service" || true
     die "Updated Sync process did not become healthy; the previous release was restored."
   fi
-  if ! wait_for_url "$public_url" 6 2; then
+  if ! wait_for_url "$public_url" 6 2 \
+    "the public HTTPS health check at ${public_url}"; then
     replace_current_release "$previous_release"
     systemctl restart "$sync_service" || true
     die "Updated public endpoint is unavailable; the previous release was restored."

--- a/deps/db-sync/deploy/logseq-sync-native
+++ b/deps/db-sync/deploy/logseq-sync-native
@@ -167,13 +167,122 @@ caddy_architecture() {
   esac
 }
 
+os_release_value() {
+  local key="$1"
+  local os_release_file="${2:-/etc/os-release}"
+  local value
+  [[ -r "$os_release_file" ]] || return 0
+  value="$(sed -n "s/^${key}=//p" "$os_release_file" | head -n 1)"
+  value="${value#\"}"
+  value="${value%\"}"
+  value="${value#\'}"
+  value="${value%\'}"
+  printf '%s' "$value"
+}
+
+linux_package_family() {
+  local distribution_id="$1"
+  local distribution_like="$2"
+  case "$distribution_id" in
+    debian|ubuntu) printf 'debian'; return 0 ;;
+    amzn|alinux|almalinux|anolis|centos|fedora|opencloudos|ol|rhel|rocky|tencentos)
+      printf 'rpm'
+      return 0
+      ;;
+  esac
+  case " $distribution_like " in
+    *' debian '*) printf 'debian' ;;
+    *' centos '*|*' fedora '*|*' rhel '*) printf 'rpm' ;;
+  esac
+}
+
+rpm_java_package() {
+  local package_manager="$1"
+  local distribution_id="$2"
+  local candidate
+  local -a candidates=(
+    java-21-openjdk-headless
+    java-21-openjdk-devel
+    java-17-openjdk-headless
+    java-17-openjdk-devel
+  )
+  if [[ "$distribution_id" == "amzn" ]]; then
+    candidates=(java-21-amazon-corretto-headless java-21-amazon-corretto-devel "${candidates[@]}")
+  elif [[ "$distribution_id" == "opencloudos" ]]; then
+    candidates=(
+      java-21-openjdk-headless
+      java-21-openjdk-devel
+      java-17-konajdk-headless
+      java-17-konajdk
+      java-17-openjdk-headless
+      java-17-openjdk-devel
+    )
+  fi
+  for candidate in "${candidates[@]}"; do
+    if [[ "$package_manager" == "dnf" ]]; then
+      if "$package_manager" -q list --installed "$candidate" >/dev/null 2>&1 \
+          || "$package_manager" -q list --available "$candidate" >/dev/null 2>&1; then
+        printf '%s' "$candidate"
+        return 0
+      fi
+    else
+      if "$package_manager" -q list installed "$candidate" >/dev/null 2>&1 \
+          || "$package_manager" -q list available "$candidate" >/dev/null 2>&1; then
+        printf '%s' "$candidate"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
 ensure_system_packages() {
-  command -v apt-get >/dev/null 2>&1 \
-    || die "Automatic dependency installation currently supports Debian and Ubuntu."
-  export DEBIAN_FRONTEND=noninteractive
-  apt-get update
-  apt-get install -y --no-install-recommends \
-    build-essential ca-certificates curl git openjdk-21-jdk-headless python3 tar util-linux xz-utils
+  local os_release_file="${1:-/etc/os-release}"
+  local distribution_id distribution_like distribution_name package_family
+  local package_manager java_package
+  distribution_id="$(os_release_value ID "$os_release_file")"
+  distribution_like="$(os_release_value ID_LIKE "$os_release_file")"
+  distribution_name="$(os_release_value PRETTY_NAME "$os_release_file")"
+  [[ -n "$distribution_name" ]] || distribution_name="${distribution_id:-unknown Linux distribution}"
+  package_family="$(linux_package_family "$distribution_id" "$distribution_like")"
+  if [[ -z "$package_family" ]]; then
+    if command -v apt-get >/dev/null 2>&1; then
+      package_family="debian"
+    elif command -v dnf >/dev/null 2>&1 || command -v yum >/dev/null 2>&1; then
+      package_family="rpm"
+    fi
+  fi
+  printf 'Detected operating system: %s\n' "$distribution_name"
+  case "$package_family" in
+    debian)
+      command -v apt-get >/dev/null 2>&1 \
+        || die "${distribution_name} is Debian-based, but apt-get is unavailable."
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update
+      apt-get install -y --no-install-recommends \
+        build-essential ca-certificates curl git openjdk-21-jdk-headless \
+        python3 tar util-linux xz-utils
+      ;;
+    rpm)
+      if command -v dnf >/dev/null 2>&1; then
+        package_manager="dnf"
+      elif command -v yum >/dev/null 2>&1; then
+        package_manager="yum"
+      else
+        die "${distribution_name} is RPM-based, but neither dnf nor yum is available."
+      fi
+      "$package_manager" -y makecache
+      java_package="$(rpm_java_package "$package_manager" "$distribution_id" || true)"
+      [[ -n "$java_package" ]] \
+        || die "No Java 17 or 21 runtime package was found for ${distribution_name}. Enable the distribution's supported Java repository and rerun setup."
+      "$package_manager" install -y \
+        gcc gcc-c++ make ca-certificates curl git "$java_package" python3 \
+        shadow-utils tar gzip util-linux xz
+      ;;
+    *)
+      die "Automatic dependency installation does not support ${distribution_name}. Use Debian/Ubuntu or an RPM-based distribution with apt, dnf, or yum."
+      ;;
+  esac
 }
 
 install_node_toolchain() {

--- a/deps/db-sync/deploy/logseq-sync-native
+++ b/deps/db-sync/deploy/logseq-sync-native
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 readonly script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-readonly checkout_source_dir="$(cd -- "$script_dir/../../.." 2>/dev/null && pwd || true)"
+readonly checkout_root="$(cd -- "$script_dir/../../.." 2>/dev/null && pwd || true)"
 readonly install_root="${LOGSEQ_SYNC_INSTALL_ROOT:-/opt/logseq-sync}"
 readonly config_dir="${LOGSEQ_SYNC_CONFIG_DIR:-/etc/logseq-sync}"
 readonly data_dir="${LOGSEQ_SYNC_DATA_DIR:-/var/lib/logseq-sync}"
@@ -13,26 +13,22 @@ readonly sync_service="logseq-sync.service"
 readonly proxy_service="logseq-sync-caddy.service"
 readonly default_public_port="10010"
 readonly default_internal_port="10011"
-readonly node_major="24"
-readonly pnpm_version="10.33.0"
-readonly clojure_version="1.12.4.1618"
+readonly default_release_repository="logseq/logseq"
+readonly default_release_tag="db-sync-native"
 readonly default_cognito_issuer="https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8"
 readonly default_cognito_client_id="69cs1lgme7p8kbgld8n5kseii6"
 readonly default_cognito_jwks_url="${default_cognito_issuer}/.well-known/jwks.json"
-configured_source_dir="$(sed -n 's/^LOGSEQ_SYNC_SOURCE_DIR=//p' "$config_dir/sync.env" 2>/dev/null || true)"
+
 configured_public_port="$(sed -n 's/^LOGSEQ_SYNC_PUBLIC_PORT=//p' "$config_dir/sync.env" 2>/dev/null || true)"
 configured_internal_port="$(sed -n 's/^LOGSEQ_SYNC_INTERNAL_PORT=//p' "$config_dir/sync.env" 2>/dev/null || true)"
-configured_node_path="${LOGSEQ_SYNC_NODE_PATH:-$(sed -n 's/^LOGSEQ_SYNC_NODE_PATH=//p' "$config_dir/sync.env" 2>/dev/null || true)}"
+configured_release_repository="$(sed -n 's/^LOGSEQ_SYNC_RELEASE_REPOSITORY=//p' "$config_dir/sync.env" 2>/dev/null || true)"
+configured_release_tag="$(sed -n 's/^LOGSEQ_SYNC_RELEASE_TAG=//p' "$config_dir/sync.env" 2>/dev/null || true)"
 public_port="${configured_public_port:-$default_public_port}"
 internal_port="${configured_internal_port:-$default_internal_port}"
+release_repository="${LOGSEQ_SYNC_RELEASE_REPOSITORY:-$configured_release_repository}"
+release_tag="${LOGSEQ_SYNC_RELEASE_TAG:-${configured_release_tag:-$default_release_tag}}"
+runtime_sha256=""
 assume_yes="${LOGSEQ_SYNC_ASSUME_YES:-false}"
-node_path="$configured_node_path"
-npm_path=""
-if [[ -f "$checkout_source_dir/deps/db-sync/package.json" ]]; then
-  readonly source_dir="$checkout_source_dir"
-else
-  readonly source_dir="$configured_source_dir"
-fi
 temporary_paths=()
 
 register_temporary_path() {
@@ -43,7 +39,7 @@ cleanup_temporary_paths() {
   local path
   for path in "${temporary_paths[@]-}"; do
     case "$path" in
-      /tmp/logseq-sync-node.*|/tmp/logseq-sync-clojure.*|/tmp/logseq-sync-build.*)
+      /tmp/logseq-sync-runtime.*)
         [[ -d "$path" ]] && rm -rf -- "$path"
         ;;
       /tmp/logseq-sync-caddy.*)
@@ -68,6 +64,14 @@ require_linux() {
 require_root() {
   [[ "${LOGSEQ_SYNC_TEST_MODE:-false}" == "true" ]] && return 0
   (( EUID == 0 )) || die "Run this command with sudo."
+}
+
+require_commands() {
+  local command_name
+  for command_name in curl tar sha256sum systemctl getent awk sed install mktemp; do
+    command -v "$command_name" >/dev/null 2>&1 \
+      || die "Required base command is missing: $command_name"
+  done
 }
 
 validate_install_paths() {
@@ -170,305 +174,28 @@ caddy_architecture() {
   esac
 }
 
-node_version_supported() {
-  local candidate="$1"
-  local version major minor
-  [[ -x "$candidate" ]] || return 1
-  version="$("$candidate" --version 2>/dev/null || true)"
-  [[ "$version" =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+ ]] || return 1
-  major="${BASH_REMATCH[1]}"
-  minor="${BASH_REMATCH[2]}"
-  [[ "$major" == "24" ]] && return 0
-  [[ "$major" == "22" ]] && (( 10#$minor >= 12 ))
-}
-
-system_service_node_path() {
-  local candidate="$1"
-  [[ "$candidate" == /* && -x "$candidate" ]] || return 1
-  candidate="$(realpath "$candidate" 2>/dev/null || true)"
-  [[ -n "$candidate" && -x "$candidate" ]] || return 1
-  if [[ "${LOGSEQ_SYNC_TEST_MODE:-false}" != "true" ]]; then
-    case "$candidate" in
-      /home/*|/root/*|/run/user/*|/tmp/*|/var/tmp/*) return 1 ;;
-    esac
-  fi
-  printf '%s' "$candidate"
-}
-
-find_npm_for_node() {
-  local candidate="$1"
-  local node_dir npm_candidate
-  node_dir="$(dirname -- "$candidate")"
-  for npm_candidate in "$node_dir/npm" "$(command -v npm 2>/dev/null || true)"; do
-    [[ "$npm_candidate" == /* && -x "$npm_candidate" ]] || continue
-    if run_with_node "$candidate" "$npm_candidate" --version >/dev/null 2>&1; then
-      printf '%s' "$npm_candidate"
-      return 0
-    fi
-  done
-  return 1
-}
-
-run_with_node() {
-  local runtime="$1"
-  local runtime_dir
-  shift
-  runtime_dir="$(dirname -- "$runtime")"
-  env PATH="$runtime_dir:$install_root/toolchain/bin:${PATH:-/usr/local/bin:/usr/bin:/bin}" "$@"
-}
-
-select_node_runtime() {
-  local candidate
-  npm_path=""
-  if [[ -n "$configured_node_path" ]]; then
-    node_version_supported "$configured_node_path" \
-      || die "Configured Node.js must be version 22.12 or newer in the 22.x line, or version 24.x: $configured_node_path"
-    node_path="$configured_node_path"
-    npm_path="$(find_npm_for_node "$node_path" || true)"
-    return 0
-  fi
-  candidate="$(command -v node 2>/dev/null || true)"
-  candidate="$(system_service_node_path "$candidate" || true)"
-  if [[ -n "$candidate" ]] && node_version_supported "$candidate"; then
-    node_path="$candidate"
-    npm_path="$(find_npm_for_node "$node_path" || true)"
-    return 0
-  fi
-  candidate="$install_root/toolchain/node/bin/node"
-  if node_version_supported "$candidate"; then
-    node_path="$candidate"
-    npm_path="$(find_npm_for_node "$node_path" || true)"
-    return 0
-  fi
-  node_path=""
-}
-
-os_release_value() {
-  local key="$1"
-  local os_release_file="${2:-/etc/os-release}"
-  local value
-  [[ -r "$os_release_file" ]] || return 0
-  value="$(sed -n "s/^${key}=//p" "$os_release_file" | head -n 1)"
-  value="${value#\"}"
-  value="${value%\"}"
-  value="${value#\'}"
-  value="${value%\'}"
-  printf '%s' "$value"
-}
-
-linux_package_family() {
-  local distribution_id="$1"
-  local distribution_like="$2"
-  case "$distribution_id" in
-    debian|ubuntu) printf 'debian'; return 0 ;;
-    amzn|alinux|almalinux|anolis|centos|fedora|opencloudos|ol|rhel|rocky|tencentos)
-      printf 'rpm'
-      return 0
-      ;;
+detect_checkout_repository() {
+  local remote repository=""
+  [[ -d "$checkout_root/.git" ]] || return 0
+  remote="$(git -C "$checkout_root" config --get remote.origin.url 2>/dev/null || true)"
+  case "$remote" in
+    https://github.com/*) repository="${remote#https://github.com/}" ;;
+    git@github.com:*) repository="${remote#git@github.com:}" ;;
+    ssh://git@github.com/*) repository="${remote#ssh://git@github.com/}" ;;
   esac
-  case " $distribution_like " in
-    *' debian '*) printf 'debian' ;;
-    *' centos '*|*' fedora '*|*' rhel '*) printf 'rpm' ;;
-  esac
+  repository="${repository%.git}"
+  [[ "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] && printf '%s' "$repository"
 }
 
-rpm_java_package() {
-  local package_manager="$1"
-  local distribution_id="$2"
-  local candidate
-  local -a candidates=(
-    java-21-openjdk-headless
-    java-21-openjdk-devel
-    java-17-openjdk-headless
-    java-17-openjdk-devel
-  )
-  if [[ "$distribution_id" == "amzn" ]]; then
-    candidates=(java-21-amazon-corretto-headless java-21-amazon-corretto-devel "${candidates[@]}")
-  elif [[ "$distribution_id" == "opencloudos" ]]; then
-    candidates=(
-      java-21-openjdk-headless
-      java-21-openjdk-devel
-      java-17-konajdk-headless
-      java-17-konajdk
-      java-17-openjdk-headless
-      java-17-openjdk-devel
-    )
+select_release_source() {
+  if [[ -z "$release_repository" ]]; then
+    release_repository="$(detect_checkout_repository)"
   fi
-  for candidate in "${candidates[@]}"; do
-    if [[ "$package_manager" == "dnf" ]]; then
-      if "$package_manager" -q list --installed "$candidate" >/dev/null 2>&1 \
-          || "$package_manager" -q list --available "$candidate" >/dev/null 2>&1; then
-        printf '%s' "$candidate"
-        return 0
-      fi
-    else
-      if "$package_manager" -q list installed "$candidate" >/dev/null 2>&1 \
-          || "$package_manager" -q list available "$candidate" >/dev/null 2>&1; then
-        printf '%s' "$candidate"
-        return 0
-      fi
-    fi
-  done
-  return 1
-}
-
-ensure_system_packages() {
-  local os_release_file="${1:-/etc/os-release}"
-  local distribution_id distribution_like distribution_name package_family
-  local package_manager java_package
-  distribution_id="$(os_release_value ID "$os_release_file")"
-  distribution_like="$(os_release_value ID_LIKE "$os_release_file")"
-  distribution_name="$(os_release_value PRETTY_NAME "$os_release_file")"
-  [[ -n "$distribution_name" ]] || distribution_name="${distribution_id:-unknown Linux distribution}"
-  package_family="$(linux_package_family "$distribution_id" "$distribution_like")"
-  if [[ -z "$package_family" ]]; then
-    if command -v apt-get >/dev/null 2>&1; then
-      package_family="debian"
-    elif command -v dnf >/dev/null 2>&1 || command -v yum >/dev/null 2>&1; then
-      package_family="rpm"
-    fi
-  fi
-  printf 'Detected operating system: %s\n' "$distribution_name"
-  case "$package_family" in
-    debian)
-      command -v apt-get >/dev/null 2>&1 \
-        || die "${distribution_name} is Debian-based, but apt-get is unavailable."
-      export DEBIAN_FRONTEND=noninteractive
-      apt-get update
-      apt-get install -y --no-install-recommends \
-        build-essential ca-certificates curl git openjdk-21-jdk-headless \
-        python3 tar util-linux xz-utils
-      ;;
-    rpm)
-      if command -v dnf >/dev/null 2>&1; then
-        package_manager="dnf"
-      elif command -v yum >/dev/null 2>&1; then
-        package_manager="yum"
-      else
-        die "${distribution_name} is RPM-based, but neither dnf nor yum is available."
-      fi
-      "$package_manager" -y makecache
-      java_package="$(rpm_java_package "$package_manager" "$distribution_id" || true)"
-      [[ -n "$java_package" ]] \
-        || die "No Java 17 or 21 runtime package was found for ${distribution_name}. Enable the distribution's supported Java repository and rerun setup."
-      "$package_manager" install -y \
-        gcc gcc-c++ make ca-certificates curl git "$java_package" python3 \
-        shadow-utils tar gzip util-linux xz
-      ;;
-    *)
-      die "Automatic dependency installation does not support ${distribution_name}. Use Debian/Ubuntu or an RPM-based distribution with apt, dnf, or yum."
-      ;;
-  esac
-}
-
-install_node_toolchain() {
-  local node_arch version archive temp_dir checksum_file
-  node_arch="$(architecture)"
-  version="$(curl --fail --silent --show-error https://nodejs.org/dist/index.tab \
-    | awk -F '\t' -v major="v${node_major}." \
-        'NR > 1 && !found && index($1, major) == 1 {print $1; found = 1}')"
-  [[ -n "$version" ]] || die "Could not determine the latest Node.js ${node_major} release."
-  archive="node-${version}-linux-${node_arch}.tar.xz"
-  temp_dir="$(mktemp -d /tmp/logseq-sync-node.XXXXXX)"
-  register_temporary_path "$temp_dir"
-  curl --fail --location --show-error \
-    "https://nodejs.org/dist/${version}/${archive}" -o "$temp_dir/$archive"
-  curl --fail --location --show-error \
-    "https://nodejs.org/dist/${version}/SHASUMS256.txt" -o "$temp_dir/SHASUMS256.txt"
-  checksum_file="$(grep "  ${archive}$" "$temp_dir/SHASUMS256.txt" || true)"
-  [[ -n "$checksum_file" ]] || die "Node.js checksum entry is missing."
-  (cd "$temp_dir" && printf '%s\n' "$checksum_file" | sha256sum --check --status)
-  mkdir -p "$install_root/toolchain"
-  rm -rf -- "$install_root/toolchain/node"
-  mkdir -p "$install_root/toolchain/node"
-  tar -xJf "$temp_dir/$archive" --strip-components=1 -C "$install_root/toolchain/node"
-  rm -rf -- "$temp_dir"
-  node_path="$install_root/toolchain/node/bin/node"
-  npm_path="$install_root/toolchain/node/bin/npm"
-}
-
-install_pnpm() {
-  [[ -n "$npm_path" && -x "$npm_path" ]] \
-    || die "A compatible Node.js runtime was found, but its npm executable is unavailable."
-  run_with_node "$node_path" "$npm_path" install --global \
-    --prefix "$install_root/toolchain" "pnpm@${pnpm_version}"
-}
-
-install_clojure_cli() {
-  local temp_dir installer
-  temp_dir="$(mktemp -d /tmp/logseq-sync-clojure.XXXXXX)"
-  register_temporary_path "$temp_dir"
-  installer="$temp_dir/linux-install-${clojure_version}.sh"
-  curl --fail --location --show-error \
-    "https://download.clojure.org/install/linux-install-${clojure_version}.sh" \
-    -o "$installer"
-  chmod +x "$installer"
-  "$installer"
-  rm -rf -- "$temp_dir"
-}
-
-install_caddy() {
-  local temp_file
-  temp_file="$(mktemp /tmp/logseq-sync-caddy.XXXXXX)"
-  register_temporary_path "$temp_file"
-  curl --fail --location --show-error \
-    "https://caddyserver.com/api/download?os=linux&arch=$(caddy_architecture)" \
-    -o "$temp_file"
-  mkdir -p "$install_root/toolchain/bin"
-  install -m 0755 "$temp_file" "$install_root/toolchain/bin/caddy"
-  rm -f -- "$temp_file"
-}
-
-dependencies_ready() {
-  command -v curl >/dev/null 2>&1 \
-    && command -v git >/dev/null 2>&1 \
-    && command -v java >/dev/null 2>&1 \
-    && command -v clojure >/dev/null 2>&1 \
-    && clojure -Sdescribe >/dev/null 2>&1 \
-    && [[ -n "$node_path" ]] \
-    && node_version_supported "$node_path" \
-    && [[ -x "$install_root/toolchain/bin/pnpm" ]] \
-    && [[ -x "$install_root/toolchain/bin/caddy" ]]
-}
-
-bootstrap() {
-  local skip_confirmation="${1:-false}"
-  require_linux
-  require_root
-  validate_install_paths
-  command -v systemctl >/dev/null 2>&1 || die "systemd is required."
-  printf 'The installer will add build tools, Clojure CLI, and Caddy.\n'
-  printf 'A compatible system Node.js is reused; otherwise a private Node.js 24 runtime is installed.\n'
-  if [[ "$skip_confirmation" != "true" ]]; then
-    confirm 'Install missing dependencies automatically?' yes || die "Dependency installation cancelled."
-  fi
-  ensure_system_packages
-  select_node_runtime
-  if [[ -z "$node_path" \
-        || ( ! -x "$install_root/toolchain/bin/pnpm" && -z "$npm_path" ) ]]; then
-    install_node_toolchain
-  fi
-  printf 'Using Node.js %s at %s.\n' "$("$node_path" --version)" "$node_path"
-  if [[ ! -x "$install_root/toolchain/bin/pnpm" ]]; then
-    install_pnpm
-  fi
-  if ! command -v clojure >/dev/null 2>&1 || ! clojure -Sdescribe >/dev/null 2>&1; then
-    install_clojure_cli
-  fi
-  if [[ ! -x "$install_root/toolchain/bin/caddy" ]]; then
-    install_caddy
-  fi
-  dependencies_ready || die "Dependency installation did not complete successfully."
-  printf 'Dependencies are ready.\n'
-}
-
-ensure_dependencies() {
-  select_node_runtime
-  if dependencies_ready; then
-    return 0
-  fi
-  printf 'Some native build or runtime dependencies are missing.\n'
-  bootstrap true
+  release_repository="${release_repository:-$default_release_repository}"
+  [[ "$release_repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] \
+    || die "Invalid GitHub release repository: $release_repository"
+  [[ "$release_tag" =~ ^db-sync-native(-v[0-9A-Za-z._-]+)?$ ]] \
+    || die "Invalid native runtime release tag: $release_tag"
 }
 
 ensure_service_users() {
@@ -489,31 +216,6 @@ ensure_service_users() {
   fi
 }
 
-verify_service_node_runtime() {
-  [[ "${LOGSEQ_SYNC_TEST_MODE:-false}" == "true" ]] && return 0
-  runuser -u logseq-sync -- "$node_path" --version >/dev/null 2>&1 \
-    || die "The selected Node.js runtime is not executable by the logseq-sync service user: $node_path"
-}
-
-builder_identity() {
-  local candidate="${SUDO_USER:-root}"
-  if id "$candidate" >/dev/null 2>&1; then
-    printf '%s' "$candidate"
-  else
-    printf 'root'
-  fi
-}
-
-run_as_builder() {
-  local builder="$1"
-  shift
-  if [[ "$builder" == "root" ]]; then
-    "$@"
-  else
-    runuser -u "$builder" -- "$@"
-  fi
-}
-
 replace_current_release() {
   local release_dir="$1"
   [[ ! -e "$install_root/current" || -L "$install_root/current" ]] \
@@ -526,50 +228,149 @@ replace_current_release() {
   mv -f "$install_root/current.new" "$install_root/current"
 }
 
-build_adapter() {
-  local build_root builder builder_home node_dir release_id release_dir suffix=0
-  build_root="$(mktemp -d /tmp/logseq-sync-build.XXXXXX)"
-  register_temporary_path "$build_root"
-  [[ -f "$source_dir/deps/db-sync/package.json" ]] \
-    || die "The configured Logseq source checkout is unavailable: $source_dir"
-  builder="$(builder_identity)"
-  builder_home="$(getent passwd "$builder" | cut -d: -f6)"
-  node_dir="$(dirname -- "$node_path")"
-  mkdir -p "$build_root/deps/db-sync"
-  cp -a "$source_dir/deps/common" "$build_root/deps/common"
-  cp -a "$source_dir/deps/db" "$build_root/deps/db"
-  cp -a "$source_dir/deps/graph-parser" "$build_root/deps/graph-parser"
-  cp -a "$source_dir/deps/outliner" "$build_root/deps/outliner"
-  cp -a "$source_dir/resources" "$build_root/resources"
-  cp -a "$source_dir/deps/db-sync/package.json" \
-    "$source_dir/deps/db-sync/pnpm-lock.yaml" \
-    "$source_dir/deps/db-sync/deps.edn" \
-    "$source_dir/deps/db-sync/shadow-cljs.edn" \
-    "$build_root/deps/db-sync/"
-  cp -a "$source_dir/deps/db-sync/src" "$build_root/deps/db-sync/src"
-  set_owner -R "$builder" "$build_root"
-  run_as_builder "$builder" env \
-    HOME="$builder_home" \
-    PATH="$node_dir:$install_root/toolchain/bin:/usr/local/bin:/usr/bin:/bin" \
-    "$install_root/toolchain/bin/pnpm" --dir "$build_root/deps/db-sync" \
-    install --frozen-lockfile --prod
-  run_as_builder "$builder" env \
-    HOME="$builder_home" \
-    PATH="$node_dir:$install_root/toolchain/bin:/usr/local/bin:/usr/bin:/bin" \
-    "$install_root/toolchain/bin/pnpm" --dir "$build_root/deps/db-sync" \
-    build:node-adapter
-  release_id="$(git -C "$source_dir" rev-parse --short=12 HEAD 2>/dev/null || date +%Y%m%d%H%M%S)"
+runtime_ready() {
+  [[ -x "$install_root/current/node/bin/node" \
+     && -f "$install_root/current/app/node-adapter.js" \
+     && -d "$install_root/current/app/node_modules" \
+     && -f "$install_root/current/VERSION" \
+     && -f "$install_root/current/ARCHITECTURE" ]] \
+    && [[ "$(<"$install_root/current/ARCHITECTURE")" == "$(architecture)" ]] \
+    && "$install_root/current/node/bin/node" --version >/dev/null 2>&1
+}
+
+download_file() {
+  local source="$1"
+  local destination="$2"
+  if [[ "$source" == /* ]]; then
+    cp -a -- "$source" "$destination"
+  else
+    curl --fail --location --show-error "$source" -o "$destination"
+  fi
+}
+
+install_runtime() {
+  local runtime_arch asset release_base archive_source checksum_source
+  local temp_dir archive checksum_file expected_checksum actual_checksum
+  local extracted_dir version release_id release_dir
+  runtime_arch="$(architecture)"
+  asset="logseq-sync-runtime-linux-${runtime_arch}.tar.gz"
+  release_base="${LOGSEQ_SYNC_RELEASE_BASE_URL:-https://github.com/${release_repository}/releases/download/${release_tag}}"
+  archive_source="${LOGSEQ_SYNC_RUNTIME_ARCHIVE:-${release_base}/${asset}}"
+  checksum_source="${LOGSEQ_SYNC_RUNTIME_CHECKSUM:-${archive_source}.sha256}"
+  temp_dir="$(mktemp -d /tmp/logseq-sync-runtime.XXXXXX)"
+  register_temporary_path "$temp_dir"
+  archive="$temp_dir/$asset"
+  checksum_file="$temp_dir/$asset.sha256"
+  printf 'Downloading prebuilt Sync runtime for Linux %s from %s (%s).\n' \
+    "$runtime_arch" "$release_repository" "$release_tag"
+  download_file "$archive_source" "$archive"
+  download_file "$checksum_source" "$checksum_file"
+  expected_checksum="$(awk -v asset="$asset" '$2 == asset || $2 == "*" asset {print $1; exit}' "$checksum_file")"
+  [[ "$expected_checksum" =~ ^[0-9a-fA-F]{64}$ ]] \
+    || die "The runtime checksum file is invalid."
+  actual_checksum="$(sha256sum "$archive" | awk '{print $1}')"
+  [[ "$actual_checksum" == "$expected_checksum" ]] \
+    || die "The downloaded Sync runtime failed checksum verification."
+  while IFS= read -r archive_entry; do
+    case "$archive_entry" in
+      logseq-sync-runtime|logseq-sync-runtime/*)
+        [[ "$archive_entry" != *'/../'* && "$archive_entry" != '../'* ]] \
+          || die "The downloaded Sync runtime contains an unsafe path."
+        ;;
+      *) die "The downloaded Sync runtime contains an unexpected path." ;;
+    esac
+  done < <(tar -tzf "$archive")
+  mkdir -p "$temp_dir/extracted"
+  tar --no-same-owner --no-same-permissions -xzf "$archive" -C "$temp_dir/extracted"
+  extracted_dir="$temp_dir/extracted/logseq-sync-runtime"
+  [[ -x "$extracted_dir/node/bin/node" \
+     && -f "$extracted_dir/app/node-adapter.js" \
+     && -d "$extracted_dir/app/node_modules" \
+     && -x "$extracted_dir/bin/logseq-sync-native" \
+     && -f "$extracted_dir/VERSION" \
+     && -f "$extracted_dir/ARCHITECTURE" ]] \
+    || die "The downloaded Sync runtime is incomplete."
+  [[ "$(<"$extracted_dir/ARCHITECTURE")" == "$runtime_arch" ]] \
+    || die "The downloaded Sync runtime architecture does not match this server."
+  "$extracted_dir/node/bin/node" --version >/dev/null 2>&1 \
+    || die "The bundled Node.js runtime cannot run on this server."
+  version="$(<"$extracted_dir/VERSION")"
+  [[ "$version" =~ ^[A-Za-z0-9._+-]+$ ]] || die "The runtime version is invalid."
+  release_id="${version}-${runtime_arch}-${actual_checksum:0:12}"
   release_dir="$install_root/releases/$release_id"
-  while [[ -e "$release_dir" ]]; do
-    suffix=$((suffix + 1))
-    release_dir="$install_root/releases/${release_id}-${suffix}"
-  done
-  mkdir -p "$release_dir"
-  cp -a "$build_root/deps/db-sync/worker/dist/node-adapter.js" "$release_dir/"
-  cp -a "$build_root/deps/db-sync/node_modules" "$release_dir/"
-  set_owner -R logseq-sync:logseq-sync "$release_dir"
+  mkdir -p "$install_root/releases"
+  if [[ ! -d "$release_dir" ]]; then
+    mv "$extracted_dir" "$release_dir"
+    set_owner -R logseq-sync:logseq-sync "$release_dir"
+  fi
   replace_current_release "$release_dir"
-  rm -rf -- "$build_root"
+  runtime_sha256="$actual_checksum"
+  printf 'Installed Sync runtime %s with bundled %s.\n' \
+    "$version" "$("$release_dir/node/bin/node" --version)"
+}
+
+install_caddy() {
+  local temp_file
+  [[ -x "$install_root/toolchain/bin/caddy" ]] && return 0
+  temp_file="$(mktemp /tmp/logseq-sync-caddy.XXXXXX)"
+  register_temporary_path "$temp_file"
+  printf 'Downloading Caddy for automatic HTTPS.\n'
+  curl --fail --location --show-error \
+    "https://caddyserver.com/api/download?os=linux&arch=$(caddy_architecture)" \
+    -o "$temp_file"
+  mkdir -p "$install_root/toolchain/bin"
+  install -m 0755 "$temp_file" "$install_root/toolchain/bin/caddy"
+  rm -f -- "$temp_file"
+}
+
+verify_service_runtime() {
+  [[ "${LOGSEQ_SYNC_TEST_MODE:-false}" == "true" ]] && return 0
+  runuser -u logseq-sync -- "$install_root/current/node/bin/node" --version >/dev/null 2>&1 \
+    || die "The bundled runtime is not executable by the logseq-sync service user."
+}
+
+install_manager() {
+  local manager_source="$install_root/current/bin/logseq-sync-native"
+  [[ -f "$manager_source" ]] || manager_source="${BASH_SOURCE[0]}"
+  mkdir -p "$(dirname -- "$manager_path")"
+  if [[ -e "$manager_path" ]]; then
+    if [[ "$manager_source" -ef "$manager_path" ]] || cmp -s "$manager_source" "$manager_path"; then
+      return 0
+    fi
+  fi
+  backup_file "$manager_path"
+  install -m 0755 "$manager_source" "$manager_path"
+}
+
+bootstrap() {
+  require_linux
+  require_root
+  validate_install_paths
+  require_commands
+  select_release_source
+  printf 'The installer will download a prebuilt Sync runtime and Caddy.\n'
+  printf 'It will not install or use system Node.js, Java, Clojure, or build tools.\n'
+  confirm 'Download the runtime components?' yes || die "Download cancelled."
+  ensure_service_users
+  install_runtime
+  install_caddy
+  verify_service_runtime
+  install_manager
+  printf 'Runtime components are ready.\n'
+}
+
+ensure_runtime_components() {
+  require_commands
+  select_release_source
+  ensure_service_users
+  if ! runtime_ready; then
+    install_runtime
+  else
+    runtime_sha256="$(read_env_value LOGSEQ_SYNC_RUNTIME_SHA256)"
+    printf 'Using installed prebuilt Sync runtime %s.\n' "$(<"$install_root/current/VERSION")"
+  fi
+  install_caddy
+  verify_service_runtime
 }
 
 write_configuration() {
@@ -585,10 +386,11 @@ write_configuration() {
   backup_file "$systemd_dir/$sync_service"
   backup_file "$systemd_dir/$proxy_service"
   write_private_file "$config_dir/sync.env" "NODE_ENV=production
-LOGSEQ_SYNC_SOURCE_DIR=${source_dir}
+LOGSEQ_SYNC_RELEASE_REPOSITORY=${release_repository}
+LOGSEQ_SYNC_RELEASE_TAG=${release_tag}
+LOGSEQ_SYNC_RUNTIME_SHA256=${runtime_sha256}
 LOGSEQ_SYNC_PUBLIC_PORT=${public_port}
 LOGSEQ_SYNC_INTERNAL_PORT=${internal_port}
-LOGSEQ_SYNC_NODE_PATH=${node_path}
 DB_SYNC_HOST=127.0.0.1
 DB_SYNC_PORT=${internal_port}
 DB_SYNC_BASE_URL=${public_url}
@@ -621,9 +423,9 @@ Wants=network-online.target
 Type=simple
 User=logseq-sync
 Group=logseq-sync
-WorkingDirectory=${install_root}/current
+WorkingDirectory=${install_root}/current/app
 EnvironmentFile=${config_dir}/sync.env
-ExecStart=${node_path} ${install_root}/current/node-adapter.js
+ExecStart=${install_root}/current/node/bin/node ${install_root}/current/app/node-adapter.js
 Restart=on-failure
 RestartSec=5s
 NoNewPrivileges=true
@@ -663,19 +465,6 @@ ReadWritePaths=${caddy_data_dir}
 WantedBy=multi-user.target
 "
   chmod 0644 "$systemd_dir/$proxy_service"
-}
-
-install_manager() {
-  local manager_source="$source_dir/deps/db-sync/deploy/logseq-sync-native"
-  [[ -f "$manager_source" ]] || manager_source="${BASH_SOURCE[0]}"
-  mkdir -p "$(dirname -- "$manager_path")"
-  if [[ -e "$manager_path" ]]; then
-    if [[ "$manager_source" -ef "$manager_path" ]] || cmp -s "$manager_source" "$manager_path"; then
-      return 0
-    fi
-  fi
-  backup_file "$manager_path"
-  install -m 0755 "$manager_source" "$manager_path"
 }
 
 wait_for_url() {
@@ -730,48 +519,31 @@ setup() {
         domain="$2"
         shift 2
         ;;
-      --domain=*)
-        domain="${1#--domain=}"
-        shift
-        ;;
+      --domain=*) domain="${1#--domain=}"; shift ;;
       --public-port)
         (( $# >= 2 )) || die "--public-port requires a value."
         requested_port="$2"
         shift 2
         ;;
-      --public-port=*)
-        requested_port="${1#--public-port=}"
-        shift
-        ;;
+      --public-port=*) requested_port="${1#--public-port=}"; shift ;;
       --internal-port)
         (( $# >= 2 )) || die "--internal-port requires a value."
         requested_internal_port="$2"
         shift 2
         ;;
-      --internal-port=*)
-        requested_internal_port="${1#--internal-port=}"
-        shift
-        ;;
-      --yes|-y)
-        assume_yes="true"
-        shift
-        ;;
-      --help|-h)
-        usage
-        return 0
-        ;;
-      *)
-        die "Unknown setup option: $1. Use --domain, --public-port, --internal-port, or --yes."
-        ;;
+      --internal-port=*) requested_internal_port="${1#--internal-port=}"; shift ;;
+      --yes|-y) assume_yes="true"; shift ;;
+      --help|-h) usage; return 0 ;;
+      *) die "Unknown setup option: $1. Use --domain, --public-port, --internal-port, or --yes." ;;
     esac
   done
   require_linux
   require_root
   validate_install_paths
-  command -v systemctl >/dev/null 2>&1 || die "systemd is required."
+  require_commands
   if [[ "$assume_yes" != "true" ]]; then
     printf '\nLogseq Sync setup\n'
-    printf 'This wizard will configure Sync Node, Caddy, automatic HTTPS, and systemd.\n'
+    printf 'This wizard will configure a prebuilt Sync runtime, Caddy, automatic HTTPS, and systemd.\n'
     printf 'You only need a domain name, public HTTPS port, and private Sync port.\n\n'
   fi
   previous_url="$(read_env_value DB_SYNC_BASE_URL)"
@@ -787,7 +559,6 @@ setup() {
     domain="$(read_value 'Step 1/3 - Sync domain name' "$previous_domain")"
   fi
   valid_domain "$domain" || die "Enter a valid DNS domain name, not an IP address."
-  command -v getent >/dev/null 2>&1 || die "The getent command is required for DNS validation."
   resolved_ips="$(getent ahosts "$domain" \
     | awk '!seen[$1]++ {printf "%s%s", separator, $1; separator=", "}' || true)"
   [[ -n "$resolved_ips" ]] \
@@ -825,22 +596,23 @@ setup() {
     || die "Private Sync port must be between 1024 and 65535."
   [[ "$public_port" != "$internal_port" ]] \
     || die "Public HTTPS port and private Sync port must be different."
+  select_release_source
   public_url="https://${domain}:${public_port}"
   printf '\nDeployment plan:\n'
   printf '  DNS: %s -> %s\n' "$domain" "$resolved_ips"
   printf '  Public endpoint (enter in Logseq): %s\n' "$public_url"
   printf '  Public inbound TCP: 80 (certificate), %s (HTTPS/WSS)\n' "$public_port"
   printf '  Private adapter: 127.0.0.1:%s (local only, do not expose)\n' "$internal_port"
+  printf '  Runtime: prebuilt Linux %s package from %s (%s)\n' \
+    "$(architecture)" "$release_repository" "$release_tag"
   printf '  Data: %s\n' "$data_dir"
   printf '  Services: Sync Node + Caddy (systemd)\n\n'
-  confirm 'Build and start Logseq Sync?' yes || die "Setup cancelled."
-  ensure_dependencies
-  ensure_service_users
-  verify_service_node_runtime
-  build_adapter
+  confirm 'Download and start Logseq Sync?' yes || die "Setup cancelled."
+  ensure_runtime_components
   write_configuration "$domain"
   install_manager
-  start_services "$public_url" || die "Setup did not complete. Generated configuration and data were preserved."
+  start_services "$public_url" \
+    || die "Setup did not complete. Generated configuration and data were preserved."
   printf '\nLogseq Sync is ready. Enter this URL in Logseq → Settings → Advanced → Sync Server URL:\n'
   printf '  %s\n' "$public_url"
   printf 'Manage it later with: sudo %s status\n' "$manager_path"
@@ -851,15 +623,18 @@ update() {
   require_linux
   require_root
   validate_install_paths
+  require_commands
   [[ -f "$config_dir/sync.env" ]] || die "Run setup first."
-  ensure_dependencies
-  verify_service_node_runtime
+  select_release_source
+  ensure_service_users
   public_url="$(read_env_value DB_SYNC_BASE_URL)"
   previous_release="$(readlink "$install_root/current" 2>/dev/null || true)"
   [[ -n "$previous_release" && -d "$previous_release" ]] \
     || die "The current adapter release is missing. Run setup to repair it."
-  printf 'Building the current checkout and preserving configuration and data.\n'
-  build_adapter
+  printf 'Downloading the current prebuilt runtime; configuration and data will be preserved.\n'
+  install_runtime
+  install_caddy
+  verify_service_runtime
   install_manager
   systemctl restart "$sync_service"
   if ! wait_for_url "http://127.0.0.1:${internal_port}" 30 2; then
@@ -877,14 +652,16 @@ update() {
 }
 
 status() {
-  local public_url internal_body public_body
+  local public_url internal_body public_body runtime_version
   require_root
   validate_install_paths
   [[ -f "$config_dir/sync.env" ]] || die "No native deployment configuration found."
   public_url="$(read_env_value DB_SYNC_BASE_URL)"
+  runtime_version="$(<"$install_root/current/VERSION")"
   systemctl --no-pager --full status "$sync_service" "$proxy_service" || true
   internal_body="$(curl --fail --silent --max-time 3 "http://127.0.0.1:${internal_port}/health" 2>/dev/null || true)"
   public_body="$(curl --fail --silent --max-time 5 "$public_url/health" 2>/dev/null || true)"
+  printf 'Runtime version: %s\n' "$runtime_version"
   printf 'Sync Server URL: %s\n' "$public_url"
   [[ "$internal_body" == '{"ok":true}' ]] || die "The private Sync health check failed."
   [[ "$public_body" == '{"ok":true}' ]] || die "The public HTTPS health check failed."
@@ -918,18 +695,27 @@ Usage:
   sudo logseq-sync-native status
   sudo logseq-sync-native logs [--follow] [sync|proxy]
 
-The public HTTPS port defaults to 10010 when setup input is left blank. Port 80
-is used only for automatic certificate issuance and renewal. The Node adapter
-uses a separate loopback-only port managed by the installer.
+The server downloads a checksum-verified, prebuilt Linux x64 or arm64 runtime.
+It does not need system Node.js, Java, Clojure, pnpm, Python, or a compiler.
+
+Advanced release overrides:
+  LOGSEQ_SYNC_RELEASE_REPOSITORY=<owner/repository>
+  LOGSEQ_SYNC_RELEASE_TAG=<db-sync-native or versioned tag>
 EOF
 }
 
-case "${1:-help}" in
-  setup) shift; setup "$@" ;;
-  update) shift; update "$@" ;;
-  bootstrap) shift; bootstrap false "$@" ;;
-  status) shift; status "$@" ;;
-  logs) shift; logs "$@" ;;
-  help|-h|--help) usage ;;
-  *) usage; exit 1 ;;
-esac
+main() {
+  local command="${1:-help}"
+  (( $# > 0 )) && shift
+  case "$command" in
+    setup) setup "$@" ;;
+    update) update "$@" ;;
+    bootstrap) bootstrap "$@" ;;
+    status) status "$@" ;;
+    logs) logs "$@" ;;
+    help|--help|-h) usage ;;
+    *) usage >&2; die "Unknown command: $command" ;;
+  esac
+}
+
+main "$@"

--- a/deps/db-sync/deploy/logseq-sync-native
+++ b/deps/db-sync/deploy/logseq-sync-native
@@ -22,9 +22,12 @@ readonly default_cognito_jwks_url="${default_cognito_issuer}/.well-known/jwks.js
 configured_source_dir="$(sed -n 's/^LOGSEQ_SYNC_SOURCE_DIR=//p' "$config_dir/sync.env" 2>/dev/null || true)"
 configured_public_port="$(sed -n 's/^LOGSEQ_SYNC_PUBLIC_PORT=//p' "$config_dir/sync.env" 2>/dev/null || true)"
 configured_internal_port="$(sed -n 's/^LOGSEQ_SYNC_INTERNAL_PORT=//p' "$config_dir/sync.env" 2>/dev/null || true)"
+configured_node_path="${LOGSEQ_SYNC_NODE_PATH:-$(sed -n 's/^LOGSEQ_SYNC_NODE_PATH=//p' "$config_dir/sync.env" 2>/dev/null || true)}"
 public_port="${configured_public_port:-$default_public_port}"
 internal_port="${configured_internal_port:-$default_internal_port}"
 assume_yes="${LOGSEQ_SYNC_ASSUME_YES:-false}"
+node_path="$configured_node_path"
+npm_path=""
 if [[ -f "$checkout_source_dir/deps/db-sync/package.json" ]]; then
   readonly source_dir="$checkout_source_dir"
 else
@@ -167,6 +170,79 @@ caddy_architecture() {
   esac
 }
 
+node_version_supported() {
+  local candidate="$1"
+  local version major minor
+  [[ -x "$candidate" ]] || return 1
+  version="$("$candidate" --version 2>/dev/null || true)"
+  [[ "$version" =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+ ]] || return 1
+  major="${BASH_REMATCH[1]}"
+  minor="${BASH_REMATCH[2]}"
+  [[ "$major" == "24" ]] && return 0
+  [[ "$major" == "22" ]] && (( 10#$minor >= 12 ))
+}
+
+system_service_node_path() {
+  local candidate="$1"
+  [[ "$candidate" == /* && -x "$candidate" ]] || return 1
+  candidate="$(realpath "$candidate" 2>/dev/null || true)"
+  [[ -n "$candidate" && -x "$candidate" ]] || return 1
+  if [[ "${LOGSEQ_SYNC_TEST_MODE:-false}" != "true" ]]; then
+    case "$candidate" in
+      /home/*|/root/*|/run/user/*|/tmp/*|/var/tmp/*) return 1 ;;
+    esac
+  fi
+  printf '%s' "$candidate"
+}
+
+find_npm_for_node() {
+  local candidate="$1"
+  local node_dir npm_candidate
+  node_dir="$(dirname -- "$candidate")"
+  for npm_candidate in "$node_dir/npm" "$(command -v npm 2>/dev/null || true)"; do
+    [[ "$npm_candidate" == /* && -x "$npm_candidate" ]] || continue
+    if run_with_node "$candidate" "$npm_candidate" --version >/dev/null 2>&1; then
+      printf '%s' "$npm_candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_with_node() {
+  local runtime="$1"
+  local runtime_dir
+  shift
+  runtime_dir="$(dirname -- "$runtime")"
+  env PATH="$runtime_dir:$install_root/toolchain/bin:${PATH:-/usr/local/bin:/usr/bin:/bin}" "$@"
+}
+
+select_node_runtime() {
+  local candidate
+  npm_path=""
+  if [[ -n "$configured_node_path" ]]; then
+    node_version_supported "$configured_node_path" \
+      || die "Configured Node.js must be version 22.12 or newer in the 22.x line, or version 24.x: $configured_node_path"
+    node_path="$configured_node_path"
+    npm_path="$(find_npm_for_node "$node_path" || true)"
+    return 0
+  fi
+  candidate="$(command -v node 2>/dev/null || true)"
+  candidate="$(system_service_node_path "$candidate" || true)"
+  if [[ -n "$candidate" ]] && node_version_supported "$candidate"; then
+    node_path="$candidate"
+    npm_path="$(find_npm_for_node "$node_path" || true)"
+    return 0
+  fi
+  candidate="$install_root/toolchain/node/bin/node"
+  if node_version_supported "$candidate"; then
+    node_path="$candidate"
+    npm_path="$(find_npm_for_node "$node_path" || true)"
+    return 0
+  fi
+  node_path=""
+}
+
 os_release_value() {
   local key="$1"
   local os_release_file="${2:-/etc/os-release}"
@@ -307,7 +383,14 @@ install_node_toolchain() {
   mkdir -p "$install_root/toolchain/node"
   tar -xJf "$temp_dir/$archive" --strip-components=1 -C "$install_root/toolchain/node"
   rm -rf -- "$temp_dir"
-  "$install_root/toolchain/node/bin/npm" install --global \
+  node_path="$install_root/toolchain/node/bin/node"
+  npm_path="$install_root/toolchain/node/bin/npm"
+}
+
+install_pnpm() {
+  [[ -n "$npm_path" && -x "$npm_path" ]] \
+    || die "A compatible Node.js runtime was found, but its npm executable is unavailable."
+  run_with_node "$node_path" "$npm_path" install --global \
     --prefix "$install_root/toolchain" "pnpm@${pnpm_version}"
 }
 
@@ -342,7 +425,8 @@ dependencies_ready() {
     && command -v java >/dev/null 2>&1 \
     && command -v clojure >/dev/null 2>&1 \
     && clojure -Sdescribe >/dev/null 2>&1 \
-    && [[ -x "$install_root/toolchain/node/bin/node" ]] \
+    && [[ -n "$node_path" ]] \
+    && node_version_supported "$node_path" \
     && [[ -x "$install_root/toolchain/bin/pnpm" ]] \
     && [[ -x "$install_root/toolchain/bin/caddy" ]]
 }
@@ -353,14 +437,20 @@ bootstrap() {
   require_root
   validate_install_paths
   command -v systemctl >/dev/null 2>&1 || die "systemd is required."
-  printf 'The installer will add build tools, a private Node.js runtime, Clojure CLI, and Caddy.\n'
+  printf 'The installer will add build tools, Clojure CLI, and Caddy.\n'
+  printf 'A compatible system Node.js is reused; otherwise a private Node.js 24 runtime is installed.\n'
   if [[ "$skip_confirmation" != "true" ]]; then
     confirm 'Install missing dependencies automatically?' yes || die "Dependency installation cancelled."
   fi
   ensure_system_packages
-  if [[ ! -x "$install_root/toolchain/node/bin/node" \
-        || ! -x "$install_root/toolchain/bin/pnpm" ]]; then
+  select_node_runtime
+  if [[ -z "$node_path" \
+        || ( ! -x "$install_root/toolchain/bin/pnpm" && -z "$npm_path" ) ]]; then
     install_node_toolchain
+  fi
+  printf 'Using Node.js %s at %s.\n' "$("$node_path" --version)" "$node_path"
+  if [[ ! -x "$install_root/toolchain/bin/pnpm" ]]; then
+    install_pnpm
   fi
   if ! command -v clojure >/dev/null 2>&1 || ! clojure -Sdescribe >/dev/null 2>&1; then
     install_clojure_cli
@@ -373,6 +463,7 @@ bootstrap() {
 }
 
 ensure_dependencies() {
+  select_node_runtime
   if dependencies_ready; then
     return 0
   fi
@@ -396,6 +487,12 @@ ensure_service_users() {
     useradd --system --gid caddy --home-dir "$caddy_data_dir" --no-create-home \
       --shell /usr/sbin/nologin caddy
   fi
+}
+
+verify_service_node_runtime() {
+  [[ "${LOGSEQ_SYNC_TEST_MODE:-false}" == "true" ]] && return 0
+  runuser -u logseq-sync -- "$node_path" --version >/dev/null 2>&1 \
+    || die "The selected Node.js runtime is not executable by the logseq-sync service user: $node_path"
 }
 
 builder_identity() {
@@ -430,13 +527,14 @@ replace_current_release() {
 }
 
 build_adapter() {
-  local build_root builder builder_home release_id release_dir suffix=0
+  local build_root builder builder_home node_dir release_id release_dir suffix=0
   build_root="$(mktemp -d /tmp/logseq-sync-build.XXXXXX)"
   register_temporary_path "$build_root"
   [[ -f "$source_dir/deps/db-sync/package.json" ]] \
     || die "The configured Logseq source checkout is unavailable: $source_dir"
   builder="$(builder_identity)"
   builder_home="$(getent passwd "$builder" | cut -d: -f6)"
+  node_dir="$(dirname -- "$node_path")"
   mkdir -p "$build_root/deps/db-sync"
   cp -a "$source_dir/deps/common" "$build_root/deps/common"
   cp -a "$source_dir/deps/db" "$build_root/deps/db"
@@ -452,12 +550,12 @@ build_adapter() {
   set_owner -R "$builder" "$build_root"
   run_as_builder "$builder" env \
     HOME="$builder_home" \
-    PATH="$install_root/toolchain/node/bin:$install_root/toolchain/bin:/usr/local/bin:/usr/bin:/bin" \
+    PATH="$node_dir:$install_root/toolchain/bin:/usr/local/bin:/usr/bin:/bin" \
     "$install_root/toolchain/bin/pnpm" --dir "$build_root/deps/db-sync" \
     install --frozen-lockfile --prod
   run_as_builder "$builder" env \
     HOME="$builder_home" \
-    PATH="$install_root/toolchain/node/bin:$install_root/toolchain/bin:/usr/local/bin:/usr/bin:/bin" \
+    PATH="$node_dir:$install_root/toolchain/bin:/usr/local/bin:/usr/bin:/bin" \
     "$install_root/toolchain/bin/pnpm" --dir "$build_root/deps/db-sync" \
     build:node-adapter
   release_id="$(git -C "$source_dir" rev-parse --short=12 HEAD 2>/dev/null || date +%Y%m%d%H%M%S)"
@@ -490,6 +588,7 @@ write_configuration() {
 LOGSEQ_SYNC_SOURCE_DIR=${source_dir}
 LOGSEQ_SYNC_PUBLIC_PORT=${public_port}
 LOGSEQ_SYNC_INTERNAL_PORT=${internal_port}
+LOGSEQ_SYNC_NODE_PATH=${node_path}
 DB_SYNC_HOST=127.0.0.1
 DB_SYNC_PORT=${internal_port}
 DB_SYNC_BASE_URL=${public_url}
@@ -524,7 +623,7 @@ User=logseq-sync
 Group=logseq-sync
 WorkingDirectory=${install_root}/current
 EnvironmentFile=${config_dir}/sync.env
-ExecStart=${install_root}/toolchain/node/bin/node ${install_root}/current/node-adapter.js
+ExecStart=${node_path} ${install_root}/current/node-adapter.js
 Restart=on-failure
 RestartSec=5s
 NoNewPrivileges=true
@@ -737,6 +836,7 @@ setup() {
   confirm 'Build and start Logseq Sync?' yes || die "Setup cancelled."
   ensure_dependencies
   ensure_service_users
+  verify_service_node_runtime
   build_adapter
   write_configuration "$domain"
   install_manager
@@ -753,6 +853,7 @@ update() {
   validate_install_paths
   [[ -f "$config_dir/sync.env" ]] || die "Run setup first."
   ensure_dependencies
+  verify_service_node_runtime
   public_url="$(read_env_value DB_SYNC_BASE_URL)"
   previous_release="$(readlink "$install_root/current" 2>/dev/null || true)"
   [[ -n "$previous_release" && -d "$previous_release" ]] \

--- a/deps/db-sync/deploy/logseq-sync-native
+++ b/deps/db-sync/deploy/logseq-sync-native
@@ -3,12 +3,21 @@ set -euo pipefail
 
 readonly script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 readonly checkout_root="$(cd -- "$script_dir/../../.." 2>/dev/null && pwd || true)"
-readonly install_root="${LOGSEQ_SYNC_INSTALL_ROOT:-/opt/logseq-sync}"
-readonly config_dir="${LOGSEQ_SYNC_CONFIG_DIR:-/etc/logseq-sync}"
-readonly data_dir="${LOGSEQ_SYNC_DATA_DIR:-/var/lib/logseq-sync}"
+resolved_script_path="$(readlink -f -- "${BASH_SOURCE[0]}" 2>/dev/null || true)"
+inferred_home=""
+if [[ "$resolved_script_path" == */bin/logseq-sync-native ]]; then
+  inferred_home="${resolved_script_path%/bin/logseq-sync-native}"
+fi
+readonly sync_home="${LOGSEQ_SYNC_HOME:-${inferred_home:-/opt/logseq-sync}}"
+readonly install_root="$sync_home"
+readonly bin_dir="$sync_home/bin"
+readonly config_dir="$sync_home/config"
+readonly data_dir="$sync_home/data"
 readonly systemd_dir="${LOGSEQ_SYNC_SYSTEMD_DIR:-/etc/systemd/system}"
-readonly caddy_data_dir="${LOGSEQ_SYNC_CADDY_DATA_DIR:-/var/lib/logseq-sync-caddy}"
+readonly caddy_data_dir="$sync_home/caddy-data"
 readonly manager_path="${LOGSEQ_SYNC_MANAGER_PATH:-/usr/local/bin/logseq-sync-native}"
+readonly canonical_manager_path="$bin_dir/logseq-sync-native"
+readonly caddy_path="$bin_dir/caddy"
 readonly sync_service="logseq-sync.service"
 readonly proxy_service="logseq-sync-caddy.service"
 readonly default_public_port="10010"
@@ -76,7 +85,7 @@ require_commands() {
 
 validate_install_paths() {
   local path
-  for path in "$install_root" "$config_dir" "$data_dir" "$systemd_dir" \
+  for path in "$sync_home" "$bin_dir" "$config_dir" "$data_dir" "$systemd_dir" \
     "$caddy_data_dir" "$manager_path"; do
     [[ "$path" == /* && "$path" != "/" && "$path" != "/opt" \
        && "$path" != "/etc" && "$path" != "/var" && "$path" != "/var/lib" \
@@ -141,7 +150,7 @@ read_env_value() {
 backup_file() {
   local path="$1"
   local timestamp backup suffix=0
-  [[ -e "$path" ]] || return 0
+  [[ -e "$path" || -L "$path" ]] || return 0
   timestamp="$(date +%Y%m%d%H%M%S)"
   backup="${path}.backup-${timestamp}"
   while [[ -e "$backup" ]]; do
@@ -316,15 +325,15 @@ install_runtime() {
 
 install_caddy() {
   local temp_file
-  [[ -x "$install_root/toolchain/bin/caddy" ]] && return 0
+  [[ -x "$caddy_path" ]] && return 0
   temp_file="$(mktemp /tmp/logseq-sync-caddy.XXXXXX)"
   register_temporary_path "$temp_file"
   printf 'Downloading Caddy for automatic HTTPS.\n'
   curl --fail --location --show-error \
     "https://caddyserver.com/api/download?os=linux&arch=$(caddy_architecture)" \
     -o "$temp_file"
-  mkdir -p "$install_root/toolchain/bin"
-  install -m 0755 "$temp_file" "$install_root/toolchain/bin/caddy"
+  mkdir -p "$bin_dir"
+  install -m 0755 "$temp_file" "$caddy_path"
   rm -f -- "$temp_file"
 }
 
@@ -337,14 +346,24 @@ verify_service_runtime() {
 install_manager() {
   local manager_source="$install_root/current/bin/logseq-sync-native"
   [[ -f "$manager_source" ]] || manager_source="${BASH_SOURCE[0]}"
-  mkdir -p "$(dirname -- "$manager_path")"
-  if [[ -e "$manager_path" ]]; then
-    if [[ "$manager_source" -ef "$manager_path" ]] || cmp -s "$manager_source" "$manager_path"; then
-      return 0
-    fi
+  mkdir -p "$bin_dir" "$(dirname -- "$manager_path")"
+  if [[ ! -e "$canonical_manager_path" ]] \
+    || ! cmp -s "$manager_source" "$canonical_manager_path"; then
+    backup_file "$canonical_manager_path"
+    install -m 0755 "$manager_source" "$canonical_manager_path"
+  fi
+  if [[ "$manager_path" == "$canonical_manager_path" ]]; then
+    return 0
+  fi
+  if [[ -L "$manager_path" \
+     && "$(readlink -f -- "$manager_path" 2>/dev/null || true)" == "$canonical_manager_path" ]]; then
+    return 0
   fi
   backup_file "$manager_path"
-  install -m 0755 "$manager_source" "$manager_path"
+  if [[ -e "$manager_path" || -L "$manager_path" ]]; then
+    unlink "$manager_path"
+  fi
+  ln -s "$canonical_manager_path" "$manager_path"
 }
 
 bootstrap() {
@@ -394,6 +413,7 @@ write_configuration() {
 LOGSEQ_SYNC_RELEASE_REPOSITORY=${release_repository}
 LOGSEQ_SYNC_RELEASE_TAG=${release_tag}
 LOGSEQ_SYNC_RUNTIME_SHA256=${runtime_sha256}
+LOGSEQ_SYNC_HOME=${sync_home}
 LOGSEQ_SYNC_PUBLIC_PORT=${public_port}
 LOGSEQ_SYNC_INTERNAL_PORT=${internal_port}
 DB_SYNC_HOST=127.0.0.1
@@ -454,8 +474,8 @@ User=caddy
 Group=caddy
 Environment=XDG_DATA_HOME=${caddy_data_dir}
 Environment=XDG_CONFIG_HOME=${caddy_data_dir}
-ExecStart=${install_root}/toolchain/bin/caddy run --environ --config ${config_dir}/Caddyfile
-ExecReload=${install_root}/toolchain/bin/caddy reload --config ${config_dir}/Caddyfile --force
+ExecStart=${caddy_path} run --environ --config ${config_dir}/Caddyfile
+ExecReload=${caddy_path} reload --config ${config_dir}/Caddyfile --force
 TimeoutStopSec=5s
 LimitNOFILE=1048576
 AmbientCapabilities=CAP_NET_BIND_SERVICE
@@ -490,7 +510,7 @@ wait_for_url() {
 
 start_services() {
   local public_url="$1"
-  if ! "$install_root/toolchain/bin/caddy" validate --config "$config_dir/Caddyfile"; then
+  if ! "$caddy_path" validate --config "$config_dir/Caddyfile"; then
     printf 'Caddy configuration validation failed.\n' >&2
     return 1
   fi
@@ -610,6 +630,7 @@ setup() {
   printf '  Private adapter: 127.0.0.1:%s (local only, do not expose)\n' "$internal_port"
   printf '  Runtime: prebuilt Linux %s package from %s (%s)\n' \
     "$(architecture)" "$release_repository" "$release_tag"
+  printf '  Home: %s\n' "$sync_home"
   printf '  Data: %s\n' "$data_dir"
   printf '  Services: Sync Node + Caddy (systemd)\n\n'
   confirm 'Download and start Logseq Sync?' yes || die "Setup cancelled."
@@ -706,6 +727,9 @@ It does not need system Node.js, Java, Clojure, pnpm, Python, or a compiler.
 Advanced release overrides:
   LOGSEQ_SYNC_RELEASE_REPOSITORY=<owner/repository>
   LOGSEQ_SYNC_RELEASE_TAG=<db-sync-native or versioned tag>
+
+Advanced install location override (first setup only):
+  LOGSEQ_SYNC_HOME=/srv/logseq-sync
 EOF
 }
 

--- a/deps/db-sync/deploy/logseq-sync-native
+++ b/deps/db-sync/deploy/logseq-sync-native
@@ -235,7 +235,9 @@ runtime_ready() {
      && -f "$install_root/current/VERSION" \
      && -f "$install_root/current/ARCHITECTURE" ]] \
     && [[ "$(<"$install_root/current/ARCHITECTURE")" == "$(architecture)" ]] \
-    && "$install_root/current/node/bin/node" --version >/dev/null 2>&1
+    && "$install_root/current/node/bin/node" --version >/dev/null 2>&1 \
+    && (cd "$install_root/current/app" \
+      && ../node/bin/node -e 'require("better-sqlite3")' >/dev/null 2>&1)
 }
 
 download_file() {
@@ -294,6 +296,9 @@ install_runtime() {
     || die "The downloaded Sync runtime architecture does not match this server."
   "$extracted_dir/node/bin/node" --version >/dev/null 2>&1 \
     || die "The bundled Node.js runtime cannot run on this server."
+  (cd "$extracted_dir/app" \
+    && ../node/bin/node -e 'require("better-sqlite3")' >/dev/null 2>&1) \
+    || die "The bundled SQLite module cannot run on this server. GLIBC 2.29 or newer is required."
   version="$(<"$extracted_dir/VERSION")"
   [[ "$version" =~ ^[A-Za-z0-9._+-]+$ ]] || die "The runtime version is invalid."
   release_id="${version}-${runtime_arch}-${actual_checksum:0:12}"

--- a/deps/db-sync/deploy/logseq-sync-native
+++ b/deps/db-sync/deploy/logseq-sync-native
@@ -20,7 +20,7 @@ readonly canonical_manager_path="$bin_dir/logseq-sync-native"
 readonly caddy_path="$bin_dir/caddy"
 readonly sync_service="logseq-sync.service"
 readonly proxy_service="logseq-sync-caddy.service"
-readonly default_public_port="10010"
+readonly default_public_port="443"
 readonly default_internal_port="10011"
 readonly default_release_repository="logseq/logseq"
 readonly default_release_tag="db-sync-native"
@@ -139,6 +139,16 @@ valid_port() {
 valid_domain() {
   [[ ${#1} -le 253 \
      && "$1" =~ ^([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}$ ]]
+}
+
+https_url() {
+  local domain="$1"
+  local port="$2"
+  if [[ "$port" == "443" ]]; then
+    printf 'https://%s' "$domain"
+  else
+    printf 'https://%s:%s' "$domain" "$port"
+  fi
 }
 
 read_env_value() {
@@ -399,7 +409,8 @@ ensure_runtime_components() {
 
 write_configuration() {
   local domain="$1"
-  local public_url="https://${domain}:${public_port}"
+  local public_url
+  public_url="$(https_url "$domain" "$public_port")"
   mkdir -p "$config_dir" "$data_dir" "$caddy_data_dir" "$systemd_dir"
   set_owner -R logseq-sync:logseq-sync "$data_dir"
   set_owner caddy:caddy "$caddy_data_dir"
@@ -429,7 +440,7 @@ COGNITO_JWKS_URL=${default_cognito_jwks_url}
 "
   set_owner root:logseq-sync "$config_dir/sync.env"
   chmod 0640 "$config_dir/sync.env"
-  printf '%s\n' "https://${domain}:${public_port} {" \
+  printf '%s\n' "${public_url} {" \
     $'\t'"reverse_proxy 127.0.0.1:${internal_port}" \
     $'\ttls {' \
     $'\t\tissuer acme {' \
@@ -582,9 +593,9 @@ setup() {
     printf 'You only need a domain name, public HTTPS port, and private Sync port.\n\n'
   fi
   previous_url="$(read_env_value DB_SYNC_BASE_URL)"
-  if [[ "$previous_url" =~ ^https://([^:/]+):([0-9]+)$ ]]; then
+  if [[ "$previous_url" =~ ^https://([^:/]+)(:([0-9]+))?$ ]]; then
     previous_domain="${BASH_REMATCH[1]}"
-    previous_port="${BASH_REMATCH[2]}"
+    previous_port="${BASH_REMATCH[3]:-443}"
   fi
   if [[ -z "$domain" ]]; then
     printf 'Domain requirements:\n'
@@ -632,7 +643,7 @@ setup() {
   [[ "$public_port" != "$internal_port" ]] \
     || die "Public HTTPS port and private Sync port must be different."
   select_release_source
-  public_url="https://${domain}:${public_port}"
+  public_url="$(https_url "$domain" "$public_port")"
   printf '\nDeployment plan:\n'
   printf '  DNS: %s -> %s\n' "$domain" "$resolved_ips"
   printf '  Public endpoint (enter in Logseq): %s\n' "$public_url"

--- a/deps/db-sync/deploy/native-test.sh
+++ b/deps/db-sync/deploy/native-test.sh
@@ -68,6 +68,15 @@ EOF
   cat > "$sandbox/bin/curl" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$MOCK_CURL_LOG"
+curl_call_count=0
+if [[ -f "$MOCK_CURL_COUNT_FILE" ]]; then
+  curl_call_count="$(<"$MOCK_CURL_COUNT_FILE")"
+fi
+curl_call_count=$((curl_call_count + 1))
+printf '%s\n' "$curl_call_count" > "$MOCK_CURL_COUNT_FILE"
+if (( curl_call_count <= MOCK_CURL_FAILURES )); then
+  exit 22
+fi
 printf '%s' '{"ok":true}'
 EOF
 
@@ -109,6 +118,8 @@ run_manager() {
     LOGSEQ_SYNC_RUNTIME_ARCHIVE="$sandbox/logseq-sync-runtime-linux-x64.tar.gz" \
     LOGSEQ_SYNC_RUNTIME_CHECKSUM="$sandbox/logseq-sync-runtime-linux-x64.tar.gz.sha256" \
     MOCK_CURL_LOG="$sandbox/curl.log" \
+    MOCK_CURL_COUNT_FILE="$sandbox/curl-count" \
+    MOCK_CURL_FAILURES="${MOCK_CURL_FAILURES:-0}" \
     MOCK_SYSTEMCTL_LOG="$sandbox/systemctl.log" \
     MOCK_JOURNAL_LOG="$sandbox/journal.log" \
     MOCK_CADDY_LOG="$sandbox/caddy.log" \
@@ -173,7 +184,24 @@ test_setup_uses_prebuilt_runtime_and_default_ports() {
   [[ -L "$sandbox/bin/logseq-sync-native-installed" ]] || return 1
   assert_not_contains "$env_file" 'LOGSEQ_SYNC_NODE_PATH=' || return 1
   assert_not_contains "$last_output" 'Clojure' || return 1
-  assert_contains "$last_output" 'Installed Sync runtime runtime-v1 with bundled v24.0.0'
+  assert_contains "$last_output" 'Installed Sync runtime runtime-v1 with bundled v24.0.0' || return 1
+  assert_contains "$last_output" 'Starting Sync Node on 127.0.0.1:10011.' || return 1
+  assert_contains "$last_output" \
+    'Waiting for the private Sync health check at 127.0.0.1:10011 ready.' || return 1
+  assert_contains "$last_output" 'Starting Caddy on public HTTPS port 10010.' || return 1
+  assert_contains "$last_output" \
+    'Caddy will obtain or renew the TLS certificate automatically; this can take a few minutes.' || return 1
+  assert_contains "$last_output" \
+    'Waiting for the public HTTPS health check at https://sync.example.com:10010 ready.'
+}
+
+test_setup_prints_progress_during_health_retries() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  MOCK_CURL_FAILURES=1 run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  assert_contains "$last_output" \
+    'Waiting for the private Sync health check at 127.0.0.1:10011. ready.'
 }
 
 test_setup_ignores_broken_system_node_and_build_tools() {
@@ -375,6 +403,7 @@ run_test() {
 }
 
 run_test test_setup_uses_prebuilt_runtime_and_default_ports
+run_test test_setup_prints_progress_during_health_retries
 run_test test_setup_ignores_broken_system_node_and_build_tools
 run_test test_setup_does_not_invoke_os_package_manager
 run_test test_setup_rejects_bad_runtime_checksum

--- a/deps/db-sync/deploy/native-test.sh
+++ b/deps/db-sync/deploy/native-test.sh
@@ -44,7 +44,7 @@ EOF
 make_sandbox() {
   local sandbox
   sandbox="$(mktemp -d "$suite_tmp/case.XXXXXX")"
-  mkdir -p "$sandbox/bin" "$sandbox/install/toolchain/bin"
+  mkdir -p "$sandbox/bin" "$sandbox/home/bin"
 
   cat > "$sandbox/bin/uname" <<'EOF'
 #!/usr/bin/env bash
@@ -83,13 +83,13 @@ printf '%s\n' "$*" >> "$MOCK_JOURNAL_LOG"
 exit 0
 EOF
 
-  cat > "$sandbox/install/toolchain/bin/caddy" <<'EOF'
+  cat > "$sandbox/home/bin/caddy" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$MOCK_CADDY_LOG"
 exit 0
 EOF
 
-  chmod +x "$sandbox/bin/"* "$sandbox/install/toolchain/bin/caddy"
+  chmod +x "$sandbox/bin/"* "$sandbox/home/bin/caddy"
   make_runtime_fixture "$sandbox"
   printf '%s' "$sandbox"
 }
@@ -102,11 +102,8 @@ run_manager() {
     PATH="$sandbox/bin:$PATH" \
     LOGSEQ_SYNC_TEST_MODE=true \
     LOGSEQ_SYNC_ASSUME_YES="${MOCK_ASSUME_YES:-true}" \
-    LOGSEQ_SYNC_INSTALL_ROOT="$sandbox/install" \
-    LOGSEQ_SYNC_CONFIG_DIR="$sandbox/config" \
-    LOGSEQ_SYNC_DATA_DIR="$sandbox/data" \
+    LOGSEQ_SYNC_HOME="${MOCK_SYNC_HOME-$sandbox/home}" \
     LOGSEQ_SYNC_SYSTEMD_DIR="$sandbox/systemd" \
-    LOGSEQ_SYNC_CADDY_DATA_DIR="$sandbox/caddy-data" \
     LOGSEQ_SYNC_MANAGER_PATH="$sandbox/bin/logseq-sync-native-installed" \
     LOGSEQ_SYNC_RELEASE_REPOSITORY="example/logseq" \
     LOGSEQ_SYNC_RUNTIME_ARCHIVE="$sandbox/logseq-sync-runtime-linux-x64.tar.gz" \
@@ -156,17 +153,24 @@ assert_failure() {
 }
 
 test_setup_uses_prebuilt_runtime_and_default_ports() {
-  local sandbox env_file service_file
+  local sandbox env_file service_file proxy_service_file
   sandbox="$(make_sandbox)"
   run_manager "$sandbox" setup --domain sync.example.com
   assert_success || return 1
-  env_file="$(<"$sandbox/config/sync.env")"
+  env_file="$(<"$sandbox/home/config/sync.env")"
   service_file="$(<"$sandbox/systemd/logseq-sync.service")"
+  proxy_service_file="$(<"$sandbox/systemd/logseq-sync-caddy.service")"
   assert_contains "$env_file" 'DB_SYNC_BASE_URL=https://sync.example.com:10010' || return 1
   assert_contains "$env_file" 'LOGSEQ_SYNC_INTERNAL_PORT=10011' || return 1
   assert_contains "$env_file" 'LOGSEQ_SYNC_RELEASE_REPOSITORY=example/logseq' || return 1
+  assert_contains "$env_file" "LOGSEQ_SYNC_HOME=$sandbox/home" || return 1
+  assert_contains "$env_file" "DB_SYNC_DATA_DIR=$sandbox/home/data" || return 1
   assert_contains "$service_file" \
-    "ExecStart=$sandbox/install/current/node/bin/node $sandbox/install/current/app/node-adapter.js" || return 1
+    "ExecStart=$sandbox/home/current/node/bin/node $sandbox/home/current/app/node-adapter.js" || return 1
+  assert_contains "$proxy_service_file" \
+    "ExecStart=$sandbox/home/bin/caddy run" || return 1
+  [[ -x "$sandbox/home/bin/logseq-sync-native" ]] || return 1
+  [[ -L "$sandbox/bin/logseq-sync-native-installed" ]] || return 1
   assert_not_contains "$env_file" 'LOGSEQ_SYNC_NODE_PATH=' || return 1
   assert_not_contains "$last_output" 'Clojure' || return 1
   assert_contains "$last_output" 'Installed Sync runtime runtime-v1 with bundled v24.0.0'
@@ -240,7 +244,7 @@ test_setup_rejects_incompatible_sqlite_runtime() {
   sandbox="$(make_sandbox)"
   MOCK_SQLITE_STATUS=1 run_manager "$sandbox" setup --domain sync.example.com
   assert_failure || return 1
-  [[ ! -e "$sandbox/config" ]] || return 1
+  [[ ! -e "$sandbox/home/config" ]] || return 1
   assert_contains "$last_output" 'SQLite module cannot run on this server'
 }
 
@@ -263,10 +267,10 @@ test_setup_accepts_custom_ports() {
   run_manager "$sandbox" setup --domain sync.example.com \
     --public-port 12000 --internal-port 13000
   assert_success || return 1
-  assert_contains "$(<"$sandbox/config/sync.env")" 'DB_SYNC_PORT=13000' || return 1
-  assert_contains "$(<"$sandbox/config/Caddyfile")" \
+  assert_contains "$(<"$sandbox/home/config/sync.env")" 'DB_SYNC_PORT=13000' || return 1
+  assert_contains "$(<"$sandbox/home/config/Caddyfile")" \
     'https://sync.example.com:12000 {' || return 1
-  assert_contains "$(<"$sandbox/config/Caddyfile")" \
+  assert_contains "$(<"$sandbox/home/config/Caddyfile")" \
     'reverse_proxy 127.0.0.1:13000'
 }
 
@@ -275,7 +279,7 @@ test_public_port_never_collides_with_private_port() {
   sandbox="$(make_sandbox)"
   run_manager "$sandbox" setup --domain sync.example.com --public-port 10011
   assert_success || return 1
-  assert_contains "$(<"$sandbox/config/sync.env")" 'LOGSEQ_SYNC_INTERNAL_PORT=10012'
+  assert_contains "$(<"$sandbox/home/config/sync.env")" 'LOGSEQ_SYNC_INTERNAL_PORT=10012'
 }
 
 test_setup_rejects_invalid_port_and_domain_inputs() {
@@ -298,8 +302,8 @@ test_unresolved_domain_stops_before_install() {
   sandbox="$(make_sandbox)"
   MOCK_DNS_STATUS=1 run_manager "$sandbox" setup --domain sync.example.com
   assert_failure || return 1
-  [[ ! -e "$sandbox/config" ]] || return 1
-  [[ ! -e "$sandbox/install/current" ]] || return 1
+  [[ ! -e "$sandbox/home/config" ]] || return 1
+  [[ ! -e "$sandbox/home/current" ]] || return 1
   assert_contains "$last_output" 'domain does not currently resolve'
 }
 
@@ -308,7 +312,7 @@ test_default_auth_is_generated_without_prompts() {
   sandbox="$(make_sandbox)"
   run_manager "$sandbox" setup --domain sync.example.com
   assert_success || return 1
-  env_file="$(<"$sandbox/config/sync.env")"
+  env_file="$(<"$sandbox/home/config/sync.env")"
   assert_contains "$env_file" \
     'COGNITO_ISSUER=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8' || return 1
   assert_contains "$env_file" 'COGNITO_CLIENT_ID=69cs1lgme7p8kbgld8n5kseii6'
@@ -333,14 +337,14 @@ test_update_preserves_configuration_and_switches_release() {
   sandbox="$(make_sandbox)"
   run_manager "$sandbox" setup --domain sync.example.com
   assert_success || return 1
-  before_env="$(<"$sandbox/config/sync.env")"
-  before_release="$(readlink "$sandbox/install/current")"
+  before_env="$(<"$sandbox/home/config/sync.env")"
+  before_release="$(readlink "$sandbox/home/current")"
   make_runtime_fixture "$sandbox" runtime-v2
   run_manager "$sandbox" update
   assert_success || return 1
-  after_release="$(readlink "$sandbox/install/current")"
+  after_release="$(readlink "$sandbox/home/current")"
   [[ "$before_release" != "$after_release" ]] || return 1
-  [[ "$before_env" == "$(<"$sandbox/config/sync.env")" ]] || return 1
+  [[ "$before_env" == "$(<"$sandbox/home/config/sync.env")" ]] || return 1
   assert_contains "$last_output" 'Installed Sync runtime runtime-v2' || return 1
   assert_contains "$last_output" 'was updated successfully'
 }
@@ -353,7 +357,7 @@ test_installed_manager_can_rerun_setup() {
   installed_manager="$sandbox/bin/logseq-sync-native-installed"
   [[ -x "$installed_manager" ]] || return 1
   manager_under_test="$installed_manager"
-  run_manager "$sandbox" setup --domain sync.example.com
+  MOCK_SYNC_HOME="" run_manager "$sandbox" setup --domain sync.example.com
   manager_under_test="$manager"
   assert_success || return 1
   assert_contains "$last_output" 'https://sync.example.com:12000'

--- a/deps/db-sync/deploy/native-test.sh
+++ b/deps/db-sync/deploy/native-test.sh
@@ -171,7 +171,10 @@ test_setup_uses_prebuilt_runtime_and_default_ports() {
   env_file="$(<"$sandbox/home/config/sync.env")"
   service_file="$(<"$sandbox/systemd/logseq-sync.service")"
   proxy_service_file="$(<"$sandbox/systemd/logseq-sync-caddy.service")"
-  assert_contains "$env_file" 'DB_SYNC_BASE_URL=https://sync.example.com:10010' || return 1
+  assert_contains "$env_file" 'DB_SYNC_BASE_URL=https://sync.example.com' || return 1
+  assert_contains "$env_file" 'LOGSEQ_SYNC_PUBLIC_PORT=443' || return 1
+  assert_contains "$(<"$sandbox/home/config/Caddyfile")" \
+    'https://sync.example.com {' || return 1
   assert_contains "$env_file" 'LOGSEQ_SYNC_INTERNAL_PORT=10011' || return 1
   assert_contains "$env_file" 'LOGSEQ_SYNC_RELEASE_REPOSITORY=example/logseq' || return 1
   assert_contains "$env_file" "LOGSEQ_SYNC_HOME=$sandbox/home" || return 1
@@ -188,11 +191,11 @@ test_setup_uses_prebuilt_runtime_and_default_ports() {
   assert_contains "$last_output" 'Starting Sync Node on 127.0.0.1:10011.' || return 1
   assert_contains "$last_output" \
     'Waiting for the private Sync health check at 127.0.0.1:10011 ready.' || return 1
-  assert_contains "$last_output" 'Starting Caddy on public HTTPS port 10010.' || return 1
+  assert_contains "$last_output" 'Starting Caddy on public HTTPS port 443.' || return 1
   assert_contains "$last_output" \
     'Caddy will obtain or renew the TLS certificate automatically; this can take a few minutes.' || return 1
   assert_contains "$last_output" \
-    'Waiting for the public HTTPS health check at https://sync.example.com:10010 ready.'
+    'Waiting for the public HTTPS health check at https://sync.example.com ready.'
 }
 
 test_setup_prints_progress_during_health_retries() {
@@ -284,9 +287,23 @@ test_setup_without_options_runs_guided_wizard() {
   assert_success || return 1
   assert_contains "$last_output" 'Logseq Sync setup' || return 1
   assert_contains "$last_output" 'Step 1/3 - Sync domain name' || return 1
-  assert_contains "$last_output" 'Step 2/3 - Public HTTPS port [10010]' || return 1
+  assert_contains "$last_output" 'Step 2/3 - Public HTTPS port [443]' || return 1
   assert_contains "$last_output" 'Step 3/3 - Private Sync port [10011]' || return 1
   assert_contains "$last_output" 'Runtime: prebuilt Linux x64 package'
+}
+
+test_guided_setup_accepts_custom_public_port() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  MOCK_ASSUME_YES=false MOCK_MANAGER_INPUT=$'sync.example.com\n10010\n\n\n' \
+    run_manager "$sandbox" setup
+  assert_success || return 1
+  assert_contains "$(<"$sandbox/home/config/sync.env")" \
+    'DB_SYNC_BASE_URL=https://sync.example.com:10010' || return 1
+  assert_contains "$(<"$sandbox/home/config/sync.env")" \
+    'LOGSEQ_SYNC_PUBLIC_PORT=10010' || return 1
+  assert_contains "$(<"$sandbox/home/config/Caddyfile")" \
+    'https://sync.example.com:10010 {'
 }
 
 test_setup_accepts_custom_ports() {
@@ -410,6 +427,7 @@ run_test test_setup_rejects_bad_runtime_checksum
 run_test test_setup_rejects_wrong_runtime_architecture
 run_test test_setup_rejects_incompatible_sqlite_runtime
 run_test test_setup_without_options_runs_guided_wizard
+run_test test_guided_setup_accepts_custom_public_port
 run_test test_setup_accepts_custom_ports
 run_test test_public_port_never_collides_with_private_port
 run_test test_setup_rejects_invalid_port_and_domain_inputs

--- a/deps/db-sync/deploy/native-test.sh
+++ b/deps/db-sync/deploy/native-test.sh
@@ -76,6 +76,9 @@ EOF
 
   cat > "$sandbox/install/toolchain/node/bin/node" <<'EOF'
 #!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'v24.0.0\n'
+fi
 exit 0
 EOF
 
@@ -127,6 +130,7 @@ run_manager() {
     LOGSEQ_SYNC_SYSTEMD_DIR="$sandbox/systemd" \
     LOGSEQ_SYNC_CADDY_DATA_DIR="$sandbox/caddy-data" \
     LOGSEQ_SYNC_MANAGER_PATH="$sandbox/bin/logseq-sync-native-installed" \
+    LOGSEQ_SYNC_NODE_PATH="${MOCK_NODE_PATH-$sandbox/install/toolchain/node/bin/node}" \
     MOCK_CURL_LOG="$sandbox/curl.log" \
     MOCK_SYSTEMCTL_LOG="$sandbox/systemctl.log" \
     MOCK_JOURNAL_LOG="$sandbox/journal.log" \
@@ -235,6 +239,108 @@ test_opencloudos_falls_back_to_kona_17() {
   assert_contains "$package_log" '-q list --available java-21-openjdk-headless' || return 1
   assert_contains "$package_log" '-q list --available java-17-konajdk' || return 1
   assert_contains "$package_log" 'java-17-konajdk'
+}
+
+test_selected_node_is_available_to_bundled_npm() {
+  local sandbox node_path npm_path
+  sandbox="$(make_sandbox)"
+  node_path="$sandbox/install/toolchain/node/bin/node"
+  npm_path="$sandbox/install/toolchain/node/bin/npm"
+  cat > "$node_path" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_PRIVATE_NODE_LOG"
+EOF
+  cat > "$npm_path" <<'EOF'
+#!/usr/bin/env node
+EOF
+  chmod +x "$node_path" "$npm_path"
+  set +e
+  last_output="$(
+    LOGSEQ_SYNC_INSTALL_ROOT="$sandbox/install" \
+    MOCK_PRIVATE_NODE_LOG="$sandbox/private-node.log" \
+    PATH="/usr/bin:/bin" \
+      bash -c 'source "$1" help >/dev/null; run_with_node "$2" "$3" install' \
+        bash "$manager" "$node_path" "$npm_path" 2>&1
+  )"
+  last_status=$?
+  set -e
+  assert_success || return 1
+  [[ -f "$sandbox/private-node.log" ]] || {
+    printf 'Expected bundled npm to run with the private Node.js binary.\n' >&2
+    return 1
+  }
+  assert_contains "$(<"$sandbox/private-node.log")" "$npm_path install"
+}
+
+test_compatible_system_node_is_reused() {
+  local sandbox expected_node
+  sandbox="$(make_sandbox)"
+  cat > "$sandbox/bin/node" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] && printf 'v22.22.0\n'
+EOF
+  cat > "$sandbox/bin/npm" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] && printf '10.0.0\n'
+EOF
+  chmod +x "$sandbox/bin/node" "$sandbox/bin/npm"
+  expected_node="$(realpath "$sandbox/bin/node")"
+  set +e
+  last_output="$(
+    LOGSEQ_SYNC_TEST_MODE=true \
+    LOGSEQ_SYNC_INSTALL_ROOT="$sandbox/unused-install" \
+    PATH="$sandbox/bin:/usr/bin:/bin" \
+      bash -c 'source "$1" help >/dev/null; select_node_runtime; printf "%s\n" "$node_path"' \
+        bash "$manager" 2>&1
+  )"
+  last_status=$?
+  set -e
+  assert_success || return 1
+  assert_contains "$last_output" "$expected_node"
+}
+
+test_setup_persists_compatible_system_node() {
+  local sandbox expected_node
+  sandbox="$(make_sandbox)"
+  cat > "$sandbox/bin/node" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] && printf 'v22.22.0\n'
+EOF
+  cat > "$sandbox/bin/npm" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] && printf '10.0.0\n'
+EOF
+  chmod +x "$sandbox/bin/node" "$sandbox/bin/npm"
+  expected_node="$(realpath "$sandbox/bin/node")"
+  MOCK_NODE_PATH="" run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  assert_contains "$(<"$sandbox/config/sync.env")" \
+    "LOGSEQ_SYNC_NODE_PATH=$expected_node" || return 1
+  assert_contains "$(<"$sandbox/systemd/logseq-sync.service")" \
+    "ExecStart=$expected_node "
+}
+
+test_unsupported_system_node_falls_back_to_private_runtime() {
+  local sandbox expected_node
+  sandbox="$(make_sandbox)"
+  cat > "$sandbox/bin/node" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] && printf 'v20.19.0\n'
+EOF
+  chmod +x "$sandbox/bin/node"
+  expected_node="$sandbox/install/toolchain/node/bin/node"
+  set +e
+  last_output="$(
+    LOGSEQ_SYNC_TEST_MODE=true \
+    LOGSEQ_SYNC_INSTALL_ROOT="$sandbox/install" \
+    PATH="$sandbox/bin:/usr/bin:/bin" \
+      bash -c 'source "$1" help >/dev/null; select_node_runtime; printf "%s\n" "$node_path"' \
+        bash "$manager" 2>&1
+  )"
+  last_status=$?
+  set -e
+  assert_success || return 1
+  assert_contains "$last_output" "$expected_node"
 }
 
 test_rpm_distribution_can_install_with_yum() {
@@ -448,6 +554,10 @@ run_test test_setup_uses_public_10010_and_private_10011
 run_test test_rpm_distribution_installs_system_dependencies_with_dnf
 run_test test_amazon_linux_uses_corretto_21
 run_test test_opencloudos_falls_back_to_kona_17
+run_test test_selected_node_is_available_to_bundled_npm
+run_test test_compatible_system_node_is_reused
+run_test test_setup_persists_compatible_system_node
+run_test test_unsupported_system_node_falls_back_to_private_runtime
 run_test test_rpm_distribution_can_install_with_yum
 run_test test_setup_without_options_runs_guided_wizard
 run_test test_setup_rejects_ambiguous_positional_arguments

--- a/deps/db-sync/deploy/native-test.sh
+++ b/deps/db-sync/deploy/native-test.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly test_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly manager="$test_dir/logseq-sync-native"
+readonly suite_tmp="$(mktemp -d "${TMPDIR:-/tmp}/logseq-sync-native-test.XXXXXX")"
+manager_under_test="$manager"
+
+cleanup() {
+  if [[ -d "$suite_tmp" && "$suite_tmp" == *logseq-sync-native-test.* ]]; then
+    rm -rf -- "$suite_tmp"
+  fi
+}
+
+trap cleanup EXIT
+
+pass_count=0
+fail_count=0
+
+make_sandbox() {
+  local sandbox
+  sandbox="$(mktemp -d "$suite_tmp/case.XXXXXX")"
+  mkdir -p "$sandbox/bin" "$sandbox/install/toolchain/node/bin" \
+    "$sandbox/install/toolchain/bin"
+
+  cat > "$sandbox/bin/uname" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  -s) printf 'Linux\n' ;;
+  -m) printf 'x86_64\n' ;;
+  *) printf 'Linux\n' ;;
+esac
+EOF
+
+  cat > "$sandbox/bin/clojure" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+  cat > "$sandbox/bin/java" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+  cat > "$sandbox/bin/getent" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "passwd" ]]; then
+  printf '%s:x:0:0:test:/tmp:/bin/sh\n' "$2"
+  exit 0
+fi
+if [[ "$1" == "ahosts" ]]; then
+  [[ "${MOCK_DNS_STATUS:-0}" -eq 0 ]] || exit "$MOCK_DNS_STATUS"
+  printf '%s STREAM %s\n' "${MOCK_DNS_IP:-203.0.113.10}" "$2"
+  exit 0
+fi
+exit 1
+EOF
+
+  cat > "$sandbox/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_CURL_LOG"
+printf '%s' '{"ok":true}'
+EOF
+
+  cat > "$sandbox/bin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_SYSTEMCTL_LOG"
+exit 0
+EOF
+
+  cat > "$sandbox/bin/journalctl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_JOURNAL_LOG"
+exit 0
+EOF
+
+  cat > "$sandbox/install/toolchain/node/bin/node" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+  cat > "$sandbox/install/toolchain/bin/caddy" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_CADDY_LOG"
+exit 0
+EOF
+
+  cat > "$sandbox/install/toolchain/bin/pnpm" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_PNPM_LOG"
+workdir=""
+while (( $# > 0 )); do
+  if [[ "$1" == "--dir" ]]; then
+    workdir="$2"
+    shift 2
+    continue
+  fi
+  case "$1" in
+    install)
+      mkdir -p "$workdir/node_modules"
+      ;;
+    build:node-adapter)
+      mkdir -p "$workdir/worker/dist"
+      printf 'mock adapter\n' > "$workdir/worker/dist/node-adapter.js"
+      ;;
+  esac
+  shift
+done
+EOF
+
+  chmod +x "$sandbox/bin/"* "$sandbox/install/toolchain/node/bin/node" \
+    "$sandbox/install/toolchain/bin/caddy" "$sandbox/install/toolchain/bin/pnpm"
+  printf '%s' "$sandbox"
+}
+
+run_manager() {
+  local sandbox="$1"
+  shift
+  set +e
+  last_output="$(printf '%s' "${MOCK_MANAGER_INPUT:-}" | env \
+    PATH="$sandbox/bin:$PATH" \
+    LOGSEQ_SYNC_TEST_MODE=true \
+    LOGSEQ_SYNC_ASSUME_YES="${MOCK_ASSUME_YES:-true}" \
+    LOGSEQ_SYNC_INSTALL_ROOT="$sandbox/install" \
+    LOGSEQ_SYNC_CONFIG_DIR="$sandbox/config" \
+    LOGSEQ_SYNC_DATA_DIR="$sandbox/data" \
+    LOGSEQ_SYNC_SYSTEMD_DIR="$sandbox/systemd" \
+    LOGSEQ_SYNC_CADDY_DATA_DIR="$sandbox/caddy-data" \
+    LOGSEQ_SYNC_MANAGER_PATH="$sandbox/bin/logseq-sync-native-installed" \
+    MOCK_CURL_LOG="$sandbox/curl.log" \
+    MOCK_SYSTEMCTL_LOG="$sandbox/systemctl.log" \
+    MOCK_JOURNAL_LOG="$sandbox/journal.log" \
+    MOCK_CADDY_LOG="$sandbox/caddy.log" \
+    MOCK_PNPM_LOG="$sandbox/pnpm.log" \
+    MOCK_DNS_STATUS="${MOCK_DNS_STATUS:-0}" \
+    MOCK_DNS_IP="${MOCK_DNS_IP:-203.0.113.10}" \
+    "$manager_under_test" "$@" 2>&1)"
+  last_status=$?
+  set -e
+}
+
+assert_contains() {
+  local value="$1"
+  local expected="$2"
+  [[ "$value" == *"$expected"* ]] || {
+    printf 'Expected to find %q in:\n%s\n' "$expected" "$value" >&2
+    return 1
+  }
+}
+
+assert_success() {
+  [[ "$last_status" -eq 0 ]] || {
+    printf 'Expected success, got status %s:\n%s\n' "$last_status" "$last_output" >&2
+    return 1
+  }
+}
+
+assert_failure() {
+  [[ "$last_status" -ne 0 ]] || {
+    printf 'Expected failure:\n%s\n' "$last_output" >&2
+    return 1
+  }
+}
+
+test_setup_uses_public_10010_and_private_10011() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  assert_contains "$(<"$sandbox/config/sync.env")" \
+    'DB_SYNC_BASE_URL=https://sync.example.com:10010' || return 1
+  assert_contains "$(<"$sandbox/config/sync.env")" 'LOGSEQ_SYNC_PUBLIC_PORT=10010' || return 1
+  assert_contains "$(<"$sandbox/config/sync.env")" 'LOGSEQ_SYNC_INTERNAL_PORT=10011' || return 1
+  assert_contains "$(<"$sandbox/config/sync.env")" 'DB_SYNC_HOST=127.0.0.1' || return 1
+  assert_contains "$(<"$sandbox/config/sync.env")" 'DB_SYNC_PORT=10011' || return 1
+  assert_contains "$(<"$sandbox/config/Caddyfile")" \
+    'https://sync.example.com:10010 {' || return 1
+  assert_contains "$(<"$sandbox/config/Caddyfile")" \
+    'reverse_proxy 127.0.0.1:10011' || return 1
+  assert_contains "$(<"$sandbox/systemd/logseq-sync.service")" \
+    'EnvironmentFile=' || return 1
+  assert_contains "$(<"$sandbox/pnpm.log")" 'install --frozen-lockfile --prod' || return 1
+  assert_contains "$(<"$sandbox/pnpm.log")" 'build:node-adapter' || return 1
+  assert_contains "$last_output" 'https://sync.example.com:10010'
+}
+
+test_setup_without_options_runs_guided_wizard() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  MOCK_ASSUME_YES=false \
+    MOCK_MANAGER_INPUT=$'sync.example.com\n\n\n\n' \
+    run_manager "$sandbox" setup
+  assert_success || return 1
+  assert_contains "$last_output" 'Logseq Sync setup' || return 1
+  assert_contains "$last_output" 'Step 1/3 - Sync domain name' || return 1
+  assert_contains "$last_output" 'Step 2/3 - Public HTTPS port [10010]' || return 1
+  assert_contains "$last_output" 'Step 3/3 - Private Sync port [10011]' || return 1
+  assert_contains "$last_output" 'Its public A/AAAA record must already resolve to this server' || return 1
+  assert_contains "$last_output" 'Logseq clients connect here using HTTPS' || return 1
+  assert_contains "$last_output" 'Do not expose or allow this port' || return 1
+  assert_contains "$last_output" 'DNS: sync.example.com -> 203.0.113.10' || return 1
+  assert_contains "$last_output" 'https://sync.example.com:10010'
+}
+
+test_setup_rejects_ambiguous_positional_arguments() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup sync.example.com
+  assert_failure || return 1
+  assert_contains "$last_output" 'Unknown setup option' || return 1
+  assert_contains "$last_output" 'Use --domain, --public-port, --internal-port, or --yes'
+}
+
+test_setup_accepts_custom_public_port() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com --public-port 12000
+  assert_success || return 1
+  assert_contains "$(<"$sandbox/config/sync.env")" \
+    'DB_SYNC_BASE_URL=https://sync.example.com:12000' || return 1
+  assert_contains "$(<"$sandbox/config/sync.env")" 'LOGSEQ_SYNC_PUBLIC_PORT=12000' || return 1
+  assert_contains "$(<"$sandbox/config/Caddyfile")" \
+    'https://sync.example.com:12000 {' || return 1
+  assert_contains "$last_output" 'https://sync.example.com:12000'
+}
+
+test_setup_accepts_custom_private_port() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com \
+    --public-port 12000 --internal-port 13000
+  assert_success || return 1
+  assert_contains "$(<"$sandbox/config/sync.env")" 'LOGSEQ_SYNC_INTERNAL_PORT=13000' || return 1
+  assert_contains "$(<"$sandbox/config/sync.env")" 'DB_SYNC_PORT=13000' || return 1
+  assert_contains "$(<"$sandbox/config/Caddyfile")" \
+    'reverse_proxy 127.0.0.1:13000' || return 1
+  assert_contains "$last_output" 'Private adapter: 127.0.0.1:13000'
+}
+
+test_public_port_never_collides_with_private_port() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com --public-port 10011
+  assert_success || return 1
+  assert_contains "$(<"$sandbox/config/sync.env")" 'LOGSEQ_SYNC_PUBLIC_PORT=10011' || return 1
+  assert_contains "$(<"$sandbox/config/sync.env")" 'LOGSEQ_SYNC_INTERNAL_PORT=10012' || return 1
+  assert_contains "$(<"$sandbox/config/sync.env")" 'DB_SYNC_PORT=10012'
+}
+
+test_setup_rejects_duplicate_public_and_private_ports() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com \
+    --public-port 12000 --internal-port 12000
+  assert_failure || return 1
+  [[ ! -e "$sandbox/config" ]] || return 1
+  assert_contains "$last_output" 'must be different'
+}
+
+test_port_80_is_reserved_for_certificates() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com --public-port 80
+  assert_failure || return 1
+  [[ ! -e "$sandbox/config" ]] || return 1
+  assert_contains "$last_output" 'port 80 is reserved'
+}
+
+test_default_auth_is_generated_without_prompts() {
+  local sandbox env_file
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  env_file="$(<"$sandbox/config/sync.env")"
+  assert_contains "$env_file" \
+    'COGNITO_ISSUER=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8' || return 1
+  assert_contains "$env_file" 'COGNITO_CLIENT_ID=69cs1lgme7p8kbgld8n5kseii6'
+}
+
+test_invalid_domain_stops_before_writes() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain 'https://sync.example.com'
+  assert_failure || return 1
+  [[ ! -e "$sandbox/config" ]] || return 1
+  assert_contains "$last_output" 'Enter a valid DNS domain name'
+}
+
+test_unresolved_domain_stops_before_writes() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  MOCK_DNS_STATUS=1 run_manager "$sandbox" setup --domain sync.example.com
+  assert_failure || return 1
+  [[ ! -e "$sandbox/config" ]] || return 1
+  assert_contains "$last_output" 'domain does not currently resolve'
+}
+
+test_status_checks_private_and_public_endpoints_once() {
+  local sandbox curl_count
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  : > "$sandbox/curl.log"
+  run_manager "$sandbox" status
+  assert_success || return 1
+  curl_count="$(wc -l < "$sandbox/curl.log" | tr -d ' ')"
+  [[ "$curl_count" -eq 2 ]] || {
+    printf 'Expected two status probes, got %s.\n' "$curl_count" >&2
+    return 1
+  }
+  assert_contains "$last_output" 'Health: ok'
+}
+
+test_update_preserves_configuration_and_switches_release() {
+  local sandbox before_env before_release after_release
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  before_env="$(<"$sandbox/config/sync.env")"
+  before_release="$(readlink "$sandbox/install/current")"
+  run_manager "$sandbox" update
+  assert_success || return 1
+  after_release="$(readlink "$sandbox/install/current")"
+  [[ "$before_release" != "$after_release" ]] || {
+    printf 'Expected update to switch releases, both were %s.\n' "$before_release" >&2
+    return 1
+  }
+  [[ "$before_env" == "$(<"$sandbox/config/sync.env")" ]] || {
+    printf 'Expected update to preserve sync.env.\n' >&2
+    return 1
+  }
+  assert_contains "$last_output" 'was updated successfully'
+}
+
+test_installed_manager_can_rerun_setup() {
+  local sandbox installed_manager
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com --public-port 12000
+  assert_success || return 1
+  installed_manager="$sandbox/bin/logseq-sync-native-installed"
+  [[ -x "$installed_manager" ]] || return 1
+  manager_under_test="$installed_manager"
+  run_manager "$sandbox" setup --domain sync.example.com
+  manager_under_test="$manager"
+  assert_success || return 1
+  assert_contains "$last_output" 'https://sync.example.com:12000'
+}
+
+run_test() {
+  local name="$1"
+  if "$name"; then
+    pass_count=$((pass_count + 1))
+    printf 'ok - %s\n' "$name"
+  else
+    fail_count=$((fail_count + 1))
+    printf 'not ok - %s\n' "$name"
+  fi
+}
+
+run_test test_setup_uses_public_10010_and_private_10011
+run_test test_setup_without_options_runs_guided_wizard
+run_test test_setup_rejects_ambiguous_positional_arguments
+run_test test_setup_accepts_custom_public_port
+run_test test_setup_accepts_custom_private_port
+run_test test_public_port_never_collides_with_private_port
+run_test test_setup_rejects_duplicate_public_and_private_ports
+run_test test_port_80_is_reserved_for_certificates
+run_test test_default_auth_is_generated_without_prompts
+run_test test_invalid_domain_stops_before_writes
+run_test test_unresolved_domain_stops_before_writes
+run_test test_status_checks_private_and_public_endpoints_once
+run_test test_update_preserves_configuration_and_switches_release
+run_test test_installed_manager_can_rerun_setup
+
+printf '%s passed, %s failed\n' "$pass_count" "$fail_count"
+[[ "$fail_count" -eq 0 ]]

--- a/deps/db-sync/deploy/native-test.sh
+++ b/deps/db-sync/deploy/native-test.sh
@@ -27,6 +27,9 @@ make_runtime_fixture() {
 if [[ "${1:-}" == "--version" ]]; then
   printf 'v24.0.0\n'
 fi
+if [[ "${1:-}" == "-e" ]]; then
+  exit "${MOCK_SQLITE_STATUS:-0}"
+fi
 exit 0
 EOF
   printf 'mock adapter\n' > "$fixture/app/node-adapter.js"
@@ -114,6 +117,7 @@ run_manager() {
     MOCK_CADDY_LOG="$sandbox/caddy.log" \
     MOCK_DNS_STATUS="${MOCK_DNS_STATUS:-0}" \
     MOCK_DNS_IP="${MOCK_DNS_IP:-203.0.113.10}" \
+    MOCK_SQLITE_STATUS="${MOCK_SQLITE_STATUS:-0}" \
     "$manager_under_test" "$@" 2>&1)"
   last_status=$?
   set -e
@@ -229,6 +233,15 @@ test_setup_rejects_wrong_runtime_architecture() {
   run_manager "$sandbox" setup --domain sync.example.com
   assert_failure || return 1
   assert_contains "$last_output" 'architecture does not match'
+}
+
+test_setup_rejects_incompatible_sqlite_runtime() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  MOCK_SQLITE_STATUS=1 run_manager "$sandbox" setup --domain sync.example.com
+  assert_failure || return 1
+  [[ ! -e "$sandbox/config" ]] || return 1
+  assert_contains "$last_output" 'SQLite module cannot run on this server'
 }
 
 test_setup_without_options_runs_guided_wizard() {
@@ -362,6 +375,7 @@ run_test test_setup_ignores_broken_system_node_and_build_tools
 run_test test_setup_does_not_invoke_os_package_manager
 run_test test_setup_rejects_bad_runtime_checksum
 run_test test_setup_rejects_wrong_runtime_architecture
+run_test test_setup_rejects_incompatible_sqlite_runtime
 run_test test_setup_without_options_runs_guided_wizard
 run_test test_setup_accepts_custom_ports
 run_test test_public_port_never_collides_with_private_port

--- a/deps/db-sync/deploy/native-test.sh
+++ b/deps/db-sync/deploy/native-test.sh
@@ -5,23 +5,43 @@ readonly test_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 readonly manager="$test_dir/logseq-sync-native"
 readonly suite_tmp="$(mktemp -d "${TMPDIR:-/tmp}/logseq-sync-native-test.XXXXXX")"
 manager_under_test="$manager"
+pass_count=0
+fail_count=0
 
 cleanup() {
   if [[ -d "$suite_tmp" && "$suite_tmp" == *logseq-sync-native-test.* ]]; then
     rm -rf -- "$suite_tmp"
   fi
 }
-
 trap cleanup EXIT
 
-pass_count=0
-fail_count=0
+make_runtime_fixture() {
+  local sandbox="$1"
+  local version="${2:-runtime-v1}"
+  local fixture="$sandbox/runtime-fixture/logseq-sync-runtime"
+  local asset="$sandbox/logseq-sync-runtime-linux-x64.tar.gz"
+  rm -rf -- "$sandbox/runtime-fixture"
+  mkdir -p "$fixture/node/bin" "$fixture/app/node_modules" "$fixture/bin"
+  cat > "$fixture/node/bin/node" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'v24.0.0\n'
+fi
+exit 0
+EOF
+  printf 'mock adapter\n' > "$fixture/app/node-adapter.js"
+  cp "$manager" "$fixture/bin/logseq-sync-native"
+  printf '%s\n' "$version" > "$fixture/VERSION"
+  printf 'x64\n' > "$fixture/ARCHITECTURE"
+  chmod +x "$fixture/node/bin/node" "$fixture/bin/logseq-sync-native"
+  tar -czf "$asset" -C "$sandbox/runtime-fixture" logseq-sync-runtime
+  (cd "$sandbox" && sha256sum "$(basename "$asset")" > "$(basename "$asset").sha256")
+}
 
 make_sandbox() {
   local sandbox
   sandbox="$(mktemp -d "$suite_tmp/case.XXXXXX")"
-  mkdir -p "$sandbox/bin" "$sandbox/install/toolchain/node/bin" \
-    "$sandbox/install/toolchain/bin"
+  mkdir -p "$sandbox/bin" "$sandbox/install/toolchain/bin"
 
   cat > "$sandbox/bin/uname" <<'EOF'
 #!/usr/bin/env bash
@@ -32,22 +52,8 @@ case "${1:-}" in
 esac
 EOF
 
-  cat > "$sandbox/bin/clojure" <<'EOF'
-#!/usr/bin/env bash
-exit 0
-EOF
-
-  cat > "$sandbox/bin/java" <<'EOF'
-#!/usr/bin/env bash
-exit 0
-EOF
-
   cat > "$sandbox/bin/getent" <<'EOF'
 #!/usr/bin/env bash
-if [[ "$1" == "passwd" ]]; then
-  printf '%s:x:0:0:test:/tmp:/bin/sh\n' "$2"
-  exit 0
-fi
 if [[ "$1" == "ahosts" ]]; then
   [[ "${MOCK_DNS_STATUS:-0}" -eq 0 ]] || exit "$MOCK_DNS_STATUS"
   printf '%s STREAM %s\n' "${MOCK_DNS_IP:-203.0.113.10}" "$2"
@@ -74,45 +80,14 @@ printf '%s\n' "$*" >> "$MOCK_JOURNAL_LOG"
 exit 0
 EOF
 
-  cat > "$sandbox/install/toolchain/node/bin/node" <<'EOF'
-#!/usr/bin/env bash
-if [[ "${1:-}" == "--version" ]]; then
-  printf 'v24.0.0\n'
-fi
-exit 0
-EOF
-
   cat > "$sandbox/install/toolchain/bin/caddy" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$MOCK_CADDY_LOG"
 exit 0
 EOF
 
-  cat > "$sandbox/install/toolchain/bin/pnpm" <<'EOF'
-#!/usr/bin/env bash
-printf '%s\n' "$*" >> "$MOCK_PNPM_LOG"
-workdir=""
-while (( $# > 0 )); do
-  if [[ "$1" == "--dir" ]]; then
-    workdir="$2"
-    shift 2
-    continue
-  fi
-  case "$1" in
-    install)
-      mkdir -p "$workdir/node_modules"
-      ;;
-    build:node-adapter)
-      mkdir -p "$workdir/worker/dist"
-      printf 'mock adapter\n' > "$workdir/worker/dist/node-adapter.js"
-      ;;
-  esac
-  shift
-done
-EOF
-
-  chmod +x "$sandbox/bin/"* "$sandbox/install/toolchain/node/bin/node" \
-    "$sandbox/install/toolchain/bin/caddy" "$sandbox/install/toolchain/bin/pnpm"
+  chmod +x "$sandbox/bin/"* "$sandbox/install/toolchain/bin/caddy"
+  make_runtime_fixture "$sandbox"
   printf '%s' "$sandbox"
 }
 
@@ -130,12 +105,13 @@ run_manager() {
     LOGSEQ_SYNC_SYSTEMD_DIR="$sandbox/systemd" \
     LOGSEQ_SYNC_CADDY_DATA_DIR="$sandbox/caddy-data" \
     LOGSEQ_SYNC_MANAGER_PATH="$sandbox/bin/logseq-sync-native-installed" \
-    LOGSEQ_SYNC_NODE_PATH="${MOCK_NODE_PATH-$sandbox/install/toolchain/node/bin/node}" \
+    LOGSEQ_SYNC_RELEASE_REPOSITORY="example/logseq" \
+    LOGSEQ_SYNC_RUNTIME_ARCHIVE="$sandbox/logseq-sync-runtime-linux-x64.tar.gz" \
+    LOGSEQ_SYNC_RUNTIME_CHECKSUM="$sandbox/logseq-sync-runtime-linux-x64.tar.gz.sha256" \
     MOCK_CURL_LOG="$sandbox/curl.log" \
     MOCK_SYSTEMCTL_LOG="$sandbox/systemctl.log" \
     MOCK_JOURNAL_LOG="$sandbox/journal.log" \
     MOCK_CADDY_LOG="$sandbox/caddy.log" \
-    MOCK_PNPM_LOG="$sandbox/pnpm.log" \
     MOCK_DNS_STATUS="${MOCK_DNS_STATUS:-0}" \
     MOCK_DNS_IP="${MOCK_DNS_IP:-203.0.113.10}" \
     "$manager_under_test" "$@" 2>&1)"
@@ -148,6 +124,15 @@ assert_contains() {
   local expected="$2"
   [[ "$value" == *"$expected"* ]] || {
     printf 'Expected to find %q in:\n%s\n' "$expected" "$value" >&2
+    return 1
+  }
+}
+
+assert_not_contains() {
+  local value="$1"
+  local unexpected="$2"
+  [[ "$value" != *"$unexpected"* ]] || {
+    printf 'Did not expect to find %q in:\n%s\n' "$unexpected" "$value" >&2
     return 1
   }
 }
@@ -166,268 +151,110 @@ assert_failure() {
   }
 }
 
-run_system_package_install() {
-  local sandbox="$1"
-  local distribution_id="$2"
-  local distribution_like="$3"
-  local distribution_name="$4"
-  local available_java="$5"
-  local package_manager="${6:-dnf}"
-  printf 'ID=%s\nID_LIKE="%s"\nPRETTY_NAME="%s"\n' \
-    "$distribution_id" "$distribution_like" "$distribution_name" \
-    > "$sandbox/os-release"
-  set +e
-  (
-    source "$manager" help >/dev/null
-    mock_package_manager() {
-      printf '%s\n' "$*" >> "$sandbox/packages.log"
-      case "$*" in
-        '-y makecache'|install\ -y\ *) return 0 ;;
-        "-q list --available $available_java"|"-q list available $available_java")
-          return 0
-          ;;
-        *) return 1 ;;
-      esac
-    }
-    if [[ "$package_manager" == "dnf" ]]; then
-      dnf() { mock_package_manager "$@"; }
-    else
-      yum() { mock_package_manager "$@"; }
-    fi
-    ensure_system_packages "$sandbox/os-release"
-  ) > "$sandbox/system-packages-output.log" 2>&1
-  last_status=$?
-  last_output="$(<"$sandbox/system-packages-output.log")"
-  set -e
-}
-
-test_rpm_distribution_installs_system_dependencies_with_dnf() {
-  local sandbox package_log
-  sandbox="$(make_sandbox)"
-  run_system_package_install "$sandbox" rocky 'rhel centos fedora' \
-    'Rocky Linux 9.6' java-21-openjdk-headless
-  assert_success || return 1
-  package_log="$(<"$sandbox/packages.log")"
-  assert_contains "$last_output" 'Detected operating system: Rocky Linux 9.6' || return 1
-  assert_contains "$package_log" '-y makecache' || return 1
-  assert_contains "$package_log" '-q list --available java-21-openjdk-headless' || return 1
-  assert_contains "$package_log" 'install -y gcc gcc-c++ make' || return 1
-  assert_contains "$package_log" 'java-21-openjdk-headless' || return 1
-  assert_contains "$package_log" 'shadow-utils'
-}
-
-test_amazon_linux_uses_corretto_21() {
-  local sandbox package_log
-  sandbox="$(make_sandbox)"
-  run_system_package_install "$sandbox" amzn fedora \
-    'Amazon Linux 2023.7' java-21-amazon-corretto-headless
-  assert_success || return 1
-  package_log="$(<"$sandbox/packages.log")"
-  assert_contains "$last_output" 'Detected operating system: Amazon Linux 2023.7' || return 1
-  assert_contains "$package_log" '-q list --available java-21-amazon-corretto-headless' || return 1
-  assert_contains "$package_log" 'java-21-amazon-corretto-headless'
-}
-
-test_opencloudos_falls_back_to_kona_17() {
-  local sandbox package_log
-  sandbox="$(make_sandbox)"
-  run_system_package_install "$sandbox" opencloudos opencloudos \
-    'OpenCloudOS 9.4' java-17-konajdk
-  assert_success || return 1
-  package_log="$(<"$sandbox/packages.log")"
-  assert_contains "$last_output" 'Detected operating system: OpenCloudOS 9.4' || return 1
-  assert_contains "$package_log" '-q list --available java-21-openjdk-headless' || return 1
-  assert_contains "$package_log" '-q list --available java-17-konajdk' || return 1
-  assert_contains "$package_log" 'java-17-konajdk'
-}
-
-test_selected_node_is_available_to_bundled_npm() {
-  local sandbox node_path npm_path
-  sandbox="$(make_sandbox)"
-  node_path="$sandbox/install/toolchain/node/bin/node"
-  npm_path="$sandbox/install/toolchain/node/bin/npm"
-  cat > "$node_path" <<'EOF'
-#!/usr/bin/env bash
-printf '%s\n' "$*" >> "$MOCK_PRIVATE_NODE_LOG"
-EOF
-  cat > "$npm_path" <<'EOF'
-#!/usr/bin/env node
-EOF
-  chmod +x "$node_path" "$npm_path"
-  set +e
-  last_output="$(
-    LOGSEQ_SYNC_INSTALL_ROOT="$sandbox/install" \
-    MOCK_PRIVATE_NODE_LOG="$sandbox/private-node.log" \
-    PATH="/usr/bin:/bin" \
-      bash -c 'source "$1" help >/dev/null; run_with_node "$2" "$3" install' \
-        bash "$manager" "$node_path" "$npm_path" 2>&1
-  )"
-  last_status=$?
-  set -e
-  assert_success || return 1
-  [[ -f "$sandbox/private-node.log" ]] || {
-    printf 'Expected bundled npm to run with the private Node.js binary.\n' >&2
-    return 1
-  }
-  assert_contains "$(<"$sandbox/private-node.log")" "$npm_path install"
-}
-
-test_compatible_system_node_is_reused() {
-  local sandbox expected_node
-  sandbox="$(make_sandbox)"
-  cat > "$sandbox/bin/node" <<'EOF'
-#!/usr/bin/env bash
-[[ "${1:-}" == "--version" ]] && printf 'v22.22.0\n'
-EOF
-  cat > "$sandbox/bin/npm" <<'EOF'
-#!/usr/bin/env bash
-[[ "${1:-}" == "--version" ]] && printf '10.0.0\n'
-EOF
-  chmod +x "$sandbox/bin/node" "$sandbox/bin/npm"
-  expected_node="$(realpath "$sandbox/bin/node")"
-  set +e
-  last_output="$(
-    LOGSEQ_SYNC_TEST_MODE=true \
-    LOGSEQ_SYNC_INSTALL_ROOT="$sandbox/unused-install" \
-    PATH="$sandbox/bin:/usr/bin:/bin" \
-      bash -c 'source "$1" help >/dev/null; select_node_runtime; printf "%s\n" "$node_path"' \
-        bash "$manager" 2>&1
-  )"
-  last_status=$?
-  set -e
-  assert_success || return 1
-  assert_contains "$last_output" "$expected_node"
-}
-
-test_setup_persists_compatible_system_node() {
-  local sandbox expected_node
-  sandbox="$(make_sandbox)"
-  cat > "$sandbox/bin/node" <<'EOF'
-#!/usr/bin/env bash
-[[ "${1:-}" == "--version" ]] && printf 'v22.22.0\n'
-EOF
-  cat > "$sandbox/bin/npm" <<'EOF'
-#!/usr/bin/env bash
-[[ "${1:-}" == "--version" ]] && printf '10.0.0\n'
-EOF
-  chmod +x "$sandbox/bin/node" "$sandbox/bin/npm"
-  expected_node="$(realpath "$sandbox/bin/node")"
-  MOCK_NODE_PATH="" run_manager "$sandbox" setup --domain sync.example.com
-  assert_success || return 1
-  assert_contains "$(<"$sandbox/config/sync.env")" \
-    "LOGSEQ_SYNC_NODE_PATH=$expected_node" || return 1
-  assert_contains "$(<"$sandbox/systemd/logseq-sync.service")" \
-    "ExecStart=$expected_node "
-}
-
-test_unsupported_system_node_falls_back_to_private_runtime() {
-  local sandbox expected_node
-  sandbox="$(make_sandbox)"
-  cat > "$sandbox/bin/node" <<'EOF'
-#!/usr/bin/env bash
-[[ "${1:-}" == "--version" ]] && printf 'v20.19.0\n'
-EOF
-  chmod +x "$sandbox/bin/node"
-  expected_node="$sandbox/install/toolchain/node/bin/node"
-  set +e
-  last_output="$(
-    LOGSEQ_SYNC_TEST_MODE=true \
-    LOGSEQ_SYNC_INSTALL_ROOT="$sandbox/install" \
-    PATH="$sandbox/bin:/usr/bin:/bin" \
-      bash -c 'source "$1" help >/dev/null; select_node_runtime; printf "%s\n" "$node_path"' \
-        bash "$manager" 2>&1
-  )"
-  last_status=$?
-  set -e
-  assert_success || return 1
-  assert_contains "$last_output" "$expected_node"
-}
-
-test_rpm_distribution_can_install_with_yum() {
-  local sandbox package_log
-  sandbox="$(make_sandbox)"
-  run_system_package_install "$sandbox" tencentos 'rhel centos fedora' \
-    'TencentOS Server 3.1' java-21-openjdk-headless yum
-  assert_success || return 1
-  package_log="$(<"$sandbox/packages.log")"
-  assert_contains "$last_output" 'Detected operating system: TencentOS Server 3.1' || return 1
-  assert_contains "$package_log" '-q list available java-21-openjdk-headless' || return 1
-  assert_contains "$package_log" 'install -y gcc gcc-c++ make'
-}
-
-test_setup_uses_public_10010_and_private_10011() {
-  local sandbox
+test_setup_uses_prebuilt_runtime_and_default_ports() {
+  local sandbox env_file service_file
   sandbox="$(make_sandbox)"
   run_manager "$sandbox" setup --domain sync.example.com
   assert_success || return 1
-  assert_contains "$(<"$sandbox/config/sync.env")" \
-    'DB_SYNC_BASE_URL=https://sync.example.com:10010' || return 1
-  assert_contains "$(<"$sandbox/config/sync.env")" 'LOGSEQ_SYNC_PUBLIC_PORT=10010' || return 1
-  assert_contains "$(<"$sandbox/config/sync.env")" 'LOGSEQ_SYNC_INTERNAL_PORT=10011' || return 1
-  assert_contains "$(<"$sandbox/config/sync.env")" 'DB_SYNC_HOST=127.0.0.1' || return 1
-  assert_contains "$(<"$sandbox/config/sync.env")" 'DB_SYNC_PORT=10011' || return 1
-  assert_contains "$(<"$sandbox/config/Caddyfile")" \
-    'https://sync.example.com:10010 {' || return 1
-  assert_contains "$(<"$sandbox/config/Caddyfile")" \
-    'reverse_proxy 127.0.0.1:10011' || return 1
-  assert_contains "$(<"$sandbox/systemd/logseq-sync.service")" \
-    'EnvironmentFile=' || return 1
-  assert_contains "$(<"$sandbox/pnpm.log")" 'install --frozen-lockfile --prod' || return 1
-  assert_contains "$(<"$sandbox/pnpm.log")" 'build:node-adapter' || return 1
-  assert_contains "$last_output" 'https://sync.example.com:10010'
+  env_file="$(<"$sandbox/config/sync.env")"
+  service_file="$(<"$sandbox/systemd/logseq-sync.service")"
+  assert_contains "$env_file" 'DB_SYNC_BASE_URL=https://sync.example.com:10010' || return 1
+  assert_contains "$env_file" 'LOGSEQ_SYNC_INTERNAL_PORT=10011' || return 1
+  assert_contains "$env_file" 'LOGSEQ_SYNC_RELEASE_REPOSITORY=example/logseq' || return 1
+  assert_contains "$service_file" \
+    "ExecStart=$sandbox/install/current/node/bin/node $sandbox/install/current/app/node-adapter.js" || return 1
+  assert_not_contains "$env_file" 'LOGSEQ_SYNC_NODE_PATH=' || return 1
+  assert_not_contains "$last_output" 'Clojure' || return 1
+  assert_contains "$last_output" 'Installed Sync runtime runtime-v1 with bundled v24.0.0'
+}
+
+test_setup_ignores_broken_system_node_and_build_tools() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  cat > "$sandbox/bin/node" <<'EOF'
+#!/usr/bin/env bash
+exit 99
+EOF
+  cat > "$sandbox/bin/java" <<'EOF'
+#!/usr/bin/env bash
+exit 99
+EOF
+  cat > "$sandbox/bin/clojure" <<'EOF'
+#!/usr/bin/env bash
+exit 99
+EOF
+  chmod +x "$sandbox/bin/node" "$sandbox/bin/java" "$sandbox/bin/clojure"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  assert_contains "$last_output" 'bundled v24.0.0'
+}
+
+test_setup_does_not_invoke_os_package_manager() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  cat > "$sandbox/bin/dnf" <<'EOF'
+#!/usr/bin/env bash
+printf 'dnf was invoked\n' >&2
+exit 91
+EOF
+  cat > "$sandbox/bin/yum" <<'EOF'
+#!/usr/bin/env bash
+printf 'yum was invoked\n' >&2
+exit 92
+EOF
+  chmod +x "$sandbox/bin/dnf" "$sandbox/bin/yum"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  assert_not_contains "$last_output" 'was invoked'
+}
+
+test_setup_rejects_bad_runtime_checksum() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  printf '%064d  logseq-sync-runtime-linux-x64.tar.gz\n' 0 \
+    > "$sandbox/logseq-sync-runtime-linux-x64.tar.gz.sha256"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_failure || return 1
+  assert_contains "$last_output" 'failed checksum verification'
+}
+
+test_setup_rejects_wrong_runtime_architecture() {
+  local sandbox fixture asset
+  sandbox="$(make_sandbox)"
+  fixture="$sandbox/runtime-fixture/logseq-sync-runtime"
+  asset="$sandbox/logseq-sync-runtime-linux-x64.tar.gz"
+  printf 'arm64\n' > "$fixture/ARCHITECTURE"
+  tar -czf "$asset" -C "$sandbox/runtime-fixture" logseq-sync-runtime
+  (cd "$sandbox" && sha256sum "$(basename "$asset")" > "$(basename "$asset").sha256")
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_failure || return 1
+  assert_contains "$last_output" 'architecture does not match'
 }
 
 test_setup_without_options_runs_guided_wizard() {
   local sandbox
   sandbox="$(make_sandbox)"
-  MOCK_ASSUME_YES=false \
-    MOCK_MANAGER_INPUT=$'sync.example.com\n\n\n\n' \
+  MOCK_ASSUME_YES=false MOCK_MANAGER_INPUT=$'sync.example.com\n\n\n\n' \
     run_manager "$sandbox" setup
   assert_success || return 1
   assert_contains "$last_output" 'Logseq Sync setup' || return 1
   assert_contains "$last_output" 'Step 1/3 - Sync domain name' || return 1
   assert_contains "$last_output" 'Step 2/3 - Public HTTPS port [10010]' || return 1
   assert_contains "$last_output" 'Step 3/3 - Private Sync port [10011]' || return 1
-  assert_contains "$last_output" 'Its public A/AAAA record must already resolve to this server' || return 1
-  assert_contains "$last_output" 'Logseq clients connect here using HTTPS' || return 1
-  assert_contains "$last_output" 'Do not expose or allow this port' || return 1
-  assert_contains "$last_output" 'DNS: sync.example.com -> 203.0.113.10' || return 1
-  assert_contains "$last_output" 'https://sync.example.com:10010'
+  assert_contains "$last_output" 'Runtime: prebuilt Linux x64 package'
 }
 
-test_setup_rejects_ambiguous_positional_arguments() {
-  local sandbox
-  sandbox="$(make_sandbox)"
-  run_manager "$sandbox" setup sync.example.com
-  assert_failure || return 1
-  assert_contains "$last_output" 'Unknown setup option' || return 1
-  assert_contains "$last_output" 'Use --domain, --public-port, --internal-port, or --yes'
-}
-
-test_setup_accepts_custom_public_port() {
-  local sandbox
-  sandbox="$(make_sandbox)"
-  run_manager "$sandbox" setup --domain sync.example.com --public-port 12000
-  assert_success || return 1
-  assert_contains "$(<"$sandbox/config/sync.env")" \
-    'DB_SYNC_BASE_URL=https://sync.example.com:12000' || return 1
-  assert_contains "$(<"$sandbox/config/sync.env")" 'LOGSEQ_SYNC_PUBLIC_PORT=12000' || return 1
-  assert_contains "$(<"$sandbox/config/Caddyfile")" \
-    'https://sync.example.com:12000 {' || return 1
-  assert_contains "$last_output" 'https://sync.example.com:12000'
-}
-
-test_setup_accepts_custom_private_port() {
+test_setup_accepts_custom_ports() {
   local sandbox
   sandbox="$(make_sandbox)"
   run_manager "$sandbox" setup --domain sync.example.com \
     --public-port 12000 --internal-port 13000
   assert_success || return 1
-  assert_contains "$(<"$sandbox/config/sync.env")" 'LOGSEQ_SYNC_INTERNAL_PORT=13000' || return 1
   assert_contains "$(<"$sandbox/config/sync.env")" 'DB_SYNC_PORT=13000' || return 1
   assert_contains "$(<"$sandbox/config/Caddyfile")" \
-    'reverse_proxy 127.0.0.1:13000' || return 1
-  assert_contains "$last_output" 'Private adapter: 127.0.0.1:13000'
+    'https://sync.example.com:12000 {' || return 1
+  assert_contains "$(<"$sandbox/config/Caddyfile")" \
+    'reverse_proxy 127.0.0.1:13000'
 }
 
 test_public_port_never_collides_with_private_port() {
@@ -435,28 +262,32 @@ test_public_port_never_collides_with_private_port() {
   sandbox="$(make_sandbox)"
   run_manager "$sandbox" setup --domain sync.example.com --public-port 10011
   assert_success || return 1
-  assert_contains "$(<"$sandbox/config/sync.env")" 'LOGSEQ_SYNC_PUBLIC_PORT=10011' || return 1
-  assert_contains "$(<"$sandbox/config/sync.env")" 'LOGSEQ_SYNC_INTERNAL_PORT=10012' || return 1
-  assert_contains "$(<"$sandbox/config/sync.env")" 'DB_SYNC_PORT=10012'
+  assert_contains "$(<"$sandbox/config/sync.env")" 'LOGSEQ_SYNC_INTERNAL_PORT=10012'
 }
 
-test_setup_rejects_duplicate_public_and_private_ports() {
+test_setup_rejects_invalid_port_and_domain_inputs() {
   local sandbox
   sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain 'https://sync.example.com'
+  assert_failure || return 1
+  assert_contains "$last_output" 'Enter a valid DNS domain name' || return 1
   run_manager "$sandbox" setup --domain sync.example.com \
     --public-port 12000 --internal-port 12000
   assert_failure || return 1
-  [[ ! -e "$sandbox/config" ]] || return 1
-  assert_contains "$last_output" 'must be different'
-}
-
-test_port_80_is_reserved_for_certificates() {
-  local sandbox
-  sandbox="$(make_sandbox)"
+  assert_contains "$last_output" 'must be different' || return 1
   run_manager "$sandbox" setup --domain sync.example.com --public-port 80
   assert_failure || return 1
-  [[ ! -e "$sandbox/config" ]] || return 1
   assert_contains "$last_output" 'port 80 is reserved'
+}
+
+test_unresolved_domain_stops_before_install() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  MOCK_DNS_STATUS=1 run_manager "$sandbox" setup --domain sync.example.com
+  assert_failure || return 1
+  [[ ! -e "$sandbox/config" ]] || return 1
+  [[ ! -e "$sandbox/install/current" ]] || return 1
+  assert_contains "$last_output" 'domain does not currently resolve'
 }
 
 test_default_auth_is_generated_without_prompts() {
@@ -470,24 +301,6 @@ test_default_auth_is_generated_without_prompts() {
   assert_contains "$env_file" 'COGNITO_CLIENT_ID=69cs1lgme7p8kbgld8n5kseii6'
 }
 
-test_invalid_domain_stops_before_writes() {
-  local sandbox
-  sandbox="$(make_sandbox)"
-  run_manager "$sandbox" setup --domain 'https://sync.example.com'
-  assert_failure || return 1
-  [[ ! -e "$sandbox/config" ]] || return 1
-  assert_contains "$last_output" 'Enter a valid DNS domain name'
-}
-
-test_unresolved_domain_stops_before_writes() {
-  local sandbox
-  sandbox="$(make_sandbox)"
-  MOCK_DNS_STATUS=1 run_manager "$sandbox" setup --domain sync.example.com
-  assert_failure || return 1
-  [[ ! -e "$sandbox/config" ]] || return 1
-  assert_contains "$last_output" 'domain does not currently resolve'
-}
-
 test_status_checks_private_and_public_endpoints_once() {
   local sandbox curl_count
   sandbox="$(make_sandbox)"
@@ -497,10 +310,8 @@ test_status_checks_private_and_public_endpoints_once() {
   run_manager "$sandbox" status
   assert_success || return 1
   curl_count="$(wc -l < "$sandbox/curl.log" | tr -d ' ')"
-  [[ "$curl_count" -eq 2 ]] || {
-    printf 'Expected two status probes, got %s.\n' "$curl_count" >&2
-    return 1
-  }
+  [[ "$curl_count" -eq 2 ]] || return 1
+  assert_contains "$last_output" 'Runtime version: runtime-v1' || return 1
   assert_contains "$last_output" 'Health: ok'
 }
 
@@ -511,17 +322,13 @@ test_update_preserves_configuration_and_switches_release() {
   assert_success || return 1
   before_env="$(<"$sandbox/config/sync.env")"
   before_release="$(readlink "$sandbox/install/current")"
+  make_runtime_fixture "$sandbox" runtime-v2
   run_manager "$sandbox" update
   assert_success || return 1
   after_release="$(readlink "$sandbox/install/current")"
-  [[ "$before_release" != "$after_release" ]] || {
-    printf 'Expected update to switch releases, both were %s.\n' "$before_release" >&2
-    return 1
-  }
-  [[ "$before_env" == "$(<"$sandbox/config/sync.env")" ]] || {
-    printf 'Expected update to preserve sync.env.\n' >&2
-    return 1
-  }
+  [[ "$before_release" != "$after_release" ]] || return 1
+  [[ "$before_env" == "$(<"$sandbox/config/sync.env")" ]] || return 1
+  assert_contains "$last_output" 'Installed Sync runtime runtime-v2' || return 1
   assert_contains "$last_output" 'was updated successfully'
 }
 
@@ -550,25 +357,17 @@ run_test() {
   fi
 }
 
-run_test test_setup_uses_public_10010_and_private_10011
-run_test test_rpm_distribution_installs_system_dependencies_with_dnf
-run_test test_amazon_linux_uses_corretto_21
-run_test test_opencloudos_falls_back_to_kona_17
-run_test test_selected_node_is_available_to_bundled_npm
-run_test test_compatible_system_node_is_reused
-run_test test_setup_persists_compatible_system_node
-run_test test_unsupported_system_node_falls_back_to_private_runtime
-run_test test_rpm_distribution_can_install_with_yum
+run_test test_setup_uses_prebuilt_runtime_and_default_ports
+run_test test_setup_ignores_broken_system_node_and_build_tools
+run_test test_setup_does_not_invoke_os_package_manager
+run_test test_setup_rejects_bad_runtime_checksum
+run_test test_setup_rejects_wrong_runtime_architecture
 run_test test_setup_without_options_runs_guided_wizard
-run_test test_setup_rejects_ambiguous_positional_arguments
-run_test test_setup_accepts_custom_public_port
-run_test test_setup_accepts_custom_private_port
+run_test test_setup_accepts_custom_ports
 run_test test_public_port_never_collides_with_private_port
-run_test test_setup_rejects_duplicate_public_and_private_ports
-run_test test_port_80_is_reserved_for_certificates
+run_test test_setup_rejects_invalid_port_and_domain_inputs
+run_test test_unresolved_domain_stops_before_install
 run_test test_default_auth_is_generated_without_prompts
-run_test test_invalid_domain_stops_before_writes
-run_test test_unresolved_domain_stops_before_writes
 run_test test_status_checks_private_and_public_endpoints_once
 run_test test_update_preserves_configuration_and_switches_release
 run_test test_installed_manager_can_rerun_setup

--- a/deps/db-sync/deploy/native-test.sh
+++ b/deps/db-sync/deploy/native-test.sh
@@ -162,6 +162,93 @@ assert_failure() {
   }
 }
 
+run_system_package_install() {
+  local sandbox="$1"
+  local distribution_id="$2"
+  local distribution_like="$3"
+  local distribution_name="$4"
+  local available_java="$5"
+  local package_manager="${6:-dnf}"
+  printf 'ID=%s\nID_LIKE="%s"\nPRETTY_NAME="%s"\n' \
+    "$distribution_id" "$distribution_like" "$distribution_name" \
+    > "$sandbox/os-release"
+  set +e
+  (
+    source "$manager" help >/dev/null
+    mock_package_manager() {
+      printf '%s\n' "$*" >> "$sandbox/packages.log"
+      case "$*" in
+        '-y makecache'|install\ -y\ *) return 0 ;;
+        "-q list --available $available_java"|"-q list available $available_java")
+          return 0
+          ;;
+        *) return 1 ;;
+      esac
+    }
+    if [[ "$package_manager" == "dnf" ]]; then
+      dnf() { mock_package_manager "$@"; }
+    else
+      yum() { mock_package_manager "$@"; }
+    fi
+    ensure_system_packages "$sandbox/os-release"
+  ) > "$sandbox/system-packages-output.log" 2>&1
+  last_status=$?
+  last_output="$(<"$sandbox/system-packages-output.log")"
+  set -e
+}
+
+test_rpm_distribution_installs_system_dependencies_with_dnf() {
+  local sandbox package_log
+  sandbox="$(make_sandbox)"
+  run_system_package_install "$sandbox" rocky 'rhel centos fedora' \
+    'Rocky Linux 9.6' java-21-openjdk-headless
+  assert_success || return 1
+  package_log="$(<"$sandbox/packages.log")"
+  assert_contains "$last_output" 'Detected operating system: Rocky Linux 9.6' || return 1
+  assert_contains "$package_log" '-y makecache' || return 1
+  assert_contains "$package_log" '-q list --available java-21-openjdk-headless' || return 1
+  assert_contains "$package_log" 'install -y gcc gcc-c++ make' || return 1
+  assert_contains "$package_log" 'java-21-openjdk-headless' || return 1
+  assert_contains "$package_log" 'shadow-utils'
+}
+
+test_amazon_linux_uses_corretto_21() {
+  local sandbox package_log
+  sandbox="$(make_sandbox)"
+  run_system_package_install "$sandbox" amzn fedora \
+    'Amazon Linux 2023.7' java-21-amazon-corretto-headless
+  assert_success || return 1
+  package_log="$(<"$sandbox/packages.log")"
+  assert_contains "$last_output" 'Detected operating system: Amazon Linux 2023.7' || return 1
+  assert_contains "$package_log" '-q list --available java-21-amazon-corretto-headless' || return 1
+  assert_contains "$package_log" 'java-21-amazon-corretto-headless'
+}
+
+test_opencloudos_falls_back_to_kona_17() {
+  local sandbox package_log
+  sandbox="$(make_sandbox)"
+  run_system_package_install "$sandbox" opencloudos opencloudos \
+    'OpenCloudOS 9.4' java-17-konajdk
+  assert_success || return 1
+  package_log="$(<"$sandbox/packages.log")"
+  assert_contains "$last_output" 'Detected operating system: OpenCloudOS 9.4' || return 1
+  assert_contains "$package_log" '-q list --available java-21-openjdk-headless' || return 1
+  assert_contains "$package_log" '-q list --available java-17-konajdk' || return 1
+  assert_contains "$package_log" 'java-17-konajdk'
+}
+
+test_rpm_distribution_can_install_with_yum() {
+  local sandbox package_log
+  sandbox="$(make_sandbox)"
+  run_system_package_install "$sandbox" tencentos 'rhel centos fedora' \
+    'TencentOS Server 3.1' java-21-openjdk-headless yum
+  assert_success || return 1
+  package_log="$(<"$sandbox/packages.log")"
+  assert_contains "$last_output" 'Detected operating system: TencentOS Server 3.1' || return 1
+  assert_contains "$package_log" '-q list available java-21-openjdk-headless' || return 1
+  assert_contains "$package_log" 'install -y gcc gcc-c++ make'
+}
+
 test_setup_uses_public_10010_and_private_10011() {
   local sandbox
   sandbox="$(make_sandbox)"
@@ -358,6 +445,10 @@ run_test() {
 }
 
 run_test test_setup_uses_public_10010_and_private_10011
+run_test test_rpm_distribution_installs_system_dependencies_with_dnf
+run_test test_amazon_linux_uses_corretto_21
+run_test test_opencloudos_falls_back_to_kona_17
+run_test test_rpm_distribution_can_install_with_yum
 run_test test_setup_without_options_runs_guided_wizard
 run_test test_setup_rejects_ambiguous_positional_arguments
 run_test test_setup_accepts_custom_public_port

--- a/deps/db-sync/deploy/package-native-runtime.sh
+++ b/deps/db-sync/deploy/package-native-runtime.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly db_sync_dir="$(cd -- "$script_dir/.." && pwd)"
+
+die() {
+  printf 'Error: %s\n' "$*" >&2
+  exit 1
+}
+
+runtime_version="${1:-}"
+runtime_arch="${2:-}"
+output_dir="${3:-}"
+node_binary="${NODE_BINARY:-$(command -v node 2>/dev/null || true)}"
+default_release_repository="${DEFAULT_RELEASE_REPOSITORY:-}"
+
+[[ -n "$runtime_version" ]] || die "Usage: $0 <version> <x64|arm64> <output-directory>"
+[[ "$runtime_version" =~ ^[A-Za-z0-9._+-]+$ ]] \
+  || die "Runtime version contains unsupported characters: $runtime_version"
+[[ "$runtime_arch" == "x64" || "$runtime_arch" == "arm64" ]] \
+  || die "Runtime architecture must be x64 or arm64."
+[[ -n "$output_dir" ]] || die "Output directory is required."
+[[ -x "$node_binary" ]] || die "NODE_BINARY must point to an executable Node.js binary."
+if [[ -n "$default_release_repository" ]]; then
+  [[ "$default_release_repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] \
+    || die "DEFAULT_RELEASE_REPOSITORY must be an owner/repository pair."
+fi
+[[ -f "$db_sync_dir/worker/dist/node-adapter.js" ]] \
+  || die "Build worker/dist/node-adapter.js before packaging."
+[[ -d "$db_sync_dir/node_modules" ]] || die "Install production dependencies before packaging."
+
+case "$(uname -m)" in
+  x86_64) host_arch="x64" ;;
+  aarch64|arm64) host_arch="arm64" ;;
+  *) die "Unsupported build host architecture: $(uname -m)" ;;
+esac
+[[ "$host_arch" == "$runtime_arch" ]] \
+  || die "Native runtime must be packaged on its target architecture ($runtime_arch)."
+
+stage_dir="$(mktemp -d "${TMPDIR:-/tmp}/logseq-sync-runtime-package.XXXXXX")"
+cleanup() {
+  [[ -d "$stage_dir" ]] && rm -rf -- "$stage_dir"
+}
+trap cleanup EXIT
+
+runtime_dir="$stage_dir/logseq-sync-runtime"
+mkdir -p "$runtime_dir/node/bin" "$runtime_dir/app" "$runtime_dir/bin" "$output_dir"
+install -m 0755 "$node_binary" "$runtime_dir/node/bin/node"
+install -m 0644 "$db_sync_dir/worker/dist/node-adapter.js" \
+  "$runtime_dir/app/node-adapter.js"
+cp -a "$db_sync_dir/node_modules" "$runtime_dir/app/node_modules"
+if [[ -n "$default_release_repository" ]]; then
+  sed "s|readonly default_release_repository=\"logseq/logseq\"|readonly default_release_repository=\"${default_release_repository}\"|" \
+    "$script_dir/logseq-sync-native" > "$runtime_dir/bin/logseq-sync-native"
+  chmod 0755 "$runtime_dir/bin/logseq-sync-native"
+else
+  install -m 0755 "$script_dir/logseq-sync-native" "$runtime_dir/bin/logseq-sync-native"
+fi
+printf '%s\n' "$runtime_version" > "$runtime_dir/VERSION"
+printf '%s\n' "$runtime_arch" > "$runtime_dir/ARCHITECTURE"
+
+archive="logseq-sync-runtime-linux-${runtime_arch}.tar.gz"
+tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner \
+  -czf "$output_dir/$archive" -C "$stage_dir" logseq-sync-runtime
+(
+  cd "$output_dir"
+  sha256sum "$archive" > "$archive.sha256"
+)
+printf 'Created %s\n' "$output_dir/$archive"

--- a/deps/db-sync/deploy/test.sh
+++ b/deps/db-sync/deploy/test.sh
@@ -165,7 +165,7 @@ LOGSEQ_SYNC_GID=1000
 LOGSEQ_SYNC_ENDPOINT_MODE=https
 DB_SYNC_BASE_URL=https://old-sync.example.com:10010
 DB_SYNC_BIND_ADDRESS=127.0.0.1
-DB_SYNC_PUBLIC_PORT=8080
+DB_SYNC_PUBLIC_PORT=10010
 DB_SYNC_LOG_LEVEL=debug
 COGNITO_ISSUER=https://issuer.example.com/pool
 COGNITO_CLIENT_ID=custom-client
@@ -202,7 +202,7 @@ LOGSEQ_SYNC_GID=1000
 LOGSEQ_SYNC_ENDPOINT_MODE=https
 DB_SYNC_BASE_URL=https://old-sync.example.com:10010
 DB_SYNC_BIND_ADDRESS=127.0.0.1
-DB_SYNC_PUBLIC_PORT=8080
+DB_SYNC_PUBLIC_PORT=10010
 DB_SYNC_LOG_LEVEL=info
 COGNITO_ISSUER=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8
 COGNITO_CLIENT_ID=69cs1lgme7p8kbgld8n5kseii6
@@ -236,9 +236,9 @@ test_https_setup_force_recreates_caddy() {
   assert_success || return 1
   assert_contains "$(<"$sandbox/docker.log")" '--force-recreate'
   assert_contains "$(<"$sandbox/install/.env")" \
-    'DB_SYNC_BASE_URL=https://sync.example.com:10010' || return 1
+    'DB_SYNC_BASE_URL=https://sync.example.com' || return 1
   assert_contains "$(<"$sandbox/install/Caddyfile")" \
-    'https://sync.example.com:10010 {'
+    'https://sync.example.com {'
 }
 
 test_http_setup_verifies_public_endpoint() {

--- a/deps/db-sync/deploy/test.sh
+++ b/deps/db-sync/deploy/test.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly test_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly manager="$test_dir/logseq-sync"
+readonly suite_tmp="$(mktemp -d "${TMPDIR:-/tmp}/logseq-sync-test-suite.XXXXXX")"
+
+cleanup() {
+  if [[ -d "$suite_tmp" && "$suite_tmp" == *logseq-sync-test-suite.* ]]; then
+    rm -rf -- "$suite_tmp"
+  fi
+}
+
+trap cleanup EXIT
+
+pass_count=0
+fail_count=0
+
+make_sandbox() {
+  local sandbox
+  sandbox="$(mktemp -d "$suite_tmp/case.XXXXXX")"
+  mkdir -p "$sandbox/bin" "$sandbox/home"
+
+  cat > "$sandbox/bin/uname" <<'EOF'
+#!/usr/bin/env bash
+printf 'Linux\n'
+EOF
+
+  cat > "$sandbox/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_DOCKER_LOG"
+case "$*" in
+  "compose version") exit 0 ;;
+  "info") exit "${MOCK_DOCKER_INFO_STATUS:-0}" ;;
+  *" ps --format json "*)
+    printf '{"Health":"%s","State":"running"}\n' "${MOCK_DOCKER_HEALTH:-healthy}"
+    ;;
+  *) exit "${MOCK_DOCKER_STATUS:-0}" ;;
+esac
+EOF
+
+  cat > "$sandbox/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_CURL_LOG"
+if [[ "${MOCK_CURL_STATUS:-0}" -ne 0 ]]; then
+  exit "$MOCK_CURL_STATUS"
+fi
+printf '%s' "${MOCK_CURL_BODY:-{\"ok\":true}}"
+EOF
+
+  cat > "$sandbox/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_SLEEP_LOG"
+EOF
+
+  chmod +x "$sandbox/bin/uname" "$sandbox/bin/docker" "$sandbox/bin/curl" "$sandbox/bin/sleep"
+  printf '%s' "$sandbox"
+}
+
+run_manager() {
+  local sandbox="$1"
+  local input="$2"
+  shift 2
+  set +e
+  last_output="$(printf '%s' "$input" | env \
+    HOME="$sandbox/home" \
+    PATH="$sandbox/bin:$PATH" \
+    MOCK_DOCKER_LOG="$sandbox/docker.log" \
+    MOCK_CURL_LOG="$sandbox/curl.log" \
+    MOCK_SLEEP_LOG="$sandbox/sleep.log" \
+    "$@" \
+    "$manager" setup 2>&1)"
+  last_status=$?
+  set -e
+}
+
+assert_contains() {
+  local value="$1"
+  local expected="$2"
+  [[ "$value" == *"$expected"* ]] || {
+    printf 'Expected to find %q in:\n%s\n' "$expected" "$value" >&2
+    return 1
+  }
+}
+
+assert_not_contains() {
+  local value="$1"
+  local unexpected="$2"
+  [[ "$value" != *"$unexpected"* ]] || {
+    printf 'Did not expect to find %q in:\n%s\n' "$unexpected" "$value" >&2
+    return 1
+  }
+}
+
+assert_success() {
+  [[ "$last_status" -eq 0 ]] || {
+    printf 'Expected success, got status %s:\n%s\n' "$last_status" "$last_output" >&2
+    return 1
+  }
+}
+
+assert_failure() {
+  [[ "$last_status" -ne 0 ]] || {
+    printf 'Expected failure:\n%s\n' "$last_output" >&2
+    return 1
+  }
+}
+
+test_unhealthy_service_is_rejected() {
+  local sandbox input
+  sandbox="$(make_sandbox)"
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    https \
+    sync.example.com \
+    logseq-client \
+    y)"
+  run_manager "$sandbox" "$input" MOCK_DOCKER_HEALTH=unhealthy
+  assert_failure || return 1
+  assert_not_contains "$last_output" 'Logseq Sync is ready'
+}
+
+test_health_body_is_verified() {
+  local sandbox input
+  sandbox="$(make_sandbox)"
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    https \
+    sync.example.com \
+    logseq-client \
+    y)"
+  run_manager "$sandbox" "$input" 'MOCK_CURL_BODY={"ok":false}'
+  assert_failure || return 1
+  assert_not_contains "$last_output" 'Logseq Sync is ready'
+}
+
+test_docker_daemon_is_checked_before_writes() {
+  local sandbox input
+  sandbox="$(make_sandbox)"
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    https \
+    sync.example.com \
+    logseq-client \
+    y)"
+  run_manager "$sandbox" "$input" MOCK_DOCKER_INFO_STATUS=1
+  assert_failure || return 1
+  [[ ! -e "$sandbox/install" ]]
+}
+
+test_existing_configuration_becomes_prompt_defaults() {
+  local sandbox input env_file
+  sandbox="$(make_sandbox)"
+  mkdir -p "$sandbox/install"
+  env_file="$sandbox/install/.env"
+  cat > "$env_file" <<EOF
+LOGSEQ_SYNC_SOURCE_DIR=/old/source
+LOGSEQ_SYNC_INSTALL_DIR=$sandbox/install
+LOGSEQ_SYNC_DATA_DIR=$sandbox/existing-data
+LOGSEQ_SYNC_UID=1000
+LOGSEQ_SYNC_GID=1000
+LOGSEQ_SYNC_ENDPOINT_MODE=https
+DB_SYNC_BASE_URL=https://old-sync.example.com:10010
+DB_SYNC_BIND_ADDRESS=127.0.0.1
+DB_SYNC_PUBLIC_PORT=8080
+DB_SYNC_LOG_LEVEL=debug
+COGNITO_ISSUER=https://issuer.example.com/pool
+COGNITO_CLIENT_ID=custom-client
+COGNITO_JWKS_URL=https://issuer.example.com/pool/.well-known/jwks.json
+EOF
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    '' \
+    '' \
+    '' \
+    '' \
+    '' \
+    '' \
+    '' \
+    y \
+    y)"
+  run_manager "$sandbox" "$input"
+  assert_success || return 1
+  assert_contains "$(<"$env_file")" "LOGSEQ_SYNC_DATA_DIR=$sandbox/existing-data"
+  assert_contains "$(<"$env_file")" 'DB_SYNC_BASE_URL=https://old-sync.example.com:10010'
+  assert_contains "$(<"$env_file")" 'COGNITO_CLIENT_ID=custom-client'
+}
+
+test_https_to_http_removes_caddy_container() {
+  local sandbox input
+  sandbox="$(make_sandbox)"
+  mkdir -p "$sandbox/install"
+  cat > "$sandbox/install/.env" <<EOF
+LOGSEQ_SYNC_SOURCE_DIR=/old/source
+LOGSEQ_SYNC_INSTALL_DIR=$sandbox/install
+LOGSEQ_SYNC_DATA_DIR=$sandbox/data
+LOGSEQ_SYNC_UID=1000
+LOGSEQ_SYNC_GID=1000
+LOGSEQ_SYNC_ENDPOINT_MODE=https
+DB_SYNC_BASE_URL=https://old-sync.example.com:10010
+DB_SYNC_BIND_ADDRESS=127.0.0.1
+DB_SYNC_PUBLIC_PORT=8080
+DB_SYNC_LOG_LEVEL=info
+COGNITO_ISSUER=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8
+COGNITO_CLIENT_ID=69cs1lgme7p8kbgld8n5kseii6
+COGNITO_JWKS_URL=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8/.well-known/jwks.json
+EOF
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    http \
+    http://127.0.0.1:18080 \
+    I_ACCEPT_HTTP \
+    logseq-client \
+    y \
+    y)"
+  run_manager "$sandbox" "$input"
+  assert_success || return 1
+  assert_contains "$(<"$sandbox/docker.log")" 'rm --stop --force caddy'
+}
+
+test_https_setup_force_recreates_caddy() {
+  local sandbox input
+  sandbox="$(make_sandbox)"
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    https \
+    sync.example.com \
+    logseq-client \
+    y)"
+  run_manager "$sandbox" "$input"
+  assert_success || return 1
+  assert_contains "$(<"$sandbox/docker.log")" '--force-recreate'
+  assert_contains "$(<"$sandbox/install/.env")" \
+    'DB_SYNC_BASE_URL=https://sync.example.com:10010' || return 1
+  assert_contains "$(<"$sandbox/install/Caddyfile")" \
+    'https://sync.example.com:10010 {'
+}
+
+test_http_setup_verifies_public_endpoint() {
+  local sandbox input
+  sandbox="$(make_sandbox)"
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    http \
+    http://127.0.0.1:18080 \
+    I_ACCEPT_HTTP \
+    logseq-client \
+    y)"
+  run_manager "$sandbox" "$input" MOCK_CURL_STATUS=1
+  assert_failure || return 1
+  assert_contains "$last_output" 'Public endpoint did not return {"ok":true}'
+}
+
+test_invalid_http_host_is_rejected() {
+  local sandbox input
+  sandbox="$(make_sandbox)"
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    http \
+    http://999.999.999.999:18080)"
+  run_manager "$sandbox" "$input"
+  assert_failure || return 1
+  assert_contains "$last_output" 'HTTP URL must include a valid hostname or IPv4 address and port.'
+  [[ ! -e "$sandbox/install" ]]
+}
+
+test_invalid_custom_auth_url_is_rejected() {
+  local sandbox input
+  sandbox="$(make_sandbox)"
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    https \
+    sync.example.com \
+    custom-client \
+    https://-)"
+  run_manager "$sandbox" "$input"
+  assert_failure || return 1
+  assert_contains "$last_output" 'Cognito issuer must be a valid HTTPS URL.'
+  [[ ! -e "$sandbox/install" ]]
+}
+
+test_logs_proxy_maps_to_caddy() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  mkdir -p "$sandbox/install"
+  cat > "$sandbox/install/.env" <<EOF
+LOGSEQ_SYNC_ENDPOINT_MODE=https
+LOGSEQ_SYNC_SOURCE_DIR=$test_dir/../../..
+LOGSEQ_SYNC_INSTALL_DIR=$sandbox/install
+LOGSEQ_SYNC_DATA_DIR=$sandbox/data
+LOGSEQ_SYNC_UID=1000
+LOGSEQ_SYNC_GID=1000
+DB_SYNC_BASE_URL=https://sync.example.com:10010
+COGNITO_ISSUER=https://issuer.example.com
+COGNITO_CLIENT_ID=client
+COGNITO_JWKS_URL=https://issuer.example.com/.well-known/jwks.json
+EOF
+  cp "$test_dir/compose.yaml" "$sandbox/install/compose.yaml"
+  set +e
+  last_output="$(env \
+    HOME="$sandbox/home" \
+    PATH="$sandbox/bin:$PATH" \
+    MOCK_DOCKER_LOG="$sandbox/docker.log" \
+    MOCK_CURL_LOG="$sandbox/curl.log" \
+    MOCK_SLEEP_LOG="$sandbox/sleep.log" \
+    "$manager" logs proxy "$sandbox/install" 2>&1)"
+  last_status=$?
+  set -e
+  assert_success || return 1
+  assert_contains "$(<"$sandbox/docker.log")" 'logs --tail 200 caddy'
+}
+
+test_status_uses_one_shot_health_checks() {
+  local sandbox health_check_count
+  sandbox="$(make_sandbox)"
+  mkdir -p "$sandbox/install"
+  cat > "$sandbox/install/.env" <<EOF
+LOGSEQ_SYNC_ENDPOINT_MODE=http
+LOGSEQ_SYNC_SOURCE_DIR=$test_dir/../../..
+LOGSEQ_SYNC_INSTALL_DIR=$sandbox/install
+LOGSEQ_SYNC_DATA_DIR=$sandbox/data
+LOGSEQ_SYNC_UID=1000
+LOGSEQ_SYNC_GID=1000
+DB_SYNC_BASE_URL=http://127.0.0.1:18080
+COGNITO_ISSUER=https://issuer.example.com
+COGNITO_CLIENT_ID=client
+COGNITO_JWKS_URL=https://issuer.example.com/.well-known/jwks.json
+EOF
+  cp "$test_dir/compose.yaml" "$sandbox/install/compose.yaml"
+  cp "$test_dir/compose.http.yaml" "$sandbox/install/compose.http.yaml"
+  set +e
+  last_output="$(env \
+    HOME="$sandbox/home" \
+    PATH="$sandbox/bin:$PATH" \
+    MOCK_DOCKER_LOG="$sandbox/docker.log" \
+    MOCK_CURL_LOG="$sandbox/curl.log" \
+    MOCK_SLEEP_LOG="$sandbox/sleep.log" \
+    MOCK_DOCKER_HEALTH=unhealthy \
+    "$manager" status "$sandbox/install" 2>&1)"
+  last_status=$?
+  set -e
+  assert_failure || return 1
+  health_check_count="$(grep -c 'ps --format json sync' "$sandbox/docker.log")"
+  [[ "$health_check_count" -eq 1 ]] || {
+    printf 'Expected one health check, got %s:\n%s\n' "$health_check_count" "$(<"$sandbox/docker.log")" >&2
+    return 1
+  }
+}
+
+run_test() {
+  local name="$1"
+  if "$name"; then
+    pass_count=$((pass_count + 1))
+    printf 'ok - %s\n' "$name"
+  else
+    fail_count=$((fail_count + 1))
+    printf 'not ok - %s\n' "$name"
+  fi
+}
+
+run_test test_unhealthy_service_is_rejected
+run_test test_health_body_is_verified
+run_test test_docker_daemon_is_checked_before_writes
+run_test test_existing_configuration_becomes_prompt_defaults
+run_test test_https_to_http_removes_caddy_container
+run_test test_https_setup_force_recreates_caddy
+run_test test_http_setup_verifies_public_endpoint
+run_test test_invalid_http_host_is_rejected
+run_test test_invalid_custom_auth_url_is_rejected
+run_test test_logs_proxy_maps_to_caddy
+run_test test_status_uses_one_shot_health_checks
+
+printf '%s passed, %s failed\n' "$pass_count" "$fail_count"
+[[ "$fail_count" -eq 0 ]]

--- a/deps/db-sync/package.json
+++ b/deps/db-sync/package.json
@@ -2,6 +2,9 @@
   "name": "@logseq/db-sync",
   "version": "1.0.0",
   "packageManager": "pnpm@10.33.0",
+  "engines": {
+    "node": "^22.12.0 || ^24.0.0"
+  },
   "private": true,
   "scripts": {
     "dev": "cd ./worker && pnpm exec wrangler dev",

--- a/deps/db-sync/src/logseq/db_sync/node/config.cljs
+++ b/deps/db-sync/src/logseq/db_sync/node/config.cljs
@@ -11,7 +11,8 @@
 
 (defn config-from-env []
   (let [env (.-env js/process)]
-    {:port (when-let [v (env-value env "DB_SYNC_PORT")] (parse-int v 8080))
+    {:host (env-value env "DB_SYNC_HOST")
+     :port (when-let [v (env-value env "DB_SYNC_PORT")] (parse-int v 8080))
      :base-url (env-value env "DB_SYNC_BASE_URL")
      :data-dir (or (env-value env "DB_SYNC_DATA_DIR") "data/db-sync")
      :storage-driver (or (env-value env "DB_SYNC_STORAGE_DRIVER") "sqlite")
@@ -22,11 +23,12 @@
      :cognito-jwks-url (env-value env "COGNITO_JWKS_URL")}))
 
 (def ^:private allowed-config-keys
-  [:port :base-url :data-dir :storage-driver :assets-driver :log-level
+  [:host :port :base-url :data-dir :storage-driver :assets-driver :log-level
    :cognito-issuer :cognito-client-id :cognito-jwks-url])
 
 (defn normalize-config [overrides]
-  (let [defaults {:port 8080
+  (let [defaults {:host "127.0.0.1"
+                  :port 8080
                   :data-dir "data/db-sync"
                   :storage-driver "sqlite"
                   :assets-driver "filesystem"

--- a/deps/db-sync/src/logseq/db_sync/node/config.cljs
+++ b/deps/db-sync/src/logseq/db_sync/node/config.cljs
@@ -33,7 +33,8 @@
                   :storage-driver "sqlite"
                   :assets-driver "filesystem"
                   :log-level "info"}
-        merged (merge defaults (config-from-env) overrides)
+        env-config (into {} (remove (comp nil? val)) (config-from-env))
+        merged (merge defaults env-config overrides)
         storage-driver (string/lower-case (:storage-driver merged))
         assets-driver (string/lower-case (:assets-driver merged))]
     (when-not (#{"sqlite"} storage-driver)

--- a/deps/db-sync/src/logseq/db_sync/node/server.cljs
+++ b/deps/db-sync/src/logseq/db_sync/node/server.cljs
@@ -161,7 +161,7 @@
                  (.destroy socket)))))
       (p/let [_ (js/Promise.
                  (fn [resolve]
-                   (.listen server (:port cfg)
+                   (.listen server (:port cfg) (:host cfg)
                             (fn [] (resolve nil)))))
               address (.address server)
               port (if (number? address) address (.-port address))

--- a/deps/db-sync/test/logseq/db_sync/node_config_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/node_config_test.cljs
@@ -9,12 +9,17 @@
     (catch :default _ true)))
 
 (deftest normalize-config-drops-unknown-keys-test
-  (let [cfg (config/normalize-config {:port 7777
+  (let [cfg (config/normalize-config {:host "127.0.0.2"
+                                      :port 7777
                                       :unknown-key "value"
                                       :legacy-auth-key "value"})]
+    (is (= "127.0.0.2" (:host cfg)))
     (is (= 7777 (:port cfg)))
     (is (nil? (:unknown-key cfg)))
     (is (nil? (:legacy-auth-key cfg)))))
+
+(deftest normalize-config-default-host-test
+  (is (= "127.0.0.1" (:host (config/normalize-config {})))))
 
 (deftest normalize-config-storage-driver-test
   (testing "sqlite storage driver accepted"

--- a/deps/db-sync/test/logseq/db_sync/node_config_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/node_config_test.cljs
@@ -18,8 +18,10 @@
     (is (nil? (:unknown-key cfg)))
     (is (nil? (:legacy-auth-key cfg)))))
 
-(deftest normalize-config-default-host-test
-  (is (= "127.0.0.1" (:host (config/normalize-config {})))))
+(deftest normalize-config-defaults-test
+  (let [cfg (config/normalize-config {})]
+    (is (= "127.0.0.1" (:host cfg)))
+    (is (= 8080 (:port cfg)))))
 
 (deftest normalize-config-storage-driver-test
   (testing "sqlite storage driver accepted"

--- a/docs/superpowers/specs/2026-07-14-sync-installer-design.md
+++ b/docs/superpowers/specs/2026-07-14-sync-installer-design.md
@@ -98,6 +98,9 @@ connections are held in process memory, while the adapter uses local SQLite.
 The data directory is mounted from the host so container recreation does not
 discard graphs or assets.
 
+The adapter is published on the host only in HTTP mode. HTTPS mode keeps it on
+the internal Compose network and lets Caddy provide the public ports 80 and 443.
+
 ## Client compatibility
 
 The existing client accepts a custom HTTP(S) Sync Server URL and derives the

--- a/docs/superpowers/specs/2026-07-14-sync-installer-design.md
+++ b/docs/superpowers/specs/2026-07-14-sync-installer-design.md
@@ -1,0 +1,106 @@
+# Interactive self-hosted Sync installer
+
+## Goal
+
+Provide a Linux-server deployment path for the experimental DB Sync Node adapter.
+The operator runs one interactive script, makes explicit choices, and receives a
+running Docker Compose deployment plus the URL to enter in Logseq.
+
+The installer does not install Docker. When Docker Compose is unavailable, it
+stops before writing deployment files and links to the official Docker Engine
+installation guide: <https://docs.docker.com/engine/install/>.
+
+## Scope
+
+The deployment assets will live under `deps/db-sync/deploy/` and include:
+
+- an interactive `install-sync.sh` entrypoint;
+- a Dockerfile that builds the Node adapter and runs it;
+- a Compose definition with a durable data volume;
+- optional Caddy reverse proxy configuration for TLS;
+- generated `.env` configuration, never committed with secrets.
+
+The installer targets one Linux host and one Sync adapter instance. It does not
+install Docker, run a multi-node cluster, provide backups, or delete existing
+data.
+
+## Operator flow
+
+1. Check Linux, Docker Engine, and `docker compose` availability. If missing,
+   print the official Docker documentation URL and exit without changes.
+2. Ask for a deployment directory and a persistent data directory.
+3. Ask for an endpoint mode:
+   - `https`: domain name plus Caddy-managed TLS certificate;
+   - `http`: bind a public HTTP endpoint only after the operator types an
+     explicit risk acknowledgement.
+4. Ask for an authentication mode:
+   - verified JWT through the current Cognito-compatible environment variables;
+   - shared access token, requiring a future client settings field and matching
+     server validation;
+   - anonymous mode only for private-network testing. It must reject public
+     endpoint selection.
+5. Print the full plan, including paths, URL, exposed ports, and authentication
+   choice. Require a final confirmation before creating configuration files or
+   running Compose.
+6. Start the service with `docker compose up -d`, poll `/health`, and print the
+   Sync Server URL for Logseq settings.
+
+## Safety behavior
+
+- Never run recursive deletion, `docker compose down -v`, or remove volumes.
+- If a generated file already exists, offer only `cancel` or write a new
+  timestamped backup beside it; no overwrite occurs without explicit
+  confirmation.
+- Warn that public HTTP exposes bearer credentials and shared tokens in transit.
+- Do not allow anonymous mode with a public HTTP or HTTPS endpoint.
+
+## Architecture
+
+```text
+Logseq Desktop/Web
+  -> HTTPS/WSS or HTTP/WS
+  -> optional Caddy reverse proxy
+  -> DB Sync Node adapter (single container)
+  -> persistent host-mounted data directory
+     - index.sqlite
+     - graphs/
+     - assets/
+```
+
+Compose runs a single adapter because graph state and active WebSocket
+connections are held in process memory, while the adapter uses local SQLite.
+The data directory is mounted from the host so container recreation does not
+discard graphs or assets.
+
+## Client compatibility
+
+The existing client accepts a custom HTTP(S) Sync Server URL and derives the
+matching WebSocket URL. It already supports the verified-JWT path.
+
+Shared-token and anonymous choices require additional implementation before the
+installer exposes them as working choices:
+
+- the server must validate the selected authentication mode;
+- the client must persist and send a shared token when selected;
+- the UI must clearly mark the mode and its risk.
+
+Until that implementation exists, the installer must either omit those choices
+or display them as unavailable rather than silently starting an insecure
+server.
+
+## Verification
+
+- Build the adapter: `pnpm --dir deps/db-sync build:node-adapter`.
+- Start the generated Compose deployment.
+- Verify `GET /health` returns `{"ok":true}`.
+- Verify a client configured with the displayed URL can connect and create a
+  graph using the selected verified-JWT mode.
+- Add non-interactive shell tests for missing Docker, HTTP acknowledgement,
+  existing configuration, and health-check failure paths.
+
+## Open constraint
+
+The Node adapter is currently experimental: its HTTP and WebSocket end-to-end
+tests are disabled in `deps/db-sync/test/logseq/db_sync/node_adapter_test.cljs`.
+The installer must label this deployment as experimental and must not claim
+production support.

--- a/docs/superpowers/specs/2026-07-14-sync-installer-design.md
+++ b/docs/superpowers/specs/2026-07-14-sync-installer-design.md
@@ -35,16 +35,16 @@ data.
    - `http`: bind a public HTTP endpoint only after the operator types an
      explicit risk acknowledgement.
 4. Ask for an authentication mode:
-   - verified JWT through the current Cognito-compatible environment variables;
-   - shared access token, requiring a future client settings field and matching
-     server validation;
-   - anonymous mode only for private-network testing. It must reject public
-     endpoint selection.
+   - `logseq-client` verified JWT, using the issuer and client ID embedded in
+     the current Logseq client;
+   - `custom-client` verified JWT, which requires a separately built client
+     that issues tokens for the entered issuer and client ID.
 5. Print the full plan, including paths, URL, exposed ports, and authentication
    choice. Require a final confirmation before creating configuration files or
    running Compose.
-6. Start the service with `docker compose up -d`, poll `/health`, and print the
-   Sync Server URL for Logseq settings.
+6. Start the service with `docker compose up -d`, poll the adapter `/health`.
+   For HTTPS, also require Caddy health and a successful public HTTPS
+   `/health` request before printing the Sync Server URL for Logseq settings.
 
 ## Management commands
 
@@ -64,8 +64,8 @@ After `setup`, the manager checks both `docker compose ps` and the unauthenticat
 `/health` endpoint. It reports success only when the containers are running and
 the endpoint returns `{"ok":true}`.
 
-`status` reports container state, the health result, the configured Sync Server
-URL, and a short recent-error summary. `logs` prints the most recent 200 lines;
+`status` reports container state, the health result, and the configured Sync
+Server URL. `logs` prints the most recent 200 lines;
 `--follow` streams new lines. `sync` selects the Node adapter logs, while `proxy`
 selects Caddy logs and reports that the service is unavailable in HTTP mode.
 
@@ -78,8 +78,7 @@ data intact, shows the failed check, and directs the operator to `logs --follow`
 - If a generated file already exists, offer only `cancel` or write a new
   timestamped backup beside it; no overwrite occurs without explicit
   confirmation.
-- Warn that public HTTP exposes bearer credentials and shared tokens in transit.
-- Do not allow anonymous mode with a public HTTP or HTTPS endpoint.
+- Warn that public HTTP exposes bearer credentials in transit.
 
 ## Architecture
 
@@ -102,7 +101,10 @@ discard graphs or assets.
 ## Client compatibility
 
 The existing client accepts a custom HTTP(S) Sync Server URL and derives the
-matching WebSocket URL. It already supports the verified-JWT path.
+matching WebSocket URL. It signs in through its embedded Logseq Cognito
+configuration, so `logseq-client` is the only mode directly usable by an
+unmodified client. `custom-client` is for operators who also build a client
+configured for their own issuer.
 
 Shared-token and anonymous choices require additional implementation before the
 installer exposes them as working choices:

--- a/docs/superpowers/specs/2026-07-14-sync-installer-design.md
+++ b/docs/superpowers/specs/2026-07-14-sync-installer-design.md
@@ -1,10 +1,10 @@
-# Interactive self-hosted Sync installer
+# Interactive self-hosted Sync manager
 
 ## Goal
 
 Provide a Linux-server deployment path for the experimental DB Sync Node adapter.
-The operator runs one interactive script, makes explicit choices, and receives a
-running Docker Compose deployment plus the URL to enter in Logseq.
+The operator runs one interactive manager, makes explicit choices, and receives
+a running Docker Compose deployment plus the URL to enter in Logseq.
 
 The installer does not install Docker. When Docker Compose is unavailable, it
 stops before writing deployment files and links to the official Docker Engine
@@ -14,7 +14,7 @@ installation guide: <https://docs.docker.com/engine/install/>.
 
 The deployment assets will live under `deps/db-sync/deploy/` and include:
 
-- an interactive `install-sync.sh` entrypoint;
+- an interactive `logseq-sync` entrypoint;
 - a Dockerfile that builds the Node adapter and runs it;
 - a Compose definition with a durable data volume;
 - optional Caddy reverse proxy configuration for TLS;
@@ -26,7 +26,8 @@ data.
 
 ## Operator flow
 
-1. Check Linux, Docker Engine, and `docker compose` availability. If missing,
+1. Run `logseq-sync setup`, which checks Linux, Docker Engine, and `docker
+   compose` availability. If missing,
    print the official Docker documentation URL and exit without changes.
 2. Ask for a deployment directory and a persistent data directory.
 3. Ask for an endpoint mode:
@@ -44,6 +45,32 @@ data.
    running Compose.
 6. Start the service with `docker compose up -d`, poll `/health`, and print the
    Sync Server URL for Logseq settings.
+
+## Management commands
+
+`logseq-sync` is a deployment manager, not an install-only script. It exposes:
+
+```bash
+logseq-sync setup
+logseq-sync status
+logseq-sync logs
+logseq-sync logs --follow
+logseq-sync logs sync
+logseq-sync logs proxy
+logseq-sync help
+```
+
+After `setup`, the manager checks both `docker compose ps` and the unauthenticated
+`/health` endpoint. It reports success only when the containers are running and
+the endpoint returns `{"ok":true}`.
+
+`status` reports container state, the health result, the configured Sync Server
+URL, and a short recent-error summary. `logs` prints the most recent 200 lines;
+`--follow` streams new lines. `sync` selects the Node adapter logs, while `proxy`
+selects Caddy logs and reports that the service is unavailable in HTTP mode.
+
+On startup or health-check failure, the manager leaves containers and persistent
+data intact, shows the failed check, and directs the operator to `logs --follow`.
 
 ## Safety behavior
 

--- a/docs/superpowers/specs/2026-07-14-sync-installer-design.md
+++ b/docs/superpowers/specs/2026-07-14-sync-installer-design.md
@@ -2,104 +2,97 @@
 
 ## Goal
 
-Provide a Linux-server deployment path for the experimental DB Sync Node adapter.
-The operator runs one interactive manager, makes explicit choices, and receives
-a running Docker Compose deployment plus the URL to enter in Logseq.
-
-The installer does not install Docker. When Docker Compose is unavailable, it
-stops before writing deployment files and links to the official Docker Engine
-installation guide: <https://docs.docker.com/engine/install/>.
+Provide a low-configuration Linux-server deployment path for the experimental
+DB Sync Node adapter. The primary path runs Sync Node and Caddy as native
+systemd services without requiring Docker. The operator supplies a domain,
+accepts or customizes the public and private port defaults, and receives the
+exact HTTPS URL to enter in Logseq.
 
 ## Scope
 
 The deployment assets will live under `deps/db-sync/deploy/` and include:
 
-- an interactive `logseq-sync` entrypoint;
+- a native `logseq-sync-native` entrypoint;
 - a Dockerfile that builds the Node adapter and runs it;
-- a Compose definition with a durable data volume;
-- optional Caddy reverse proxy configuration for TLS;
-- generated `.env` configuration, never committed with secrets.
+- a Compose definition retained as an alternative deployment;
+- Caddy reverse proxy configuration for automatic TLS;
+- generated `sync.env` configuration, never committed with secrets.
 
-The installer targets one Linux host and one Sync adapter instance. It does not
-install Docker, run a multi-node cluster, provide backups, or delete existing
-data.
+The native installer targets one Debian or Ubuntu systemd host and one Sync
+adapter instance. It installs its build/runtime dependencies, but does not run
+a multi-node cluster, provide backups, or delete existing data.
 
 ## Operator flow
 
-1. Run `logseq-sync setup`, which checks Linux, Docker Engine, and `docker
-   compose` availability. If missing,
-   print the official Docker documentation URL and exit without changes.
-2. Ask for a deployment directory and a persistent data directory.
-3. Ask for an endpoint mode:
-   - `https`: domain name plus Caddy-managed TLS certificate;
-   - `http`: bind a public HTTP endpoint only after the operator types an
-     explicit risk acknowledgement.
-4. Ask for an authentication mode:
-   - `logseq-client` verified JWT, using the issuer and client ID embedded in
-     the current Logseq client;
-   - `custom-client` verified JWT, which requires a separately built client
-     that issues tokens for the entered issuer and client ID.
-5. Print the full plan, including paths, URL, exposed ports, and authentication
-   choice. Require a final confirmation before creating configuration files or
-   running Compose.
-6. Start the service with `docker compose up -d`, poll the adapter `/health`.
-   For HTTPS, also require Caddy health and a successful public HTTPS
-   `/health` request before printing the Sync Server URL for Logseq settings.
+1. Run `sudo logseq-sync-native setup` to enter the guided flow.
+2. Validate Linux and systemd, explain that the domain must be a hostname whose
+   propagated public `A`/`AAAA` record points to this server, then prompt for
+   and validate it. Show the addresses returned by DNS.
+3. Prompt for the public HTTPS/WSS port with `10010` as the default, then prompt
+   for the private loopback-only adapter port with `10011` as the default. Keep
+   ACME HTTP validation on port `80`, explain the public/private exposure rules,
+   reject duplicate ports, print the topology, and require one confirmation.
+4. Install missing native build/runtime dependencies on Debian or Ubuntu.
+5. Build into a new versioned release directory, then atomically switch the
+   `current` symlink only after the build succeeds.
+6. Generate systemd, adapter, and Caddy configuration. Normal setup uses the
+   verified JWT identity embedded in the current Logseq client and does not ask
+   for Cognito settings.
+7. Start Sync Node and Caddy, then require successful private HTTP and public
+   HTTPS `/health` checks before printing the Sync Server URL.
 
 ## Management commands
 
-`logseq-sync` is a deployment manager, not an install-only script. It exposes:
+`logseq-sync-native` is a deployment manager, not an install-only script. Its
+default setup is interactive, with named options available for automation:
 
 ```bash
-logseq-sync setup
-logseq-sync status
-logseq-sync logs
-logseq-sync logs --follow
-logseq-sync logs sync
-logseq-sync logs proxy
-logseq-sync help
+logseq-sync-native setup
+logseq-sync-native setup --domain <domain> --public-port <port> \
+  --internal-port <port> --yes
+logseq-sync-native update
+logseq-sync-native status
+logseq-sync-native logs --follow sync
+logseq-sync-native logs --follow proxy
+logseq-sync-native help
 ```
 
-After `setup`, the manager checks both `docker compose ps` and the unauthenticated
-`/health` endpoint. It reports success only when the containers are running and
-the endpoint returns `{"ok":true}`.
+After `setup`, the manager checks systemd plus the unauthenticated private and
+public `/health` endpoints. It reports success only when both return
+`{"ok":true}`.
 
-`status` reports container state, the health result, and the configured Sync
-Server URL. `logs` prints the most recent 200 lines;
-`--follow` streams new lines. `sync` selects the Node adapter logs, while `proxy`
-selects Caddy logs and reports that the service is unavailable in HTTP mode.
+`status` reports service state, both health results, and the configured Sync
+Server URL. `logs` prints the most recent 200 journal lines; `--follow` streams
+new lines. `sync` selects the Node adapter and `proxy` selects Caddy.
 
-On startup or health-check failure, the manager leaves containers and persistent
-data intact, shows the failed check, and directs the operator to `logs --follow`.
+On startup or health-check failure, the manager leaves releases and persistent
+data intact, shows recent journal entries, and directs the operator to logs.
 
 ## Safety behavior
 
-- Never run recursive deletion, `docker compose down -v`, or remove volumes.
-- If a generated file already exists, offer only `cancel` or write a new
-  timestamped backup beside it; no overwrite occurs without explicit
-  confirmation.
-- Warn that public HTTP exposes bearer credentials in transit.
+- Never remove the persistent data or Caddy certificate directories.
+- Back up generated configuration with a timestamp before replacement.
+- Bind the Node adapter to `127.0.0.1`; only Caddy listens publicly.
+- Do not expose an HTTP mode in the native quickstart.
 
 ## Architecture
 
 ```text
 Logseq Desktop/Web
-  -> HTTPS/WSS or HTTP/WS
-  -> optional Caddy reverse proxy
-  -> DB Sync Node adapter (single container)
-  -> persistent host-mounted data directory
+  -> HTTPS/WSS :10010 (default, operator-configurable)
+  -> Caddy systemd service
+  -> DB Sync Node adapter at 127.0.0.1:10011
+  -> persistent host data directory
      - index.sqlite
      - graphs/
      - assets/
 ```
 
-Compose runs a single adapter because graph state and active WebSocket
+Systemd runs a single adapter because graph state and active WebSocket
 connections are held in process memory, while the adapter uses local SQLite.
-The data directory is mounted from the host so container recreation does not
-discard graphs or assets.
-
-The adapter is published on the host only in HTTP mode. HTTPS mode keeps it on
-the internal Compose network and lets Caddy provide the public ports 80 and 443.
+Caddy owns public port 80 and the selected HTTPS port. The adapter bind address
+is enforced in its own configuration rather than relying only on firewall
+rules.
 
 ## Client compatibility
 
@@ -123,12 +116,13 @@ server.
 ## Verification
 
 - Build the adapter: `pnpm --dir deps/db-sync build:node-adapter`.
-- Start the generated Compose deployment.
+- Start the generated systemd deployment.
 - Verify `GET /health` returns `{"ok":true}`.
 - Verify a client configured with the displayed URL can connect and create a
   graph using the selected verified-JWT mode.
-- Add non-interactive shell tests for missing Docker, HTTP acknowledgement,
-  existing configuration, and health-check failure paths.
+- Run the non-interactive native-manager tests for default/custom port
+  selection, default authentication, domain validation, generated service
+  files, and one-shot status checks. Keep the Docker alternative tests green.
 
 ## Open constraint
 

--- a/docs/superpowers/specs/2026-07-14-sync-installer-design.md
+++ b/docs/superpowers/specs/2026-07-14-sync-installer-design.md
@@ -32,7 +32,9 @@ not run a multi-node cluster, provide backups, or delete existing data.
    for the private loopback-only adapter port with `10011` as the default. Keep
    ACME HTTP validation on port `80`, explain the public/private exposure rules,
    reject duplicate ports, print the topology, and require one confirmation.
-4. Install missing native build/runtime dependencies with `apt`, `dnf`, or `yum`.
+4. Reuse a compatible service-accessible Node.js 22 or 24 runtime when present;
+   otherwise install a private Node.js 24 runtime. Install other missing native
+   build/runtime dependencies with `apt`, `dnf`, or `yum`.
 5. Build into a new versioned release directory, then atomically switch the
    `current` symlink only after the build succeeds.
 6. Generate systemd, adapter, and Caddy configuration. Normal setup uses the

--- a/docs/superpowers/specs/2026-07-14-sync-installer-design.md
+++ b/docs/superpowers/specs/2026-07-14-sync-installer-design.md
@@ -13,14 +13,18 @@ exact HTTPS URL to enter in Logseq.
 The deployment assets will live under `deps/db-sync/deploy/` and include:
 
 - a native `logseq-sync-native` entrypoint;
+- checksum-verified native runtime archives built for Linux `x64` and `arm64`;
+- a GitHub Actions workflow that builds, smoke-tests, and publishes the archives;
 - a Dockerfile that builds the Node adapter and runs it;
 - a Compose definition retained as an alternative deployment;
 - Caddy reverse proxy configuration for automatic TLS;
 - generated `sync.env` configuration, never committed with secrets.
 
-The native installer targets one Debian/Ubuntu or RPM-based systemd host and
-one Sync adapter instance. It installs its build/runtime dependencies, but does
-not run a multi-node cluster, provide backups, or delete existing data.
+The native installer targets one glibc-based Linux systemd host and one Sync
+adapter instance. The server does not compile source or install Node.js, Java,
+Clojure, pnpm, Python, or compiler packages. It downloads a prebuilt runtime
+and Caddy, but does not run a multi-node cluster, provide backups, or delete
+existing data.
 
 ## Operator flow
 
@@ -32,11 +36,13 @@ not run a multi-node cluster, provide backups, or delete existing data.
    for the private loopback-only adapter port with `10011` as the default. Keep
    ACME HTTP validation on port `80`, explain the public/private exposure rules,
    reject duplicate ports, print the topology, and require one confirmation.
-4. Reuse a compatible service-accessible Node.js 22 or 24 runtime when present;
-   otherwise install a private Node.js 24 runtime. Install other missing native
-   build/runtime dependencies with `apt`, `dnf`, or `yum`.
-5. Build into a new versioned release directory, then atomically switch the
-   `current` symlink only after the build succeeds.
+4. Select the prebuilt Linux `x64` or `arm64` runtime, download its archive and
+   SHA-256 file from the configured GitHub Release, and reject incomplete,
+   corrupt, or wrong-architecture packages.
+5. Extract into a new versioned release directory, then atomically switch the
+   `current` symlink only after validation succeeds. The archive supplies its
+   own Node.js binary, compiled adapter, production `node_modules` (including
+   the architecture-specific `better-sqlite3` addon), and manager command.
 6. Generate systemd, adapter, and Caddy configuration. Normal setup uses the
    verified JWT identity embedded in the current Logseq client and does not ask
    for Cognito settings.
@@ -67,6 +73,10 @@ public `/health` endpoints. It reports success only when both return
 Server URL. `logs` prints the most recent 200 journal lines; `--follow` streams
 new lines. `sync` selects the Node adapter and `proxy` selects Caddy.
 
+`update` downloads the configured rolling or versioned release, atomically
+switches it, and restores the previous runtime if either health check fails.
+It does not require a repository checkout on the server.
+
 On startup or health-check failure, the manager leaves releases and persistent
 data intact, shows recent journal entries, and directs the operator to logs.
 
@@ -96,6 +106,35 @@ Caddy owns public port 80 and the selected HTTPS port. The adapter bind address
 is enforced in its own configuration rather than relying only on firewall
 rules.
 
+## Runtime build and release
+
+GitHub Actions builds on native Linux x64 and arm64 runners with Java 21,
+Node.js 24, and the pinned pnpm/Clojure toolchain. Compilation and native module
+installation happen there, not on the target host. Each published archive has
+this layout:
+
+```text
+logseq-sync-runtime/
+  node/bin/node
+  app/node-adapter.js
+  app/node_modules/
+  bin/logseq-sync-native
+  VERSION
+  ARCHITECTURE
+```
+
+The manager verifies the separately published SHA-256 value before extraction,
+checks the declared architecture, and executes the bundled Node.js runtime.
+This archive is preferred over a literal single executable because the adapter
+loads `better-sqlite3` as a native `.node` addon from the filesystem. Hiding it
+inside Node SEA or another single-file wrapper would add a fragile extraction
+and module-resolution layer without reducing the target host requirements.
+
+The rolling GitHub Release tag `db-sync-native` is the default install/update
+channel. Tags matching `db-sync-native-v*` provide pin-able releases. Forks can
+override the release repository during first setup; the manager persists that
+choice for later updates.
+
 ## Client compatibility
 
 The existing client accepts a custom HTTP(S) Sync Server URL and derives the
@@ -117,14 +156,18 @@ server.
 
 ## Verification
 
-- Build the adapter: `pnpm --dir deps/db-sync build:node-adapter`.
+- Build and package both runtime architectures in GitHub Actions.
+- Extract each packaged runtime and start its bundled adapter in the workflow.
+- Install the published runtime on a clean glibc/systemd host without a system
+  Node.js, Java, Clojure, pnpm, Python, or compiler toolchain.
 - Start the generated systemd deployment.
 - Verify `GET /health` returns `{"ok":true}`.
 - Verify a client configured with the displayed URL can connect and create a
   graph using the selected verified-JWT mode.
 - Run the non-interactive native-manager tests for default/custom port
-  selection, default authentication, domain validation, generated service
-  files, and one-shot status checks. Keep the Docker alternative tests green.
+  selection, default authentication, domain validation, checksum and
+  architecture rejection, generated service files, update rollback path, and
+  one-shot status checks. Keep the Docker alternative tests green.
 
 ## Open constraint
 

--- a/docs/superpowers/specs/2026-07-14-sync-installer-design.md
+++ b/docs/superpowers/specs/2026-07-14-sync-installer-design.md
@@ -26,6 +26,13 @@ Clojure, pnpm, Python, or compiler packages. It downloads a prebuilt runtime
 and Caddy, but does not run a multi-node cluster, provide backups, or delete
 existing data.
 
+All deployment-owned files use one home directory, `/opt/logseq-sync` by
+default. Its `bin`, `current`, `releases`, `config`, `data`, and `caddy-data`
+children contain the executable tools, runtime, configuration, graph data, and
+certificate state. Only the systemd unit files and the conventional
+`/usr/local/bin/logseq-sync-native` symlink live outside that home. Operators
+can select a different home once with `LOGSEQ_SYNC_HOME`.
+
 ## Operator flow
 
 1. Run `sudo logseq-sync-native setup` to enter the guided flow.

--- a/docs/superpowers/specs/2026-07-14-sync-installer-design.md
+++ b/docs/superpowers/specs/2026-07-14-sync-installer-design.md
@@ -124,7 +124,9 @@ logseq-sync-runtime/
 ```
 
 The manager verifies the separately published SHA-256 value before extraction,
-checks the declared architecture, and executes the bundled Node.js runtime.
+checks the declared architecture, and executes both the bundled Node.js runtime
+and `better-sqlite3` loader before switching releases. Published Linux binaries
+must not require a GLIBC version newer than 2.29.
 This archive is preferred over a literal single executable because the adapter
 loads `better-sqlite3` as a native `.node` addon from the filesystem. Hiding it
 inside Node SEA or another single-file wrapper would add a fragile extraction

--- a/docs/superpowers/specs/2026-07-14-sync-installer-design.md
+++ b/docs/superpowers/specs/2026-07-14-sync-installer-design.md
@@ -18,9 +18,9 @@ The deployment assets will live under `deps/db-sync/deploy/` and include:
 - Caddy reverse proxy configuration for automatic TLS;
 - generated `sync.env` configuration, never committed with secrets.
 
-The native installer targets one Debian or Ubuntu systemd host and one Sync
-adapter instance. It installs its build/runtime dependencies, but does not run
-a multi-node cluster, provide backups, or delete existing data.
+The native installer targets one Debian/Ubuntu or RPM-based systemd host and
+one Sync adapter instance. It installs its build/runtime dependencies, but does
+not run a multi-node cluster, provide backups, or delete existing data.
 
 ## Operator flow
 
@@ -32,7 +32,7 @@ a multi-node cluster, provide backups, or delete existing data.
    for the private loopback-only adapter port with `10011` as the default. Keep
    ACME HTTP validation on port `80`, explain the public/private exposure rules,
    reject duplicate ports, print the topology, and require one confirmation.
-4. Install missing native build/runtime dependencies on Debian or Ubuntu.
+4. Install missing native build/runtime dependencies with `apt`, `dnf`, or `yum`.
 5. Build into a new versioned release directory, then atomically switch the
    `current` symlink only after the build succeeds.
 6. Generate systemd, adapter, and Caddy configuration. Normal setup uses the

--- a/docs/superpowers/specs/2026-07-14-sync-installer-design.md
+++ b/docs/superpowers/specs/2026-07-14-sync-installer-design.md
@@ -39,7 +39,7 @@ can select a different home once with `LOGSEQ_SYNC_HOME`.
 2. Validate Linux and systemd, explain that the domain must be a hostname whose
    propagated public `A`/`AAAA` record points to this server, then prompt for
    and validate it. Show the addresses returned by DNS.
-3. Prompt for the public HTTPS/WSS port with `10010` as the default, then prompt
+3. Prompt for the public HTTPS/WSS port with `443` as the default, then prompt
    for the private loopback-only adapter port with `10011` as the default. Keep
    ACME HTTP validation on port `80`, explain the public/private exposure rules,
    reject duplicate ports, print the topology, and require one confirmation.
@@ -98,7 +98,7 @@ data intact, shows recent journal entries, and directs the operator to logs.
 
 ```text
 Logseq Desktop/Web
-  -> HTTPS/WSS :10010 (default, operator-configurable)
+  -> HTTPS/WSS :443 (default, operator-configurable)
   -> Caddy systemd service
   -> DB Sync Node adapter at 127.0.0.1:10011
   -> persistent host data directory


### PR DESCRIPTION
## Summary

- add an interactive Linux deployment manager for the experimental DB Sync Node adapter
- provide Docker Compose assets for HTTP and Caddy-managed HTTPS deployments
- validate image builds and manager setup with a dedicated db-sync CI job

## Validation

- `npm run test:node-adapter`
- `git diff --check`
- Ubuntu CI will build the image and run the deployment-manager HTTP smoke test