### PR TITLE
fix(cli): treat sync remote-graphs transport errors as failures

### DIFF
--- a/cli/lib/sync.ml
+++ b/cli/lib/sync.ml
@@ -470,7 +470,8 @@ let graphs_value graphs =
 
 let tagged_error_value value =
   match unquote_transit_value value with
-  | Melange_edn_melange.Any (Melange_edn_melange.Tagged ("error", value)) ->
+  | Melange_edn_melange.Any
+      (Melange_edn_melange.Tagged (("error" | "js/Error"), value)) ->
       Some value
   | _ -> None
 

--- a/cli/test/test_cases.ml
+++ b/cli/test/test_cases.ml
@@ -2660,7 +2660,7 @@ let () =
                        (Edn_util.keyword "message", Edn_util.string message);
                      |])))))
   in
-  let run_sync_remote_graphs_json root_prefix response_for_body =
+  let run_sync_remote_graphs_json root_prefix response_for_body check_result =
     let root = temp_dir root_prefix in
     let config_path = Node.Path.join [| root; "cli.edn" |] in
     let server = invoke_server response_for_body in
@@ -2680,72 +2680,71 @@ let () =
             |]
         in
         remove_tree root;
-        Js.Promise.resolve result)
+        check_result result)
   in
   test_promise
     "sync remote-graphs treats js/Error transport failure as command error"
     (fun () ->
-      let* result =
-        run_sync_remote_graphs_json "logseq-cli-sync-remote-graphs-js-error-"
-          (fun body ->
-            if
-              Js.String.includes ~search:"thread-api/db-sync-list-remote-graphs"
-                body
-            then js_error_transit "fetch failed"
-            else "null")
-      in
-      ignore
-        (expect_cli_exit_non_zero "sync remote-graphs js/Error" result);
-      ignore
-        (expect_named_contains "error status" result.stdout
-           "\"status\":\"error\"");
-      ignore
-        (expect_named_contains "remote graphs error code" result.stdout
-           "\"code\":\"sync-remote-graphs-failed\"");
-      ignore
-        (expect_named_contains "fetch failed message" result.stdout
-           "fetch failed");
-      ignore
-        (expect_named_not_contains "js/Error graph data" result.stdout
-           "js/Error");
-      Js.Promise.resolve pass);
+      run_sync_remote_graphs_json
+        "logseq-cli-sync-remote-graphs-js-error-"
+        (fun body ->
+          if
+            Js.String.includes ~search:"thread-api/db-sync-list-remote-graphs"
+              body
+          then js_error_transit "fetch failed"
+          else "null")
+        (fun result ->
+          ignore
+            (expect_cli_exit_non_zero "sync remote-graphs js/Error" result);
+          ignore
+            (expect_named_contains "error status" result.stdout
+               "\"status\":\"error\"");
+          ignore
+            (expect_named_contains "remote graphs error code" result.stdout
+               "\"code\":\"sync-remote-graphs-failed\"");
+          ignore
+            (expect_named_contains "fetch failed message" result.stdout
+               "fetch failed");
+          ignore
+            (expect_named_not_contains "js/Error graph data" result.stdout
+               "js/Error");
+          Js.Promise.resolve pass));
 
   test_promise "sync remote-graphs empty list still returns ok" (fun () ->
-      let* result =
-        run_sync_remote_graphs_json "logseq-cli-sync-remote-graphs-empty-"
-          (fun body ->
-            if
-              Js.String.includes ~search:"thread-api/db-sync-list-remote-graphs"
-                body
-            then "[]"
-            else "null")
-      in
-      ignore (expect_cli_exit_zero "sync remote-graphs empty" result);
-      ignore
-        (expect_named_contains "ok status" result.stdout "\"status\":\"ok\"");
-      ignore
-        (expect_named_contains "empty graphs" result.stdout "\"graphs\":[]");
-      Js.Promise.resolve pass);
+      run_sync_remote_graphs_json "logseq-cli-sync-remote-graphs-empty-"
+        (fun body ->
+          if
+            Js.String.includes ~search:"thread-api/db-sync-list-remote-graphs"
+              body
+          then "[]"
+          else "null")
+        (fun result ->
+          ignore (expect_cli_exit_zero "sync remote-graphs empty" result);
+          ignore
+            (expect_named_contains "ok status" result.stdout "\"status\":\"ok\"");
+          ignore
+            (expect_named_contains "empty graphs" result.stdout "\"graphs\":[]");
+          Js.Promise.resolve pass));
 
   test_promise "sync remote-graphs non-empty list still returns ok" (fun () ->
-      let* result =
-        run_sync_remote_graphs_json "logseq-cli-sync-remote-graphs-ok-"
-          (fun body ->
-            if
-              Js.String.includes ~search:"thread-api/db-sync-list-remote-graphs"
-                body
-            then sync_remote_graph_transit
-            else "null")
-      in
-      ignore (expect_cli_exit_zero "sync remote-graphs non-empty" result);
-      ignore
-        (expect_named_contains "ok status" result.stdout "\"status\":\"ok\"");
-      ignore
-        (expect_named_contains "graph name" result.stdout "\"graph-name\":\"alpha\"");
-      ignore
-        (expect_named_not_contains "error status" result.stdout
-           "\"status\":\"error\"");
-      Js.Promise.resolve pass);
+      run_sync_remote_graphs_json "logseq-cli-sync-remote-graphs-ok-"
+        (fun body ->
+          if
+            Js.String.includes ~search:"thread-api/db-sync-list-remote-graphs"
+              body
+          then sync_remote_graph_transit
+          else "null")
+        (fun result ->
+          ignore (expect_cli_exit_zero "sync remote-graphs non-empty" result);
+          ignore
+            (expect_named_contains "ok status" result.stdout "\"status\":\"ok\"");
+          ignore
+            (expect_named_contains "graph name" result.stdout
+               "\"graph-name\":\"alpha\"");
+          ignore
+            (expect_named_not_contains "error status" result.stdout
+               "\"status\":\"error\"");
+          Js.Promise.resolve pass));
 
   test_promise "agent bridge keeps codex alive and forwards worker env"
     (fun () ->

--- a/cli/test/test_cases.ml
+++ b/cli/test/test_cases.ml
@@ -2648,6 +2648,105 @@ let () =
           then Js.Promise.resolve pass
           else fail_promise "missing sync-app-state auth payload"));
 
