### PR TITLE
fix: prevent plugin settings crash

### DIFF
--- a/src/main/frontend/components/plugins_settings.cljs
+++ b/src/main/frontend/components/plugins_settings.cljs
@@ -111,17 +111,20 @@
   [schema ^js pl]
   (let [^js plugin-settings (.-settings pl)
         pid (.-id pl)
-        [settings, set-settings!] (hooks/use-state (bean/->clj (.toJSON plugin-settings)))
+        [settings, set-settings!] (hooks/use-state (some-> plugin-settings (.toJSON) (bean/->clj)))
         [edit-mode, set-edit-mode!] (hooks/use-state nil) ;; code
-        update-setting! (fn [k v] (.set plugin-settings (name k) (bean/->js v)))]
+        update-setting! (fn [k v]
+                          (when plugin-settings
+                            (.set plugin-settings (name k) (bean/->js v))))]
 
     (hooks/use-effect!
      (fn []
-       (let [on-change (fn [^js s]
-                         (when-let [s (bean/->clj s)]
-                           (set-settings! s)))]
-         (.on plugin-settings "change" on-change)
-         #(.off plugin-settings "change" on-change)))
+       (when plugin-settings
+         (let [on-change (fn [^js s]
+                           (when-let [s (bean/->clj s)]
+                             (set-settings! s)))]
+           (.on plugin-settings "change" on-change)
+           #(.off plugin-settings "change" on-change))))
      [pid])
 
     (if (seq schema)

--- a/src/test/frontend/components/plugins_settings_test.cljs
+++ b/src/test/frontend/components/plugins_settings_test.cljs
@@ -1,0 +1,34 @@
+(ns frontend.components.plugins-settings-test
+  (:require ["react" :as react]
+            ["react-dom/server" :as react-dom-server]
+            [cljs.test :refer [deftest is testing]]
+            [frontend.components.plugins-settings :as plugins-settings]
+            [frontend.handler.plugin :as plugin-handler]
+            [frontend.security :as security]
+            [goog.object :as gobj]))
+
+(defn- render-static
+  [element]
+  (let [previous-react (gobj/get js/globalThis "React")]
+    (gobj/set js/globalThis "React" react)
+    (try
+      (.renderToStaticMarkup react-dom-server element)
+      (finally
+        (if (some? previous-react)
+          (gobj/set js/globalThis "React" previous-react)
+          (js-delete js/globalThis "React"))))))
+
+(deftest settings-container-renders-plugin-without-settings-state
+  (let [schema [{:key "github-theme"
+                 :type "string"
+                 :title "Theme"
+                 :default "dark-dimmed"
+                 :description "Theme id"}]
+        plugin #js {:id "logseq-github-theme"
+                    :settingsSchema #js []}]
+    (testing "A plugin with settingsSchema but no settings object must not crash settings"
+      (with-redefs [plugin-handler/markdown-to-html identity
+                    security/sanitize-html identity]
+        (is (re-find #"logseq-github-theme"
+                     (render-static
+                      (plugins-settings/settings-container schema plugin))))))))


### PR DESCRIPTION
## Summary

Fixes logseq/db-test#1027.

Plugin settings rendering no longer assumes every plugin with a settings schema also exposes a settings object. Missing settings state is treated as empty state, and subscriptions/updates are skipped when the plugin settings API is absent.

## Validation

- Reproduced the old renderer failure in the live :app REPL: `Cannot read properties of undefined (reading 'toJSON')`\n- Verified the fixed renderer path in the live :app REPL renders `logseq-github-theme` without throwing\n- `bb dev:test -v frontend.components.plugins-settings-test`\n- `bb dev:lint-and-test` was started; lint passed and many test batches passed, then it was interrupted on request before full completion\n