### PR TITLE
fix: clone live blocks on keep-uuid paste

### DIFF
--- a/deps/outliner/src/logseq/outliner/core.cljs
+++ b/deps/outliner/src/logseq/outliner/core.cljs
@@ -665,13 +665,45 @@
           (recur db (inc idx) (rest blocks) (conj entries nil)))
         entries))))
 
+(defn- entity-page-id
+  [block]
+  (or (:db/id (:block/page block))
+      (when (ldb/page? block)
+        (:db/id block))))
+
+(defn- reuse-uuid-on-insert?
+  "keep-uuid? preserves identity for new or recycled entities.
+  Paste must not reparent a live entity. Tag-template apply may reuse a UUID
+  already on the target page (idempotent journal re-apply)."
+  [db uuid keep-uuid? target-block outliner-op]
+  (boolean
+   (and keep-uuid?
+        uuid
+        (let [existing (d/entity db [:block/uuid uuid])]
+          (or (nil? existing)
+              (ldb/recycled? existing)
+              (case outliner-op
+                :paste false
+                :insert-template-blocks
+                (let [existing-page (entity-page-id existing)
+                      target-page (entity-page-id target-block)]
+                  (and existing-page
+                       target-page
+                       (= existing-page target-page)))
+                true))))))
+
 (defn- insert-blocks-aux
-  [db blocks target-block {:keys [replace-empty-target? keep-uuid?]
+  [db blocks target-block {:keys [replace-empty-target? keep-uuid? outliner-op]
                            :as opts}]
   (let [block-uuids (map :block/uuid blocks)
         uuids (zipmap block-uuids
                       (if keep-uuid?
-                        block-uuids
+                        (map (fn [uuid]
+                               (if (reuse-uuid-on-insert? db uuid keep-uuid? target-block outliner-op)
+                                 uuid
+                                 (when uuid
+                                   (common-uuid/gen-uuid))))
+                             block-uuids)
                         (repeatedly common-uuid/gen-uuid)))
         uuids (if replace-empty-target?
                 (assoc uuids (:block/uuid (first blocks)) (:block/uuid target-block))
@@ -788,9 +820,10 @@
       `sibling?`: as siblings (true) or children (false).
       `bottom?`: inserts block to the bottom.
       `top?`: inserts block to the top.
-      `keep-uuid?`: whether to replace `:block/uuid` from the parameter `blocks`.
-                    For example, if `blocks` are from internal copy, the uuids
-                    need to be changed, but there's no need for internal cut or drag & drop.
+      `keep-uuid?`: whether to keep `:block/uuid` from the parameter `blocks`.
+                    New and recycled identities are kept. Paste of a live entity
+                    always clones. Tag-template apply may keep a UUID already on
+                    the target page.
       `keep-block-order?`: whether to replace `:block/order` from the parameter `blocks`.
       `outliner-op`: what's the current outliner operation.
       `replace-empty-target?`: If the `target-block` is an empty block, whether

--- a/deps/outliner/src/logseq/outliner/op.cljs
+++ b/deps/outliner/src/logseq/outliner/op.cljs
@@ -243,11 +243,11 @@
                                                                {:include-property-block? true})
                                    rest)]
       (when (seq template-blocks)
-        (cons (assoc (into {} (first template-blocks))
-                     :db/id (:db/id (first template-blocks))
-                     :logseq.property/used-template (:db/id template))
+        (cons (-> (into {} (first template-blocks))
+                  (dissoc :db/id)
+                  (assoc :logseq.property/used-template (:db/id template)))
               (map (fn [block]
-                     (assoc (into {} block) :db/id (:db/id block)))
+                     (dissoc (into {} block) :db/id))
                    (rest template-blocks)))))))
 
 (defn- journal-title

--- a/deps/outliner/test/logseq/outliner/core_test.cljs
+++ b/deps/outliner/test/logseq/outliner/core_test.cljs
@@ -6,6 +6,70 @@
             [logseq.outliner.core :as outliner-core]
             [logseq.common.config :as common-config]))
 
