### PR TITLE
fix: return HTTP API write identity without renderer wait

### DIFF
--- a/src/electron/electron/server.cljs
+++ b/src/electron/electron/server.cljs
@@ -10,6 +10,7 @@
             [electron.configs :as cfgs]
             [electron.logger :as logger]
             [electron.mcp-server :as desktop-mcp-server]
+            [electron.server-invoke :as server-invoke]
             [electron.utils :as utils]
             [electron.window :as window]
             [promesa.core :as p]))
@@ -105,12 +106,24 @@
 (defonce ^:private *cid (volatile! 0))
 (defn- invoke-logseq-api!
   [method args]
-  (p/create
-   (fn [resolve _reject]
-     (let [sid        (vswap! *cid inc)
-           ret-handle (fn [^js _w ret] (resolve ret))]
-       (utils/send-to-renderer @*win :invokeLogseqAPI {:syncId sid :method method :args args})
-       (.handleOnce ipcMain (str ::sync! sid) ret-handle)))))
+  (let [sid (vswap! *cid inc)
+        channel (str ::sync! sid)]
+    (utils/send-to-renderer @*win :invokeLogseqAPI {:syncId sid :method method :args args})
+    (server-invoke/await-ipc-reply!
+     {:channel channel
+      :timeout-ms server-invoke/invoke-timeout-ms
+      :handle-once! (fn [ch handler]
+                      (.handleOnce ipcMain ch handler))
+      :remove-handler! (fn [ch]
+                         (.removeHandler ipcMain ch))})))
+
+(defn- send-api-error!
+  [^js rep error]
+  (if (server-invoke/api-invoke-timeout? error)
+    (-> rep
+        (.code 504)
+        (.send #js {:error (ex-message error)}))
+    (.send rep error)))
 
 (defn- api-handler!
   [^js req ^js rep]
@@ -123,7 +136,7 @@
                        (.code rep 500)
                        (js/console.error "Unexpected API error:" msg))
                      (.send rep %)))
-          (p/catch #(.send rep %)))
+          (p/catch #(send-api-error! rep %)))
       (-> rep
           (.code 400)
           (.send (js/Error. ":method of body is missing!"))))

--- a/src/electron/electron/server_invoke.cljs
+++ b/src/electron/electron/server_invoke.cljs
@@ -1,0 +1,45 @@
+(ns electron.server-invoke
+  "One-shot IPC wait used by the desktop HTTP API.
+  Isolated so the timeout contract can be tested without loading Electron."
+  (:require [promesa.core :as p]))
+
+(def invoke-timeout-ms
+  "Fail fast if the renderer never replies. Fastify requestTimeout only
+  covers receiving the request body, not this IPC round-trip."
+  30000)
+
+(defn api-invoke-timeout?
+  [error]
+  (= :api-invoke-timeout (:type (ex-data error))))
+
+(defn timeout-error
+  []
+  (ex-info "Logseq API invoke timed out"
+           {:type :api-invoke-timeout
+            :status 504}))
+
+(defn await-ipc-reply!
+  "Wait for a one-shot IPC reply. Rejects with `timeout-error` if the
+  renderer never answers. `handle-once!` and `remove-handler!` are
+  injected so tests can exercise the contract without ipcMain."
+  [{:keys [channel handle-once! remove-handler! timeout-ms]
+    :or {timeout-ms invoke-timeout-ms}}]
+  (p/create
+   (fn [resolve reject]
+     (let [settled? (atom false)
+           *timer (atom nil)
+           finish! (fn [cb value]
+                     (when (compare-and-set! settled? false true)
+                       (when-let [timer @*timer]
+                         (js/clearTimeout timer))
+                       (cb value)))]
+       (reset! *timer
+               (js/setTimeout
+                (fn []
+                  (when remove-handler!
+                    (remove-handler! channel))
+                  (finish! reject (timeout-error)))
+                timeout-ms))
+       (handle-once! channel
+                     (fn [_event ret]
+                       (finish! resolve ret)))))))

--- a/src/main/frontend/db/transact.cljs
+++ b/src/main/frontend/db/transact.cljs
@@ -188,7 +188,7 @@
                        :client-id (:client-id (state/get-state))
                        :ui/perf-id perf-id
                        :local-tx? true))
