### PR TITLE
feat(sync): add self-hosted deployment managers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.shadow-cljs
+**/.shadow-cljs
+node_modules
+**/node_modules
+dist
+**/dist
+static
+tmp
+**/tmp
+cli/dist

--- a/.github/workflows/db-sync-native-release.yml
+++ b/.github/workflows/db-sync-native-release.yml
@@ -1,0 +1,105 @@
+name: db-sync native release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to create or update'
+        required: true
+        default: 'db-sync-native'
+        type: string
+  workflow_run:
+    workflows:
+      - 'logseq/db-sync CI'
+    types:
+      - completed
+  push:
+    tags:
+      - 'db-sync-native-v*'
+
+concurrency:
+  group: db-sync-native-release-${{ github.ref_type == 'tag' && github.ref_name || 'rolling' }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  runtime:
+    name: Build native runtime packages
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'master')
+    uses: ./.github/workflows/db-sync-native-runtime.yml
+
+  release:
+    name: Publish runtime release
+    needs: runtime
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Reject a superseded rolling release
+        if: github.event_name == 'workflow_run'
+        env:
+          RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          current_master_sha="$(git ls-remote origin refs/heads/master | awk '{print $1}')"
+          if [[ "$current_master_sha" != "$RELEASE_SHA" ]]; then
+            printf 'Skipping superseded release %s; master is now %s.\n' \
+              "$RELEASE_SHA" "$current_master_sha" >&2
+            exit 1
+          fi
+
+      - name: Download runtime artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: logseq-sync-runtime-linux-*
+          path: artifacts
+          merge-multiple: true
+
+      - name: Prepare manager asset
+        env:
+          DEFAULT_RELEASE_REPOSITORY: ${{ github.repository }}
+        run: |
+          sed "s|readonly default_release_repository=\"logseq/logseq\"|readonly default_release_repository=\"${DEFAULT_RELEASE_REPOSITORY}\"|" \
+            deps/db-sync/deploy/logseq-sync-native \
+            > artifacts/logseq-sync-native
+          chmod 0755 artifacts/logseq-sync-native
+          cd artifacts
+          sha256sum logseq-sync-native > logseq-sync-native.sha256
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_TAG: ${{ inputs.release_tag || 'db-sync-native' }}
+          RELEASE_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            release_tag="${GITHUB_REF#refs/tags/}"
+          else
+            release_tag="$REQUESTED_TAG"
+          fi
+          [[ "$release_tag" =~ ^db-sync-native(-v[0-9A-Za-z._-]+)?$ ]] || {
+            printf 'Invalid native runtime release tag: %s\n' "$release_tag" >&2
+            exit 1
+          }
+          if ! gh release view "$release_tag" >/dev/null 2>&1; then
+            release_flags=()
+            case "$release_tag" in
+              *-test.*|*-rc.*) release_flags+=(--prerelease) ;;
+            esac
+            gh release create "$release_tag" \
+              --target "$RELEASE_SHA" \
+              --title "Logseq Sync native runtime" \
+              --notes "Prebuilt Linux x64 and arm64 runtimes for the native self-hosted Sync installer." \
+              "${release_flags[@]}"
+          fi
+          gh release upload "$release_tag" artifacts/* --clobber

--- a/.github/workflows/db-sync-native-release.yml
+++ b/.github/workflows/db-sync-native-release.yml
@@ -27,17 +27,21 @@ permissions:
 jobs:
   runtime:
     name: Build native runtime packages
-    if: >-
-      github.event_name != 'workflow_run' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'master')
+    if: github.event_name != 'workflow_run'
     uses: ./.github/workflows/db-sync-native-runtime.yml
 
   release:
     name: Publish runtime release
     needs: runtime
+    if: >-
+      always() &&
+      ((github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'master') ||
+      (github.event_name != 'workflow_run' && needs.runtime.result == 'success'))
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
 
     steps:
@@ -64,6 +68,9 @@ jobs:
           pattern: logseq-sync-runtime-linux-*
           path: artifacts
           merge-multiple: true
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id || github.run_id }}
 
       - name: Prepare manager asset
         env:

--- a/.github/workflows/db-sync-native-runtime.yml
+++ b/.github/workflows/db-sync-native-runtime.yml
@@ -1,0 +1,143 @@
+name: db-sync native runtime
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CLOJURE_VERSION: '1.12.4.1618'
+  JAVA_VERSION: '21'
+  NODE_VERSION: '24'
+  PNPM_VERSION: '10.33.0'
+
+jobs:
+  build:
+    name: Build Linux ${{ matrix.arch }} runtime
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        working-directory: deps/db-sync
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: deps/db-sync/pnpm-lock.yaml
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Set up Clojure
+        uses: DeLaGuardo/setup-clojure@13.5
+        with:
+          cli: ${{ env.CLOJURE_VERSION }}
+
+      - name: Install production dependencies
+        run: |
+          pnpm install --frozen-lockfile --prod --ignore-workspace
+          pnpm rebuild better-sqlite3 --ignore-workspace
+
+      - name: Build Node adapter
+        run: pnpm build:node-adapter
+
+      - name: Check Linux runtime compatibility baseline
+        run: |
+          sqlite_addon="$(find node_modules -path '*/better-sqlite3/build/Release/better_sqlite3.node' -print -quit)"
+          test -n "$sqlite_addon"
+          for binary in "$(command -v node)" "$sqlite_addon"; do
+            highest_glibc="$(
+              readelf --version-info "$binary" \
+                | sed -n 's/.*Name: \(GLIBC_[0-9.]*\).*/\1/p' \
+                | sort -Vu \
+                | tail -n 1
+            )"
+            test -n "$highest_glibc"
+            compatible_highest="$(printf '%s\n%s\n' \
+              'GLIBC_2.29' "$highest_glibc" | sort -V | tail -n 1)"
+            if [[ "$compatible_highest" != 'GLIBC_2.29' ]]; then
+              printf '%s requires %s; the runtime baseline is GLIBC_2.29.\n' \
+                "$binary" "$highest_glibc" >&2
+              exit 1
+            fi
+          done
+
+      - name: Package runtime
+        env:
+          DEFAULT_RELEASE_REPOSITORY: ${{ github.repository }}
+          RUNTIME_ARCH: ${{ matrix.arch }}
+          RUNTIME_VERSION: ${{ github.event.workflow_run.head_sha || github.sha }}
+        run: |
+          chmod +x deploy/package-native-runtime.sh deploy/logseq-sync-native
+          deploy/package-native-runtime.sh \
+            "$RUNTIME_VERSION" "$RUNTIME_ARCH" "$RUNNER_TEMP/artifacts"
+
+      - name: Smoke test packaged runtime
+        env:
+          RUNTIME_ARCH: ${{ matrix.arch }}
+        run: |
+          runtime_test_dir="$RUNNER_TEMP/runtime-test"
+          mkdir -p "$runtime_test_dir"
+          tar -xzf \
+            "$RUNNER_TEMP/artifacts/logseq-sync-runtime-linux-${RUNTIME_ARCH}.tar.gz" \
+            -C "$runtime_test_dir"
+          runtime="$runtime_test_dir/logseq-sync-runtime"
+          test "$(cat "$runtime/ARCHITECTURE")" = "$RUNTIME_ARCH"
+          "$runtime/node/bin/node" --version
+          DB_SYNC_HOST=127.0.0.1 \
+          DB_SYNC_PORT=18080 \
+          DB_SYNC_BASE_URL=http://127.0.0.1:18080 \
+          DB_SYNC_DATA_DIR="$RUNNER_TEMP/runtime-data" \
+          DB_SYNC_STORAGE_DRIVER=sqlite \
+          DB_SYNC_ASSETS_DRIVER=filesystem \
+            "$runtime/node/bin/node" "$runtime/app/node-adapter.js" \
+              >"$RUNNER_TEMP/runtime.log" 2>&1 &
+          runtime_pid=$!
+          trap 'kill "$runtime_pid" 2>/dev/null || true' EXIT
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent http://127.0.0.1:18080/health \
+                | grep -q '"ok":true'; then
+              exit 0
+            fi
+            if ! kill -0 "$runtime_pid" 2>/dev/null; then
+              cat "$RUNNER_TEMP/runtime.log"
+              exit 1
+            fi
+            sleep 1
+          done
+          cat "$RUNNER_TEMP/runtime.log"
+          exit 1
+
+      - name: Upload runtime artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: logseq-sync-runtime-linux-${{ matrix.arch }}
+          path: |
+            ${{ runner.temp }}/artifacts/*.tar.gz
+            ${{ runner.temp }}/artifacts/*.sha256
+          if-no-files-found: error

--- a/.github/workflows/deps-db-sync.yml
+++ b/.github/workflows/deps-db-sync.yml
@@ -1,12 +1,19 @@
 name: logseq/db-sync CI
 
 on:
+  workflow_dispatch:
   # Path filters ensure jobs only kick off if a change is made to db-sync or
   # its local dependencies
   push:
     branches: [master]
     paths:
       - 'deps/db-sync/**'
+      - 'deps/graph-parser/**'
+      - 'deps/outliner/**'
+      - 'resources/**'
+      - '.dockerignore'
+      - '.github/workflows/db-sync-native-runtime.yml'
+      - '.github/workflows/db-sync-native-release.yml'
       - '.github/workflows/deps-db-sync.yml'
       - '!deps/db-sync/**.md'
       # Deps that logseq/db-sync depends on should trigger this workflow
@@ -16,6 +23,12 @@ on:
     branches: [master]
     paths:
       - 'deps/db-sync/**'
+      - 'deps/graph-parser/**'
+      - 'deps/outliner/**'
+      - 'resources/**'
+      - '.dockerignore'
+      - '.github/workflows/db-sync-native-runtime.yml'
+      - '.github/workflows/db-sync-native-release.yml'
       - '.github/workflows/deps-db-sync.yml'
       - '!deps/db-sync/**.md'
       # Deps that logseq/db-sync depends on should trigger this workflow
@@ -34,6 +47,10 @@ env:
   BABASHKA_VERSION: '1.12.215'
 
 jobs:
+  native-runtime:
+    name: Build native runtime packages
+    uses: ./.github/workflows/db-sync-native-runtime.yml
+
   test:
     runs-on: ubuntu-latest
 
@@ -99,3 +116,40 @@ jobs:
 
       - name: Lint for vars that are too large
         run: bb lint:large-vars
+
+  deployment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate shell syntax
+        run: |
+          bash -n deploy/logseq-sync
+          bash -n deploy/logseq-sync-native
+          bash -n deploy/package-native-runtime.sh
+          bash -n deploy/test.sh
+          bash -n deploy/native-test.sh
+
+      - name: Run deployment manager tests
+        run: |
+          bash deploy/test.sh
+          bash deploy/native-test.sh
+
+      - name: Run deployment manager HTTP smoke test
+        run: |
+          install_dir="$RUNNER_TEMP/logseq-sync-install"
+          data_dir="$RUNNER_TEMP/logseq-sync-data"
+          printf '%s\n' \
+            "$install_dir" \
+            "$data_dir" \
+            http \
+            http://127.0.0.1:18080 \
+            I_ACCEPT_HTTP \
+            logseq-client \
+            y \
+            | bash deploy/logseq-sync setup
+          curl --fail --silent http://127.0.0.1:18080/health
+          docker compose --env-file "$install_dir/.env" -f "$install_dir/compose.yaml" -f "$install_dir/compose.http.yaml" config -q
+          docker compose --profile https --env-file "$install_dir/.env" -f "$install_dir/compose.yaml" config -q

--- a/deps/db-sync/README.md
+++ b/deps/db-sync/README.md
@@ -103,6 +103,11 @@ It requires typing `DELETE` as confirmation.
 
 ### Node.js Adapter (self-hosted)
 
+For the guided native systemd setup, including automatic HTTPS, persistent
+storage, and day-two management commands, follow the
+[deployment manager quickstart](deploy/README.md). The commands below are the
+manual developer workflow.
+
 Build the adapter:
 
 ```bash
@@ -114,6 +119,7 @@ Run the adapter with Cognito auth:
 
 ```bash
 DB_SYNC_PORT=8787 \
+DB_SYNC_HOST=127.0.0.1 \
 COGNITO_ISSUER=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8 \
 COGNITO_CLIENT_ID=69cs1lgme7p8kbgld8n5kseii6 \
 COGNITO_JWKS_URL=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8/.well-known/jwks.json \
@@ -133,6 +139,7 @@ pnpm test:node-adapter
 
 | Variable | Purpose |
 | --- | --- |
+| DB_SYNC_HOST | HTTP server bind address (uses the Node.js all-interface default when omitted) |
 | DB_SYNC_PORT | HTTP server port |
 | DB_SYNC_BASE_URL | External base URL for asset links |
 | DB_SYNC_ADMIN_TOKEN | Admin-only token for operator graph deletion endpoints |

--- a/deps/db-sync/deploy/Caddyfile.template
+++ b/deps/db-sync/deploy/Caddyfile.template
@@ -1,0 +1,8 @@
+{PUBLIC_URL} {
+	reverse_proxy sync:8080
+	tls {
+		issuer acme {
+			disable_tlsalpn_challenge
+		}
+	}
+}

--- a/deps/db-sync/deploy/Dockerfile
+++ b/deps/db-sync/deploy/Dockerfile
@@ -22,11 +22,23 @@ RUN pnpm install --frozen-lockfile --prod \
 
 WORKDIR /workspace
 
+COPY deps/common/deps.edn ./deps/common/deps.edn
+COPY deps/db/deps.edn ./deps/db/deps.edn
+COPY deps/graph-parser/deps.edn ./deps/graph-parser/deps.edn
+COPY deps/outliner/deps.edn ./deps/outliner/deps.edn
+COPY deps/db-sync/deps.edn deps/db-sync/shadow-cljs.edn ./deps/db-sync/
+
+WORKDIR /workspace/deps/db-sync
+
+# Cache Maven and Git dependencies independently from application source.
+RUN clojure -P -M:cljs
+
+WORKDIR /workspace
+
 COPY deps/common ./deps/common
 COPY deps/db ./deps/db
 COPY deps/graph-parser ./deps/graph-parser
 COPY deps/outliner ./deps/outliner
-COPY deps/db-sync/deps.edn deps/db-sync/shadow-cljs.edn ./deps/db-sync/
 COPY deps/db-sync/src ./deps/db-sync/src
 COPY resources ./resources
 

--- a/deps/db-sync/deploy/Dockerfile
+++ b/deps/db-sync/deploy/Dockerfile
@@ -1,0 +1,56 @@
+FROM node:24-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03 AS node-runtime
+
+FROM clojure:temurin-21-tools-deps-1.12.4.1618-bookworm-slim@sha256:e41b7b42ba9edfc0cbdff4e403606f02500287f09a03efce505efd35713d4336 AS build
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates build-essential git python3 \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=node-runtime /usr/local/ /usr/local/
+
+WORKDIR /workspace
+
+RUN npm install --global pnpm@10.33.0
+
+# Keep dependency installation cached when only application source changes.
+WORKDIR /workspace/deps/db-sync
+
+COPY deps/db-sync/package.json deps/db-sync/pnpm-lock.yaml ./
+
+RUN pnpm install --frozen-lockfile --prod \
+ && pnpm rebuild better-sqlite3
+
+WORKDIR /workspace
+
+COPY deps/common ./deps/common
+COPY deps/db ./deps/db
+COPY deps/graph-parser ./deps/graph-parser
+COPY deps/outliner ./deps/outliner
+COPY deps/db-sync/deps.edn deps/db-sync/shadow-cljs.edn ./deps/db-sync/
+COPY deps/db-sync/src ./deps/db-sync/src
+COPY resources ./resources
+
+WORKDIR /workspace/deps/db-sync
+
+RUN pnpm build:node-adapter
+
+FROM node:24-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03
+
+ENV NODE_ENV=production \
+    DB_SYNC_HOST=0.0.0.0 \
+    DB_SYNC_PORT=8080 \
+    DB_SYNC_DATA_DIR=/var/lib/logseq-sync
+
+WORKDIR /app
+
+COPY --from=build /workspace/deps/db-sync/node_modules ./node_modules
+COPY --from=build /workspace/deps/db-sync/worker/dist/node-adapter.js ./node-adapter.js
+
+RUN mkdir -p /var/lib/logseq-sync \
+ && chown node:node /var/lib/logseq-sync
+
+USER node
+
+EXPOSE 8080
+
+CMD ["node", "node-adapter.js"]

--- a/deps/db-sync/deploy/README.md
+++ b/deps/db-sync/deploy/README.md
@@ -1,0 +1,215 @@
+# Self-host Logseq Sync on Linux
+
+The recommended lightweight deployment runs a prebuilt Sync Node runtime and
+Caddy as two native systemd services. It does not require Docker or a local
+build environment. Caddy serves `HTTPS/WSS` on public port `443` by default,
+obtains and renews the certificate, and forwards traffic to the adapter on
+`127.0.0.1:10011`.
+
+## Before you start
+
+Use a systemd-based Linux server on `x86_64` or `arm64`. The server does not
+need Node.js, Java, Clojure, pnpm, Python, gcc, or a Linux package manager. It
+only needs standard base utilities (`curl`, `tar`, `sha256sum`, and
+`sha512sum`) plus sudo.
+The prebuilt runtime requires GLIBC 2.29 or newer, which covers current Debian,
+Ubuntu, OpenCloudOS 9, TencentOS, and RHEL 9-compatible distributions. Setup
+loads the bundled SQLite module before switching services, so an older or
+otherwise incompatible host fails before its running release is replaced.
+
+You also need:
+
+- a domain whose DNS `A`/`AAAA` record already points to the server;
+- inbound TCP port `80` for certificate issuance and renewal;
+- inbound TCP port `443` by default, or the custom HTTPS port selected during setup;
+- `sudo` access.
+
+Do not expose the private adapter port printed in the deployment plan. The
+installer binds the adapter to the loopback interface only.
+
+## Install
+
+Download the small management command from the native runtime release and run
+the guided setup:
+
+```bash
+curl -fL \
+  https://github.com/logseq/logseq/releases/download/db-sync-native/logseq-sync-native \
+  -o /tmp/logseq-sync-native
+curl -fL \
+  https://github.com/logseq/logseq/releases/download/db-sync-native/logseq-sync-native.sha256 \
+  -o /tmp/logseq-sync-native.sha256
+cd /tmp
+sha256sum --check logseq-sync-native.sha256
+chmod +x logseq-sync-native
+sudo ./logseq-sync-native setup
+```
+
+Setup automatically selects the Linux `x64` or `arm64` runtime, verifies its
+SHA-256 checksum, installs the runtime, configuration, data, and Caddy under
+one `/opt/logseq-sync` directory, and creates the two systemd services. The
+Caddy version is pinned and its release archive is verified with SHA-512.
+Compilation happens only in GitHub Actions, not on the server.
+
+The setup wizard asks for the domain, public HTTPS port, and private Sync port.
+Press Enter to accept the port defaults, or enter other available ports. It
+prints the complete deployment plan before downloading or changing services.
+
+```text
+Logseq Sync setup
+This wizard will configure a prebuilt Sync runtime, Caddy, automatic HTTPS, and systemd.
+You only need a domain name, public HTTPS port, and private Sync port.
+
+Step 1/3 - Sync domain name: sync.example.com
+Step 2/3 - Public HTTPS port [443]:
+Step 3/3 - Private Sync port [10011]:
+```
+
+The wizard explains each value before asking:
+
+- **Domain** — enter a hostname only, without `https://` or a path. Its public
+  `A`/`AAAA` record must have propagated and point to this server's public
+  address. Setup prints the IP addresses returned by DNS.
+- **Public HTTPS port** — Logseq clients use this port for HTTPS and secure
+  WebSockets. Allow it through the cloud security group and server firewall.
+- **Private Sync port** — Sync Node listens on `127.0.0.1` at this port and
+  Caddy forwards requests to it. Never expose it publicly.
+- **TCP 80** — Caddy uses it only to obtain and renew the HTTPS certificate.
+
+Cloud NAT and multi-address hosts make it unreliable to infer the intended
+public server address from local interfaces alone. Confirm that the displayed
+DNS addresses belong to this server; setup then verifies the final public
+`/health` endpoint before reporting success.
+
+For unattended or repeatable deployment, provide named options explicitly:
+
+```bash
+sudo ./logseq-sync-native setup \
+  --domain sync.example.com \
+  --public-port 12000 \
+  --internal-port 12001 \
+  --yes
+```
+
+No Cognito values are requested in the normal flow. The installer uses the
+verified JWT settings already used by an unmodified Logseq client.
+
+After setup succeeds, enter the printed value in **Logseq → Settings → Advanced
+→ Sync Server URL**:
+
+```text
+https://sync.example.com
+```
+
+The URL must include `https://`. Include the selected port only when it is not
+the default HTTPS port `443`.
+
+## Cloud firewall
+
+Allow these inbound rules in the cloud provider's security group and in the
+server firewall:
+
+| Port | Source | Purpose |
+| --- | --- | --- |
+| TCP 80 | Internet | Automatic HTTPS certificate validation and renewal |
+| Selected HTTPS port (default TCP 443) | Internet | Logseq HTTPS and secure WebSocket traffic |
+
+The adapter's internal port is private and must not be opened. If another
+process already owns port `80` or the selected HTTPS port, stop it or integrate
+the generated Caddy site into the existing reverse proxy before running setup.
+
+## Operate and update
+
+```bash
+sudo logseq-sync-native status
+sudo logseq-sync-native logs --follow sync
+sudo logseq-sync-native logs --follow proxy
+sudo logseq-sync-native update
+```
+
+`update` checks the small checksum file first and downloads the runtime only
+when the release changed. Configuration and graph data are preserved. The new
+runtime is verified before the `current` link is switched. If restart, health,
+or manager installation fails, the previous runtime is restarted and checked
+before rollback is reported as successful. The active and previous runtimes
+are retained for rollback; older runtime directories are pruned after a
+successful update. The runtime also carries the corresponding management
+command, so updates do not require another repository checkout.
+
+For testing a fork or pinning a versioned runtime release, set the source on the
+first setup:
+
+```bash
+sudo LOGSEQ_SYNC_RELEASE_REPOSITORY=owner/logseq \
+  LOGSEQ_SYNC_RELEASE_TAG=db-sync-native-v1 \
+  ./logseq-sync-native setup
+```
+
+The selected repository and tag are persisted for later updates.
+
+To put the complete deployment somewhere other than `/opt/logseq-sync`, set
+one home directory on the first setup. The installed management command
+remembers its home through its symlink, so later commands need no extra option:
+
+```bash
+sudo LOGSEQ_SYNC_HOME=/srv/logseq-sync ./logseq-sync-native setup
+sudo logseq-sync-native status
+```
+
+Use an absolute path containing only letters, digits, `/`, `.`, `_`, or `-` so
+it can be represented safely in the generated systemd units.
+
+## What gets installed
+
+| Path | Contents |
+| --- | --- |
+| `/opt/logseq-sync/bin` | Caddy and the canonical management command |
+| `/opt/logseq-sync/releases` | active and previous self-contained Sync runtimes |
+| `/opt/logseq-sync/current` | active runtime symlink |
+| `/opt/logseq-sync/config` | generated environment and Caddy configuration |
+| `/opt/logseq-sync/data` | graph SQLite files and assets |
+| `/opt/logseq-sync/caddy-data` | certificates and Caddy state |
+| `/etc/systemd/system` | Sync and Caddy service units |
+| `/usr/local/bin/logseq-sync-native` | symlink to the management command |
+
+The service is experimental. Back up `/opt/logseq-sync/data` before relying on
+it for important graphs. Back up the complete `/opt/logseq-sync` directory when
+you also want to preserve configuration and existing certificates.
+
+## Building and publishing runtimes
+
+The `db-sync native runtime` GitHub Actions workflow builds on native Linux x64
+and arm64 runners with Java 21 and Node.js 24. Each archive contains:
+
+```text
+logseq-sync-runtime/
+  node/bin/node
+  app/node-adapter.js
+  app/node_modules/
+  bin/logseq-sync-native
+  VERSION
+  ARCHITECTURE
+```
+
+Pull requests and the existing db-sync CI build and smoke-test both
+architectures. A merge to `master` that changes the runtime inputs updates the
+rolling `db-sync-native` installation channel automatically. The workflow can
+also be run manually, or a `db-sync-native-v*` tag can publish a versioned
+release. It uploads the runtime archives, checksums, manager, and manager
+checksum as GitHub Release assets. Runtime build jobs use read-only repository
+permissions; only the release job receives permission to write release assets.
+
+## Docker alternative
+
+The Docker Compose manager remains available when container isolation is
+preferred. Run it on a Linux host from the deployment directory in a Logseq
+checkout:
+
+```bash
+git clone https://github.com/logseq/logseq.git
+cd logseq/deps/db-sync/deploy
+./logseq-sync setup
+```
+
+It exposes the same public `https://domain` endpoint on port `443`, but requires Docker
+Engine and Docker Compose.

--- a/deps/db-sync/deploy/compose.http.yaml
+++ b/deps/db-sync/deploy/compose.http.yaml
@@ -1,0 +1,4 @@
+services:
+  sync:
+    ports:
+      - "${DB_SYNC_BIND_ADDRESS:-127.0.0.1}:${DB_SYNC_PUBLIC_PORT:-8080}:8080"

--- a/deps/db-sync/deploy/compose.yaml
+++ b/deps/db-sync/deploy/compose.yaml
@@ -1,0 +1,51 @@
+services:
+  sync:
+    build:
+      context: ${LOGSEQ_SYNC_SOURCE_DIR:?Set by logseq-sync}
+      dockerfile: deps/db-sync/deploy/Dockerfile
+    environment:
+      DB_SYNC_HOST: "0.0.0.0"
+      DB_SYNC_PORT: "8080"
+      DB_SYNC_BASE_URL: ${DB_SYNC_BASE_URL:?Set by logseq-sync}
+      DB_SYNC_DATA_DIR: /var/lib/logseq-sync
+      DB_SYNC_STORAGE_DRIVER: sqlite
+      DB_SYNC_ASSETS_DRIVER: filesystem
+      DB_SYNC_LOG_LEVEL: ${DB_SYNC_LOG_LEVEL:-info}
+      COGNITO_ISSUER: ${COGNITO_ISSUER:?Set by logseq-sync}
+      COGNITO_CLIENT_ID: ${COGNITO_CLIENT_ID:?Set by logseq-sync}
+      COGNITO_JWKS_URL: ${COGNITO_JWKS_URL:?Set by logseq-sync}
+    user: "${LOGSEQ_SYNC_UID:?Set by logseq-sync}:${LOGSEQ_SYNC_GID:?Set by logseq-sync}"
+    volumes:
+      - ${LOGSEQ_SYNC_DATA_DIR:?Set by logseq-sync}:/var/lib/logseq-sync
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8080/health').then(async (response) => { const body = await response.json(); if (!response.ok || body.ok !== true) process.exit(1) }).catch(() => process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    restart: unless-stopped
+
+  caddy:
+    image: caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
+    profiles: ["https"]
+    depends_on:
+      sync:
+        condition: service_healthy
+    ports:
+      - "80:80"
+      - "${DB_SYNC_PUBLIC_PORT:-443}:${DB_SYNC_PUBLIC_PORT:-443}"
+    volumes:
+      - ${LOGSEQ_SYNC_INSTALL_DIR:?Set by logseq-sync}/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:2019/config/"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    restart: unless-stopped
+
+volumes:
+  caddy-data:
+  caddy-config:

--- a/deps/db-sync/deploy/logseq-sync
+++ b/deps/db-sync/deploy/logseq-sync
@@ -1,0 +1,485 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly script_dir
+source_dir="$(cd -- "$script_dir/../../.." && pwd)"
+readonly source_dir
+readonly docker_install_url="https://docs.docker.com/engine/install/"
+readonly default_install_dir="${HOME}/.local/share/logseq-sync"
+readonly default_data_dir="${HOME}/.local/share/logseq-sync-data"
+readonly default_public_port="443"
+readonly default_cognito_issuer="https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8"
+readonly default_cognito_client_id="69cs1lgme7p8kbgld8n5kseii6"
+readonly default_cognito_jwks_url="${default_cognito_issuer}/.well-known/jwks.json"
+
+die() {
+  printf 'Error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_docker() {
+  if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
+    printf 'Docker Engine with Docker Compose is required. Install it first:\n%s\n' "$docker_install_url" >&2
+    exit 1
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    die "Docker Engine is not reachable. Start Docker and ensure the current user can access it without sudo."
+  fi
+}
+
+require_linux() {
+  [[ "$(uname -s)" == "Linux" ]] || die "logseq-sync must run on a Linux host."
+}
+
+read_value() {
+  local prompt="$1"
+  local default_value="${2:-}"
+  local value
+  if [[ -n "$default_value" ]]; then
+    read -r -p "$prompt [$default_value]: " value
+    printf '%s' "${value:-$default_value}"
+  else
+    read -r -p "$prompt: " value
+    printf '%s' "$value"
+  fi
+}
+
+confirm() {
+  local prompt="$1"
+  local value
+  read -r -p "$prompt [y/N]: " value
+  [[ "$value" == "y" || "$value" == "Y" ]]
+}
+
+compose() {
+  local install_dir="$1"
+  local endpoint_mode
+  local -a files=(-f "$install_dir/compose.yaml")
+  shift
+  endpoint_mode="$(sed -n 's/^LOGSEQ_SYNC_ENDPOINT_MODE=//p' "$install_dir/.env")"
+  case "$endpoint_mode" in
+    http) files+=(-f "$install_dir/compose.http.yaml") ;;
+    https) ;;
+    *) die "Deployment configuration has an invalid endpoint mode." ;;
+  esac
+  docker compose --env-file "$install_dir/.env" "${files[@]}" "$@"
+}
+
+compose_https() {
+  local install_dir="$1"
+  shift
+  docker compose --env-file "$install_dir/.env" \
+    -f "$install_dir/compose.yaml" --profile https "$@"
+}
+
+read_env_value() {
+  local path="$1"
+  local key="$2"
+  sed -n "s/^${key}=//p" "$path"
+}
+
+write_file() {
+  local path="$1"
+  shift
+  umask 077
+  printf '%s' "$*" > "$path"
+}
+
+valid_env_value() {
+  [[ -n "$1" && "$1" != *$'\n'* && "$1" != *$'\r'* \
+     && "$1" != *'$'* && "$1" != *'#'* && "$1" != *[[:space:]]* ]]
+}
+
+valid_port() {
+  [[ "$1" =~ ^[0-9]+$ ]] && (( 10#$1 >= 1 && 10#$1 <= 65535 ))
+}
+
+valid_hostname() {
+  local hostname="$1"
+  local label
+  local -a labels=()
+  [[ -n "$hostname" && ${#hostname} -le 253 \
+     && "$hostname" != .* && "$hostname" != *. ]] || return 1
+  IFS='.' read -r -a labels <<<"$hostname"
+  for label in "${labels[@]}"; do
+    [[ "$label" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$ ]] || return 1
+  done
+}
+
+valid_ipv4() {
+  local address="$1"
+  local a b c d extra
+  IFS='.' read -r a b c d extra <<<"$address"
+  [[ -z "${extra:-}" && "$a" =~ ^[0-9]+$ && "$b" =~ ^[0-9]+$ \
+     && "$c" =~ ^[0-9]+$ && "$d" =~ ^[0-9]+$ \
+     && ${#a} -le 3 && ${#b} -le 3 && ${#c} -le 3 && ${#d} -le 3 ]] \
+    && (( 10#$a <= 255 && 10#$b <= 255 && 10#$c <= 255 && 10#$d <= 255 ))
+}
+
+valid_host() {
+  if [[ "$1" =~ ^[0-9.]+$ ]]; then
+    valid_ipv4 "$1"
+  else
+    valid_hostname "$1"
+  fi
+}
+
+valid_domain() {
+  [[ ${#1} -le 253 \
+     && "$1" =~ ^([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}$ ]]
+}
+
+https_url() {
+  local domain="$1"
+  local port="$2"
+  if [[ "$port" == "443" ]]; then
+    printf 'https://%s' "$domain"
+  else
+    printf 'https://%s:%s' "$domain" "$port"
+  fi
+}
+
+valid_http_url() {
+  local url="$1"
+  local authority host port
+  [[ "$url" == http://* ]] || return 1
+  authority="${url#http://}"
+  [[ "$authority" != *[/?#@]* ]] || return 1
+  [[ "$authority" == *:* ]] || return 1
+  host="${authority%:*}"
+  port="${authority##*:}"
+  valid_host "$host" && valid_port "$port"
+}
+
+valid_https_url() {
+  local url="$1"
+  local remainder authority host port=""
+  [[ "$url" == https://* && "$url" != *[[:space:]?#@]* ]] || return 1
+  remainder="${url#https://}"
+  authority="${remainder%%/*}"
+  host="$authority"
+  if [[ "$authority" == *:* ]]; then
+    host="${authority%:*}"
+    port="${authority##*:}"
+    valid_port "$port" || return 1
+  fi
+  valid_host "$host"
+}
+
+confirm_existing() {
+  local path="$1"
+  if [[ -e "$path" ]]; then
+    if ! confirm "${path} exists. Create a timestamped backup before replacement?"; then
+      die "Existing file was not changed."
+    fi
+  fi
+}
+
+backup_existing() {
+  local path="$1"
+  local timestamp backup suffix=0
+  [[ -e "$path" ]] || return 0
+  timestamp="$(date +%Y%m%d%H%M%S)"
+  backup="${path}.backup-${timestamp}"
+  while [[ -e "$backup" ]]; do
+    suffix=$((suffix + 1))
+    backup="${path}.backup-${timestamp}-${suffix}"
+  done
+  cp -a -- "$path" "$backup"
+}
+
+service_is_healthy() {
+  local install_dir="$1"
+  local service="$2"
+  local status
+  status="$(compose "$install_dir" ps --format json "$service" 2>/dev/null || true)"
+  grep -Eq '"Health"[[:space:]]*:[[:space:]]*"healthy"' <<<"$status"
+}
+
+wait_for_service_health() {
+  local install_dir="$1"
+  local service="$2"
+  local attempts=30
+  while (( attempts > 0 )); do
+    if service_is_healthy "$install_dir" "$service"; then
+      printf '%s is healthy.\n' "$service"
+      return 0
+    fi
+    sleep 2
+    attempts=$((attempts - 1))
+  done
+  printf '%s did not become healthy. Inspect logs with:\n  %s/logseq-sync logs --follow %s\n' "$service" "$script_dir" "$install_dir" >&2
+  return 1
+}
+
+public_endpoint_is_healthy() {
+  local public_url="$1"
+  local body
+  body="$(curl --fail --silent --max-time 5 "$public_url/health" 2>/dev/null)" || return 1
+  [[ "$body" == '{"ok":true}' ]]
+}
+
+wait_for_public_endpoint() {
+  local public_url="$1"
+  local attempts=12
+  while (( attempts > 0 )); do
+    if public_endpoint_is_healthy "$public_url"; then
+      printf 'Public endpoint is healthy.\n'
+      return 0
+    fi
+    sleep 5
+    attempts=$((attempts - 1))
+  done
+  printf 'Public endpoint did not return {"ok":true}: %s/health\n' "$public_url" >&2
+  return 1
+}
+
+setup() {
+  require_linux
+  require_docker
+  local install_dir data_dir endpoint_mode public_url bind_address public_port domain
+  local issuer client_id jwks_url auth_mode log_level
+  local existing_env="" previous_data_dir="" previous_endpoint_mode="" previous_public_url=""
+  local previous_public_port="" previous_url_port=""
+  local previous_issuer="" previous_client_id="" previous_jwks_url="" previous_log_level=""
+  local data_default endpoint_default domain_default public_url_default auth_default exposure
+  local -a compose_args=()
+
+  install_dir="$(read_value 'Deployment directory' "$default_install_dir")"
+  if [[ -f "$install_dir/.env" ]]; then
+    existing_env="$install_dir/.env"
+    previous_data_dir="$(read_env_value "$existing_env" LOGSEQ_SYNC_DATA_DIR)"
+    previous_endpoint_mode="$(read_env_value "$existing_env" LOGSEQ_SYNC_ENDPOINT_MODE)"
+    previous_public_url="$(read_env_value "$existing_env" DB_SYNC_BASE_URL)"
+    previous_public_port="$(read_env_value "$existing_env" DB_SYNC_PUBLIC_PORT)"
+    previous_log_level="$(read_env_value "$existing_env" DB_SYNC_LOG_LEVEL)"
+    previous_issuer="$(read_env_value "$existing_env" COGNITO_ISSUER)"
+    previous_client_id="$(read_env_value "$existing_env" COGNITO_CLIENT_ID)"
+    previous_jwks_url="$(read_env_value "$existing_env" COGNITO_JWKS_URL)"
+    [[ "$previous_endpoint_mode" == "https" || "$previous_endpoint_mode" == "http" ]] \
+      || die "Existing deployment configuration has an invalid endpoint mode."
+    if ! valid_env_value "$previous_data_dir" \
+       || ! valid_env_value "$previous_public_url" \
+       || ! valid_env_value "$previous_log_level" \
+       || ! valid_env_value "$previous_issuer" \
+       || ! valid_env_value "$previous_client_id" \
+       || ! valid_env_value "$previous_jwks_url"; then
+      die "Existing deployment configuration is missing required values or contains invalid values."
+    fi
+  fi
+
+  data_default="${previous_data_dir:-$default_data_dir}"
+  endpoint_default="${previous_endpoint_mode:-https}"
+  data_dir="$(read_value 'Persistent data directory' "$data_default")"
+  if ! valid_env_value "$source_dir" \
+     || ! valid_env_value "$install_dir" \
+     || ! valid_env_value "$data_dir"; then
+    die "Paths must not be empty or contain whitespace, $, #, or newlines."
+  fi
+  endpoint_mode="$(read_value 'Endpoint mode (https/http)' "$endpoint_default")"
+  [[ "$endpoint_mode" == "https" || "$endpoint_mode" == "http" ]] || die "Endpoint mode must be https or http."
+  command -v curl >/dev/null 2>&1 || die "Setup requires curl to verify the public endpoint."
+
+  if [[ "$endpoint_mode" == "https" ]]; then
+    domain_default=""
+    if [[ "$previous_public_url" =~ ^https://([^:/]+)(:([0-9]+))?$ ]]; then
+      domain_default="${BASH_REMATCH[1]}"
+      previous_url_port="${BASH_REMATCH[3]:-443}"
+    fi
+    domain="$(read_value 'Public domain name' "$domain_default")"
+    valid_domain "$domain" || die "HTTPS requires a valid DNS domain name, not an IP address."
+    public_port="${previous_public_port:-${previous_url_port:-$default_public_port}}"
+    valid_port "$public_port" || die "The configured public HTTPS port is invalid."
+    public_url="$(https_url "$domain" "$public_port")"
+    bind_address="127.0.0.1"
+    exposure="ports 80/tcp and ${public_port}/tcp"
+  else
+    public_url_default=""
+    if [[ "$previous_public_url" == http://* ]]; then
+      public_url_default="$previous_public_url"
+    fi
+    public_url="$(read_value 'Public HTTP URL (for example http://203.0.113.10:8080)' "$public_url_default")"
+    valid_http_url "$public_url" || die "HTTP URL must include a valid hostname or IPv4 address and port."
+    printf 'Warning: HTTP exposes Logseq bearer tokens in transit.\n' >&2
+    [[ "$(read_value 'Type I_ACCEPT_HTTP to continue')" == "I_ACCEPT_HTTP" ]] || die "HTTP risk acknowledgement was not accepted."
+    bind_address="0.0.0.0"
+    public_port="${public_url##*:}"
+    exposure="${bind_address}:${public_port}"
+  fi
+
+  auth_default="logseq-client"
+  if [[ -n "$existing_env" ]] \
+     && [[ "$previous_issuer" != "$default_cognito_issuer" \
+           || "$previous_client_id" != "$default_cognito_client_id" \
+           || "$previous_jwks_url" != "$default_cognito_jwks_url" ]]; then
+    auth_default="custom-client"
+  fi
+  auth_mode="$(read_value 'Authentication (logseq-client/custom-client)' "$auth_default")"
+  case "$auth_mode" in
+    logseq-client)
+      issuer="$default_cognito_issuer"
+      client_id="$default_cognito_client_id"
+      jwks_url="$default_cognito_jwks_url"
+      ;;
+    custom-client)
+      printf 'Custom JWT settings require a Logseq client built to issue matching tokens.\n' >&2
+      issuer="$(read_value 'Cognito issuer URL' "$previous_issuer")"
+      client_id="$(read_value 'Cognito client ID' "$previous_client_id")"
+      jwks_url="$(read_value 'Cognito JWKS URL' "$previous_jwks_url")"
+      valid_https_url "$issuer" || die "Cognito issuer must be a valid HTTPS URL."
+      [[ "$client_id" =~ ^[A-Za-z0-9._-]+$ ]] || die "Cognito client ID contains unsupported characters."
+      valid_https_url "$jwks_url" || die "Cognito JWKS URL must be a valid HTTPS URL."
+      ;;
+    *) die "Authentication must be logseq-client or custom-client." ;;
+  esac
+  if ! valid_env_value "$issuer" \
+     || ! valid_env_value "$client_id" \
+     || ! valid_env_value "$jwks_url"; then
+    die "JWT settings must not be empty or contain whitespace, $, #, or newlines."
+  fi
+  log_level="${previous_log_level:-info}"
+  valid_env_value "$log_level" || die "The existing log level is invalid."
+
+  printf '\nDeployment plan:\n  URL: %s\n  Exposure: %s\n  Install: %s\n  Data: %s\n  Authentication: %s JWT over %s\n' "$public_url" "$exposure" "$install_dir" "$data_dir" "$auth_mode" "$endpoint_mode"
+  if [[ -n "$existing_env" && "$data_dir" != "$previous_data_dir" ]]; then
+    confirm 'The persistent data directory changed. Continue with the new directory?' \
+      || die "Cancelled before changing the persistent data directory."
+  fi
+  if [[ -n "$existing_env" ]] \
+     && [[ "$issuer" != "$previous_issuer" \
+           || "$client_id" != "$previous_client_id" \
+           || "$jwks_url" != "$previous_jwks_url" ]]; then
+    confirm 'Authentication settings changed. Existing graph identities may not match. Continue?' \
+      || die "Cancelled before changing authentication settings."
+  fi
+  confirm 'Write deployment configuration and start Sync?' || die "Cancelled before writing configuration."
+
+  confirm_existing "$install_dir/compose.yaml"
+  confirm_existing "$install_dir/compose.http.yaml"
+  confirm_existing "$install_dir/.env"
+  if [[ "$endpoint_mode" == "https" ]]; then
+    confirm_existing "$install_dir/Caddyfile"
+  fi
+
+  mkdir -p -- "$install_dir" "$data_dir"
+  backup_existing "$install_dir/compose.yaml"
+  backup_existing "$install_dir/compose.http.yaml"
+  backup_existing "$install_dir/.env"
+  if [[ "$endpoint_mode" == "https" ]]; then
+    backup_existing "$install_dir/Caddyfile"
+  fi
+
+  cp -- "$script_dir/compose.yaml" "$install_dir/compose.yaml"
+  cp -- "$script_dir/compose.http.yaml" "$install_dir/compose.http.yaml"
+  write_file "$install_dir/.env" "LOGSEQ_SYNC_SOURCE_DIR=${source_dir}
+LOGSEQ_SYNC_INSTALL_DIR=${install_dir}
+LOGSEQ_SYNC_DATA_DIR=${data_dir}
+LOGSEQ_SYNC_UID=$(id -u)
+LOGSEQ_SYNC_GID=$(id -g)
+LOGSEQ_SYNC_ENDPOINT_MODE=${endpoint_mode}
+DB_SYNC_BASE_URL=${public_url}
+DB_SYNC_BIND_ADDRESS=${bind_address}
+DB_SYNC_PUBLIC_PORT=${public_port}
+DB_SYNC_LOG_LEVEL=${log_level}
+COGNITO_ISSUER=${issuer}
+COGNITO_CLIENT_ID=${client_id}
+COGNITO_JWKS_URL=${jwks_url}
+"
+  if [[ "$endpoint_mode" == "https" ]]; then
+    sed "s|{PUBLIC_URL}|${public_url}|g" "$script_dir/Caddyfile.template" > "$install_dir/Caddyfile"
+  fi
+
+  if [[ "$endpoint_mode" == "https" ]]; then
+    compose_args=(--profile https up -d --build --force-recreate)
+  else
+    compose_args=(up -d --build)
+  fi
+  if ! compose "$install_dir" "${compose_args[@]}"; then
+    printf 'Sync startup failed. Inspect logs with:\n  %s/logseq-sync logs --follow %s\n' "$script_dir" "$install_dir" >&2
+    return 1
+  fi
+  wait_for_service_health "$install_dir" sync
+  if [[ "$endpoint_mode" == "https" ]]; then
+    wait_for_service_health "$install_dir" caddy
+  fi
+  wait_for_public_endpoint "$public_url"
+  if [[ "$previous_endpoint_mode" == "https" && "$endpoint_mode" == "http" ]]; then
+    compose_https "$install_dir" rm --stop --force caddy
+  fi
+  printf 'Logseq Sync is ready. In Logseq, set Sync Server URL to:\n  %s\n' "$public_url"
+  printf 'Status: %s/logseq-sync status %s\n' "$script_dir" "$install_dir"
+}
+
+status() {
+  local install_dir="${1:-$default_install_dir}"
+  [[ -f "$install_dir/.env" ]] || die "No deployment configuration at $install_dir."
+  require_docker
+  compose "$install_dir" ps
+  printf 'Sync Server URL: %s\n' "$(sed -n 's/^DB_SYNC_BASE_URL=//p' "$install_dir/.env")"
+  if service_is_healthy "$install_dir" sync; then
+    printf 'Health endpoint: ok\n'
+  else
+    printf 'Health endpoint: unavailable\n' >&2
+    return 1
+  fi
+  if [[ "$(sed -n 's/^LOGSEQ_SYNC_ENDPOINT_MODE=//p' "$install_dir/.env")" == "https" ]]; then
+    if ! service_is_healthy "$install_dir" caddy; then
+      printf 'HTTPS proxy health: unavailable\n' >&2
+      return 1
+    fi
+  fi
+  if ! public_endpoint_is_healthy "$(sed -n 's/^DB_SYNC_BASE_URL=//p' "$install_dir/.env")"; then
+    printf 'Public endpoint: unavailable\n' >&2
+    return 1
+  fi
+}
+
+logs() {
+  local install_dir="$default_install_dir"
+  local follow=""
+  local service=""
+  while (( $# > 0 )); do
+    case "$1" in
+      --follow) follow="--follow" ;;
+      sync|proxy) service="$1" ;;
+      *) install_dir="$1" ;;
+    esac
+    shift
+  done
+  [[ -f "$install_dir/.env" ]] || die "No deployment configuration at $install_dir."
+  require_docker
+  if [[ "$service" == "proxy" ]] \
+     && [[ "$(sed -n 's/^LOGSEQ_SYNC_ENDPOINT_MODE=//p' "$install_dir/.env")" != "https" ]]; then
+    die "Proxy logging is unavailable because this deployment uses HTTP mode."
+  fi
+  local -a args=(logs --tail 200)
+  if [[ -n "$follow" ]]; then
+    args+=(--follow)
+  fi
+  if [[ -n "$service" ]]; then
+    if [[ "$service" == "proxy" ]]; then
+      service="caddy"
+    fi
+    args+=("$service")
+  fi
+  compose "$install_dir" "${args[@]}"
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  logseq-sync setup
+  logseq-sync status [deployment-directory]
+  logseq-sync logs [--follow] [sync|proxy] [deployment-directory]
+  logseq-sync help
+EOF
+}
+
+case "${1:-help}" in
+  setup) setup ;;
+  status) shift; status "$@" ;;
+  logs) shift; logs "$@" ;;
+  help|-h|--help) usage ;;
+  *) usage; exit 1 ;;
+esac

--- a/deps/db-sync/deploy/logseq-sync
+++ b/deps/db-sync/deploy/logseq-sync
@@ -12,6 +12,25 @@ readonly default_public_port="443"
 readonly default_cognito_issuer="https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8"
 readonly default_cognito_client_id="69cs1lgme7p8kbgld8n5kseii6"
 readonly default_cognito_jwks_url="${default_cognito_issuer}/.well-known/jwks.json"
+temporary_paths=()
+
+register_temporary_path() {
+  temporary_paths+=("$1")
+}
+
+cleanup_temporary_paths() {
+  local path
+  for path in "${temporary_paths[@]-}"; do
+    case "$path" in
+      /tmp/logseq-sync-config.*)
+        [[ -d "$path" ]] && rm -rf -- "$path"
+        ;;
+    esac
+  done
+  return 0
+}
+
+trap cleanup_temporary_paths EXIT
 
 die() {
   printf 'Error: %s\n' "$*" >&2
@@ -189,6 +208,34 @@ backup_existing() {
   cp -a -- "$path" "$backup"
 }
 
+snapshot_configuration() {
+  local install_dir="$1"
+  local snapshot_dir="$2"
+  local name index=0
+  for name in compose.yaml compose.http.yaml .env Caddyfile; do
+    if [[ -e "$install_dir/$name" || -L "$install_dir/$name" ]]; then
+      cp -a -- "$install_dir/$name" "$snapshot_dir/$index"
+      : > "$snapshot_dir/$index.present"
+    fi
+    index=$((index + 1))
+  done
+}
+
+restore_configuration() {
+  local install_dir="$1"
+  local snapshot_dir="$2"
+  local name index=0
+  for name in compose.yaml compose.http.yaml .env Caddyfile; do
+    if [[ -e "$install_dir/$name" || -L "$install_dir/$name" ]]; then
+      rm -f -- "$install_dir/$name" || return 1
+    fi
+    if [[ -f "$snapshot_dir/$index.present" ]]; then
+      cp -a -- "$snapshot_dir/$index" "$install_dir/$name" || return 1
+    fi
+    index=$((index + 1))
+  done
+}
+
 service_is_healthy() {
   local install_dir="$1"
   local service="$2"
@@ -235,6 +282,45 @@ wait_for_public_endpoint() {
   return 1
 }
 
+start_replacement_deployment() {
+  local install_dir="$1"
+  local endpoint_mode="$2"
+  local public_url="$3"
+  local previous_endpoint_mode="$4"
+  local -a compose_args=()
+  if [[ "$endpoint_mode" == "https" ]]; then
+    compose_args=(--profile https up -d --build --force-recreate)
+  else
+    compose_args=(up -d --build)
+  fi
+  compose "$install_dir" "${compose_args[@]}" || return 1
+  wait_for_service_health "$install_dir" sync || return 1
+  if [[ "$endpoint_mode" == "https" ]]; then
+    wait_for_service_health "$install_dir" caddy || return 1
+  fi
+  wait_for_public_endpoint "$public_url" || return 1
+  if [[ "$previous_endpoint_mode" == "https" && "$endpoint_mode" == "http" ]]; then
+    compose_https "$install_dir" rm --stop --force caddy || return 1
+  fi
+}
+
+restart_previous_deployment() {
+  local install_dir="$1"
+  local endpoint_mode="$2"
+  local public_url="$3"
+  if [[ "$endpoint_mode" == "https" ]]; then
+    compose "$install_dir" --profile https up -d --force-recreate || return 1
+  else
+    compose_https "$install_dir" rm --stop --force caddy || return 1
+    compose "$install_dir" up -d --force-recreate || return 1
+  fi
+  wait_for_service_health "$install_dir" sync || return 1
+  if [[ "$endpoint_mode" == "https" ]]; then
+    wait_for_service_health "$install_dir" caddy || return 1
+  fi
+  wait_for_public_endpoint "$public_url"
+}
+
 setup() {
   require_linux
   require_docker
@@ -244,7 +330,7 @@ setup() {
   local previous_public_port="" previous_url_port=""
   local previous_issuer="" previous_client_id="" previous_jwks_url="" previous_log_level=""
   local data_default endpoint_default domain_default public_url_default auth_default exposure
-  local -a compose_args=()
+  local configuration_snapshot staging_dir activation_failed="false"
 
   install_dir="$(read_value 'Deployment directory' "$default_install_dir")"
   if [[ -f "$install_dir/.env" ]]; then
@@ -362,17 +448,16 @@ setup() {
     confirm_existing "$install_dir/Caddyfile"
   fi
 
-  mkdir -p -- "$install_dir" "$data_dir"
-  backup_existing "$install_dir/compose.yaml"
-  backup_existing "$install_dir/compose.http.yaml"
-  backup_existing "$install_dir/.env"
-  if [[ "$endpoint_mode" == "https" ]]; then
-    backup_existing "$install_dir/Caddyfile"
-  fi
+  configuration_snapshot="$(mktemp -d /tmp/logseq-sync-config.XXXXXX)"
+  register_temporary_path "$configuration_snapshot"
+  snapshot_configuration "$install_dir" "$configuration_snapshot"
+  staging_dir="$(mktemp -d /tmp/logseq-sync-config.XXXXXX)"
+  register_temporary_path "$staging_dir"
 
-  cp -- "$script_dir/compose.yaml" "$install_dir/compose.yaml"
-  cp -- "$script_dir/compose.http.yaml" "$install_dir/compose.http.yaml"
-  write_file "$install_dir/.env" "LOGSEQ_SYNC_SOURCE_DIR=${source_dir}
+  mkdir -p -- "$install_dir" "$data_dir"
+  if ! cp -- "$script_dir/compose.yaml" "$staging_dir/compose.yaml" \
+     || ! cp -- "$script_dir/compose.http.yaml" "$staging_dir/compose.http.yaml" \
+     || ! write_file "$staging_dir/.env" "LOGSEQ_SYNC_SOURCE_DIR=${source_dir}
 LOGSEQ_SYNC_INSTALL_DIR=${install_dir}
 LOGSEQ_SYNC_DATA_DIR=${data_dir}
 LOGSEQ_SYNC_UID=$(id -u)
@@ -385,27 +470,55 @@ DB_SYNC_LOG_LEVEL=${log_level}
 COGNITO_ISSUER=${issuer}
 COGNITO_CLIENT_ID=${client_id}
 COGNITO_JWKS_URL=${jwks_url}
-"
+"; then
+    die "Deployment configuration could not be staged; the existing configuration was not changed."
+  fi
   if [[ "$endpoint_mode" == "https" ]]; then
-    sed "s|{PUBLIC_URL}|${public_url}|g" "$script_dir/Caddyfile.template" > "$install_dir/Caddyfile"
+    sed "s|{PUBLIC_URL}|${public_url}|g" "$script_dir/Caddyfile.template" \
+      > "$staging_dir/Caddyfile" \
+      || die "Caddy configuration could not be staged; the existing configuration was not changed."
   fi
 
+  backup_existing "$install_dir/compose.yaml"
+  backup_existing "$install_dir/compose.http.yaml"
+  backup_existing "$install_dir/.env"
   if [[ "$endpoint_mode" == "https" ]]; then
-    compose_args=(--profile https up -d --build --force-recreate)
-  else
-    compose_args=(up -d --build)
+    backup_existing "$install_dir/Caddyfile"
   fi
-  if ! compose "$install_dir" "${compose_args[@]}"; then
+  if ! mv -f -- "$staging_dir/compose.yaml" "$install_dir/compose.yaml" \
+     || ! mv -f -- "$staging_dir/compose.http.yaml" "$install_dir/compose.http.yaml" \
+     || ! mv -f -- "$staging_dir/.env" "$install_dir/.env"; then
+    activation_failed="true"
+  elif [[ "$endpoint_mode" == "https" ]] \
+       && ! mv -f -- "$staging_dir/Caddyfile" "$install_dir/Caddyfile"; then
+    activation_failed="true"
+  fi
+  if [[ "$activation_failed" == "true" ]]; then
+    if [[ -n "$existing_env" ]]; then
+      if restore_configuration "$install_dir" "$configuration_snapshot" \
+         && restart_previous_deployment \
+           "$install_dir" "$previous_endpoint_mode" "$previous_public_url"; then
+        die "Deployment configuration could not be activated; the previous working deployment was restored."
+      fi
+      die "Deployment configuration could not be activated, and the previous deployment could not be restarted. Use the timestamped configuration backups to recover it."
+    fi
+    restore_configuration "$install_dir" "$configuration_snapshot" \
+      || die "Deployment configuration activation failed, and partial files could not be removed."
+    die "Deployment configuration could not be activated. No services were started."
+  fi
+
+  if ! start_replacement_deployment \
+      "$install_dir" "$endpoint_mode" "$public_url" "$previous_endpoint_mode"; then
+    if [[ -n "$existing_env" ]]; then
+      if restore_configuration "$install_dir" "$configuration_snapshot" \
+         && restart_previous_deployment \
+           "$install_dir" "$previous_endpoint_mode" "$previous_public_url"; then
+        die "Replacement deployment failed; the previous working deployment was restored."
+      fi
+      die "Replacement deployment failed, and the previous deployment could not be restarted. Use the timestamped configuration backups to recover it."
+    fi
     printf 'Sync startup failed. Inspect logs with:\n  %s/logseq-sync logs --follow %s\n' "$script_dir" "$install_dir" >&2
     return 1
-  fi
-  wait_for_service_health "$install_dir" sync
-  if [[ "$endpoint_mode" == "https" ]]; then
-    wait_for_service_health "$install_dir" caddy
-  fi
-  wait_for_public_endpoint "$public_url"
-  if [[ "$previous_endpoint_mode" == "https" && "$endpoint_mode" == "http" ]]; then
-    compose_https "$install_dir" rm --stop --force caddy
   fi
   printf 'Logseq Sync is ready. In Logseq, set Sync Server URL to:\n  %s\n' "$public_url"
   printf 'Status: %s/logseq-sync status %s\n' "$script_dir" "$install_dir"

--- a/deps/db-sync/deploy/logseq-sync-native
+++ b/deps/db-sync/deploy/logseq-sync-native
@@ -1,0 +1,1145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly script_dir
+checkout_root="$(cd -- "$script_dir/../../.." 2>/dev/null && pwd || true)"
+readonly checkout_root
+resolved_script_path="$(readlink -f -- "${BASH_SOURCE[0]}" 2>/dev/null || true)"
+inferred_home=""
+if [[ "$resolved_script_path" == */bin/logseq-sync-native ]]; then
+  inferred_home="${resolved_script_path%/bin/logseq-sync-native}"
+fi
+readonly sync_home="${LOGSEQ_SYNC_HOME:-${inferred_home:-/opt/logseq-sync}}"
+readonly install_root="$sync_home"
+readonly bin_dir="$sync_home/bin"
+readonly config_dir="$sync_home/config"
+readonly data_dir="$sync_home/data"
+readonly systemd_dir="${LOGSEQ_SYNC_SYSTEMD_DIR:-/etc/systemd/system}"
+readonly caddy_data_dir="$sync_home/caddy-data"
+readonly releases_dir="$install_root/releases"
+readonly manager_path="${LOGSEQ_SYNC_MANAGER_PATH:-/usr/local/bin/logseq-sync-native}"
+readonly canonical_manager_path="$bin_dir/logseq-sync-native"
+readonly caddy_path="$bin_dir/caddy"
+readonly caddy_metadata_path="$bin_dir/caddy.metadata"
+readonly sync_service="logseq-sync.service"
+readonly proxy_service="logseq-sync-caddy.service"
+readonly default_public_port="443"
+readonly default_internal_port="10011"
+readonly default_release_repository="logseq/logseq"
+readonly default_release_tag="db-sync-native"
+readonly default_caddy_version="2.11.4"
+readonly default_cognito_issuer="https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8"
+readonly default_cognito_client_id="69cs1lgme7p8kbgld8n5kseii6"
+readonly default_cognito_jwks_url="${default_cognito_issuer}/.well-known/jwks.json"
+
+configured_public_port="$(sed -n 's/^LOGSEQ_SYNC_PUBLIC_PORT=//p' "$config_dir/sync.env" 2>/dev/null || true)"
+configured_internal_port="$(sed -n 's/^DB_SYNC_PORT=//p' "$config_dir/sync.env" 2>/dev/null || true)"
+configured_release_repository="$(sed -n 's/^LOGSEQ_SYNC_RELEASE_REPOSITORY=//p' "$config_dir/sync.env" 2>/dev/null || true)"
+configured_release_tag="$(sed -n 's/^LOGSEQ_SYNC_RELEASE_TAG=//p' "$config_dir/sync.env" 2>/dev/null || true)"
+public_port="${configured_public_port:-$default_public_port}"
+internal_port="${configured_internal_port:-$default_internal_port}"
+release_repository="${LOGSEQ_SYNC_RELEASE_REPOSITORY:-$configured_release_repository}"
+release_tag="${LOGSEQ_SYNC_RELEASE_TAG:-${configured_release_tag:-$default_release_tag}}"
+installed_release_dir=""
+runtime_changed="true"
+assume_yes="${LOGSEQ_SYNC_ASSUME_YES:-false}"
+temporary_paths=()
+
+register_temporary_path() {
+  temporary_paths+=("$1")
+}
+
+cleanup_temporary_paths() {
+  local path
+  for path in "${temporary_paths[@]-}"; do
+    case "$path" in
+      /tmp/logseq-sync-runtime.*)
+        [[ -d "$path" ]] && rm -rf -- "$path"
+        ;;
+      /tmp/logseq-sync-caddy.*)
+        if [[ -d "$path" ]]; then
+          rm -rf -- "$path"
+        elif [[ -f "$path" ]]; then
+          rm -f -- "$path"
+        fi
+        ;;
+      /tmp/logseq-sync-config.*)
+        [[ -d "$path" ]] && rm -rf -- "$path"
+        ;;
+    esac
+  done
+  return 0
+}
+
+trap cleanup_temporary_paths EXIT
+
+die() {
+  printf 'Error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_linux() {
+  [[ "$(uname -s)" == "Linux" ]] || die "Native deployment requires Linux."
+}
+
+require_root() {
+  [[ "${LOGSEQ_SYNC_TEST_MODE:-false}" == "true" ]] && return 0
+  (( EUID == 0 )) || die "Run this command with sudo."
+}
+
+require_commands() {
+  local command_name
+  for command_name in curl tar sha256sum sha512sum systemctl getent awk sed install mktemp readlink stat; do
+    command -v "$command_name" >/dev/null 2>&1 \
+      || die "Required base command is missing: $command_name"
+  done
+}
+
+canonicalize_target_path() {
+  local path="$1"
+  local existing_path="$path"
+  local suffix=""
+  local resolved_path
+  while [[ ! -e "$existing_path" && ! -L "$existing_path" ]]; do
+    suffix="/$(basename -- "$existing_path")${suffix}"
+    existing_path="$(dirname -- "$existing_path")"
+  done
+  resolved_path="$(readlink -f -- "$existing_path" 2>/dev/null)" || return 1
+  if [[ "$resolved_path" == "/" ]]; then
+    printf '/%s' "${suffix#/}"
+  else
+    printf '%s%s' "$resolved_path" "$suffix"
+  fi
+}
+
+safe_deployment_path() {
+  local path="$1"
+  [[ "$path" =~ ^/[A-Za-z0-9._/-]+$ \
+     && ! "$path" =~ (^|/)\.{1,2}(/|$) ]] || return 1
+  case "$path" in
+    /|/bin|/boot|/dev|/etc|/home|/lib|/lib64|/opt|/proc|/root|/run|/sbin|/srv|/sys|/tmp|/usr|/usr/local|/var|/var/lib)
+      return 1
+      ;;
+  esac
+}
+
+validate_releases_boundary() {
+  local resolved_install_root resolved_releases_dir
+  resolved_install_root="$(canonicalize_target_path "$install_root")" || return 1
+  resolved_releases_dir="$(canonicalize_target_path "$releases_dir")" || return 1
+  [[ "$resolved_releases_dir" == "${resolved_install_root%/}/releases" ]]
+}
+
+release_path_within_boundary() {
+  local release_path="$1"
+  local resolved_release_path resolved_releases_dir
+  [[ ! -L "$release_path" ]] || return 1
+  resolved_release_path="$(canonicalize_target_path "$release_path")" || return 1
+  resolved_releases_dir="$(canonicalize_target_path "$releases_dir")" || return 1
+  [[ "$(dirname -- "$resolved_release_path")" == "$resolved_releases_dir" ]]
+}
+
+trusted_release_directory() {
+  local release_path="$1"
+  local metadata owner group mode
+  [[ "${LOGSEQ_SYNC_TEST_MODE:-false}" == "true" ]] && return 0
+  metadata="$(stat -c '%U:%G:%a' "$release_path" 2>/dev/null)" || return 1
+  IFS=: read -r owner group mode <<< "$metadata"
+  [[ "$owner" == "root" && "$group" == "root" && "$mode" =~ ^[0-7]{3,4}$ ]] \
+    && (( (8#$mode & 8#022) == 0 ))
+}
+
+validate_install_paths() {
+  local path resolved_path
+  for path in "$sync_home" "$bin_dir" "$config_dir" "$data_dir" "$systemd_dir" \
+    "$caddy_data_dir" "$releases_dir" "$manager_path"; do
+    safe_deployment_path "$path" || die "Unsafe deployment path: $path"
+    resolved_path="$(canonicalize_target_path "$path")" \
+      || die "Deployment path cannot be resolved safely: $path"
+    safe_deployment_path "$resolved_path" \
+      || die "Deployment path resolves to an unsafe location: $path -> $resolved_path"
+  done
+  validate_releases_boundary \
+    || die "The runtime releases directory escapes the Sync installation home."
+}
+
+validate_existing_configuration() {
+  [[ -f "$config_dir/sync.env" ]] || return 0
+  local configured_base_url configured_domain configured_url_port
+  local configured_home configured_data_dir configured_host
+  local configured_storage_driver configured_assets_driver configured_log_level
+  local configured_node_env
+  local configured_issuer configured_client_id configured_jwks_url
+  if [[ -z "$configured_public_port" ]] \
+     || ! valid_port "$configured_public_port"; then
+    die "The existing public HTTPS port is missing or invalid."
+  fi
+  if [[ -z "$configured_internal_port" ]] \
+     || ! valid_port "$configured_internal_port" \
+     || (( 10#$configured_internal_port < 1024 )); then
+    die "The existing private Sync port is missing or invalid."
+  fi
+  [[ "$configured_public_port" != "$configured_internal_port" ]] \
+    || die "The existing public and private Sync ports must be different."
+  configured_base_url="$(read_env_value DB_SYNC_BASE_URL)"
+  if [[ "$configured_base_url" =~ ^https://([^:/]+)(:([0-9]+))?$ ]]; then
+    configured_domain="${BASH_REMATCH[1]}"
+    configured_url_port="${BASH_REMATCH[3]:-443}"
+  else
+    die "The existing public Sync URL is missing or invalid."
+  fi
+  valid_domain "$configured_domain" \
+    || die "The existing public Sync URL contains an invalid domain."
+  [[ "$configured_url_port" == "$configured_public_port" \
+     && "$(https_url "$configured_domain" "$configured_public_port")" == "$configured_base_url" ]] \
+    || die "The existing public Sync URL and HTTPS port are inconsistent."
+  configured_home="$(read_env_value LOGSEQ_SYNC_HOME)"
+  configured_data_dir="$(read_env_value DB_SYNC_DATA_DIR)"
+  configured_host="$(read_env_value DB_SYNC_HOST)"
+  [[ "$(readlink -f -- "$configured_home" 2>/dev/null || true)" \
+     == "$(readlink -f -- "$sync_home" 2>/dev/null || true)" ]] \
+    || die "The existing Sync home does not match this installation."
+  [[ "$(readlink -f -- "$configured_data_dir" 2>/dev/null || true)" \
+     == "$(readlink -f -- "$data_dir" 2>/dev/null || true)" ]] \
+    || die "The existing Sync data directory does not match this installation."
+  [[ "$configured_host" == "127.0.0.1" ]] \
+    || die "The existing private Sync host must be 127.0.0.1."
+  [[ "$configured_release_repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] \
+    || die "The existing native runtime repository is missing or invalid."
+  [[ "$configured_release_tag" =~ ^db-sync-native(-v[0-9A-Za-z._-]+)?$ ]] \
+    || die "The existing native runtime release tag is missing or invalid."
+  configured_storage_driver="$(read_env_value DB_SYNC_STORAGE_DRIVER)"
+  configured_assets_driver="$(read_env_value DB_SYNC_ASSETS_DRIVER)"
+  configured_log_level="$(read_env_value DB_SYNC_LOG_LEVEL)"
+  configured_node_env="$(read_env_value NODE_ENV)"
+  [[ "$configured_storage_driver" == "sqlite" \
+     && "$configured_assets_driver" == "filesystem" \
+     && "$configured_log_level" == "info" \
+     && "$configured_node_env" == "production" ]] \
+    || die "The existing native storage configuration is missing or invalid."
+  configured_issuer="$(read_env_value COGNITO_ISSUER)"
+  configured_client_id="$(read_env_value COGNITO_CLIENT_ID)"
+  configured_jwks_url="$(read_env_value COGNITO_JWKS_URL)"
+  [[ "$configured_issuer" == "$default_cognito_issuer" \
+     && "$configured_client_id" == "$default_cognito_client_id" \
+     && "$configured_jwks_url" == "$default_cognito_jwks_url" ]] \
+    || die "The existing authentication configuration is missing or invalid."
+}
+
+set_owner() {
+  [[ "${LOGSEQ_SYNC_TEST_MODE:-false}" == "true" ]] && return 0
+  chown "$@"
+}
+
+confirm() {
+  local prompt="$1"
+  local default_answer="${2:-no}"
+  local answer
+  if [[ "$assume_yes" == "true" ]]; then
+    return 0
+  fi
+  if [[ "$default_answer" == "yes" ]]; then
+    printf '%s [Y/n]: ' "$prompt" >&2
+    read -r answer || answer=""
+    [[ -z "$answer" || "$answer" == "y" || "$answer" == "Y" ]]
+  else
+    printf '%s [y/N]: ' "$prompt" >&2
+    read -r answer || answer=""
+    [[ "$answer" == "y" || "$answer" == "Y" ]]
+  fi
+}
+
+read_value() {
+  local prompt="$1"
+  local default_value="${2:-}"
+  local value
+  if [[ -n "$default_value" ]]; then
+    printf '%s [%s]: ' "$prompt" "$default_value" >&2
+    read -r value || value=""
+    printf '%s' "${value:-$default_value}"
+  else
+    printf '%s: ' "$prompt" >&2
+    read -r value || value=""
+    printf '%s' "$value"
+  fi
+}
+
+valid_port() {
+  [[ "$1" =~ ^[0-9]+$ ]] && (( 10#$1 >= 1 && 10#$1 <= 65535 ))
+}
+
+valid_domain() {
+  [[ ${#1} -le 253 \
+     && "$1" =~ ^([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}$ ]]
+}
+
+https_url() {
+  local domain="$1"
+  local port="$2"
+  if [[ "$port" == "443" ]]; then
+    printf 'https://%s' "$domain"
+  else
+    printf 'https://%s:%s' "$domain" "$port"
+  fi
+}
+
+read_env_value() {
+  local key="$1"
+  [[ -f "$config_dir/sync.env" ]] || return 0
+  sed -n "s/^${key}=//p" "$config_dir/sync.env"
+}
+
+backup_file() {
+  local path="$1"
+  local timestamp backup suffix=0
+  [[ -e "$path" || -L "$path" ]] || return 0
+  timestamp="$(date +%Y%m%d%H%M%S)"
+  backup="${path}.backup-${timestamp}"
+  while [[ -e "$backup" ]]; do
+    suffix=$((suffix + 1))
+    backup="${path}.backup-${timestamp}-${suffix}"
+  done
+  cp -a -- "$path" "$backup"
+}
+
+write_private_file() {
+  local path="$1"
+  shift
+  umask 077
+  printf '%s' "$*" > "$path"
+}
+
+architecture() {
+  case "$(uname -m)" in
+    x86_64) printf 'x64' ;;
+    aarch64|arm64) printf 'arm64' ;;
+    *) die "Only x86_64 and arm64 Linux hosts are currently supported." ;;
+  esac
+}
+
+caddy_architecture() {
+  case "$(uname -m)" in
+    x86_64) printf 'amd64' ;;
+    aarch64|arm64) printf 'arm64' ;;
+    *) die "Only x86_64 and arm64 Linux hosts are currently supported." ;;
+  esac
+}
+
+detect_checkout_repository() {
+  local remote repository=""
+  [[ -d "$checkout_root/.git" ]] || return 0
+  remote="$(git -C "$checkout_root" config --get remote.origin.url 2>/dev/null || true)"
+  case "$remote" in
+    https://github.com/*) repository="${remote#https://github.com/}" ;;
+    git@github.com:*) repository="${remote#git@github.com:}" ;;
+    ssh://git@github.com/*) repository="${remote#ssh://git@github.com/}" ;;
+  esac
+  repository="${repository%.git}"
+  [[ "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] && printf '%s' "$repository"
+}
+
+select_release_source() {
+  if [[ -z "$release_repository" ]]; then
+    release_repository="$(detect_checkout_repository)"
+  fi
+  release_repository="${release_repository:-$default_release_repository}"
+  [[ "$release_repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] \
+    || die "Invalid GitHub release repository: $release_repository"
+  [[ "$release_tag" =~ ^db-sync-native(-v[0-9A-Za-z._-]+)?$ ]] \
+    || die "Invalid native runtime release tag: $release_tag"
+}
+
+ensure_service_users() {
+  [[ "${LOGSEQ_SYNC_TEST_MODE:-false}" == "true" ]] && return 0
+  if ! getent group logseq-sync >/dev/null; then
+    groupadd --system logseq-sync
+  fi
+  if ! id logseq-sync >/dev/null 2>&1; then
+    useradd --system --gid logseq-sync --home-dir "$data_dir" --no-create-home \
+      --shell /usr/sbin/nologin logseq-sync
+  fi
+  if ! getent group caddy >/dev/null; then
+    groupadd --system caddy
+  fi
+  if ! id caddy >/dev/null 2>&1; then
+    useradd --system --gid caddy --home-dir "$caddy_data_dir" --no-create-home \
+      --shell /usr/sbin/nologin caddy
+  fi
+}
+
+replace_current_release() {
+  local release_dir="$1"
+  [[ ! -e "$install_root/current" || -L "$install_root/current" ]] \
+    || die "$install_root/current must be a symbolic link."
+  ln -sfn "$release_dir" "$install_root/current.new"
+  if mv -Tf "$install_root/current.new" "$install_root/current" 2>/dev/null; then
+    return 0
+  fi
+  [[ -L "$install_root/current" ]] && unlink "$install_root/current"
+  mv -f "$install_root/current.new" "$install_root/current"
+}
+
+release_ready() {
+  local release_dir="$1"
+  release_path_within_boundary "$release_dir" \
+    && trusted_release_directory "$release_dir" \
+    && [[ -x "$release_dir/node/bin/node" \
+     && -f "$release_dir/app/node-adapter.js" \
+     && -d "$release_dir/app/node_modules" \
+     && -f "$release_dir/VERSION" \
+     && -f "$release_dir/ARCHITECTURE" \
+     && -f "$release_dir/ARCHIVE_SHA256" ]] \
+    && [[ "$(<"$release_dir/ARCHITECTURE")" == "$(architecture)" ]] \
+    && [[ "$(<"$release_dir/ARCHIVE_SHA256")" =~ ^[0-9a-f]{64}$ ]] \
+    && "$release_dir/node/bin/node" --version >/dev/null 2>&1 \
+    && (cd "$release_dir/app" \
+      && ../node/bin/node -e 'require("better-sqlite3")' >/dev/null 2>&1)
+}
+
+runtime_ready() {
+  local current_release
+  [[ -L "$install_root/current" ]] || return 1
+  current_release="$(readlink -f -- "$install_root/current" 2>/dev/null)" || return 1
+  release_path_within_boundary "$current_release" && release_ready "$current_release"
+}
+
+download_file() {
+  local source="$1"
+  local destination="$2"
+  if [[ "$source" == /* ]]; then
+    cp -a -- "$source" "$destination"
+  else
+    curl --fail --location --show-error "$source" -o "$destination"
+  fi
+}
+
+install_runtime() {
+  local runtime_arch asset release_base archive_source checksum_source
+  local temp_dir archive checksum_file expected_checksum actual_checksum
+  local extracted_dir version release_id release_dir
+  runtime_arch="$(architecture)"
+  asset="logseq-sync-runtime-linux-${runtime_arch}.tar.gz"
+  release_base="${LOGSEQ_SYNC_RELEASE_BASE_URL:-https://github.com/${release_repository}/releases/download/${release_tag}}"
+  archive_source="${LOGSEQ_SYNC_RUNTIME_ARCHIVE:-${release_base}/${asset}}"
+  checksum_source="${LOGSEQ_SYNC_RUNTIME_CHECKSUM:-${archive_source}.sha256}"
+  temp_dir="$(mktemp -d /tmp/logseq-sync-runtime.XXXXXX)"
+  register_temporary_path "$temp_dir"
+  archive="$temp_dir/$asset"
+  checksum_file="$temp_dir/$asset.sha256"
+  printf 'Checking the current Sync runtime for Linux %s from %s (%s).\n' \
+    "$runtime_arch" "$release_repository" "$release_tag"
+  download_file "$checksum_source" "$checksum_file"
+  expected_checksum="$(awk -v asset="$asset" '$2 == asset || $2 == "*" asset {print $1; exit}' "$checksum_file")"
+  [[ "$expected_checksum" =~ ^[0-9a-fA-F]{64}$ ]] \
+    || die "The runtime checksum file is invalid."
+  expected_checksum="$(printf '%s' "$expected_checksum" | awk '{print tolower($0)}')"
+  if runtime_ready \
+     && [[ "$(<"$install_root/current/ARCHIVE_SHA256")" == "$expected_checksum" ]]; then
+    installed_release_dir="$(readlink -f -- "$install_root/current")"
+    runtime_changed="false"
+    printf 'The installed Sync runtime is already current (%s).\n' \
+      "$(<"$install_root/current/VERSION")"
+    return 0
+  fi
+  printf 'Downloading prebuilt Sync runtime for Linux %s.\n' "$runtime_arch"
+  download_file "$archive_source" "$archive"
+  actual_checksum="$(sha256sum "$archive" | awk '{print $1}')"
+  [[ "$actual_checksum" == "$expected_checksum" ]] \
+    || die "The downloaded Sync runtime failed checksum verification."
+  while IFS= read -r archive_entry; do
+    case "$archive_entry" in
+      logseq-sync-runtime|logseq-sync-runtime/*)
+        [[ "$archive_entry" != *'/../'* && "$archive_entry" != '../'* ]] \
+          || die "The downloaded Sync runtime contains an unsafe path."
+        ;;
+      *) die "The downloaded Sync runtime contains an unexpected path." ;;
+    esac
+  done < <(tar -tzf "$archive")
+  mkdir -p "$temp_dir/extracted"
+  tar --no-same-owner --no-same-permissions -xzf "$archive" -C "$temp_dir/extracted"
+  extracted_dir="$temp_dir/extracted/logseq-sync-runtime"
+  [[ -x "$extracted_dir/node/bin/node" \
+     && -f "$extracted_dir/app/node-adapter.js" \
+     && -d "$extracted_dir/app/node_modules" \
+     && -x "$extracted_dir/bin/logseq-sync-native" \
+     && -f "$extracted_dir/VERSION" \
+     && -f "$extracted_dir/ARCHITECTURE" ]] \
+    || die "The downloaded Sync runtime is incomplete."
+  [[ "$(<"$extracted_dir/ARCHITECTURE")" == "$runtime_arch" ]] \
+    || die "The downloaded Sync runtime architecture does not match this server."
+  "$extracted_dir/node/bin/node" --version >/dev/null 2>&1 \
+    || die "The bundled Node.js runtime cannot run on this server."
+  (cd "$extracted_dir/app" \
+    && ../node/bin/node -e 'require("better-sqlite3")' >/dev/null 2>&1) \
+    || die "The bundled SQLite module cannot run on this server. GLIBC 2.29 or newer is required."
+  version="$(<"$extracted_dir/VERSION")"
+  [[ "$version" =~ ^[A-Za-z0-9._+-]+$ ]] || die "The runtime version is invalid."
+  printf '%s\n' "$actual_checksum" > "$extracted_dir/ARCHIVE_SHA256"
+  release_id="${version}-${runtime_arch}-${actual_checksum:0:12}"
+  release_dir="$releases_dir/$release_id"
+  validate_releases_boundary \
+    || die "The runtime releases directory escapes the Sync installation home."
+  mkdir -p "$releases_dir"
+  release_path_within_boundary "$release_dir" \
+    || die "Refusing to use an unsafe runtime path: $release_dir"
+  if [[ -e "$release_dir" ]] \
+     && { ! release_ready "$release_dir" \
+          || [[ "$(<"$release_dir/ARCHIVE_SHA256")" != "$actual_checksum" ]]; }; then
+    release_path_within_boundary "$release_dir" \
+      || die "Refusing to replace an unsafe runtime path: $release_dir"
+    rm -rf -- "$release_dir"
+  fi
+  if [[ ! -d "$release_dir" ]]; then
+    mv "$extracted_dir" "$release_dir"
+    set_owner -R root:root "$release_dir"
+  fi
+  installed_release_dir="$release_dir"
+  runtime_changed="true"
+  printf 'Prepared Sync runtime %s with bundled %s.\n' \
+    "$version" "$("$release_dir/node/bin/node" --version)"
+}
+
+install_caddy() {
+  local caddy_arch asset archive_source expected_checksum
+  local temp_dir archive actual_checksum archive_entry binary_checksum
+  local installed_version installed_archive_checksum installed_binary_checksum
+  caddy_arch="$(caddy_architecture)"
+  asset="caddy_${default_caddy_version}_linux_${caddy_arch}.tar.gz"
+  archive_source="${LOGSEQ_SYNC_CADDY_ARCHIVE:-https://github.com/caddyserver/caddy/releases/download/v${default_caddy_version}/${asset}}"
+  case "$caddy_arch" in
+    amd64)
+      expected_checksum="8220d1f013b6f27510247b2360c9e0ca9f018feebd82515f07635318b34ff9777ccc8fd0b6e6f2486ce3a33fe389fbb7db12d05baa474f4587509fb4f5ebf1c9"
+      ;;
+    arm64)
+      expected_checksum="d5a7c423853c24a799765e0e8210d5c7c22a8f56ed37a3cae2fb9f58be138853c02b4efd6b59d576e6d8c7c0d30b9c1592deeaa6a536ff69bcca23b8c1ea709c"
+      ;;
+    *) die "Unsupported Caddy architecture: $caddy_arch" ;;
+  esac
+  expected_checksum="${LOGSEQ_SYNC_CADDY_SHA512:-$expected_checksum}"
+  [[ "$expected_checksum" =~ ^[0-9a-fA-F]{128}$ ]] \
+    || die "The configured Caddy checksum is invalid."
+  expected_checksum="$(printf '%s' "$expected_checksum" | awk '{print tolower($0)}')"
+  if [[ -x "$caddy_path" && -f "$caddy_metadata_path" ]]; then
+    installed_version="$(sed -n 's/^VERSION=//p' "$caddy_metadata_path")"
+    installed_archive_checksum="$(sed -n 's/^ARCHIVE_SHA512=//p' "$caddy_metadata_path")"
+    installed_binary_checksum="$(sed -n 's/^BINARY_SHA512=//p' "$caddy_metadata_path")"
+    binary_checksum="$(sha512sum "$caddy_path" | awk '{print $1}')"
+    if [[ "$installed_version" == "$default_caddy_version" \
+       && "$installed_archive_checksum" == "$expected_checksum" \
+       && "$installed_binary_checksum" =~ ^[0-9a-f]{128}$ \
+       && "$installed_binary_checksum" == "$binary_checksum" ]]; then
+      return 0
+    fi
+    printf 'The installed Caddy binary does not match the pinned release; replacing it.\n'
+  fi
+  temp_dir="$(mktemp -d /tmp/logseq-sync-caddy.XXXXXX)"
+  register_temporary_path "$temp_dir"
+  archive="$temp_dir/$asset"
+  printf 'Downloading checksum-pinned Caddy %s for automatic HTTPS.\n' \
+    "$default_caddy_version"
+  download_file "$archive_source" "$archive"
+  actual_checksum="$(sha512sum "$archive" | awk '{print $1}')"
+  [[ "$actual_checksum" == "$expected_checksum" ]] \
+    || die "The downloaded Caddy archive failed checksum verification."
+  while IFS= read -r archive_entry; do
+    case "$archive_entry" in
+      caddy|LICENSE|README.md) ;;
+      *) die "The downloaded Caddy archive contains an unexpected path." ;;
+    esac
+  done < <(tar -tzf "$archive")
+  tar --no-same-owner --no-same-permissions -xzf "$archive" -C "$temp_dir" caddy
+  [[ -x "$temp_dir/caddy" ]] || die "The downloaded Caddy archive is incomplete."
+  "$temp_dir/caddy" version >/dev/null 2>&1 \
+    || die "The downloaded Caddy binary cannot run on this server."
+  binary_checksum="$(sha512sum "$temp_dir/caddy" | awk '{print $1}')"
+  mkdir -p "$bin_dir"
+  install -m 0755 "$temp_dir/caddy" "${caddy_path}.new" \
+    || die "The verified Caddy binary could not be staged."
+  write_private_file "${caddy_metadata_path}.new" "VERSION=${default_caddy_version}
+ARCHIVE_SHA512=${expected_checksum}
+BINARY_SHA512=${binary_checksum}
+" || die "The verified Caddy metadata could not be staged."
+  chmod 0644 "${caddy_metadata_path}.new" \
+    || die "The verified Caddy metadata permissions could not be set."
+  mv -f -- "${caddy_path}.new" "$caddy_path" \
+    || die "The verified Caddy binary could not be activated."
+  mv -f -- "${caddy_metadata_path}.new" "$caddy_metadata_path" \
+    || die "The verified Caddy metadata could not be activated."
+}
+
+verify_service_runtime() {
+  local release_dir="${1:-$install_root/current}"
+  [[ "${LOGSEQ_SYNC_TEST_MODE:-false}" == "true" ]] && return 0
+  runuser -u logseq-sync -- "$release_dir/node/bin/node" --version >/dev/null 2>&1 \
+    || die "The bundled runtime is not executable by the logseq-sync service user."
+}
+
+install_manager() {
+  local manager_source="$install_root/current/bin/logseq-sync-native"
+  local staged_manager="${canonical_manager_path}.new"
+  local canonical_manager_identity
+  [[ -f "$manager_source" ]] || manager_source="${BASH_SOURCE[0]}"
+  mkdir -p "$bin_dir" "$(dirname -- "$manager_path")" || return 1
+  canonical_manager_identity="$(cd -- "$(dirname -- "$canonical_manager_path")" \
+    && printf '%s/%s' "$(pwd -P)" "$(basename -- "$canonical_manager_path")")"
+  if [[ "$manager_path" != "$canonical_manager_path" ]] \
+     && { [[ ! -L "$manager_path" ]] \
+          || [[ "$(readlink -f -- "$manager_path" 2>/dev/null || true)" != "$canonical_manager_identity" ]]; }; then
+    backup_file "$manager_path" || return 1
+    if [[ -e "$manager_path" || -L "$manager_path" ]]; then
+      unlink "$manager_path" || return 1
+    fi
+    ln -s "$canonical_manager_path" "$manager_path" || return 1
+  fi
+  if [[ ! -e "$canonical_manager_path" ]] \
+    || ! cmp -s "$manager_source" "$canonical_manager_path"; then
+    backup_file "$canonical_manager_path" || return 1
+    install -m 0755 "$manager_source" "$staged_manager" || return 1
+    mv -f -- "$staged_manager" "$canonical_manager_path" || return 1
+  fi
+  if [[ "$manager_path" == "$canonical_manager_path" ]]; then
+    return 0
+  fi
+  [[ -L "$manager_path" \
+     && "$(readlink -f -- "$manager_path" 2>/dev/null || true)" == "$canonical_manager_identity" ]]
+}
+
+bootstrap() {
+  require_linux
+  require_root
+  validate_install_paths
+  require_commands
+  validate_existing_configuration
+  select_release_source
+  printf 'The installer will download a prebuilt Sync runtime and Caddy.\n'
+  printf 'It will not install or use system Node.js, Java, Clojure, or build tools.\n'
+  confirm 'Download the runtime components?' yes || die "Download cancelled."
+  ensure_service_users
+  install_runtime
+  replace_current_release "$installed_release_dir"
+  install_caddy
+  verify_service_runtime
+  install_manager
+  printf 'Runtime components are ready.\n'
+}
+
+ensure_runtime_components() {
+  require_commands
+  select_release_source
+  ensure_service_users
+  if ! runtime_ready; then
+    install_runtime
+    replace_current_release "$installed_release_dir"
+  else
+    printf 'Using installed prebuilt Sync runtime %s.\n' "$(<"$install_root/current/VERSION")"
+  fi
+  install_caddy
+  verify_service_runtime
+}
+
+write_configuration() {
+  local domain="$1"
+  local public_url
+  local staged_env="$config_dir/sync.env.new"
+  local staged_caddyfile="$config_dir/Caddyfile.new"
+  local staged_sync_service="$systemd_dir/${sync_service}.new"
+  local staged_proxy_service="$systemd_dir/${proxy_service}.new"
+  public_url="$(https_url "$domain" "$public_port")"
+  if ! mkdir -p "$config_dir" "$data_dir" "$caddy_data_dir" "$systemd_dir" \
+     || ! set_owner logseq-sync:logseq-sync "$data_dir" \
+     || ! set_owner caddy:caddy "$caddy_data_dir" \
+     || ! set_owner root:caddy "$config_dir" \
+     || ! chmod 0750 "$config_dir" "$data_dir" "$caddy_data_dir"; then
+    return 1
+  fi
+  if ! write_private_file "$staged_env" "NODE_ENV=production
+LOGSEQ_SYNC_RELEASE_REPOSITORY=${release_repository}
+LOGSEQ_SYNC_RELEASE_TAG=${release_tag}
+LOGSEQ_SYNC_HOME=${sync_home}
+LOGSEQ_SYNC_PUBLIC_PORT=${public_port}
+DB_SYNC_HOST=127.0.0.1
+DB_SYNC_PORT=${internal_port}
+DB_SYNC_BASE_URL=${public_url}
+DB_SYNC_DATA_DIR=${data_dir}
+DB_SYNC_STORAGE_DRIVER=sqlite
+DB_SYNC_ASSETS_DRIVER=filesystem
+DB_SYNC_LOG_LEVEL=info
+COGNITO_ISSUER=${default_cognito_issuer}
+COGNITO_CLIENT_ID=${default_cognito_client_id}
+COGNITO_JWKS_URL=${default_cognito_jwks_url}
+"; then
+    return 1
+  fi
+  if ! set_owner root:logseq-sync "$staged_env" \
+     || ! chmod 0640 "$staged_env" \
+     || ! printf '%s\n' "${public_url} {" \
+    $'\t'"reverse_proxy 127.0.0.1:${internal_port}" \
+    $'\ttls {' \
+    $'\t\tissuer acme {' \
+    $'\t\t\tdisable_tlsalpn_challenge' \
+    $'\t\t}' \
+    $'\t}' \
+    '}' > "$staged_caddyfile" \
+     || ! set_owner root:caddy "$staged_caddyfile" \
+     || ! chmod 0640 "$staged_caddyfile"; then
+    rm -f -- "$staged_env" "$staged_caddyfile"
+    return 1
+  fi
+  if ! write_private_file "$staged_sync_service" "[Unit]
+Description=Logseq Sync Node adapter
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=logseq-sync
+Group=logseq-sync
+WorkingDirectory=${install_root}/current/app
+EnvironmentFile=${config_dir}/sync.env
+ExecStart=${install_root}/current/node/bin/node ${install_root}/current/app/node-adapter.js
+Restart=on-failure
+RestartSec=5s
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=${data_dir}
+
+[Install]
+WantedBy=multi-user.target
+" || ! chmod 0644 "$staged_sync_service"; then
+    rm -f -- "$staged_env" "$staged_caddyfile" "$staged_sync_service"
+    return 1
+  fi
+  if ! write_private_file "$staged_proxy_service" "[Unit]
+Description=Logseq Sync HTTPS proxy
+After=network-online.target ${sync_service}
+Wants=network-online.target ${sync_service}
+
+[Service]
+Type=notify
+User=caddy
+Group=caddy
+Environment=XDG_DATA_HOME=${caddy_data_dir}
+Environment=XDG_CONFIG_HOME=${caddy_data_dir}
+ExecStart=${caddy_path} run --environ --config ${config_dir}/Caddyfile
+ExecReload=${caddy_path} reload --config ${config_dir}/Caddyfile --force
+TimeoutStopSec=5s
+LimitNOFILE=1048576
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=${caddy_data_dir}
+
+[Install]
+WantedBy=multi-user.target
+" || ! chmod 0644 "$staged_proxy_service"; then
+    rm -f -- "$staged_env" "$staged_caddyfile" \
+      "$staged_sync_service" "$staged_proxy_service"
+    return 1
+  fi
+  if ! backup_file "$config_dir/sync.env" \
+     || ! backup_file "$config_dir/Caddyfile" \
+     || ! backup_file "$systemd_dir/$sync_service" \
+     || ! backup_file "$systemd_dir/$proxy_service" \
+     || ! mv -f -- "$staged_env" "$config_dir/sync.env" \
+     || ! mv -f -- "$staged_caddyfile" "$config_dir/Caddyfile" \
+     || ! mv -f -- "$staged_sync_service" "$systemd_dir/$sync_service" \
+     || ! mv -f -- "$staged_proxy_service" "$systemd_dir/$proxy_service"; then
+    rm -f -- "$staged_env" "$staged_caddyfile" \
+      "$staged_sync_service" "$staged_proxy_service"
+    return 1
+  fi
+}
+
+snapshot_configuration() {
+  local snapshot_dir="$1"
+  local path index=0
+  for path in "$config_dir/sync.env" "$config_dir/Caddyfile" \
+    "$systemd_dir/$sync_service" "$systemd_dir/$proxy_service"; do
+    if [[ -e "$path" || -L "$path" ]]; then
+      cp -a -- "$path" "$snapshot_dir/$index"
+      : > "$snapshot_dir/$index.present"
+    fi
+    index=$((index + 1))
+  done
+}
+
+restore_configuration() {
+  local snapshot_dir="$1"
+  local path index=0
+  for path in "$config_dir/sync.env" "$config_dir/Caddyfile" \
+    "$systemd_dir/$sync_service" "$systemd_dir/$proxy_service"; do
+    if [[ -e "$path" || -L "$path" ]]; then
+      rm -f -- "$path" || return 1
+    fi
+    if [[ -f "$snapshot_dir/$index.present" ]]; then
+      cp -a -- "$snapshot_dir/$index" "$path" || return 1
+    fi
+    index=$((index + 1))
+  done
+}
+
+restart_restored_configuration() {
+  local restored_internal_port restored_public_url
+  restored_internal_port="$(read_env_value DB_SYNC_PORT)"
+  restored_public_url="$(read_env_value DB_SYNC_BASE_URL)"
+  "$caddy_path" validate --config "$config_dir/Caddyfile" \
+    && systemctl daemon-reload \
+    && systemctl restart "$sync_service" \
+    && wait_for_url "http://127.0.0.1:${restored_internal_port}" 30 2 \
+      "the restored private Sync health check at 127.0.0.1:${restored_internal_port}" \
+    && systemctl restart "$proxy_service" \
+    && wait_for_url "$restored_public_url" 24 5 \
+      "the restored public HTTPS health check at ${restored_public_url}"
+}
+
+wait_for_url() {
+  local url="$1"
+  local attempts="$2"
+  local delay="$3"
+  local description="${4:-$url}"
+  local body
+  printf 'Waiting for %s' "$description"
+  while (( attempts > 0 )); do
+    body="$(curl --fail --silent --show-error --max-time 5 "$url/health" 2>/dev/null || true)"
+    if [[ "$body" == '{"ok":true}' ]]; then
+      printf ' ready.\n'
+      return 0
+    fi
+    attempts=$((attempts - 1))
+    printf '.'
+    (( attempts > 0 )) && sleep "$delay"
+  done
+  printf '\n'
+  return 1
+}
+
+start_services() {
+  local public_url="$1"
+  if ! "$caddy_path" validate --config "$config_dir/Caddyfile"; then
+    printf 'Caddy configuration validation failed.\n' >&2
+    return 1
+  fi
+  systemctl daemon-reload
+  systemctl enable "$sync_service" "$proxy_service" >/dev/null
+  printf 'Starting Sync Node on 127.0.0.1:%s.\n' "$internal_port"
+  systemctl restart "$sync_service"
+  if ! wait_for_url "http://127.0.0.1:${internal_port}" 30 2 \
+    "the private Sync health check at 127.0.0.1:${internal_port}"; then
+    journalctl -u "$sync_service" --no-pager -n 30 >&2 || true
+    printf 'Sync did not become healthy.\n' >&2
+    return 1
+  fi
+  printf 'Starting Caddy on public HTTPS port %s.\n' "$public_port"
+  printf 'Caddy will obtain or renew the TLS certificate automatically; this can take a few minutes.\n'
+  systemctl restart "$proxy_service"
+  if ! wait_for_url "$public_url" 24 5 \
+    "the public HTTPS health check at ${public_url}"; then
+    journalctl -u "$proxy_service" --no-pager -n 30 >&2 || true
+    printf 'HTTPS did not become reachable. Confirm DNS and inbound TCP ports 80 and %s.\n' \
+      "$public_port" >&2
+    return 1
+  fi
+}
+
+setup() {
+  local domain=""
+  local requested_port=""
+  local requested_internal_port=""
+  local internal_port_default
+  local previous_url previous_domain="" previous_port="" public_url resolved_ips
+  local configuration_snapshot="" had_existing_configuration="false"
+  while (( $# > 0 )); do
+    case "$1" in
+      --domain)
+        (( $# >= 2 )) || die "--domain requires a value."
+        domain="$2"
+        shift 2
+        ;;
+      --domain=*) domain="${1#--domain=}"; shift ;;
+      --public-port)
+        (( $# >= 2 )) || die "--public-port requires a value."
+        requested_port="$2"
+        shift 2
+        ;;
+      --public-port=*) requested_port="${1#--public-port=}"; shift ;;
+      --internal-port)
+        (( $# >= 2 )) || die "--internal-port requires a value."
+        requested_internal_port="$2"
+        shift 2
+        ;;
+      --internal-port=*) requested_internal_port="${1#--internal-port=}"; shift ;;
+      --yes|-y) assume_yes="true"; shift ;;
+      --help|-h) usage; return 0 ;;
+      *) die "Unknown setup option: $1. Use --domain, --public-port, --internal-port, or --yes." ;;
+    esac
+  done
+  require_linux
+  require_root
+  validate_install_paths
+  require_commands
+  validate_existing_configuration
+  if [[ "$assume_yes" != "true" ]]; then
+    printf '\nLogseq Sync setup\n'
+    printf 'This wizard will configure a prebuilt Sync runtime, Caddy, automatic HTTPS, and systemd.\n'
+    printf 'You only need a domain name, public HTTPS port, and private Sync port.\n\n'
+  fi
+  previous_url="$(read_env_value DB_SYNC_BASE_URL)"
+  if [[ "$previous_url" =~ ^https://([^:/]+)(:([0-9]+))?$ ]]; then
+    previous_domain="${BASH_REMATCH[1]}"
+    previous_port="${BASH_REMATCH[3]:-443}"
+  fi
+  if [[ -z "$domain" ]]; then
+    printf 'Domain requirements:\n'
+    printf '  - Enter a hostname only, for example sync.example.com (no https:// or path).\n'
+    printf '  - Its public A/AAAA record must already resolve to this server.\n'
+    printf '  - Wait for DNS propagation before continuing.\n\n'
+    domain="$(read_value 'Step 1/3 - Sync domain name' "$previous_domain")"
+  fi
+  valid_domain "$domain" || die "Enter a valid DNS domain name, not an IP address."
+  resolved_ips="$(getent ahosts "$domain" \
+    | awk '!seen[$1]++ {printf "%s%s", separator, $1; separator=", "}' || true)"
+  [[ -n "$resolved_ips" ]] \
+    || die "The domain does not currently resolve. Create its DNS record before setup."
+  if [[ -n "$requested_port" ]]; then
+    public_port="$requested_port"
+  else
+    printf '\nPublic HTTPS port:\n'
+    printf '  - Logseq clients connect here using HTTPS and secure WebSockets.\n'
+    printf '  - Allow this TCP port in the cloud security group and server firewall.\n'
+    printf '  - TCP 80 must also be reachable for automatic certificate validation.\n\n'
+    public_port="$(read_value 'Step 2/3 - Public HTTPS port' "${previous_port:-$default_public_port}")"
+  fi
+  valid_port "$public_port" || die "Public HTTPS port must be between 1 and 65535."
+  [[ "$public_port" != "80" ]] \
+    || die "Public HTTPS port 80 is reserved for automatic certificate validation."
+  internal_port_default="$internal_port"
+  if [[ "$public_port" == "$internal_port_default" ]]; then
+    if (( 10#$public_port < 65535 )); then
+      internal_port_default="$((10#$public_port + 1))"
+    else
+      internal_port_default="$((10#$public_port - 1))"
+    fi
+  fi
+  if [[ -n "$requested_internal_port" ]]; then
+    internal_port="$requested_internal_port"
+  else
+    printf '\nPrivate Sync port:\n'
+    printf '  - Sync Node listens on 127.0.0.1 only; Caddy forwards requests here.\n'
+    printf '  - Do not expose or allow this port in the public firewall.\n\n'
+    internal_port="$(read_value 'Step 3/3 - Private Sync port' "$internal_port_default")"
+  fi
+  valid_port "$internal_port" || die "Private Sync port must be between 1024 and 65535."
+  (( 10#$internal_port >= 1024 )) \
+    || die "Private Sync port must be between 1024 and 65535."
+  [[ "$public_port" != "$internal_port" ]] \
+    || die "Public HTTPS port and private Sync port must be different."
+  select_release_source
+  public_url="$(https_url "$domain" "$public_port")"
+  printf '\nDeployment plan:\n'
+  printf '  DNS: %s -> %s\n' "$domain" "$resolved_ips"
+  printf '  Public endpoint (enter in Logseq): %s\n' "$public_url"
+  printf '  Public inbound TCP: 80 (certificate), %s (HTTPS/WSS)\n' "$public_port"
+  printf '  Private adapter: 127.0.0.1:%s (local only, do not expose)\n' "$internal_port"
+  printf '  Runtime: prebuilt Linux %s package from %s (%s)\n' \
+    "$(architecture)" "$release_repository" "$release_tag"
+  printf '  Home: %s\n' "$sync_home"
+  printf '  Data: %s\n' "$data_dir"
+  printf '  Services: Sync Node + Caddy (systemd)\n\n'
+  confirm 'Download and start Logseq Sync?' yes || die "Setup cancelled."
+  ensure_runtime_components
+  install_manager
+  configuration_snapshot="$(mktemp -d /tmp/logseq-sync-config.XXXXXX)"
+  register_temporary_path "$configuration_snapshot"
+  snapshot_configuration "$configuration_snapshot"
+  if [[ -f "$config_dir/sync.env" ]]; then
+    had_existing_configuration="true"
+  fi
+  if ! write_configuration "$domain"; then
+    if [[ "$had_existing_configuration" == "true" ]]; then
+      if restore_configuration "$configuration_snapshot" \
+         && restart_restored_configuration; then
+        die "Setup could not write the new configuration; the previous working configuration was restored."
+      fi
+      die "Setup could not write the new configuration, and the previous configuration could not be restarted. Check the service logs and the timestamped configuration backups."
+    fi
+    restore_configuration "$configuration_snapshot" \
+      || die "Setup could not write or clean up the configuration. Check the timestamped configuration backups."
+    die "Setup could not write the configuration. No services were started."
+  fi
+  if ! start_services "$public_url"; then
+    if [[ "$had_existing_configuration" == "true" ]]; then
+      if restore_configuration "$configuration_snapshot" \
+         && restart_restored_configuration; then
+        die "Setup did not complete; the previous working configuration was restored."
+      fi
+      die "Setup failed, and the previous configuration could not be restarted. Check the service logs and the timestamped configuration backups."
+    fi
+    die "Setup did not complete. Generated configuration and data were preserved."
+  fi
+  printf '\nLogseq Sync is ready. Enter this URL in Logseq → Settings → Advanced → Sync Server URL:\n'
+  printf '  %s\n' "$public_url"
+  printf 'Manage it later with: sudo %s status\n' "$manager_path"
+}
+
+rollback_update() {
+  local previous_release="$1"
+  replace_current_release "$previous_release"
+  if systemctl restart "$sync_service" \
+     && wait_for_url "http://127.0.0.1:${internal_port}" 30 2 \
+       "the restored private Sync health check at 127.0.0.1:${internal_port}"; then
+    return 0
+  fi
+  journalctl -u "$sync_service" --no-pager -n 30 >&2 || true
+  return 1
+}
+
+prune_releases() {
+  local active_release="$1"
+  local previous_release="$2"
+  local candidate
+  shopt -s nullglob
+  validate_releases_boundary \
+    || die "The runtime releases directory escapes the Sync installation home."
+  for candidate in "$releases_dir"/*; do
+    [[ -d "$candidate" ]] || continue
+    [[ "$candidate" == "$active_release" || "$candidate" == "$previous_release" ]] \
+      && continue
+    release_path_within_boundary "$candidate" \
+      || die "Refusing to prune an unsafe runtime path: $candidate"
+    rm -rf -- "$candidate"
+  done
+  shopt -u nullglob
+}
+
+update() {
+  local public_url previous_release active_release
+  require_linux
+  require_root
+  validate_install_paths
+  require_commands
+  [[ -f "$config_dir/sync.env" ]] || die "Run setup first."
+  validate_existing_configuration
+  select_release_source
+  ensure_service_users
+  public_url="$(read_env_value DB_SYNC_BASE_URL)"
+  previous_release="$(readlink "$install_root/current" 2>/dev/null || true)"
+  [[ -n "$previous_release" && -d "$previous_release" ]] \
+    || die "The current adapter release is missing. Run setup to repair it."
+  release_path_within_boundary "$previous_release" \
+    || die "The current adapter release is outside the managed releases directory."
+  printf 'Checking the current prebuilt runtime; configuration and data will be preserved.\n'
+  install_runtime
+  if [[ "$runtime_changed" == "false" ]]; then
+    printf 'Logseq Sync is already up to date: %s\n' "$public_url"
+    return 0
+  fi
+  install_caddy
+  verify_service_runtime "$installed_release_dir"
+  replace_current_release "$installed_release_dir"
+  if ! systemctl restart "$sync_service"; then
+    rollback_update "$previous_release" \
+      || die "The update failed and the previous release could not be restarted."
+    die "The update failed to restart Sync; the previous release was restored."
+  fi
+  if ! wait_for_url "http://127.0.0.1:${internal_port}" 30 2 \
+    "the private Sync health check at 127.0.0.1:${internal_port}"; then
+    journalctl -u "$sync_service" --no-pager -n 30 >&2 || true
+    rollback_update "$previous_release" \
+      || die "The update failed and the previous release could not be restored."
+    die "Updated Sync process did not become healthy; the previous release was restored."
+  fi
+  if ! wait_for_url "$public_url" 6 2 \
+    "the public HTTPS health check at ${public_url}"; then
+    journalctl -u "$proxy_service" --no-pager -n 30 >&2 || true
+    rollback_update "$previous_release" \
+      || die "The public endpoint failed and the previous release could not be restored."
+    die "Updated public endpoint is unavailable; the previous release was restored."
+  fi
+  if ! install_manager; then
+    rollback_update "$previous_release" \
+      || die "The manager update failed and the previous release could not be restored."
+    die "The manager update failed; the previous release was restored."
+  fi
+  active_release="$(readlink "$install_root/current")"
+  prune_releases "$active_release" "$previous_release"
+  printf 'Logseq Sync was updated successfully: %s\n' "$public_url"
+}
+
+status() {
+  local public_url internal_body public_body runtime_version
+  require_root
+  validate_install_paths
+  [[ -f "$config_dir/sync.env" ]] || die "No native deployment configuration found."
+  validate_existing_configuration
+  public_url="$(read_env_value DB_SYNC_BASE_URL)"
+  runtime_version="$(<"$install_root/current/VERSION")"
+  systemctl --no-pager --full status "$sync_service" "$proxy_service" || true
+  internal_body="$(curl --fail --silent --max-time 3 "http://127.0.0.1:${internal_port}/health" 2>/dev/null || true)"
+  public_body="$(curl --fail --silent --max-time 5 "$public_url/health" 2>/dev/null || true)"
+  printf 'Runtime version: %s\n' "$runtime_version"
+  printf 'Sync Server URL: %s\n' "$public_url"
+  [[ "$internal_body" == '{"ok":true}' ]] || die "The private Sync health check failed."
+  [[ "$public_body" == '{"ok":true}' ]] || die "The public HTTPS health check failed."
+  printf 'Health: ok\n'
+}
+
+logs() {
+  local follow="" unit="$sync_service"
+  require_root
+  validate_install_paths
+  while (( $# > 0 )); do
+    case "$1" in
+      --follow|-f) follow="--follow" ;;
+      sync) unit="$sync_service" ;;
+      proxy|caddy) unit="$proxy_service" ;;
+      *) die "Unknown logs option: $1" ;;
+    esac
+    shift
+  done
+  journalctl -u "$unit" --no-pager -n 200 $follow
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  sudo logseq-sync-native setup
+  sudo logseq-sync-native setup --domain <domain> --public-port <port> \
+    --internal-port <port> [--yes]
+  sudo logseq-sync-native update
+  sudo logseq-sync-native bootstrap
+  sudo logseq-sync-native status
+  sudo logseq-sync-native logs [--follow] [sync|proxy]
+
+The server downloads a checksum-verified, prebuilt Linux x64 or arm64 runtime.
+It does not need system Node.js, Java, Clojure, pnpm, Python, or a compiler.
+
+Advanced release overrides:
+  LOGSEQ_SYNC_RELEASE_REPOSITORY=<owner/repository>
+  LOGSEQ_SYNC_RELEASE_TAG=<db-sync-native or versioned tag>
+
+Advanced install location override (first setup only):
+  LOGSEQ_SYNC_HOME=/srv/logseq-sync
+EOF
+}
+
+main() {
+  local command="${1:-help}"
+  (( $# > 0 )) && shift
+  case "$command" in
+    setup) setup "$@" ;;
+    update) update "$@" ;;
+    bootstrap) bootstrap "$@" ;;
+    status) status "$@" ;;
+    logs) logs "$@" ;;
+    help|--help|-h) usage ;;
+    *) usage >&2; die "Unknown command: $command" ;;
+  esac
+}
+
+main "$@"

--- a/deps/db-sync/deploy/native-test.sh
+++ b/deps/db-sync/deploy/native-test.sh
@@ -1,0 +1,835 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+test_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly test_dir
+readonly manager="$test_dir/logseq-sync-native"
+suite_tmp="$(mktemp -d "${TMPDIR:-/tmp}/logseq-sync-native-test.XXXXXX")"
+readonly suite_tmp
+manager_under_test="$manager"
+pass_count=0
+fail_count=0
+
+cleanup() {
+  if [[ -d "$suite_tmp" && "$suite_tmp" == *logseq-sync-native-test.* ]]; then
+    rm -rf -- "$suite_tmp"
+  fi
+}
+trap cleanup EXIT
+
+make_runtime_fixture() {
+  local sandbox="$1"
+  local version="${2:-runtime-v1}"
+  local fixture="$sandbox/runtime-fixture/logseq-sync-runtime"
+  local asset="$sandbox/logseq-sync-runtime-linux-x64.tar.gz"
+  rm -rf -- "$sandbox/runtime-fixture"
+  mkdir -p "$fixture/node/bin" "$fixture/app/node_modules" "$fixture/bin"
+  cat > "$fixture/node/bin/node" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'v24.0.0\n'
+fi
+if [[ "${1:-}" == "-e" ]]; then
+  exit "${MOCK_SQLITE_STATUS:-0}"
+fi
+exit 0
+EOF
+  printf 'mock adapter\n' > "$fixture/app/node-adapter.js"
+  cp "$manager" "$fixture/bin/logseq-sync-native"
+  printf '# fixture-manager=%s\n' "$version" >> "$fixture/bin/logseq-sync-native"
+  printf '%s\n' "$version" > "$fixture/VERSION"
+  printf 'x64\n' > "$fixture/ARCHITECTURE"
+  chmod +x "$fixture/node/bin/node" "$fixture/bin/logseq-sync-native"
+  tar -czf "$asset" -C "$sandbox/runtime-fixture" logseq-sync-runtime
+  (cd "$sandbox" && sha256sum "$(basename "$asset")" > "$(basename "$asset").sha256")
+}
+
+make_caddy_fixture() {
+  local sandbox="$1"
+  local fixture="$sandbox/caddy-fixture"
+  local asset="$sandbox/caddy_2.11.4_linux_amd64.tar.gz"
+  mkdir -p "$fixture"
+  cp "$sandbox/home/bin/caddy" "$fixture/caddy"
+  printf 'test license\n' > "$fixture/LICENSE"
+  printf 'test readme\n' > "$fixture/README.md"
+  tar -czf "$asset" -C "$fixture" caddy LICENSE README.md
+  sha512sum "$asset" | awk '{print $1}' > "$asset.sha512"
+}
+
+make_sandbox() {
+  local sandbox
+  sandbox="$(mktemp -d "$suite_tmp/case.XXXXXX")"
+  mkdir -p "$sandbox/bin" "$sandbox/home/bin"
+
+  cat > "$sandbox/bin/uname" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  -s) printf 'Linux\n' ;;
+  -m) printf 'x86_64\n' ;;
+  *) printf 'Linux\n' ;;
+esac
+EOF
+
+  cat > "$sandbox/bin/getent" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "ahosts" ]]; then
+  [[ "${MOCK_DNS_STATUS:-0}" -eq 0 ]] || exit "$MOCK_DNS_STATUS"
+  printf '%s STREAM %s\n' "${MOCK_DNS_IP:-203.0.113.10}" "$2"
+  exit 0
+fi
+exit 1
+EOF
+
+  cat > "$sandbox/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_CURL_LOG"
+curl_call_count=0
+if [[ -f "$MOCK_CURL_COUNT_FILE" ]]; then
+  curl_call_count="$(<"$MOCK_CURL_COUNT_FILE")"
+fi
+curl_call_count=$((curl_call_count + 1))
+printf '%s\n' "$curl_call_count" > "$MOCK_CURL_COUNT_FILE"
+if (( curl_call_count <= MOCK_CURL_FAILURES )); then
+  exit 22
+fi
+if (( MOCK_CURL_FAIL_FROM > 0 \
+      && curl_call_count >= MOCK_CURL_FAIL_FROM \
+      && curl_call_count <= MOCK_CURL_FAIL_THROUGH )); then
+  exit 22
+fi
+printf '%s' '{"ok":true}'
+EOF
+
+  cat > "$sandbox/bin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_SYSTEMCTL_LOG"
+systemctl_call_count=0
+if [[ -f "$MOCK_SYSTEMCTL_COUNT_FILE" ]]; then
+  systemctl_call_count="$(<"$MOCK_SYSTEMCTL_COUNT_FILE")"
+fi
+systemctl_call_count=$((systemctl_call_count + 1))
+printf '%s\n' "$systemctl_call_count" > "$MOCK_SYSTEMCTL_COUNT_FILE"
+if (( MOCK_SYSTEMCTL_FAIL_CALL > 0 \
+      && systemctl_call_count == MOCK_SYSTEMCTL_FAIL_CALL )); then
+  exit 1
+fi
+exit 0
+EOF
+
+  cat > "$sandbox/bin/journalctl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_JOURNAL_LOG"
+exit 0
+EOF
+
+  cat > "$sandbox/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+  cat > "$sandbox/home/bin/caddy" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_CADDY_LOG"
+if [[ "${1:-}" == "version" ]]; then
+  printf 'v2.11.4 test-build\n'
+fi
+exit 0
+EOF
+
+  chmod +x "$sandbox/bin/"* "$sandbox/home/bin/caddy"
+  make_runtime_fixture "$sandbox"
+  make_caddy_fixture "$sandbox"
+  printf '%s' "$sandbox"
+}
+
+run_manager() {
+  local sandbox="$1"
+  shift
+  last_output="$(printf '%s' "${MOCK_MANAGER_INPUT:-}" | env \
+    PATH="$sandbox/bin:$PATH" \
+    LOGSEQ_SYNC_TEST_MODE=true \
+    LOGSEQ_SYNC_ASSUME_YES="${MOCK_ASSUME_YES:-true}" \
+    LOGSEQ_SYNC_HOME="${MOCK_SYNC_HOME-$sandbox/home}" \
+    LOGSEQ_SYNC_SYSTEMD_DIR="$sandbox/systemd" \
+    LOGSEQ_SYNC_MANAGER_PATH="$sandbox/bin/logseq-sync-native-installed" \
+    LOGSEQ_SYNC_RELEASE_REPOSITORY="example/logseq" \
+    LOGSEQ_SYNC_RUNTIME_ARCHIVE="$sandbox/logseq-sync-runtime-linux-x64.tar.gz" \
+    LOGSEQ_SYNC_RUNTIME_CHECKSUM="$sandbox/logseq-sync-runtime-linux-x64.tar.gz.sha256" \
+    LOGSEQ_SYNC_CADDY_ARCHIVE="$sandbox/caddy_2.11.4_linux_amd64.tar.gz" \
+    LOGSEQ_SYNC_CADDY_SHA512="${MOCK_CADDY_SHA512:-$(<"$sandbox/caddy_2.11.4_linux_amd64.tar.gz.sha512")}" \
+    MOCK_CURL_LOG="$sandbox/curl.log" \
+    MOCK_CURL_COUNT_FILE="$sandbox/curl-count" \
+    MOCK_CURL_FAILURES="${MOCK_CURL_FAILURES:-0}" \
+    MOCK_CURL_FAIL_FROM="${MOCK_CURL_FAIL_FROM:-0}" \
+    MOCK_CURL_FAIL_THROUGH="${MOCK_CURL_FAIL_THROUGH:-0}" \
+    MOCK_SYSTEMCTL_LOG="$sandbox/systemctl.log" \
+    MOCK_SYSTEMCTL_COUNT_FILE="$sandbox/systemctl-count" \
+    MOCK_SYSTEMCTL_FAIL_CALL="${MOCK_SYSTEMCTL_FAIL_CALL:-0}" \
+    MOCK_JOURNAL_LOG="$sandbox/journal.log" \
+    MOCK_CADDY_LOG="$sandbox/caddy.log" \
+    MOCK_DNS_STATUS="${MOCK_DNS_STATUS:-0}" \
+    MOCK_DNS_IP="${MOCK_DNS_IP:-203.0.113.10}" \
+    MOCK_SQLITE_STATUS="${MOCK_SQLITE_STATUS:-0}" \
+    "$manager_under_test" "$@" 2>&1)"
+  last_status=$?
+}
+
+assert_contains() {
+  local value="$1"
+  local expected="$2"
+  [[ "$value" == *"$expected"* ]] || {
+    printf 'Expected to find %q in:\n%s\n' "$expected" "$value" >&2
+    return 1
+  }
+}
+
+assert_not_contains() {
+  local value="$1"
+  local unexpected="$2"
+  [[ "$value" != *"$unexpected"* ]] || {
+    printf 'Did not expect to find %q in:\n%s\n' "$unexpected" "$value" >&2
+    return 1
+  }
+}
+
+assert_success() {
+  [[ "$last_status" -eq 0 ]] || {
+    printf 'Expected success, got status %s:\n%s\n' "$last_status" "$last_output" >&2
+    return 1
+  }
+}
+
+assert_failure() {
+  [[ "$last_status" -ne 0 ]] || {
+    printf 'Expected failure:\n%s\n' "$last_output" >&2
+    return 1
+  }
+}
+
+test_setup_uses_prebuilt_runtime_and_default_ports() {
+  local sandbox env_file service_file proxy_service_file
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  env_file="$(<"$sandbox/home/config/sync.env")"
+  service_file="$(<"$sandbox/systemd/logseq-sync.service")"
+  proxy_service_file="$(<"$sandbox/systemd/logseq-sync-caddy.service")"
+  assert_contains "$env_file" 'DB_SYNC_BASE_URL=https://sync.example.com' || return 1
+  assert_contains "$env_file" 'LOGSEQ_SYNC_PUBLIC_PORT=443' || return 1
+  assert_contains "$(<"$sandbox/home/config/Caddyfile")" \
+    'https://sync.example.com {' || return 1
+  assert_contains "$env_file" 'DB_SYNC_PORT=10011' || return 1
+  assert_contains "$env_file" 'LOGSEQ_SYNC_RELEASE_REPOSITORY=example/logseq' || return 1
+  assert_contains "$env_file" "LOGSEQ_SYNC_HOME=$sandbox/home" || return 1
+  assert_contains "$env_file" "DB_SYNC_DATA_DIR=$sandbox/home/data" || return 1
+  assert_contains "$service_file" \
+    "ExecStart=$sandbox/home/current/node/bin/node $sandbox/home/current/app/node-adapter.js" || return 1
+  assert_contains "$proxy_service_file" \
+    "ExecStart=$sandbox/home/bin/caddy run" || return 1
+  [[ -x "$sandbox/home/bin/logseq-sync-native" ]] || return 1
+  [[ -L "$sandbox/bin/logseq-sync-native-installed" ]] || return 1
+  assert_not_contains "$env_file" 'LOGSEQ_SYNC_NODE_PATH=' || return 1
+  assert_not_contains "$last_output" 'Clojure' || return 1
+  assert_contains "$last_output" 'Prepared Sync runtime runtime-v1 with bundled v24.0.0' || return 1
+  assert_contains "$last_output" 'Starting Sync Node on 127.0.0.1:10011.' || return 1
+  assert_contains "$last_output" \
+    'Waiting for the private Sync health check at 127.0.0.1:10011 ready.' || return 1
+  assert_contains "$last_output" 'Starting Caddy on public HTTPS port 443.' || return 1
+  assert_contains "$last_output" \
+    'Caddy will obtain or renew the TLS certificate automatically; this can take a few minutes.' || return 1
+  assert_contains "$last_output" \
+    'Waiting for the public HTTPS health check at https://sync.example.com ready.'
+}
+
+test_setup_prints_progress_during_health_retries() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  MOCK_CURL_FAILURES=1 run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  assert_contains "$last_output" \
+    'Waiting for the private Sync health check at 127.0.0.1:10011. ready.'
+}
+
+test_setup_ignores_broken_system_node_and_build_tools() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  cat > "$sandbox/bin/node" <<'EOF'
+#!/usr/bin/env bash
+exit 99
+EOF
+  cat > "$sandbox/bin/java" <<'EOF'
+#!/usr/bin/env bash
+exit 99
+EOF
+  cat > "$sandbox/bin/clojure" <<'EOF'
+#!/usr/bin/env bash
+exit 99
+EOF
+  chmod +x "$sandbox/bin/node" "$sandbox/bin/java" "$sandbox/bin/clojure"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  assert_contains "$last_output" 'bundled v24.0.0'
+}
+
+test_setup_does_not_invoke_os_package_manager() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  cat > "$sandbox/bin/dnf" <<'EOF'
+#!/usr/bin/env bash
+printf 'dnf was invoked\n' >&2
+exit 91
+EOF
+  cat > "$sandbox/bin/yum" <<'EOF'
+#!/usr/bin/env bash
+printf 'yum was invoked\n' >&2
+exit 92
+EOF
+  chmod +x "$sandbox/bin/dnf" "$sandbox/bin/yum"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  assert_not_contains "$last_output" 'was invoked'
+}
+
+test_setup_rejects_bad_runtime_checksum() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  printf '%064d  logseq-sync-runtime-linux-x64.tar.gz\n' 0 \
+    > "$sandbox/logseq-sync-runtime-linux-x64.tar.gz.sha256"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_failure || return 1
+  assert_contains "$last_output" 'failed checksum verification'
+}
+
+test_setup_installs_checksum_verified_caddy() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  rm -f -- "$sandbox/home/bin/caddy"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  [[ -x "$sandbox/home/bin/caddy" ]] || return 1
+  assert_contains "$last_output" 'Downloading checksum-pinned Caddy 2.11.4'
+}
+
+test_setup_rejects_bad_caddy_checksum() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  rm -f -- "$sandbox/home/bin/caddy"
+  MOCK_CADDY_SHA512="$(printf '%0128d' 0)" \
+    run_manager "$sandbox" setup --domain sync.example.com
+  assert_failure || return 1
+  assert_contains "$last_output" 'Caddy archive failed checksum verification'
+}
+
+test_setup_replaces_tampered_caddy() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  printf '# tampered\n' >> "$sandbox/home/bin/caddy"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  assert_contains "$last_output" \
+    'installed Caddy binary does not match the pinned release' || return 1
+  assert_not_contains "$(<"$sandbox/home/bin/caddy")" '# tampered'
+}
+
+test_setup_rejects_wrong_runtime_architecture() {
+  local sandbox fixture asset
+  sandbox="$(make_sandbox)"
+  fixture="$sandbox/runtime-fixture/logseq-sync-runtime"
+  asset="$sandbox/logseq-sync-runtime-linux-x64.tar.gz"
+  printf 'arm64\n' > "$fixture/ARCHITECTURE"
+  tar -czf "$asset" -C "$sandbox/runtime-fixture" logseq-sync-runtime
+  (cd "$sandbox" && sha256sum "$(basename "$asset")" > "$(basename "$asset").sha256")
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_failure || return 1
+  assert_contains "$last_output" 'architecture does not match'
+}
+
+test_setup_rejects_incompatible_sqlite_runtime() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  MOCK_SQLITE_STATUS=1 run_manager "$sandbox" setup --domain sync.example.com
+  assert_failure || return 1
+  [[ ! -e "$sandbox/home/config" ]] || return 1
+  assert_contains "$last_output" 'SQLite module cannot run on this server'
+}
+
+test_setup_without_options_runs_guided_wizard() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  MOCK_ASSUME_YES=false MOCK_MANAGER_INPUT=$'sync.example.com\n\n\n\n' \
+    run_manager "$sandbox" setup
+  assert_success || return 1
+  assert_contains "$last_output" 'Logseq Sync setup' || return 1
+  assert_contains "$last_output" 'Step 1/3 - Sync domain name' || return 1
+  assert_contains "$last_output" 'Step 2/3 - Public HTTPS port [443]' || return 1
+  assert_contains "$last_output" 'Step 3/3 - Private Sync port [10011]' || return 1
+  assert_contains "$last_output" 'Runtime: prebuilt Linux x64 package'
+}
+
+test_guided_setup_accepts_custom_public_port() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  MOCK_ASSUME_YES=false MOCK_MANAGER_INPUT=$'sync.example.com\n10010\n\n\n' \
+    run_manager "$sandbox" setup
+  assert_success || return 1
+  assert_contains "$(<"$sandbox/home/config/sync.env")" \
+    'DB_SYNC_BASE_URL=https://sync.example.com:10010' || return 1
+  assert_contains "$(<"$sandbox/home/config/sync.env")" \
+    'LOGSEQ_SYNC_PUBLIC_PORT=10010' || return 1
+  assert_contains "$(<"$sandbox/home/config/Caddyfile")" \
+    'https://sync.example.com:10010 {'
+}
+
+test_setup_accepts_custom_ports() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com \
+    --public-port 12000 --internal-port 13000
+  assert_success || return 1
+  assert_contains "$(<"$sandbox/home/config/sync.env")" 'DB_SYNC_PORT=13000' || return 1
+  assert_contains "$(<"$sandbox/home/config/Caddyfile")" \
+    'https://sync.example.com:12000 {' || return 1
+  assert_contains "$(<"$sandbox/home/config/Caddyfile")" \
+    'reverse_proxy 127.0.0.1:13000'
+}
+
+test_custom_private_port_is_used_by_status() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com \
+    --public-port 12000 --internal-port 13000
+  assert_success || return 1
+  : > "$sandbox/curl.log"
+  run_manager "$sandbox" status
+  assert_success || return 1
+  assert_contains "$(<"$sandbox/curl.log")" \
+    'http://127.0.0.1:13000/health' || return 1
+  assert_contains "$(<"$sandbox/curl.log")" \
+    'https://sync.example.com:12000/health'
+}
+
+test_public_port_never_collides_with_private_port() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com --public-port 10011
+  assert_success || return 1
+  assert_contains "$(<"$sandbox/home/config/sync.env")" 'DB_SYNC_PORT=10012'
+}
+
+test_setup_rejects_invalid_port_and_domain_inputs() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain 'https://sync.example.com'
+  assert_failure || return 1
+  assert_contains "$last_output" 'Enter a valid DNS domain name' || return 1
+  run_manager "$sandbox" setup --domain sync.example.com \
+    --public-port 12000 --internal-port 12000
+  assert_failure || return 1
+  assert_contains "$last_output" 'must be different' || return 1
+  run_manager "$sandbox" setup --domain sync.example.com --public-port 80
+  assert_failure || return 1
+  assert_contains "$last_output" 'port 80 is reserved'
+}
+
+test_setup_rejects_unsafe_install_path() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  MOCK_SYNC_HOME="$sandbox/home with space" \
+    run_manager "$sandbox" setup --domain sync.example.com
+  assert_failure || return 1
+  assert_contains "$last_output" 'Unsafe deployment path'
+}
+
+test_setup_rejects_parent_path_segments() {
+  local sandbox unsafe_path
+  sandbox="$(make_sandbox)"
+  for unsafe_path in /opt/.. /var/lib/../.. /srv/x/../../; do
+    MOCK_SYNC_HOME="$unsafe_path" \
+      run_manager "$sandbox" setup --domain sync.example.com
+    assert_failure || return 1
+    assert_contains "$last_output" 'Unsafe deployment path' || return 1
+  done
+}
+
+test_setup_rejects_home_symlink_to_root() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  rm -rf -- "${sandbox:?}/home"
+  ln -s / "$sandbox/home"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_failure || return 1
+  assert_contains "$last_output" 'resolves to an unsafe location' || return 1
+  [[ ! -s "$sandbox/systemctl.log" ]]
+}
+
+test_setup_rejects_releases_symlink_to_root() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  ln -s / "$sandbox/home/releases"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_failure || return 1
+  assert_contains "$last_output" 'resolves to an unsafe location' || return 1
+  [[ ! -s "$sandbox/systemctl.log" ]]
+}
+
+test_setup_does_not_execute_release_symlink_target() {
+  local sandbox checksum release_id external_release marker
+  sandbox="$(make_sandbox)"
+  checksum="$(awk '{print $1}' "$sandbox/logseq-sync-runtime-linux-x64.tar.gz.sha256")"
+  release_id="runtime-v1-x64-${checksum:0:12}"
+  external_release="$sandbox/external-release"
+  marker="$sandbox/external-node-executed"
+  mkdir -p "$sandbox/home/releases" "$external_release/node/bin"
+  cat > "$external_release/node/bin/node" <<EOF
+#!/usr/bin/env bash
+touch "$marker"
+exit 0
+EOF
+  /bin/chmod +x "$external_release/node/bin/node"
+  ln -s "$external_release" "$sandbox/home/releases/$release_id"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_failure || return 1
+  assert_contains "$last_output" 'Refusing to use an unsafe runtime path' || return 1
+  [[ ! -e "$marker" ]]
+}
+
+test_status_rejects_missing_persisted_private_port() {
+  local sandbox env_file rewritten_env
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  env_file="$sandbox/home/config/sync.env"
+  rewritten_env="${env_file}.new"
+  sed '/^DB_SYNC_PORT=/d' "$env_file" > "$rewritten_env"
+  mv "$rewritten_env" "$env_file"
+  run_manager "$sandbox" status
+  assert_failure || return 1
+  assert_contains "$last_output" 'private Sync port is missing or invalid'
+}
+
+test_status_rejects_missing_private_bind_host() {
+  local sandbox env_file rewritten_env
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  env_file="$sandbox/home/config/sync.env"
+  rewritten_env="${env_file}.new"
+  sed '/^DB_SYNC_HOST=/d' "$env_file" > "$rewritten_env"
+  mv "$rewritten_env" "$env_file"
+  run_manager "$sandbox" status
+  assert_failure || return 1
+  assert_contains "$last_output" 'private Sync host must be 127.0.0.1'
+}
+
+test_status_rejects_missing_release_repository() {
+  local sandbox env_file rewritten_env
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  env_file="$sandbox/home/config/sync.env"
+  rewritten_env="${env_file}.new"
+  sed '/^LOGSEQ_SYNC_RELEASE_REPOSITORY=/d' "$env_file" > "$rewritten_env"
+  mv "$rewritten_env" "$env_file"
+  run_manager "$sandbox" status
+  assert_failure || return 1
+  assert_contains "$last_output" 'runtime repository is missing or invalid'
+}
+
+test_unresolved_domain_stops_before_install() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  MOCK_DNS_STATUS=1 run_manager "$sandbox" setup --domain sync.example.com
+  assert_failure || return 1
+  [[ ! -e "$sandbox/home/config" ]] || return 1
+  [[ ! -e "$sandbox/home/current" ]] || return 1
+  assert_contains "$last_output" 'domain does not currently resolve'
+}
+
+test_default_auth_is_generated_without_prompts() {
+  local sandbox env_file
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  env_file="$(<"$sandbox/home/config/sync.env")"
+  assert_contains "$env_file" \
+    'COGNITO_ISSUER=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8' || return 1
+  assert_contains "$env_file" 'COGNITO_CLIENT_ID=69cs1lgme7p8kbgld8n5kseii6'
+}
+
+test_status_checks_private_and_public_endpoints_once() {
+  local sandbox curl_count
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  : > "$sandbox/curl.log"
+  run_manager "$sandbox" status
+  assert_success || return 1
+  curl_count="$(wc -l < "$sandbox/curl.log" | tr -d ' ')"
+  [[ "$curl_count" -eq 2 ]] || return 1
+  assert_contains "$last_output" 'Runtime version: runtime-v1' || return 1
+  assert_contains "$last_output" 'Health: ok'
+}
+
+test_update_preserves_configuration_and_switches_release() {
+  local sandbox before_env before_release after_release
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  before_env="$(<"$sandbox/home/config/sync.env")"
+  before_release="$(readlink "$sandbox/home/current")"
+  make_runtime_fixture "$sandbox" runtime-v2
+  run_manager "$sandbox" update
+  assert_success || return 1
+  after_release="$(readlink "$sandbox/home/current")"
+  [[ "$before_release" != "$after_release" ]] || return 1
+  [[ "$before_env" == "$(<"$sandbox/home/config/sync.env")" ]] || return 1
+  assert_contains "$(<"$sandbox/home/bin/logseq-sync-native")" \
+    '# fixture-manager=runtime-v2' || return 1
+  assert_contains "$last_output" 'Prepared Sync runtime runtime-v2' || return 1
+  assert_contains "$last_output" 'was updated successfully'
+}
+
+test_update_skips_unchanged_runtime() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  : > "$sandbox/systemctl.log"
+  run_manager "$sandbox" update
+  assert_success || return 1
+  [[ ! -s "$sandbox/systemctl.log" ]] || return 1
+  assert_contains "$last_output" 'already up to date'
+}
+
+test_setup_repairs_corrupt_current_runtime() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  rm -f -- "$sandbox/home/current/app/node-adapter.js"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  [[ -f "$sandbox/home/current/app/node-adapter.js" ]]
+}
+
+test_setup_restores_previous_configuration_on_health_failure() {
+  local sandbox before_env before_caddyfile
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  before_env="$(<"$sandbox/home/config/sync.env")"
+  before_caddyfile="$(<"$sandbox/home/config/Caddyfile")"
+  printf '0\n' > "$sandbox/curl-count"
+  MOCK_CURL_FAILURES=30 run_manager "$sandbox" setup \
+    --domain other.example.com --public-port 12000 --internal-port 13000
+  assert_failure || return 1
+  [[ "$(<"$sandbox/home/config/sync.env")" == "$before_env" ]] || return 1
+  [[ "$(<"$sandbox/home/config/Caddyfile")" == "$before_caddyfile" ]] || return 1
+  assert_contains "$last_output" 'previous working configuration was restored'
+}
+
+test_setup_restores_previous_configuration_on_write_failure() {
+  local sandbox before_env before_caddyfile before_sync_service before_proxy_service
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  before_env="$(<"$sandbox/home/config/sync.env")"
+  before_caddyfile="$(<"$sandbox/home/config/Caddyfile")"
+  before_sync_service="$(<"$sandbox/systemd/logseq-sync.service")"
+  before_proxy_service="$(<"$sandbox/systemd/logseq-sync-caddy.service")"
+  cat > "$sandbox/bin/chmod" <<'EOF'
+#!/usr/bin/env bash
+for argument in "$@"; do
+  if [[ "$argument" == */Caddyfile.new ]]; then
+    exit 1
+  fi
+done
+exec /bin/chmod "$@"
+EOF
+  /bin/chmod +x "$sandbox/bin/chmod"
+  run_manager "$sandbox" setup --domain other.example.com \
+    --public-port 12000 --internal-port 13000
+  assert_failure || return 1
+  [[ "$(<"$sandbox/home/config/sync.env")" == "$before_env" ]] || return 1
+  [[ "$(<"$sandbox/home/config/Caddyfile")" == "$before_caddyfile" ]] || return 1
+  [[ "$(<"$sandbox/systemd/logseq-sync.service")" == "$before_sync_service" ]] || return 1
+  [[ "$(<"$sandbox/systemd/logseq-sync-caddy.service")" == "$before_proxy_service" ]] || return 1
+  assert_contains "$last_output" \
+    'could not write the new configuration; the previous working configuration was restored'
+}
+
+test_update_rolls_back_private_health_failure() {
+  local sandbox previous_release
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  previous_release="$(readlink "$sandbox/home/current")"
+  make_runtime_fixture "$sandbox" runtime-v2
+  printf '0\n' > "$sandbox/curl-count"
+  MOCK_CURL_FAILURES=30 run_manager "$sandbox" update
+  assert_failure || return 1
+  [[ "$(readlink "$sandbox/home/current")" == "$previous_release" ]] || return 1
+  assert_contains "$(<"$sandbox/home/bin/logseq-sync-native")" \
+    '# fixture-manager=runtime-v1' || return 1
+  assert_contains "$last_output" 'previous release was restored'
+}
+
+test_update_rolls_back_public_health_failure() {
+  local sandbox previous_release
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  previous_release="$(readlink "$sandbox/home/current")"
+  make_runtime_fixture "$sandbox" runtime-v2
+  printf '0\n' > "$sandbox/curl-count"
+  MOCK_CURL_FAIL_FROM=2 MOCK_CURL_FAIL_THROUGH=7 \
+    run_manager "$sandbox" update
+  assert_failure || return 1
+  [[ "$(readlink "$sandbox/home/current")" == "$previous_release" ]] || return 1
+  assert_contains "$(<"$sandbox/home/bin/logseq-sync-native")" \
+    '# fixture-manager=runtime-v1' || return 1
+  assert_contains "$last_output" 'previous release was restored'
+}
+
+test_update_rolls_back_restart_failure() {
+  local sandbox previous_release
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  previous_release="$(readlink "$sandbox/home/current")"
+  make_runtime_fixture "$sandbox" runtime-v2
+  printf '0\n' > "$sandbox/systemctl-count"
+  MOCK_SYSTEMCTL_FAIL_CALL=1 run_manager "$sandbox" update
+  assert_failure || return 1
+  [[ "$(readlink "$sandbox/home/current")" == "$previous_release" ]] || return 1
+  assert_contains "$last_output" 'previous release was restored'
+}
+
+test_update_rolls_back_manager_install_failure() {
+  local sandbox previous_release
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  previous_release="$(readlink "$sandbox/home/current")"
+  make_runtime_fixture "$sandbox" runtime-v2
+  cat > "$sandbox/bin/install" <<'EOF'
+#!/usr/bin/env bash
+last_argument=""
+for argument in "$@"; do
+  last_argument="$argument"
+done
+if [[ "$last_argument" == *.new ]]; then
+  exit 1
+fi
+exec /usr/bin/install "$@"
+EOF
+  chmod +x "$sandbox/bin/install"
+  run_manager "$sandbox" update
+  assert_failure || return 1
+  [[ "$(readlink "$sandbox/home/current")" == "$previous_release" ]] || return 1
+  assert_contains "$(<"$sandbox/home/bin/logseq-sync-native")" \
+    '# fixture-manager=runtime-v1' || return 1
+  assert_contains "$last_output" 'manager update failed'
+}
+
+test_update_rolls_back_public_manager_link_failure() {
+  local sandbox previous_release
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  previous_release="$(readlink "$sandbox/home/current")"
+  make_runtime_fixture "$sandbox" runtime-v2
+  unlink "$sandbox/bin/logseq-sync-native-installed"
+  mkdir "$sandbox/bin/logseq-sync-native-installed"
+  run_manager "$sandbox" update
+  assert_failure || return 1
+  [[ "$(readlink "$sandbox/home/current")" == "$previous_release" ]] || return 1
+  assert_contains "$(<"$sandbox/home/bin/logseq-sync-native")" \
+    '# fixture-manager=runtime-v1' || return 1
+  assert_contains "$last_output" 'manager update failed'
+}
+
+test_update_keeps_only_current_and_previous_releases() {
+  local sandbox release_count
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com
+  assert_success || return 1
+  make_runtime_fixture "$sandbox" runtime-v2
+  run_manager "$sandbox" update
+  assert_success || return 1
+  make_runtime_fixture "$sandbox" runtime-v3
+  run_manager "$sandbox" update
+  assert_success || return 1
+  release_count="$(find "$sandbox/home/releases" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+  [[ "$release_count" -eq 2 ]]
+}
+
+test_installed_manager_can_rerun_setup() {
+  local sandbox installed_manager
+  sandbox="$(make_sandbox)"
+  run_manager "$sandbox" setup --domain sync.example.com --public-port 12000
+  assert_success || return 1
+  installed_manager="$sandbox/bin/logseq-sync-native-installed"
+  [[ -x "$installed_manager" ]] || return 1
+  manager_under_test="$installed_manager"
+  MOCK_SYNC_HOME="" run_manager "$sandbox" setup --domain sync.example.com
+  manager_under_test="$manager"
+  assert_success || return 1
+  assert_contains "$last_output" 'https://sync.example.com:12000'
+}
+
+run_test() {
+  local name="$1"
+  if "$name"; then
+    pass_count=$((pass_count + 1))
+    printf 'ok - %s\n' "$name"
+  else
+    fail_count=$((fail_count + 1))
+    printf 'not ok - %s\n' "$name"
+  fi
+}
+
+run_test test_setup_uses_prebuilt_runtime_and_default_ports
+run_test test_setup_prints_progress_during_health_retries
+run_test test_setup_ignores_broken_system_node_and_build_tools
+run_test test_setup_does_not_invoke_os_package_manager
+run_test test_setup_rejects_bad_runtime_checksum
+run_test test_setup_installs_checksum_verified_caddy
+run_test test_setup_rejects_bad_caddy_checksum
+run_test test_setup_replaces_tampered_caddy
+run_test test_setup_rejects_wrong_runtime_architecture
+run_test test_setup_rejects_incompatible_sqlite_runtime
+run_test test_setup_without_options_runs_guided_wizard
+run_test test_guided_setup_accepts_custom_public_port
+run_test test_setup_accepts_custom_ports
+run_test test_custom_private_port_is_used_by_status
+run_test test_public_port_never_collides_with_private_port
+run_test test_setup_rejects_invalid_port_and_domain_inputs
+run_test test_setup_rejects_unsafe_install_path
+run_test test_setup_rejects_parent_path_segments
+run_test test_setup_rejects_home_symlink_to_root
+run_test test_setup_rejects_releases_symlink_to_root
+run_test test_setup_does_not_execute_release_symlink_target
+run_test test_status_rejects_missing_persisted_private_port
+run_test test_status_rejects_missing_private_bind_host
+run_test test_status_rejects_missing_release_repository
+run_test test_unresolved_domain_stops_before_install
+run_test test_default_auth_is_generated_without_prompts
+run_test test_status_checks_private_and_public_endpoints_once
+run_test test_update_preserves_configuration_and_switches_release
+run_test test_update_skips_unchanged_runtime
+run_test test_setup_repairs_corrupt_current_runtime
+run_test test_setup_restores_previous_configuration_on_health_failure
+run_test test_setup_restores_previous_configuration_on_write_failure
+run_test test_update_rolls_back_private_health_failure
+run_test test_update_rolls_back_public_health_failure
+run_test test_update_rolls_back_restart_failure
+run_test test_update_rolls_back_manager_install_failure
+run_test test_update_rolls_back_public_manager_link_failure
+run_test test_update_keeps_only_current_and_previous_releases
+run_test test_installed_manager_can_rerun_setup
+
+printf '%s passed, %s failed\n' "$pass_count" "$fail_count"
+[[ "$fail_count" -eq 0 ]]

--- a/deps/db-sync/deploy/package-native-runtime.sh
+++ b/deps/db-sync/deploy/package-native-runtime.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly script_dir
+db_sync_dir="$(cd -- "$script_dir/.." && pwd)"
+readonly db_sync_dir
+
+die() {
+  printf 'Error: %s\n' "$*" >&2
+  exit 1
+}
+
+runtime_version="${1:-}"
+runtime_arch="${2:-}"
+output_dir="${3:-}"
+node_binary="${NODE_BINARY:-$(command -v node 2>/dev/null || true)}"
+default_release_repository="${DEFAULT_RELEASE_REPOSITORY:-}"
+
+[[ -n "$runtime_version" ]] || die "Usage: $0 <version> <x64|arm64> <output-directory>"
+[[ "$runtime_version" =~ ^[A-Za-z0-9._+-]+$ ]] \
+  || die "Runtime version contains unsupported characters: $runtime_version"
+[[ "$runtime_arch" == "x64" || "$runtime_arch" == "arm64" ]] \
+  || die "Runtime architecture must be x64 or arm64."
+[[ -n "$output_dir" ]] || die "Output directory is required."
+[[ -x "$node_binary" ]] || die "NODE_BINARY must point to an executable Node.js binary."
+if [[ -n "$default_release_repository" ]]; then
+  [[ "$default_release_repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] \
+    || die "DEFAULT_RELEASE_REPOSITORY must be an owner/repository pair."
+fi
+[[ -f "$db_sync_dir/worker/dist/node-adapter.js" ]] \
+  || die "Build worker/dist/node-adapter.js before packaging."
+[[ -d "$db_sync_dir/node_modules" ]] || die "Install production dependencies before packaging."
+
+case "$(uname -m)" in
+  x86_64) host_arch="x64" ;;
+  aarch64|arm64) host_arch="arm64" ;;
+  *) die "Unsupported build host architecture: $(uname -m)" ;;
+esac
+[[ "$host_arch" == "$runtime_arch" ]] \
+  || die "Native runtime must be packaged on its target architecture ($runtime_arch)."
+
+stage_dir="$(mktemp -d "${TMPDIR:-/tmp}/logseq-sync-runtime-package.XXXXXX")"
+cleanup() {
+  [[ -d "$stage_dir" ]] && rm -rf -- "$stage_dir"
+}
+trap cleanup EXIT
+
+runtime_dir="$stage_dir/logseq-sync-runtime"
+mkdir -p "$runtime_dir/node/bin" "$runtime_dir/app" "$runtime_dir/bin" "$output_dir"
+install -m 0755 "$node_binary" "$runtime_dir/node/bin/node"
+install -m 0644 "$db_sync_dir/worker/dist/node-adapter.js" \
+  "$runtime_dir/app/node-adapter.js"
+cp -a "$db_sync_dir/node_modules" "$runtime_dir/app/node_modules"
+if [[ -n "$default_release_repository" ]]; then
+  sed "s|readonly default_release_repository=\"logseq/logseq\"|readonly default_release_repository=\"${default_release_repository}\"|" \
+    "$script_dir/logseq-sync-native" > "$runtime_dir/bin/logseq-sync-native"
+  chmod 0755 "$runtime_dir/bin/logseq-sync-native"
+else
+  install -m 0755 "$script_dir/logseq-sync-native" "$runtime_dir/bin/logseq-sync-native"
+fi
+printf '%s\n' "$runtime_version" > "$runtime_dir/VERSION"
+printf '%s\n' "$runtime_arch" > "$runtime_dir/ARCHITECTURE"
+
+archive="logseq-sync-runtime-linux-${runtime_arch}.tar.gz"
+tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner \
+  -czf "$output_dir/$archive" -C "$stage_dir" logseq-sync-runtime
+(
+  cd "$output_dir"
+  sha256sum "$archive" > "$archive.sha256"
+)
+printf 'Created %s\n' "$output_dir/$archive"

--- a/deps/db-sync/deploy/test.sh
+++ b/deps/db-sync/deploy/test.sh
@@ -1,0 +1,418 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+test_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly test_dir
+readonly manager="$test_dir/logseq-sync"
+suite_tmp="$(mktemp -d "${TMPDIR:-/tmp}/logseq-sync-test-suite.XXXXXX")"
+readonly suite_tmp
+
+cleanup() {
+  if [[ -d "$suite_tmp" && "$suite_tmp" == *logseq-sync-test-suite.* ]]; then
+    rm -rf -- "$suite_tmp"
+  fi
+}
+
+trap cleanup EXIT
+
+pass_count=0
+fail_count=0
+
+make_sandbox() {
+  local sandbox
+  sandbox="$(mktemp -d "$suite_tmp/case.XXXXXX")"
+  mkdir -p "$sandbox/bin" "$sandbox/home"
+
+  cat > "$sandbox/bin/uname" <<'EOF'
+#!/usr/bin/env bash
+printf 'Linux\n'
+EOF
+
+  cat > "$sandbox/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_DOCKER_LOG"
+case "$*" in
+  "compose version") exit 0 ;;
+  "info") exit "${MOCK_DOCKER_INFO_STATUS:-0}" ;;
+  *" ps --format json "*)
+    printf '{"Health":"%s","State":"running"}\n' "${MOCK_DOCKER_HEALTH:-healthy}"
+    ;;
+  *) exit "${MOCK_DOCKER_STATUS:-0}" ;;
+esac
+EOF
+
+  cat > "$sandbox/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_CURL_LOG"
+if [[ "${MOCK_CURL_STATUS:-0}" -ne 0 ]]; then
+  exit "$MOCK_CURL_STATUS"
+fi
+printf '%s' "${MOCK_CURL_BODY:-{\"ok\":true}}"
+EOF
+
+  cat > "$sandbox/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_SLEEP_LOG"
+EOF
+
+  chmod +x "$sandbox/bin/uname" "$sandbox/bin/docker" "$sandbox/bin/curl" "$sandbox/bin/sleep"
+  printf '%s' "$sandbox"
+}
+
+run_manager() {
+  local sandbox="$1"
+  local input="$2"
+  shift 2
+  set +e
+  last_output="$(printf '%s' "$input" | env \
+    HOME="$sandbox/home" \
+    PATH="$sandbox/bin:$PATH" \
+    MOCK_DOCKER_LOG="$sandbox/docker.log" \
+    MOCK_CURL_LOG="$sandbox/curl.log" \
+    MOCK_SLEEP_LOG="$sandbox/sleep.log" \
+    "$@" \
+    "$manager" setup 2>&1)"
+  last_status=$?
+  set -e
+}
+
+assert_contains() {
+  local value="$1"
+  local expected="$2"
+  [[ "$value" == *"$expected"* ]] || {
+    printf 'Expected to find %q in:\n%s\n' "$expected" "$value" >&2
+    return 1
+  }
+}
+
+assert_not_contains() {
+  local value="$1"
+  local unexpected="$2"
+  [[ "$value" != *"$unexpected"* ]] || {
+    printf 'Did not expect to find %q in:\n%s\n' "$unexpected" "$value" >&2
+    return 1
+  }
+}
+
+assert_success() {
+  [[ "$last_status" -eq 0 ]] || {
+    printf 'Expected success, got status %s:\n%s\n' "$last_status" "$last_output" >&2
+    return 1
+  }
+}
+
+assert_failure() {
+  [[ "$last_status" -ne 0 ]] || {
+    printf 'Expected failure:\n%s\n' "$last_output" >&2
+    return 1
+  }
+}
+
+test_unhealthy_service_is_rejected() {
+  local sandbox input
+  sandbox="$(make_sandbox)"
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    https \
+    sync.example.com \
+    logseq-client \
+    y)"
+  run_manager "$sandbox" "$input" MOCK_DOCKER_HEALTH=unhealthy
+  assert_failure || return 1
+  assert_not_contains "$last_output" 'Logseq Sync is ready'
+}
+
+test_health_body_is_verified() {
+  local sandbox input
+  sandbox="$(make_sandbox)"
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    https \
+    sync.example.com \
+    logseq-client \
+    y)"
+  run_manager "$sandbox" "$input" 'MOCK_CURL_BODY={"ok":false}'
+  assert_failure || return 1
+  assert_not_contains "$last_output" 'Logseq Sync is ready'
+}
+
+test_docker_daemon_is_checked_before_writes() {
+  local sandbox input
+  sandbox="$(make_sandbox)"
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    https \
+    sync.example.com \
+    logseq-client \
+    y)"
+  run_manager "$sandbox" "$input" MOCK_DOCKER_INFO_STATUS=1
+  assert_failure || return 1
+  [[ ! -e "$sandbox/install" ]]
+}
+
+test_existing_configuration_becomes_prompt_defaults() {
+  local sandbox input env_file
+  sandbox="$(make_sandbox)"
+  mkdir -p "$sandbox/install"
+  env_file="$sandbox/install/.env"
+  cat > "$env_file" <<EOF
+LOGSEQ_SYNC_SOURCE_DIR=/old/source
+LOGSEQ_SYNC_INSTALL_DIR=$sandbox/install
+LOGSEQ_SYNC_DATA_DIR=$sandbox/existing-data
+LOGSEQ_SYNC_UID=1000
+LOGSEQ_SYNC_GID=1000
+LOGSEQ_SYNC_ENDPOINT_MODE=https
+DB_SYNC_BASE_URL=https://old-sync.example.com:10010
+DB_SYNC_BIND_ADDRESS=127.0.0.1
+DB_SYNC_PUBLIC_PORT=10010
+DB_SYNC_LOG_LEVEL=debug
+COGNITO_ISSUER=https://issuer.example.com/pool
+COGNITO_CLIENT_ID=custom-client
+COGNITO_JWKS_URL=https://issuer.example.com/pool/.well-known/jwks.json
+EOF
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    '' \
+    '' \
+    '' \
+    '' \
+    '' \
+    '' \
+    '' \
+    y \
+    y)"
+  run_manager "$sandbox" "$input"
+  assert_success || return 1
+  assert_contains "$(<"$env_file")" "LOGSEQ_SYNC_DATA_DIR=$sandbox/existing-data"
+  assert_contains "$(<"$env_file")" 'DB_SYNC_BASE_URL=https://old-sync.example.com:10010'
+  assert_contains "$(<"$env_file")" 'COGNITO_CLIENT_ID=custom-client'
+}
+
+test_https_to_http_removes_caddy_container() {
+  local sandbox input
+  sandbox="$(make_sandbox)"
+  mkdir -p "$sandbox/install"
+  cat > "$sandbox/install/.env" <<EOF
+LOGSEQ_SYNC_SOURCE_DIR=/old/source
+LOGSEQ_SYNC_INSTALL_DIR=$sandbox/install
+LOGSEQ_SYNC_DATA_DIR=$sandbox/data
+LOGSEQ_SYNC_UID=1000
+LOGSEQ_SYNC_GID=1000
+LOGSEQ_SYNC_ENDPOINT_MODE=https
+DB_SYNC_BASE_URL=https://old-sync.example.com:10010
+DB_SYNC_BIND_ADDRESS=127.0.0.1
+DB_SYNC_PUBLIC_PORT=10010
+DB_SYNC_LOG_LEVEL=info
+COGNITO_ISSUER=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8
+COGNITO_CLIENT_ID=69cs1lgme7p8kbgld8n5kseii6
+COGNITO_JWKS_URL=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8/.well-known/jwks.json
+EOF
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    http \
+    http://127.0.0.1:18080 \
+    I_ACCEPT_HTTP \
+    logseq-client \
+    y \
+    y)"
+  run_manager "$sandbox" "$input"
+  assert_success || return 1
+  assert_contains "$(<"$sandbox/docker.log")" 'rm --stop --force caddy'
+}
+
+test_https_to_http_keeps_caddy_when_replacement_fails() {
+  local sandbox input
+  sandbox="$(make_sandbox)"
+  mkdir -p "$sandbox/install"
+  cat > "$sandbox/install/.env" <<EOF
+LOGSEQ_SYNC_SOURCE_DIR=/old/source
+LOGSEQ_SYNC_INSTALL_DIR=$sandbox/install
+LOGSEQ_SYNC_DATA_DIR=$sandbox/data
+LOGSEQ_SYNC_UID=1000
+LOGSEQ_SYNC_GID=1000
+LOGSEQ_SYNC_ENDPOINT_MODE=https
+DB_SYNC_BASE_URL=https://old-sync.example.com
+DB_SYNC_BIND_ADDRESS=127.0.0.1
+DB_SYNC_PUBLIC_PORT=443
+DB_SYNC_LOG_LEVEL=info
+COGNITO_ISSUER=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8
+COGNITO_CLIENT_ID=69cs1lgme7p8kbgld8n5kseii6
+COGNITO_JWKS_URL=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8/.well-known/jwks.json
+EOF
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    http \
+    http://127.0.0.1:18080 \
+    I_ACCEPT_HTTP \
+    logseq-client \
+    y \
+    y)"
+  run_manager "$sandbox" "$input" MOCK_DOCKER_STATUS=1
+  assert_failure || return 1
+  assert_not_contains "$(<"$sandbox/docker.log")" 'rm --stop --force caddy'
+}
+
+test_https_setup_force_recreates_caddy() {
+  local sandbox input
+  sandbox="$(make_sandbox)"
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    https \
+    sync.example.com \
+    logseq-client \
+    y)"
+  run_manager "$sandbox" "$input"
+  assert_success || return 1
+  assert_contains "$(<"$sandbox/docker.log")" '--force-recreate'
+  assert_contains "$(<"$sandbox/install/.env")" \
+    'DB_SYNC_BASE_URL=https://sync.example.com' || return 1
+  assert_contains "$(<"$sandbox/install/Caddyfile")" \
+    'https://sync.example.com {'
+}
+
+test_http_setup_verifies_public_endpoint() {
+  local sandbox input
+  sandbox="$(make_sandbox)"
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    http \
+    http://127.0.0.1:18080 \
+    I_ACCEPT_HTTP \
+    logseq-client \
+    y)"
+  run_manager "$sandbox" "$input" MOCK_CURL_STATUS=1
+  assert_failure || return 1
+  assert_contains "$last_output" 'Public endpoint did not return {"ok":true}'
+}
+
+test_invalid_http_host_is_rejected() {
+  local sandbox input
+  sandbox="$(make_sandbox)"
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    http \
+    http://999.999.999.999:18080)"
+  run_manager "$sandbox" "$input"
+  assert_failure || return 1
+  assert_contains "$last_output" 'HTTP URL must include a valid hostname or IPv4 address and port.'
+  [[ ! -e "$sandbox/install" ]]
+}
+
+test_invalid_custom_auth_url_is_rejected() {
+  local sandbox input
+  sandbox="$(make_sandbox)"
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    https \
+    sync.example.com \
+    custom-client \
+    https://-)"
+  run_manager "$sandbox" "$input"
+  assert_failure || return 1
+  assert_contains "$last_output" 'Cognito issuer must be a valid HTTPS URL.'
+  [[ ! -e "$sandbox/install" ]]
+}
+
+test_logs_proxy_maps_to_caddy() {
+  local sandbox
+  sandbox="$(make_sandbox)"
+  mkdir -p "$sandbox/install"
+  cat > "$sandbox/install/.env" <<EOF
+LOGSEQ_SYNC_ENDPOINT_MODE=https
+LOGSEQ_SYNC_SOURCE_DIR=$test_dir/../../..
+LOGSEQ_SYNC_INSTALL_DIR=$sandbox/install
+LOGSEQ_SYNC_DATA_DIR=$sandbox/data
+LOGSEQ_SYNC_UID=1000
+LOGSEQ_SYNC_GID=1000
+DB_SYNC_BASE_URL=https://sync.example.com:10010
+COGNITO_ISSUER=https://issuer.example.com
+COGNITO_CLIENT_ID=client
+COGNITO_JWKS_URL=https://issuer.example.com/.well-known/jwks.json
+EOF
+  cp "$test_dir/compose.yaml" "$sandbox/install/compose.yaml"
+  set +e
+  last_output="$(env \
+    HOME="$sandbox/home" \
+    PATH="$sandbox/bin:$PATH" \
+    MOCK_DOCKER_LOG="$sandbox/docker.log" \
+    MOCK_CURL_LOG="$sandbox/curl.log" \
+    MOCK_SLEEP_LOG="$sandbox/sleep.log" \
+    "$manager" logs proxy "$sandbox/install" 2>&1)"
+  last_status=$?
+  set -e
+  assert_success || return 1
+  assert_contains "$(<"$sandbox/docker.log")" 'logs --tail 200 caddy'
+}
+
+test_status_uses_one_shot_health_checks() {
+  local sandbox health_check_count
+  sandbox="$(make_sandbox)"
+  mkdir -p "$sandbox/install"
+  cat > "$sandbox/install/.env" <<EOF
+LOGSEQ_SYNC_ENDPOINT_MODE=http
+LOGSEQ_SYNC_SOURCE_DIR=$test_dir/../../..
+LOGSEQ_SYNC_INSTALL_DIR=$sandbox/install
+LOGSEQ_SYNC_DATA_DIR=$sandbox/data
+LOGSEQ_SYNC_UID=1000
+LOGSEQ_SYNC_GID=1000
+DB_SYNC_BASE_URL=http://127.0.0.1:18080
+COGNITO_ISSUER=https://issuer.example.com
+COGNITO_CLIENT_ID=client
+COGNITO_JWKS_URL=https://issuer.example.com/.well-known/jwks.json
+EOF
+  cp "$test_dir/compose.yaml" "$sandbox/install/compose.yaml"
+  cp "$test_dir/compose.http.yaml" "$sandbox/install/compose.http.yaml"
+  set +e
+  last_output="$(env \
+    HOME="$sandbox/home" \
+    PATH="$sandbox/bin:$PATH" \
+    MOCK_DOCKER_LOG="$sandbox/docker.log" \
+    MOCK_CURL_LOG="$sandbox/curl.log" \
+    MOCK_SLEEP_LOG="$sandbox/sleep.log" \
+    MOCK_DOCKER_HEALTH=unhealthy \
+    "$manager" status "$sandbox/install" 2>&1)"
+  last_status=$?
+  set -e
+  assert_failure || return 1
+  health_check_count="$(grep -c 'ps --format json sync' "$sandbox/docker.log")"
+  [[ "$health_check_count" -eq 1 ]] || {
+    printf 'Expected one health check, got %s:\n%s\n' "$health_check_count" "$(<"$sandbox/docker.log")" >&2
+    return 1
+  }
+}
+
+run_test() {
+  local name="$1"
+  if "$name"; then
+    pass_count=$((pass_count + 1))
+    printf 'ok - %s\n' "$name"
+  else
+    fail_count=$((fail_count + 1))
+    printf 'not ok - %s\n' "$name"
+  fi
+}
+
+run_test test_unhealthy_service_is_rejected
+run_test test_health_body_is_verified
+run_test test_docker_daemon_is_checked_before_writes
+run_test test_existing_configuration_becomes_prompt_defaults
+run_test test_https_to_http_removes_caddy_container
+run_test test_https_to_http_keeps_caddy_when_replacement_fails
+run_test test_https_setup_force_recreates_caddy
+run_test test_http_setup_verifies_public_endpoint
+run_test test_invalid_http_host_is_rejected
+run_test test_invalid_custom_auth_url_is_rejected
+run_test test_logs_proxy_maps_to_caddy
+run_test test_status_uses_one_shot_health_checks
+
+printf '%s passed, %s failed\n' "$pass_count" "$fail_count"
+[[ "$fail_count" -eq 0 ]]

