### PR TITLE
fix: remove Task tag when clearing status

### DIFF
--- a/deps/outliner/src/logseq/outliner/property.cljs
+++ b/deps/outliner/src/logseq/outliner/property.cljs
@@ -553,8 +553,9 @@
 (defn- remove-status!
   [conn block-ids {:keys [preserve-task-tag?]} tx-meta]
   (let [blocks (keep #(d/entity @conn (->eid %)) block-ids)
-        other-task-properties (disj (set (get-in db-class/built-in-classes
-                                                 [:logseq.class/Task :schema :properties]))
+        task-properties (:logseq.property.class/properties
+                         (d/entity @conn :logseq.class/Task))
+        other-task-properties (disj (set (map :db/ident task-properties))
                                     :logseq.property/status)]
     (validate-batch-deletion-of-property blocks :logseq.property/status)
     (when (seq blocks)

--- a/deps/outliner/src/logseq/outliner/property.cljs
+++ b/deps/outliner/src/logseq/outliner/property.cljs
@@ -570,10 +570,9 @@
                                                     (:db/ident status)))
                          task? (some #(= :logseq.class/Task (:db/ident %))
                                      (:block/tags block))
-                         status-available? (or direct-status?
-                                               task?
-                                               (block-classes-provide-property?
-                                                @conn block :logseq.property/status))
+                         status-provided? (or task?
+                                              (block-classes-provide-property?
+                                               @conn block :logseq.property/status))
                          remove-task? (and task?
                                            (not empty-placeholder?)
                                            (not preserve-task-tag?)
@@ -586,9 +585,12 @@
                        [[:db/retract (:db/id block) :logseq.property/status]
                         [:db/retract (:db/id block) :block/tags :logseq.class/Task]]
 
-                       status-available?
+                       status-provided?
                        [{:db/id (:db/id block)
                          :logseq.property/status :logseq.property/empty-placeholder}]
+
+                       direct-status?
+                       [[:db/retract (:db/id block) :logseq.property/status]]
 
                        :else
                        [])))

--- a/deps/outliner/src/logseq/outliner/property.cljs
+++ b/deps/outliner/src/logseq/outliner/property.cljs
@@ -550,10 +550,59 @@
                                  :i18n-key :property.validation/cant-set-self-value
                                  :type :error}})))))
 
