### PR TITLE
fix: keep journal tag templates after RTC rebase

### DIFF
--- a/src/main/frontend/worker/pipeline.cljs
+++ b/src/main/frontend/worker/pipeline.cljs
@@ -90,6 +90,15 @@
     :tx-data []}
    (outliner-template/dynamic-template-journal-days blocks)))
 
+(defn- entity-used-template?
+  [entity template]
+  (let [template-id (:db/id template)]
+    (some (fn [block]
+            (let [used (:logseq.property/used-template block)]
+              (or (= template-id used)
+                  (= template-id (:db/id used)))))
+          (:block/_parent entity))))
+
 (defn- insert-tag-templates
   [tx-report]
   (let [db (:db-after tx-report)
@@ -127,14 +136,16 @@
                            (group-by :e))
         insertion-inputs (mapcat
                           (fn [[e datoms]]
-                            (let [templates (->> (set (map :v datoms))
+                            (let [object (d/entity db e)
+                                  templates (->> (set (map :v datoms))
                                                  (mapcat tag->templates)
                                                  distinct
                                                  (sort-by :block/created-at))]
-                              (map (fn [template]
-                                     {:object-id e
-                                      :blocks (raw-template-blocks template)})
-                                   templates)))
+                              (keep (fn [template]
+                                      (when-not (entity-used-template? object template)
+                                        {:object-id e
+                                         :blocks (raw-template-blocks template)}))
+                                    templates)))
                           tag-additions)
         {db-with-pages :db page-tx-data :tx-data} (ensure-template-journal-pages db (mapcat :blocks insertion-inputs))
         insert-tx-data (mapcat
@@ -156,6 +167,27 @@
                                          (:blocks result)))))))
                         insertion-inputs)]
     (concat page-tx-data insert-tx-data)))
+
+(defn insert-tag-templates-for-entity
+  "Tx-data that applies missing tag templates to an existing entity.
+  Skips templates that already have a `:logseq.property/used-template` child."
+  [db entity]
+  (when entity
+    (let [tag-datoms (mapv (fn [tag]
+                             {:e (:db/id entity)
+                              :a :block/tags
+                              :v (:db/id tag)
+                              :added true})
+                           (:block/tags entity))
+          journal-datoms (when-let [day (:block/journal-day entity)]
+                           [{:e (:db/id entity)
+                             :a :block/journal-day
+                             :v day
+                             :added true}])]
+      (when (seq tag-datoms)
+        (seq (insert-tag-templates
+              {:db-after db
+               :tx-data (into tag-datoms journal-datoms)}))))))
 
 (defn- fix-page-tags
   "Add missing attributes and remove #Page when inserting or updating block/title with inline tags"

--- a/src/main/frontend/worker/sync/apply_txs.cljs
+++ b/src/main/frontend/worker/sync/apply_txs.cljs
@@ -4,6 +4,7 @@
    [clojure.set :as set]
    [clojure.string :as string]
    [datascript.core :as d]
+   [frontend.worker.pipeline :as worker-pipeline]
    [frontend.worker.platform :as platform]
    [frontend.worker.shared-service :as shared-service]
    [frontend.worker.state :as worker-state]
@@ -1514,11 +1515,19 @@
           page-uuid (:uuid opts)
           existing-page (or (when (uuid? page-uuid)
                               (d/entity @conn [:block/uuid page-uuid]))
-                            (ldb/get-page @conn title))]
-      (if (and existing-page
-               (not (ldb/recycled? existing-page)))
-        [(:block/title existing-page) (:block/uuid existing-page)]
-        (outliner-page/create! conn title opts)))
+                            (ldb/get-page @conn title))
+          [title' page-uuid'] (if (and existing-page
+                                       (not (ldb/recycled? existing-page)))
+                                [(:block/title existing-page) (:block/uuid existing-page)]
+                                (outliner-page/create! conn title opts))
+          page (or (when (uuid? page-uuid')
+                     (d/entity @conn [:block/uuid page-uuid']))
+                   (ldb/get-page @conn title'))]
+      (when-let [tx-data (seq (worker-pipeline/insert-tag-templates-for-entity @conn page))]
+        (ldb/transact! conn tx-data {:outliner-op :insert-template-blocks
+                                     :persist-op? false
+                                     :gen-undo-ops? false}))
+      [title' page-uuid'])
 
     :delete-page
     (let [[page-uuid opts] args]

--- a/src/test/frontend/worker/db_sync_test.cljs
+++ b/src/test/frontend/worker/db_sync_test.cljs
@@ -30,6 +30,7 @@
    [frontend.worker.undo-redo :as undo-redo]
    [logseq.common.config :as common-config]
    [logseq.common.util :as common-util]
+   [logseq.common.util.date-time :as date-time-util]
    [logseq.common.util.page-ref :as page-ref]
    [logseq.db :as ldb]
    [logseq.db-sync.checksum :as sync-checksum]
@@ -4637,6 +4638,78 @@
             (let [page-after (db-test/find-page-by-title @conn page-title)]
               (is (some? page-after))
               (is (= page-uuid (:block/uuid page-after))))))))))
