### PR TITLE
fix: prefer mounted blocks for visible range selection

### DIFF
--- a/src/main/frontend/components/block/selection.cljs
+++ b/src/main/frontend/components/block/selection.cljs
@@ -36,3 +36,22 @@
             ids (subvec block-ids from-idx to-idx)]
         {:direction direction
          :block-ids (if (= direction :up) (vec (reverse ids)) ids)}))))
+
+(defn mounted-nodes?
+  [start-node end-node]
+  (boolean (and (some-> start-node .-isConnected)
+                (some-> end-node .-isConnected))))
+
+(defn mounted-node-range
+  [nodes start-node end-node]
+  (let [nodes (vec nodes)
+        start-idx (.indexOf nodes start-node)
+        end-idx (.indexOf nodes end-node)]
+    (when (and (<= 0 start-idx)
+               (<= 0 end-idx))
+      (let [direction (if (> start-idx end-idx) :up :down)
+            from-idx (min start-idx end-idx)
+            to-idx (inc (max start-idx end-idx))
+            nodes (subvec nodes from-idx to-idx)]
+        {:direction direction
+         :nodes (if (= direction :up) (vec (reverse nodes)) nodes)}))))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1238,6 +1238,22 @@
     {:direction (:direction range)
      :blocks (mapv selection-node-for-block-id (:block-ids range))}))
 
+(defn- selection-blocks-by-mounted-nodes
+  [start-node end-node]
+  (when-let [range (block-selection/mounted-node-range
+                    (array-seq (js/document.getElementsByClassName "ls-block"))
+                    start-node
+                    end-node)]
+    {:direction (:direction range)
+     :blocks (:nodes range)}))
+
+(defn- selection-blocks
+  [block-ids start-node end-node]
+  (when (seq block-ids)
+    (if (block-selection/mounted-nodes? start-node end-node)
+      (selection-blocks-by-mounted-nodes start-node end-node)
+      (selection-blocks-by-block-ids block-ids start-node end-node))))
+
 (defn highlight-selection-area!
   [end-block-id block-dom-element & {:keys [append? block-ids]}]
   (when-let [start-node (state/get-selection-start-block-or-first)]
@@ -1247,7 +1263,7 @@
           last-node (last selected-blocks)
           latest-visible-block (or last-node start-node)
           latest-block-id (when latest-visible-block (.-id latest-visible-block))]
-      (if-let [{:keys [blocks direction]} (selection-blocks-by-block-ids block-ids start-node end-block-node)]
+      (if-let [{:keys [blocks direction]} (selection-blocks block-ids start-node end-block-node)]
         (state/exit-editing-and-set-selected-blocks! blocks direction)
         (if (and start-node end-block-node)
         (let [blocks (util/get-nodes-between-two-nodes start-node end-block-node "ls-block")

--- a/src/test/frontend/components/block/selection_test.cljs
+++ b/src/test/frontend/components/block/selection_test.cljs
@@ -54,3 +54,14 @@
     {:direction :down :block-ids [:c]} :c :c
     nil :missing :c
     nil :a :missing))
+
+(deftest mounted-node-range-uses-current-rendered-order
+  (let [upper #js {:isConnected true}
+        middle #js {:isConnected true}
+        lower #js {:isConnected true}]
+    (is (true? (selection/mounted-nodes? lower upper)))
+    (is (= {:direction :up
+            :nodes [lower middle upper]}
+           (selection/mounted-node-range [upper middle lower] lower upper)))
+    (set! (.-isConnected lower) false)
+    (is (false? (selection/mounted-nodes? lower upper)))))


### PR DESCRIPTION
fix https://github.com/logseq/db-test/issues/1002

- Use the current DOM order when both block-selection endpoints are mounted.
- Prevent visible blocks from being omitted when the journal selection ID snapshot is stale.
- Preserve ID-based range selection when an endpoint is unmounted during virtualized scrolling.