-            worker-opts (cond-> (dissoc opts' :ui/page-id :editor/edit-block-fn)
+            worker-opts (cond-> (dissoc opts' :ui/page-id :editor/edit-block-fn :await-ui-publish?)
                           (:editor/edit-block-fn opts')
                           (assoc :editor-row-uuids (operation-row-uuids ops)))
             request #(p/do!
@@ -209,24 +209,43 @@
                 publish? (or delta
                              (and current-context?
                                   (:editor/edit-block-fn opts')))
-                ui-refresh-perf (when publish?
-                                  (publish-worker-response!
-                                   opts' delta editor-rows editor-row-uuids current-context?))
-                ui-updated-at (now-ms)]
-          (when publish?
-            (on-next-frame!
-             (fn []
-               (log-outliner-op-perf!
-                {:stage :ui-updated
-                 :perf-id perf-id
-                 :op-names (mapv first ops)
-                 :op-count (count ops)
-                 :worker-apply-ms (:apply-ms perf)
-                 :worker-perf (dissoc perf :listener)
-                 :worker-listener (:listener perf)
-                 :worker-roundtrip-ms (- mutation-returned-at started-at)
-                 :worker-to-ui-ms (- worker-returned-at mutation-returned-at)
-                 :ui-refresh ui-refresh-perf
-                 :state-update-ms (- ui-updated-at worker-returned-at)
-                 :total-to-next-frame-ms (- (now-ms) started-at)}))))
-          result)))))
+                ;; HTTP/plugin writes persist in the worker. Do not gate their
+                ;; return on renderer flushSync / get-block hydration.
+                await-ui? (not (false? (:await-ui-publish? opts')))
+                log-ui-perf! (fn [ui-refresh-perf]
+                               (on-next-frame!
+                                (fn []
+                                  (log-outliner-op-perf!
+                                   {:stage :ui-updated
+                                    :perf-id perf-id
+                                    :op-names (mapv first ops)
+                                    :op-count (count ops)
+                                    :worker-apply-ms (:apply-ms perf)
+                                    :worker-perf (dissoc perf :listener)
+                                    :worker-listener (:listener perf)
+                                    :worker-roundtrip-ms (- mutation-returned-at started-at)
+                                    :worker-to-ui-ms (- worker-returned-at mutation-returned-at)
+                                    :ui-refresh ui-refresh-perf
+                                    :state-update-ms (- (now-ms) worker-returned-at)
+                                    :total-to-next-frame-ms (- (now-ms) started-at)}))))]
+          (cond
+            (and publish? await-ui?)
+            (p/let [ui-refresh-perf (publish-worker-response!
+                                     opts' delta editor-rows editor-row-uuids current-context?)]
+              (log-ui-perf! ui-refresh-perf)
+              result)
+
+            publish?
+            (do
+              (js/setTimeout
+               (fn []
+                 (-> (publish-worker-response!
+                      opts' delta editor-rows editor-row-uuids current-context?)
+                     (p/then log-ui-perf!)
+                     (p/catch (fn [error]
+                                (log/error :db/ui-publish-failed {:error error})))))
+               0)
+              result)
+
+            :else
+            result))))))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -417,7 +417,10 @@
        (assoc :source-outliner-op outliner-op)
 
        (:editor/edit-block-fn config)
-       (assoc :editor/edit-block-fn (:editor/edit-block-fn config)))
+       (assoc :editor/edit-block-fn (:editor/edit-block-fn config))
+
+       (false? (:edit-block? config))
+       (assoc :await-ui-publish? false))
      (save-current-block! {:current-block current-block})
      (outliner-op/insert-blocks! [new-block'] current-block insert-opts))))
 
@@ -785,8 +788,7 @@
                                               :outliner-op outliner-op}))
                    (when edit-existing-block?
                      (edit-block! last-block :max))
