### PR TITLE
Fix editor caret position during content change

### DIFF
--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1030,11 +1030,12 @@ should be done through this fn in order to get global config and config defaults
 (defn set-edit-content!
   ([value] (set-edit-content! (get-edit-input-id) value))
   ([input-id value] (set-edit-content! input-id value true))
-  ([input-id value set-input-value?]
+  ([input-id value set-input-value?] (set-edit-content! input-id value set-input-value? nil))
+  ([input-id value set-input-value? caret-pos]
    (when input-id
      (when set-input-value?
        (when-let [input (gdom/getElement input-id)]
-         (util/set-change-value input value)))
+         (util/set-change-value input value caret-pos)))
      (set-state! :editor/content value :path-in-sub-atom
                  (or (:block/uuid (get-edit-block)) input-id)))))
 
@@ -1426,7 +1427,7 @@ should be done through this fn in order to get global config and config defaults
 (defn set-block-content-and-last-pos!
   [edit-input-id content new-pos]
   (when edit-input-id
-    (set-edit-content! edit-input-id content)
+    (set-edit-content! edit-input-id content true new-pos)
     (set-editor-last-pos! new-pos)))
 
 (defn set-theme-mode!

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -157,8 +157,10 @@
 #?(:cljs
    (defn set-change-value
      "compatible change event for React"
-     [node value]
-     (utils/triggerInputChange node value)))
+     ([node value]
+      (utils/triggerInputChange node value))
+     ([node value caret-pos]
+      (utils/triggerInputChange node value caret-pos))))
 
 #?(:cljs
    (defn p-handle

--- a/src/main/frontend/utils.js
+++ b/src/main/frontend/utils.js
@@ -189,7 +189,7 @@ const inputTypes = [
   window.HTMLTextAreaElement,
 ]
 
-export const triggerInputChange = (node, value = '', name = 'change') => {
+export const triggerInputChange = (node, value = '', caretPosition) => {
 
   // only process the change on elements we know have a value setter in their constructor
   if (inputTypes.indexOf(node.__proto__.constructor) > -1) {
@@ -200,6 +200,9 @@ export const triggerInputChange = (node, value = '', name = 'change') => {
     })
 
     setValue.call(node, value)
+    if (Number.isInteger(caretPosition)) {
+      node.setSelectionRange(caretPosition, caretPosition)
+    }
     node.dispatchEvent(event)
   }
 }

--- a/src/test/frontend/state_test.cljs
+++ b/src/test/frontend/state_test.cljs
@@ -1,6 +1,58 @@
 (ns frontend.state-test
-  (:require [clojure.test :refer [deftest is]]
-            [frontend.state :as state]))
+  (:require [clojure.test :refer [deftest is testing]]
+            [frontend.state :as state]
+            [frontend.util :as util]
+            [frontend.util.cursor :as cursor]
+            [goog.dom :as gdom]))
+
+(defn- caret-pos-when-editor-content-changes
+  [initial-content updated-content new-pos]
+  (let [block-id (random-uuid)
+        input-id (str "edit-block-" block-id)
+        input #js {:id input-id
+                   :value initial-content
+                   :selectionStart 2
+                   :selectionEnd 2}
+        editor-content (:editor/content @state/state)
+        last-saved-cursor (:editor/last-saved-cursor @state/state)
+        watch-key (keyword (str "caret-pos-" block-id))
+        observed-pos (atom nil)]
+    (set! (.-setSelectionRange input)
+          (fn [start end]
+            (set! (.-selectionStart input) start)
+            (set! (.-selectionEnd input) end)))
+    (add-watch editor-content watch-key
+               (fn [_ _ _ content-by-block]
+                 (when (= updated-content (get content-by-block block-id))
+                   (reset! observed-pos (cursor/pos input)))))
+    (try
+      (with-redefs [state/get-edit-block (constantly {:block/uuid block-id})
+                    gdom/getElement (constantly input)
+                    util/set-change-value
+                    (fn [node value & [caret-pos]]
+                      ;; Match the browser value setter, which moves the caret to the end.
+                      (set! (.-value node) value)
+                      (.setSelectionRange node (count value) (count value))
+                      (when (number? caret-pos)
+                        (.setSelectionRange node caret-pos caret-pos))
+                      ;; Match the synchronous React change handler.
+                      (state/set-edit-content! input-id value false))]
+        (state/set-block-content-and-last-pos! input-id updated-content new-pos))
+      {:observed-pos @observed-pos
+       :final-pos (cursor/pos input)}
+      (finally
+        (remove-watch editor-content watch-key)
+        (swap! editor-content dissoc block-id)
+        (swap! last-saved-cursor dissoc block-id)))))
+
+(deftest set-block-content-exposes-new-caret-before-content-change
+  (testing "Caret before trailing page-reference brackets"
+    (is (= {:observed-pos 8 :final-pos 8}
+           (caret-pos-when-editor-content-changes "[[]]" "[[foobar]]" 8))))
+
+  (testing "Caret at the end of the updated content"
+    (is (= {:observed-pos 6 :final-pos 6}
+           (caret-pos-when-editor-content-changes "" "foobar" 6)))))
 
 (deftest merge-configs
   (let [global-config


### PR DESCRIPTION
## Summary

- preserve the intended editor caret before dispatching programmatic change events
- ensure page search subscribers read the caret before trailing page-reference brackets
- add regression coverage for caret visibility during content updates

## Testing

- bb dev:lint-and-test
- app runtime probe: content subscriber and final caret both report position 8 for [[foobar]]