### PR TITLE
enhance: allow eager query result loading

### DIFF
--- a/src/main/frontend/common_keywords.cljs
+++ b/src/main/frontend/common_keywords.cljs
@@ -7,5 +7,6 @@
   :block/name      {:doc "block name, lowercase, only page-blocks have this attr"}
   :block/raw-title {:doc "like `:block/title`,
                           but when eval `(:block/raw-title block-entity)`, return raw title of this block"}
+  :query/eager-load-results? {:doc "When true, eagerly load canonical block query results."}
   :kv/value        {:doc "Used to store key-value, the value could be anything,
                           e.g. {:db/ident :logseq.kv/xxx :kv/value value}"})

--- a/src/main/frontend/components/query/result.cljs
+++ b/src/main/frontend/components/query/result.cljs
@@ -39,6 +39,9 @@
       (:today-day config)
       (assoc :today-day (:today-day config))
 
+      (contains? query :query/eager-load-results?)
+      (assoc :query/eager-load-results? (:query/eager-load-results? query))
+
       (contains? query :remove-block-children?)
       (assoc :remove-block-children? (boolean (:remove-block-children? query)))
 

--- a/src/main/frontend/worker/handler/render_resource/common.cljs
+++ b/src/main/frontend/worker/handler/render_resource/common.cljs
@@ -5,6 +5,10 @@
 
 (def watch-all ::watch-all)
 
+(def max-blocks-per-snapshot
+  "Maximum number of root blocks loaded by one renderer snapshot."
+  1000)
+
 (defn fail!
   [message data]
   (throw (ex-info message data)))

--- a/src/main/frontend/worker/handler/render_resource/engine.cljs
+++ b/src/main/frontend/worker/handler/render_resource/engine.cljs
@@ -59,7 +59,7 @@
      :slots (or slots {})}))
 
 (def ^:private snapshot-request-limits
-  {:blocks 1000 :children 25 :resources 25})
+  {:blocks common/max-blocks-per-snapshot :children 25 :resources 25})
 
 (defn- require-snapshot-request!
   [request]

--- a/src/main/frontend/worker/handler/render_resource/query.cljs
+++ b/src/main/frontend/worker/handler/render_resource/query.cljs
@@ -2,6 +2,7 @@
   "DSL and Datalog query execution and result normalization."
   (:require [clojure.string :as string]
             [datascript.impl.entity :as de]
+            [frontend.worker.handler.block :as block-handler]
             [frontend.worker.handler.query :as query-handler]
             [frontend.worker.handler.render-resource.common :as common]
             [frontend.worker.handler.search :as search-handler]
@@ -50,6 +51,7 @@
     :current-page-title
     :current-block-uuid
     :today-day
+    :query/eager-load-results?
     :remove-block-children?
     :result-transform-edn})
 
@@ -82,6 +84,8 @@
                        (uuid? (:current-block-uuid query-spec)))
                    (or (not (contains? query-spec :today-day))
                        (valid-today-day? (:today-day query-spec)))
+                   (or (not (contains? query-spec :query/eager-load-results?))
+                       (boolean? (:query/eager-load-results? query-spec)))
                    (or (not (contains? query-spec :remove-block-children?))
                        (boolean? (:remove-block-children? query-spec)))
                    (or (not (contains? query-spec :result-transform-edn))
@@ -200,6 +204,19 @@
         rows (apply-result-transform rows (:result-transform-edn query-spec))]
     (mapv normalize-query-row rows)))
 
