### PR TITLE
fix: remove deleted pages from recents

### DIFF
--- a/src/main/frontend/modules/outliner/pipeline.cljs
+++ b/src/main/frontend/modules/outliner/pipeline.cljs
@@ -50,8 +50,16 @@
         blocks (:blocks delta)
         deleted (:deleted delta)]
     (when (= repo (state/get-current-repo))
-      (when-let [ids (not-empty (keep :db/id (vals deleted)))]
-        (state/sidebar-remove-deleted-block! ids))
+      (let [deleted-ids (not-empty (keep :db/id (vals deleted)))
+            recycled-ids (keep (fn [block]
+                                 (when (and (ldb/page? block)
+                                            (ldb/recycled? block))
+                                   (:db/id block)))
+                               (vals blocks))]
+        (when deleted-ids
+          (state/sidebar-remove-deleted-block! deleted-ids))
+        (when-let [removed-page-ids (not-empty (concat deleted-ids recycled-ids))]
+          (state/remove-pages-from-recent! removed-page-ids)))
       (when (and (current-page-deleted? current-page deleted)
                  (not (util/mobile?)))
         (route-handler/redirect-to-home!))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -1736,6 +1736,16 @@ should be done through this fn in order to get global config and config defaults
   (set-state! [:ui/recent-pages (get-current-repo)] v)
   (storage/set :ui/recent-pages (:ui/recent-pages (rfx/snapshot))))
 
+(defn remove-pages-from-recent!
+  [page-ids]
+  (when (seq page-ids)
+    (let [page-ids (set page-ids)
+          recent-pages (get-recent-pages)
+          remaining-pages (vec (remove page-ids recent-pages))]
+      (when (and (seq recent-pages)
+                 (not= recent-pages remaining-pages))
+        (set-recent-pages! remaining-pages)))))
+
 (defn get-export-block-text-remove-options []
   (:copy/export-block-text-remove-options (rfx/snapshot)))
 

--- a/src/test/frontend/handler/db_based/recent_test.cljs
+++ b/src/test/frontend/handler/db_based/recent_test.cljs
@@ -140,8 +140,8 @@
               (p/let [recent-pages (db-recent-handler/get-recent-pages)]
                 (is (= (map :block/title recent-pages) (reverse pages)))))))))))
 
-(deftest-async recents-hide-recycled-pages-without-removing-history-test
-  (testing "Recycled recent pages are hidden from display without mutating recents"
+(deftest-async recents-hide-recycled-pages-test
+  (testing "Recycled recent pages are hidden from display"
     (let [env (make-test-env!)
           active-page "Active page"
           recycled-page "Recycled page"]
@@ -151,12 +151,10 @@
           (doseq [page [active-page recycled-page]]
             (create-page! env page)
             (db-recent-handler/add-page-to-recent! (:db/id (get-page env page)) false))
-          (let [recycled-page-id (:db/id (get-page env recycled-page))]
-            (mark-page-recycled! env recycled-page)
-            (p/let [recent-pages (db-recent-handler/get-recent-pages)]
-              (is (= [active-page]
-                     (map :block/title recent-pages)))
-              (is (contains? (set (state/get-recent-pages)) recycled-page-id)))))))))
+          (mark-page-recycled! env recycled-page)
+          (p/let [recent-pages (db-recent-handler/get-recent-pages)]
+            (is (= [active-page]
+                   (map :block/title recent-pages)))))))))
 
 (deftest add-page-to-recent-updates-state-without-renderer-entity-test
   (let [recent-pages (atom [2 3])

--- a/src/test/frontend/modules/outliner/pipeline_test.cljs
+++ b/src/test/frontend/modules/outliner/pipeline_test.cljs
@@ -70,3 +70,63 @@
             "Deleted block tombstones drop the matching sidebar entries."))
       (finally
         (state/replace-state! original-state)))))
+
+(deftest recycled-pages-are-removed-from-recents-test
+  (let [original-state (state/get-state)
+        repo "recycled-page-recents-test"
+        page-uuid (random-uuid)
+        delta {:graph-id repo
+               :rev 10
+               :blocks {page-uuid {:db/id 42
+                                   :block/uuid page-uuid
+                                   :block/tags [{:db/ident :logseq.class/Page}]
+                                   :logseq.property/deleted-at 1}}
+               :deleted {}
+               :children {}
+               :affected-keys #{[:entity page-uuid]}}
+        tx-meta {:client-id "client"
+                 :outliner-op :delete-page
+                 :deleted-page "Deleted page"}]
+    (try
+      (state/replace-state! {:client-id "client"
+                             :git/current-repo repo
+                             :ui/recent-pages {repo [42 7]}})
+      (with-redefs [db-subs/apply-delta! (constantly true)
+                    state/get-current-page (constantly nil)
+                    state/pub-event! (constantly nil)]
+        (pipeline/invoke-hooks {:repo repo
+                                :tx-meta tx-meta
+                                :delta delta})
+        (is (= [7] (state/get-recent-pages))
+            "Recycling a page removes only that page from recent history."))
+      (finally
+        (state/replace-state! original-state)))))
+
+(deftest hard-deleted-pages-are-removed-from-recents-test
+  (let [original-state (state/get-state)
+        repo "hard-deleted-page-recents-test"
+        page-uuid (random-uuid)
+        delta {:graph-id repo
+               :rev 11
+               :blocks {}
+               :deleted {page-uuid {:rev 11 :db/id 42}}
+               :children {}
+               :affected-keys #{[:entity page-uuid]}}
+        tx-meta {:client-id "client"
+                 :outliner-op :delete-page
+                 :deleted-page "Deleted page"}]
+    (try
+      (state/replace-state! {:client-id "client"
+                             :git/current-repo repo
+                             :ui/recent-pages {repo [42 7]}})
+      (with-redefs [db-subs/apply-delta! (constantly true)
+                    state/get-current-page (constantly nil)
+                    state/sidebar-remove-deleted-block! (constantly nil)
+                    state/pub-event! (constantly nil)]
+        (pipeline/invoke-hooks {:repo repo
+                                :tx-meta tx-meta
+                                :delta delta})
+        (is (= [7] (state/get-recent-pages))
+            "Hard deletion removes only that page from recent history."))
+      (finally
+        (state/replace-state! original-state)))))


### PR DESCRIPTION
## Summary

- remove recycled page IDs from persisted recent-page history when the worker delta is applied
- remove hard-deleted page IDs from recent history while preserving unrelated entries
- retain display-time filtering for recycled pages

## Root cause

Deleting a page hid its database entity, but its ID remained in persisted recent-page history. On revisions where the recent sidebar did not react to entity changes, that stale ID could remain clickable; on current master it still reduced usable history and could reappear after restoration.

## Testing

- regression tests for recycled and hard-deleted pages
- focused recent-page visibility test
- built-in browser reproduction and post-fix state verification
- `bb dev:lint-and-test` (one unrelated graph-view timing assertion exceeded its 1000 ms threshold by 1.46 ms; the focused retry passed)

Fixes #12988