-                   (when-let [id (:block/uuid new-block)]
-                     (db-async/<get-block repo id {:children? false}))))))))))))
+                   new-block))))))))))
 
 (defn get-selected-blocks
   []

--- a/src/main/logseq/api/db_based.cljs
+++ b/src/main/logseq/api/db_based.cljs
@@ -81,12 +81,11 @@
 
 (defn insert-block
   [this content properties schema opts]
-  (p/let [new-block (editor-handler/api-insert-new-block! content opts)]
-    (when (seq properties)
-      (api-block/db-based-save-block-properties! new-block properties {:plugin this
-                                                                       :schema schema}))
-    (p/let [block (<get-block (:block/uuid new-block))]
-      (sdk-utils/result->js block))))
+  (p/let [new-block (editor-handler/api-insert-new-block! content opts)
+          _ (when (seq properties)
+              (api-block/db-based-save-block-properties! new-block properties {:plugin this
+                                                                               :schema schema}))]
+    (sdk-utils/result->js new-block)))
 
 
 (defn update-block

--- a/src/test/electron/server_invoke_test.cljs
+++ b/src/test/electron/server_invoke_test.cljs
@@ -5,21 +5,17 @@
 
 (deftest await-ipc-reply-resolves-when-renderer-answers
   (async done
-    (let [handlers (atom {})
-          result (server-invoke/await-ipc-reply!
-                  {:channel "sync-1"
-                   :timeout-ms 50
-                   :handle-once! (fn [channel handler]
-                                   (swap! handlers assoc channel handler))
-                   :remove-handler! (fn [channel]
-                                      (swap! handlers dissoc channel))})]
-      ((get @handlers "sync-1") nil {:uuid "abc"})
-      (-> result
-          (p/then (fn [value]
-                    (is (= {:uuid "abc"} value))))
-          (p/catch (fn [error]
-                     (is false (str error))))
-          (p/finally done)))))
+    (-> (server-invoke/await-ipc-reply!
+         {:channel "sync-1"
+          :timeout-ms 50
+          :handle-once! (fn [_channel handler]
+                          (js/setTimeout #(handler nil {:uuid "abc"}) 0))
+          :remove-handler! (fn [_channel])})
+        (p/then (fn [value]
+                  (is (= {:uuid "abc"} value))))
+        (p/catch (fn [error]
+                   (is false (str error))))
+        (p/finally done))))
 
 (deftest await-ipc-reply-times-out-when-renderer-never-answers
   (async done

--- a/src/test/electron/server_invoke_test.cljs
+++ b/src/test/electron/server_invoke_test.cljs
@@ -1,0 +1,39 @@
+(ns electron.server-invoke-test
+  (:require [cljs.test :refer [async deftest is]]
+            [electron.server-invoke :as server-invoke]
+            [promesa.core :as p]))
+
+(deftest await-ipc-reply-resolves-when-renderer-answers
+  (async done
+    (let [handlers (atom {})
+          result (server-invoke/await-ipc-reply!
+                  {:channel "sync-1"
+                   :timeout-ms 50
+                   :handle-once! (fn [channel handler]
+                                   (swap! handlers assoc channel handler))
+                   :remove-handler! (fn [channel]
+                                      (swap! handlers dissoc channel))})]
+      ((get @handlers "sync-1") nil {:uuid "abc"})
+      (-> result
+          (p/then (fn [value]
+                    (is (= {:uuid "abc"} value))))
+          (p/catch (fn [error]
+                     (is false (str error))))
+          (p/finally done)))))
+
+(deftest await-ipc-reply-times-out-when-renderer-never-answers
+  (async done
+    (let [removed (atom [])]
+      (-> (server-invoke/await-ipc-reply!
+           {:channel "sync-timeout"
+            :timeout-ms 20
+            :handle-once! (fn [_channel _handler])
+            :remove-handler! (fn [channel]
+                               (swap! removed conj channel))})
+          (p/then (fn [_]
+                    (is false "Timed-out invoke must reject")))
+          (p/catch (fn [error]
+                     (is (server-invoke/api-invoke-timeout? error))
+                     (is (= 504 (:status (ex-data error))))
+                     (is (= ["sync-timeout"] @removed))))
+          (p/finally done)))))

--- a/src/test/frontend/db/transact_test.cljs
+++ b/src/test/frontend/db/transact_test.cljs
@@ -379,6 +379,60 @@
           (p/finally
            done)))))
 