+(defn- remove-status!
+  [conn block-ids {:keys [preserve-task-tag?]} tx-meta]
+  (let [blocks (keep #(d/entity @conn (->eid %)) block-ids)
+        other-task-properties (disj (set (get-in db-class/built-in-classes
+                                                 [:logseq.class/Task :schema :properties]))
+                                    :logseq.property/status)]
+    (validate-batch-deletion-of-property blocks :logseq.property/status)
+    (when (seq blocks)
+      (let [txs (mapcat
+                 (fn [block]
+                   (let [status (:logseq.property/status block)
+                         direct-status? (contains? (d/pull @conn
+                                                           [:logseq.property/status]
+                                                           (:db/id block))
+                                                   :logseq.property/status)
+                         empty-placeholder? (and direct-status?
+                                                 (= :logseq.property/empty-placeholder
+                                                    (:db/ident status)))
+                         task? (some #(= :logseq.class/Task (:db/ident %))
+                                     (:block/tags block))
+                         status-available? (or direct-status?
+                                               task?
+                                               (block-classes-provide-property?
+                                                @conn block :logseq.property/status))
+                         remove-task? (and task?
+                                           (not empty-placeholder?)
+                                           (not preserve-task-tag?)
+                                           (not-any? #(get block %) other-task-properties))]
+                     (cond
+                       empty-placeholder?
+                       []
+
+                       remove-task?
+                       [[:db/retract (:db/id block) :logseq.property/status]
+                        [:db/retract (:db/id block) :block/tags :logseq.class/Task]]
+
+                       status-available?
+                       [{:db/id (:db/id block)
+                         :logseq.property/status :logseq.property/empty-placeholder}]
+
+                       :else
+                       [])))
+                 blocks)]
+        (ldb/transact! conn txs tx-meta)))))
+
 (defn batch-remove-property!
-  [conn block-ids property-id]
-  (throw-error-if-read-only-property property-id)
-  (let [block-eids (map ->eid block-ids)
+  ([conn block-ids property-id]
+   (batch-remove-property! conn block-ids property-id {}))
+  ([conn block-ids property-id opts]
+   (throw-error-if-read-only-property property-id)
+   (if (= :logseq.property/status property-id)
+     (remove-status! conn block-ids opts {:outliner-op :batch-remove-property})
+    (let [block-eids (map ->eid block-ids)
         blocks (keep (fn [id] (d/entity @conn id)) block-eids)
         block-id-set (set (map :db/id blocks))]
     (validate-batch-deletion-of-property blocks property-id)
@@ -599,7 +648,7 @@
                    blocks)]
           (when (seq txs)
             (ldb/transact! conn txs
-                           {:outliner-op :batch-remove-property})))))))
+                           {:outliner-op :batch-remove-property})))))))))
 
 (defn- validate-batch-set-property
   [conn block-eids property-id v]
@@ -684,7 +733,7 @@
    (assert property-id "property-id is nil")
    (throw-error-if-read-only-property property-id)
    (if (nil? v)
-     (batch-remove-property! conn block-ids property-id)
+     (batch-remove-property! conn block-ids property-id options)
      (let [block-eids (map ->eid block-ids)
            _ (throw-error-if-batch-alias-targets block-eids property-id)
            _ (validate-batch-set-property conn block-eids property-id v)
@@ -741,7 +790,7 @@
         block (d/entity @conn eid)
         property (d/entity @conn property-id)
         tx-meta {:outliner-op :remove-block-property}]
-    (when-not (= :logseq.property.class/extends property-id)
+    (when-not (contains? #{:logseq.property.class/extends :logseq.property/status} property-id)
       (validate-batch-deletion-of-property [block] property-id))
     (when block
       (cond
@@ -749,10 +798,7 @@
         nil
 
         (= :logseq.property/status property-id)
-        (ldb/transact! conn
-                       [[:db/retract (:db/id block) property-id]
-                        [:db/retract (:db/id block) :block/tags :logseq.class/Task]]
-                       tx-meta)
+        (remove-status! conn [eid] {} tx-meta)
 
         (and (:logseq.property/default-value property)
              (= (:logseq.property/default-value property) (get block property-id)))

--- a/src/main/frontend/components/objects.cljs
+++ b/src/main/frontend/components/objects.cljs
@@ -40,8 +40,10 @@
 (defn build-class-object-columns
   [config class properties]
   (let [properties' (remove nil? properties)
-        columns* (views/build-columns config properties' {:add-tags-column? true
-                                                          :add-page-column? true})
+        columns* (views/build-columns (assoc config :view-parent class)
+                                      properties'
+                                      {:add-tags-column? true
+                                       :add-page-column? true})
         columns (cond
                   (= (:db/ident class) :logseq.class/Pdf-annotation)
                   (remove #(contains? #{:logseq.property/ls-type} (:id %)) columns*)
@@ -87,7 +89,8 @@
   (let [*ref (hooks/use-ref nil)
         db-ident (:db/ident class)
         asset? (= db-ident :logseq.class/Asset)
-        columns (build-class-object-columns config class properties)
+        config' (assoc config :view-parent class)
+        columns (build-class-object-columns config' class properties)
         add-new-object! (when (or asset? (not (ldb/private-tags (:db/ident class))))
                           (fn [view table {:keys [properties]}]
                             (if (= :logseq.class/Asset (:db/ident class))
@@ -107,7 +110,7 @@
                                   (state/sidebar-add-block! (state/get-current-repo) (:db/id block) :block))))))]
 
     [:div {:ref *ref}
-     (views/view {:config config
+     (views/view {:config config'
                   :view-parent class
                   :view-feature-type :class-objects
                   :columns columns

--- a/src/main/frontend/components/property.cljs
+++ b/src/main/frontend/components/property.cljs
@@ -266,7 +266,7 @@
 	       [:span.bullet]])))
 
 (defn- property-input-on-chosen
-  [block *property *property-key *show-new-property-config? {:keys [class-schema? remove-property?]}]
+  [block *property *property-key *show-new-property-config? {:keys [class-schema? remove-property? view-parent]}]
   (fn [{:keys [value label convert-page-to-property?]}]
     (let [property (cond
                      (uuid? value) (db/entity [:block/uuid value])
@@ -277,7 +277,10 @@
           batch? (pv/batch-operation?)]
       (if (and property remove-property?)
         (let [block-ids (map :block/uuid (pv/get-operating-blocks block))]
-          (property-handler/batch-remove-block-property! block-ids (:db/ident property))
+          (property-handler/batch-remove-block-property!
+           block-ids
+           (:db/ident property)
+           {:preserve-task-tag? (= :logseq.class/Task (:db/ident view-parent))})
           (shui/popup-hide!))
         (do
           (when (and *show-new-property-config? (not (ldb/property? property)))

--- a/src/main/frontend/components/property/value.cljs
+++ b/src/main/frontend/components/property/value.cljs
@@ -536,10 +536,13 @@
         content))))
 
 (defn- delete-block-property!
-  [block property]
+  [block property opts]
   (editor-handler/move-cross-boundary-up-down :up {})
   (property-handler/remove-block-property! (:db/id block)
-                                           (:db/ident property)))
+                                           (:db/ident property)
+                                           {:preserve-task-tag?
+                                            (= :logseq.class/Task
+                                               (:db/ident (:view-parent opts)))}))
 
 (defn- prevent-bottom-property-edit-pointer-dismiss
   [^js e]
@@ -549,7 +552,8 @@
 
 (hsx/defc date-picker
   [value {:keys [block property datetime? on-change on-delete del-btn? editing? multiple-values? other-position?
-                 suppress-inline-edit-icon? property-position]}]
+                 suppress-inline-edit-icon? property-position]
+          :as opts}]
   (let [*el (hooks/use-ref nil)
         content-fn (fn [{:keys [id]}] (calendar-inner id
                                                       {:block block
@@ -580,7 +584,7 @@
           :on-click open-popup!
           :on-key-down (fn [e]
                          (when (contains? #{"Backspace" "Delete"} (util/ekey e))
-                           (delete-block-property! block property)))}
+                           (delete-block-property! block property opts)))}
          (ui/icon "calendar-plus" {:size 16}))
         (shui/trigger-as
          :div.flex.flex-1.flex-row.gap-1.items-center.flex-wrap
@@ -591,7 +595,7 @@
           :on-key-down (fn [e]
                          (case (util/ekey e)
                            ("Backspace" "Delete")
-                           (delete-block-property! block property)
+                           (delete-block-property! block property opts)
                            (" " "Enter")
                            (do (some-> (hooks/deref *el) (.click))
                                (util/stop e))
@@ -753,7 +757,10 @@
                       block-ids (map :block/uuid blocks)]
                   (property-handler/batch-remove-block-property!
                    block-ids
-                   (:db/ident property)))
+                   (:db/ident property)
+                   {:preserve-task-tag?
+                    (= :logseq.class/Task
+                       (:db/ident (:view-parent opts)))}))
                 (when-not (false? (:exit-edit? opts))
                   (shui/popup-hide!)))
                (f chosen selected?)))]
@@ -1492,7 +1499,7 @@
           :on-key-down (fn [e]
                          (case (util/ekey e)
                            ("Backspace" "Delete")
-                           (delete-block-property! block property)
+                           (delete-block-property! block property opts)
                            (" " "Enter")
                            (do (some-> (hooks/deref *el) (.click))
                                (util/stop e))
@@ -1517,7 +1524,7 @@
       :on-key-down (fn [e]
                      (when-not text-ref-type?
                        (when (contains? #{"Backspace" "Delete"} (util/ekey e))
-                         (delete-block-property! block property))))
+                         (delete-block-property! block property opts))))
       :style {:min-height 24}}
      (cond
        (and (= :logseq.property/default-value (:db/ident property)) (nil? (:block/title value)))
@@ -1971,7 +1978,7 @@
 
                          ("Backspace" "Delete")
                          (when-not config/publishing?
-                           (delete-block-property! block property))
+                           (delete-block-property! block property opts))
                          (" " "Enter")
                          (do (show-grid! (or (.-currentTarget e) (hooks/deref *el)))
                              (util/stop e))
@@ -2057,7 +2064,7 @@
 	                                            (when (= (util/ekey e) "Enter")
 	                                              (add-property! (not value)))
 	                                            (when (contains? #{"Backspace" "Delete"} (util/ekey e))
-	                                              (delete-block-property! block property)))})])
+	                                              (delete-block-property! block property opts)))})])
           ;; :others
           [:div.flex.flex-1
            (property-value-inner block property value opts)])))))
