### PR TITLE
perf(views): keep table rows mounted while scrolling

### DIFF
--- a/clj-e2e/test/logseq/e2e/view_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/view_basic_test.clj
@@ -189,6 +189,90 @@
   (assert/assert-is-visible
    (loc/filter ".ls-table-header-cell" :has-text "Status")))
 
+(defn- seed-scroll-table-view!
+  [tag-name row-count]
+  (let [container-page (page/get-page-name)]
+    (ls-api-call! :editor.createTag
+                  tag-name
+                  {:tagProperties [{:name "Status"}
+                                   {:name "Priority"
+                                    :schema {:type "number"}}
+                                   {:name "Owner"}
+                                   {:name "Team"}
+                                   {:name "Estimate"
+                                    :schema {:type "number"}}
+                                   {:name "Label"}
+                                   {:name "Sprint"}
+                                   {:name "Notes"}
+                                   {:name "Risk"}
+                                   {:name "Area"}]})
+    (dotimes [i row-count]
+      (ls-api-call! :editor.insertBlock
+                    container-page
+                    (str "Scroll row " i " #" tag-name)
+                    {:properties {"Status" (if (even? i) "Open" "Closed")
+                                  "Priority" i
+                                  "Owner" "Ada"
+                                  "Team" "Core"
+                                  "Estimate" 3
+                                  "Label" "perf"
+                                  "Sprint" "S1"
+                                  "Notes" "n"
+                                  "Risk" "low"
+                                  "Area" "views"}}))
+    (page/goto-page tag-name)
+    (assert/assert-is-visible ".ls-view-body .ls-table-header-cell")
+    (assert/assert-is-visible
+     (loc/filter ".ls-view-body .ls-table-row" :has-text "Scroll row 0"))))
+
+(defn- table-row-remounts-after-scroll
+  []
+  (w/eval-js
+   "() => {
+      const rows = () => Array.from(document.querySelectorAll('.ls-view-body .ls-table-row'));
+      window.__tableRowNodes = new Map(rows().map((el) => [el.getAttribute('data-id'), el]));
+      const scroller = document.getElementById('main-content-container');
+      if (!scroller) {
+        return {error: 'missing-scroller', overlap: 0, remounted: 0};
+      }
+      scroller.scrollBy(0, 120);
+      return {
+        before: window.__tableRowNodes.size
+      };
+    }")
+  (util/wait-timeout 400)
+  (w/eval-js
+   "() => {
+      const next = new Map(
+        Array.from(document.querySelectorAll('.ls-view-body .ls-table-row'))
+          .map((el) => [el.getAttribute('data-id'), el])
+      );
+      let overlap = 0;
+      let remounted = 0;
+      (window.__tableRowNodes || new Map()).forEach((node, id) => {
+        const current = next.get(id);
+        if (current) {
+          overlap += 1;
+          if (current !== node) {
+            remounted += 1;
+          }
+        }
+      });
+      return {overlap, remounted, after: next.size};
+    }"))
+
+(deftest table-view-scroll-does-not-remount-visible-rows-test
+  (seed-scroll-table-view! "table-scroll-perf" 36)
+  (let [result (table-row-remounts-after-scroll)
+        overlap (or (get result "overlap") (:overlap result))
+        remounted (or (get result "remounted") (:remounted result))]
+    (is (pos? (or overlap 0))
+        (str "Expected overlapping table rows after a small scroll: " (pr-str result)))
+    (is (number? remounted)
+        (str "Scroll remount probe did not return a count: " (pr-str result)))
+    (is (zero? remounted)
+        (str "Visible table rows remounted during scroll: " (pr-str result)))))
+
 (deftest table-view-group-and-export-actions-test
   (seed-table-view! "table-group-export-actions")
 

--- a/src/main/frontend/components/views.cljs
+++ b/src/main/frontend/components/views.cljs
@@ -1304,8 +1304,10 @@
        cell-placeholder)]))
 
 (defn- eager-table-cells?
-  [view-feature-type]
-  (= :all-pages view-feature-type))
+  "Virtualized rows are already windowed, so per-cell IntersectionObservers
+  only add main-thread work. Keep lazy cells for fully mounted grouped tables."
+  [option]
+  (not (:disable-virtualized? option)))
 
 (defn- click-cell
   [node]
@@ -1402,9 +1404,9 @@
      body)))
 
 (hsx/defc table-row-inner
-  [table row props {:keys [show-add-property? scrolling? view-feature-type]}]
+  [table row props {:keys [show-add-property?] :as option}]
   (let [*ref (hooks/use-ref nil)
-        eager-cells? (eager-table-cells? view-feature-type)
+        eager-cells? (eager-table-cells? option)
         pinned-columns (get-in table [:state :pinned-columns])
         unpinned (get-in table [:state :unpinned-columns])
         unpinned-columns (if show-add-property?
@@ -1423,16 +1425,14 @@
                                       :select? select?
                                       :add-property? add-property?
                                       :style style}]
-                       (if (and scrolling? (not (:block/title row)))
-                         (table-cell-container cell-opts nil)
-                         (when-let [render (get column :cell)]
-                           (let [cell-render (fn []
-                                               (table-cell-container
-                                                cell-opts (render table row column style)))]
-                             (if eager-cells?
-                               [:div.h-full (cell-render)]
-                               (lazy-table-cell cell-render
-                                                (table-cell-container cell-opts nil))))))))]
+                       (when-let [render (get column :cell)]
+                         (let [cell-render (fn []
+                                             (table-cell-container
+                                              cell-opts (render table row column style)))]
+                           (if eager-cells?
+                             [:div.h-full (cell-render)]
+                             (lazy-table-cell cell-render
+                                              (table-cell-container cell-opts nil)))))))]
     (shui/table-row
      (merge
       props
@@ -2035,7 +2035,17 @@
   [table-view?]
   (if table-view? 33 24))
 
+(def ^:private table-viewport-overscan
+  {:top 96 :bottom 96})
+
 (def ^:private view-prefetch-limit 50)
+
+(defn- table-scroll-parent
+  [option]
+  (get-scroll-parent
+   (cond-> (:config option)
+     (and (exists? js/document) (:viewid option))
+     (assoc :viewel (js/document.getElementById (:viewid option))))))
 
 (defn- initial-view-prefetch-count
   [viewport-height item-height]
@@ -2084,16 +2094,18 @@
           (set-initial-prefetch-ready! true)))
       [prefetch-ready?])
      [(or initial-prefetch-ready? prefetch-ready?)
-      (fn [^js rendered-items]
-        (when (pos? (alength rendered-items))
-          (let [next-range [(rendered-item-index (aget rendered-items 0))
-                            (rendered-item-index
-                             (aget rendered-items (dec (alength rendered-items))))]]
-            (set-rendered-range!
-             (fn [current-range]
-               (if (= current-range next-range)
-                 current-range
-                 next-range))))))])))
+      (hooks/use-callback
+       (fn [^js rendered-items]
+         (when (pos? (alength rendered-items))
+           (let [next-range [(rendered-item-index (aget rendered-items 0))
+                             (rendered-item-index
+                              (aget rendered-items (dec (alength rendered-items))))]]
+             (set-rendered-range!
+              (fn [current-range]
+                (if (= current-range next-range)
+                  current-range
+                  next-range))))))
+       [])])))
 
 (hsx/defc lazy-item
   [data idx {:keys [gallery-view? table-view?]} item-render]
@@ -2105,39 +2117,78 @@
         [:div.ls-card-item {:aria-hidden true}]
         [:div {:style {:min-height (lazy-item-placeholder-height table-view?)}}]))))
 
