### PR TITLE
fix: accept idempotent sync deletes

### DIFF
--- a/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
+++ b/deps/db-sync/src/logseq/db_sync/worker/handler/sync.cljs
@@ -527,14 +527,16 @@
 
 (defn- sanitize-tx-entry
   [db {:keys [tx outliner-op] :as tx-entry}]
-  (let [tx-data (tx-sanitize/sanitize-tx db
-                                         (protocol/transit->tx tx)
+  (let [input-tx-data (protocol/transit->tx tx)
+        tx-data (tx-sanitize/sanitize-tx db
+                                         input-tx-data
                                          {:drop-missing-retract-ops? (or (= outliner-op :fix)
                                                                          (contains? delete-outliner-ops outliner-op))
                                           :drop-ops-targeting-retracted-entities? (contains? delete-outliner-ops
                                                                                              outliner-op)
                                           :retract-touched-descendants? (contains? delete-outliner-ops outliner-op)})]
-    {:tx-data tx-data
+    {:input-tx-data input-tx-data
+     :tx-data tx-data
      :tx-entry tx-entry}))
 
 (defn- apply-tx-entry!
@@ -542,6 +544,7 @@
    (apply-tx-entry! nil conn tx-entry nil))
   ([self conn {:keys [outliner-op] :as tx-entry} request-context]
    (let [sanitized (sanitize-tx-entry @conn tx-entry)
+         input-tx-data (:input-tx-data sanitized)
          tx-data (:tx-data sanitized)
          sanitized-entry (:tx-entry sanitized)]
      (if (seq tx-data)
@@ -565,8 +568,9 @@
                           :error (str e)})
                false)
              (throw e))))
-       (if (contains? delete-outliner-ops outliner-op)
-         (throw (ex-info "delete tx sanitized to empty"
+       (if (and (contains? delete-outliner-ops outliner-op)
+                (empty? input-tx-data))
+         (throw (ex-info "delete tx input is empty"
                          {:type :db-sync/empty-delete-tx
                           :outliner-op outliner-op}))
          false)))))

--- a/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/worker_handler_sync_test.cljs
@@ -2335,8 +2335,50 @@
       (is (some? (d/entity @conn [:block/uuid success-block-uuid])))
       (is (nil? (d/entity @conn [:block/uuid missing-uuid]))))))
 
