### PR TITLE
fix: surface DB graph download failures in the UI

### DIFF
--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -469,12 +469,10 @@
     (when (util/mobile?)
       (download-progress/hide!)))
    (p/catch (fn [e]
-              (println "RTC download graph failed, error:")
               (log/error :rtc-download-graph-failed e)
               (when (util/mobile?)
                 (download-progress/hide!))
-              (when (rtc-error/e2ee-decrypt-failed? e)
-                (notification/show! (t :encryption/wrong-password) :error false))))))
+              (rtc-error/notify-download-failure! graph-uuid e)))))
 
 ;; db-worker -> UI
 (defevent! :db/sync-changes [[_ data]]

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -459,20 +459,24 @@
              (:major (db-schema/parse-schema-version graph-schema-version)))
           {:app db-schema/version
            :remote-graph graph-schema-version})
-  (->
-   (p/do!
-    (when (util/mobile?)
-      (download-progress/show! graph-name))
-    (rtc-handler/<rtc-download-graph! graph-name graph-uuid graph-e2ee?)
-    (rtc-handler/<get-remote-graphs)
-    (state/pub-event! [:graph/switch (str config/db-version-prefix graph-name) {:rtc-download? true}])
-    (when (util/mobile?)
-      (download-progress/hide!)))
-   (p/catch (fn [e]
-              (log/error :rtc-download-graph-failed e)
-              (when (util/mobile?)
-                (download-progress/hide!))
-              (rtc-error/notify-download-failure! graph-uuid e)))))
+  (when (util/mobile?)
+    (download-progress/show! graph-name))
+  (-> (p/let [downloaded? (-> (rtc-handler/<rtc-download-graph! graph-name graph-uuid graph-e2ee?)
+                               (p/then (constantly true))
+                               (p/catch (fn [e]
+                                          (log/error :rtc-download-graph-failed e)
+                                          (rtc-error/notify-download-failure! graph-uuid e)
+                                          false)))]
+        (when downloaded?
+          (-> (p/do!
+               (rtc-handler/<get-remote-graphs)
+               (state/pub-event! [:graph/switch (str config/db-version-prefix graph-name)
+                                  {:rtc-download? true}]))
+              (p/catch (fn [e]
+                         (log/error :rtc-download-graph-failed e))))))
+      (p/finally (fn []
+                   (when (util/mobile?)
+                     (download-progress/hide!))))))
 
 ;; db-worker -> UI
 (defevent! :db/sync-changes [[_ data]]

--- a/src/main/frontend/handler/events/rtc_error.cljs
+++ b/src/main/frontend/handler/events/rtc_error.cljs
@@ -1,8 +1,17 @@
 (ns frontend.handler.events.rtc-error
-  "RTC event error helpers.")
+  "RTC event error helpers."
+  (:require [clojure.string :as string]
+            [frontend.context.i18n :as i18n]
+            [frontend.handler.notification :as notification]
+            [frontend.state :as state]))
 
 (def ^:private e2ee-decrypt-error-codes
   #{:db-sync/invalid-e2ee-password})
+
+(def ^:private generic-download-wrapper-messages
+  #{"db-sync download failed"})
+
+(def ^:private download-failure-detail-max-length 280)
 
 (defn- throwable-message
   [error]
@@ -36,3 +45,66 @@
   (boolean
    (or (some e2ee-decrypt-error-codes (error-codes error))
        (some #{"decrypt-aes-key"} (error-texts error)))))
+
+(defn- download-failure-stage
+  [error]
+  (when error
+    (let [data (ex-data error)]
+      (or (:stage data)
+          (download-failure-stage (:error data))
+          (download-failure-stage (ex-cause error))))))
+
+(defn- non-blank-texts
+  [error]
+  (->> (error-texts error)
+       (keep identity)
+       (map str)
+       (map string/trim)
+       (remove string/blank?)
+       distinct))
+
+(defn- sanitize-download-failure-detail
+  [detail]
+  (when (seq detail)
+    (let [normalized (-> detail
+                         (string/replace #"\s+" " ")
+                         string/trim)]
+      (when (seq normalized)
+        (subs normalized 0 (min (count normalized) download-failure-detail-max-length))))))
+
+(defn download-failure-detail
+  "Short user-facing detail for a graph download failure: failed stage plus
+  underlying message, without wrapper text or stacks."
+  [error]
+  (when error
+    (let [stage (some-> (download-failure-stage error) name)
+          texts (non-blank-texts error)
+          preferred (->> texts
+                         (remove generic-download-wrapper-messages)
+                         (take 2)
+                         vec)
+          chosen (if (seq preferred)
+                   preferred
+                   (vec (take 1 texts)))
+          parts (cond-> []
+                  (seq stage) (conj stage)
+                  (seq chosen) (into chosen))]
+      (sanitize-download-failure-detail (string/join ": " parts)))))
+
+(defn notify-download-failure!
+  "Clear download progress UI and show a user-visible error toast."
+  [graph-uuid error]
+  (state/pub-event!
+   [:rtc/log {:type :rtc.log/download
+              :sub-type :download-completed
+              :graph-uuid graph-uuid
+              :message "Graph snapshot download failed"}])
+  (notification/show!
+   (if (e2ee-decrypt-failed? error)
+     (i18n/t :encryption/wrong-password)
+     (i18n/t :sync/download-error
+             (or (download-failure-detail error)
+                 (throwable-message error))))
+   :error
+   false)
+  nil)

--- a/src/main/frontend/handler/events/rtc_error.cljs
+++ b/src/main/frontend/handler/events/rtc_error.cljs
@@ -1,17 +1,11 @@
 (ns frontend.handler.events.rtc-error
   "RTC event error helpers."
-  (:require [clojure.string :as string]
-            [frontend.context.i18n :as i18n]
+  (:require [frontend.context.i18n :as i18n]
             [frontend.handler.notification :as notification]
             [frontend.state :as state]))
 
 (def ^:private e2ee-decrypt-error-codes
   #{:db-sync/invalid-e2ee-password})
-
-(def ^:private generic-download-wrapper-messages
-  #{"db-sync download failed"})
-
-(def ^:private download-failure-detail-max-length 280)
 
 (defn- throwable-message
   [error]
@@ -46,65 +40,32 @@
    (or (some e2ee-decrypt-error-codes (error-codes error))
        (some #{"decrypt-aes-key"} (error-texts error)))))
 
-(defn- download-failure-stage
-  [error]
+(defn- error-data-value?
+  [error k value]
   (when error
     (let [data (ex-data error)]
-      (or (:stage data)
-          (download-failure-stage (:error data))
-          (download-failure-stage (ex-cause error))))))
+      (or (= value (get data k))
+          (error-data-value? (:error data) k value)
+          (error-data-value? (ex-cause error) k value)))))
 
-(defn- non-blank-texts
+(defn- worker-download-failure?
   [error]
-  (->> (error-texts error)
-       (keep identity)
-       (map str)
-       (map string/trim)
-       (remove string/blank?)
-       distinct))
-
-(defn- sanitize-download-failure-detail
-  [detail]
-  (when (seq detail)
-    (let [normalized (-> detail
-                         (string/replace #"\s+" " ")
-                         string/trim)]
-      (when (seq normalized)
-        (subs normalized 0 (min (count normalized) download-failure-detail-max-length))))))
-
-(defn download-failure-detail
-  "Short user-facing detail for a graph download failure: failed stage plus
-  underlying message, without wrapper text or stacks."
-  [error]
-  (when error
-    (let [stage (some-> (download-failure-stage error) name)
-          texts (non-blank-texts error)
-          preferred (->> texts
-                         (remove generic-download-wrapper-messages)
-                         (take 2)
-                         vec)
-          chosen (if (seq preferred)
-                   preferred
-                   (vec (take 1 texts)))
-          parts (cond-> []
-                  (seq stage) (conj stage)
-                  (seq chosen) (into chosen))]
-      (sanitize-download-failure-detail (string/join ": " parts)))))
+  (some #{"db-sync download failed"} (error-texts error)))
 
 (defn notify-download-failure!
   "Clear download progress UI and show a user-visible error toast."
   [graph-uuid error]
-  (state/pub-event!
-   [:rtc/log {:type :rtc.log/download
-              :sub-type :download-completed
-              :graph-uuid graph-uuid
-              :message "Graph snapshot download failed"}])
-  (notification/show!
-   (if (e2ee-decrypt-failed? error)
-     (i18n/t :encryption/wrong-password)
-     (i18n/t :sync/download-error
-             (or (download-failure-detail error)
-                 (throwable-message error))))
-   :error
-   false)
+  (when-not (error-data-value? error :type :db-sync/graph-operation-in-progress)
+    (when-not (worker-download-failure? error)
+      (state/pub-event!
+       [:rtc/log {:type :rtc.log/download
+                  :sub-type :download-completed
+                  :graph-uuid graph-uuid
+                  :message "Graph snapshot download failed"}]))
+    (notification/show!
+     (if (e2ee-decrypt-failed? error)
+       (i18n/t :encryption/wrong-password)
+       (i18n/t :sync/download-error))
+     :error
+     false))
   nil)

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -1832,7 +1832,7 @@
  :sync/conflicts-description "These server versions conflicted with local edits. Copy the text you want and edit the block manually."
  :sync/conflicts-title "Sync conflicts"
  :sync/creating-remote-graph "Creating remote graph..."
- :sync/download-error "Couldn't download the graph: {1}"
+ :sync/download-error "Couldn't download the graph. Check the logs for details."
  :sync/downloading "Downloading..."
  :sync/downloading-graph "Downloading {1} ..."
  :sync/graph-count-exceed-limit "Sync graph count exceed limit"

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -1832,6 +1832,7 @@
  :sync/conflicts-description "These server versions conflicted with local edits. Copy the text you want and edit the block manually."
  :sync/conflicts-title "Sync conflicts"
  :sync/creating-remote-graph "Creating remote graph..."
+ :sync/download-error "Couldn't download the graph: {1}"
  :sync/downloading "Downloading..."
  :sync/downloading-graph "Downloading {1} ..."
  :sync/graph-count-exceed-limit "Sync graph count exceed limit"

--- a/src/resources/dicts/zh-cn.edn
+++ b/src/resources/dicts/zh-cn.edn
@@ -1832,7 +1832,7 @@
  :sync/conflicts-description "这些服务器版本与本地编辑冲突。复制你需要的文本，然后手动编辑该块。"
  :sync/conflicts-title "同步冲突"
  :sync/creating-remote-graph "正在创建远程图谱..."
- :sync/download-error "无法下载图谱：{1}"
+ :sync/download-error "无法下载图谱。请查看日志以了解详情。"
  :sync/downloading "下载中..."
  :sync/downloading-graph "正在下载 {1}……"
  :sync/graph-count-exceed-limit "同步图谱数量超出限制"

--- a/src/resources/dicts/zh-cn.edn
+++ b/src/resources/dicts/zh-cn.edn
@@ -1832,6 +1832,7 @@
  :sync/conflicts-description "这些服务器版本与本地编辑冲突。复制你需要的文本，然后手动编辑该块。"
  :sync/conflicts-title "同步冲突"
  :sync/creating-remote-graph "正在创建远程图谱..."
+ :sync/download-error "无法下载图谱：{1}"
  :sync/downloading "下载中..."
  :sync/downloading-graph "正在下载 {1}……"
  :sync/graph-count-exceed-limit "同步图谱数量超出限制"

--- a/src/test/frontend/handler/events/rtc_error_test.cljs
+++ b/src/test/frontend/handler/events/rtc_error_test.cljs
@@ -23,28 +23,28 @@
         (ex-info "db-sync download failed"
                  {:error-message "snapshot download failed"})))))
 
-(deftest download-failure-detail-includes-fetch-pull-stage-test
-  (is (= "fetch-pull: fetch failed"
-         (rtc-error/download-failure-detail
-          (ex-info "db-sync download failed"
-                   {:stage :fetch-pull
-                    :error-message "fetch failed"})))))
-
-(deftest download-failure-detail-includes-pre-worker-start-error-test
-  (is (= "db-worker-node failed to start"
-         (rtc-error/download-failure-detail
-          (ex-info "db-worker-node failed to start"
-                   {:code :server-start-failed})))))
-
-(deftest download-failure-detail-includes-cause-after-fetch-message-test
-  (is (= "fetch-pull: fetch failed: self-signed certificate"
-         (rtc-error/download-failure-detail
-          (ex-info "db-sync download failed"
-                   {:stage :fetch-pull
-                    :error-message "fetch failed"
-                    :error-cause "self-signed certificate"})))))
-
 (deftest notify-download-failure-completes-progress-and-shows-error-test
+  (let [events (atom [])
+        notifications (atom [])]
+    (with-redefs [state/pub-event! (fn [event]
+                                     (swap! events conj event)
+                                     nil)
+                  notification/show! (fn [content status clear?]
+                                       (swap! notifications conj [content status clear?])
+                                       nil)]
+      (rtc-error/notify-download-failure!
+       "graph-1"
+       (ex-info "db-worker-node failed to start"
+                {:code :server-start-failed})))
+    (is (= [[:rtc/log {:type :rtc.log/download
+                       :sub-type :download-completed
+                       :graph-uuid "graph-1"
+                       :message "Graph snapshot download failed"}]]
+           @events))
+    (is (= [[(i18n/t :sync/download-error) :error false]]
+           @notifications))))
+
+(deftest notify-download-failure-does-not-duplicate-worker-completion-test
   (let [events (atom [])
         notifications (atom [])]
     (with-redefs [state/pub-event! (fn [event]
@@ -58,12 +58,40 @@
        (ex-info "db-sync download failed"
                 {:stage :fetch-pull
                  :error-message "fetch failed"})))
-    (is (= [[:rtc/log {:type :rtc.log/download
-                       :sub-type :download-completed
-                       :graph-uuid "graph-1"
-                       :message "Graph snapshot download failed"}]]
-           @events))
-    (is (= [[(i18n/t :sync/download-error "fetch-pull: fetch failed") :error false]]
+    (is (= [] @events))
+    (is (= [[(i18n/t :sync/download-error) :error false]]
+           @notifications))))
+
+(deftest notify-download-failure-ignores-active-operation-rejection-test
+  (let [events (atom [])
+        notifications (atom [])]
+    (with-redefs [state/pub-event! (fn [event]
+                                     (swap! events conj event)
+                                     nil)
+                  notification/show! (fn [content status clear?]
+                                       (swap! notifications conj [content status clear?])
+                                       nil)]
+      (rtc-error/notify-download-failure!
+       "graph-2"
+       (ex-info "graph operation already in progress"
+                {:type :db-sync/graph-operation-in-progress
+                 :active-operation :download
+                 :active-graph-uuid "graph-1"})))
+    (is (= [] @events))
+    (is (= [] @notifications))))
+
+(deftest notify-download-failure-does-not-surface-runtime-details-test
+  (let [notifications (atom [])]
+    (with-redefs [state/pub-event! (fn [_event] nil)
+                  notification/show! (fn [content status clear?]
+                                       (swap! notifications conj [content status clear?])
+                                       nil)]
+      (rtc-error/notify-download-failure!
+       "graph-1"
+       (ex-info "request to https://sync.example.com failed"
+                {:stage :fetch-pull
+                 :error-message "certificate at /Users/alice/private.pem failed"})))
+    (is (= [[(i18n/t :sync/download-error) :error false]]
            @notifications))))
 
 (deftest notify-download-failure-keeps-wrong-password-toast-test
@@ -97,5 +125,5 @@
                   {:code :server-start-failed})))
       (is (= :download-completed
              (get-in @events [0 1 :sub-type])))
-      (is (= [[(i18n/t :sync/download-error "db-worker-node failed to start") :error false]]
+      (is (= [[(i18n/t :sync/download-error) :error false]]
              @notifications)))))

--- a/src/test/frontend/handler/events/rtc_error_test.cljs
+++ b/src/test/frontend/handler/events/rtc_error_test.cljs
@@ -1,6 +1,9 @@
 (ns frontend.handler.events.rtc-error-test
-  (:require [cljs.test :refer [deftest is]]
-            [frontend.handler.events.rtc-error :as rtc-error]))
+  (:require [cljs.test :refer [deftest is testing]]
+            [frontend.context.i18n :as i18n]
+            [frontend.handler.events.rtc-error :as rtc-error]
+            [frontend.handler.notification :as notification]
+            [frontend.state :as state]))
 
 (deftest e2ee-decrypt-failed-detects-invalid-password-code-test
   (is (true?
@@ -19,3 +22,80 @@
        (rtc-error/e2ee-decrypt-failed?
         (ex-info "db-sync download failed"
                  {:error-message "snapshot download failed"})))))
+
+(deftest download-failure-detail-includes-fetch-pull-stage-test
+  (is (= "fetch-pull: fetch failed"
+         (rtc-error/download-failure-detail
+          (ex-info "db-sync download failed"
+                   {:stage :fetch-pull
+                    :error-message "fetch failed"})))))
+
+(deftest download-failure-detail-includes-pre-worker-start-error-test
+  (is (= "db-worker-node failed to start"
+         (rtc-error/download-failure-detail
+          (ex-info "db-worker-node failed to start"
+                   {:code :server-start-failed})))))
+
+(deftest download-failure-detail-includes-cause-after-fetch-message-test
+  (is (= "fetch-pull: fetch failed: self-signed certificate"
+         (rtc-error/download-failure-detail
+          (ex-info "db-sync download failed"
+                   {:stage :fetch-pull
+                    :error-message "fetch failed"
+                    :error-cause "self-signed certificate"})))))
+
+(deftest notify-download-failure-completes-progress-and-shows-error-test
+  (let [events (atom [])
+        notifications (atom [])]
+    (with-redefs [state/pub-event! (fn [event]
+                                     (swap! events conj event)
+                                     nil)
+                  notification/show! (fn [content status clear?]
+                                       (swap! notifications conj [content status clear?])
+                                       nil)]
+      (rtc-error/notify-download-failure!
+       "graph-1"
+       (ex-info "db-sync download failed"
+                {:stage :fetch-pull
+                 :error-message "fetch failed"})))
+    (is (= [[:rtc/log {:type :rtc.log/download
+                       :sub-type :download-completed
+                       :graph-uuid "graph-1"
+                       :message "Graph snapshot download failed"}]]
+           @events))
+    (is (= [[(i18n/t :sync/download-error "fetch-pull: fetch failed") :error false]]
+           @notifications))))
+
+(deftest notify-download-failure-keeps-wrong-password-toast-test
+  (let [notifications (atom [])]
+    (with-redefs [state/pub-event! (fn [_event] nil)
+                  notification/show! (fn [content status clear?]
+                                       (swap! notifications conj [content status clear?])
+                                       nil)]
+      (rtc-error/notify-download-failure!
+       "graph-1"
+       (ex-info "db-sync download failed"
+                {:code :db-sync/invalid-e2ee-password
+                 :stage :prepare-e2ee
+                 :error-message "decrypt-aes-key"})))
+    (is (= [[(i18n/t :encryption/wrong-password) :error false]]
+           @notifications))))
+
+(deftest notify-download-failure-surfaces-pre-worker-start-error-test
+  (testing "runtime start failures still clear progress and toast the real error"
+    (let [events (atom [])
+          notifications (atom [])]
+      (with-redefs [state/pub-event! (fn [event]
+                                       (swap! events conj event)
+                                       nil)
+                    notification/show! (fn [content status clear?]
+                                         (swap! notifications conj [content status clear?])
+                                         nil)]
+        (rtc-error/notify-download-failure!
+         "graph-1"
+         (ex-info "db-worker-node failed to start"
+                  {:code :server-start-failed})))
+      (is (= :download-completed
+             (get-in @events [0 1 :sub-type])))
+      (is (= [[(i18n/t :sync/download-error "db-worker-node failed to start") :error false]]
+             @notifications)))))

--- a/src/test/frontend/worker/sync/download_test.cljs
+++ b/src/test/frontend/worker/sync/download_test.cljs
@@ -109,3 +109,28 @@
                (p/finally (fn []
                             (reset! worker-state/*db-sync-config config-prev)
                             (done)))))))
+
+(deftest fetch-pull-failure-emits-completed-log-and-stage-test
+  (async done
+         (let [config-prev @worker-state/*db-sync-config
+               log-events (atom [])]
+           (reset! worker-state/*db-sync-config {:http-base "https://sync.example.test"})
+           (-> (p/with-redefs [sync-download/fetch-json (fn [_url _opts schema]
+                                                          (if (= schema :sync/pull)
+                                                            (p/rejected (js/TypeError. "fetch failed"))
+                                                            (p/rejected (ex-info "unexpected schema" {:schema schema}))))
+                               rtc-log-and-state/rtc-log (fn [type payload]
+                                                           (swap! log-events conj (assoc payload :type type))
+                                                           nil)]
+                 (sync-download/download-graph-by-id! "repo" "graph-1" false))
+               (p/then (fn [_]
+                         (is false "expected download failure")))
+               (p/catch (fn [error]
+                          (is (= "db-sync download failed" (ex-message error)))
+                          (is (= :fetch-pull (:stage (ex-data error))))
+                          (is (= "fetch failed" (:error-message (ex-data error))))
+                          (is (= [:download-progress :download-completed]
+                                 (mapv :sub-type @log-events)))))
+               (p/finally (fn []
+                            (reset! worker-state/*db-sync-config config-prev)
+                            (done)))))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Desktop DB graph snapshot downloads could fail without a user-visible error. Pre-worker failures (for example db-worker-node failing to start) left the last progress message on "Preparing graph snapshot download". Worker `:fetch-pull` failures emitted `:download-completed` with "Graph snapshot download failed", which hid the indicator and still showed no toast.

This change notifies on every download failure path and always emits `:download-completed` so the progress UI cannot stay stuck. The existing E2EE wrong-password toast is unchanged. Empty-graph retry after a failed download (db-test#1059) is intentionally left for a separate change.

Fixes https://github.com/logseq/db-test/issues/1058

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-327af216-df64-4280-92bc-561eb8b57c15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-327af216-df64-4280-92bc-561eb8b57c15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