--- a/deps/db-sync/deploy/test.sh
+++ b/deps/db-sync/deploy/test.sh
@@ -34,8 +34,23 @@ printf '%s\n' "$*" >> "$MOCK_DOCKER_LOG"
 case "$*" in
   "compose version") exit 0 ;;
   "info") exit "${MOCK_DOCKER_INFO_STATUS:-0}" ;;
+esac
+if [[ -n "${MOCK_DOCKER_FAIL_ONCE_PATTERN:-}" \
+      && "$*" == *"$MOCK_DOCKER_FAIL_ONCE_PATTERN"* \
+      && "$(grep -F -c -- "$MOCK_DOCKER_FAIL_ONCE_PATTERN" "$MOCK_DOCKER_LOG")" -eq 1 ]]; then
+  exit 1
+fi
+if [[ "$*" == *" up -d --force-recreate"* ]]; then
+  : > "$MOCK_DOCKER_STATE_DIR/rollback-started"
+fi
+case "$*" in
   *" ps --format json "*)
-    printf '{"Health":"%s","State":"running"}\n' "${MOCK_DOCKER_HEALTH:-healthy}"
+    health="${MOCK_DOCKER_HEALTH:-healthy}"
+    if [[ "${MOCK_DOCKER_UNHEALTHY_UNTIL_ROLLBACK:-0}" == "1" \
+          && ! -f "$MOCK_DOCKER_STATE_DIR/rollback-started" ]]; then
+      health="unhealthy"
+    fi
+    printf '{"Health":"%s","State":"running"}\n' "$health"
     ;;
   *) exit "${MOCK_DOCKER_STATUS:-0}" ;;
 esac
