### PR TITLE
enhance(ui): option to show a page's full hierarchy in links

### DIFF
--- a/deps/common/resources/templates/config.edn
+++ b/deps/common/resources/templates/config.edn
@@ -12,6 +12,10 @@
  ;; Default value: true
  ;; :ui/show-brackets? true
 
+ ;; Display a page's full hierarchy in links, e.g. Superhuman/Docs instead of Docs.
+ ;; Default value: false
+ ;; :ui/show-hierarchy false
+
  ;; Display all lines of a block when referencing ((block)).
  ;; Default value: false
  :ui/show-full-blocks? false

--- a/deps/db/src/logseq/db/frontend/block_title.cljs
+++ b/deps/db/src/logseq/db/frontend/block_title.cljs
@@ -80,7 +80,7 @@
 
   `title` may be supplied when a caller has already prepared a display title,
   such as a search snippet with highlight markers."
-  [db block {:keys [with-tags? alias truncate? title]
+  [db block {:keys [with-tags? with-parents? alias truncate? title]
              :or {with-tags? true
                   truncate? true}}]
   (let [block-e (resolve-block db block)]
@@ -93,11 +93,24 @@
                                  (db-class/private-tags (:db/ident tag))))
                            (map #(resolve-tag db %) (or (:block/tags block)
                                                         (:block/tags block-e)))))
-            base-title (if class?
+            base-title (cond
+                         class?
                          (let [display-title (or title (:block/title block-e))]
                            (if (class-title-conflicts? db block-e)
                              (class-title-with-extends block-e display-title)
                              display-title))
+
+                         ;; `title` is a caller-prepared display string, such as a
+                         ;; search snippet with highlight markers, so it wins.
+                         ;; The path itself is computed in the worker, since the
+                         ;; renderer holds no db to walk ancestors with.
+                         (and with-parents?
+                              (nil? title)
+                              (:block.temp/hierarchy-title block)
+                              (entity-util/internal-page? block-e))
+                         (:block.temp/hierarchy-title block)
+
+                         :else
                          (or title (:block/title block-e)))
             trunc-title (if (and truncate? base-title (> (count base-title) 256))
                           (subs base-title 0 256)

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -481,6 +481,12 @@
           show-full-blocks?
           config-handler/toggle-show-full-blocks!))
 