-(deftest tx-batch-rejects-stale-delete-before-later-failure-test
-  (testing "stale delete-blocks entries are not reported as successfully applied"
+(deftest tx-batch-accepts-stale-delete-as-idempotent-test
+  (doseq [outliner-op [:delete-blocks :delete-page]]
+    (testing (str outliner-op " succeeds when the target is already absent")
+      (let [sql (test-sql/make-sql)
+            conn (storage/open-conn sql)
+            self #js {:sql sql
+                      :conn conn
+                      :schema-ready true}
+            stale-delete-tx-id (random-uuid)
+            missing-delete-uuid (random-uuid)
+            t-before (storage/get-t sql)
+            checksum-before (storage/get-checksum sql)
+            stale-delete-entry {:tx-id stale-delete-tx-id
+                                :tx (protocol/tx->transit
+                                     [[:db/retractEntity [:block/uuid missing-delete-uuid]]])
+                                :outliner-op outliner-op}
+            changed-messages (atom [])
+            response (with-redefs [ws/broadcast! (fn [_self _sender payload]
+                                                   (swap! changed-messages conj payload))]
+                       (sync-handler/handle-tx-batch! self nil [stale-delete-entry] t-before))]
+        (is (= "tx/batch/ok" (:type response)))
+        (is (= t-before (:t response)))
+        (is (= checksum-before (:checksum response)))
+        (is (empty? @changed-messages))))))
+
+(deftest tx-batch-rejects-empty-delete-input-test
+  (testing "an originally empty delete remains invalid"
+    (let [sql (test-sql/make-sql)
+          conn (storage/open-conn sql)
+          self #js {:sql sql
+                    :conn conn
+                    :schema-ready true}
+          empty-delete-tx-id (random-uuid)
+          t-before (storage/get-t sql)
+          empty-delete-entry {:tx-id empty-delete-tx-id
+                              :tx (protocol/tx->transit [])
+                              :outliner-op :delete-blocks}
+          response (sync-handler/handle-tx-batch! self nil [empty-delete-entry] t-before)]
+      (is (= "tx/reject" (:type response)))
+      (is (= "db transact failed" (:reason response)))
+      (is (= empty-delete-tx-id (:failed-tx-id response))))))
+
+(deftest tx-batch-reports-stale-delete-success-before-later-failure-test
+  (testing "an idempotent delete is acknowledged before a later tx fails"
     (let [sql (test-sql/make-sql)
           conn (storage/open-conn sql)
           self #js {:sql sql
@@ -2362,8 +2404,8 @@
       (is (= "tx/reject" (:type response)))
       (is (= "db transact failed" (:reason response)))
       (is (= t-before (:t response)))
-      (is (= stale-delete-tx-id (:failed-tx-id response)))
-      (is (nil? (:success-tx-ids response)))
+      (is (= later-failed-tx-id (:failed-tx-id response)))
+      (is (= [stale-delete-tx-id] (:success-tx-ids response)))
       (is (empty? @changed-messages)))))
 
 (deftest tx-batch-ignores-empty-rebase-entry-test

--- a/docs/agent-guide/db-sync/db-sync-guide.md
+++ b/docs/agent-guide/db-sync/db-sync-guide.md
@@ -30,7 +30,9 @@ This guide helps AI agents implement and review db-sync features consistently ac
   - Response parse/coercion failures (e.g., transit decode, malli coercion).
   - Unexpected WS/HTTP message type or reason value on the client.
   - Asset operations missing required fields when processing client-side metadata.
-  - Invariant violations in tx apply (e.g., tx-data empty after normalization).
+  - Invariant violations in tx apply (e.g., an originally empty delete tx).
+- Retry-safe operations may normalize to an intentional no-op. For example, a
+  non-empty delete tx is already satisfied when its target no longer exists.
 - Server-side validation of client input should not throw. Respond with `tx/reject` or `400` errors for:
   - tx payload type mismatch (e.g., `:txs` not a sequence of strings).
   - Invalid graph identity (missing/empty graph id or uuid in sync path).

--- a/docs/agent-guide/db-sync/protocol.md
+++ b/docs/agent-guide/db-sync/protocol.md
@@ -28,7 +28,8 @@
 - `{"type":"pull/ok","t":<t>,"checksum":"<hex>","txs":[{"t":<t>,"tx":"<tx-transit>","outliner-op":"<keyword?>"}...]}`
   - Pull response with txs and post-apply entity checksum.
 - `{"type":"tx/batch/ok","t":<t>,"checksum":"<hex>"}`
-  - Batch accepted; server advanced to t and returns the resulting entity checksum.
+  - Batch accepted; `t` and `checksum` describe the resulting server state.
+    `t` remains unchanged when every entry is an idempotent no-op.
 - `{"type":"changed","t":<t>}`
   - Broadcast once after a handled `tx/batch` that advanced server state (`t` increased); client should pull.
 - `{"type":"tx/reject","reason":"stale","t":<t>}`


### PR DESCRIPTION
## Summary

- acknowledge non-empty block and page deletes as idempotent successes when their targets are already absent
- keep originally empty delete payloads invalid and preserve partial-batch failure attribution
- document that accepted no-op batches can leave the server transaction counter unchanged

## Root cause

The sync server rejected delete entries that sanitized to an empty transaction after another client had already removed the target. The client treated that rejection as a failed local delete and rolled it back, restoring the block or page.

## Validation

- `pnpm test` in `deps/db-sync` — 195 tests, 4,216 assertions
- `bb dev:lint-and-test` — lint clean; 931 tests / 4,198 assertions and 1,107 tests / 4,757 assertions
- eight independent review passes completed; all validated findings addressed

Fixes logseq/db-test#1019