@@ -44,6 +59,10 @@ EOF
   cat > "$sandbox/bin/curl" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$MOCK_CURL_LOG"
+if [[ -n "${MOCK_CURL_FAIL_PATTERN:-}" \
+      && "$*" == *"$MOCK_CURL_FAIL_PATTERN"* ]]; then
+  exit 1
+fi
 if [[ "${MOCK_CURL_STATUS:-0}" -ne 0 ]]; then
   exit "$MOCK_CURL_STATUS"
 fi
@@ -55,7 +74,19 @@ EOF
 printf '%s\n' "$*" >> "$MOCK_SLEEP_LOG"
 EOF
 
-  chmod +x "$sandbox/bin/uname" "$sandbox/bin/docker" "$sandbox/bin/curl" "$sandbox/bin/sleep"
+  cat > "$sandbox/bin/mv" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_MV_LOG"
+if [[ -n "${MOCK_MV_FAIL_ONCE_PATTERN:-}" \
+      && "$*" == *"$MOCK_MV_FAIL_ONCE_PATTERN"* \
+      && "$(grep -F -c -- "$MOCK_MV_FAIL_ONCE_PATTERN" "$MOCK_MV_LOG")" -eq 1 ]]; then
+  exit 1
+fi
+PATH=/usr/bin:/bin exec mv "$@"
+EOF
+
+  chmod +x "$sandbox/bin/uname" "$sandbox/bin/docker" "$sandbox/bin/curl" \
+    "$sandbox/bin/sleep" "$sandbox/bin/mv"
   printf '%s' "$sandbox"
 }
 
