### PR TITLE
fix(editor/db): dead-key composition on international keyboard layouts

### DIFF
--- a/clj-e2e/src/logseq/e2e/ime.clj
+++ b/clj-e2e/src/logseq/e2e/ime.clj
@@ -1,0 +1,140 @@
+(ns logseq.e2e.ime
+  "Emulates dead-key input (IME composition) via CDP.
+   On many international keyboard layouts, keys like ` ~ ^ ´ are dead keys:
+   pressing one starts a composition; the char resolves on space
+   (compositionend data = the char itself) or composes into an accented
+   letter (e.g. ~ + a => ã)."
+  (:require [jsonista.core :as json]
+            [wally.main :as w])
+  (:import [com.google.gson JsonParser]))
+
+(defonce ^:private *sessions (atom {}))
+
+(defn- json-params
+  [m]
+  (.getAsJsonObject (JsonParser/parseString (json/write-value-as-string m))))
+
+(defn- cdp-session
+  []
+  (let [page (w/get-page)]
+    (or (get @*sessions page)
+        (let [session (.newCDPSession (.context page) page)]
+          (swap! *sessions assoc page session)
+          session))))
+
+(defn- cdp-send!
+  [method params]
+  (.send (cdp-session) method (json-params params)))
+
+;; Chromium reports keyCode 229 for key events that are part of a composition.
+(def ^:private composition-key-code 229)
+
+(defn- key-event!
+  [m]
+  (cdp-send! "Input.dispatchKeyEvent" m))
+
+(defn dead-key!
+  "Press a dead key: keydown (key \"Dead\", keyCode 229) + start/extend the
+   composition to `text`. No commit happens until commit-with-space!,
+   commit-with-letter! or another dead-key! press commits it.
+   `key-code` is the key's real keyCode reported on keyup (e.g. 192 for `)."
+  [text code key-code]
+  (key-event! {:type "rawKeyDown"
+               :key "Dead"
+               :code code
+               :windowsVirtualKeyCode composition-key-code
+               :nativeVirtualKeyCode composition-key-code})
+  (cdp-send! "Input.imeSetComposition" {:text text
+                                        :selectionStart (count text)
+                                        :selectionEnd (count text)})
+  (key-event! {:type "keyUp"
+               :key "Dead"
+               :code code
+               :windowsVirtualKeyCode key-code
+               :nativeVirtualKeyCode key-code}))
+
+(defn- commit!
+  "Commit the active composition as `text` (fires input + compositionend)."
+  [text]
+  (cdp-send! "Input.insertText" {:text text}))
+
+(defn commit-with-space!
+  "Space resolves the pending dead key to its literal char, e.g. ` + space => `.
+   Calibrated against a real macOS international-layout trace: the commit
+   keydown is synthesized with the *resolved char* as its key (not the space),
+   keyCode 229; the space keyup arrives afterwards with the real space keyCode."
+  [text]
+  (key-event! {:type "rawKeyDown"
+               :key text
+               :code "Space"
+               :windowsVirtualKeyCode composition-key-code
+               :nativeVirtualKeyCode composition-key-code})
+  (commit! text)
+  (key-event! {:type "keyUp"
+               :key " "
+               :code "Space"
+               :windowsVirtualKeyCode 32
+               :nativeVirtualKeyCode 32}))
+
+(defn commit-with-letter!
+  "A letter composes with the pending dead key into an accented char,
+   e.g. ~ + a => ã. `key`/`code` are the letter's (\"a\"/\"KeyA\");
+   `composed` is the resulting char (\"ã\")."
+  [composed key code]
+  (key-event! {:type "rawKeyDown"
+               :key key
+               :code code
+               :windowsVirtualKeyCode composition-key-code
+               :nativeVirtualKeyCode composition-key-code})
+  (commit! composed)
+  (key-event! {:type "keyUp"
+               :key key
+               :code code
+               :windowsVirtualKeyCode composition-key-code
+               :nativeVirtualKeyCode composition-key-code}))
+
+(defn dead-key-twice!
+  "Pressing the same dead key twice: the second press commits the first char
+   and starts a new composition, e.g. ~ then ~ => \"~\" committed + \"~\" composing."
+  [text code key-code]
+  (dead-key! text code key-code)
+  (key-event! {:type "rawKeyDown"
+               :key "Dead"
+               :code code
+               :windowsVirtualKeyCode composition-key-code
+               :nativeVirtualKeyCode composition-key-code})
+  (commit! text)
+  (cdp-send! "Input.imeSetComposition" {:text text
+                                        :selectionStart (count text)
+                                        :selectionEnd (count text)})
+  (key-event! {:type "keyUp"
+               :key "Dead"
+               :code code
+               :windowsVirtualKeyCode key-code
+               :nativeVirtualKeyCode key-code}))
+
+(defn backtick+space!
+  []
+  (dead-key! "`" "Backquote" 192)
+  (commit-with-space! "`"))
+
+(defn tilde+space!
+  []
+  (dead-key! "~" "Backquote" 192)
+  (commit-with-space! "~"))
+
+(defn caret+space!
+  []
+  (dead-key! "^" "Digit6" 54)
+  (commit-with-space! "^"))
+
+(defn acute+space!
+  []
+  (dead-key! "´" "Quote" 222)
+  (commit-with-space! "´"))
+
+(defn tilde+a!
+  "~ + a => ã"
+  []
+  (dead-key! "~" "Backquote" 192)
+  (commit-with-letter! "ã" "a" "KeyA"))

--- a/clj-e2e/test/logseq/e2e/ime_dead_key_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/ime_dead_key_basic_test.clj
@@ -1,0 +1,197 @@
+(ns logseq.e2e.ime-dead-key-basic-test
+  "Dead-key (international keyboard layout) input: autopair parity and
+   corruption regressions. Event shapes calibrated against a real macOS
+   international-layout trace: the composition commit synthesizes a keydown
+   carrying the resolved char with keyCode 229. Prints each scenario's event
+   trace to ease debugging."
+  (:require [clojure.string :as string]
+            [clojure.test :refer [deftest testing is use-fixtures]]
+            [jsonista.core :as json]
+            [logseq.e2e.assert :as assert]
+            [logseq.e2e.block :as b]
+            [logseq.e2e.fixtures :as fixtures]
+            [logseq.e2e.ime :as ime]
+            [logseq.e2e.util :as util]
+            [wally.main :as w]))
+
+(use-fixtures :once fixtures/open-page)
+(use-fixtures :each fixtures/new-logseq-page)
+
+(def ^:private logger-js
+  "(() => {
+     const el = document.querySelector('.editor-wrapper textarea');
+     if (!el) throw new Error('editor textarea not found');
+     window.__ime_events = [];
+     const rec = (e) => window.__ime_events.push({
+       type: e.type,
+       key: e.key,
+       keyCode: e.keyCode,
+       isComposing: e.isComposing,
+       data: e.data,
+       inputType: e.inputType,
+       value: el.value,
+       selectionStart: el.selectionStart});
+     ['keydown','keyup','compositionstart','compositionupdate','compositionend','beforeinput','input']
+       .forEach((t) => el.addEventListener(t, rec, true));
+   })()")
+
+(defn- start-recording!
+  []
+  (w/eval-js logger-js))
+
+(defn- recorded-events
+  []
+  (json/read-value (w/eval-js "JSON.stringify(window.__ime_events)")
+                   json/keyword-keys-object-mapper))
+
+(defn- print-trace!
+  [scenario]
+  (println "=== trace:" scenario)
+  (doseq [e (recorded-events)]
+    (prn e))
+  (println "=== textarea value:" (pr-str (util/get-edit-content)))
+  (println "=== end trace:" scenario))
+
+(defn- fresh-block!
+  []
+  (b/new-blocks [""])
+  (start-recording!))
+
+(deftest single-backtick-dead-key-test
+  (testing "dead ` + space autopairs like a plain ` keydown"
+    (fresh-block!)
+    (ime/backtick+space!)
+    (print-trace! "backtick+space")
+    (is (= "``" (util/get-edit-content)) "textarea after dead ` + space")))
+
+(deftest inline-code-sequence-test
+  (testing "dead ` + space, type code, dead ` + space skips over the closing pair"
+    (fresh-block!)
+    (ime/backtick+space!)
+    (util/press-seq "code")
+    (ime/backtick+space!)
+    (print-trace! "`code`")
+    (is (= "`code`" (util/get-edit-content))
+        "textarea after full inline-code sequence")
+    (util/exit-edit)
+    (is (= ["code"] (util/get-page-blocks-contents)) "rendered inline code text")))
+
+(deftest tilde-composes-accent-test
+  (testing "n + dead ~ + a + o => não, accents must not trigger autopair"
+    (fresh-block!)
+    (util/press-seq "n")
+    (ime/tilde+a!)
+    (util/press-seq "o")
+    (print-trace! "não")
+    (is (= "não" (util/get-edit-content)) "textarea after composing ã")
+    (util/exit-edit)
+    (is (= ["não"] (util/get-page-blocks-contents)) "saved block content")))
+
+(deftest double-dead-key-test
+  (testing "dead ~ twice then space behaves like typing ~~ on a US layout"
+    (fresh-block!)
+    (ime/dead-key-twice! "~" "Backquote" 192)
+    (ime/commit-with-space! "~")
+    (print-trace! "~~ via double dead key")
+    (is (= "~~" (util/get-edit-content)) "textarea after double dead ~")))
+
+(deftest strikethrough-sequence-test
+  (testing "~~strike~~ via dead keys"
+    (fresh-block!)
+    (ime/tilde+space!)
+    (ime/tilde+space!)
+    (util/press-seq "strike")
+    (ime/tilde+space!)
+    (ime/tilde+space!)
+    (print-trace! "~~strike~~")
+    (is (= "~~strike~~" (util/get-edit-content))
+        "textarea after strikethrough sequence")))
+
+(deftest triple-backtick-codeblock-test
+  (testing "dead ` + space three times converts the block into a code block"
+    (fresh-block!)
+    (ime/backtick+space!)
+    (ime/backtick+space!)
+    (ime/backtick+space!)
+    ;; no print-trace! here: the conversion replaces the block textarea
+    (assert/assert-is-visible ".CodeMirror")))
+
+(deftest vanishing-text-test
+  (testing "content typed after a dead-key commit persists after leaving the block"
+    (fresh-block!)
+    (ime/backtick+space!)
+    (util/press-seq "asd")
+    (print-trace! "vanishing text")
+    (util/exit-edit)
+    (let [contents (remove string/blank? (util/get-page-blocks-contents))]
+      (println "=== persisted contents:" (pr-str contents))
+      (is (= ["asd"] contents)
+          "the typed content must survive leaving the block"))))
+
+(deftest slow-composition-test
+  (testing "composition held open across the 450ms auto-save debounce"
+    (fresh-block!)
+    (util/press-seq "antes ")
+    (ime/dead-key! "`" "Backquote" 192)
+    ;; keep the composition open long enough for the pending auto-save to fire
+    (util/wait-timeout 1500)
+    (ime/commit-with-space! "`")
+    (util/press-seq "depois")
+    (print-trace! "slow composition")
+    (is (= "antes `depois`" (util/get-edit-content))
+        "textarea after slow composition")))
+
+(deftest composition-with-action-popup-test
+  (testing "dead key composition while the [[ ]] page-search popup is open"
+    (fresh-block!)
+    (util/press-seq "[")
+    (util/press-seq "[")
+    (w/wait-for ".ui__popover-content")
+    (ime/tilde+a!)
+    (util/press-seq "o")
+    (print-trace! "composition inside [[ ]]")
+    (is (= "[[ão]]" (util/get-edit-content))
+        "textarea after composing inside page-search")))
+
+(deftest other-dead-keys-insert-cleanly-test
+  (testing "dead keys without a no-selection autopair insert their char cleanly"
+    (fresh-block!)
+    ;; ^ only autopairs with a selection, so parity means no pair here
+    (ime/caret+space!)
+    (ime/acute+space!)
+    (print-trace! "^ and ´ commits")
+    (is (= "^´" (util/get-edit-content)) "textarea after ^ and ´ commits")
+    (util/exit-edit)
+    (is (= ["^´"] (util/get-page-blocks-contents)) "saved block content")))
+
+(deftest double-caret-highlight-test
+  (testing "dead ^ + space twice creates the ^^ highlight pair like a US layout"
+    (fresh-block!)
+    (ime/caret+space!)
+    (ime/caret+space!)
+    (util/press-seq "hl")
+    (print-trace! "^^hl^^")
+    (is (= "^^hl^^" (util/get-edit-content))
+        "textarea after double dead ^ and typed text")))
+
+(deftest unbalanced-markers-render-test
+  (testing "unbalanced ` and ~~ must not hide text when rendered"
+    (b/new-blocks ["antes `x depois"])
+    (b/new-block "antes ~~x depois")
+    (util/exit-edit)
+    (let [contents (util/get-page-blocks-contents)]
+      (println "=== rendered unbalanced contents:" (pr-str contents))
+      (is (= ["antes `x depois" "antes ~~x depois"] contents)
+          "unbalanced markers keep the raw text visible"))))
+
+(deftest interleaved-typing-test
+  (testing "normal typing interleaved with dead keys must not duplicate chars"
+    (fresh-block!)
+    (util/press-seq "antes ")
+    (ime/backtick+space!)
+    (util/press-seq "x")
+    (ime/backtick+space!)
+    (util/press-seq " depois")
+    (print-trace! "interleaved")
+    (is (= "antes `x` depois" (util/get-edit-content))
+        "textarea after interleaved sequence")))

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -745,6 +745,7 @@
                :minRows           (if (state/enable-grammarly?) 2 1)
                :on-click          (editor-handler/editor-on-click! id)
                :on-change         (editor-handler/editor-on-change! block id search-timeout)