+(defn- eager-result-slots
+  [db rows {:query/keys [eager-load-results?]}]
+  (if (and (true? eager-load-results?)
+           (seq rows)
+           (every? uuid? rows))
+    (let [block-uuids (->> rows
+                           distinct
+                           (take common/max-blocks-per-snapshot)
+                           vec)
+          blocks (:blocks (block-handler/canonical-blocks db block-uuids))]
+      (common/block-slots blocks))
+    {}))
+
 (defn- dependency-watch
   [{:keys [attrs task-attrs tasks? opaque?]}]
   (let [watch-keys (cond-> (into #{} (map (fn [attr] [:attr attr])) attrs)
@@ -220,10 +237,12 @@
 
 (defn- query
   [db resource-key runtime]
-  (let [query-spec (require-query-spec! (second resource-key))]
+  (let [query-spec (require-query-spec! (second resource-key))
+        rows (query-result-rows (execute-query-spec db query-spec runtime)
+                                query-spec)]
     [(query-watch-keys db query-spec)
-     {:rows (query-result-rows (execute-query-spec db query-spec runtime)
-                               query-spec)}]))
+     {:rows rows}
+     (eager-result-slots db rows query-spec)]))
 
 (def resource-renderers
   {:query (common/renderer 2 query)})

--- a/src/test/frontend/components/query/result_test.cljs
+++ b/src/test/frontend/components/query/result_test.cljs
@@ -9,6 +9,7 @@
         datalog-row-uuid (random-uuid)
         resource-keys (atom [])
         dsl-query {:query "(task TODO)"
+                   :query/eager-load-results? true
                    :remove-block-children? false
                    :result-transform '(partial sort-by :block/title)}
         datalog-form '[:find (pull ?block [:block/uuid])
@@ -19,6 +20,7 @@
         rules '[[(journal-block ?block)
                  [?block :block/journal-day]]]
         datalog-query {:query datalog-form
+                       :query/eager-load-results? false
                        :inputs [:today]
                        :rules rules}]
     (with-redefs [db-hooks/use-resource
@@ -46,12 +48,14 @@
                 :query "(task TODO)"
                 :cards? true
                 :current-block-uuid current-block-uuid
+                :query/eager-load-results? true
                 :remove-block-children? false
                 :result-transform-edn
                 "(partial sort-by :block/title)"}]
               [:query
                {:kind :datalog
                 :query datalog-form
+                :query/eager-load-results? false
                 :inputs [:today]
                 :rules rules
                 :today-day 20260721

--- a/src/test/frontend/worker/handler/render_resource_test.cljs
+++ b/src/test/frontend/worker/handler/render_resource_test.cljs
@@ -4,6 +4,7 @@
             [frontend.common.thread-api :as thread-api]
             [frontend.db.subs-loader :as subs-loader]
             [frontend.worker.handler.block :as block-handler]
+            [frontend.worker.handler.render-resource.common :as render-common]
             [frontend.worker.handler.render-resource.engine :as render-engine]
             [frontend.worker.handler.query :as query-handler]
             [frontend.worker.handler.search :as search-handler]
@@ -1901,6 +1902,61 @@
                                     {:rows [view-row]}
                                     response))))))
 
