### PR TITLE
fix: emit TODO for default task status in markdown mirror

### DIFF
--- a/src/main/frontend/worker/markdown_mirror.cljs
+++ b/src/main/frontend/worker/markdown_mirror.cljs
@@ -2,6 +2,7 @@
   "Markdown mirror derived-file support for DB graphs."
   (:require [clojure.string :as string]
             [datascript.core :as d]
+            [datascript.impl.entity :as de]
             [frontend.worker.graph-dir :as graph-dir]
             [frontend.worker.platform :as platform]
             [lambdaisland.glogi :as log]
@@ -239,29 +240,6 @@
           string/upper-case
           (string/replace #"\s+" "-")))))
 
-(defn- empty-placeholder-status?
-  [status]
-  (= :logseq.property/empty-placeholder
-     (if (keyword? status) status (:db/ident status))))
-
-(defn- class-provides-status?
-  [class]
-  (some #(= :logseq.property/status (:db/ident %))
-        (:logseq.property.class/properties class)))
-
-(defn- block-classes-provide-status?
-  [block]
-  (let [tags (:block/tags block)]
-    (boolean
-     (some class-provides-status?
-           (concat tags (ldb/get-classes-parents tags))))))
-
-(defn- block-status
-  [db block]
-  (when (or (seq (d/datoms db :eavt (:db/id block) :logseq.property/status))
-            (block-classes-provide-status? block))
-    (:logseq.property/status block)))
-
 (defn- simple-tag-token?
   [title]
   (boolean
@@ -396,12 +374,11 @@
             (:block/tags block))))
 
 (defn- block-line-info
-  [db block marker]
+  [_db block marker]
   {:first-line-fragment (block-first-line-fragment block)
    :code-block? (code-block? block)
-   :status-marker (when-let [status (block-status db block)]
-                    (when-not (empty-placeholder-status? status)
-                      (status-marker status)))
+   :status-marker (when (de/entity? block)
+                    (some-> (:logseq.property/status block) status-marker))
    :tag-tokens (mirror-tag-tokens block)
    :marker marker
    :embed-target (embed-target block)})

--- a/src/main/frontend/worker/markdown_mirror.cljs
+++ b/src/main/frontend/worker/markdown_mirror.cljs
@@ -375,15 +375,15 @@
 
 (defn- block-line-info
   [db block marker]
-  {:first-line-fragment (block-first-line-fragment block)
-   :code-block? (code-block? block)
-   :status-marker (when (de/entity? block)
-                    (when (or (seq (d/datoms db :eavt (:db/id block) :logseq.property/status))
+  (let [block (if (de/entity? block) block (d/entity db (:db/id block)))]
+    {:first-line-fragment (block-first-line-fragment block)
+     :code-block? (code-block? block)
+     :status-marker (when (or (seq (d/datoms db :eavt (:db/id block) :logseq.property/status))
                               (ldb/class-instance? (d/entity db :logseq.class/Task) block))
-                      (some-> (:logseq.property/status block) status-marker)))
-   :tag-tokens (mirror-tag-tokens block)
-   :marker marker
-   :embed-target (embed-target block)})
+                      (some-> (:logseq.property/status block) status-marker))
+     :tag-tokens (mirror-tag-tokens block)
+     :marker marker
+     :embed-target (embed-target block)}))
 
 (defn- property-derived-block?
   [block]

--- a/src/main/frontend/worker/markdown_mirror.cljs
+++ b/src/main/frontend/worker/markdown_mirror.cljs
@@ -239,6 +239,29 @@
           string/upper-case
           (string/replace #"\s+" "-")))))
 
+(defn- empty-placeholder-status?
+  [status]
+  (= :logseq.property/empty-placeholder
+     (if (keyword? status) status (:db/ident status))))
+
+(defn- class-provides-status?
+  [class]
+  (some #(= :logseq.property/status (:db/ident %))
+        (:logseq.property.class/properties class)))
+
+(defn- block-classes-provide-status?
+  [block]
+  (let [tags (:block/tags block)]
+    (boolean
+     (some class-provides-status?
+           (concat tags (ldb/get-classes-parents tags))))))
+
+(defn- block-status
+  [db block]
+  (when (or (seq (d/datoms db :eavt (:db/id block) :logseq.property/status))
+            (block-classes-provide-status? block))
+    (:logseq.property/status block)))
+
 (defn- simple-tag-token?
   [title]
   (boolean
@@ -376,8 +399,9 @@
   [db block marker]
   {:first-line-fragment (block-first-line-fragment block)
    :code-block? (code-block? block)
-   :status-marker (when (seq (d/datoms db :eavt (:db/id block) :logseq.property/status))
-                    (some-> (:logseq.property/status block) status-marker))
+   :status-marker (when-let [status (block-status db block)]
+                    (when-not (empty-placeholder-status? status)
+                      (status-marker status)))
    :tag-tokens (mirror-tag-tokens block)
    :marker marker
    :embed-target (embed-target block)})

--- a/src/main/frontend/worker/markdown_mirror.cljs
+++ b/src/main/frontend/worker/markdown_mirror.cljs
@@ -374,11 +374,13 @@
             (:block/tags block))))
 
 (defn- block-line-info
-  [_db block marker]
+  [db block marker]
   {:first-line-fragment (block-first-line-fragment block)
    :code-block? (code-block? block)
    :status-marker (when (de/entity? block)
-                    (some-> (:logseq.property/status block) status-marker))
+                    (when (or (seq (d/datoms db :eavt (:db/id block) :logseq.property/status))
+                              (ldb/class-instance? (d/entity db :logseq.class/Task) block))
+                      (some-> (:logseq.property/status block) status-marker)))
    :tag-tokens (mirror-tag-tokens block)
    :marker marker
    :embed-target (embed-target block)})

