### PR TITLE
fix(editor): regression with node ref completion

### DIFF
--- a/clj-e2e/README.md
+++ b/clj-e2e/README.md
@@ -18,6 +18,10 @@ To use a custom port:
     $ bb serve --port 3001
     $ bb serve -p 3001
 
+If `pnpm watch` is already running, skip `bb serve`: shadow-cljs's dev-http
+already serves the desktop app from `../static/` on port 3001, so run tests
+with `bb test -p 3001 ...`.
+
 ## Running Tests
 
 Run all tests (namespaces ending in `-basic-test`):

--- a/clj-e2e/test/logseq/e2e/editor_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/editor_basic_test.clj
@@ -1548,8 +1548,8 @@
     (is (= ["alpha" "middle-omega"]
            (take-last 2 (util/get-page-blocks-contents))))))
 
-(deftest node-reference-autocomplete-and-label-test
-  (testing "node reference autocomplete keeps its label and opens the updated target"
+(deftest node-reference-autocomplete-test
+  (testing "node reference search inserts a reference and rerenders target updates"
     (let [source-page (p/get-page-name)]
       (b/new-block "reference autocomplete unique target")
       (let [target-uuid (.getAttribute (util/get-edit-block-container) "blockid")]
@@ -1569,14 +1569,11 @@
         (util/press-seq "reference autocomplete updated target")
         (util/exit-edit)
         (assert/assert-is-visible
-         (loc/filter ".block-title-wrap"
-                     :has-text "reference autocomplete updated target"))
-        (assert/assert-is-visible
          (loc/filter ".page-reference"
-                     :has-text "reference autocomplete unique target"))
+                     :has-text "reference autocomplete updated target"))
         (is (= source-page (p/get-page-name)))
         (w/click (.first (loc/filter ".page-reference .page-ref"
-                                     :has-text "reference autocomplete unique target")))
+                                     :has-text "reference autocomplete updated target")))
         (is (string/includes? (.url (w/get-page)) target-uuid))
         (assert/assert-is-visible
          (loc/filter ".ls-page-blocks .block-title-wrap"

--- a/src/main/frontend/handler/page.cljs
+++ b/src/main/frontend/handler/page.cljs
@@ -200,10 +200,6 @@
                            [:db/id :block/title :block/name :block/uuid :block/tags]
                            [:block/name (util/page-name-sanity-lc page)]))
 
-(defn- labeled-node-ref
-  [block]
-  (str "[" (:block/title block) "](" (ref/->page-ref (:block/uuid block)) ")"))
-
 (defn- tag-on-chosen-handler
   [input id pos format current-pos edit-content q]
   (fn [chosen-result ^js e]
@@ -274,16 +270,10 @@
                                         [chosen' chosen-result])
             datoms (state/<invoke-db-worker :thread-api/datoms repo :avet :block/name (util/page-name-sanity-lc chosen'))
             multiple-pages-same-name? (> (count datoms) 1)
-            ref-text (cond
-                       (and (existing-chosen-result? chosen-result)
-                            (not (entity/page? chosen-result)))
-                       (labeled-node-ref chosen-result)
-
-                       (and (existing-chosen-result? chosen-result)
-                            multiple-pages-same-name?)
+            ref-text (if (and (existing-chosen-result? chosen-result)
+                              (or multiple-pages-same-name?
+                                  (not (entity/page? chosen-result))))
                        (ref/->page-ref (:block/uuid chosen-result))
-
-                       :else
                        (get-page-ref-text chosen'))
             result (when-not (existing-chosen-result? chosen-result)
                      (<create! chosen'


### PR DESCRIPTION
When completing a block ref, title was getting hardcoded instead of just referring to the block. Looks like this regressed in #12892

Take for example the block `b1`. In a new block if you type `[[b1]]` and press enter the block now completes as `[b1]([[<uuid>]])`. Pressing enter used to complete as `[[uuid]]`. The old behavior is much more desirable as it is a true block ref that keeps in sync with the block. With the new behavior, the current block title is hardcoded and goes out of date with any change to b1