+(hsx/defc table-lazy-item
+  "Table rows keep value-comparable props so HSX memo can skip already-mounted
+  items when Virtuoso asks for the same index again."
+  [data idx table option]
+  (let [row-uuid (util/nth-safe data idx)
+        item (db-hooks/use-block row-uuid)]
+    (if item
+      (table-row table item {} option)
+      [:div {:style {:min-height (lazy-item-placeholder-height true)}}])))
+
+(hsx/defc view-row-prefetcher
+  "Owns the sliding prefetch window so range updates do not re-render the list."
+  [rows initial-prefetch-count *prefetch-rows!]
+  (let [[_initial-rows-ready? prefetch-rows!]
+        (use-view-row-prefetch rows initial-prefetch-count)]
+    (reset! *prefetch-rows! prefetch-rows!)
+    nil))
+
+(hsx/defc table-virtualized-rows
+  [table option rows *scroller-ref on-items-rendered]
+  (let [scroll-parent (table-scroll-parent option)
+        row-data (:data table)
+        table-option (hooks/use-memo
+                      #(assoc option :table-view? true)
+                      [option])
+        item-content (hooks/use-callback
+                      (fn [idx]
+                        (table-lazy-item row-data idx table table-option))
+                      [row-data table table-option])
+        compute-item-key (hooks/use-callback
+                          (fn [idx]
+                            (str "table-row-" (util/nth-safe rows idx)))
+                          [rows])]
+    (virtualized-list
+     {:ref #(reset! *scroller-ref %)
+      :increase-viewport-by table-viewport-overscan
+      :custom-scroll-parent scroll-parent
+      :compute-item-key compute-item-key
+      :skipAnimationFrameInResizeObserver true
+      :total-count (count rows)
+      :item-content item-content
+      :items-rendered on-items-rendered}
+     (:disable-virtualized? option))))
+
 (hsx/defc table-body
   [table option rows *scroller-ref set-items-rendered!]
-  (let [scroll-parent (get-scroll-parent
-                       (-> (:config option)
-                           (assoc :viewel (js/document.getElementById (:viewid option)))))
+  (let [scroll-parent (table-scroll-parent option)
         initial-prefetch-count (initial-view-prefetch-count
                                 (.-clientHeight scroll-parent)
                                 (lazy-item-placeholder-height true))
-        [initial-rows-ready? prefetch-rows!]
-        (use-view-row-prefetch (:data table) initial-prefetch-count)]
-    (when (seq rows)
-      (if initial-rows-ready?
-        (virtualized-list
-         {:ref #(reset! *scroller-ref %)
-          :increase-viewport-by {:top 300 :bottom 300}
-          :custom-scroll-parent scroll-parent
-          :compute-item-key (fn [idx]
-                              (str "table-row-" (util/nth-safe rows idx)))
-          :skipAnimationFrameInResizeObserver true
-          :total-count (count rows)
-          :item-content (fn [idx]
-                          (let [option (assoc option :table-view? true)]
-                            (lazy-item (:data table) idx option
-                                       (fn [row]
-                                         (table-row table row {} option)))))
-          :items-rendered (fn [props]
-                            (prefetch-rows! props)
-                            (when (seq props)
-                              (set-items-rendered! true)))}
-         (:disable-virtualized? option))
-        [:div.flex.flex-col.gap-1.py-1
-         (for [idx (range 3)]
-           (shui/skeleton {:key idx :class "h-8 w-full"}))]))))
+        row-data (:data table)
+        initial-rows (if (seq row-data)
+                       (subvec (vec row-data) 0 (min (count row-data) initial-prefetch-count))
+                       [])
+        initial-rows-ready? (db-hooks/use-block-prefetch initial-rows)
+        *prefetch-rows! (hooks/use-memo #(atom nil) [])
+        on-items-rendered (hooks/use-callback
+                           (fn [props]
+                             (when-let [prefetch! @*prefetch-rows!]
+                               (prefetch! props))
+                             (when (seq props)
+                               (set-items-rendered! true)))
+                           [set-items-rendered!])]
+    [:<>
+     (when (seq row-data)
+       (view-row-prefetcher row-data initial-prefetch-count *prefetch-rows!))
+     (when (seq rows)
+       (if initial-rows-ready?
+         (table-virtualized-rows table option rows *scroller-ref on-items-rendered)
+         [:div.flex.flex-col.gap-1.py-1
+          (for [idx (range 3)]
+            (shui/skeleton {:key idx :class "h-8 w-full"}))]))]))
 
 (hsx/defc table-view
   [table option _row-selection *scroller-ref]

--- a/src/test/frontend/components/views_test.cljs
+++ b/src/test/frontend/components/views_test.cljs
@@ -8,8 +8,10 @@
             [frontend.components.views :as views]
             [frontend.db.hooks :as db-hooks]
             [frontend.db.subs :as subs]
+            [frontend.ui :as ui]
             [frontend.util :as util]
             [goog.object :as gobj]
+            [logseq.shui.hooks :as hooks]
             [promesa.core :as p]))
 
 (def ^:private test-graph-id "view-resource-test")