+
+(defn- tx-item-entity-uuid
+  [item]
+  (let [e (second item)]
+    (cond
+      (uuid? e) e
+      (and (vector? e) (= :block/uuid (first e))) (second e)
+      (and (string? e) (common-util/uuid-string? e)) (parse-uuid e)
+      :else nil)))
+
+(defn- page-only-remote-tx
+  [page-uuid tx]
+  (filterv (fn [item]
+             (= page-uuid (tx-item-entity-uuid item)))
+           tx))
+
+(defn- page-child-titles
+  [page]
+  (->> (:block/_parent page)
+       (remove ldb/page?)
+       ldb/sort-by-order
+       (map :block/title)
+       vec))
+
+(deftest rebase-create-journal-keeps-tag-template-children-test
+  (testing "rebase against a remote empty/page-only journal keeps local #Journal template children"
+    (let [today (date-time-util/ms->journal-day (js/Date.))
+          conn (db-test/create-conn-with-blocks
+                {:pages-and-blocks
+                 [{:page {:block/title "Templates"}
+                   :blocks [{:block/title "journal template root"
+                             :build/children [{:block/title "Daily plan"}]}]}]})
+          journal-title (date-time-util/int->journal-title
+                         today
+                         (:logseq.property.journal/title-format
+                          (d/entity @conn :logseq.class/Journal)))
+          client-ops-conn (new-client-ops-db)
+          template-root (db-test/find-block-by-content @conn "journal template root")]
+      (ldb/transact! conn [[:db/add (:db/id template-root)
+                            :logseq.property/template-applied-to
+                            :logseq.class/Journal]])
+      (reset! ldb/*transact-pipeline-fn worker-pipeline/transact-pipeline)
+      (with-datascript-conns conn client-ops-conn
+        (fn []
+          (apply-ops! conn
+                      [[:create-page [journal-title {:today-journal? true
+                                                     :redirect? false
+                                                     :split-namespace? false
+                                                     :tags ()}]]]
+                      local-tx-meta)
+          (let [journal-before (db-test/find-journal-by-journal-day @conn today)
+                page-uuid (:block/uuid journal-before)
+                pending-before (last (#'sync-apply/pending-txs test-repo))
+                remote-page-tx (page-only-remote-tx page-uuid (:tx pending-before))]
+            (is (some? journal-before))
+            (is (= ["Daily plan"] (page-child-titles journal-before)))
+            (is (= [:create-page] (map first (:forward-outliner-ops pending-before))))
+            (is (seq remote-page-tx))
+            (is (some (fn [item]
+                        (and (not= page-uuid (tx-item-entity-uuid item))
+                             (= :block/title (nth item 2 nil))))
+                      (:tx pending-before))
+                "pending create-page tx includes pipeline template children")
+            (#'sync-apply/apply-remote-txs!
+             test-repo
+             nil
+             [{:tx-data remote-page-tx}])
+            (let [journal-after (db-test/find-journal-by-journal-day @conn today)]
+              (is (some? journal-after))
+              (is (= page-uuid (:block/uuid journal-after)))
+              (is (= ["Daily plan"] (page-child-titles journal-after))
+                  "template children survive rebase with a remote page-only journal"))))))))
 
 (deftest rebase-duplicate-create-page-keeps-remote-children-test
   (testing "rebased duplicate create-page should not remove remote children"

--- a/src/test/frontend/worker/pipeline_test.cljs
+++ b/src/test/frontend/worker/pipeline_test.cljs
@@ -1127,6 +1127,38 @@
       (finally
         (ldb/register-transact-pipeline-fn! identity)))))
 
+(deftest create-journal-applies-journal-tag-template-once-test
+  (testing "creating a journal page applies #Journal templates and does not insert them twice"
+    (let [today (date-time-util/ms->journal-day (js/Date.))
+          conn (db-test/create-conn-with-blocks
+                {:pages-and-blocks
+                 [{:page {:block/title "Templates"}
+                   :blocks [{:block/title "journal template root"
+                             :build/children [{:block/title "Daily plan"}]}]}]})
+          journal-title (date-time-util/int->journal-title
+                         today
+                         (:logseq.property.journal/title-format
+                          (d/entity @conn :logseq.class/Journal)))
+          template-root (db-test/find-block-by-content @conn "journal template root")]
+      (ldb/transact! conn [[:db/add (:db/id template-root)
+                            :logseq.property/template-applied-to
+                            :logseq.class/Journal]])
+      (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
+      (try
+        (outliner-page/create! conn journal-title {:today-journal? true
+                                                   :redirect? false})
+        (let [journal (db-test/find-journal-by-journal-day @conn today)
+              children (->> (:block/_parent journal)
+                            (remove ldb/page?)
+                            (map :block/title)
+                            vec)]
+          (is (some? journal))
+          (is (= ["Daily plan"] children))
+          (is (nil? (worker-pipeline/insert-tag-templates-for-entity @conn journal))
+              "Already-applied journal templates are not inserted again"))
+        (finally
+          (ldb/register-transact-pipeline-fn! identity))))))
+
 (deftest import-tx-skips-property-history-recording-test
   (let [conn (db-test/create-conn-with-blocks
               {:pages-and-blocks [{:page {:block/title "page1"}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/logseq/db-test/issues/1035.

A new journal page can show its `#Journal` tag template and then lose those children as soon as sync rebases against a remote empty or page-only journal. Local apply still works; history only stores `[:create-page ...]`, reverse retracts the page plus template children, and replay skips create-page when the journal already exists.

This change re-applies missing tag templates when replaying `:create-page`. Templates that already have a `used-template` child are left alone, so existing children are not duplicated.

## Tests
- Worker RTC rebase: creating today's journal with a `#Journal` template keeps those children after rebase against a remote page-only journal.
- Pipeline: creating a journal applies the template once and does not insert it again.

No editor UI changes, so no clj-e2e coverage.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6be9db87-4e51-4c4d-9b41-123fb2502c40?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6be9db87-4e51-4c4d-9b41-123fb2502c40&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