+(defn show-hierarchy-row [t show-hierarchy?]
+  (toggle "show_hierarchy"
+          (t :settings.editor/show-hierarchy)
+          show-hierarchy?
+          config-handler/toggle-ui-show-hierarchy!))
+
 (defn preferred-pasting-file [t preferred-pasting-file?]
   (toggle "preferred_pasting_file"
           [(t :settings.editor/preferred-pasting-file)
@@ -894,11 +900,13 @@
         enable-tooltip? (state/enable-tooltip?)
         enable-shortcut-tooltip? (rfx/use-sub [:ui/shortcut-tooltip?])
         show-brackets? (state/show-brackets?)
+        show-hierarchy? (state/show-hierarchy?)
         wide-mode? (rfx/use-sub [:ui/wide-mode?])]
 
     [:div.panel-wrap.is-editor
      (date-format-row t preferred-date-format)
      (show-brackets-row t show-brackets?)
+     (show-hierarchy-row t show-hierarchy?)
      (toggle-wide-mode-row t wide-mode?)
 
      (when (util/electron?) (switch-spell-check-row t))

--- a/src/main/frontend/db/subs.cljs
+++ b/src/main/frontend/db/subs.cljs
@@ -365,7 +365,11 @@
     (if (or (> (slot-revision current) (:rev store))
             (and (= :block (first slot-key))
                  (:tx-id current)
-                 (= (:tx-id current) (:tx-id next-slot))))
+                 (= (:tx-id current) (:tx-id next-slot))
+                 ;; A page's displayed path embeds its ancestors' titles, so its
+                 ;; snapshot can change while its own tx-id does not. Those fall
+                 ;; through to the value comparison below.
+                 (nil? (get-in next-slot [:snapshot :value :block.temp/hierarchy-title]))))
       [store false]
       [(if (mounted? slot-key)
          (assoc-in store [:slots slot-key] next-slot)

--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -67,7 +67,10 @@
   "Multiple pages/objects may have the same `:block/title`.
    Notice: this doesn't prevent for pages/objects that have the same tag or created by different clients."
   [block & {:as opts}]
-  (db-block-title/block-unique-title (:db opts) block (dissoc opts :db)))
+  (db-block-title/block-unique-title
+   (:db opts)
+   block
+   (merge {:with-parents? (state/show-hierarchy?)} (dissoc opts :db))))
 
 (defn block-title-with-icon
   "Used for select item"

--- a/src/main/frontend/handler/config.cljs
+++ b/src/main/frontend/handler/config.cljs
@@ -40,6 +40,10 @@
   (let [show-brackets? (state/show-brackets?)]
     (set-config! :ui/show-brackets? (not show-brackets?))))
 
+(defn toggle-ui-show-hierarchy! []
+  (let [show-hierarchy? (state/show-hierarchy?)]
+    (set-config! :ui/show-hierarchy (not show-hierarchy?))))
+
 (defn toggle-logical-outdenting! []
   (let [logical-outdenting? (state/logical-outdenting?)]
     (set-config! :editor/logical-outdenting? (not logical-outdenting?))))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -684,6 +684,13 @@ should be done through this fn in order to get global config and config defaults
   []
   (not (false? (:ui/show-brackets? (get-config)))))
 
+;; Disabled by default
+(defn show-hierarchy?
+  "Whether page references show the page's full hierarchy, e.g. `Superhuman/Docs`
+  instead of `Docs`. Display only, stored content is unaffected."
+  []
+  (boolean (:ui/show-hierarchy (get-config))))
+
 (defn- get-selected-block-ids
   [blocks]
   (->> blocks

--- a/src/main/frontend/worker/db_listener.cljs
+++ b/src/main/frontend/worker/db_listener.cljs
@@ -12,6 +12,7 @@
             [frontend.worker.state :as worker-state]
             [frontend.worker.sync :as db-sync]
             [lambdaisland.glogi :as log]
+            [logseq.db :as ldb]
             [promesa.core :as p]))
 
 (defmulti listen-db-changes
@@ -90,10 +91,59 @@
                      [(:block/uuid block) block])))))
         tx-data))
 