@@ -70,6 +101,8 @@ run_manager() {
     MOCK_DOCKER_LOG="$sandbox/docker.log" \
     MOCK_CURL_LOG="$sandbox/curl.log" \
     MOCK_SLEEP_LOG="$sandbox/sleep.log" \
+    MOCK_MV_LOG="$sandbox/mv.log" \
+    MOCK_DOCKER_STATE_DIR="$sandbox" \
     "$@" \
     "$manager" setup 2>&1)"
   last_status=$?
@@ -108,6 +141,15 @@ assert_failure() {
   }
 }
 
+assert_managed_configuration_matches() {
+  local expected_dir="$1"
+  local actual_dir="$2"
+  local name
+  for name in compose.yaml compose.http.yaml .env Caddyfile; do
+    cmp "$expected_dir/$name" "$actual_dir/$name" || return 1
+  done
+}
+
 test_unhealthy_service_is_rejected() {
   local sandbox input
   sandbox="$(make_sandbox)"
@@ -121,6 +163,9 @@ test_unhealthy_service_is_rejected() {
   run_manager "$sandbox" "$input" MOCK_DOCKER_HEALTH=unhealthy
   assert_failure || return 1
   assert_not_contains "$last_output" 'Logseq Sync is ready'
+  [[ -f "$sandbox/install/.env" ]] || return 1
+  assert_not_contains "$last_output" 'previous working deployment was restored'
+  assert_not_contains "$(<"$sandbox/docker.log")" ' up -d --force-recreate'
 }
 
 test_health_body_is_verified() {
@@ -136,6 +181,8 @@ test_health_body_is_verified() {
   run_manager "$sandbox" "$input" 'MOCK_CURL_BODY={"ok":false}'
   assert_failure || return 1
   assert_not_contains "$last_output" 'Logseq Sync is ready'
+  [[ -f "$sandbox/install/.env" ]] || return 1
+  assert_not_contains "$last_output" 'previous working deployment was restored'
 }
 
 test_docker_daemon_is_checked_before_writes() {
@@ -151,6 +198,27 @@ test_docker_daemon_is_checked_before_writes() {
   run_manager "$sandbox" "$input" MOCK_DOCKER_INFO_STATUS=1
   assert_failure || return 1
   [[ ! -e "$sandbox/install" ]]
+}
+
+test_first_setup_compose_failure_preserves_staged_configuration() {
+  local sandbox input
+  sandbox="$(make_sandbox)"
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    https \
+    sync.example.com \
+    logseq-client \
+    y)"
+  run_manager "$sandbox" "$input" \
+    'MOCK_DOCKER_FAIL_ONCE_PATTERN= up -d --build'
+  assert_failure || return 1
+  [[ -f "$sandbox/install/.env" ]] || return 1
+  [[ -f "$sandbox/install/compose.yaml" ]] || return 1
+  [[ -f "$sandbox/install/Caddyfile" ]] || return 1
+  assert_contains "$last_output" 'Sync startup failed'
+  assert_not_contains "$last_output" 'previous working deployment was restored'
+  assert_not_contains "$(<"$sandbox/docker.log")" ' up -d --force-recreate'
 }
 
 test_existing_configuration_becomes_prompt_defaults() {
@@ -224,10 +292,14 @@ EOF
   assert_contains "$(<"$sandbox/docker.log")" 'rm --stop --force caddy'
 }
 
-test_https_to_http_keeps_caddy_when_replacement_fails() {
-  local sandbox input
+test_https_to_http_restores_configuration_when_replacement_fails() {
+  local sandbox input original_dir
   sandbox="$(make_sandbox)"
   mkdir -p "$sandbox/install"
+  cp "$test_dir/compose.yaml" "$sandbox/install/compose.yaml"
+  cp "$test_dir/compose.http.yaml" "$sandbox/install/compose.http.yaml"
+  printf 'https://old-sync.example.com {\n\treverse_proxy sync:8080\n}\n' \
+    > "$sandbox/install/Caddyfile"
   cat > "$sandbox/install/.env" <<EOF
 LOGSEQ_SYNC_SOURCE_DIR=/old/source
 LOGSEQ_SYNC_INSTALL_DIR=$sandbox/install
@@ -243,6 +315,9 @@ COGNITO_ISSUER=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8
 COGNITO_CLIENT_ID=69cs1lgme7p8kbgld8n5kseii6
 COGNITO_JWKS_URL=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8/.well-known/jwks.json
 EOF
+  original_dir="$sandbox/original"
+  mkdir -p "$original_dir"
+  cp -a "$sandbox/install/." "$original_dir/"
   input="$(printf '%s\n' \
     "$sandbox/install" \
     "$sandbox/data" \
@@ -251,10 +326,150 @@ EOF
     I_ACCEPT_HTTP \
     logseq-client \
     y \
+    y \
+    y \
+    y \
     y)"
-  run_manager "$sandbox" "$input" MOCK_DOCKER_STATUS=1
+  run_manager "$sandbox" "$input" \
+    'MOCK_DOCKER_FAIL_ONCE_PATTERN= up -d --build'
   assert_failure || return 1
   assert_not_contains "$(<"$sandbox/docker.log")" 'rm --stop --force caddy'
+  assert_managed_configuration_matches "$original_dir" "$sandbox/install" || return 1
+  assert_contains "$last_output" 'the previous working deployment was restored'
+  assert_contains "$(<"$sandbox/docker.log")" '--profile https up -d --force-recreate'
+}
+
+test_https_reconfiguration_restores_after_service_health_failure() {
+  local sandbox input original_dir
+  sandbox="$(make_sandbox)"
+  mkdir -p "$sandbox/install"
+  cp "$test_dir/compose.yaml" "$sandbox/install/compose.yaml"
+  cp "$test_dir/compose.http.yaml" "$sandbox/install/compose.http.yaml"
+  printf 'https://old-sync.example.com {\n\treverse_proxy sync:8080\n}\n' \
+    > "$sandbox/install/Caddyfile"
+  cat > "$sandbox/install/.env" <<EOF
+LOGSEQ_SYNC_SOURCE_DIR=/old/source
+LOGSEQ_SYNC_INSTALL_DIR=$sandbox/install
+LOGSEQ_SYNC_DATA_DIR=$sandbox/data
+LOGSEQ_SYNC_UID=1000
+LOGSEQ_SYNC_GID=1000
+LOGSEQ_SYNC_ENDPOINT_MODE=https
+DB_SYNC_BASE_URL=https://old-sync.example.com
+DB_SYNC_BIND_ADDRESS=127.0.0.1
+DB_SYNC_PUBLIC_PORT=443
+DB_SYNC_LOG_LEVEL=info
+COGNITO_ISSUER=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8
+COGNITO_CLIENT_ID=69cs1lgme7p8kbgld8n5kseii6
+COGNITO_JWKS_URL=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8/.well-known/jwks.json
+EOF
+  original_dir="$sandbox/original"
+  mkdir -p "$original_dir"
+  cp -a "$sandbox/install/." "$original_dir/"
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    https \
+    new-sync.example.com \
+    logseq-client \
+    y \
+    y \
+    y \
+    y \
+    y)"
+  run_manager "$sandbox" "$input" MOCK_DOCKER_UNHEALTHY_UNTIL_ROLLBACK=1
+  assert_failure || return 1
+  assert_managed_configuration_matches "$original_dir" "$sandbox/install" || return 1
+  assert_contains "$last_output" 'the previous working deployment was restored'
+}
+
+test_https_reconfiguration_restores_after_public_health_failure() {
+  local sandbox input original_dir
+  sandbox="$(make_sandbox)"
+  mkdir -p "$sandbox/install"
+  cp "$test_dir/compose.yaml" "$sandbox/install/compose.yaml"
+  cp "$test_dir/compose.http.yaml" "$sandbox/install/compose.http.yaml"
+  printf 'https://old-sync.example.com {\n\treverse_proxy sync:8080\n}\n' \
+    > "$sandbox/install/Caddyfile"
+  cat > "$sandbox/install/.env" <<EOF
+LOGSEQ_SYNC_SOURCE_DIR=/old/source
+LOGSEQ_SYNC_INSTALL_DIR=$sandbox/install
+LOGSEQ_SYNC_DATA_DIR=$sandbox/data
+LOGSEQ_SYNC_UID=1000
+LOGSEQ_SYNC_GID=1000
+LOGSEQ_SYNC_ENDPOINT_MODE=https
+DB_SYNC_BASE_URL=https://old-sync.example.com
+DB_SYNC_BIND_ADDRESS=127.0.0.1
+DB_SYNC_PUBLIC_PORT=443
+DB_SYNC_LOG_LEVEL=info
+COGNITO_ISSUER=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8
+COGNITO_CLIENT_ID=69cs1lgme7p8kbgld8n5kseii6
+COGNITO_JWKS_URL=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8/.well-known/jwks.json
+EOF
+  original_dir="$sandbox/original"
+  mkdir -p "$original_dir"
+  cp -a "$sandbox/install/." "$original_dir/"
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    https \
+    new-sync.example.com \
+    logseq-client \
+    y \
+    y \
+    y \
+    y \
+    y)"
+  run_manager "$sandbox" "$input" \
+    'MOCK_CURL_FAIL_PATTERN=https://new-sync.example.com/health'
+  assert_failure || return 1
+  assert_managed_configuration_matches "$original_dir" "$sandbox/install" || return 1
+  assert_contains "$last_output" 'the previous working deployment was restored'
+  assert_contains "$(<"$sandbox/curl.log")" 'https://old-sync.example.com/health'
+}
+
+test_configuration_activation_failure_restores_previous_deployment() {
+  local sandbox input original_dir
+  sandbox="$(make_sandbox)"
+  mkdir -p "$sandbox/install"
+  cp "$test_dir/compose.yaml" "$sandbox/install/compose.yaml"
+  cp "$test_dir/compose.http.yaml" "$sandbox/install/compose.http.yaml"
+  printf 'https://old-sync.example.com {\n\treverse_proxy sync:8080\n}\n' \
+    > "$sandbox/install/Caddyfile"
+  cat > "$sandbox/install/.env" <<EOF
+LOGSEQ_SYNC_SOURCE_DIR=/old/source
+LOGSEQ_SYNC_INSTALL_DIR=$sandbox/install
+LOGSEQ_SYNC_DATA_DIR=$sandbox/data
+LOGSEQ_SYNC_UID=1000
+LOGSEQ_SYNC_GID=1000
+LOGSEQ_SYNC_ENDPOINT_MODE=https
+DB_SYNC_BASE_URL=https://old-sync.example.com
+DB_SYNC_BIND_ADDRESS=127.0.0.1
+DB_SYNC_PUBLIC_PORT=443
+DB_SYNC_LOG_LEVEL=info
+COGNITO_ISSUER=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8
+COGNITO_CLIENT_ID=69cs1lgme7p8kbgld8n5kseii6
+COGNITO_JWKS_URL=https://cognito-idp.us-east-1.amazonaws.com/us-east-1_dtagLnju8/.well-known/jwks.json
+EOF
+  original_dir="$sandbox/original"
+  mkdir -p "$original_dir"
+  cp -a "$sandbox/install/." "$original_dir/"
+  input="$(printf '%s\n' \
+    "$sandbox/install" \
+    "$sandbox/data" \
+    https \
+    new-sync.example.com \
+    logseq-client \
+    y \
+    y \
+    y \
+    y \
+    y)"
+  run_manager "$sandbox" "$input" 'MOCK_MV_FAIL_ONCE_PATTERN=/.env '
+  assert_failure || return 1
+  assert_managed_configuration_matches "$original_dir" "$sandbox/install" || return 1
+  assert_contains "$last_output" 'the previous working deployment was restored'
+  assert_contains "$(<"$sandbox/docker.log")" '--profile https up -d --force-recreate'
+  assert_not_contains "$(<"$sandbox/docker.log")" ' up -d --build'
 }
 
 test_https_setup_force_recreates_caddy() {
@@ -404,9 +619,13 @@ run_test() {
 run_test test_unhealthy_service_is_rejected
 run_test test_health_body_is_verified
 run_test test_docker_daemon_is_checked_before_writes
+run_test test_first_setup_compose_failure_preserves_staged_configuration
 run_test test_existing_configuration_becomes_prompt_defaults
 run_test test_https_to_http_removes_caddy_container
-run_test test_https_to_http_keeps_caddy_when_replacement_fails
+run_test test_https_to_http_restores_configuration_when_replacement_fails
+run_test test_https_reconfiguration_restores_after_service_health_failure
+run_test test_https_reconfiguration_restores_after_public_health_failure
+run_test test_configuration_activation_failure_restores_previous_deployment
 run_test test_https_setup_force_recreates_caddy
 run_test test_http_setup_verifies_public_endpoint
 run_test test_invalid_http_host_is_rejected

--- a/deps/db-sync/package.json
+++ b/deps/db-sync/package.json
@@ -2,6 +2,9 @@
   "name": "@logseq/db-sync",
   "version": "1.0.0",
   "packageManager": "pnpm@10.33.0",
+  "engines": {
+    "node": "^22.12.0 || ^24.0.0"
+  },
   "private": true,
   "scripts": {
     "dev": "cd ./worker && pnpm exec wrangler dev",

--- a/deps/db-sync/src/logseq/db_sync/node/config.cljs
+++ b/deps/db-sync/src/logseq/db_sync/node/config.cljs
@@ -11,7 +11,8 @@
 
 (defn config-from-env []
   (let [env (.-env js/process)]
-    {:port (when-let [v (env-value env "DB_SYNC_PORT")] (parse-int v 8080))
+    {:host (env-value env "DB_SYNC_HOST")
+     :port (when-let [v (env-value env "DB_SYNC_PORT")] (parse-int v 8080))
      :base-url (env-value env "DB_SYNC_BASE_URL")
      :data-dir (or (env-value env "DB_SYNC_DATA_DIR") "data/db-sync")
      :storage-driver (or (env-value env "DB_SYNC_STORAGE_DRIVER") "sqlite")
@@ -22,7 +23,7 @@
      :cognito-jwks-url (env-value env "COGNITO_JWKS_URL")}))
 
 (def ^:private allowed-config-keys
-  [:port :base-url :data-dir :storage-driver :assets-driver :log-level
+  [:host :port :base-url :data-dir :storage-driver :assets-driver :log-level
    :cognito-issuer :cognito-client-id :cognito-jwks-url])
 
 (defn normalize-config [overrides]
@@ -31,7 +32,8 @@
                   :storage-driver "sqlite"
                   :assets-driver "filesystem"
                   :log-level "info"}
-        merged (merge defaults (config-from-env) overrides)
+        env-config (into {} (remove (comp nil? val)) (config-from-env))
+        merged (merge defaults env-config overrides)
         storage-driver (string/lower-case (:storage-driver merged))
         assets-driver (string/lower-case (:assets-driver merged))]
     (when-not (#{"sqlite"} storage-driver)

--- a/deps/db-sync/src/logseq/db_sync/node/entry.cljs
+++ b/deps/db-sync/src/logseq/db_sync/node/entry.cljs
@@ -15,4 +15,5 @@
                   (reset! *server result)
                   (js/console.log (str "Logseq sync listening on port " (:port result)))))
         (p/catch (fn [error]
-                   (js/console.error "Logseq sync failed to start" error))))))
+                   (js/console.error "Logseq sync failed to start" error)
+                   (set! (.-exitCode js/process) 1))))))

