### PR TITLE
fix: align page property value columns

### DIFF
--- a/src/main/frontend/components/property.css
+++ b/src/main/frontend/components/property.css
@@ -76,14 +76,15 @@
 
   .property-pair.property-panel-row {
     @apply grid items-start pr-3 gap-3 w-full;
-    grid-template-columns: fit-content(260px) minmax(0, 1fr);
+    /* Fixed key column so every row shares one value-column axis.
+       Per-row fit-content(260px) sized keys independently (150–260px). */
+    grid-template-columns: 160px minmax(0, 1fr);
     margin-left: 0;
   }
 
   .property-key-panel {
-    @apply flex items-center min-w-0;
+    @apply flex items-center min-w-0 w-full;
     min-height: 28px;
-    min-width: 150px;
     font-size: inherit;
     color: var(--ls-primary-text-color);
   }
@@ -141,13 +142,23 @@
   }
 
   .property-panel-bullet {
-    @apply inline-flex items-center opacity-60;
-    margin-left: 2px;
+    @apply inline-flex items-center justify-center opacity-60 shrink-0;
+    width: 16px;
+    min-width: 16px;
     min-height: 24px;
   }
 
   .property-panel-bullet .bullet-container {
     @apply relative left-0 top-0;
+    width: 15px;
+    height: 15px;
+    min-width: 15px;
+  }
+
+  .property-value-panel.ls-block.property-value-container:not(:has(> .property-panel-bullet)) {
+    /* Reserve the in-flow bullet slot (16px) plus gap-1 so filled default/url
+       values start on the same axis as rows that render a bullet. */
+    padding-left: calc(16px + 0.25rem);
   }
 
   .property-panel-edit-btn {
@@ -514,10 +525,20 @@ a.control-link {
   @apply flex flex-row items-center gap-1 relative;
 
   .property-icon {
-    @apply flex items-center;
+    @apply flex items-center justify-center shrink-0;
+    width: 16px;
+    min-width: 16px;
+    height: 16px;
+
     svg {
         width: 15px;
         height: 15px;
+    }
+
+    .bullet-container {
+        width: 15px;
+        height: 15px;
+        min-width: 15px;
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes page property values under the page title so mixed types share one value-column axis.

https://github.com/logseq/db-test/issues/1044

## What changed

Each page-property row is its own CSS grid. The key column used `fit-content(260px)` with a 150px min-width, so keys between 150px and 260px started their values at different x positions. Type icons also had no fixed slot, and filled `:default` / `:url` rows omitted the value bullet, which shifted those values left.

This keeps the per-row grid (so drag-and-drop wrappers stay intact) and aligns columns with CSS only:

- Fixed 160px key column, matching `.property-key`
- 16px centered type-icon slot (page / № / default bullet)
- Reserved value-bullet gutter when the in-flow bullet is omitted

## Tests

CSS/layout only. Existing `show-property-panel-bullet?` coverage is unchanged. No new unit tests; alignment is visual.

## How to verify

1. Open a page and add mixed properties: short key + long key, page / number / url / text / checkbox.
2. Confirm values share one vertical axis, type icons sit at the same x, and filled text/url rows are not shifted left relative to rows with a value bullet.
3. Drag a property key to reorder rows; drop still persists the new order.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1bae130-d45f-4589-a677-50399fc4c5ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1bae130-d45f-4589-a677-50399fc4c5ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

