### PR TITLE
fix: import OG favorites with page refs and namespaces

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -3018,17 +3018,49 @@
                                     :block/page page-id}))))
                    []
                    favorited-ids)]
-    (ldb/transact! repo-or-conn tx)))
+    (ldb/transact! repo-or-conn tx {::imported-data? true ::new-graph? true})))
+
+(defn- favorite-config-page-name
+  "OG :favorites may be a bare name or a [[page]] ref."
+  [page-name]
+  (if (string? page-name)
+    (page-ref/get-page-name! (string/trim page-name))
+    page-name))
+
+(defn- find-namespace-page
+  "Resolve a flattened namespace page by walking parent/child after import.
+   OG `foo/bar` is stored as page `bar` whose parent is `foo`."
+  [db page-name]
+  (let [parts (string/split page-name ns-util/namespace-char)]
+    (when (next parts)
+      (reduce (fn [parent part]
+                (when parent
+                  (some (fn [child]
+                          (when (and (page-entity? child)
+                                     (= (common-util/page-name-sanity-lc part)
+                                        (:block/name child)))
+                            child))
+                        (:block/_parent parent))))
+              (ldb/get-page db (first parts))
+              (rest parts)))))
+
+(defn- get-imported-favorite-page
+  [db page-name]
+  (let [page-name' (favorite-config-page-name page-name)]
+    (or (ldb/get-page db page-name')
+        (when (and (string? page-name')
+                   (ns-util/namespace-page? page-name'))
+          (find-namespace-page db page-name')))))
 
 (defn- export-favorites-from-config-edn
   [conn repo config {:keys [log-fn] :or {log-fn prn}}]
   (when-let [favorites (seq (:favorites config))]
     (p/do!
      (if-let [favorited-ids
-              (keep (fn [page-name]
-                      (some-> (ldb/get-page @conn page-name)
-                              :block/uuid))
-                    favorites)]
+              (seq (keep (fn [page-name]
+                           (some-> (get-imported-favorite-page @conn page-name)
+                                   :block/uuid))
+                         favorites))]
        (let [page-entity (ldb/get-page @conn common-config/favorites-page-name)]
          (insert-favorites repo favorited-ids (:db/id page-entity)))
        (log-fn :no-favorites-found {:favorites favorites})))))
@@ -3118,7 +3150,7 @@
                                    (merge (select-keys options [:notify-user :set-ui-state :rpath-key])
                                           {:assets (get-in doc-options [:import-state :assets])}))
         (export-doc-files conn doc-files <read-file doc-options)
-        (export-favorites-from-config-edn conn repo-or-conn config {})
+        (export-favorites-from-config-edn conn repo-or-conn config {:log-fn log-fn})
         (export-class-properties conn repo-or-conn)
         (move-top-parent-pages-to-library conn repo-or-conn)
         {:import-state (-> (:import-state doc-options)

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -1174,7 +1174,7 @@ abc
 
     (testing "favorites"
       (is (= #{"Interstellar" "some page" "new page" "n1/x/y"}
-             (set (imported-favorite-titles @conn)))))))
+             (set (imported-favorite-titles @conn)))))
 
     (testing "user properties"
       (is (= 23

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -131,6 +131,13 @@
                 (false? (:added datom))))
          (:tx-data tx-report))))
 
+(defn- imported-favorite-titles
+  [db]
+  (->> (ldb/get-page-blocks db (:db/id (ldb/get-page db common-config/favorites-page-name)))
+       (keep :block/link)
+       (map #(d/entity db (:db/id %)))
+       (map ldb/get-title-with-parents)))
+
 
 (defn- build-graph-files
   "Given a file graph directory, return all files including assets and adds relative paths
@@ -1166,13 +1173,8 @@ abc
              (ffirst (d/q '[:find ?content :where [?b :file/path "logseq/custom.js"] [?b :file/content ?content]] @conn)))))
 
     (testing "favorites"
-      (is (= #{"Interstellar" "some page"}
-             (->>
-              (ldb/get-page-blocks @conn
-                                   (:db/id (ldb/get-page @conn common-config/favorites-page-name))
-                                   {:pull-keys '[* {:block/link [:block/title]}]})
-              (map #(get-in % [:block/link :block/title]))
-              set))))
+      (is (= #{"Interstellar" "some page" "new page" "n1/x/y"}
+             (set (imported-favorite-titles @conn)))))))
 
     (testing "user properties"
       (is (= 23
@@ -1979,6 +1981,22 @@ abc
     (is (= #{(:block/uuid missing-page)}
            (set (map :block/uuid (:block/refs source-block))))
         "Missing ordinary page ref points at the created page")))
+
+(deftest-async import-favorites-from-og-config-edn
+  (p/let [dir (write-temp-file-graph
+               {"logseq/config.edn"
+                (str "{:favorites [\"Projects\" \"[[Projects]]\" \"foo/bar\"]\n"
+                     " :file/name-format :triple-lowbar}\n")
+                "pages/Projects.md" "- project work\n- [[foo/bar]]\n"})
+          conn (db-test/create-conn)
+          _ (db-pipeline/add-listener conn)
+          _ (import-file-graph-to-db dir conn {})
+          favorite-titles (imported-favorite-titles @conn)]
+    (is (= 3 (count favorite-titles))
+        "Bare names, bracketed page refs, and namespaced pages each become a favorite link")
+    (is (= #{"Projects" "foo/bar"}
+           (set favorite-titles))
+        "Imported favorites resolve to the original pages including flattened namespaces")))
 
 (deftest-async import-normalizes-existing-random-journal-uuid-and-text-refs
   (let [old-journal-uuid (random-uuid)

--- a/deps/graph-parser/test/resources/exporter-test-graph/logseq/config.edn
+++ b/deps/graph-parser/test/resources/exporter-test-graph/logseq/config.edn
@@ -280,7 +280,7 @@
  ;;  :journal?        false} ; Default value: false
 
  ;; Favorites to list on the left sidebar
-   :favorites ["Interstellar" "some page"]
+   :favorites ["Interstellar" "some page" "[[new page]]" "n1/x/y"]
 
  ;; Set flashcards interval.
  ;; Expected value:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/logseq/db-test/issues/1045.

File-to-DB import copies OG `logseq/config.edn` `:favorites` onto hidden page `$$$favorites` as `:block/link` children. Lookup used `get-page` on the raw config string, so:

- `[[Projects]]` did not match page `Projects`
- `foo/bar` did not match the flattened imported page (`title`/`name` is `bar`, parent is `foo`)

Misses were also silent because `if-let` on `keep` is always truthy.

## Change

- Un-bracket page refs before lookup
- Resolve namespaced favorites by walking parent/child after flatten
- Treat an empty keep result as no favorites found
- Pass import `log-fn` and `{::imported-data? true ::new-graph? true}`

## Tests

- Existing bare-name favorites still import (`Interstellar`, `some page`)
- Exporter coverage for `[[page]]` and namespaced favorites (`[[new page]]`, `n1/x/y`)
- Focused graph for `Projects`, `[[Projects]]`, and `foo/bar`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be81fbe1-b1f6-4ca1-878b-7c4aaa4010fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be81fbe1-b1f6-4ca1-878b-7c4aaa4010fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