--- a/deps/db-sync/src/logseq/db_sync/node/server.cljs
+++ b/deps/db-sync/src/logseq/db_sync/node/server.cljs
@@ -160,9 +160,16 @@
                      (.destroy socket)))
                  (.destroy socket)))))
       (p/let [_ (js/Promise.
-                 (fn [resolve]
-                   (.listen server (:port cfg)
-                            (fn [] (resolve nil)))))
+                 (fn [resolve reject]
+                   (let [on-listen-error (fn [error]
+                                           (when-let [close (.-close index-db)]
+                                             (close))
+                                           (reject error))]
+                     (.once server "error" on-listen-error)
+                     (.listen server (:port cfg) (:host cfg)
+                              (fn []
+                                (.off server "error" on-listen-error)
+                                (resolve nil))))))
               address (.address server)
               port (if (number? address) address (.-port address))
               base-url (or (:base-url cfg) (str "http://localhost:" port))]

--- a/deps/db-sync/test/logseq/db_sync/node_config_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/node_config_test.cljs
@@ -9,12 +9,19 @@
     (catch :default _ true)))
 
 (deftest normalize-config-drops-unknown-keys-test
-  (let [cfg (config/normalize-config {:port 7777
+  (let [cfg (config/normalize-config {:host "127.0.0.2"
+                                      :port 7777
                                       :unknown-key "value"
                                       :legacy-auth-key "value"})]
+    (is (= "127.0.0.2" (:host cfg)))
     (is (= 7777 (:port cfg)))
     (is (nil? (:unknown-key cfg)))
     (is (nil? (:legacy-auth-key cfg)))))
+
+(deftest normalize-config-defaults-test
+  (let [cfg (config/normalize-config {})]
+    (is (nil? (:host cfg)))
+    (is (= 8080 (:port cfg)))))
 
 (deftest normalize-config-storage-driver-test
   (testing "sqlite storage driver accepted"

--- a/deps/db-sync/test/logseq/db_sync/node_server_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/node_server_test.cljs
@@ -27,6 +27,11 @@
                                    (resolve timeout-sentinel)
                                    (reject error))))))))}))
 