@@ -249,6 +251,118 @@
                        :rows [row-a row-b]}
                       {:value {:kind :scalar :value "B"}
                        :rows [row-b row-c]}]})))))
+
+(deftest eager-table-cells-follow-virtualization-test
+  (is (true? (#'views/eager-table-cells? {:view-feature-type :class-objects})))
+  (is (true? (#'views/eager-table-cells? {:view-feature-type :all-pages})))
+  (is (false? (#'views/eager-table-cells? {:disable-virtualized? true
+                                          :view-feature-type :class-objects}))
+      "Grouped tables keep lazy cells because every row stays mounted."))
+
+(deftest table-viewport-overscan-stays-near-list-overscan-test
+  (is (= {:top 96 :bottom 96} #'views/table-viewport-overscan))
+  (is (< (:top #'views/table-viewport-overscan) 300)
+      "Table overscan must not keep a 300px extra row band mounted."))
+
+(deftest table-lazy-item-hydrates-only-its-uuid-through-use-block-test
+  (let [row-uuid (random-uuid)
+        block {:block/uuid row-uuid
+               :db/id 11
+               :block/tx-id 9
+               :block/title "Loaded table row"
+               :block/tags []}
+        calls (atom [])
+        row-renders (atom 0)]
+    (with-redefs [db-hooks/use-block
+                  (fn [requested-uuid]
+                    (swap! calls conj requested-uuid)
+                    block)
+                  views/table-row
+                  (fn [table row props option]
+                    (swap! row-renders inc)
+                    (is (= {:data [row-uuid]} table))
+                    (is (= block row))
+                    (is (= {} props))
+                    (is (true? (:table-view? option)))
+                    (.createElement react "span" nil (:block/title row)))]
+      (is (= "<span>Loaded table row</span>"
+             (render-static
+              (views/table-lazy-item
+               [row-uuid]
+               0
+               {:data [row-uuid]}
+               {:table-view? true}))))
+      (is (= [row-uuid] @calls)
+          "A mounted table row supplies one UUID and owns no loader closure.")
+      (is (= 1 @row-renders)))))
+
+(deftest table-body-keeps-value-comparable-row-props-on-range-change-test
+  (let [row-uuid (random-uuid)
+        virtual-opts (atom nil)
+        lazy-item-calls (atom [])
+        table {:data [row-uuid]
+               :rows [{:db/id 1 :block/uuid row-uuid}]}
+        option {:config {}}]
+    (with-redefs [db-hooks/use-block-prefetch (constantly true)
+                  util/app-scroll-container-node (constantly #js {:clientHeight 800})
+                  views/table-lazy-item
+                  (fn [data idx table' option']
+                    (swap! lazy-item-calls conj [data idx table' option'])
+                    [:div])
+                  ui/virtualized-list
+                  (fn [opts]
+                    (reset! virtual-opts opts)
+                    [:div])]
+      (render-static
+       (views/table-body table option (:rows table) (atom nil) (fn [_])))
+      (is (fn? (:item-content @virtual-opts)))
+      (is (nil? (:is-scrolling @virtual-opts))
+          "Table scroll must not flip a shared scrolling React state.")
+      (is (nil? (:context @virtual-opts)))
+      (is (= {:top 96 :bottom 96} (:increase-viewport-by @virtual-opts)))
+      ((:item-content @virtual-opts) 0)
+      ((:item-content @virtual-opts) 0)
+      (is (= 2 (count @lazy-item-calls)))
+      (is (= (first @lazy-item-calls) (second @lazy-item-calls))
+          "The same index keeps equal table-lazy-item props across item-content calls.")
+      (let [[data idx table' option'] (first @lazy-item-calls)]
+        (is (= [row-uuid] data))
+        (is (zero? idx))
+        (is (identical? table table'))
+        (is (true? (:table-view? option')))
+        (is (not (some fn? [data idx table' option'])))))))
+
+(deftest virtualized-table-rows-skip-per-cell-intersection-observers-test
+  (let [in-view-calls (atom 0)
+        row {:db/id 1
+             :block/uuid (random-uuid)
+             :block/title "Row"
+             :block/tags []}
+        columns [{:id :block/title
+                  :cell (fn [_table _row _column _style] [:span "Name"])}
+                 {:id :user.property/status
+                  :cell (fn [_table _row _column _style] [:span "Open"])}]
+        table {:state {:pinned-columns []
+                       :unpinned-columns columns
+                       :sized-columns {}}
+               :data []}
+        option {:view-feature-type :class-objects}]
+    (with-redefs [ui/useInView (fn [_]
+                                 (swap! in-view-calls inc)
+                                 #js {:inView true :ref nil})
+                  hooks/use-ref (fn [value] #js {:current value})
+                  hooks/use-effect! (fn [& _args])]
+      (is (string/includes?
+           (render-static (views/table-row table row {} option))
+           "Name"))
+      (is (zero? @in-view-calls)
+          "Virtualized table cells render eagerly without IntersectionObserver.")
+      (is (string/includes?
+           (render-static
+            (views/table-row table row {} (assoc option :disable-virtualized? true)))
+           "Open"))
+      (is (= (count columns) @in-view-calls)
+          "Grouped non-virtualized tables still lazy-mount offscreen cells."))))
 
 (deftest view-row-hydrates-only-its-uuid-through-use-block-test
   (let [row-uuid (random-uuid)

--- a/src/test/frontend/components/views_test.cljs
+++ b/src/test/frontend/components/views_test.cljs
@@ -260,8 +260,8 @@
       "Grouped tables keep lazy cells because every row stays mounted."))
 
 (deftest table-viewport-overscan-stays-near-list-overscan-test
-  (is (= {:top 96 :bottom 96} #'views/table-viewport-overscan))
-  (is (< (:top #'views/table-viewport-overscan) 300)
+  (is (= {:top 96 :bottom 96} @#'views/table-viewport-overscan))
+  (is (< (:top @#'views/table-viewport-overscan) 300)
       "Table overscan must not keep a 300px extra row band mounted."))
 
 (deftest table-lazy-item-hydrates-only-its-uuid-through-use-block-test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/logseq/db-test/issues/1033.

Table View scroll on a class/tag page was still saturating the main thread. The 2.0.1 `is-scrolling` context path is already gone on master; the remaining cost was a visible-range prefetch `setState` inside `table-body` plus a new row-render function on every Virtuoso `item-content` call. That combination re-rendered every mounted row × cell on each range change. Virtualized cells also installed one IntersectionObserver per cell.

This change:

- Moves the sliding prefetch window into a sibling so range updates do not re-render the virtualized list
- Renders table rows through `table-lazy-item` with value-comparable props (no per-call render fn)
- Renders virtualized cells eagerly; keeps lazy cells only for grouped non-virtualized tables
- Tightens table overscan from 300px to 96px
- Removes the unused `scrolling?` placeholder branch

## Tests
- Unit: `frontend.components.views-test` covers stable `table-lazy-item` props, no scroll context, eager virtualized cells, and bounded overscan
- E2E: `table-view-scroll-does-not-remount-visible-rows-test` scrolls a multi-column table and asserts overlapping row DOM nodes are reused

This is a new scroll-path fix, not a duplicate close of logseq/db-test#141.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe0311e0-ebd8-4bde-a2cb-a2e2568b2aaa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe0311e0-ebd8-4bde-a2cb-a2e2568b2aaa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

