### PR TITLE
fix: honor keyboard date selection in property calendar

### DIFF
--- a/clj-e2e/test/logseq/e2e/commands_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/commands_basic_test.clj
@@ -65,9 +65,7 @@
       (is (= (:label initial) (:label (focused-date-picker-day)))
           (str command " should move focused date back with ArrowUp.")))
     (k/enter)
-    (if (= command "date picker")
-      (w/wait-for-not-visible ".ui__calendar")
-      (assert/assert-is-visible ".ui__calendar"))))
+    (w/wait-for-not-visible ".ui__calendar")))
 
 (deftest command-trigger-test
   (testing "/command trigger popup"
@@ -231,10 +229,35 @@
         (b/new-block text)
         (util/input-command command)
         (k/enter)
+        (w/wait-for-not-visible ".ui__calendar")
         (assert/assert-editor-mode)
         (util/exit-edit)
         (is (= command (util/get-text ".property-k")))
         (is (= "Today" (util/get-text ".ls-datetime a.page-ref")))))))
+
+(deftest scheduled-deadline-keyboard-selects-focused-day-test
+  (testing "arrow + enter commits the focused day and closes the picker"
+    (doseq [command ["Scheduled" "Deadline"]]
+      (fixtures/create-page)
+      (b/new-block (str command " focused day"))
+      (util/input-command command)
+      (w/wait-for date-picker-day-selector)
+      (let [initial (focused-date-picker-day)]
+        (is (:focused initial)
+            (str command " should focus a calendar day when opened."))
+        (k/arrow-right)
+        (let [focused (focused-date-picker-day)]
+          (is (:focused focused)
+              (str command " should keep calendar focus after ArrowRight."))
+          (is (not= (:label initial) (:label focused))
+              (str command " should move focused date with ArrowRight."))
+          (k/enter)
+          (w/wait-for-not-visible ".ui__calendar")
+          (assert/assert-editor-mode)
+          (util/exit-edit)
+          (is (= command (util/get-text ".property-k")))
+          (is (not= "Today" (util/get-text ".ls-datetime a.page-ref"))
+              (str command " should commit the focused day, not today.")))))))
 
 (deftest date-command-keyboard-navigation-test
   (testing "date commands focus the calendar and support keyboard navigation"

--- a/src/main/frontend/components/property/value.cljs
+++ b/src/main/frontend/components/property/value.cljs
@@ -474,6 +474,33 @@
       (.focus selected-day)
       (js/setTimeout #(focus-selected-day! id (dec remaining)) 16))))
 
+(defn- calendar-enter-commit-day
+  "Day the property calendar should commit on Enter.
+  Prefer the react-day-picker focused day over the initially selected day."
+  [focused-day initial-day]
+  (or focused-day initial-day))
+
+(defn- calendar-window-enter?
+  "Whether the window-level Enter handler should commit a date.
+  Skip NLP input and focused calendar days; those are handled locally."
+  [^js e]
+  (and (= "Enter" (util/ekey e))
+       (not (some-> (.-target e)
+                    (.closest ".ls-nlp-calendar input")))
+       (not (some-> (.-target e)
+                    (.closest "[role='gridcell']")))))
+
+(defn- hide-property-date-picker!
+  "Hide the calendar popup, or the parent property dialog when the calendar is inlined."
+  [id]
+  (if (= id :date-picker)
+    (do
+      (shui/popup-hide!)
+      (shui/dialog-close! :property-dialog))
+    (when id
+      (shui/popup-hide! id)))
+  (ui/hide-popups-until-preview-popup!))
+
 (hsx/defc calendar-inner
   [id {:keys [block property datetime? on-change del-btn? on-delete]}]
   (let [value (get block (:db/ident property))
@@ -491,6 +518,7 @@
                   (.setHours d 0 0 0)
                   d))
         *ident (hooks/use-memo #(atom (str "calendar-inner-" (js/Date.now))) [])
+        *focused-day (hooks/use-ref nil)
         initial-day value
         initial-month (when value (calendar-default-month value))
         select-handler! (hooks/use-callback
@@ -501,16 +529,12 @@
                                 (when (fn? on-change)
                                   (let [value (if datetime? (tc/to-long d) journal-page)]
                                     (on-change value)))
-                                (when-not datetime?
-                                  (shui/popup-hide! id)
-                                  (ui/hide-popups-until-preview-popup!))))))
+                                (hide-property-date-picker! id)))))
                          [id datetime? on-change])]
     (hooks/use-window-keydown
      (fn [^js e]
-       (when (and (= "Enter" (util/ekey e))
-                  (not (some-> (.-target e)
-                               (.closest ".ls-nlp-calendar input"))))
-         (select-handler! initial-day)
+       (when (calendar-window-enter? e)
+         (select-handler! (calendar-enter-commit-day (hooks/deref *focused-day) initial-day))
          (util/stop e)))
      [initial-day select-handler!])
     (hooks/use-effect!
@@ -531,7 +555,12 @@
           :id @*ident
           :del-btn? del-btn?
           :on-delete on-delete
-          :on-day-click select-handler!}
+          :on-day-click select-handler!
+          :on-day-key-down (fn [^js d _ ^js e]
+                             (hooks/set-ref! *focused-day d)
+                             (when (= "Enter" (.-key e))
+                               (select-handler! d)
+                               (util/stop e)))}
          initial-month
          (assoc :default-month initial-month)))]
      [:div.hidden.sm:initial

--- a/src/test/frontend/components/property/value_test.cljs
+++ b/src/test/frontend/components/property/value_test.cljs
@@ -7,7 +7,41 @@
             [frontend.handler.editor :as editor-handler]
             [frontend.handler.property :as property-handler]
             [frontend.state :as state]
+            [frontend.ui :as ui]
+            [logseq.shui.ui :as shui]
             [promesa.core :as p]))