+(defn- restore-env-value! [env key value]
+  (if (nil? value)
+    (js-delete env key)
+    (aset env key value)))
+
 (deftest node-server-rejects-listen-failure-test
   (async done
          (-> (node-server/start! {:host "256.256.256.256"
@@ -40,6 +45,28 @@
              (p/catch (fn [error]
                         (is (= "ENOTFOUND" (.-code error)))
                         (done))))))
+
+(deftest node-server-uses-bind-host-from-env-test
+  (async done
+         (let [env (.-env js/process)
+               previous-host (aget env "DB_SYNC_HOST")
+               previous-port (aget env "DB_SYNC_PORT")
+               previous-data-dir (aget env "DB_SYNC_DATA_DIR")]
+           (aset env "DB_SYNC_HOST" "127.0.0.1")
+           (aset env "DB_SYNC_PORT" "0")
+           (aset env "DB_SYNC_DATA_DIR"
+                 (str "tmp/db-sync-node-env-host-test/" (random-uuid)))
+           (-> (p/let [{:keys [server stop!]} (node-server/start! {})
+                       address (.address server)]
+                 (is (= "127.0.0.1" (.-address address)))
+                 (stop!))
+               (p/catch (fn [error]
+                          (is false (str error))))
+               (p/finally (fn []
+                            (restore-env-value! env "DB_SYNC_HOST" previous-host)
+                            (restore-env-value! env "DB_SYNC_PORT" previous-port)
+                            (restore-env-value! env "DB_SYNC_DATA_DIR" previous-data-dir)
+                            (done)))))))
 
 (deftest node-server-returns-500-when-auth-claims-rejects-test
   (async done

--- a/deps/db-sync/test/logseq/db_sync/node_server_test.cljs
+++ b/deps/db-sync/test/logseq/db_sync/node_server_test.cljs
@@ -27,6 +27,20 @@
                                    (resolve timeout-sentinel)
                                    (reject error))))))))}))
 
