### PR TITLE
docs: fix missing article 'an' in CODEBASE_OVERVIEW.md

### DIFF
--- a/CODEBASE_OVERVIEW.md
+++ b/CODEBASE_OVERVIEW.md
@@ -32,7 +32,7 @@ For other tasks like bundling static resources and building the desktop app, whi
 
 ## Important Directories and Files
 
-This is overview of this repository's most important directories and files.
+This is an overview of this repository's most important directories and files.
 
 - Config files are located at the root directory. `package.json` contains the JavaScript dependencies while `deps.edn` contains their ClojureScript counterparts. `shadow-cljs.edn` and `gulpfile.js` contain all the build scripts.
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `CODEBASE_OVERVIEW.md` (line 35).

## Problem

Missing article 'an' before 'overview'.

The problematic text:

```markdown
This is overview of this repository's most important directories and files.
```

## Fix

Replaced with:

```markdown
This is an overview of this repository's most important directories and files.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text