+  let js_error_transit message =
+    let module T = Transit_melange.Transit.Json in
+    T.to_string
+      (T.of_edn
+         (Edn_util.any
+            (Melange_edn_melange.tagged "js/Error"
+               (Edn_util.map_vec
+                  (Vec.of_array
+                     [|
+                       (Edn_util.keyword "message", Edn_util.string message);
+                     |])))))
+  in
+  let run_sync_remote_graphs_json root_prefix response_for_body =
+    let root = temp_dir root_prefix in
+    let config_path = Node.Path.join [| root; "cli.edn" |] in
+    let server = invoke_server response_for_body in
+    with_server server (fun base_url ->
+        write_file config_path
+          "{:refresh-token \"refresh-token\"\n :id-token \"id-token\"}\n";
+        let env = [| ("LOGSEQ_CLI_BASE_URL", base_url) |] in
+        let* result =
+          run_cli_p ~env
+            [|
+              "--root-dir";
+              root;
+              "--output";
+              "json";
+              "sync";
+              "remote-graphs";
+            |]
+        in
+        remove_tree root;
+        Js.Promise.resolve result)
+  in
+  test_promise
+    "sync remote-graphs treats js/Error transport failure as command error"
+    (fun () ->
+      let* result =
+        run_sync_remote_graphs_json "logseq-cli-sync-remote-graphs-js-error-"
+          (fun body ->
+            if
+              Js.String.includes ~search:"thread-api/db-sync-list-remote-graphs"
+                body
+            then js_error_transit "fetch failed"
+            else "null")
+      in
+      ignore
+        (expect_cli_exit_non_zero "sync remote-graphs js/Error" result);
+      ignore
+        (expect_named_contains "error status" result.stdout
+           "\"status\":\"error\"");
+      ignore
+        (expect_named_contains "remote graphs error code" result.stdout
+           "\"code\":\"sync-remote-graphs-failed\"");
+      ignore
+        (expect_named_contains "fetch failed message" result.stdout
+           "fetch failed");
+      ignore
+        (expect_named_not_contains "js/Error graph data" result.stdout
+           "js/Error");
+      Js.Promise.resolve pass);
+
+  test_promise "sync remote-graphs empty list still returns ok" (fun () ->
+      let* result =
+        run_sync_remote_graphs_json "logseq-cli-sync-remote-graphs-empty-"
+          (fun body ->
+            if
+              Js.String.includes ~search:"thread-api/db-sync-list-remote-graphs"
+                body
+            then "[]"
+            else "null")
+      in
+      ignore (expect_cli_exit_zero "sync remote-graphs empty" result);
+      ignore
+        (expect_named_contains "ok status" result.stdout "\"status\":\"ok\"");
+      ignore
+        (expect_named_contains "empty graphs" result.stdout "\"graphs\":[]");
+      Js.Promise.resolve pass);
+
+  test_promise "sync remote-graphs non-empty list still returns ok" (fun () ->
+      let* result =
+        run_sync_remote_graphs_json "logseq-cli-sync-remote-graphs-ok-"
+          (fun body ->
+            if
+              Js.String.includes ~search:"thread-api/db-sync-list-remote-graphs"
+                body
+            then sync_remote_graph_transit
+            else "null")
+      in
+      ignore (expect_cli_exit_zero "sync remote-graphs non-empty" result);
+      ignore
+        (expect_named_contains "ok status" result.stdout "\"status\":\"ok\"");
+      ignore
+        (expect_named_contains "graph name" result.stdout "\"graph-name\":\"alpha\"");
+      ignore
+        (expect_named_not_contains "error status" result.stdout
+           "\"status\":\"error\"");
+      Js.Promise.resolve pass);
+
   test_promise "agent bridge keeps codex alive and forwards worker env"
     (fun () ->
       let tmp = temp_dir "logseq-cli-agent-" in

--- a/cli/test/test_support.ml
+++ b/cli/test/test_support.ml
@@ -413,6 +413,12 @@ let assert_cli_exit_zero name output =
     (Printf.sprintf "%s: expected exit 0, got %d\nstdout:\n%s\nstderr:\n%s" name
        output.code output.stdout output.stderr)
 
+let assert_cli_exit_non_zero name output =
+  assert_true name (output.code <> 0)
+    (Printf.sprintf
+       "%s: expected non-zero exit, got 0\nstdout:\n%s\nstderr:\n%s" name
+       output.stdout output.stderr)
+
 let assert_line_starts_with name text prefix =
   let lines = string_split (string_trim_end text) "\n" in
   assert_true name
@@ -540,5 +546,6 @@ let expect_named_not_contains _name text needle =
 let expect_exit_zero = assert_exit_zero
 let expect_exit_non_zero = assert_exit_non_zero
 let expect_cli_exit_zero = assert_cli_exit_zero
+let expect_cli_exit_non_zero = assert_cli_exit_non_zero
 let expect_line_starts_with = assert_line_starts_with
 let expect_created_at_column_aligned = assert_created_at_column_aligned

--- a/src/main/logseq/cli/command/sync.cljs
+++ b/src/main/logseq/cli/command/sync.cljs
@@ -220,6 +220,13 @@
                    (when (seq data) {:context data})
                    extra)}))
 