+
+(deftest calendar-enter-commit-day-does-not-use-initial-day-when-focused-test
+  (let [initial-day (js/Date. 2026 7 17)
+        focused-day (js/Date. 2026 7 20)]
+    (is (= focused-day
+           (#'property-value/calendar-enter-commit-day focused-day initial-day))
+        "Enter commits the focused day, not the initially selected day.")
+    (is (= initial-day
+           (#'property-value/calendar-enter-commit-day nil initial-day))
+        "Enter falls back to the initially selected day when no other day is focused.")))
+
+(deftest calendar-window-enter-skips-focused-calendar-day-test
+  (let [day-event #js {:key "Enter"
+                       :target #js {:closest (fn [sel]
+                                               (when (= sel "[role='gridcell']")
+                                                 #js {}))}}
+        other-event #js {:key "Enter"
+                         :target #js {:closest (fn [_] nil)}}]
+    (is (false? (boolean (#'property-value/calendar-window-enter? day-event)))
+        "Window Enter must not handle a focused calendar day.")
+    (is (true? (boolean (#'property-value/calendar-window-enter? other-event))))))
+
+(deftest hide-property-date-picker-hides-parent-when-inlined-test
+  (let [hidden* (atom [])]
+    (with-redefs [shui/popup-hide! (fn
+                                     ([] (swap! hidden* conj :parent))
+                                     ([id] (swap! hidden* conj id)))
+                  shui/dialog-close! (fn [id] (swap! hidden* conj [:dialog id]))
+                  ui/hide-popups-until-preview-popup! (fn [] (swap! hidden* conj :until-preview))]
+      (#'property-value/hide-property-date-picker! :date-picker)
+      (is (= [:parent [:dialog :property-dialog] :until-preview] @hidden*)
+          "Inlined slash-command calendars hide the parent property dialog, not :date-picker."))))
 
 (deftest alias-node-selection-preserves-entity-id-semantics-test
   (async done


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/logseq/db-test/issues/1041

`/deadline` and `/scheduled` ignored arrow-key focus in the property calendar. Enter always committed today (or the existing value), and the slash-command picker stayed open after a successful select. Mouse click already set the correct day.

**Cause**
- The property calendar window Enter handler committed `initial-day`. Arrow keys only move react-day-picker focus; that day was never read back. The editor datepicker already handles this via `:on-day-key-down`.
- Deadline/scheduled are datetime properties, so hide was skipped. Inline editing also called `content-fn` with id `:date-picker`, so `popup-hide! :date-picker` was a no-op.

**Change**
- Commit the focused day on Enter (`on-day-key-down` + window handler that does not override a focused day).
- After a successful select, hide the calendar popup or the parent property dialog when the calendar is inlined.
- Unit test: Enter does not commit `initial-day` when another day is focused.
- clj-e2e: slash-command calendars close after Enter, and arrow+Enter does not set Today.

Mouse click is unchanged. This does not include the date-link blank page fix from db-test#1046.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-940cc6fc-044e-48fc-a5c0-33b3c71be747?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-940cc6fc-044e-48fc-a5c0-33b3c71be747&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

