### PR TITLE
fix: remove page from recent list after deletion

### DIFF
--- a/src/main/frontend/components/page_menu.cljs
+++ b/src/main/frontend/components/page_menu.cljs
@@ -61,6 +61,7 @@
   [page]
   (page-handler/<delete! (:block/uuid page)
                          (fn []
+                           (state/remove-page-from-recent! (:db/id page))
                            (notification/show!
                             (if (db-model/today-journal-page? page)
                               (t :page.delete/today-journal-truncate-success)

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1847,6 +1847,10 @@ should be done through this fn in order to get global config and config defaults
   (set-state! [:ui/recent-pages (get-current-repo)] v)
   (storage/set :ui/recent-pages (:ui/recent-pages @state)))
 
+(defn remove-page-from-recent!
+  [page-id]
+  (set-recent-pages! (vec (remove #{page-id} (get-recent-pages)))))
+
 (defn get-export-block-text-remove-options []
   (:copy/export-block-text-remove-options @state))
 


### PR DESCRIPTION
**Fixes #12988**

**What is the problem?**
When a page is deleted, it's moved to the Recycle Bin, but it stays in the "Recent" list in the left sidebar. Clicking it there shows "Cannot go to an internal page" (or in the current version, a "Node has been moved to Recycle" message), instead of the page just being removed from the list.

**How does this PR fix it?**
Deleting a page already has a cleanup step for Favorites (<db-unfavorite-page!), but the same cleanup was never added for Recent pages. Added a remove-page-from-recent! function in frontend.state that filters a given page id out of the stored recent-pages list, and call it from the "Delete page" success handler in page_menu.cljs, right where the page is already deleted successfully.

I also tried wiring this into the existing after-page-deleted!/:page/deleted event flow (which already handles Favorites cleanup), but found that the page name carried in that event's tx-meta is dropped by the time it reaches the main thread, because apply-ops! batches all ops in a transaction under one shared tx-meta before it's sent to the listener. Doing the cleanup directly in the UI action handler (where the page entity is already in scope) avoids depending on that.

Tested manually: create a page, open it so it shows in Recent, delete it via the "..." menu, and confirm it's removed from Recent right away.

**Note:** I used Claude Code to help investigate the root cause and write this fix. I manually tested the described behavior myself on a local build before opening this PR.