### PR TITLE
fix: normalize property value choice identities

### DIFF
--- a/src/main/logseq/api/db_based.cljs
+++ b/src/main/logseq/api/db_based.cljs
@@ -405,10 +405,21 @@
     (db-property-handler/remove-block-property! (:block/uuid block)
                                                 :logseq.property/icon)))
 
+(defn- block-identity->uuid
+  [block-identity]
+  (let [block-uuid (if (map? block-identity)
+                     (:uuid block-identity)
+                     block-identity)]
+    (sdk-utils/uuid-or-throw-error block-uuid)))
+
 (defn add-property-value-choices [property-id ^js choices]
   (when-let [values (and property-id (bean/->clj choices))]
-    (db-property-handler/add-existing-values-to-closed-values!
-     property-id values)))
+    (p/let [property (<get-block (block-identity->uuid (bean/->clj property-id)))]
+      (when-not (entity/property? property)
+        (throw (ex-info "Not a valid property" {:property property-id})))
+      (db-property-handler/add-existing-values-to-closed-values!
+       (:db/ident property)
+       (mapv block-identity->uuid values)))))
 
 (defn set-property-node-tags [property-id ^js tag-ids]
   (let [tag-ids (and property-id (seq (bean/->clj tag-ids)))]

--- a/src/test/logseq/api_test.cljs
+++ b/src/test/logseq/api_test.cljs
@@ -6,8 +6,10 @@
             [frontend.db.async :as db-async]
             [frontend.db.conn :as conn]
             [frontend.db.utils :as db-utils]
+            [frontend.handler.db-based.property :as db-property-handler]
             [frontend.test.helper :as test-helper]
             [logseq.api.block :as api-block]
+            [logseq.api.db-based :as db-based-api]
             [promesa.core :as p]))
 
 (use-fixtures :each {:before #(test-helper/start-test-db! {:build-init-data? false})
@@ -118,6 +120,70 @@
               (is (= "grandchild"
                      (get-in (js->clj result :keywordize-keys true)
                              [:children 0 :children 0 :title])))))
+          (p/catch (fn [error]
+                     (is false (str error))))
+          (p/finally done)))))
+
+(deftest add-property-value-choices-normalizes-block-identities
+  (async done
+    (let [property-uuid #uuid "4406f839-6410-43b5-87db-25e9b8f54cc0"
+          choice-uuid #uuid "d9b7b45f-267f-4794-9569-f43d1ce77172"
+          calls (atom [])]
+      (-> (p/with-redefs [db-property-handler/add-existing-values-to-closed-values!
+                          (fn [property-id values]
+                            (swap! calls conj [property-id values])
+                            (p/resolved nil))
+                          db-async/<get-block
+                          (fn [_repo property-id options]
+                            (is (= property-uuid property-id))
+                            (is (= {:children? false} options))
+                            (p/resolved {:db/ident :user.property/status
+                                         :block/tags [{:db/ident :logseq.class/Property}]}))]
+            (p/let [_ (db-based-api/add-property-value-choices
+                       (str property-uuid)
+                       #js [(str choice-uuid)])
+                    _ (db-based-api/add-property-value-choices
+                       #js {:uuid (str property-uuid)}
+                       #js [#js {:uuid (str choice-uuid)}])]
+              (is (= [[:user.property/status [choice-uuid]]
+                      [:user.property/status [choice-uuid]]]
+                     @calls))))
+          (p/catch (fn [error]
+                     (is false (str error))))
+          (p/finally done)))))
+
+(deftest add-property-value-choices-rejects-invalid-identities
+  (async done
+    (let [property-uuid #uuid "4406f839-6410-43b5-87db-25e9b8f54cc0"
+          choice-uuid #uuid "d9b7b45f-267f-4794-9569-f43d1ce77172"
+          get-block-calls (atom 0)
+          handler-called? (atom false)]
+      (-> (p/with-redefs [db-property-handler/add-existing-values-to-closed-values!
+                          (fn [& _args]
+                            (reset! handler-called? true)
+                            (p/resolved nil))
+                          db-async/<get-block
+                          (fn [_repo _property-id _options]
+                            (p/resolved
+                             (if (= 1 (swap! get-block-calls inc))
+                               {:db/ident :user.property/status
+                                :block/tags [{:db/ident :logseq.class/Property}]}
+                               {:block/tags []})))]
+            (p/let [{invalid-choice-error :error}
+                    (p/catch
+                     (db-based-api/add-property-value-choices
+                      (str property-uuid)
+                      #js ["not-a-uuid"])
+                     (fn [error] {:error error}))
+                    {invalid-property-error :error}
+                    (p/catch
+                     (db-based-api/add-property-value-choices
+                      (str property-uuid)
+                      #js [(str choice-uuid)])
+                     (fn [error] {:error error}))]
+              (is (re-find #"not a valid UUID string" (ex-message invalid-choice-error)))
+              (is (re-find #"Not a valid property" (ex-message invalid-property-error)))
+              (is (false? @handler-called?))))
           (p/catch (fn [error]
                      (is false (str error))))
           (p/finally done)))))


### PR DESCRIPTION
## Summary

- normalize both supported `BlockIdentity` forms at the plugin API boundary
- resolve the property UUID to its canonical `:db/ident` before constructing the outliner op
- add regression coverage for UUID strings and `{ uuid }` objects

## Problem

`Editor.addPropertyValueChoices` accepts `BlockIdentity` values, but its DB implementation forwarded JS values into an outliner path that requires native UUID choices and a qualified property ident. As a result, valid SDK calls could resolve without persisting any closed-value relation.

## Fix

Convert plugin-facing block identities at the JS/CLJS boundary, validate that the requested property exists and is a property, then pass the canonical property ident and native choice UUIDs to the existing handler.

The outliner transaction and persisted schema are unchanged.

## Follow-up scope

This PR intentionally does not change the shared renderer/worker transaction error transport or the existing best-effort handling of well-formed UUIDs that do not resolve to entities. Those behaviors affect multiple outliner APIs and should be addressed separately from this public identity-contract fix.

## Tests

- `node static/tests.js -n logseq.api-test`
- `bb lint:kondo-git-changes`
- `git diff --check`
- manual DB-graph verification with SDK 0.2.12:
  - UUID string identity resolves and persists the relation
  - `{ uuid }` identity resolves and persists the relation
  - the relation remains after switching away from and reopening the graph
  - invalid identity and non-property inputs reject before the mutation handler

Fixes logseq/db-test#1032
