### PR TITLE
fix: restore mobile rtc sync triggers

### DIFF
--- a/src/main/frontend/handler/db_based/rtc_background_tasks.cljs
+++ b/src/main/frontend/handler/db_based/rtc_background_tasks.cljs
@@ -13,7 +13,9 @@
   [atom' key' f]
   (when-not config/publishing?
     (remove-watch atom' key')
-    (add-watch atom' key' (fn [_ _ _ value] (f value)))))
+    (add-watch atom' key' (fn [_ _ _ value] (f value)))
+    (when-some [value @atom']
+      (f value))))
 
 (add-watch-when-not-publishing!
  rtc-flows/rtc-try-restart

--- a/src/main/frontend/worker/state.cljs
+++ b/src/main/frontend/worker/state.cljs
@@ -132,7 +132,7 @@
   []
   (if (node-runtime?)
     (node-online?)
-    @(:thread-atom/online-event @*state)))
+    (not (false? @(:thread-atom/online-event @*state)))))
 
 (comment
   (defn mobile?

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -931,62 +931,84 @@
   (let [inflight @(:inflight client)
         local-tx (client-op/get-local-tx repo)
         remote-tx (get @*repo->latest-remote-tx repo)
-        conn (worker-state/get-datascript-conn repo)]
-    (when (and conn (= local-tx remote-tx) (empty? inflight)) ; rebase
-      (when-let [ws (:ws client)]
-        (when (and (ws-open? ws) (worker-state/online?) (not (upload-stopped? repo)))
-          (let [batch (pending-txs repo {:limit 50})]
-            (when (seq batch)
-              (let [{:keys [tx-entries drop-tx-ids drop-txs]} (prepare-upload-tx-entries repo conn batch)]
-                (when (seq drop-tx-ids)
-                  (log/info :db-sync/drop-tx-ids {:tx-ids drop-tx-ids
-                                                  :drops drop-txs})
-                  (mark-pending-txs-false! repo drop-tx-ids))
-                (-> (p/let [aes-key (when (and (seq tx-entries) (sync-crypt/graph-e2ee? repo))
-                                      (sync-crypt/<ensure-graph-aes-key repo (:graph-id client)))
-                            _ (when (and (seq tx-entries) (sync-crypt/graph-e2ee? repo) (nil? aes-key))
-                                (fail-fast :db-sync/missing-field {:repo repo :field :aes-key}))
-                            tx-entries* (p/all
-                                         (mapv (fn [{:keys [tx-data] :as tx-entry}]
-                                                 (p/let [tx-data* (offload-large-titles
-                                                                   tx-data
-                                                                   {:repo repo
-                                                                    :graph-id (:graph-id client)
-                                                                    :aes-key aes-key})
-                                                         tx-data** (if aes-key
-                                                                     (sync-crypt/<encrypt-tx-data aes-key tx-data*)
-                                                                     tx-data*)]
-                                                   (assoc tx-entry :tx-data tx-data**)))
-                                               tx-entries))
-                            payload (mapv (fn [{:keys [tx-id tx-data outliner-op]}]
-                                            (cond-> {:tx (sqlite-util/write-transit-str tx-data)}
-                                              tx-id
-                                              (assoc :tx-id (str tx-id))
-                                              outliner-op
-                                              (assoc :outliner-op outliner-op)))
-                                          tx-entries*)
-                            tx-ids (into [] (keep :tx-id) tx-entries)]
-                      (when (seq tx-entries)
-                        (reset! (:inflight client) tx-ids)
-                        (p/do!
-                         (send! ws {:type "tx/batch"
-                                    :client-revision (build-version/revision)
-                                    :t-before local-tx
-                                    :txs payload})
-                         (start-upload-response-timeout!
-                          client
-                          {:tx-ids tx-ids
-                           :outliner-ops (->> tx-entries
-                                              (keep :outliner-op)
-                                              distinct
-                                              vec)
-                           :large-upload-progress (large-upload-progress tx-entries*)
-                           :t-before local-tx}))))
-                    (p/catch (fn [error]
-                               (sync-util/set-last-sync-error! client error)
-                               (log/error :db-sync/flush-pending-failed
-                                          {:repo repo
-                                           :error error}))))))))))))
+        conn (worker-state/get-datascript-conn repo)
+        ws (:ws client)
+        ws-open-state? (when ws (ws-open? ws))
+        online? (worker-state/online?)
+        upload-stopped-state? (upload-stopped? repo)
+        pending-count (client-op/get-pending-local-tx-count repo)
+        ready? (and conn
+                    (= local-tx remote-tx)
+                    (empty? inflight)
+                    ws-open-state?
+                    online?
+                    (not upload-stopped-state?))]
+    (when (and (pos? (or pending-count 0))
+               (not ready?))
+      (log/info :db-sync/flush-pending-skipped
+                {:repo repo
+                 :pending-local-tx-count pending-count
+                 :has-db? (some? conn)
+                 :local-tx local-tx
+                 :remote-tx remote-tx
+                 :inflight-count (count inflight)
+                 :ws-open? ws-open-state?
+                 :ws-ready-state (ws-ready-state ws)
+                 :online? online?
+                 :upload-stopped? upload-stopped-state?}))
+    (when ready?
+      (let [batch (pending-txs repo {:limit 50})]
+        (when (seq batch)
+          (let [{:keys [tx-entries drop-tx-ids drop-txs]} (prepare-upload-tx-entries repo conn batch)]
+            (when (seq drop-tx-ids)
+              (log/info :db-sync/drop-tx-ids {:tx-ids drop-tx-ids
+                                              :drops drop-txs})
+              (mark-pending-txs-false! repo drop-tx-ids))
+            (-> (p/let [aes-key (when (and (seq tx-entries) (sync-crypt/graph-e2ee? repo))
+                                  (sync-crypt/<ensure-graph-aes-key repo (:graph-id client)))
+                        _ (when (and (seq tx-entries) (sync-crypt/graph-e2ee? repo) (nil? aes-key))
+                            (fail-fast :db-sync/missing-field {:repo repo :field :aes-key}))
+                        tx-entries* (p/all
+                                     (mapv (fn [{:keys [tx-data] :as tx-entry}]
+                                             (p/let [tx-data* (offload-large-titles
+                                                               tx-data
+                                                               {:repo repo
+                                                                :graph-id (:graph-id client)
+                                                                :aes-key aes-key})
+                                                     tx-data** (if aes-key
+                                                                 (sync-crypt/<encrypt-tx-data aes-key tx-data*)
+                                                                 tx-data*)]
+                                               (assoc tx-entry :tx-data tx-data**)))
+                                           tx-entries))
+                        payload (mapv (fn [{:keys [tx-id tx-data outliner-op]}]
+                                        (cond-> {:tx (sqlite-util/write-transit-str tx-data)}
+                                          tx-id
+                                          (assoc :tx-id (str tx-id))
+                                          outliner-op
+                                          (assoc :outliner-op outliner-op)))
+                                      tx-entries*)
+                        tx-ids (into [] (keep :tx-id) tx-entries)]
+                  (when (seq tx-entries)
+                    (reset! (:inflight client) tx-ids)
+                    (p/do!
+                     (send! ws {:type "tx/batch"
+                                :client-revision (build-version/revision)
+                                :t-before local-tx
+                                :txs payload})
+                     (start-upload-response-timeout!
+                      client
+                      {:tx-ids tx-ids
+                       :outliner-ops (->> tx-entries
+                                          (keep :outliner-op)
+                                          distinct
+                                          vec)
+                       :large-upload-progress (large-upload-progress tx-entries*)
+                       :t-before local-tx}))))
+                (p/catch (fn [error]
+                           (sync-util/set-last-sync-error! client error)
+                           (log/error :db-sync/flush-pending-failed
+                                      {:repo repo
+                                       :error error}))))))))))
 
 (defn enqueue-flush-pending!
   [repo client]

--- a/src/main/mobile/init.cljs
+++ b/src/main/mobile/init.cljs
@@ -64,6 +64,12 @@
                                             (js/window.location.reload)))))))))
   (reset! mobile-flows/*mobile-app-state (.-isActive state)))
 
+(defn- sync-current-network-status! []
+  (-> (.getStatus Network)
+      (p/then #(reset! mobile-flows/*mobile-network-status %))
+      (p/catch (fn [error]
+                 (log/warn ::network-status-read-failed error)))))
+
 (defn- general-init!
   "Initialize event listeners used by both iOS and Android"
   []
@@ -96,6 +102,7 @@
                      #(util/scroll-to-top true))
 
   (.addListener App "appStateChange" app-state-change-handler)
+  (sync-current-network-status!)
   (.addListener Network "networkStatusChange" #(reset! mobile-flows/*mobile-network-status %)))
 
 (defn init! []

--- a/src/test/frontend/handler/db_based/rtc_flows_test.cljs
+++ b/src/test/frontend/handler/db_based/rtc_flows_test.cljs
@@ -1,5 +1,7 @@
 (ns frontend.handler.db-based.rtc-flows-test
   (:require [cljs.test :refer [deftest is]]
+            [frontend.config :as config]
+            [frontend.handler.db-based.rtc-background-tasks :as rtc-background-tasks]
             [frontend.handler.db-based.rtc-flows :as rtc-flows]))
 
 (deftest resume-restart-events-do-not-depend-on-cached-rtc-lock-test
@@ -9,3 +11,14 @@
          (#'rtc-flows/network-online->restart-event true)))
   (is (= :mobile-app-active&rtc-not-running
          (#'rtc-flows/mobile-app-active->restart-event true))))
+
+(deftest rtc-background-watch-consumes-existing-event-test
+  (let [source (atom [:graph-switch "repo"])
+        events (atom [])]
+    (with-redefs [config/publishing? false]
+      (#'rtc-background-tasks/add-watch-when-not-publishing!
+       source
+       ::consume-existing-event
+       #(swap! events conj %))
+      (is (= [[:graph-switch "repo"]] @events))
+      (remove-watch source ::consume-existing-event))))

--- a/src/test/frontend/worker/state_test.cljs
+++ b/src/test/frontend/worker/state_test.cljs
@@ -20,6 +20,17 @@
       (finally
         (reset! worker-state/*state state-prev)))))
 
+(deftest online?-treats-uninitialized-thread-online-event-as-online
+  (let [state-prev @worker-state/*state]
+    (try
+      (with-redefs [platform/current (fn []
+                                       {:env {:runtime :web}})]
+        (reset! worker-state/*state (with-online-event nil))
+        (testing "an uninitialized mobile network status should not block sync uploads"
+          (is (true? (worker-state/online?)))))
+      (finally
+        (reset! worker-state/*state state-prev)))))
+
 (deftest online?-node-runtime-does-not-require-main-thread-online-event
   (let [state-prev @worker-state/*state]
     (try


### PR DESCRIPTION
## Summary

- Restore initial mobile network status sync so db-worker upload gating does not see an uninitialized online state.
- Treat only explicit offline state as offline in the worker.
- Consume existing RTC background events when watchers attach, preserving pre-refactor startup behavior.
- Add debug logging for skipped pending local tx flushes.

## Root cause

The remove-missionary refactor replaced flows with atom watchers. Mobile lost the initial `Network.getStatus()` emission, so iOS could leave the worker online event unset until a network change event occurred. The same watcher conversion could also miss RTC events that were already present before the background watcher attached.

## Validation

- `bb dev:test -v 'frontend.worker.state-test/online?-treats-uninitialized-thread-online-event-as-online' -v frontend.handler.db-based.rtc-flows-test/rtc-background-watch-consumes-existing-event-test -v frontend.worker.db-sync-test/flush-pending-honors-stop-upload-debug-flag-test -v frontend.worker.db-sync-test/tx-batch-ok-removes-acked-pending-txs-test`