### PR TITLE
fix(pdf): use assets:// protocol for local PDFs/images on Electron

### DIFF
--- a/src/main/frontend/extensions/pdf/assets.cljs
+++ b/src/main/frontend/extensions/pdf/assets.cljs
@@ -45,7 +45,10 @@
               (assets-handler/normalize-asset-resource-url (fs/asset-path-normalize href))
 
               protocol-link?
-              href
+              (if (and (util/electron?)
+                       (string/starts-with? href "file://"))
+                (string/replace-first href "file://" "assets://")
+                href)
 
               :else
               (assets-handler/normalize-asset-resource-url original-path))
@@ -214,16 +217,17 @@
   (let [zotero-config (get-in (state/get-config) [:zotero/settings-v2 "default"])
         zotero-data-directory (:zotero-data-directory zotero-config)
         zotero-linked-attachment-base-directory (:zotero-linked-attachment-base-directory zotero-config)
-        relative-path (subs path 14)]
+        relative-path (subs path 14)
+        protocol (if (util/electron?) "assets://" "file://")]
     (cond
       (string/starts-with? path "zotero-link://")
-      (str "file://" (util/node-path.join zotero-linked-attachment-base-directory relative-path))
+      (str protocol (util/node-path.join zotero-linked-attachment-base-directory relative-path))
 
       (string/starts-with? path "zotero-path://")
-      (str "file://" (util/node-path.join zotero-data-directory "storage" relative-path))
+      (str protocol (util/node-path.join zotero-data-directory "storage" relative-path))
 
       :else ;; compatible with commit 33db791
-      (str "file://" (util/node-path.join zotero-data-directory "storage" id path)))))
+      (str protocol (util/node-path.join zotero-data-directory "storage" id path)))))
 
 (defn db-based-open-block-ref!
   [block]

--- a/src/main/frontend/extensions/pdf/assets.cljs
+++ b/src/main/frontend/extensions/pdf/assets.cljs
@@ -47,7 +47,8 @@
               protocol-link?
               (if (and (util/electron?)
                        (string/starts-with? href "file://"))
-                (string/replace-first href "file://" "assets://")
+                ;; strip file:// then normalize (protects Windows drive: C: -> C/logseq__colon/)
+                (assets-handler/normalize-asset-resource-url (string/replace-first href "file://" ""))
                 href)
 
               :else

--- a/src/main/frontend/extensions/pdf/assets.cljs
+++ b/src/main/frontend/extensions/pdf/assets.cljs
@@ -218,16 +218,20 @@
         zotero-data-directory (:zotero-data-directory zotero-config)
         zotero-linked-attachment-base-directory (:zotero-linked-attachment-base-directory zotero-config)
         relative-path (subs path 14)
-        protocol (if (util/electron?) "assets://" "file://")]
-    (cond
-      (string/starts-with? path "zotero-link://")
-      (str protocol (util/node-path.join zotero-linked-attachment-base-directory relative-path))
+        local-path (cond
+                     (string/starts-with? path "zotero-link://")
+                     (util/node-path.join zotero-linked-attachment-base-directory relative-path)
 
-      (string/starts-with? path "zotero-path://")
-      (str protocol (util/node-path.join zotero-data-directory "storage" relative-path))
+                     (string/starts-with? path "zotero-path://")
+                     (util/node-path.join zotero-data-directory "storage" relative-path)
 
-      :else ;; compatible with commit 33db791
-      (str protocol (util/node-path.join zotero-data-directory "storage" id path)))))
+                     :else ;; compatible with commit 33db791
+                     (util/node-path.join zotero-data-directory "storage" id path))]
+    ;; normalize-asset-resource-url converts to assets:// on Electron,
+    ;; protecting Windows drive letters (C: -> C/logseq__colon/)
+    (if (util/electron?)
+      (assets-handler/normalize-asset-resource-url local-path)
+      (str "file://" local-path))))
 
 (defn db-based-open-block-ref!
   [block]

--- a/src/main/frontend/extensions/zotero.cljs
+++ b/src/main/frontend/extensions/zotero.cljs
@@ -3,6 +3,7 @@
             [clojure.string :as string]
             [frontend.context.i18n :refer [t]]
             [frontend.extensions.pdf.assets :as pdf-assets]
+            [frontend.handler.assets :as assets-handler]
             [frontend.state :as state]
             [frontend.storage :as storage]
             [frontend.ui :as ui]
@@ -66,12 +67,14 @@
 
 (defn zotero-full-path
   [config item-key filename]
-  (str "file://"
-       (util/node-path.join
-        (setting config :zotero-data-directory)
-        "storage"
-        item-key
-        filename)))
+  (let [local-path (util/node-path.join
+                    (setting config :zotero-data-directory)
+                    "storage"
+                    item-key
+                    filename)]
+    (if (util/electron?)
+      (assets-handler/normalize-asset-resource-url local-path)
+      (str "file://" local-path))))
 
 (hsx/defc zotero-imported-file
   [item-key filename]
@@ -90,9 +93,10 @@
     (if (string/blank? attachment-directory)
       [:p.warning (t :zotero/linked-file-warning)]
       (let [path (read-string path)
-            full-path
-            (str "file://"
-                 (util/node-path.join
-                  attachment-directory
-                  (string/replace-first path "attachments:" "")))]
+            local-path (util/node-path.join
+                        attachment-directory
+                        (string/replace-first path "attachments:" ""))
+            full-path (if (util/electron?)
+                        (assets-handler/normalize-asset-resource-url local-path)
+                        (str "file://" local-path))]
         (open-button full-path)))))