+(deftest node-server-rejects-listen-failure-test
+  (async done
+         (-> (node-server/start! {:host "256.256.256.256"
+                                  :port 0
+                                  :data-dir (str "tmp/db-sync-node-listen-failure-test/"
+                                                 (random-uuid))})
+             (p/then (fn [{:keys [stop!]}]
+                       (is false "server startup should reject an invalid bind host")
+                       (-> (stop!)
+                           (p/finally done))))
+             (p/catch (fn [error]
+                        (is (= "ENOTFOUND" (.-code error)))
+                        (done))))))
+
 (deftest node-server-returns-500-when-auth-claims-rejects-test
   (async done
          (let [stop-server! (atom nil)


### PR DESCRIPTION
## Summary

- add a guided native Linux installer for the DB Sync Node adapter using a prebuilt runtime, systemd, and Caddy-managed HTTPS
- keep Docker Compose as an alternative deployment path with interactive setup and one-shot status diagnostics
- build, test, package, and publish x64/arm64 native runtime assets through GitHub Actions
- allow the Node adapter bind host to be configured while preserving the existing all-interface default when omitted

## Why

Self-hosting the Sync Node adapter currently requires a local Node, Java, Clojure, native build toolchain, and manual reverse-proxy configuration. This makes initial setup and upgrades fragile, especially on small Linux cloud servers.

The native flow reduces the server-side requirements to standard base utilities and systemd. It downloads checksum-verified prebuilt runtime assets, installs all managed state under one home directory, and configures Caddy for automatic certificate issuance and renewal.

## Behavior

- `setup` provides an interactive wizard and also accepts named options for unattended deployment.
- Public HTTPS defaults to port 443; a user-supplied port is preserved in the generated URL and Caddy configuration.
- The private adapter port is separately configurable and binds to `127.0.0.1` only.
- The normal flow uses the existing Cognito configuration expected by unmodified Logseq clients.
- `update` stages and verifies a runtime before switching, rolls back failed health checks or manager updates, and retains the previous release.
- Re-running setup restores the previous configuration and services if configuration activation or health validation fails.

## Safety

- runtime and Caddy archives are checksum verified before activation
- Caddy is version pinned and its installed binary digest is revalidated
- Docker base images are pinned by multi-architecture digest
- native install and release paths reject unsafe lexical and symlink-resolved boundaries before root writes, execution, or cleanup
- installed runtimes are root owned and cannot be modified by the service account
- rolling release publication waits for the complete db-sync CI workflow and rejects stale master runs

## Validation

- `bash deps/db-sync/deploy/native-test.sh` — 39 passed
- `bash deps/db-sync/deploy/test.sh` — 16 passed
- ShellCheck 0.11.0 — clean for all deployment scripts
- actionlint 1.7.12 — clean for the changed workflows
- clj-kondo 2026.05.25 — 0 errors, 0 warnings for db-sync source and tests
- `bash -n` and `git diff --check` — clean

The Node adapter test command is also covered by the existing `logseq/db-sync CI` workflow. A local retry could not resolve `org.clojure:core.async` because Maven Central terminated the TLS handshake before compilation; no test assertion ran.

## Release note

After the first successful master CI run, the release workflow creates or updates the rolling `db-sync-native` release used by the quickstart. Versioned `db-sync-native-v*` tags remain supported.
