### PR TITLE
fix(graph-parser): preserve special content in imported quote blocks

### DIFF
--- a/deps/graph-parser/bb.edn
+++ b/deps/graph-parser/bb.edn
@@ -26,4 +26,5 @@
 
  :tasks/config
  {:large-vars
-  {:max-lines-count 75}}}
+  {:metadata-exceptions #{:large-vars/cleanup-todo}
+   :max-lines-count 75}}}

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -1833,10 +1833,12 @@
 
 (defn- handle-math
   "If a block's entire content is a single displayed math formula, convert to #Math node.
-  Detects blocks whose title is entirely delimited by $$ markers."
+  Detects blocks whose title is entirely delimited by $$ markers. Quote-blocks retain their
+  quote type and math delimiters."
   [block]
   (let [title (string/trim (:block/title block))]
-    (if (and (string/starts-with? title "$$")
+    (if (and (not= :quote (:logseq.property.node/display-type block))
+             (string/starts-with? title "$$")
              (string/ends-with? title "$$")
              (> (count title) 4)
              ;; ensure there's no nested $$ pair (i.e. not two separate inline formulas)
@@ -1945,8 +1947,9 @@
 (defn- handle-code-blocks
   "Returns a vector of block and optional block children tx. If a block
   contains code fence(s) i.e. ```, converts block to a #Code node.  If user
-  enables :extract-code-snippets? option, multiple code fences are extracted out
-  of text and put into children blocks in the order they appear"
+  enables the `:extract-code-snippets?` option, multiple code fences are extracted out
+  of text and put into children blocks in the order they appear. Quote-blocks containing
+  only one code fence retain their quote type and code fence."
   [block' options]
   (let [title (:block/title block')
         has-fence? (and (string? title) (at-least-two? title "```"))
@@ -1961,13 +1964,15 @@
                                         (some #(not (string/blank? %)) text-parts))]
             (cond
               pure-single-code?
-              (let [{:keys [text lang]} (first code-segs)]
-                [(cond-> (assoc block'
-                                :block/title text
-                                :block/tags [:logseq.class/Code-block]
-                                :logseq.property.node/display-type :code)
-                   lang (assoc :logseq.property.code/lang lang))
-                 []])
+              (if (= :quote (:logseq.property.node/display-type block'))
+                [block' []]
+                (let [{:keys [text lang]} (first code-segs)]
+                  [(cond-> (assoc block'
+                                  :block/title text
+                                  :block/tags [:logseq.class/Code-block]
+                                  :logseq.property.node/display-type :code)
+                     lang (assoc :logseq.property.code/lang lang))
+                   []]))
               has-mixed-content?
               (let [remaining-title (-> (string/join "\n" text-parts)
                                         (string/replace #"\n{2,}" "\n")

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -1160,7 +1160,18 @@
                       (vec (concat ["~~"] (mapcat extract coll') ["~~"]))
                       "Highlight"
                       (vec (concat ["^^"] (mapcat extract coll') ["^^"]))
-                      (throw (ex-info (str "Failed to wrap Emphasis AST block of type " (pr-str type')) {})))))]
+                      (throw (ex-info (str "Failed to wrap Emphasis AST block of type " (pr-str type')) {})))))
+                extract-table
+                (fn [{:keys [header groups]}]
+                  (let [row->text (fn [row]
+                                    (str "| "
+                                         (string/join " | " (map #(apply str (mapcat extract %)) row))
+                                         " |"))
+                        header-lines (when (seq header)
+                                       [(row->text header)
+                                        (str "| " (string/join " | " (repeat (count header) "---")) " |")])
+                        body-lines (map row->text (mapcat identity groups))]
+                    [(string/join "\n" (concat header-lines body-lines))]))]
             (cond
               (and (vector? node) (#{"Inline_Html" "Plain" "Inline_Hiccup"} (first node)))
               [(second node)]
@@ -1195,6 +1206,8 @@
                "```"]
               (and (vector? node) (= (first node) "Displayed_Math"))
               ["$$" (second node) "$$"]
+              (and (vector? node) (= (first node) "Table"))
+              (extract-table (second node))
               (and (vector? node) (= (first node) "List"))
               (extract-block-list (second node))
               :else

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -1141,7 +1141,7 @@
                           (not in-list?))
                  ["\n\n"]))))
 
-(defn- ast->text
+(defn- ^:large-vars/cleanup-todo ast->text
   "Given an ast block, convert it to text for use as a block title. This is a
   slimmer version of handler.export.text/export-blocks-as-markdown"
   [ast-block {:keys [log-fn]

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -1107,7 +1107,7 @@ abc
     (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
         "Imported graph validates")))
 
-(deftest-async import-markdown-table-in-quote-block
+(deftest-async import-special-content-in-quote-blocks
   (p/let [file-graph-dir "test/resources/exporter-test-graph"
           file (path/path-join file-graph-dir "journals/2025_09_14.md")
           conn (db-test/create-conn)
@@ -1118,7 +1118,23 @@ abc
                                 "| A1 | Tomato | March |"
                                 "| B4 | Thyme | April |"])
            (:block/title (db-test/find-block-by-content @conn #"Tray")))
-        "Markdown tables are retained in imported quote blocks")))
+        "Markdown tables are retained in imported quote blocks")
+
+    (is (= {:block/title "$$\na^2 + b^2 = c^2\n$$"
+            :block/tags [:logseq.class/Quote-block]
+            :logseq.property.node/display-type :quote}
+           (-> (db-test/find-block-by-content @conn #"a\^2")
+               (select-keys [:block/title :block/tags :logseq.property.node/display-type])
+               (update :block/tags #(mapv :db/ident %))))
+        "Displayed math does not replace the containing Quote-block type")
+
+    (is (= {:block/title "```clojure\n(map inc [1 2 3])\n```"
+            :block/tags [:logseq.class/Quote-block]
+            :logseq.property.node/display-type :quote}
+           (-> (db-test/find-block-by-content @conn #"map inc")
+               (select-keys [:block/title :block/tags :logseq.property.node/display-type])
+               (update :block/tags #(mapv :db/ident %))))
+        "Source blocks do not replace the containing Quote-block type")))
 
 (deftest-async export-basic-graph-with-convert-all-tags
   ;; This graph will contain basic examples of different features to import
@@ -1146,7 +1162,7 @@ abc
       (is (= 2 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Code-block]] @conn))))
       (is (= 1 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Math-block]] @conn))))
       (is (= 9 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Template]] @conn))))
-      (is (= 7 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Quote-block]] @conn))))
+      (is (= 9 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Quote-block]] @conn))))
       (is (= 8 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Pdf-annotation]] @conn))))
 
       ;; Properties and tags aren't included in this count as they aren't a Page

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -1107,6 +1107,19 @@ abc
     (is (empty? (map :entity (:errors (db-validate/validate-local-db! @conn))))
         "Imported graph validates")))
 
+(deftest-async import-markdown-table-in-quote-block
+  (p/let [file-graph-dir "test/resources/exporter-test-graph"
+          file (path/path-join file-graph-dir "journals/2025_09_14.md")
+          conn (db-test/create-conn)
+          _ (db-pipeline/add-listener conn)
+          _ (import-files-to-db [file] conn {})]
+    (is (= (string/join "\n" ["| Tray | Seedling | Ready month |"
+                                "| --- | --- | --- |"
+                                "| A1 | Tomato | March |"
+                                "| B4 | Thyme | April |"])
+           (:block/title (db-test/find-block-by-content @conn #"Tray")))
+        "Markdown tables are retained in imported quote blocks")))
+
 (deftest-async export-basic-graph-with-convert-all-tags
   ;; This graph will contain basic examples of different features to import
   (p/let [file-graph-dir "test/resources/exporter-test-graph"
@@ -1123,7 +1136,7 @@ abc
 
       ;; Counts
       ;; Includes journals as property values e.g. :logseq.property/deadline
-      (is (= 34 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Journal]] @conn))))
+      (is (= 35 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Journal]] @conn))))
 
       (is (= 9 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Asset]] @conn))))
       (is (= 6 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Task]] @conn))))
@@ -1133,7 +1146,7 @@ abc
       (is (= 2 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Code-block]] @conn))))
       (is (= 1 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Math-block]] @conn))))
       (is (= 9 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Template]] @conn))))