+(deftest query-resource-eagerly-loads-block-results-only-when-requested-test
+  (when-let [api (render-resource-api)]
+    (let [{:keys [conn task-block]} (render-resource-fixture)
+          status-property (d/entity @conn :logseq.property/status)
+          status-property-uuid (:block/uuid status-property)
+          _ (d/transact! conn [[:db/add (:db/id status-property)
+                                :block/tx-id 20]])
+          query-result [[(query-block-row @conn task-block)]]
+          query-spec {:kind :dsl :query "(task DONE)"}
+          eager-resource-key [:query (assoc query-spec
+                                            :query/eager-load-results? true)]]
+      (with-redefs [query-dsl/execute-query
+                    (fn [& _args] query-result)]
+        (doseq [resource-key [[:query query-spec]
+                              [:query (assoc query-spec
+                                             :query/eager-load-results? false)]]]
+          (is (empty? (:slots (call-resource api conn resource-key)))
+              "Queries remain lazy unless eager loading is enabled."))
+        (let [response (call-resource api conn eager-resource-key)
+              task (get-in response [:slots [:block task-block] :value])]
+          (is (= {:rows [task-block]} (:value response)))
+          (is (= task-block (:block/uuid task)))
+          (is (some #{status-property-uuid}
+                    (get-in task
+                            [:block.temp/positioned-properties :block-left])))
+          (is (contains? (:slots response)
+                         [:block status-property-uuid])
+              "Positioned property metadata is ready with the result block."))))))
+
+(deftest query-resource-bounds-eager-block-loading-test
+  (when-let [api (render-resource-api)]
+    (let [{:keys [conn]} (render-resource-fixture)
+          limit render-common/max-blocks-per-snapshot
+          block-uuids (vec (repeatedly (inc limit) random-uuid))
+          query-result (mapv (fn [block-uuid]
+                               [{:block/uuid block-uuid}])
+                             block-uuids)
+          loaded-block-uuids (atom nil)
+          resource-key [:query {:kind :dsl
+                                :query "(task TODO)"
+                                :query/eager-load-results? true}]]
+      (with-redefs [query-dsl/execute-query
+                    (fn [& _args] query-result)
+                    block-handler/canonical-blocks
+                    (fn [_db requested-block-uuids]
+                      (when (seq requested-block-uuids)
+                        (reset! loaded-block-uuids requested-block-uuids))
+                      {:blocks {}})]
+        (let [response (call-resource api conn resource-key)]
+          (is (= block-uuids (get-in response [:value :rows]))
+              "Every query row remains available for lazy rendering.")
+          (is (= (subvec block-uuids 0 limit)
+                 @loaded-block-uuids)
+              "Eager loading shares the renderer snapshot block limit."))))))
+
 (deftest blank-dsl-query-resource-renders-an-empty-result-test
   (when-let [api (render-resource-api)]
     (let [{:keys [conn]} (render-resource-fixture)
@@ -1986,6 +2042,7 @@
     (let [{:keys [conn]} (render-resource-fixture)
           resource-key
           [:query {:kind :datalog
+                   :query/eager-load-results? true
                    :query '[:find ?title ?day
                             :in $ ?day
                             :where
@@ -1997,7 +2054,9 @@
                                 resource-key
                                 (datalog-query-watch-keys resource-key)
                                 {:rows [["Jan 1st, 2020" 20200101]]}
-                                response))))
+                                response)
+      (is (empty? (:slots response))
+          "Eager loading applies only to block-only query results."))))
 
 (deftest query-resource-applies-serialized-transform-and-top-level-filter-test
   (when-let [api (render-resource-api)]
@@ -2106,6 +2165,9 @@
       (testing "query specs contain no closures, entities, or untyped options"
         (doseq [resource-key
                 [[:query {:kind :dsl :query "(task TODO)" :cards? "false"}]
+                 [:query {:kind :dsl
+                          :query "(task TODO)"
+                          :query/eager-load-results? "true"}]
                  [:query {:kind :dsl
                           :query "(task TODO)"
                           :query-fn identity}]


### PR DESCRIPTION
## Summary

- Add the advanced/default query option `:query/eager-load-results? true`.
- Return canonical result blocks and positioned-property dependencies in the same atomic resource response as the query rows.
- Preserve the current lazy behavior when the option is absent or `false`, and for scalar or tuple results.
- Reuse the renderer's existing 1,000-root snapshot ceiling; all overflow rows are still returned and remain lazily loadable.

## Motivation

DB graph queries initially expose normalized block UUIDs, then hydrate each rendered row independently. Positioned properties such as Status can therefore be unavailable on the initial render.

The opt-in lets bounded dashboard-style queries make their block snapshots and positioned-property definitions ready with the query result, without changing default query performance.

```clojure
{:title "NEXT"
 :query [:find (pull ?b [*])
         :where
         (task ?b #{"Todo"})]
 :query/eager-load-results? true}
```

The option is serialized as data and validated as a Boolean by the worker. Canonical slots are deduplicated and installed through the existing resource-group path, so normal block subscriptions continue to own subsequent updates.

## Safety and compatibility

- Existing queries keep their current lazy behavior.
- Non-block results never trigger eager block loading.
- At most 1,000 distinct root blocks are eagerly loaded in one snapshot.
- Query row order and cardinality are unchanged; rows beyond the limit fall back to normal lazy loading.
- No schema migration or UI string change is required.

## Tests

- `pnpm cljs:test`
- `frontend.components.query.result-test`: 1 test, 3 assertions
- `frontend.worker.handler.render-resource-test`: 68 tests, 594 assertions
- `frontend.db.subs-test`: 50 tests, 407 assertions
- Full source lint: 0 errors, 0 warnings
- Carve, large-var, worker/frontend-boundary, namespace-docstring, and translation-key checks

The aggregate Windows test command is not reported as green because the upstream suite has unrelated Windows-only failures in Electron embedding path assertions and a DOM timer leak. The complete affected namespaces above pass.

Closes #13023

Related, independent collapse-setting fix: #13022