--- a/src/main/frontend/handler/assets.cljs
+++ b/src/main/frontend/handler/assets.cljs
@@ -108,7 +108,8 @@
       protocol-link?
       (if (and (util/electron?)
                (string/starts-with? path "file://"))
-        (string/replace-first path "file://" "assets://")
+        ;; strip file:// then normalize (protects Windows drive: C: -> C/logseq__colon/)
+        (normalize-asset-resource-url (string/replace-first path "file://" ""))
         path)
 
       ;; BUG: avoid double encoding from PDF assets
@@ -169,7 +170,8 @@
          js-url?
          (if (and (util/electron?)
                   (string/starts-with? (.-protocol js-url) "file:"))
-           (string/replace-first path "file://" "assets://")
+           ;; strip file:// then normalize (protects Windows drive: C: -> C/logseq__colon/)
+           (normalize-asset-resource-url (string/replace-first path "file://" ""))
            path)                                               ;; just return the original
 
          (and (alias-enabled?)

--- a/src/main/frontend/handler/assets.cljs
+++ b/src/main/frontend/handler/assets.cljs
@@ -106,7 +106,10 @@
                             (common-config/protocol-path? path))]
     (cond
       protocol-link?
-      path
+      (if (and (util/electron?)
+               (string/starts-with? path "file://"))
+        (string/replace-first path "file://" "assets://")
+        path)
 
       ;; BUG: avoid double encoding from PDF assets
       (or (path/absolute? path)
@@ -164,7 +167,10 @@
            js-url? (not (nil? js-url))]
        (cond
          js-url?
-         path                                               ;; just return the original
+         (if (and (util/electron?)
+                  (string/starts-with? (.-protocol js-url) "file:"))
+           (string/replace-first path "file://" "assets://")
+           path)                                               ;; just return the original
 
          (and (alias-enabled?)
               (check-alias-path? path))


### PR DESCRIPTION
## Summary

Fixes #12746 — local PDFs and inline images fail to open in the Electron app because Chromium's security policy blocks `file://` URLs in the renderer ("Not allowed to load local resource" / `Unexpected server response (0)`).

**Note:** this PR was generated with the assistance of AI agents. The key findings from our debugging trials are documented below so reviewers can verify the reasoning rather than just the diff.

## Root cause

Three code paths assembled PDF/image URLs by raw string concatenation, bypassing Logseq's registered `assets://` protocol on Electron:

1. `frontend.extensions.zotero/zotero-linked-file` and `zotero-full-path` — `(str "file://" (node-path/join ...))`
2. `frontend.extensions.pdf.assets/get-zotero-local-pdf-path` — `(str "assets://" (node-path/join ...))`
3. `frontend.handler.assets/normalize-asset-resource-url` and `<make-asset-url` — returned `file://` URLs unchanged

## Key findings from our trials

### Finding 1: naive `file://` → `assets://` replacement is NOT enough on Windows

The first fix attempt simply replaced the `file://` prefix with `assets://`. This broke on Windows: `assets://C:/Users/...` is parsed by the URL parser as **host=`c`**, port=`/Users/...` — the drive letter is consumed as the authority, the path is lost, and the request fails. The error shown in the app was:

```
Unexpected server response (0) while retrieving PDF "assets://c/Users/zhang/biblio/library/qn/Cao et al....pdf"
```

Note the lowercase `c` — that's the host component, not the path.

### Finding 2: the drive letter must be protected before URL assembly

Logseq already has `protect-windows-drive-in-assets-path` (`C:` → `C/logseq__colon/`), used by the normal asset path. The Electron main process reverses it in `decode-protected-assets-schema-path` (`src/electron/electron/utils.cljs`). The fix routes every `file://` URL and zotero path through `normalize-asset-resource-url`, which applies this protection:

```
file://C:/Users/...  →  assets:///C/logseq__colon/Users/...
```

The correct form has three slashes and the encoded drive — the host is empty, the path is preserved.

### Finding 3: verify the transformation, not just the prefix

Verified end-to-end with the real file paths from a user graph: the produced URL decodes through the Electron handler to the exact filesystem path (`C:/Users/zhang/biblio/library/qn/Cao et al....pdf`) and the file exists. All three code paths produce the canonical `assets:///C/logseq__colon/...` form that Electron already serves correctly for Windows images.

## Changes

- `src/main/frontend/handler/assets.cljs`
  - `normalize-asset-resource-url`: on Electron, strip `file://` then re-normalize (applies drive protection)
  - `<make-asset-url`: same conversion when the URL protocol is `file:`
- `src/main/frontend/extensions/pdf/assets.cljs`
  - `get-zotero-local-pdf-path`: build the local path, then normalize on Electron
  - `inflate-asset`: strip `file://` then normalize on Electron
- `src/main/frontend/extensions/zotero.cljs`
  - `zotero-linked-file` / `zotero-full-path`: build the local path, normalize on Electron instead of raw `file://` concat

Non-Electron (web browser) behavior is unchanged — `file://` is still emitted there since it's the only way a browser can reference local files.

## Test plan

- `bb dev:test -v frontend.handler.assets-test` — 14 tests, 23 assertions, 0 failures
- Manual: open a `{{zotero-linked-file ...}}` PDF and an asset-block PDF on Windows Electron — both load via `assets://`