+(deftest apply-outliner-ops-does-not-wait-on-flush-sync-when-ui-publish-is-skipped-test
+  (async done
+    (let [repo "api-write-no-flush-wait"
+          inserted-block-id (random-uuid)
+          inserted-block {:block/uuid inserted-block-id
+                          :block/tx-id 2}
+          delta {:graph-id repo
+                 :rev 1
+                 :blocks {inserted-block-id inserted-block}
+                 :deleted {}
+                 :children {}
+                 :affected-keys #{[:graph]}}
+          original-flush-sync (.-flushSync react-dom)
+          calls (atom [])]
+      (set! (.-flushSync react-dom)
+            (fn [f]
+              (swap! calls conj :flush)
+              (f)))
+      (-> (p/with-redefs [util/node-test? false
+                          db-subs/apply-delta!
+                          (fn [value]
+                            (swap! calls conj [:delta value])
+                            true)
+                          state/get-current-repo (constantly repo)
+                          state/get-route-match (constantly nil)
+                          state/get-editor-info (constantly nil)
+                          state/<invoke-db-worker
+                          (fn [api & _args]
+                            (case api
+                              :thread-api/undo-redo-set-pending-editor-info
+                              (p/resolved nil)
+
+                              :thread-api/apply-outliner-ops
+                              (p/resolved {:result {:block/uuid inserted-block-id}
+                                           :delta delta})
+
+                              (p/resolved nil)))]
+            (p/let [value (db-transact/apply-outliner-ops
+                           nil
+                           [[:insert-blocks [[{:block/uuid inserted-block-id}] nil {}]]]
+                           {:await-ui-publish? false})
+                    _ (is (= {:block/uuid inserted-block-id} value)
+                          "The worker write result must be returned without waiting on flushSync.")
+                    _ (is (not (some #{:flush} @calls))
+                          "flushSync must not run before the write promise resolves.")
+                    _ (p/delay 0)]
+              (is (some #{:flush} @calls)
+                  "UI publish should still be scheduled after the write returns.")))
+          (p/catch (fn [error]
+                     (is false (str "Unexpected transaction failure: " error))))
+          (p/finally (fn []
+                       (set! (.-flushSync react-dom) original-flush-sync)
+                       (done)))))))
+
 (deftest apply-outliner-ops-does-not-run-editor-callback-on-worker-failure-test
   (async done
     (let [callback-called? (atom false)]

--- a/src/test/frontend/handler/editor_async_test.cljs
+++ b/src/test/frontend/handler/editor_async_test.cljs
@@ -534,12 +534,15 @@
                                                  :edit-block? false
                                                  :end? true}))
         (p/then
-         (fn [_]
+         (fn [inserted]
            (is (= [[page-id {:children? false}]]
-                  (take 1 @block-reads)))
+                  @block-reads)
+               "API insert must not hydrate the new block via renderer <get-block>.")
            (is (= [[10 :last-child]] @sibling-reads))
            (is (= last-child (:target @insertion)))
-           (is (true? (get-in @insertion [:opts :sibling?]))))))))
+           (is (true? (get-in @insertion [:opts :sibling?])))
+           (is (= "new" (:block/title inserted)))
+           (is (uuid? (:block/uuid inserted))))))))
 
 (deftest-async insert-above-awaits-async-insert
   (let [current-block {:db/id 1

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -1391,6 +1391,27 @@
                @calls)
             "Insert metadata and operations must use one transaction."))))
 
