### PR TITLE
fix: traverse raw block children for deletion

### DIFF
--- a/deps/db/src/logseq/db/common/delete_blocks.cljs
+++ b/deps/db/src/logseq/db/common/delete_blocks.cljs
@@ -5,6 +5,7 @@
             [logseq.common.util :as common-util]
             [logseq.common.util.block-ref :as block-ref]
             [logseq.common.util.page-ref :as page-ref]
+            [logseq.db.common.entity-plus :as entity-plus]
             [logseq.db.frontend.entity-util :as entity-util]))
 
 (defn- replace-ref-with-deleted-block-title
@@ -157,7 +158,9 @@
       (if (or (nil? (:db/id entity))
               (contains? seen-ids (:db/id entity)))
         (recur (rest pending) seen-ids result)
-        (recur (concat (rest pending) (filter block-entity? (:block/_parent entity)))
+        (recur (concat (rest pending)
+                       (filter block-entity?
+                               (entity-plus/lookup-kv-then-entity entity :block/_raw-parent)))
                (conj seen-ids (:db/id entity))
                (conj result entity)))
       result)))

--- a/deps/outliner/src/logseq/outliner/recycle.cljs
+++ b/deps/outliner/src/logseq/outliner/recycle.cljs
@@ -73,12 +73,17 @@
                   (common-initial-data/get-block-full-children-ids db (:db/id block)))]
     (keep #(d/entity db %) ids)))
 
+(defn- block-children
+  [db block]
+  (map #(d/entity db (:e %))
+       (d/datoms db :avet :block/parent (:db/id block))))
+
 (defn- page-descendants
-  [page]
+  [db page]
   (loop [pages [page]
          result []]
     (if-let [page' (first pages)]
-      (let [children (->> (:block/_parent page')
+      (let [children (->> (block-children db page')
                           (filter ldb/page?)
                           ldb/sort-by-order)]
         (recur (concat (rest pages) children)
@@ -88,7 +93,7 @@
 (defn- page-block-subtree-ids
   [db page]
   (let [root-blocks (->> (concat (:block/_page page)
-                                 (remove ldb/page? (:block/_parent page)))
+                                 (remove ldb/page? (block-children db page)))
                          (common-util/distinct-by :db/id)
                          ldb/sort-by-order)]
     (->> root-blocks
@@ -97,7 +102,7 @@
 
 (defn- page-tree-ids
   [db page]
-  (->> (page-descendants page)
+  (->> (page-descendants db page)
        (mapcat (fn [page']
                  (cons (:db/id page')
                        (page-block-subtree-ids db page'))))

--- a/deps/outliner/src/logseq/outliner/recycle.cljs
+++ b/deps/outliner/src/logseq/outliner/recycle.cljs
@@ -5,6 +5,7 @@
             [logseq.common.uuid :as common-uuid]
             [logseq.db :as ldb]
             [logseq.db.common.delete-blocks :as delete-blocks]
+            [logseq.db.common.entity-plus :as entity-plus]
             [logseq.db.common.initial-data :as common-initial-data]
             [logseq.db.common.order :as db-order]))
 
@@ -74,16 +75,15 @@
     (keep #(d/entity db %) ids)))
 
 (defn- block-children
-  [db block]
-  (map #(d/entity db (:e %))
-       (d/datoms db :avet :block/parent (:db/id block))))
+  [block]
+  (entity-plus/lookup-kv-then-entity block :block/_raw-parent))
 
 (defn- page-descendants
-  [db page]
+  [page]
   (loop [pages [page]
          result []]
     (if-let [page' (first pages)]
-      (let [children (->> (block-children db page')
+      (let [children (->> (block-children page')
                           (filter ldb/page?)
                           ldb/sort-by-order)]
         (recur (concat (rest pages) children)
@@ -93,7 +93,7 @@
 (defn- page-block-subtree-ids
   [db page]
   (let [root-blocks (->> (concat (:block/_page page)
-                                 (remove ldb/page? (block-children db page)))
+                                 (remove ldb/page? (block-children page)))
                          (common-util/distinct-by :db/id)
                          ldb/sort-by-order)]
     (->> root-blocks
@@ -102,7 +102,7 @@
 
 (defn- page-tree-ids
   [db page]
-  (->> (page-descendants db page)
+  (->> (page-descendants page)
        (mapcat (fn [page']
                  (cons (:db/id page')
                        (page-block-subtree-ids db page'))))

--- a/deps/outliner/test/logseq/outliner/recycle_test.cljs
+++ b/deps/outliner/test/logseq/outliner/recycle_test.cljs
@@ -68,6 +68,69 @@
     (is (true? (recycle/permanently-delete! conn (:block/uuid page1))))
     (is (nil? (d/entity @conn [:block/uuid block-uuid])))))
 
+(deftest permanently-delete-recycled-converted-page-removes-property-value-blocks
+  (let [conn (db-test/create-conn-with-blocks
+              [{:page {:block/title "outer"}
+                :blocks [{:block/title "target"
+                          :build/properties {:default "value"}}]}])
+        target (db-test/find-block-by-content @conn "target")
+        target-id (:db/id target)
+        target-uuid (:block/uuid target)
+        value-id (d/q '[:find ?value .
+                        :in $ ?target
+                        :where
+                        [?value :block/parent ?target]
+                        [?value :logseq.property/created-from-property]]
+                      @conn target-id)]
+    (d/transact! conn [[:db/retract target-id :block/page]
+                       [:db/add target-id :block/name "target"]
+                       [:db/add target-id :block/tags :logseq.class/Page]])
+    (let [page (d/entity @conn target-id)]
+      (ldb/transact! conn (recycle/recycle-page-tx-data @conn page {}) {:outliner-op :delete-page}))
+    (is (true? (recycle/permanently-delete! conn target-uuid)))
+    (is (nil? (d/entity @conn target-id)))
+    (is (nil? (d/entity @conn value-id)))))
+
+(deftest gc-recycled-converted-page-removes-property-value-blocks
+  (let [conn (db-test/create-conn-with-blocks
+              [{:page {:block/title "outer"}
+                :blocks [{:block/title "target"
+                          :build/properties {:default "value"}}
+                         {:block/title "unrelated"}]}])
+        outer (ldb/get-page @conn "outer")
+        target (db-test/find-block-by-content @conn "target")
+        unrelated (db-test/find-block-by-content @conn "unrelated")
+        target-id (:db/id target)
+        value-id (d/q '[:find ?value .
+                        :in $ ?target
+                        :where
+                        [?value :block/parent ?target]
+                        [?value :logseq.property/created-from-property]]
+                      @conn target-id)]
+    (d/transact! conn [[:db/retract target-id :block/page]
+                       [:db/add target-id :block/name "target"]
+                       [:db/add target-id :block/tags :logseq.class/Page]])
+    (let [page (d/entity @conn target-id)]
+      (ldb/transact! conn
+                     (recycle/recycle-page-tx-data @conn page {:now-ms 0})
+                     {:outliner-op :delete-page}))
+    (is (true? (recycle/gc! conn {:now-ms (* 31 24 3600 1000)})))
+    (is (nil? (d/entity @conn target-id)))
+    (is (nil? (d/entity @conn value-id)))
+    (is (some? (d/entity @conn (:db/id outer))))
+    (is (some? (d/entity @conn (:db/id unrelated))))))
+
+(deftest gc-keeps-unexpired-recycled-page
+  (let [conn (db-test/create-conn-with-blocks
+              [{:page {:block/title "page1"}}])
+        page (ldb/get-page @conn "page1")
+        page-id (:db/id page)]
+    (ldb/transact! conn
+                   (recycle/recycle-page-tx-data @conn page {:now-ms 0})
+                   {:outliner-op :delete-page})
+    (is (nil? (recycle/gc! conn {:now-ms (* 29 24 3600 1000)})))
+    (is (some? (d/entity @conn page-id)))))
+
 (deftest apply-ops-permanently-delete-recycled-page-removes-page-and-descendants
   (let [conn (db-test/create-conn-with-blocks
               [{:page {:block/title "page1"}

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -23,6 +23,7 @@
    [logseq.db :as ldb]
    [logseq.db-sync.order :as sync-order]
    [logseq.db-sync.tx-sanitize :as tx-sanitize]
+   [logseq.db.common.entity-plus :as entity-plus]
    [logseq.db.common.normalize :as db-normalize]
    [logseq.db.sqlite.util :as sqlite-util]
    [logseq.outliner.core :as outliner-core]
@@ -998,7 +999,8 @@
   (letfn [(collect [block]
             (mapcat (fn [child]
                       (cons child (collect child)))
-                    (sort-by :block/order (:block/_parent block))))]
+                    (sort-by :block/order
+                             (entity-plus/lookup-kv-then-entity block :block/_raw-parent))))]
     (collect entity)))
 
 (defn- retract-entity-op?

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -36,6 +36,7 @@
    [logseq.db-sync.storage :as sync-storage]
    [logseq.db-sync.worker.handler.sync :as sync-handler]
    [logseq.db-sync.worker.ws :as ws]
+   [logseq.db.common.delete-blocks :as delete-blocks]
    [logseq.db.common.normalize :as db-normalize]
    [logseq.db.frontend.schema :as db-schema]
    [logseq.db.frontend.validate :as db-validate]
@@ -6545,6 +6546,45 @@
           (let [validation (db-validate/validate-local-db! @conn)]
             (is (empty? (non-recycle-validation-entities validation))
                 (str (:errors validation)))))))))
+
+(deftest delete-expansion-includes-generated-property-value-children-test
+  (testing "physical delete expansion includes generated property value children"
+    (let [property-value-uuid (random-uuid)
+          conn (db-test/create-conn-with-blocks
+                {:properties {:user.property/delete-expansion {:logseq.property/type :default}}
+                 :pages-and-blocks
+                 [{:page {:block/title "page 1"}
+                   :blocks [{:block/title "parent"
+                             :build/properties
+                             {:user.property/delete-expansion
+                              {:build/property-value :block
+                               :block/title "property value"
+                               :block/uuid property-value-uuid
+                               :build/keep-uuid? true
+                               :build/children [{:block/title "nested property child"}]}}}]}]})
+          parent (db-test/find-block-by-content @conn "parent")
+          property-value (d/entity @conn [:block/uuid property-value-uuid])
+          nested-child (db-test/find-block-by-content @conn "nested property child")
+          root-retract [:db/retractEntity (:db/id parent)]
+          generic-expanded (delete-blocks/expand-delete-blocks-tx
+                            @conn [root-retract] {:outliner-op :delete-blocks})
+          sync-expanded (#'sync-apply/expand-block-retracts-to-descendants
+                         @conn [root-retract])
+          property-value-retract [:db/retractEntity (:db/id property-value)]
+          nested-child-retract [:db/retractEntity (:db/id nested-child)]
+          sync-retracted-ids (->> sync-expanded
+                                  (keep (fn [[op ref]]
+                                          (when (= :db/retractEntity op)
+                                            (:db/id (d/entity @conn ref)))))
+                                  set)]
+      (is (some? (:logseq.property/created-from-property property-value)))
+      (is (empty? (:block/_parent parent)))
+      (is (= [(:db/id property-value)]
+             (mapv :db/id (:block/_raw-parent parent))))
+      (is (some #{property-value-retract} generic-expanded))
+      (is (some #{nested-child-retract} generic-expanded))
+      (is (contains? sync-retracted-ids (:db/id property-value)))
+      (is (contains? sync-retracted-ids (:db/id nested-child))))))
 
 (deftest apply-remote-txs-computes-remote-deletes-once-per-batch-test
   (testing "a large remote batch keeps delete filtering without repeatedly rescanning the pull"


### PR DESCRIPTION
## Summary

- traverse explicit `:block/_raw-parent` relationships for recycle cleanup, hard-delete expansion, and sync retract expansion
- include generated property values and nested descendants in physical subtree deletion
- keep filtered `:block/_parent` behavior unchanged for visible outline ordering and navigation
- add compiled CLJS regression coverage for generic and sync deletion paths

## Root cause

`entity-plus` intentionally filters generated property value and closed-value entities from `:block/_parent`. Physical deletion code reused that visible-outline view, so it could omit real descendants linked by `:block/parent`.

For converted pages, historical property values can also retain the outer page in `:block/page`. They are then reachable through neither the converted page `:block/_page` relation nor filtered `:block/_parent` traversal.

## Impact

Recycle cleanup, direct hard deletion, sync replay, and reverse-history cleanup now traverse the complete physical parent tree. Generated property values and their nested descendants are retracted with their owners instead of becoming invalid orphan entities.

## Verification

- reproduced filtered versus raw reverse navigation in the `:db-worker-node` runtime
- verified generic delete and sync expansion include generated and nested property descendants
- verified converted-page recycle deletion removes both the page and property value in `:db-worker-node`
- targeted db-sync suite: 217 tests, 835 assertions, 0 failures
- `bb dev:lint-and-test`: lint clean; 941 tests / 4164 assertions and 1027 tests / 4546 assertions, 0 failures
- `clj-e2e`: 85 tests, 730 assertions, 0 failures
- CLI E2E harness: 83 tests, 317 assertions, 0 failures
- CLI non-sync E2E: 90 passed, 0 failed
- CLI sync E2E: 10 passed, 0 failed