### PR TITLE
docs: fix missing verb 'are' in dev-practices.md

### DIFF
--- a/docs/dev-practices.md
+++ b/docs/dev-practices.md
@@ -215,7 +215,7 @@ There are a couple different ways to run tests:
 * [Autorun tests](#autorun-tests) - Autorun tests from the CLI
 * [Repl tests](#repl-tests) - Run tests from REPL
 
-There a couple types of tests and they can overlap with each other:
+There are a couple types of tests and they can overlap with each other:
 
 * [Database tests](#database-tests) - Tests that involve a datascript DB.
 * [Performance tests](#performance-tests) - Tests that aim to measure and enforce a performance characteristic.


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `docs/dev-practices.md` (line 218).

## Problem

Missing verb 'are' — should be 'There are a couple types of tests'.

The problematic text:

```markdown
There a couple types of tests and they can overlap with each other:
```

## Fix

Replaced with:

```markdown
There are a couple types of tests and they can overlap with each other:
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text