### PR TITLE
fix(cli): keep OAuth on Cognito when http-base is custom

### DIFF
--- a/cli/lib/auth_state.ml
+++ b/cli/lib/auth_state.ml
@@ -232,7 +232,6 @@ let raw_config_string config keys =
 
 let default_oauth_domain = "logseq-prod.auth.us-east-1.amazoncognito.com"
 let default_oauth_client_id = "69cs1lgme7p8kbgld8n5kseii6"
-let default_api_http_base = "https://api.logseq.io"
 
 let normalize_base_url value =
   let value = String.trim value in
@@ -247,29 +246,13 @@ let oauth_domain_base config =
   | Some domain when String.trim domain <> "" -> "https://" ^ String.trim domain
   | _ -> "https://" ^ default_oauth_domain
 
-let raw_http_base config = raw_config_string config (Vec.singleton "http-base")
-
-let configured_http_base config =
-  match raw_http_base config with
-  | Some base when String.trim base <> "" -> Some base
-  | _ -> (
-      match config.Cli_config.http_base with
-      | Some base
-        when String.trim base <> ""
-             && normalize_base_url base <> default_api_http_base ->
-          Some base
-      | _ -> None)
-
-let oauth_endpoint_base config =
-  Option.value (configured_http_base config) ~default:(oauth_domain_base config)
-
 let token_endpoint config =
   match
     raw_config_string config
       (Vec.of_array [| "oauth-token-endpoint"; "token-endpoint" |])
   with
   | Some endpoint when String.trim endpoint <> "" -> Some endpoint
-  | _ -> Some (normalize_base_url (oauth_endpoint_base config) ^ "/oauth2/token")
+  | _ -> Some (normalize_base_url (oauth_domain_base config) ^ "/oauth2/token")
 
 let logout_endpoint config =
   match
@@ -277,7 +260,7 @@ let logout_endpoint config =
       (Vec.of_array [| "oauth-logout-endpoint"; "logout-endpoint" |])
   with
   | Some endpoint when String.trim endpoint <> "" -> Some endpoint
-  | _ -> Some (normalize_base_url (oauth_endpoint_base config) ^ "/logout")
+  | _ -> Some (normalize_base_url (oauth_domain_base config) ^ "/logout")
 
 let oauth_client_id config =
   match
@@ -293,8 +276,7 @@ let authorize_endpoint config =
   with
   | Some endpoint when String.trim endpoint <> "" -> Some endpoint
   | _ ->
-      Some
-        (normalize_base_url (oauth_endpoint_base config) ^ "/oauth2/authorize")
+      Some (normalize_base_url (oauth_domain_base config) ^ "/oauth2/authorize")
 
 let oauth_scope config =
   Option.value

--- a/cli/test/cli_parity_test_cases.ml
+++ b/cli/test/cli_parity_test_cases.ml
@@ -4,6 +4,11 @@ let expect_equal name expected actual =
   if expected = actual then pass
   else fail_test (Printf.sprintf "%s: expected %S, got %S" name expected actual)
 
+let expect_url_prefix name prefix url =
+  if Js.String.startsWith ~prefix url then pass
+  else
+    fail_test (Printf.sprintf "%s: expected prefix %S, got %S" name prefix url)
+
 let expect_string_vec name expected actual =
   if Vec.to_array actual = expected then pass
   else
@@ -283,6 +288,28 @@ let config ?graph ?repo ?output_format ?auth_path ?id_token ?access_token
     project_dir = None;
     raw_file_config;
     profile_session = None;
+  }
+
+let default_oauth_idp = "https://logseq-prod.auth.us-east-1.amazoncognito.com"
+
+let sync_oauth_config ?(http_base = "http://127.0.0.1:18765")
+    ?(ws_url = "ws://127.0.0.1:18765/sync/%s") ~root extra =
+  let auth_path = Node.Path.join [| root; "auth.json" |] in
+  let fields =
+    [
+      (Edn_util.keyword "open-browser", Edn_util.bool false);
+      (Edn_util.keyword "http-base", Edn_util.string http_base);
+      (Edn_util.keyword "ws-url", Edn_util.string ws_url);
+    ]
+    @ extra
+  in
+  {
+    (config ~root_dir:root ~auth_path ~raw_file_config:(Edn_util.map fields) ())
+    with
+    http_base = Some http_base;
+    ws_url = Some ws_url;
+    timeout_span = Time.span_of_ms 500L;
+    login_timeout_span = Time.span_of_ms 8000L;
   }
 
 let config_with_output config mode =