--- a/src/test/frontend/worker/markdown_mirror_test.cljs
+++ b/src/test/frontend/worker/markdown_mirror_test.cljs
@@ -448,6 +448,55 @@
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
           (p/finally done)))))
 
+(deftest page-mirror-emits-todo-for-task-with-default-status-test
+  (async done
+    (let [{:keys [platform files]} (fake-platform)
+          conn (db-test/create-conn-with-blocks
+                {:pages-and-blocks [{:page {:block/title "Tasks"}
+                                     :blocks [{:block/title "default todo"
+                                               :build/tags [:logseq.class/Task]}
+                                              {:block/title "doing task"
+                                               :build/tags [:logseq.class/Task]
+                                               :build/properties {:logseq.property/status :logseq.property/status.doing}}
+                                              {:block/title "done task"
+                                               :build/tags [:logseq.class/Task]
+                                               :build/properties {:logseq.property/status :logseq.property/status.done}}
+                                              {:block/title "canceled task"
+                                               :build/tags [:logseq.class/Task]
+                                               :build/properties {:logseq.property/status :logseq.property/status.canceled}}]}]})
+          page (db-test/find-page-by-title @conn "Tasks")
+          default-block (db-test/find-block-by-content @conn "default todo")]
+      (-> (markdown-mirror/<mirror-page! test-repo @conn (:db/id page) {:platform platform})
+          (p/then (fn [_]
+                    (is (empty? (d/datoms @conn :eavt (:db/id default-block) :logseq.property/status)))
+                    (is (= :logseq.property/status.todo
+                           (:db/ident (:logseq.property/status default-block))))
+                    (is (= (str (page-marker (:block/uuid page)) "\n\n"
+                                "- TODO default todo\n"
+                                "- DOING doing task\n"
+                                "- DONE done task\n"
+                                "- CANCELED canceled task")
+                           (get @files (page-path "pages/Tasks.md"))))))
+          (p/catch (fn [e] (is false (str "unexpected error: " e))))
+          (p/finally done)))))
+
+(deftest page-mirror-skips-empty-placeholder-status-test
+  (async done
+    (let [{:keys [platform files]} (fake-platform)
+          conn (db-test/create-conn-with-blocks
+                {:pages-and-blocks [{:page {:block/title "Cleared"}
+                                     :blocks [{:block/title "cleared status"
+                                               :build/tags [:logseq.class/Task]
+                                               :build/properties {:logseq.property/status :logseq.property/empty-placeholder}}]}]})
+          page (db-test/find-page-by-title @conn "Cleared")]
+      (-> (markdown-mirror/<mirror-page! test-repo @conn (:db/id page) {:platform platform})
+          (p/then (fn [_]
+                    (is (= (str (page-marker (:block/uuid page)) "\n\n"
+                                "- cleared status")
+                           (get @files (page-path "pages/Cleared.md"))))))
+          (p/catch (fn [e] (is false (str "unexpected error: " e))))
+          (p/finally done)))))
+
 (deftest page-mirror-preserves-numbered-list-markers-status-and-tags-test
   (async done
     (let [{:keys [platform files]} (fake-platform)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes default Todo tasks missing the `TODO` keyword in the markdown mirror.

https://github.com/logseq/db-test/issues/1043

## Change
If the block is not already an entity, look it up first. Then read `(:logseq.property/status block)` so Task default Todo is included even with no status datom.

That lookup returns the property default for every entity, not only tasks. Emit a keyword only when the block is a Task (including subclasses) or already has an explicit status datom, so plain blocks stay `- title`.

## Tests
- Tag Task without setting status and expect `- TODO title`.
- Explicit Doing/Done/Canceled still emit their keywords.
- Cleared status (`empty-placeholder`) does not emit a keyword.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea81c008-147c-4cd4-970a-6a5487961462?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea81c008-147c-4cd4-970a-6a5487961462&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