+(deftest insert-blocks-keep-uuid-paste-does-not-reparent-live-source
+  (testing "keep-uuid paste of a live block clones it instead of moving the source"
+    (let [conn (db-test/create-conn-with-blocks
+                [{:page {:block/title "source page"}
+                  :blocks [{:block/title "live child"}]}
+                 {:page {:block/title "target page"}
+                  :blocks [{:block/title "target"}]}])
+          live (db-test/find-block-by-content @conn "live child")
+          target (db-test/find-block-by-content @conn "target")
+          source-parent (:db/id (:block/parent live))
+          source-uuid (:block/uuid live)]
+      (outliner-core/insert-blocks!
+       conn
+       [(assoc (into {} live)
+               :db/id (:db/id live)
+               :block/uuid source-uuid)]
+       target
+       {:sibling? true
+        :keep-uuid? true
+        :outliner-op :paste})
+      (let [db @conn
+            live-after (d/entity db (:db/id live))
+            target-parent (d/entity db (:db/id (:block/parent target)))
+            pasted (->> (:block/_parent target-parent)
+                        ldb/sort-by-order
+                        (remove #(= (:db/id live) (:db/id %)))
+                        (some #(when (= "live child" (:block/title %)) %)))]
+        (is (= source-parent (:db/id (:block/parent live-after))))
+        (is (= source-uuid (:block/uuid live-after)))
+        (is (some? pasted))
+        (is (not= source-uuid (:block/uuid pasted)))))))
+
+(deftest insert-template-blocks-keep-uuid-does-not-reparent-other-page-source
+  (testing "tag-template insert clones live children that still belong to another page"
+    (let [conn (db-test/create-conn-with-blocks
+                [{:page {:block/title "template page"}
+                  :blocks [{:block/title "template child"}]}
+                 {:page {:block/title "journal page"}
+                  :blocks [{:block/title "journal target"}]}])
+          live (db-test/find-block-by-content @conn "template child")
+          target (db-test/find-block-by-content @conn "journal target")
+          source-parent (:db/id (:block/parent live))
+          source-uuid (:block/uuid live)]
+      (outliner-core/insert-blocks!
+       conn
+       [(assoc (into {} live)
+               :db/id (:db/id live)
+               :block/uuid source-uuid)]
+       target
+       {:sibling? true
+        :keep-uuid? true
+        :outliner-op :insert-template-blocks})
+      (let [db @conn
+            live-after (d/entity db (:db/id live))
+            target-parent (d/entity db (:db/id (:block/parent target)))
+            inserted (->> (:block/_parent target-parent)
+                          ldb/sort-by-order
+                          (remove #(= (:db/id live) (:db/id %)))
+                          (some #(when (= "template child" (:block/title %)) %)))]
+        (is (= source-parent (:db/id (:block/parent live-after))))
+        (is (= source-uuid (:block/uuid live-after)))
+        (is (some? inserted))
+        (is (not= source-uuid (:block/uuid inserted)))))))
+
 (deftest insert-blocks-does-not-trust-stale-right-order
   (let [conn (db-test/create-conn-with-blocks
               [{:page {:block/title "page1"}

--- a/src/main/frontend/worker/pipeline.cljs
+++ b/src/main/frontend/worker/pipeline.cljs
@@ -115,13 +115,13 @@
                                                   :logseq.property/used-template (:db/id template))
                                            (rest template-children))
                                      (map (fn [block]
-                                            (cond->
-                                             (assoc (into {} block) :db/id (:db/id block))
-                                              (:journal template)
-                                              (assoc :block/uuid
-                                                     (common-uuid/gen-journal-template-block
-                                                      (:block/uuid (:journal template))
-                                                      (:block/uuid block)))))))))
+                                            (let [original-uuid (:block/uuid block)]
+                                              (cond-> (dissoc (into {} block) :db/id)
+                                                (:journal template)
+                                                (assoc :block/uuid
+                                                       (common-uuid/gen-journal-template-block
+                                                        (:block/uuid (:journal template))
+                                                        original-uuid))))))))))
         tag-additions (->> (:tx-data tx-report)
                            (filter (fn [d] (and (= (:a d) :block/tags) (:added d))))
                            (group-by :e))

--- a/src/main/frontend/worker/pipeline.cljs
+++ b/src/main/frontend/worker/pipeline.cljs
@@ -121,7 +121,7 @@
                                                 (assoc :block/uuid
                                                        (common-uuid/gen-journal-template-block
                                                         (:block/uuid (:journal template))
-                                                        original-uuid))))))))))
+                                                        original-uuid)))))))))
         tag-additions (->> (:tx-data tx-report)
                            (filter (fn [d] (and (= (:a d) :block/tags) (:added d))))
                            (group-by :e))

--- a/src/test/frontend/worker/pipeline_test.cljs
+++ b/src/test/frontend/worker/pipeline_test.cljs
@@ -1209,8 +1209,7 @@
             (outliner-core/insert-blocks! conn [{:block/title "v2 extra"}] body {:sibling? true})
 
             (let [aug-20 (create-journal! 20260820)
-                  heading (d/entity @conn (:db/id heading))
-                  body (d/entity @conn (:db/id body))]
+                  heading (d/entity @conn (:db/id heading))]
               (is (= ["v1 heading" "v1 body"] (child-titles @conn aug-19))
                   "Earlier journals keep the version applied at creation")
               (is (= ["v2 heading" "v2 body" "v2 extra"] (child-titles @conn aug-20)))

--- a/src/test/frontend/worker/pipeline_test.cljs
+++ b/src/test/frontend/worker/pipeline_test.cljs
@@ -1152,3 +1152,83 @@
               "No :logseq.property.history entries are added for an imported transaction")))
       (finally
         (ldb/register-transact-pipeline-fn! identity)))))
