### PR TITLE
fix: open deadline and scheduled dates on their journal

### DIFF
--- a/src/main/frontend/components/property/value.cljs
+++ b/src/main/frontend/components/property/value.cljs
@@ -31,6 +31,7 @@
             [goog.functions :refer [debounce]]
             [lambdaisland.glogi :as log]
             [logseq.common.config :as common-config]
+            [logseq.common.util.date-time :as date-time-util]
             [logseq.common.util.macro :as macro-util]
             [logseq.db :as ldb]
             [logseq.db.frontend.content :as db-content]
@@ -456,7 +457,8 @@
                           page)]
      (if journal-page
        journal-page
-       (create-page-f journal {:redirect? false})))))
+       (create-page-f journal {:redirect? false
+                              :journal? true})))))
 
 (def ^:private selected-day-selector
   "[role='gridcell'][aria-selected='true'] button, [role='gridcell'] button[tabindex='0']")
@@ -576,32 +578,67 @@
     other-position?
     (assoc :on-click util/stop-propagation)))
 
+(defn- datetime-value-page
+  "Page entity passed to page-cp for a datetime property pill.
+   Must be the journal entity (uuid route), not a computed title string."
+  [utc-ms journal-page]
+  (when (and (number? utc-ms)
+             (uuid? (:block/uuid journal-page))
+             (= (date-time-util/ms->journal-day utc-ms)
+                (:block/journal-day journal-page)))
+    journal-page))
+
+(defn- <resolve-datetime-journal-page
+  ([utc-ms]
+   (<resolve-datetime-journal-page utc-ms
+                                   state/get-current-repo
+                                   db-async/<get-journal-page-by-day
+                                   <resolve-journal-page-for-date))
+  ([utc-ms get-current-repo-f get-journal-page-by-day-f resolve-journal-page-for-date-f]
+   (let [journal-day (date-time-util/ms->journal-day utc-ms)]
+     (p/let [page (when journal-day
+                    (get-journal-page-by-day-f (get-current-repo-f) journal-day))]
+       (or (datetime-value-page utc-ms page)
+           (resolve-journal-page-for-date-f (js/Date. utc-ms)))))))
+
 (hsx/defc datetime-value
   [value property-id repeated-task? {:keys [datetime? other-position? suppress-inline-edit-icon?]}]
-  (when-let [date (t/to-default-time-zone (tc/from-long value))]
-    (let [content [:div.ls-datetime.flex.flex-row.gap-1.items-center
-                   (when-let [page-cp (state/get-component :block/page-cp)]
-                     (let [page-title (date/journal-name date)]
-                       ^{:key page-title}
-                       [:span.inline-flex (date-page-link-props other-position?)
+  (let [date (when (number? value)
+               (t/to-default-time-zone (tc/from-long value)))
+        [journal-page set-journal-page!] (hooks/use-state nil)]
+    (hooks/use-effect!
+     (fn []
+       (set-journal-page! nil)
+       (when (number? value)
+         (p/let [page (<resolve-datetime-journal-page value)]
+           (set-journal-page! page))))
+     [value])
+    (when date
+      (let [page (datetime-value-page value journal-page)
+            page-cp (state/get-component :block/page-cp)
+            content [:div.ls-datetime.flex.flex-row.gap-1.items-center
+                     ^{:key (or (:block/uuid page) (date/journal-name date))}
+                     [:span.inline-flex (date-page-link-props other-position?)
+                      (if (and page page-cp)
                         (page-cp {:disable-preview? true
-                                  :show-non-exists-page? true
                                   :label (human-date-label value)}
-                                 {:block/name page-title})]))
-                   (when datetime?
-                     (let [date (js/Date. value)
-                           hours (.getHours date)
-                           minutes (.getMinutes date)]
-                       [:span.select-none
-                        (if (= 0 hours minutes)
-                          (when-not (or other-position? suppress-inline-edit-icon?)
-                            (ui/icon "edit" {:size 14 :class "text-muted-foreground hover:text-foreground align-middle"}))
-                          (str (util/zero-pad hours)
-                               ":"
-                               (util/zero-pad minutes)))]))]]
-      (if (or repeated-task? (contains? #{:logseq.property/deadline :logseq.property/scheduled} property-id))
-        (overdue date content)
-        content))))
+                                 page)
+                        (or (human-date-label value)
+                            (date/journal-name date)))]
+                     (when datetime?
+                       (let [date (js/Date. value)
+                             hours (.getHours date)
+                             minutes (.getMinutes date)]
+                         [:span.select-none
+                          (if (= 0 hours minutes)
+                            (when-not (or other-position? suppress-inline-edit-icon?)
+                              (ui/icon "edit" {:size 14 :class "text-muted-foreground hover:text-foreground align-middle"}))
+                            (str (util/zero-pad hours)
+                                 ":"
+                                 (util/zero-pad minutes)))]))]]
+        (if (or repeated-task? (contains? #{:logseq.property/deadline :logseq.property/scheduled} property-id))
+          (overdue date content)
+          content)))))
 
 (defn- delete-block-property!
   [block property opts]

--- a/src/test/frontend/components/property/value_test.cljs
+++ b/src/test/frontend/components/property/value_test.cljs
@@ -7,6 +7,7 @@
             [frontend.handler.editor :as editor-handler]
             [frontend.handler.property :as property-handler]
             [frontend.state :as state]
+            [logseq.common.util.date-time :as date-time-util]
             [promesa.core :as p]))
 
 (deftest alias-node-selection-preserves-entity-id-semantics-test
@@ -116,7 +117,86 @@
                 (constantly "Jan 2nd, 2025"))
                (p/then (fn [page]
                          (is (= created-page page))
-                         (is (= [["Jan 2nd, 2025" {:redirect? false}]] @created-calls*))
+                         (is (= [["Jan 2nd, 2025" {:redirect? false
+                                                   :journal? true}]] @created-calls*))
+                         (done)))
+               (p/catch (fn [error]
+                          (is false (str error))
+                          (done)))))))
+
+(deftest datetime-value-page-uses-journal-entity-uuid-test
+  (let [utc-ms (.getTime (js/Date. 2026 7 20 12 0 0))
+        journal-day (date-time-util/ms->journal-day utc-ms)
+        journal-uuid #uuid "00000001-2026-0820-0000-000000000000"
+        journal-page {:block/uuid journal-uuid
+                      :block/journal-day journal-day
+                      :block/title "Aug 20th, 2026"
+                      :block/name "aug 20th, 2026"}
+        page (#'property-value/datetime-value-page utc-ms journal-page)]
+    (is (= journal-page page))
+    (is (uuid? (:block/uuid page)))
+    (is (= journal-day (:block/journal-day page)))
+    (is (not= {:block/name "Aug 20th, 2026"} page)
+        "Date-pill navigation must not use a computed title string")
+    (is (nil? (#'property-value/datetime-value-page
+               utc-ms
+               {:block/name "Aug 20th, 2026"}))
+        "A title-only fake page is rejected")
+    (is (nil? (#'property-value/datetime-value-page
+               utc-ms
+               (assoc journal-page :block/journal-day (inc journal-day))))
+        "A journal for a different day is rejected")))
+
+(deftest resolve-datetime-journal-page-looks-up-by-journal-day-test
+  (async done
+         (let [utc-ms (.getTime (js/Date. 2026 7 20 12 0 0))
+               journal-day (date-time-util/ms->journal-day utc-ms)
+               journal-uuid #uuid "00000001-2026-0820-0000-000000000000"
+               journal-page {:block/uuid journal-uuid
+                             :block/journal-day journal-day
+                             :block/title "Aug 20th, 2026"}
+               lookup-args* (atom [])
+               created?* (atom false)]
+           (-> (#'property-value/<resolve-datetime-journal-page
+                utc-ms
+                (constantly "test-repo")
+                (fn [repo day]
+                  (swap! lookup-args* conj [repo day])
+                  (p/resolved journal-page))
+                (fn [_d]
+                  (reset! created?* true)
+                  (p/resolved {:block/uuid (random-uuid)
+                               :block/journal-day journal-day})))
+               (p/then (fn [page]
+                         (is (= [["test-repo" journal-day]] @lookup-args*))
+                         (is (= journal-page page))
+                         (is (uuid? (:block/uuid page)))
+                         (is (false? @created?*))
+                         (done)))
+               (p/catch (fn [error]
+                          (is false (str error))
+                          (done)))))))
+
+(deftest resolve-datetime-journal-page-creates-journal-when-missing-test
+  (async done
+         (let [utc-ms (.getTime (js/Date. 2026 7 20 12 0 0))
+               journal-day (date-time-util/ms->journal-day utc-ms)
+               created-page {:block/uuid #uuid "00000001-2026-0820-0000-000000000001"
+                             :block/journal-day journal-day}
+               created-args* (atom [])]
+           (-> (#'property-value/<resolve-datetime-journal-page
+                utc-ms
+                (constantly "test-repo")
+                (fn [_repo _day]
+                  (p/resolved nil))
+                (fn [d]
+                  (swap! created-args* conj d)
+                  (p/resolved created-page)))
+               (p/then (fn [page]
+                         (is (= 1 (count @created-args*)))
+                         (is (inst? (first @created-args*)))
+                         (is (= created-page page))
+                         (is (uuid? (:block/uuid page)))
                          (done)))
                (p/catch (fn [error]
                           (is false (str error))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Deadline and Scheduled property pills stored a UTC-ms timestamp and rendered the date as a fake page `{:block/name (journal-name ts)}`. Clicking that text called `redirect-to-page!` with a title such as `"Aug 20th, 2026"`. Desktop title routing keeps the raw title and looks up `:block/name`, not `:block/journal-day`, so a missing or mismatched name opened a blank/not-found page.

Custom `:date` properties already store the journal entity and navigate by `:block/uuid`. This change does the same for datetime pills:

- Resolve the journal by `journal-day` from the timestamp
- Pass that entity (uuid) to `page-cp`
- Create a journal with `:journal? true` only if it is missing
- Leave calendar open-from-empty/edit-area behavior unchanged

Fixes https://github.com/logseq/db-test/issues/1046

This is distinct from db-test#1041 / #13040 (datepicker Enter committing the initial day).

Tests cover `datetime-value-page` / date-pill navigation using the journal entity uuid, not a computed title string.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43e5278e-6dfd-4a99-b06b-05b4051c9993?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43e5278e-6dfd-4a99-b06b-05b4051c9993&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

