### PR TITLE
docs: fix typo 'Cloudlare' to 'Cloudflare' in develop-logseq.md

### DIFF
--- a/docs/develop-logseq.md
+++ b/docs/develop-logseq.md
@@ -132,7 +132,7 @@ about db sync, see [its readme](/deps/db-sync/README.md).
 
 ### DB sync Cloudflare Worker adapter
 
-Build and run a Cloudlare worker locally
+Build and run a Cloudflare worker locally
 
 ```bash
 cd deps/db-sync


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `docs/develop-logseq.md` (line 135).

## Problem

Typo: 'Cloudlare' should be 'Cloudflare'.

The problematic text:

```markdown
Build and run a Cloudlare worker locally
```

## Fix

Replaced with:

```markdown
Build and run a Cloudflare worker locally
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text