+               :on-composition-commit (editor-handler/editor-on-composition-commit! id format)
                :on-paste          (paste-handler/editor-on-paste! id)
                :on-key-down       (fn [e]
                                     (if-let [on-key-down (:on-key-down config)]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2988,7 +2988,7 @@
         (contains? #{"ArrowLeft" "ArrowRight"} key)
         (state/clear-editor-action!)
 
-        (and (util/goog-event-is-composing? e true) ;; #3218
+        (and (util/keyboard-event-composing? e true) ;; #3218
              (not hashtag?) ;; #3283 @Rime
              (not (state/get-editor-show-page-search-hashtag?))) ;; #3283 @MacOS pinyin
         nil
@@ -3247,6 +3247,54 @@
           (edit-box-on-change! e block id)
           (when-not editor-action
             (util/scroll-editor-cursor input)))))))
+
+(def ^:private dead-key-autopair-chars
+  "Autopair chars that are dead keys on international keyboard layouts: they
+   reach the editor through an IME composition commit instead of a plain
+   keydown, so the keydown autopair path never sees them.
+   `^` is also a dead key but is excluded since it only autopairs with a
+   selection (see `autopair-when-selected`); its `^^` pair is handled
+   separately below."
+  #{"`" "~"})
+
+(defn editor-on-composition-commit!
+  "Markdown shortcuts for chars committed by a dead-key composition, mirroring
+   the keydown behavior: autopair/skip-close for ` and ~, and the ^^ highlight
+   pair. On international keyboard layouts these chars are dead keys, so they
+   never produce the plain keydowns the shortcut branches listen for."
+  [id format]
+  (fn [e]
+    (let [data (some-> ^js (util/native-event e) (gobj/get "data"))
+          input (gdom/getElement id)]
+      (when (and input (nil? (state/get-editor-action)))
+        (let [value (gobj/get input "value")
+              pos (cursor/pos input)]
+          ;; The committed char is already in the textarea when this runs;
+          ;; if it isn't (unexpected event ordering), leave the input as-is.
+          (when (= data (util/nth-safe value (dec pos)))
+            (cond
+              (contains? dead-key-autopair-chars data)
+              (do
+                ;; Remove the committed char so the caret state matches what
+                ;; the keydown autopair path expects, then re-run its decision.
+                (state/set-edit-content! id
+                                         (str (subs value 0 (dec pos)) (subs value pos))
+                                         true
+                                         (dec pos))
+                (let [curr (get-current-input-char input)
+                      prev (util/nth-safe (gobj/get input "value") (- pos 2))]
+                  (if (and (= curr data)
+                           (or (not= data "`") (not= prev "`")))
+                    (cursor/move-cursor-forward input)
+                    (autopair id data format nil))))
+
+              ;; ^^ highlight: mirrors the `double-chars-typed?` keydown branch.
+              ;; That branch relies on the typed char inserting itself afterwards;
+              ;; here the committed char is already in place, so just add the pair.
+              (and (= data "^")
+                   (= "^" (util/nth-safe value (- pos 2)))
+                   (not= "^" (util/nth-safe value pos)))
+              (commands/simple-insert! id "^^" {:backward-pos 2}))))))))
 
 (defn- cut-blocks-and-clear-selections!
   [copy?]

--- a/src/main/frontend/ui.cljs
+++ b/src/main/frontend/ui.cljs
@@ -163,22 +163,35 @@
                                                        active-ring)}} "-"]]]])))
 
 (hsx/defc ls-textarea
-  [{:keys [on-change] :as props}]
+  [{:keys [on-change on-composition-commit] :as props}]
   (let [*el (hooks/use-ref nil)
         skip-composition? (state/use-sub :editor/action)
+        ;; The in-composition check doubles as a reentrancy guard: WebKit can
+        ;; deliver both a non-composing input and a compositionend for the
+        ;; same commit, and the commit hook triggers synthetic change events.
+        end-composition! (fn [e]
+                           (when (state/editor-in-composition?)
+                             (state/set-editor-in-composition! false)
+                             (when on-composition-commit (on-composition-commit e))
+                             (on-change e)))
         on-composition (fn [e]
                          (if skip-composition?
                            (on-change e)
                            (case e.type
-                             "compositionend" (do
-                                                (state/set-editor-in-composition! false)
-                                                (on-change e))
+                             "compositionend" (end-composition! e)
                              (state/set-editor-in-composition! true))))
-        props (assoc props
+        props (assoc (dissoc props :on-composition-commit)
                      :ref *el
                      "data-testid" "block editor"
-                     :on-change (fn [e] (when-not (state/editor-in-composition?)
-                                          (on-change e)))
+                     :on-change (fn [e]
+                                  (if (state/editor-in-composition?)
+                                    ;; A composition canceled by a programmatic
+                                    ;; value write or a macOS dead-key commit
+                                    ;; never fires compositionend; the first
+                                    ;; non-composing input marks its real end.
+                                    (when-not (util/native-event-is-composing? e)
+                                      (end-composition! e))
+                                    (on-change e)))
                      :on-composition-start on-composition
                      :on-composition-update on-composition
                      :on-composition-end on-composition)]

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1149,25 +1149,46 @@
               (or event-composing?
                   (= (gobj/get e "keyCode") 229)
                   (= (gobj/get e "key") "Process"))
-              event-composing?)))))))
+              event-composing?)))))
+
+     (defn keyboard-event-composing?
+       "Check if a keyboard event is part of an IME composition. Unlike
+        `goog-event-is-composing?`, this also works for raw DOM events (the
+        editor key listeners are registered with addEventListener, so they
+        receive raw events, for which the goog variant always returns nil).
+        macOS dead-key commits synthesize a keydown carrying the resolved char
+        as its key, with keyCode 229 and isComposing true."
+       [^js e include-process?]
+       (let [^js browser-event (if (goog-event? e) (.getBrowserEvent e) e)]
+         (boolean
+          (or (.-isComposing browser-event)
+              (when include-process?
+                (or (= (gobj/get browser-event "keyCode") 229)
+                    (= (gobj/get browser-event "key") "Process")))))))))
+
+#?(:cljs
+   (defn native-event
+     "Unwrap a goog or React synthetic event to the underlying DOM event."
+     [^js e]
+     (when e
+       (cond
+         (goog-event? e)
+         (.getBrowserEvent e)
+
+         (js-in "_reactName" e)
+         (.-nativeEvent e)
+
+         :else e))))
 
 #?(:cljs
    (defn native-event-is-composing?
      "Check if onchange event of Input is a composing (IME) event.
        Always ignore the IME process."
      [^js e]
-     (when-let [^js native-event
-                (and e (cond
-                         (goog-event? e)
-                         (.getBrowserEvent e)
-
-                         (js-in "_reactName" e)
-                         (.-nativeEvent e)
-
-                         :else e))]
-       (or (.-isComposing native-event)
-           (= (gobj/get native-event "keyCode") 229)
-           (= (gobj/get native-event "key") "Process")))))
+     (when-let [^js native-event' (native-event e)]
+       (or (.-isComposing native-event')
+           (= (gobj/get native-event' "keyCode") 229)
+           (= (gobj/get native-event' "key") "Process")))))
 
 #?(:cljs
    (defn open-url


### PR DESCRIPTION
Fix [#logseq/db-test#10](https://github.com/logseq/db-test/issues/1021)

## Problem
On layouts where ` ~ ^ are dead keys (macOS BR, US International, etc.) the composition guard never fired for the editor's raw keydown events, so autopair ran mid-composition: chars were duplicated and the canceled composition never fired compositionend, leaving :editor/in-composition? stuck and suppressing every save until the block content vanished.

## Solution
- detect composition on raw DOM keyboard events in the keydown autopair guard
- treat the first non-composing input as composition end when compositionend never fires
- run autopair for ` and ~ (and the ^^ pair) on composition commit, restoring markdown shortcut parity with US layouts
- add CDP-based dead-key emulation helpers and an e2e regression suite