### PR TITLE
fix: avoid logging database contents on worker invocation errors

### DIFF
--- a/src/main/frontend/worker/db_worker_node.cljs
+++ b/src/main/frontend/worker/db_worker_node.cljs
@@ -302,7 +302,6 @@
     (log/error :db-worker-node-invoke-failed
                {:status status
                 :code code
-                :error error
                 :message message
                 :method method-kw})
     (send-json! res status payload)))
@@ -344,19 +343,7 @@
                              result (<invoke-binary! proxy method-str method-kw repo binary)]
                        (send-json! res 200 {:ok true :resultTransit (ldb/write-transit-str result)}))))
                  (p/catch (fn [error]
-                            (let [data (ex-data error)
-                                  status (invoke-error-status data)
-                                  code (invoke-error-code data)
-                                  message (invoke-error-message error data)
-                                  payload {:ok false
-                                           :error {:code code
-                                                   :message message}}]
-                              (log/error :db-worker-node-invoke-failed
-                                         {:status status
-                                          :code code
-                                          :method method-str
-                                          :error error})
-                              (send-json! res status payload))))))
+                            (log-invoke-error! res error method-kw)))))
            (send-text! res 405 "method-not-allowed"))
 
          (= request-path "/v1/invoke")

--- a/src/test/frontend/worker/db_worker_node_test.cljs
+++ b/src/test/frontend/worker/db_worker_node_test.cljs
@@ -1683,6 +1683,40 @@
                               (-> (stop!) (p/finally (fn [] (done))))
                               (done))))))))
 
+(deftest db-worker-node-query-input-error-does-not-log-db
+  (async done
+         (let [daemon (atom nil)
+               data-dir (node-helper/create-tmp-dir "db-worker-query-input-error")
+               repo (str "logseq_db_query_input_" (subs (str (random-uuid)) 0 8))
+               log-file (log-path data-dir repo)]
+           (-> (p/let [{:keys [host port stop!]}
+                       (start-daemon! {:root-dir data-dir :repo repo})
+                       _ (reset! daemon {:stop! stop!})
+                       _ (invoke host port "thread-api/create-or-open-db" [repo {}])
+                       {:keys [status body]}
+                       (invoke-raw host port "thread-api/q"
+                                   [repo
+                                    ['[:find ?e
+                                       :in $ ?property
+                                       :where
+                                       [?e :block/title ?property]]]])
+                       _ (p/delay 50)
+                       parsed (js->clj (js/JSON.parse body) :keywordize-keys true)
+                       contents (.toString (fs/readFileSync log-file) "utf8")]
+                 (is (= 500 status))
+                 (is (false? (:ok parsed)))
+                 (is (string/includes? contents
+                                       "Too few inputs passed, expected: [$ ?property], got: 1"))
+                 (is (not (string/includes? contents "#datascript/DB")))
+                 (is (not (string/includes? contents ":schema")))
+                 (is (< (count contents) 20000)))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (if-let [stop! (:stop! @daemon)]
+                              (-> (stop!) (p/finally (fn [] (done))))
+                              (done))))))))
+
 (deftest db-worker-node-opening-graph-does-not-run-maintenance
   (async done
          (let [daemon (atom nil)


### PR DESCRIPTION
Fixes logseq/db-test#1052

## Description

A failed `db-worker-node` invocation can currently serialize a full DataScript DB into the graph-local log.

DataScript query input errors include the received DB in `ex-data`. Passing the complete exception object to `log/error` therefore writes the graph schema and datoms to disk. A caller that retries the rejected query can create a multi-gigabyte log in less than a minute.

This change:

- stops adding the raw exception object to `:db-worker-node-invoke-failed` log entries;
- preserves the status, normalized error code, message, and method;
- routes `/v1/import-db-binary` failures through the same sanitized error helper; and
- adds a worker integration regression test using the actual missing-query-input failure path.

The HTTP response contract is unchanged.

## Test plan

- Run `frontend.worker.db-worker-node-test/db-worker-node-query-input-error-does-not-log-db` against the compiled CLJS test target.
- Verify the request still returns HTTP 500 and `{ok: false}`.
- Verify the log contains `Too few inputs passed, expected: [$ ?property], got: 1`.
- Verify the log does not contain `#datascript/DB` or `:schema` and remains below 20 KB.

## Local verification

- Targeted worker regression test: 1 test, 8 assertions, 0 failures, 0 errors.
- `git diff --check` passed.

No schema, persisted data, protocol, public API, or UI text changes are involved, so no migration, schema version bump, or i18n update is required.