+(defn- js-error-value
+  [value]
+  (cond
+    (instance? js/Error value) value
+    (sequential? value) (some #(when (instance? js/Error %) %) value)
+    :else nil))
+
 (defn- missing-e2ee-password-diagnostic?
   [error]
   (let [data (or (ex-data error) {})
@@ -996,8 +1003,10 @@
   [action config]
   (-> (p/let [config' (resolve-runtime-config! action config)
               graphs (invoke-global config' :thread-api/db-sync-list-remote-graphs [])]
-        {:status :ok
-         :data {:graphs (or graphs [])}})
+        (if-let [error (js-error-value graphs)]
+          (exception->error error {:code :sync-remote-graphs-failed})
+          {:status :ok
+           :data {:graphs (or graphs [])}}))
       (p/catch (fn [error]
                  (exception->error error nil)))))
 

--- a/src/test/logseq/cli/command/sync_test.cljs
+++ b/src/test/logseq/cli/command/sync_test.cljs
@@ -1487,12 +1487,14 @@
                                transport/invoke (fn [_ method args]
                                                   (swap! invoke-calls conj [method args])
                                                   (p/resolved []))]
-                 (p/let [_ (sync-command/execute {:type :sync-remote-graphs}
+                 (p/let [result (sync-command/execute {:type :sync-remote-graphs}
                                                  {:base-url "http://example"
                                                   :http-base "https://sync.example.com"
                                                   :ws-url "wss://sync.example.com/sync/%s"
                                                   :e2ee-password "pw"
                                                   :root-dir "/tmp"})]
+                   (is (= :ok (:status result)))
+                   (is (= [] (get-in result [:data :graphs])))
                    (is (= [] @ensure-calls))
                    (is (= [{:base-url "http://example"
                             :http-base "https://sync.example.com"
@@ -1505,6 +1507,35 @@
                    (is (= [:thread-api/set-db-sync-config [{:ws-url "wss://sync.example.com/sync/%s"
                                                                    :http-base "https://sync.example.com"}]]
                           (nth @invoke-calls 1)))
+                   (is (= [:thread-api/db-sync-list-remote-graphs []]
+                          (nth @invoke-calls 2)))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
+(deftest test-execute-sync-remote-graphs-js-error
+  (async done
+         (let [invoke-calls (atom [])]
+           (-> (p/with-redefs [cli-auth/resolve-auth! (fn [_config]
+                                                        (p/resolved {:id-token "resolved-token"
+                                                                     :refresh-token "refresh-token"}))
+                               cli-server/ensure-server! (fn [config _repo]
+                                                           (p/resolved (assoc config :base-url "http://example")))
+                               transport/invoke (fn [_ method args]
+                                                  (swap! invoke-calls conj [method args])
+                                                  (case method
+                                                    :thread-api/db-sync-list-remote-graphs
+                                                    (p/resolved (js/Error. "fetch failed"))
+                                                    (p/resolved nil)))]
+                 (p/let [result (sync-command/execute {:type :sync-remote-graphs}
+                                                      {:base-url "http://example"
+                                                       :http-base "https://sync.example.com"
+                                                       :ws-url "wss://sync.example.com/sync/%s"
+                                                       :root-dir "/tmp"})]
+                   (is (= :error (:status result)))
+                   (is (= :sync-remote-graphs-failed (get-in result [:error :code])))
+                   (is (= "fetch failed" (get-in result [:error :message])))
+                   (is (nil? (get-in result [:data :graphs])))
                    (is (= [:thread-api/db-sync-list-remote-graphs []]
                           (nth @invoke-calls 2)))))
                (p/catch (fn [e]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Treat worker `js/Error` results from `sync remote-graphs` as command failures instead of graph data.
- TLS/fetch transport rejections now return `status: error`, code `sync-remote-graphs-failed`, and a non-zero exit.
- Empty and non-empty remote graph lists still return `status: ok`.

This is separate from db-test#1056 (`remote-graphs` requiring a local graph).

Fixes https://github.com/logseq/db-test/issues/1057

## Tests

- OCaml CLI: `js/Error` transit from `db-sync-list-remote-graphs` exits non-zero and does not put `js/Error` in `graphs`.
- OCaml CLI: empty `[]` and non-empty remote lists still return `status: ok`.
- CLJS: `logseq.cli.command.sync-test/test-execute-sync-remote-graphs-js-error` covers the fetch-failed path.

## Validation

- `bb dev:test-no-worker -v logseq.cli.command.sync-test`: 47 tests, 302 assertions, 0 failures
- Focused rerun of empty-list + js/Error + missing-auth cases: 13 assertions, 0 failures
- `clojure -M:clj-kondo --lint src/main/logseq/cli/command/sync.cljs src/test/logseq/cli/command/sync_test.cljs --cache false`: 0 errors, 0 warnings
- `git diff --check`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5cece60-7e4d-4695-b001-7e4a9963abf5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5cece60-7e4d-4695-b001-7e4a9963abf5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