@@ -2120,7 +2127,7 @@
                            (do (some-> (hooks/deref *el) (.click))
                                (util/stop e))
                            ("Backspace" "Delete")
-                           (delete-block-property! block property)
+                           (delete-block-property! block property opts)
                            :dune))
           :class (multiple-values-trigger-class opts)}
          (let [not-empty-value? (not= (map :db/ident items) [:logseq.property/empty-placeholder])]

--- a/src/main/frontend/components/selection.cljs
+++ b/src/main/frontend/components/selection.cljs
@@ -17,6 +17,15 @@
    (and outliner?
         (seq comment-targets))))
 
+(defn- unset-property-event
+  [target selected-blocks view-parent]
+  [:editor/new-property {:target target
+                         :selected-blocks selected-blocks
+                         :view-parent view-parent
+                         :remove-property? true
+                         :select-opts {:show-new-when-not-exact-match? false}
+                         :on-dialog-close #(state/pub-event! [:editor/hide-action-bar])}])
+
 (hsx/defc action-bar
   [& {:keys [on-cut on-copy selected-blocks hide-dots? button-border? view-parent outliner?]
       :or {on-cut #(editor-handler/cut-selection-blocks true)
@@ -77,11 +86,9 @@
          (assoc button-opts
                 :on-pointer-down (fn [e]
                                    (util/stop e)
-                                   (state/pub-event! [:editor/new-property {:target (.-target e)
-                                                                            :selected-blocks selected-blocks
-                                                                            :remove-property? true
-                                                                            :select-opts {:show-new-when-not-exact-match? false}
-                                                                            :on-dialog-close #(state/pub-event! [:editor/hide-action-bar])}])))
+                                   (state/pub-event! (unset-property-event (.-target e)
+                                                                          selected-blocks
+                                                                          view-parent))))
          (t :property/unset-property))
         (when-not (contains? #{:logseq.class/Page} (:db/ident view-parent))
           (shui/button

--- a/src/main/frontend/components/views.cljs
+++ b/src/main/frontend/components/views.cljs
@@ -486,6 +486,7 @@
                                 (fn [_table row _column style]
                                   (pv/property-value row property {:view? true
                                                                    :table-view? true
+                                                                   :view-parent (:view-parent config)
                                                                    :table-text-property-render
                                                                    (fn [block opts]
                                                                      (block-title block (assoc opts
@@ -2040,8 +2041,14 @@
           ^{:key (str "partition-" idx)}
           [:<> (lazy-item-render rows idx)])))))
 
+(defn- gallery-property-value-opts
+  [config]
+  {:view? true
+   :gallery-view? true
+   :view-parent (:view-parent config)})
+
 (hsx/defc gallery-property-value
-  [block property-ident]
+  [block property-ident config]
   (if (= :block/title property-ident)
     [:div.ls-gallery-card-title
      (some->> (:block/title block)
@@ -2050,8 +2057,7 @@
               first)]
     (when-let [property (db/entity property-ident)]
       [:div.ls-gallery-card-property
-       (pv/property-value block property {:view? true
-                                          :gallery-view? true})])))
+       (pv/property-value block property (gallery-property-value-opts config))])))
 
 (defn gallery-card-asset-block
   [block asset-property-ident]
@@ -2098,7 +2104,7 @@
          (asset-cp (assoc config :disable-resize? true :gallery-view? true) asset-block))]
       [:div.ls-gallery-card-meta
        (for [property-ident display-property-idents
-             :let [property-value (gallery-property-value block property-ident)]
+             :let [property-value (gallery-property-value block property-ident config)]
              :when property-value]
          ^{:key (str "gallery-property-" (:db/id block) "-" property-ident)}
          [:<> property-value])]]]))

--- a/src/main/frontend/handler/property.cljs
+++ b/src/main/frontend/handler/property.cljs
@@ -5,27 +5,31 @@
             [frontend.state :as state]))
 
 (defn remove-block-property!
-  [block-id property-id-or-key]
+  [block-id property-id-or-key & [opts]]
   (assert (some? property-id-or-key) "remove-block-property! remove-block-property! is nil")
-  (db-property-handler/remove-block-property! block-id property-id-or-key))
+  (if (= :logseq.property/status property-id-or-key)
+    (db-property-handler/batch-set-property! [block-id] property-id-or-key nil (or opts {}))
+    (db-property-handler/remove-block-property! block-id property-id-or-key)))
 
 (defn set-block-property!
   [block-id key v]
   (assert (some? key) "set-block-property! key is nil")
   (if (or (nil? v) (and (coll? v) (empty? v)))
-    (db-property-handler/remove-block-property! block-id key)
+    (remove-block-property! block-id key)
     (db-property-handler/set-block-property! block-id key v)))
 
 (defn batch-remove-block-property!
-  [block-ids key]
+  [block-ids key & [opts]]
   (assert (some? key) "key is nil")
-  (db-property-handler/batch-remove-property! block-ids key))
+  (if (= :logseq.property/status key)
+    (db-property-handler/batch-set-property! block-ids key nil (or opts {}))
+    (db-property-handler/batch-remove-property! block-ids key)))
 
 (defn batch-set-block-property!
   [block-ids key value & {:as opts}]
   (assert (some? key) "key is nil")
   (if (nil? value)
-    (db-property-handler/batch-remove-property! block-ids key)
+    (batch-remove-block-property! block-ids key opts)
     (db-property-handler/batch-set-property! block-ids key value opts)))
 
 (defn set-block-properties!

--- a/src/test/frontend/components/objects_test.cljs
+++ b/src/test/frontend/components/objects_test.cljs
@@ -1,6 +1,16 @@
 (ns frontend.components.objects-test
   (:require [cljs.test :refer [deftest is]]
-            [frontend.components.objects :as objects]))
+            [frontend.components.objects :as objects]
+            [frontend.components.views :as views]))
+
+(deftest class-object-columns-forward-view-parent-through-config
+  (let [class {:db/ident :logseq.class/Task}
+        config* (atom nil)]
+    (with-redefs [views/build-columns (fn [config _properties _opts]
+                                        (reset! config* config)
+                                        [])]
+      (objects/build-class-object-columns {} class [])
+      (is (= class (:view-parent @config*))))))
 
 (deftest class-object-columns-include-page
   (let [columns (objects/build-class-object-columns {} {:db/ident :user.class/task} [])]

--- a/src/test/frontend/components/property/property_test.cljs
+++ b/src/test/frontend/components/property/property_test.cljs
@@ -1,11 +1,35 @@
 (ns frontend.components.property.property-test
   (:require [cljs.test :refer [deftest is]]
             [frontend.components.property :as property-component]
+            [frontend.components.property.value :as property-value]
             [frontend.db :as db]
+            [frontend.handler.property :as property-handler]
             [frontend.state :as state]
             [logseq.db.frontend.entity-util :as entity-util]
             [logseq.db.frontend.property :as db-property]
-            [logseq.outliner.property :as outliner-property]))
+            [logseq.outliner.property :as outliner-property]
+            [logseq.shui.ui :as shui]))
+
+(deftest removing-status-from-task-view-preserves-task-tag-test
+  (let [block-id (random-uuid)
+        calls* (atom [])
+        block {:block/uuid block-id}
+        status-property {:db/ident :logseq.property/status}
+        on-chosen (#'property-component/property-input-on-chosen
+                   block (atom nil) (atom nil) nil
+                   {:remove-property? true
+                    :view-parent {:db/ident :logseq.class/Task}})]
+    (with-redefs [db/entity (constantly status-property)
+                  property-value/batch-operation? (constantly false)
+                  property-value/get-operating-blocks (fn [_] [block])
+                  property-handler/batch-remove-block-property!
+                  (fn [& args] (swap! calls* conj args))
+                  shui/popup-hide! (constantly nil)]
+      (on-chosen {:value :logseq.property/status})
+      (is (= [[[block-id]
+               :logseq.property/status
+               {:preserve-task-tag? true}]]
+             @calls*)))))
 
 (deftest sanitize-property-values-for-display-filters-recycled-entity-values-test
   (let [active-value {:db/id 101

--- a/src/test/frontend/components/property/value_test.cljs
+++ b/src/test/frontend/components/property/value_test.cljs
@@ -5,7 +5,23 @@
             [frontend.db :as db]
             [frontend.db.async :as db-async]
             [frontend.db.model :as model]
+            [frontend.handler.editor :as editor-handler]
+            [frontend.handler.property :as property-handler]
             [promesa.core :as p]))
+
+(deftest deleting-status-from-task-view-preserves-task-tag-test
+  (let [calls* (atom [])
+        block {:db/id 1}
+        property {:db/ident :logseq.property/status}]
+    (with-redefs [editor-handler/move-cross-boundary-up-down (constantly nil)
+                  property-handler/remove-block-property!
+                  (fn [& args] (swap! calls* conj args))]
+      (#'property-value/delete-block-property!
+       block property {:view-parent {:db/ident :logseq.class/Task}})
+      (is (= [[1
+               :logseq.property/status
+               {:preserve-task-tag? true}]]
+             @calls*)))))
 
 (deftest resolve-journal-page-for-date-returns-existing-page-test
   (async done

--- a/src/test/frontend/components/selection_test.cljs
+++ b/src/test/frontend/components/selection_test.cljs
@@ -1,0 +1,11 @@
+(ns frontend.components.selection-test
+  (:require [cljs.test :refer [deftest is]]
+            [frontend.components.selection :as selection]))
+
+(deftest unset-property-event-includes-view-parent
+  (let [view-parent {:db/ident :logseq.class/Task}
+        selected-blocks [{:db/id 1}]
+        [_ payload] (#'selection/unset-property-event nil selected-blocks view-parent)]
+    (is (= view-parent (:view-parent payload)))
+    (is (= selected-blocks (:selected-blocks payload)))
+    (is (:remove-property? payload))))

--- a/src/test/frontend/components/views_test.cljs
+++ b/src/test/frontend/components/views_test.cljs
@@ -1,7 +1,36 @@
 (ns frontend.components.views-test
   (:require [cljs.test :refer [deftest is]]
+            [datascript.impl.entity :as de]
+            [frontend.components.property.value :as property-value]
             [frontend.db]
             [frontend.components.views :as views]))
+
+(deftest table-property-value-receives-view-parent
+  (let [view-parent {:db/ident :logseq.class/Task}
+        property {:db/ident :logseq.property/status
+                  :block/title "Status"
+                  :logseq.property/type :default}
+        row {:db/id 1}
+        calls* (atom [])]
+    (with-redefs [de/entity? map?
+                  property-value/property-value
+                  (fn [& args] (swap! calls* conj args))]
+      (let [columns (views/build-columns {:view-parent view-parent}
+                                         [property]
+                                         {:with-object-name? false
+                                          :add-tags-column? false})
+            column (some #(when (= :logseq.property/status (:id %)) %) columns)]
+        ((:cell column) nil row column {})
+        (is (= view-parent
+               (some #(get-in (vec %) [2 :view-parent]) @calls*))
+            (pr-str @calls*))))))
+
+(deftest gallery-property-value-receives-view-parent
+  (let [view-parent {:db/ident :logseq.class/Task}]
+    (is (= {:view? true
+            :gallery-view? true
+            :view-parent view-parent}
+           (#'views/gallery-property-value-opts {:view-parent view-parent})))))
 
 (deftest build-columns-should-allow-name-property-when-no-object-name
   "When with-object-name? is false, the user property 'Name' should be kept"

--- a/src/test/frontend/db/model_test.cljs
+++ b/src/test/frontend/db/model_test.cljs
@@ -162,6 +162,25 @@
         (is (= [:user.class/Project]
                (mapv :db/ident (:block/tags block))))))))
 
+(deftest clear-status-uses-task-class-properties
+  (let [conn (db-test/create-conn-with-blocks
+              [{:page {:block/title "page1"}
+                :blocks [{:block/title "task"
+                          :build/tags [:logseq.class/Task]
+                          :build/properties {:logseq.property/status :logseq.property/status.todo
+                                             :logseq.property/description "details"}}]}])
+        block-id (:block/uuid (db-test/find-block-by-content @conn "task"))]
+    (d/transact! conn [[:db/add :logseq.class/Task
+                        :logseq.property.class/properties
+                        :logseq.property/description]])
+    (outliner-op/apply-ops! conn [[:batch-remove-property [[block-id]
+                                                           :logseq.property/status]]] {})
+    (let [block (d/entity @conn [:block/uuid block-id])]
+      (is (= :logseq.property/empty-placeholder
+             (:db/ident (:logseq.property/status block))))
+      (is (contains? (set (map :db/ident (:block/tags block)))
+                     :logseq.class/Task)))))
+
 (deftest clear-status-public-remove-ops
   (testing "keeps Task when the public remove-property op clears status with another task property"
     (let [conn (db-test/create-conn-with-blocks

--- a/src/test/frontend/db/model_test.cljs
+++ b/src/test/frontend/db/model_test.cljs
@@ -129,8 +129,9 @@
           (is (= :logseq.property/empty-placeholder
                  (:db/ident (:logseq.property/status block))))
           (is (contains? (set (map :db/ident (:block/tags block)))
-                         :logseq.class/Task))))))
+                         :logseq.class/Task)))))))
 
+(deftest clear-status-handles-default-and-class-provided-status
   (testing "removes Task when clearing its implicit default status"
     (let [conn (db-test/create-conn-with-blocks
                 [{:page {:block/title "page1"}
@@ -159,8 +160,9 @@
         (is (= :logseq.property/empty-placeholder
                (:db/ident (:logseq.property/status block))))
         (is (= [:user.class/Project]
-               (mapv :db/ident (:block/tags block)))))))
+               (mapv :db/ident (:block/tags block))))))))
 
+(deftest clear-status-public-remove-ops
   (testing "keeps Task when the public remove-property op clears status with another task property"
     (let [conn (db-test/create-conn-with-blocks
                 [{:page {:block/title "page1"}
@@ -219,6 +221,23 @@
                (:db/ident (:logseq.property/status scheduled-task))))
         (is (contains? (set (map :db/ident (:block/tags scheduled-task)))
                        :logseq.class/Task))))))
+
+(deftest clear-status-retracts-direct-status-without-provider
+  (let [conn (db-test/create-conn-with-blocks
+              [{:page {:block/title "page1"}
+                :blocks [{:block/title "plain block"}]}])
+        block-id (:block/uuid (db-test/find-block-by-content @conn "plain block"))]
+    (d/transact! conn [[:db/add [:block/uuid block-id]
+                        :logseq.property/status
+                        :logseq.property/status.doing]])
+    (outliner-op/apply-ops! conn [[:batch-remove-property [[block-id]
+                                                           :logseq.property/status]]] {})
+    (let [block (d/entity @conn [:block/uuid block-id])]
+      (is (not (contains? (d/pull @conn [:logseq.property/status]
+                                  [:block/uuid block-id])
+                          :logseq.property/status)))
+      (is (not (contains? (set (map :db/ident (:block/tags block)))
+                          :logseq.class/Task))))))
 
 (deftest page-alias-invariants-reject-invalid-via-batch-set-property
   (testing "batch path: duplicate owner is rejected"

--- a/src/test/frontend/db/model_test.cljs
+++ b/src/test/frontend/db/model_test.cljs
@@ -7,6 +7,7 @@
             [frontend.db.utils]
             [frontend.test.helper :as test-helper :refer [load-test-files]]
             [logseq.db.test.helper :as db-test]
+            [logseq.outliner.op :as outliner-op]
             [logseq.outliner.property :as outliner-property]))
 
 (use-fixtures :each {:before test-helper/start-test-db!
@@ -90,6 +91,134 @@
       (is alias-page)
       (is (= #{(:db/id alias-page)}
              (set (map :db/id (:block/alias canonical'))))))))
+
+(deftest clear-status-updates-task-tag
+  (testing "removes Task when status is the only task property"
+    (let [conn (db-test/create-conn-with-blocks
+                [{:page {:block/title "page1"}
+                  :blocks [{:block/title "task"
+                            :build/tags [:logseq.class/Task]
+                            :build/properties {:logseq.property/status :logseq.property/status.todo}}]}])
+          block-id (:block/uuid (db-test/find-block-by-content @conn "task"))]
+      (outliner-op/apply-ops! conn [[:batch-remove-property [[block-id] :logseq.property/status]]] {})
+      (outliner-op/apply-ops! conn [[:batch-remove-property [[block-id] :logseq.property/status]]] {})
+      (let [block (d/entity @conn [:block/uuid block-id])]
+        (is (not (contains? (d/pull @conn [:logseq.property/status] [:block/uuid block-id])
+                            :logseq.property/status)))
+        (is (not (contains? (set (map :db/ident (:block/tags block)))
+                            :logseq.class/Task))))))
+
+  (testing "keeps Task for other task properties and in the Task view"
+    (doseq [[properties opts] [[{:logseq.property/priority :logseq.property/priority.high} {}]
+                               [{:logseq.property/deadline 20260715} {}]
+                               [{:logseq.property/scheduled 20260716} {}]
+                               [{} {:preserve-task-tag? true}]]]
+      (let [conn (db-test/create-conn-with-blocks
+                  [{:page {:block/title "page1"}
+                    :blocks [{:block/title "task"
+                              :build/tags [:logseq.class/Task]
+                              :build/properties (assoc properties
+                                                       :logseq.property/status
+                                                       :logseq.property/status.todo)}]}])
+            block-id (:block/uuid (db-test/find-block-by-content @conn "task"))]
+        (outliner-op/apply-ops! conn [[:batch-set-property [[block-id]
+                                                            :logseq.property/status
+                                                            nil
+                                                            opts]]] {})
+        (let [block (d/entity @conn [:block/uuid block-id])]
+          (is (= :logseq.property/empty-placeholder
+                 (:db/ident (:logseq.property/status block))))
+          (is (contains? (set (map :db/ident (:block/tags block)))
+                         :logseq.class/Task))))))
+
+  (testing "removes Task when clearing its implicit default status"
+    (let [conn (db-test/create-conn-with-blocks
+                [{:page {:block/title "page1"}
+                  :blocks [{:block/title "implicit task"
+                            :build/tags [:logseq.class/Task]}]}])
+          block-id (:block/uuid (db-test/find-block-by-content @conn "implicit task"))]
+      (outliner-op/apply-ops! conn [[:batch-remove-property [[block-id] :logseq.property/status]]] {})
+      (let [block (d/entity @conn [:block/uuid block-id])]
+        (is (not (contains? (d/pull @conn [:logseq.property/status] [:block/uuid block-id])
+                            :logseq.property/status)))
+        (is (not (contains? (set (map :db/ident (:block/tags block)))
+                            :logseq.class/Task))))))
+
+  (testing "stores an empty placeholder when a non-Task class provides status"
+    (let [conn (db-test/create-conn-with-blocks
+                {:classes {:Project {:build/class-properties [:logseq.property/status]}}
+                 :pages-and-blocks
+                 [{:page {:block/title "page1"}
+                   :blocks [{:block/title "project task"
+                             :build/tags [:Project]
+                             :build/properties {:logseq.property/status
+                                                :logseq.property/status.doing}}]}]})
+          block-id (:block/uuid (db-test/find-block-by-content @conn "project task"))]
+      (outliner-op/apply-ops! conn [[:batch-remove-property [[block-id] :logseq.property/status]]] {})
+      (let [block (d/entity @conn [:block/uuid block-id])]
+        (is (= :logseq.property/empty-placeholder
+               (:db/ident (:logseq.property/status block))))
+        (is (= [:user.class/Project]
+               (mapv :db/ident (:block/tags block)))))))
+
+  (testing "keeps Task when the public remove-property op clears status with another task property"
+    (let [conn (db-test/create-conn-with-blocks
+                [{:page {:block/title "page1"}
+                  :blocks [{:block/title "task"
+                            :build/tags [:logseq.class/Task]
+                            :build/properties {:logseq.property/status :logseq.property/status.todo
+                                               :logseq.property/scheduled 20260716}}]}])
+          block-id (:block/uuid (db-test/find-block-by-content @conn "task"))]
+      (outliner-op/apply-ops! conn [[:remove-block-property [block-id :logseq.property/status]]] {})
+      (let [block (d/entity @conn [:block/uuid block-id])]
+        (is (= :logseq.property/empty-placeholder
+               (:db/ident (:logseq.property/status block))))
+        (is (contains? (set (map :db/ident (:block/tags block)))
+                       :logseq.class/Task)))))
+
+  (testing "applies the same Task cleanup through the public batch-remove op"
+    (let [conn (db-test/create-conn-with-blocks
+                [{:page {:block/title "page1"}
+                  :blocks [{:block/title "status only"
+                            :build/tags [:logseq.class/Task]
+                            :build/properties {:logseq.property/status :logseq.property/status.todo}}
+                           {:block/title "scheduled task"
+                            :build/tags [:logseq.class/Task]
+                            :build/properties {:logseq.property/status :logseq.property/status.todo
+                                               :logseq.property/scheduled 20260716}}]}])
+          block-ids (mapv #(-> (db-test/find-block-by-content @conn %) :block/uuid)
+                          ["status only" "scheduled task"])]
+      (outliner-op/apply-ops! conn [[:batch-remove-property [block-ids :logseq.property/status]]] {})
+      (let [[status-only scheduled-task] (map #(d/entity @conn [:block/uuid %]) block-ids)]
+        (is (not (contains? (set (map :db/ident (:block/tags status-only)))
+                            :logseq.class/Task)))
+        (is (= :logseq.property/empty-placeholder
+               (:db/ident (:logseq.property/status scheduled-task))))
+        (is (contains? (set (map :db/ident (:block/tags scheduled-task)))
+                       :logseq.class/Task)))))
+
+  (testing "handles mixed blocks independently and keeps unrelated tags"
+    (let [conn (db-test/create-conn-with-blocks
+                {:classes {:Project {}}
+                 :pages-and-blocks
+                 [{:page {:block/title "page1"}
+                   :blocks [{:block/title "status only"
+                             :build/tags [:logseq.class/Task :Project]
+                             :build/properties {:logseq.property/status :logseq.property/status.todo}}
+                            {:block/title "scheduled task"
+                             :build/tags [:logseq.class/Task]
+                             :build/properties {:logseq.property/status :logseq.property/status.todo
+                                                :logseq.property/scheduled 20260716}}]}]})
+          block-ids (mapv #(-> (db-test/find-block-by-content @conn %) :block/uuid)
+                          ["status only" "scheduled task"])]
+      (outliner-op/apply-ops! conn [[:batch-remove-property [block-ids :logseq.property/status]]] {})
+      (let [[status-only scheduled-task] (map #(d/entity @conn [:block/uuid %]) block-ids)]
+        (is (= #{"Project"}
+               (set (map :block/title (:block/tags status-only)))))
+        (is (= :logseq.property/empty-placeholder
+               (:db/ident (:logseq.property/status scheduled-task))))
+        (is (contains? (set (map :db/ident (:block/tags scheduled-task)))
+                       :logseq.class/Task))))))
 
 (deftest page-alias-invariants-reject-invalid-via-batch-set-property
   (testing "batch path: duplicate owner is rejected"


### PR DESCRIPTION
## Summary

- remove `#Task` when Status is cleared and no other Task properties remain
- preserve `#Task` in the Task view or when another Task property remains, using the existing empty placeholder so the default Todo status does not reappear
- propagate Task-view context through table, gallery, list, single-value, and bulk property removal paths

## Tests

- `bb lint:dev`
- focused model test: 22 assertions passed
- focused Task-view propagation tests for class config, table, gallery, bulk unset, and single-value removal
- `bb dev:lint-and-test` completed lint and 2,025 tests; three unrelated graph timing thresholds failed under concurrent load and passed when rerun individually
