### PR TITLE
fix: ignore recycled pages during rename validation to prevent duplicate errors

### DIFF
--- a/deps/outliner/src/logseq/outliner/validate.cljs
+++ b/deps/outliner/src/logseq/outliner/validate.cljs
@@ -82,12 +82,14 @@
 (defn- validate-unique-for-page
   [db new-title {:block/keys [tags] :as entity}]
   (when (seq tags)
-    (when-let [another-id (first
-                           (d/q (find-other-ids-with-title-and-tags entity)
-                                db
-                                (:db/id entity)
-                                new-title
-                                (map :db/id tags)))]
+    (when-let [another-id (some (fn [id]
+                                  (when-not (ldb/recycled? (d/entity db id))
+                                    id))
+                                (d/q (find-other-ids-with-title-and-tags entity)
+                                     db
+                                     (:db/id entity)
+                                     new-title
+                                     (map :db/id tags)))]
       (let [another (d/entity db another-id)
             this-tags (set (map :db/ident tags))
             another-tags (set (map :db/ident (:block/tags another)))


### PR DESCRIPTION
Description
Fixes https://github.com/logseq/db-test/issues/1075

What is the problem?
When a page is deleted, it is moved to the Recycle Bin but retains its original :block/name and :block/original-name. When attempting to rename a different page to that deleted name, validate-unique-for-page detects a collision with the recycled entity and throws a "Duplicate page" error.

How does this PR fix it?
Updated validate-unique-for-page in deps/outliner/src/logseq/outliner/validate.cljs to explicitly ignore recycled entities. Replaced first with some and a predicate (when-not (ldb/recycled? (d/entity db id)) id) so the validation check cleanly passes if the only colliding entity is already in the Recycle Bin.