@@ -1072,6 +1099,152 @@ let () =
       with exn ->
         remove_tree root;
         fail_test (Printexc.to_string exn));
+
+  test_promise
+    "custom http-base does not change oauth authorize/token/logout urls"
+    (fun () ->
+      let root = temp_dir "logseq-cli-oauth-http-base-" in
+      let custom_sync = "http://127.0.0.1:18765" in
+      let capturing_server requests =
+        create_server (fun[@u] req res ->
+            let body = ref "" in
+            req_set_encoding req "utf8";
+            req_on_data req "data" (fun[@u] chunk -> body := !body ^ chunk);
+            req_on_end req "end" (fun[@u] () ->
+                ignore !body;
+                requests :=
+                  Vec.push_back !requests (req_method req ^ " " ^ req_url req);
+                write_json res 404 (error_response "not found")))
+      in
+      let login_authorize_url config ~state ~code =
+        let login = effect_to_promise (Auth_state.login config) in
+        let callback_url =
+          Printf.sprintf "http://localhost:8765/auth/callback?state=%s&code=%s"
+            state code
+        in
+        let* () = fetch_with_retry 100 callback_url in
+        let* result = login in
+        let result = expect_ok "login" result in
+        Js.Promise.resolve result.authorize_url
+      in
+      let logout_url config =
+        (expect_ok "logout" (effect_result "logout" (Auth_state.logout config)))
+          .logout_url
+      in
+      try
+        let default_logout =
+          logout_url (sync_oauth_config ~root ~http_base:custom_sync [])
+        in
+        expect_url_prefix "default logout" (default_oauth_idp ^ "/logout?")
+          default_logout;
+        expect_named_not_contains "logout ignores http-base" default_logout
+          custom_sync;
+        let domain_logout =
+          logout_url
+            (sync_oauth_config ~root ~http_base:custom_sync
+               [
+                 ( Edn_util.keyword "oauth-domain",
+                   Edn_util.string "idp.example.com" );
+               ])
+        in
+        expect_url_prefix "oauth-domain logout"
+          "https://idp.example.com/logout?" domain_logout;
+        let explicit_logout =
+          logout_url
+            (sync_oauth_config ~root ~http_base:custom_sync
+               [
+                 ( Edn_util.keyword "oauth-logout-endpoint",
+                   Edn_util.string "https://idp.example.com/custom-logout" );
+               ])
+        in
+        expect_url_prefix "explicit logout endpoint"
+          "https://idp.example.com/custom-logout?" explicit_logout;
+        let sync_requests = ref Vec.empty in
+        let* () =
+          with_server (capturing_server sync_requests) (fun http_base ->
+              let* result =
+                effect_to_promise
+                  (Auth_state.refresh_auth
+                     (sync_oauth_config ~root ~http_base [])
+                     (sample_auth ~refresh_token:(Some "refresh-token-1") ()))
+              in
+              expect_error_code "refresh without oauth token endpoint"
+                "auth-refresh-failed" result;
+              expect_int "token refresh ignores http-base" 0
+                (Vec.length !sync_requests);
+              Js.Promise.resolve pass)
+        in
+        let* () =
+          with_server (oauth_server ()) (fun token_base ->
+              let extra =
+                [
+                  ( Edn_util.keyword "oauth-token-endpoint",
+                    Edn_util.string (token_base ^ "/oauth2/token") );
+                ]
+              in
+              let* refreshed =
+                effect_to_promise
+                  (Auth_state.refresh_auth
+                     (sync_oauth_config ~root ~http_base:custom_sync extra)
+                     (sample_auth ~refresh_token:(Some "refresh-token-1") ()))
+              in
+              ignore (expect_ok "explicit token endpoint" refreshed);
+              Js.Promise.resolve pass)
+        in
+        let* () =
+          with_server (oauth_server ()) (fun token_base ->
+              let state = "fixed-test-state" in
+              let config =
+                sync_oauth_config ~root ~http_base:custom_sync
+                  [
+                    ( Edn_util.keyword "oauth-token-endpoint",
+                      Edn_util.string (token_base ^ "/oauth2/token") );
+                    (Edn_util.keyword "oauth-state", Edn_util.string state);
+                    ( Edn_util.keyword "oauth-client-id",
+                      Edn_util.string "test-client" );
+                  ]
+              in
+              let* authorize_url =
+                login_authorize_url config ~state ~code:"auth-code-1"
+              in
+              expect_url_prefix "default authorize"
+                (default_oauth_idp ^ "/oauth2/authorize?") authorize_url;
+              expect_named_not_contains "authorize ignores http-base"
+                authorize_url custom_sync;
+              Js.Promise.resolve pass)
+        in
+        let* () =
+          with_server (oauth_server ()) (fun token_base ->
+              let state = "fixed-authorize-state" in
+              let authorize_endpoint =
+                "https://idp.example.com/custom-authorize"
+              in
+              let config =
+                sync_oauth_config ~root ~http_base:custom_sync
+                  [
+                    ( Edn_util.keyword "oauth-authorize-endpoint",
+                      Edn_util.string authorize_endpoint );
+                    ( Edn_util.keyword "oauth-token-endpoint",
+                      Edn_util.string (token_base ^ "/oauth2/token") );
+                    (Edn_util.keyword "oauth-state", Edn_util.string state);
+                    ( Edn_util.keyword "oauth-client-id",
+                      Edn_util.string "test-client" );
+                  ]
+              in
+              let* authorize_url =
+                login_authorize_url config ~state ~code:"auth-code-2"
+              in
+              expect_url_prefix "explicit authorize endpoint"
+                (authorize_endpoint ^ "?") authorize_url;
+              expect_named_not_contains "explicit authorize ignores http-base"
+                authorize_url custom_sync;
+              Js.Promise.resolve pass)
+        in
+        remove_tree root;
+        Js.Promise.resolve pass
+      with exn ->
+        remove_tree root;
+        fail_promise (Printexc.to_string exn));
 
   test "CLI parity config resolves argv over env over file" (fun () ->
       let root = temp_dir "logseq-cli-parity-config-" in

--- a/cli/test/cli_parity_test_cases.ml
+++ b/cli/test/cli_parity_test_cases.ml
@@ -1165,10 +1165,14 @@ let () =
               let* result =
                 effect_to_promise
                   (Auth_state.refresh_auth
-                     (sync_oauth_config ~root ~http_base [])
+                     (sync_oauth_config ~root ~http_base
+                        [
+                          ( Edn_util.keyword "oauth-domain",
+                            Edn_util.string "127.0.0.1:1" );
+                        ])
                      (sample_auth ~refresh_token:(Some "refresh-token-1") ()))
               in
-              expect_error_code "refresh without oauth token endpoint"
+              expect_error_code "refresh with unreachable oauth domain"
                 "auth-refresh-failed" result;
               expect_int "token refresh ignores http-base" 0
                 (Vec.length !sync_requests);

--- a/cli/test/test_cases.ml
+++ b/cli/test/test_cases.ml
@@ -493,10 +493,10 @@ let () =
              "{:open-browser false\n\
              \ :logout-timeout-ms 5000\n\
              \ :auth-path %S\n\
-             \ :http-base %S\n\
+             \ :oauth-logout-endpoint %S\n\
              \ :oauth-client-id \"test-client\"\n\
              \ :oauth-logout-state %S}\n"
-             auth_path base_url state);
+             auth_path (base_url ^ "/logout") state);
         let logout =
           run_cli_p
             [|


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Setting only a custom `:http-base` / `:ws-url` for a self-hosted sync server no longer rewrites OAuth authorize, token, or logout URLs onto that origin.

Sync transport and identity-provider endpoints are independent:

- Default authorize / token / logout stay on the built-in Cognito domain.
- Explicit `oauth-domain` or `oauth-*-endpoint` overrides still win.

Fixes https://github.com/logseq/db-test/issues/1055

## Test coverage

Adds a focused CLI test that a custom http-base does not change authorize, token, or logout URLs, and that explicit oauth-domain / oauth-*-endpoint overrides still work.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19ed1c59-6258-43f7-92f7-1d18bdd8a8a3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19ed1c59-6258-43f7-92f7-1d18bdd8a8a3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