+
+(defn- child-titles
+  [db entity]
+  (->> (ldb/sort-by-order (:block/_parent (d/entity db (:db/id entity))))
+       (remove ldb/recycled?)
+       (mapv :block/title)))
+
+(defn- clone-block-payload
+  [block]
+  (assoc (into {} block)
+         :db/id (:db/id block)
+         :block/uuid (:block/uuid block)))
+
+(deftest journal-tag-template-keep-uuid-insert-does-not-deplete-source-test
+  (testing "Incremental v1→v2 journal template plus keep-uuid paste/insert must not move live template children"
+    (let [conn (db-test/create-conn-with-blocks
+                {:pages-and-blocks
+                 [{:page {:block/title "Templates"}
+                   :blocks [{:block/title "journal template"
+                             :build/children [{:block/title "v1 heading"}
+                                              {:block/title "v1 body"}]}]}]})
+          template-root (db-test/find-block-by-content @conn "journal template")
+          template-children (ldb/sort-by-order (:block/_parent template-root))
+          heading (first template-children)
+          body (second template-children)
+          journal-class (d/entity @conn :logseq.class/Journal)
+          create-journal! (fn [journal-day]
+                            (outliner-page/create!
+                             conn
+                             (date-time-util/int->journal-title
+                              journal-day
+                              date-time-util/default-journal-title-formatter)
+                             {:journal? true})
+                            (db-test/find-journal-by-journal-day @conn journal-day))]
+      (is (= ["v1 heading" "v1 body"] (mapv :block/title template-children)))
+      (ldb/transact! conn [[:db/add (:db/id template-root)
+                            :logseq.property/template-applied-to
+                            (:db/id journal-class)]])
+      (with-transact-pipeline
+        (fn []
+          (let [aug-19 (create-journal! 20260819)]
+            (is (= ["v1 heading" "v1 body"] (child-titles @conn aug-19)))
+            (is (= ["v1 heading" "v1 body"] (child-titles @conn template-root))
+                "Applying the template to a journal must leave the source children in place")
+            (is (not= (:block/uuid heading)
+                      (:block/uuid (first (ldb/sort-by-order (:block/_parent aug-19)))))
+                "Applied journal children use distinct UUIDs from the live template")
+
+            (outliner-core/save-block! conn {:db/id (:db/id heading)
+                                             :block/uuid (:block/uuid heading)
+                                             :block/title "v2 heading"})
+            (outliner-core/save-block! conn {:db/id (:db/id body)
+                                             :block/uuid (:block/uuid body)
+                                             :block/title "v2 body"})
+            (outliner-core/insert-blocks! conn [{:block/title "v2 extra"}] body {:sibling? true})
+
+            (let [aug-20 (create-journal! 20260820)
+                  heading (d/entity @conn (:db/id heading))
+                  body (d/entity @conn (:db/id body))]
+              (is (= ["v1 heading" "v1 body"] (child-titles @conn aug-19))
+                  "Earlier journals keep the version applied at creation")
+              (is (= ["v2 heading" "v2 body" "v2 extra"] (child-titles @conn aug-20)))
+              (is (= ["v2 heading" "v2 body" "v2 extra"] (child-titles @conn template-root)))
+
+              (outliner-core/insert-blocks!
+               conn
+               [(clone-block-payload heading)]
+               aug-20
+               {:sibling? false
+                :keep-uuid? true
+                :outliner-op :paste})
+
+              (let [heading-after (d/entity @conn (:db/id heading))
+                    aug-21 (create-journal! 20260821)]
+                (is (= (:db/id template-root) (:db/id (:block/parent heading-after)))
+                    "keep-uuid paste/insert must not reparent the live template child")
+                (is (= ["v2 heading" "v2 body" "v2 extra"] (child-titles @conn template-root))
+                    "The source template stays complete after keep-uuid paste")
+                (is (= ["v2 heading" "v2 body" "v2 extra"] (child-titles @conn aug-21))
+                    "Later journals still receive the full current template")))))))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/logseq/db-test/issues/1053

Pasting or inserting template children while keeping their original UUIDs could upsert the live template entities and reparent them off the template page. After an incremental v1→v2 edit (same child identities), later journals then applied only the leftover children, which looked like a revert.

This is not db-test#1035 / PR 13036. That bug is apply-then-strip on a new journal via RTC rebase. This change is identity-preserving insert/paste of live template entities.

## Behavior
- `insert-blocks` keeps UUIDs for new or recycled entities.
- Paste of a live entity always clones instead of moving the source.
- Tag-template apply may still reuse a UUID already on the target page so journal re-apply stays idempotent.
- Journal template clones no longer carry the source `:db/id`.

## Tests
- Outliner: keep-uuid paste and tag-template insert of a live other-page block clone it and leave the source in place.
- Pipeline: incremental v1→v2 journal template + keep-uuid paste does not deplete the source; a later journal still gets the full current template.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72965696-7160-45cc-be02-f6040f3102fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72965696-7160-45cc-be02-f6040f3102fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