-      (is (= 6 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Quote-block]] @conn))))
+      (is (= 7 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Quote-block]] @conn))))
       (is (= 8 (count (d/q '[:find ?b :where [?b :block/tags :logseq.class/Pdf-annotation]] @conn))))
 
       ;; Properties and tags aren't included in this count as they aren't a Page

--- a/deps/graph-parser/test/resources/exporter-test-graph/journals/2025_09_14.md
+++ b/deps/graph-parser/test/resources/exporter-test-graph/journals/2025_09_14.md
@@ -1,0 +1,5 @@
+-
+  > | Tray | Seedling | Ready month |
+  > | --- | --- | --- |
+  > | A1 | Tomato | March |
+  > | B4 | Thyme | April |

--- a/deps/graph-parser/test/resources/exporter-test-graph/journals/2025_09_14.md
+++ b/deps/graph-parser/test/resources/exporter-test-graph/journals/2025_09_14.md
@@ -3,3 +3,11 @@
   > | --- | --- | --- |
   > | A1 | Tomato | March |
   > | B4 | Thyme | April |
+-
+  > $$
+  > a^2 + b^2 = c^2
+  > $$
+-
+  > ```clojure
+  > (map inc [1 2 3])
+  > ```


### PR DESCRIPTION
fix https://github.com/logseq/db-test/issues/1048

- Preserve Markdown tables when importing quoted table blocks instead of dropping their content.
- Preserve Quote-block type and original delimiters when importing quotes containing only displayed math or a source block.