### PR TITLE
fix: keep typed property values visible during hydration

### DIFF
--- a/src/main/frontend/components/property.cljs
+++ b/src/main/frontend/components/property.cljs
@@ -649,8 +649,8 @@
            (every? some? value-entities))))
 
 (defn- hydrated-display-property-value
-  "Keep the resource UUID while snapshots are not ready so property-value
-   does not receive nil and overwrite optimistic scalar input state."
+  "Restore value-entity snapshots when they are ready. Otherwise keep the
+   resource UUID so callers can tell a pending value from a true empty."
   [raw-value value-uuids value-entities]
   (if (property-value-hydration-ready? value-uuids value-entities)
     (restore-resource-entity-values raw-value (zipmap value-uuids value-entities))
@@ -667,10 +667,12 @@
   (let [property (db-hooks/use-block property-uuid)
         value-uuids (->> (entity-value-uuids value) distinct (sort-by str) vec)
         value-entities (db-hooks/use-blocks value-uuids)
-        value (hydrated-display-property-value value value-uuids value-entities)]
+        value-ready? (property-value-hydration-ready? value-uuids value-entities)
+        value (when value-ready?
+                (hydrated-display-property-value value value-uuids value-entities))]
     (when (and (keyword? property-ident) property)
       (let [type (get property :logseq.property/type :default)
-            empty-value? (empty-panel-property-value? value)
+            empty-value? (and value-ready? (empty-panel-property-value? value))
             show-panel-bullet? (show-property-panel-bullet? property value)
             property-key-cp' (property-key-cp block property (select-keys opts [:class-schema?]))]
         [:div {:key (str "property-pair-" (:db/id block) "-" (:db/id property))

--- a/src/main/frontend/components/property.cljs
+++ b/src/main/frontend/components/property.cljs
@@ -639,6 +639,23 @@
               :else item))]
     (restore value)))
 
+(defn- property-value-hydration-ready?
+  "display-properties stores value-entity UUIDs. Those UUIDs are authoritative
+   for whether a value exists; use-blocks is only a hydration hop.
+   :loading (nil entities) and :missing (nil slots) are not empty values."
+  [value-uuids value-entities]
+  (or (empty? value-uuids)
+      (and (some? value-entities)
+           (every? some? value-entities))))
+
+(defn- hydrated-display-property-value
+  "Keep the resource UUID while snapshots are not ready so property-value
+   does not receive nil and overwrite optimistic scalar input state."
+  [raw-value value-uuids value-entities]
+  (if (property-value-hydration-ready? value-uuids value-entities)
+    (restore-resource-entity-values raw-value (zipmap value-uuids value-entities))
+    raw-value))
+
 (hsx/defc class-schema-property-value
   [property description-property-uuid opts]
   (let [description-property (db-hooks/use-block description-property-uuid)]
@@ -650,15 +667,12 @@
   (let [property (db-hooks/use-block property-uuid)
         value-uuids (->> (entity-value-uuids value) distinct (sort-by str) vec)
         value-entities (db-hooks/use-blocks value-uuids)
-        value-ready? (or (empty? value-uuids) (some? value-entities))
-        entities-by-uuid (zipmap value-uuids value-entities)]
+        value (hydrated-display-property-value value value-uuids value-entities)]
     (when (and (keyword? property-ident) property)
-      (let [value (when value-ready?
-                    (restore-resource-entity-values value entities-by-uuid))
-            type (get property :logseq.property/type :default)
-          empty-value? (empty-panel-property-value? value)
-          show-panel-bullet? (show-property-panel-bullet? property value)
-          property-key-cp' (property-key-cp block property (select-keys opts [:class-schema?]))]
+      (let [type (get property :logseq.property/type :default)
+            empty-value? (empty-panel-property-value? value)
+            show-panel-bullet? (show-property-panel-bullet? property value)
+            property-key-cp' (property-key-cp block property (select-keys opts [:class-schema?]))]
         [:div {:key (str "property-pair-" (:db/id block) "-" (:db/id property))
                :class (util/classnames ["property-pair property-panel-row"
                                         {:property-panel-row-empty empty-value?}])

--- a/src/main/frontend/components/property/value.cljs
+++ b/src/main/frontend/components/property/value.cljs
@@ -1380,14 +1380,24 @@
       :else
       (property-normal-block-value block property v-block opts))))
 
+(defn- keep-local-scalar-input?
+  "True when a nil hydrated scalar must not replace the current input.
+   After set-block-property!, property-cp may re-render with a value-entity
+   UUID that use-blocks has not hydrated yet. Syncing that gap to \"\"
+   makes the just-typed number/string vanish until reload."
+  [hydrated-scalar current-str]
+  (and (nil? hydrated-scalar)
+       (not (string/blank? current-str))))
+
 (hsx/defc single-string-input
   [block property value table-view?]
   (let [[editing? set-editing!] (hooks/use-state false)
         *ref (hooks/use-ref nil)
-        string-value (cond
-                       (string? value) value
-                       (some? value) (str (db-property/property-value-content value))
-                       :else "")
+        hydrated-scalar (cond
+                          (string? value) value
+                          (some? value) (db-property/property-value-content value)
+                          :else nil)
+        string-value (if (some? hydrated-scalar) (str hydrated-scalar) "")
         [value set-value!] (hooks/use-state string-value)
         set-property-value! (fn [value & {:keys [exit-editing?]
                                           :or {exit-editing? true}}]
@@ -1406,7 +1416,8 @@
                                    (set-editing! false)))))]
     (hooks/use-effect!
      (fn []
-       (set-value! string-value)
+       (when-not (keep-local-scalar-input? hydrated-scalar value)
+         (set-value! string-value))
        #())
      [string-value])
 
@@ -1690,7 +1701,8 @@
 
     (hooks/use-effect!
      (fn []
-       (set-value! number-value-str)
+       (when-not (keep-local-scalar-input? number-value value)
+         (set-value! number-value-str))
        #())
      [number-value-str])
 

--- a/src/test/frontend/components/property/property_test.cljs
+++ b/src/test/frontend/components/property/property_test.cljs
@@ -36,6 +36,28 @@
            (restore [value-uuid] {value-uuid value-entity}))
         "Entity collections retain their resource-owned shape.")))
 
+(deftest display-property-value-stays-pending-until-entities-hydrate-test
+  (let [value-uuid (random-uuid)
+        value-entity {:block/uuid value-uuid
+                      :logseq.property/value 42}
+        ready? #'property-component/property-value-hydration-ready?
+        hydrate #'property-component/hydrated-display-property-value]
+    (is (true? (ready? [] nil))
+        "A scalar or empty property has nothing to hydrate.")
+    (is (false? (ready? [value-uuid] nil))
+        "use-blocks still :loading must not be treated as empty.")
+    (is (false? (ready? [value-uuid] [nil]))
+        "A settled :missing snapshot is not an empty property value.")
+    (is (true? (ready? [value-uuid] [value-entity])))
+    (is (= value-uuid (hydrate value-uuid [value-uuid] nil))
+        "Keep the resource UUID while the value entity is loading.")
+    (is (= value-uuid (hydrate value-uuid [value-uuid] [nil]))
+        "Keep the resource UUID while the value entity snapshot is missing.")
+    (is (= value-entity (hydrate value-uuid [value-uuid] [value-entity]))
+        "Hydrate only after every value entity snapshot is present.")
+    (is (false? (#'property-component/empty-panel-property-value? value-uuid))
+        "An unhydrated value UUID must not render as an empty property row.")))
+
 (deftest property-configuration-subscribes-to-current-property-data-test
   (let [property-uuid (random-uuid)
         owner-uuid (random-uuid)

--- a/src/test/frontend/components/property/value_test.cljs
+++ b/src/test/frontend/components/property/value_test.cljs
@@ -9,6 +9,21 @@
             [frontend.state :as state]
             [promesa.core :as p]))
 
+(deftest keep-local-scalar-input-during-value-entity-hydration-test
+  (let [keep-local? #'property-value/keep-local-scalar-input?]
+    (is (true? (keep-local? nil "42"))
+        "A just-typed number must survive a nil hydration gap.")
+    (is (true? (keep-local? nil "3.14"))
+        "Decimal input must not be replaced with an empty string.")
+    (is (false? (keep-local? 42 "42"))
+        "A hydrated number is authoritative.")
+    (is (false? (keep-local? 7 "42"))
+        "A later hydrated number replaces optimistic local state.")
+    (is (false? (keep-local? nil ""))
+        "A truly empty property may sync to an empty input.")
+    (is (false? (keep-local? nil "   "))
+        "Blank local state is not treated as optimistic input.")))
+
 (deftest alias-node-selection-preserves-entity-id-semantics-test
   (async done
          (let [block-uuid #uuid "11111111-1111-1111-1111-111111111111"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the vanish-after-input display race reported in https://github.com/logseq/db-test/issues/1038.

After setting a number (or string) property, `display-properties` updates with the new value-entity UUID before `use-blocks` has a `:ready` snapshot. `property-cp` treated that gap as `nil` / empty, and `single-number-input` then synced `""` over the just-typed local state. The saved `:logseq.property/value` was still in the graph, so the number came back after reload.

This is a renderer hydration race, not data loss. It is not #895 (integer treated as entity id) or #1034 (values vanish later, still missing after restart, still visible on other devices).

## Changes
- `property-cp` does not treat `:loading` or sticky `:missing` value-entity snapshots as empty. It only restores and renders an entity after every snapshot is present.
- `single-number-input` and `single-string-input` do not replace optimistic local input with `""` while the hydrated scalar is still nil.

## Tests
- `frontend.components.property.property-test/display-property-value-stays-pending-until-entities-hydrate-test`
- `frontend.components.property.value-test/keep-local-scalar-input-during-value-entity-hydration-test`

Verified with `node static/tests.js -n frontend.components.property.property-test -n frontend.components.property.value-test` (34 tests, 0 failures) and clj-kondo on the touched files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f33c162a-dd87-4769-beb3-ea092c7462f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f33c162a-dd87-4769-beb3-ea092c7462f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

