### PR TITLE
fix: don't crash the UI on unreadable simple queries

### DIFF
--- a/src/main/frontend/db/query_dsl.cljs
+++ b/src/main/frontend/db/query_dsl.cljs
@@ -2,7 +2,6 @@
   "Handles executing dsl queries a.k.a. simple queries"
   (:require [cljs-time.coerce :as tc]
             [cljs-time.core :as t]
-            [cljs.reader :as reader]
             [clojure.set :as set]
             [clojure.string :as string]
             [clojure.walk :as walk]
@@ -646,7 +645,7 @@ Some bindings in this fn:
       (let [s (if (= \# (first s)) (page-ref/->page-ref (subs s 1)) s)
             form (some->> s
                           (pre-transform)
-                          (reader/read-string custom-readers))
+                          (common-util/safe-read-string custom-readers))
             sort-by (atom nil)
             blocks? (atom nil)
             sample (atom nil)

--- a/src/test/frontend/db/query_dsl_test.cljs
+++ b/src/test/frontend/db/query_dsl_test.cljs
@@ -664,6 +664,18 @@
     (is (= 3 (count (dsl-query "(and (task todo done) (between created-at [[Dec 26th, 2020]]))"))))
     (is (= 3 (count (dsl-query "(and (task todo done) (between created-at [[Dec 26th, 2020]] +1d))"))))))
 
+(deftest unreadable-query-input-does-not-throw
+  (testing "queries the edn reader rejects parse to an empty query instead of throwing (whole-UI crash)"
+    (is (nil? (:query (query-dsl/parse-query "(between [[2020-01-01]] ::today)" (db/get-db))))
+        "auto-resolved keyword inside between")
+    (is (nil? (:query (query-dsl/parse-query "::whatever" (db/get-db))))
+        "bare auto-resolved keyword")
+    (is (nil? (:query (query-dsl/parse-query "(and [[page 1]] ::x" (db/get-db))))
+        "unbalanced parens"))
+  (testing "running such a query returns no results instead of throwing"
+    (is (empty? (dsl-query "(between [[2020-01-01]] ::today)")))
+    (is (empty? (dsl-query "::whatever")))))
+
 (deftest custom-query-test
   (load-test-files
    [{:page {:block/title "page1", :build/properties {:foo "bar"}}


### PR DESCRIPTION
A query containing a token the edn reader rejects (like an auto-resolved keyword typo like `(between [[2020-01-01]] ::today)`), threw from `query-dsl/parse`. 

The query builder component renders inline for `#Query` blocks and calls parse-query outside any error handling, so the reader exception took down the whole React tree and left the graph unusable.

Read the query string with common-util/safe-read-string, like every other query-string read site, so unreadable input yields an empty query (the invalid-query result callers already handle) while unexpected errors keep bubbling to the block-level error boundaries.

Addresses logseq/db-test#1090 

The writing of this code was assisted by LLM (especially the test, as I don't know Clojure as much), so please double-check it. I made sure to read it and I think I understand it.