### PR TITLE
fix(import): do not convert tags that collide with built-in names

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -229,13 +229,33 @@
         (swap! page-names-to-uuids assoc page-name new-uuid)
         new-uuid)))
 
+(def ^:private built-in-names-blocked-from-tag-class-conversion
+  "Keyword tag names that must not convert to classes. Colliding with a built-in
+  property/class reuses that entity's uuid and produces an invalid hybrid
+  (logseq/db-test#1009). :card is excluded because it intentionally converts."
+  (let [property-file-ids (->> (keys db-property/built-in-properties)
+                               (map (fn [db-ident]
+                                      ;; keep in sync with get-file-pid special cases
+                                      (or ({:logseq.property/order-list-type :logseq.order-list-type
+                                            :logseq.property/publishing-public? :public} db-ident)
+                                          (keyword (name db-ident)))))
+                               set)
+        class-titles (->> (vals db-class/built-in-classes)
+                          (map (comp keyword string/lower-case :title))
+                          set)]
+    (disj (set/union property-file-ids class-titles) :card)))
+
 (defn- convert-tag? [tag-name {:keys [convert-all-tags? tag-classes]}]
   (and (or convert-all-tags?
            (contains? tag-classes tag-name)
            ;; built-in tags that always convert
            (contains? #{"card"} tag-name))
        ;; Disallow tags as it breaks :block/tags
-       (not (contains? #{"tags"} tag-name))))
+       (not (contains? #{"tags"} tag-name))
+       ;; Avoid converting tags whose names match built-in properties/classes
+       ;; (e.g. #scheduled). That reuses the built-in entity uuid and corrupts it
+       ;; into an invalid hybrid property/class (logseq/db-test#1009).
+       (not (contains? built-in-names-blocked-from-tag-class-conversion (keyword tag-name)))))
 
 (defn- find-existing-class
   "Finds a class entity by unique name and parents and returns its :block/uuid if found.

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -2006,6 +2006,39 @@ abc
       (is (= (:db/id journal) (get-in ref-block [:block/page :db/id]))
           "Structured block page reference still points to the same journal entity"))))
 
+(deftest-async import-does-not-corrupt-built-in-property-when-tag-name-collides
+  ;; logseq/db-test#1009: #scheduled with convert-all-tags reused the built-in
+  ;; :logseq.property/scheduled entity and produced an invalid hybrid.
+  (p/let [file (write-temp-graph-file
+                "pages/home.md"
+                "- DONE figure out how to schedule things for [[February 22nd, 2021]] #scheduled\n")
+          conn (db-test/create-conn)
+          _ (import-files-to-db [file] conn {:convert-all-tags? true})
+          scheduled-property (d/entity @conn :logseq.property/scheduled)
+          scheduled-pages (d/q '[:find [?e ...]
+                                 :where
+                                 [?e :block/name "scheduled"]]
+                               @conn)
+          block (db-test/find-block-by-content @conn #"figure out how to schedule")]
+    (is (empty? (:errors (db-validate/validate-local-db! @conn)))
+        "Graph validates after importing a tag named like a built-in property")
+    (is (= :logseq.property/scheduled (:db/ident scheduled-property))
+        "Built-in scheduled property keeps its ident")
+    (is (= :datetime (:logseq.property/type scheduled-property))
+        "Built-in scheduled property keeps its type")
+    (is (true? (:logseq.property/built-in? scheduled-property))
+        "Built-in scheduled property stays built-in")
+    (is (some? block)
+        "Block with #scheduled imports")
+    (is (nil? (some #(= :user.class/scheduled (:db/ident (d/entity @conn %))) scheduled-pages))
+        "Does not create invalid :user.class/scheduled hybrid entity")
+    (is (some #(let [e (d/entity @conn %)]
+                 (and (= "scheduled" (:block/name e))
+                      (not= :logseq.property/scheduled (:db/ident e))
+                      (not (ldb/class? e))))
+              scheduled-pages)
+        "User #scheduled remains a page reference rather than a class")))
+
 (deftest-async export-files-with-tag-classes-option
   (p/let [file-graph-dir "test/resources/exporter-test-graph"
           files (mapv #(path/path-join file-graph-dir %) ["journals/2024_02_07.md" "pages/Interstellar.md"])

--- a/docs/og_import_graph_cases.md
+++ b/docs/og_import_graph_cases.md
@@ -16,6 +16,13 @@ GitHub `logseq/db-test` issues with the `import` label were audited on 2026-06-2
 
 ## Fixed and Covered Cases
 
+### Built-in property name collision with tags (`#scheduled`)
+
+- Source issue: [db-test#1009](https://github.com/logseq/db-test/issues/1009).
+- Case: file graph has an inline tag whose name matches a built-in property (e.g. `#scheduled`), imported with **Import all tags** / `convert-all-tags? true`.
+- Expected import behavior: do not convert that tag into a class (keep page-ref behavior). The built-in property entity must keep its `:db/ident` and schema; graph validation must pass.
+- Regression test: `logseq.graph-parser.exporter-test/import-does-not-corrupt-built-in-property-when-tag-name-collides`.
+
 ### Legacy journal filename refs
 
 - Source issue: #906.


### PR DESCRIPTION
## Summary
- File → DB import with **Import all tags** converted tags like `#scheduled` into classes by reusing the built-in property entity uuid, producing invalid hybrid property/class entities (logseq/db-test#1009).
- Skip converting tags whose names collide with built-in property/class names (except `#card`); they remain page refs instead of overwriting built-ins.
- Add regression test and document the case in `docs/og_import_graph_cases.md`.

## Test plan
- [x] `pnpm exec nbb-logseq -cp test -m nextjournal.test-runner -v logseq.graph-parser.exporter-test/import-does-not-corrupt-built-in-property-when-tag-name-collides` (pass)
- [x] Related exporter tests with convert-all-tags / tag-classes (pass)
- [x] CLI: `db_import.cljs` minimal graph with `#scheduled` and `-a -V` → Valid after fix
- [ ] Optional: Desktop Import → File to DB graph with Import all tags on a file containing `#scheduled`

Fixes logseq/db-test#1009