+(def ^:private hierarchy-attrs
+  "Attributes that change the path a page's descendants display."
+  #{:block/title :block/parent})
+
+(defn- descendant-pages
+  "Every page below `pages`. A page's blocks are also its `:block/_parent`, so the
+  page filter is what keeps this to the hierarchy rather than the whole outline."
+  [pages]
+  (loop [queue (seq pages)
+         seen #{}
+         acc []]
+    (if-let [page (first queue)]
+      (if (contains? seen (:db/id page))
+        (recur (next queue) seen acc)
+        (let [children (filter ldb/internal-page? (:block/_parent page))]
+          (recur (concat (next queue) children)
+                 (conj seen (:db/id page))
+                 (into acc children))))
+      acc)))
+
+(defn- hierarchy-descendant-replacements
+  "A page's title is part of the path its descendants display, but renaming or
+  moving a page does not touch those descendants, so datascript never bumps their
+  `:block/tx-id` and `canonical-replacements` never sees them. Re-emit the
+  subtree here, or every path containing the renamed page stays stale until
+  reload."
+  [db-after tx-data existing-uuids]
+  (let [changed (into #{}
+                      (comp
+                       (filter (fn [datom]
+                                 (and (:added datom)
+                                      (contains? hierarchy-attrs (:a datom)))))
+                       (keep (fn [datom] (d/entity db-after (:e datom))))
+                       (filter ldb/internal-page?))
+                      tx-data)]
+    (when (seq changed)
+      (into {}
+            (comp
+             (remove (fn [page] (contains? existing-uuids (:block/uuid page))))
+             (keep (fn [page]
+                     (let [block (block-handler/canonical-block db-after page)]
+                       ;; Only pages that display a path can go stale.
+                       (when (:block.temp/hierarchy-title block)
+                         [(:block/uuid block) block])))))
+            (descendant-pages changed)))))
+
 (defn- build-render-delta
-  [repo {:keys [db-after tx-meta] :as tx-report}
+  [repo {:keys [db-after tx-data tx-meta] :as tx-report}
    {:keys [affected-keys deleted-block-uuids]}]
   (let [blocks (canonical-replacements tx-report)
+        blocks (merge blocks
+                      (hierarchy-descendant-replacements
+                       db-after tx-data (set (keys blocks))))
         deleted-block-uuids (reduce disj deleted-block-uuids (keys blocks))]
     (render-delta/build
      {:graph-id repo

--- a/src/main/frontend/worker/handler/block.cljs
+++ b/src/main/frontend/worker/handler/block.cljs
@@ -102,6 +102,16 @@
         block-tx-id (:block/tx-id entity)
         raw-title (:block/raw-title entity)
         display-title (:block/title entity)
+        ;; The renderer holds no db, and snapshot refs are flattened one level
+        ;; deep, so a page's full hierarchy path can only be computed here.
+        ;; Read by `:ui/show-hierarchy`.
+        ;;
+        ;; Renaming the referenced page itself refreshes labels, because its own
+        ;; slot is re-emitted. Renaming an ancestor does not: the delta only
+        ;; carries the renamed entity, not the blocks whose labels embed it, so
+        ;; those labels stay stale until reload.
+        hierarchy-title (when (and (ldb/internal-page? entity) (:block/parent entity))
+                          (ldb/get-title-with-parents entity))
         order-list-type (worker-plain/order-list-type entity)]
     (when-not (integer? entity-id)
       (fail-render-read! "Invalid canonical block entity"
@@ -146,6 +156,9 @@
 
         (string? display-title)
         (assoc :block/title display-title)
+
+        (and hierarchy-title (not= hierarchy-title display-title))
+        (assoc :block.temp/hierarchy-title hierarchy-title)
 
         order-list-type
         (assoc :block.temp/order-list-index

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -1722,6 +1722,7 @@
  :settings.editor/preferred-pasting-file-hint "When enabled, pasting an image from the internet will download and insert the image. When disabled, it will paste the link to the image."
  :settings.editor/show-brackets "Show brackets"
  :settings.editor/show-full-blocks "Show all lines of a block reference"
+ :settings.editor/show-hierarchy "Show full page hierarchy in links"
  :settings.editor/spell-checker "Spell checker"
  :settings.editor/wide-mode "Wide mode"
 

--- a/src/test/frontend/db/subs_test.cljs
+++ b/src/test/frontend/db/subs_test.cljs
@@ -229,6 +229,65 @@
                   (when-let [unsubscribe! @unsubscribe]
                     (unsubscribe!)))))))))
 
+(deftest renaming-an-ancestor-refreshes-a-descendants-path-test
+  (async done
+         (let [conn (db-test/create-conn-with-blocks
+                     {:pages-and-blocks [{:page {:block/title "Superhuman"}}
+                                         {:page {:block/title "Docs"}}]})
+               parent (db-test/find-page-by-title @conn "Superhuman")
+               child (db-test/find-page-by-title @conn "Docs")
+               ;; canonical-block requires a revision
+               _ (d/transact! conn [{:db/id (:db/id parent) :block/tx-id 20}
+                                    {:db/id (:db/id child)
+                                     :block/tx-id 20
+                                     :block/parent (:db/id parent)}])
+               child-uuid (:block/uuid child)
+               worker (fn [api & args]
+                        (case api
+                          :thread-api/update-thread-atom
+                          (p/resolved nil)
+
+                          :thread-api/get-render-snapshots
+                          (let [[_graph-id request] args]
+                            (p/resolved
+                             (render-engine/render-snapshots @conn request
+                                                             {:repo test-graph-id})))
+
+                          (p/rejected
+                           (ex-info "Unexpected worker API" {:api api}))))
+               path #(:block.temp/hierarchy-title
+                      (:value (subs/block-snapshot child-uuid)))
+               unsubscribe (atom nil)]
+           (finish-async!
+            done
+            (->
+             (p/let [_ (reset! state/*db-worker worker)
+                     _ (reset! unsubscribe
+                               (subs/subscribe-block! child-uuid (fn [])))
+                     _ (p/delay 0)
+                     _ (is (= "Superhuman/Docs" (path)))
+                     ;; Renaming the parent leaves the child's own tx-id at 20
+                     report (d/transact! conn
+                                         [[:db/add (:db/id parent)
+                                           :block/title "Finance"]
+                                          [:db/add (:db/id parent)
+                                           :block/tx-id 21]])
+                     render-delta (-> (#'db-listener/build-render-delta
+                                       test-graph-id report
+                                       {:affected-keys #{}
+                                        :deleted-block-uuids #{}})
+                                      ldb/write-transit-str
+                                      ldb/read-transit-str)
+                     _ (subs/apply-delta! render-delta)]
+               (is (= 20 (:block/tx-id (:value (subs/block-snapshot child-uuid))))
+                   "The descendant was not touched, so its own revision is unchanged.")
+               (is (= "Finance/Docs" (path))
+                   "Its path must still follow the rename, with no reload."))
+             (p/finally
+               (fn []
+                 (when-let [unsubscribe! @unsubscribe]
+                   (unsubscribe!)))))))))
+
 (deftest block-changed-uses-only-tx-id-test
   (let [block-uuid (random-uuid)
         old-block (block block-uuid 10 "before" {:block/format :markdown

--- a/src/test/frontend/handler/block_test.cljs
+++ b/src/test/frontend/handler/block_test.cljs
@@ -64,6 +64,29 @@
                          :block/tags [(d/entid @conn :logseq.class/Tag)]}]
     (is (= "Project/Milestone" (block-handler/block-unique-title plain-class-map :db @conn)))))
 
+(deftest block-unique-title-hierarchy-follows-show-hierarchy-setting
+  (let [block {:block/title "Docs"
+               :block/tags [{:db/ident :logseq.class/Page}]
+               :block.temp/hierarchy-title "Superhuman/Docs"}
+        title #(block-handler/block-unique-title block :with-tags? false)]
+    (testing "off by default"
+      (with-redefs [state/show-hierarchy? (constantly false)]
+        (is (= "Docs" (title)))))
+    (testing "on when enabled"
+      (with-redefs [state/show-hierarchy? (constantly true)]
+        (is (= "Superhuman/Docs" (title)))))))
+
+(deftest block-unique-title-hierarchy-keeps-caller-supplied-title
+  (testing "a prepared display title, e.g. a search snippet, wins over the hierarchy"
+    (let [block {:block/title "Docs"
+                 :block/tags [{:db/ident :logseq.class/Page}]
+                 :block.temp/hierarchy-title "Superhuman/Docs"}]
+      (with-redefs [state/show-hierarchy? (constantly true)]
+        (is (= "highlighted"
+               (block-handler/block-unique-title block
+                                                 :title "highlighted"
+                                                 :with-tags? false)))))))
+
 (deftest get-top-level-blocks-uses-original-block-without-renderer-rehydration-test
   (let [block-id #uuid "11111111-1111-1111-1111-111111111111"
         block {:db/id 1

--- a/src/test/frontend/worker/handler/render_resource_test.cljs
+++ b/src/test/frontend/worker/handler/render_resource_test.cljs
@@ -729,6 +729,32 @@
                             :value :block/uuid]))
           "The real loader partition must retain a later root's hydrated dependency."))))
 
+(deftest namespaced-page-snapshot-carries-its-hierarchy-title-test
+  (let [conn (db-test/create-conn-with-blocks
+              {:pages-and-blocks [{:page {:block/title "Superhuman"}}
+                                  {:page {:block/title "Docs"}}]})
+        parent (db-test/find-page-by-title @conn "Superhuman")
+        child (db-test/find-page-by-title @conn "Docs")
+        ;; canonical-block requires a revision, as the fixture data above does
+        _ (d/transact! conn [{:db/id (:db/id parent) :block/tx-id 20}
+                             {:db/id (:db/id child)
+                              :block/tx-id 20
+                              :block/parent (:db/id parent)}])
+        child-uuid (:block/uuid child)
+        parent-uuid (:block/uuid parent)
+        response (render-engine/render-snapshots
+                  @conn {:blocks [child-uuid parent-uuid] :children [] :resources []} {})]
+    (is (= "Superhuman/Docs"
+           (get-in response [:slots [:block child-uuid]
+                             :value :block.temp/hierarchy-title]))
+        "The renderer cannot walk ancestors, so the path must arrive in the snapshot.")
+    (is (= "Superhuman"
+           (get-in response [:slots [:block parent-uuid] :value :block/title]))
+        "The parent slot is present, so the next assertion is not vacuous.")
+    (is (nil? (get-in response [:slots [:block parent-uuid]
+                                :value :block.temp/hierarchy-title]))
+        "A top-level page has no path to add.")))
+
 (deftest render-snapshots-thread-api-fails-fast-without-a-database-test
   (when-let [api (get @thread-api/*thread-apis
                       :thread-api/get-render-snapshots)]


### PR DESCRIPTION
A link to a page inside a hierarchy currently shows only the last part. With **Settings → Editor → Show full page hierarchy in links** turned on, it shows the whole path:

| Off (today) | On |
| --- | --- |
| <img width="920" alt="Links showing only the last part of the page name: Docs, Invoices" src="https://github.com/user-attachments/assets/391cbb3d-3f7a-4988-9ca5-1670581765c4" /> | <img width="920" alt="The same links showing their full hierarchy: Superhuman/Docs, Superhuman/Billing/Invoices" src="https://github.com/user-attachments/assets/18a7f1ed-dd36-4ed9-a3cf-c721bb789de5" /> |

Off by default. Only the display changes — nothing is written to the page, and the block still holds the same text when you edit it. Renaming any page in the path updates the links straight away.

Applies to page links and tags inside blocks, and to the Pages list. Search results, the sidebar list and graph view still show the short name; they get their titles from elsewhere and can follow separately.

## How it works

A page's full path can't be assembled in the renderer: it holds no database, and refs in its snapshots are flattened one level deep. The path is computed in the worker and attached to the page's snapshot as `:block.temp/hierarchy-title`.

Renaming a page in the middle of a path doesn't touch the pages beneath it, so datascript never bumps their `:block/tx-id`. Two changes keep those labels current: the render delta re-emits the affected subtree, and the client's slot store no longer discards a page whose path changed while its own revision did not.

## Notes

Proposed in #13021. Asked for in logseq/db-test#698 and #12277. logseq/db-test#166 was closed as fixed on the grounds that namespaced pages show their full path, so this makes that behaviour available as an option rather than the default.

Tests added: the setting gating the display (`frontend.handler.block-test`), the path reaching the renderer (`frontend.worker.handler.render-resource-test`), and renaming a parent refreshing the pages beneath it (`frontend.db.subs-test`).

Run locally and green: all six lint steps from CI's `lint` job, plus the full unit suite across 230 namespaces. Fork pull requests need a maintainer to approve workflow runs, so the checks here are empty until then.

Two commits: the setting, then the display.