+(deftest api-insert-skips-waiting-on-ui-publish-test
+  (let [current-block {:db/id 1
+                       :block/uuid #uuid "11111111-1111-1111-1111-111111111111"
+                       :block/title "parent"
+                       :block/page {:db/id 10}}
+        next-block {:block/uuid #uuid "22222222-2222-2222-2222-222222222222"
+                    :block/title "child"}
+        apply-opts (atom nil)]
+    (with-redefs [frontend-outliner-op/save-block! (fn [& _])
+                  frontend-outliner-op/insert-blocks! (fn [& _])
+                  db-transact/apply-outliner-ops (fn [_ _opts opts]
+                                                   (reset! apply-opts opts)
+                                                   :tx)]
+      (editor/outliner-insert-block!
+       {:edit-block? false}
+       current-block
+       next-block
+       {:sibling? true :keep-uuid? true})
+      (is (false? (:await-ui-publish? @apply-opts))
+          "HTTP/plugin inserts must not wait on renderer flushSync."))))
+
 (deftest split-current-block-keeps-rendered-title-in-sync-test
   (let [block {:block/title "Performance row 2"
                :block/raw-title "Performance row 2"}]

--- a/src/test/logseq/api_test.cljs
+++ b/src/test/logseq/api_test.cljs
@@ -7,7 +7,9 @@
             [frontend.db.conn :as conn]
             [frontend.db.utils :as db-utils]
             [frontend.test.helper :as test-helper]
+            [frontend.handler.editor :as editor-handler]
             [logseq.api.block :as api-block]
+            [logseq.api.db-based :as db-based-api]
             [promesa.core :as p]))
 
 (use-fixtures :each {:before #(test-helper/start-test-db! {:build-init-data? false})
@@ -118,6 +120,28 @@
               (is (= "grandchild"
                      (get-in (js->clj result :keywordize-keys true)
                              [:children 0 :children 0 :title])))))
+          (p/catch (fn [error]
+                     (is false (str error))))
+          (p/finally done)))))
+
+(deftest insert-block-returns-identity-without-renderer-get-block-test
+  (async done
+    (let [block-uuid (random-uuid)
+          get-block-calls (atom [])]
+      (-> (p/with-redefs [editor-handler/api-insert-new-block!
+                          (fn [content _opts]
+                            (p/resolved {:block/uuid block-uuid
+                                         :block/title content}))
+                          db-async/<get-block
+                          (fn [_repo id & _opts]
+                            (swap! get-block-calls conj id)
+                            (p/deferred))]
+            (p/let [result (db-based-api/insert-block nil "hello" nil nil {:edit-block? false})
+                    result' (js->clj result :keywordize-keys true)]
+              (is (empty? @get-block-calls)
+                  "insertBlock must return the worker identity without renderer <get-block>.")
+              (is (= (str block-uuid) (:uuid result')))
+              (is (= "hello" (:title result')))))
           (p/catch (fn [error]
                      (is false (str error))))
           (p/finally done)))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes write calls over the desktop HTTP API hanging until the client times out after the worker has already persisted the block.

`logseq.Editor.insertBlock` and `appendBlockInPage` were waiting on renderer `<get-block>` hydration and `react-dom/flushSync` before answering. That stalls when the desktop window is backgrounded or minimized (same class as logseq/logseq#12991). `insertBatchBlock` was already a single tree write and stays on that path.

### Changes
- Return the new block UUID from the worker write instead of a post-write renderer `<get-block>`.
- Skip waiting on UI `flushSync` for API inserts (`:edit-block? false`); still publish the delta asynchronously so the journal updates.
- Time out `invoke-logseq-api!` after 30s and respond with HTTP 504 instead of hanging on `ipcMain.handleOnce`.

### Tests
- Write path does not wait on renderer `<get-block>` / `flushSync`.
- `invoke-logseq-api!` helper rejects with a 504 timeout when the renderer never replies.

Verified with:
`node static/tests.js -n electron.server-invoke-test -n frontend.db.transact-test -n logseq.api-test`
plus `frontend.handler.editor-test/api-insert-skips-waiting-on-ui-publish-test` and `frontend.handler.editor-async-test/api-insert-at-page-end-loads-only-the-page-and-last-child`.

Refs https://github.com/logseq/db-test/issues/1042
Related: https://github.com/logseq/logseq/issues/12991
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fa12fc7-77aa-4d0a-b174-4653d668740c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fa12fc7-77aa-4d0a-b174-4653d668740c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

