### PR TITLE
fix: remove leftover graph after failed DB download

### DIFF
--- a/src/main/frontend/handler/db_based/sync.cljs
+++ b/src/main/frontend/handler/db_based/sync.cljs
@@ -149,12 +149,13 @@
                    :type :db-sync/graph-operation-in-progress
                    :requested-operation requested-operation))))
 
-(defn- local-download-graph-exists?
+(defn- <local-download-graph-exists?
   [repo]
-  (boolean (some (fn [graph]
-                   (let [graph-name (or (:url graph) (:name graph))]
-                     (= graph-name repo)))
-                 (state/get-repos))))
+  (p/let [graphs (db-persist/get-all-graphs)]
+    (boolean (some (fn [graph]
+                     (= (some-> (or (:url graph) (:name graph)) string/lower-case)
+                        (string/lower-case repo)))
+                   graphs))))
 
 (defn- <remove-created-download-graph!
   [repo]
@@ -344,13 +345,16 @@
        (let [graph-e2ee? (normalize-graph-e2ee? graph-e2ee?)
              base (http-base)
              graph (str config/db-version-prefix graph-name)
-             existed-before?* (atom true)]
+             existed-before?* (atom true)
+             snapshot-imported?* (atom false)]
          (-> (if (and graph-uuid base)
                (p/let [_ (user-handler/<ensure-id&access-token!)
-                       _ (reset! existed-before?* (local-download-graph-exists? graph))
+                       graph-existed-before? (<local-download-graph-exists? graph)
+                       _ (reset! existed-before?* graph-existed-before?)
                        _ (<ensure-download-runtime-bound! graph)
                        _ (state/<invoke-db-worker :thread-api/db-sync-download-graph-by-id
                                                  graph graph-uuid graph-e2ee?)
+                       _ (reset! snapshot-imported?* true)
                        _ (when (util/electron?)
                            (state/<invoke-db-worker :thread-api/db-sync-download-missing-assets
                                                    graph graph-uuid))]
@@ -360,7 +364,8 @@
                                      :graph-uuid graph-uuid
                                      :base base})))
              (p/catch (fn [error]
-                        (let [created-in-this-attempt? (false? @existed-before?*)]
+                        (let [created-in-this-attempt? (and (false? @existed-before?*)
+                                                           (false? @snapshot-imported?*))]
                           (reset! existed-before?* true)
                           (-> (if created-in-this-attempt?
                                 (<remove-created-download-graph! graph)

--- a/src/main/frontend/handler/db_based/sync.cljs
+++ b/src/main/frontend/handler/db_based/sync.cljs
@@ -360,11 +360,13 @@
                                      :graph-uuid graph-uuid
                                      :base base})))
              (p/catch (fn [error]
-                        (-> (if @existed-before?*
-                              (p/resolved nil)
-                              (<remove-created-download-graph! graph))
-                            (p/then (fn [_]
-                                      (throw error))))))
+                        (let [created-in-this-attempt? (false? @existed-before?*)]
+                          (reset! existed-before?* true)
+                          (-> (if created-in-this-attempt?
+                                (<remove-created-download-graph! graph)
+                                (p/resolved nil))
+                              (p/then (fn [_]
+                                        (throw error))))))
              (p/finally
                (fn []
                  (state/set-state! :rtc/downloading-graph-uuid nil)))))))))

--- a/src/main/frontend/handler/db_based/sync.cljs
+++ b/src/main/frontend/handler/db_based/sync.cljs
@@ -366,7 +366,7 @@
                                 (<remove-created-download-graph! graph)
                                 (p/resolved nil))
                               (p/then (fn [_]
-                                        (throw error))))))
+                                        (throw error)))))))
              (p/finally
                (fn []
                  (state/set-state! :rtc/downloading-graph-uuid nil)))))))))

--- a/src/main/frontend/handler/db_based/sync.cljs
+++ b/src/main/frontend/handler/db_based/sync.cljs
@@ -3,6 +3,7 @@
   (:require [clojure.string :as string]
             [frontend.config :as config]
             [frontend.context.i18n :refer [t]]
+            [frontend.db.persist :as db-persist]
             [frontend.handler.notification :as notification]
             [frontend.handler.repo :as repo-handler]
             [frontend.handler.user :as user-handler]
@@ -147,6 +148,30 @@
             (assoc active-operation
                    :type :db-sync/graph-operation-in-progress
                    :requested-operation requested-operation))))
+
+(defn- local-download-graph-exists?
+  [repo]
+  (boolean (some (fn [graph]
+                   (let [graph-name (or (:url graph) (:name graph))]
+                     (= graph-name repo)))
+                 (state/get-repos))))
+
+(defn- <remove-created-download-graph!
+  [repo]
+  (-> (p/let [_ (-> (persist-db/<close-db repo)
+                    (p/catch (fn [error]
+                               (log/warn :db-sync/download-close-failed
+                                         {:repo repo
+                                          :error error})
+                               nil)))
+              _ (db-persist/delete-graph! repo)]
+        (state/delete-repo! {:url repo})
+        nil)
+      (p/catch (fn [error]
+                 (log/warn :db-sync/download-cleanup-failed
+                           {:repo repo
+                            :error error})
+                 nil))))
 
 (defn- <ensure-download-runtime-bound!
   [repo]
@@ -317,10 +342,12 @@
                    :graph-uuid graph-uuid
                    :message "Preparing graph snapshot download"}])
        (let [graph-e2ee? (normalize-graph-e2ee? graph-e2ee?)
-             base (http-base)]
+             base (http-base)
+             graph (str config/db-version-prefix graph-name)
+             existed-before?* (atom true)]
          (-> (if (and graph-uuid base)
                (p/let [_ (user-handler/<ensure-id&access-token!)
-                       graph (str config/db-version-prefix graph-name)
+                       _ (reset! existed-before?* (local-download-graph-exists? graph))
                        _ (<ensure-download-runtime-bound! graph)
                        _ (state/<invoke-db-worker :thread-api/db-sync-download-graph-by-id
                                                  graph graph-uuid graph-e2ee?)
@@ -333,7 +360,11 @@
                                      :graph-uuid graph-uuid
                                      :base base})))
              (p/catch (fn [error]
-                        (throw error)))
+                        (-> (if @existed-before?*
+                              (p/resolved nil)
+                              (<remove-created-download-graph! graph))
+                            (p/then (fn [_]
+                                      (throw error))))))
              (p/finally
                (fn []
                  (state/set-state! :rtc/downloading-graph-uuid nil)))))))))

--- a/src/main/logseq/cli/command/sync.cljs
+++ b/src/main/logseq/cli/command/sync.cljs
@@ -863,7 +863,8 @@
 (defn- execute-sync-download
   [action config]
   (let [config' (download-config config)
-        progress-enabled? (sync-download-progress-enabled? action config')]
+        progress-enabled? (sync-download-progress-enabled? action config')
+        snapshot-imported?* (atom false)]
     (p/let [local-graphs-before (cli-server/list-graphs config')
             graph-existed-before? (some #(= (:graph action) %) local-graphs-before)]
       (-> (p/let [remote-graphs (invoke-global config'
@@ -895,6 +896,7 @@
                                  (p/finally (fn []
                                               (when-let [close! (:close! events-sub)]
                                                 (close!)))))
+                      _ (reset! snapshot-imported?* true)
                       assets-result (transport/invoke cfg :thread-api/db-sync-download-missing-assets
                                                       [(:repo action) graph-id])]
                 {:status :ok
@@ -909,7 +911,8 @@
                         result)
                       result)))
           (p/catch (fn [error]
-                     (p/let [_ (when-not graph-existed-before?
+                     (p/let [_ (when (and (not graph-existed-before?)
+                                         (false? @snapshot-imported?*))
                                   (<cleanup-created-download-graph! config' (:repo action)))]
                        (if (= :e2ee-password-not-found (:code (ex-data error)))
                          (e2ee-password-not-found-error :sync-download (:repo action))

--- a/src/main/logseq/cli/command/sync.cljs
+++ b/src/main/logseq/cli/command/sync.cljs
@@ -835,26 +835,24 @@
 
 (defn- <cleanup-created-download-graph!
   [config repo]
-  (-> (p/let [stop-result (cli-server/stop-server! config repo)
-              _ (when-not (or (:ok? stop-result)
-                              (= :server-not-found (get-in stop-result [:error :code])))
-                  (throw (ex-info (get-in stop-result [:error :message] "failed to stop server")
-                                  {:code (get-in stop-result [:error :code])
-                                   :repo repo
-                                   :stage :stop-server
-                                   :stop-result stop-result})))
-              graphs-after-stop (cli-server/list-graphs config)
-              graph-exists? (some #(= (core/repo->graph repo) %) graphs-after-stop)
-              unlinked-dir (when graph-exists?
-                             (cli-common/unlink-graph! (cli-server/graphs-dir config) repo))
-              _ (when (and graph-exists? (not unlinked-dir))
-                  (throw (ex-info "unable to remove graph"
-                                  {:code :graph-not-removed
-                                   :repo repo
-                                   :stage :unlink-graph})))]
+  (-> (p/let [stop-result (-> (cli-server/stop-server! config repo)
+                              (p/catch (fn [error]
+                                         {:ok? false
+                                          :error (cleanup-error-details error)})))
+              removed-dir (cli-common/remove-graph-dir! (cli-server/graphs-dir config) repo)]
+        (when (and (not (:ok? stop-result))
+                   (not= :server-not-found (get-in stop-result [:error :code])))
+          (log/warn :cli-sync-download-cleanup-stop-failed
+                    {:repo repo
+                     :stop-result stop-result}))
+        (when-not removed-dir
+          (log/warn :cli-sync-download-cleanup-graph-missing
+                    {:repo repo
+                     :graphs-dir (cli-server/graphs-dir config)}))
         {:status :ok
          :data {:repo repo
-                :unlinked-dir unlinked-dir}})
+                :removed-dir removed-dir
+                :stop-result stop-result}})
       (p/catch (fn [error]
                  (log/warn :cli-sync-download-cleanup-failed
                            {:repo repo

--- a/src/main/logseq/cli/common.cljs
+++ b/src/main/logseq/cli/common.cljs
@@ -37,3 +37,15 @@
          (fs/ensureDirSync unlinked)
          (fs/moveSync path new-path')
          new-path')))))
+
+(defn remove-graph-dir!
+  "Deletes the graph directory from disk, including worker lock files.
+   Returns the removed path if a directory was deleted, otherwise nil."
+  ([repo]
+   (remove-graph-dir! (common-graph/expand-home (common-graph/get-default-graphs-dir)) repo))
+  ([graphs-dir repo]
+   (let [graphs-dir (common-graph/expand-home graphs-dir)]
+     (when-let [graph-dir-name (existing-graph-dir-name graphs-dir repo)]
+       (let [path (node-path/join graphs-dir graph-dir-name)]
+         (fs/removeSync path)
+         path)))))

--- a/src/test/frontend/handler/db_based/sync_test.cljs
+++ b/src/test/frontend/handler/db_based/sync_test.cljs
@@ -851,4 +851,4 @@
                (p/catch (fn [error]
                           (is (= :missing-auth (:code (ex-data error))))
                           (is (= [] @deleted))
-                          (finish-async-test! done))))))))
+                          (finish-async-test! done)))))))

--- a/src/test/frontend/handler/db_based/sync_test.cljs
+++ b/src/test/frontend/handler/db_based/sync_test.cljs
@@ -767,20 +767,21 @@
 (deftest rtc-download-graph-removes-created-local-graph-on-failure-test
   (async done
          (let [deleted (atom [])
-               closed (atom [])]
+               closed (atom [])
+               repo (str config/db-version-prefix "demo-graph")]
            (-> (p/with-redefs [db-sync/http-base (fn [] "http://base")
                                user-handler/<ensure-id&access-token! (fn [] (p/resolved true))
                                util/electron? (fn [] true)
                                state/get-repos (fn [] [])
                                persist-db/<open-and-fetch-schema (fn [_repo _opts]
                                                                    (p/resolved {:schema {}}))
-                               persist-db/<close-db (fn [repo]
-                                                      (swap! closed conj repo)
+                               persist-db/<close-db (fn [graph]
+                                                      (swap! closed conj graph)
                                                       (p/resolved nil))
-                               db-persist/delete-graph! (fn [repo]
-                                                          (swap! deleted conj repo)
+                               db-persist/delete-graph! (fn [graph]
+                                                          (swap! deleted conj graph)
                                                           (p/resolved nil))
-                               state/delete-repo! (fn [_repo] nil)
+                               state/delete-repo! (fn [_graph] nil)
                                state/<invoke-db-worker (fn [op & _args]
                                                          (if (= op :thread-api/db-sync-download-graph-by-id)
                                                            (p/rejected (ex-info "invalid-e2ee-password"
@@ -794,8 +795,8 @@
                          (finish-async-test! done)))
                (p/catch (fn [error]
                           (is (= :db-sync/invalid-e2ee-password (:code (ex-data error))))
-                          (is (= [(str config/db-version-prefix "demo-graph")] @closed))
-                          (is (= [(str config/db-version-prefix "demo-graph")] @deleted))
+                          (is (= #{repo} (set @closed)))
+                          (is (= #{repo} (set @deleted)))
                           (finish-async-test! done)))))))
 
 (deftest rtc-download-graph-keeps-preexisting-local-graph-on-failure-test

--- a/src/test/frontend/handler/db_based/sync_test.cljs
+++ b/src/test/frontend/handler/db_based/sync_test.cljs
@@ -601,6 +601,7 @@
          (let [worker-calls (atom [])]
            (-> (p/with-redefs [db-sync/http-base (fn [] "http://base")
                                user-handler/<ensure-id&access-token! (fn [] (p/resolved true))
+                               db-persist/get-all-graphs (fn [] (p/resolved []))
                                state/<invoke-db-worker (fn [& args]
                                                          (swap! worker-calls conj args)
                                                          (p/resolved :ok))
@@ -626,6 +627,7 @@
            (reset! state/*db-worker nil)
            (-> (p/with-redefs [db-sync/http-base (fn [] "http://base")
                                user-handler/<ensure-id&access-token! (fn [] (p/resolved true))
+                               db-persist/get-all-graphs (fn [] (p/resolved []))
                                state/<invoke-db-worker (fn [& _] (p/resolved :ok))
                                state/pub-event! (fn [& _] nil)
                                state/set-state! (fn [k v]
@@ -651,6 +653,7 @@
            (-> (p/with-redefs [db-sync/http-base (fn [] "http://base")
                                user-handler/<ensure-id&access-token! (fn [] (p/resolved true))
                                util/electron? (fn [] true)
+                               db-persist/get-all-graphs (fn [] (p/resolved []))
                                persist-db/<open-and-fetch-schema (fn [repo _opts]
                                                              (reset! runtime-bound-repo repo)
                                                              (p/resolved {:schema {}}))
@@ -695,6 +698,7 @@
                                user-handler/<ensure-id&access-token! (fn []
                                                                        (p/resolved true))
                                util/electron? (fn [] true)
+                               db-persist/get-all-graphs (fn [] (p/resolved []))
                                persist-db/<open-and-fetch-schema (fn [_repo _opts]
                                                              (p/resolved {:schema {}}))
                                state/<invoke-db-worker (fn [& args]
@@ -722,6 +726,7 @@
            (-> (p/with-redefs [db-sync/http-base (fn [] "http://base")
                                user-handler/<ensure-id&access-token! (fn [] (p/resolved true))
                                util/electron? (fn [] false)
+                               db-persist/get-all-graphs (fn [] (p/resolved []))
                                persist-db/<open-and-fetch-schema (fn [& args]
                                                              (swap! runtime-rebind-calls conj args)
                                                              (p/resolved {:schema {}}))
@@ -746,6 +751,7 @@
            (-> (p/with-redefs [db-sync/http-base (fn [] "http://base")
                                user-handler/<ensure-id&access-token! (fn [] (p/resolved true))
                                util/electron? (fn [] true)
+                               db-persist/get-all-graphs (fn [] (p/resolved []))
                                persist-db/<open-and-fetch-schema (fn [_repo _opts]
                                                              (p/resolved {:schema {}}))
                                state/<invoke-db-worker (fn [& args]
@@ -773,6 +779,7 @@
                                user-handler/<ensure-id&access-token! (fn [] (p/resolved true))
                                util/electron? (fn [] true)
                                state/get-repos (fn [] [])
+                               db-persist/get-all-graphs (fn [] (p/resolved []))
                                persist-db/<open-and-fetch-schema (fn [_repo _opts]
                                                                    (p/resolved {:schema {}}))
                                persist-db/<close-db (fn [graph]
@@ -799,6 +806,35 @@
                           (is (= #{repo} (set @deleted)))
                           (finish-async-test! done)))))))
 
+(deftest rtc-download-graph-keeps-imported-graph-when-assets-fail-test
+  (async done
+         (let [deleted (atom [])]
+           (-> (p/with-redefs [db-sync/http-base (fn [] "http://base")
+                               user-handler/<ensure-id&access-token! (fn [] (p/resolved true))
+                               util/electron? (fn [] true)
+                               db-persist/get-all-graphs (fn [] (p/resolved []))
+                               persist-db/<open-and-fetch-schema (fn [_repo _opts]
+                                                                   (p/resolved {:schema {}}))
+                               db-persist/delete-graph! (fn [repo]
+                                                          (swap! deleted conj repo)
+                                                          (p/resolved nil))
+                               state/<invoke-db-worker
+                               (fn [op & _args]
+                                 (if (= op :thread-api/db-sync-download-missing-assets)
+                                   (p/rejected (ex-info "asset download failed"
+                                                        {:code :db-sync/asset-download-failed}))
+                                   (p/resolved :ok)))
+                               state/pub-event! (fn [& _] nil)
+                               state/set-state! (fn [& _] nil)]
+                 (db-sync/<rtc-download-graph! "demo-graph" "graph-1" true))
+               (p/then (fn [_]
+                         (is false "expected asset download failure")
+                         (finish-async-test! done)))
+               (p/catch (fn [error]
+                          (is (= :db-sync/asset-download-failed (:code (ex-data error))))
+                          (is (= [] @deleted))
+                          (finish-async-test! done)))))))
+
 (deftest rtc-download-graph-keeps-preexisting-local-graph-on-failure-test
   (async done
          (let [deleted (atom [])
@@ -806,7 +842,8 @@
            (-> (p/with-redefs [db-sync/http-base (fn [] "http://base")
                                user-handler/<ensure-id&access-token! (fn [] (p/resolved true))
                                util/electron? (fn [] true)
-                               state/get-repos (fn [] [{:url repo}])
+                               state/get-repos (fn [] [])
+                               db-persist/get-all-graphs (fn [] (p/resolved [{:name (string/upper-case repo)}]))
                                persist-db/<open-and-fetch-schema (fn [_repo _opts]
                                                                    (p/resolved {:schema {}}))
                                persist-db/<close-db (fn [_repo] (p/resolved nil))

--- a/src/test/frontend/handler/db_based/sync_test.cljs
+++ b/src/test/frontend/handler/db_based/sync_test.cljs
@@ -2,6 +2,7 @@
   (:require [cljs.test :refer [deftest is async]]
             [clojure.string :as string]
             [frontend.config :as config]
+            [frontend.db.persist :as db-persist]
             [frontend.handler.db-based.sync :as db-sync]
             [frontend.persist-db :as persist-db]
             [frontend.handler.repo :as repo-handler]
@@ -762,3 +763,92 @@
                (p/catch (fn [error]
                           (is false (str error))
                           (finish-async-test! done)))))))
+
+(deftest rtc-download-graph-removes-created-local-graph-on-failure-test
+  (async done
+         (let [deleted (atom [])
+               closed (atom [])]
+           (-> (p/with-redefs [db-sync/http-base (fn [] "http://base")
+                               user-handler/<ensure-id&access-token! (fn [] (p/resolved true))
+                               util/electron? (fn [] true)
+                               state/get-repos (fn [] [])
+                               persist-db/<open-and-fetch-schema (fn [_repo _opts]
+                                                                   (p/resolved {:schema {}}))
+                               persist-db/<close-db (fn [repo]
+                                                      (swap! closed conj repo)
+                                                      (p/resolved nil))
+                               db-persist/delete-graph! (fn [repo]
+                                                          (swap! deleted conj repo)
+                                                          (p/resolved nil))
+                               state/delete-repo! (fn [_repo] nil)
+                               state/<invoke-db-worker (fn [op & _args]
+                                                         (if (= op :thread-api/db-sync-download-graph-by-id)
+                                                           (p/rejected (ex-info "invalid-e2ee-password"
+                                                                                {:code :db-sync/invalid-e2ee-password}))
+                                                           (p/resolved :ok)))
+                               state/pub-event! (fn [& _] nil)
+                               state/set-state! (fn [& _] nil)]
+                 (db-sync/<rtc-download-graph! "demo-graph" "graph-1" true))
+               (p/then (fn [_]
+                         (is false "expected download failure")
+                         (finish-async-test! done)))
+               (p/catch (fn [error]
+                          (is (= :db-sync/invalid-e2ee-password (:code (ex-data error))))
+                          (is (= [(str config/db-version-prefix "demo-graph")] @closed))
+                          (is (= [(str config/db-version-prefix "demo-graph")] @deleted))
+                          (finish-async-test! done)))))))
+
+(deftest rtc-download-graph-keeps-preexisting-local-graph-on-failure-test
+  (async done
+         (let [deleted (atom [])
+               repo (str config/db-version-prefix "demo-graph")]
+           (-> (p/with-redefs [db-sync/http-base (fn [] "http://base")
+                               user-handler/<ensure-id&access-token! (fn [] (p/resolved true))
+                               util/electron? (fn [] true)
+                               state/get-repos (fn [] [{:url repo}])
+                               persist-db/<open-and-fetch-schema (fn [_repo _opts]
+                                                                   (p/resolved {:schema {}}))
+                               persist-db/<close-db (fn [_repo] (p/resolved nil))
+                               db-persist/delete-graph! (fn [graph]
+                                                          (swap! deleted conj graph)
+                                                          (p/resolved nil))
+                               state/<invoke-db-worker (fn [op & _args]
+                                                         (if (= op :thread-api/db-sync-download-graph-by-id)
+                                                           (p/rejected (ex-info "invalid-e2ee-password"
+                                                                                {:code :db-sync/invalid-e2ee-password}))
+                                                           (p/resolved :ok)))
+                               state/pub-event! (fn [& _] nil)
+                               state/set-state! (fn [& _] nil)]
+                 (db-sync/<rtc-download-graph! "demo-graph" "graph-1" true))
+               (p/then (fn [_]
+                         (is false "expected download failure")
+                         (finish-async-test! done)))
+               (p/catch (fn [error]
+                          (is (= :db-sync/invalid-e2ee-password (:code (ex-data error))))
+                          (is (= [] @deleted))
+                          (finish-async-test! done)))))))
+
+(deftest rtc-download-graph-skips-cleanup-when-auth-fails-before-create-test
+  (async done
+         (let [deleted (atom [])]
+           (-> (p/with-redefs [db-sync/http-base (fn [] "http://base")
+                               user-handler/<ensure-id&access-token! (fn []
+                                                                       (p/rejected (ex-info "missing auth"
+                                                                                            {:code :missing-auth})))
+                               state/get-repos (fn [] [])
+                               persist-db/<open-and-fetch-schema (fn [_repo _opts]
+                                                                   (p/resolved {:schema {}}))
+                               db-persist/delete-graph! (fn [repo]
+                                                          (swap! deleted conj repo)
+                                                          (p/resolved nil))
+                               state/<invoke-db-worker (fn [& _] (p/resolved :ok))
+                               state/pub-event! (fn [& _] nil)
+                               state/set-state! (fn [& _] nil)]
+                 (db-sync/<rtc-download-graph! "demo-graph" "graph-1" true))
+               (p/then (fn [_]
+                         (is false "expected auth failure")
+                         (finish-async-test! done)))
+               (p/catch (fn [error]
+                          (is (= :missing-auth (:code (ex-data error))))
+                          (is (= [] @deleted))
+                          (finish-async-test! done))))))))

--- a/src/test/logseq/cli/command/sync_test.cljs
+++ b/src/test/logseq/cli/command/sync_test.cljs
@@ -976,6 +976,57 @@
                             (remove-dir! root-dir)
                             (done)))))))
 
+(deftest test-execute-sync-download-keeps-imported-graph-when-assets-fail
+  (async done
+         (let [root-dir (temp-root-dir)
+               repo "logseq_db_leftover"
+               graph-path (node-path/join (cli-server/graphs-dir {:root-dir root-dir})
+                                          (graph-dir/repo->encoded-graph-dir-name repo))
+               create-graph! (fn []
+                               (fs/mkdirSync graph-path #js {:recursive true})
+                               (fs/writeFileSync (node-path/join graph-path "db.sqlite") "imported"))]
+           (-> (p/with-redefs [cli-server/ensure-server! (fn [config _repo]
+                                                           (create-graph!)
+                                                           (p/resolved (assoc config :base-url "http://example")))
+                               cli-server/stop-server! (fn [_config _repo]
+                                                         (p/resolved {:ok? true}))
+                               transport/invoke
+                               (fn [_ method _args]
+                                 (case method
+                                   :thread-api/db-sync-list-remote-graphs
+                                   (p/resolved [{:graph-id "remote-graph-id"
+                                                 :graph-name "leftover"
+                                                 :graph-e2ee? false}])
+
+                                   :thread-api/q
+                                   (p/resolved 0)
+
+                                   :thread-api/db-sync-download-graph-by-id
+                                   (p/resolved {:graph-id "remote-graph-id"
+                                                :remote-tx 9})
+
+                                   :thread-api/db-sync-download-missing-assets
+                                   (p/rejected (ex-info "asset download failed"
+                                                        {:code :db-sync/asset-download-failed}))
+
+                                   (p/resolved nil)))]
+                 (p/let [result (execute-with-runtime-auth {:type :sync-download
+                                                            :repo repo
+                                                            :graph "leftover"}
+                                                           {:base-url "http://example"
+                                                            :root-dir root-dir
+                                                            :http-base "https://api.logseq.io"
+                                                            :refresh-token "refresh-token"})]
+                   (is (= :error (:status result)))
+                   (is (= :db-sync/asset-download-failed (get-in result [:error :code])))
+                   (is (fs/existsSync graph-path)
+                       "post-import asset failure should keep the imported graph")))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (remove-dir! root-dir)
+                            (done)))))))
+
 (deftest test-execute-sync-start-runtime-error-after-open
   (async done
          (let [status-calls (atom 0)]

--- a/src/test/logseq/cli/command/sync_test.cljs
+++ b/src/test/logseq/cli/command/sync_test.cljs
@@ -652,9 +652,9 @@
                                cli-server/stop-server! (fn [config repo]
                                                          (swap! stop-calls conj [config repo])
                                                          (p/resolved {:ok? true}))
-                               cli-common/unlink-graph! (fn [& args]
+                               cli-common/remove-graph-dir! (fn [& args]
                                                           (swap! unlink-calls conj args)
-                                                          "/tmp/unlinked-demo")
+                                                          "/tmp/removed-demo")
                                transport/invoke (fn [_ method args]
                                                   (swap! invoke-calls conj [method args])
                                                   (case method
@@ -707,9 +707,9 @@
                                                          (swap! stop-calls conj [config repo])
                                                          (p/rejected (ex-info "stop failed"
                                                                               {:code :stop-failed})))
-                               cli-common/unlink-graph! (fn [& args]
+                               cli-common/remove-graph-dir! (fn [& args]
                                                           (swap! unlink-calls conj args)
-                                                          "/tmp/unlinked-demo")
+                                                          "/tmp/removed-demo")
                                transport/invoke (fn [_ method _args]
                                                   (case method
                                                     :thread-api/db-sync-list-remote-graphs
@@ -736,7 +736,7 @@
                    (is (= :error (:status result)))
                    (is (= :e2ee-password-not-found (get-in result [:error :code])))
                    (is (= ["logseq_db_demo"] (mapv second @stop-calls)))
-                   (is (= [] @unlink-calls))))
+                   (is (= ["logseq_db_demo"] (mapv last @unlink-calls)))))
                (p/catch (fn [e]
                           (is false (str "unexpected error: " e))))
                (p/finally done)))))
@@ -796,9 +796,9 @@
                                cli-server/stop-server! (fn [config repo]
                                                          (swap! stop-calls conj [config repo])
                                                          (p/resolved {:ok? true}))
-                               cli-common/unlink-graph! (fn [& args]
+                               cli-common/remove-graph-dir! (fn [& args]
                                                           (swap! unlink-calls conj args)
-                                                          "/tmp/unlinked-demo")
+                                                          "/tmp/removed-demo")
                                transport/invoke (fn [_ method _args]
                                                   (case method
                                                     :thread-api/db-sync-list-remote-graphs
@@ -826,6 +826,155 @@
                (p/catch (fn [e]
                           (is false (str "unexpected error: " e))))
                (p/finally done)))))
+
+(deftest test-execute-sync-download-removes-leftover-graph-dir-when-stop-fails
+  (async done
+         (let [root-dir (temp-root-dir)
+               repo "logseq_db_leftover"
+               graph-path (node-path/join (cli-server/graphs-dir {:root-dir root-dir})
+                                          (graph-dir/repo->encoded-graph-dir-name repo))
+               create-leftover! (fn []
+                                  (fs/mkdirSync graph-path #js {:recursive true})
+                                  (fs/writeFileSync (node-path/join graph-path "db.sqlite") "")
+                                  (fs/writeFileSync (node-path/join graph-path "db-worker.lock") "lock"))]
+           (-> (p/with-redefs [cli-server/ensure-server! (fn [config _repo]
+                                                           (create-leftover!)
+                                                           (p/resolved (assoc config :base-url "http://example")))
+                               cli-server/stop-server! (fn [_config _repo]
+                                                         (p/resolved {:ok? false
+                                                                      :error {:code :server-stop-timeout
+                                                                              :message "timed out stopping server"}}))
+                               transport/invoke (fn [_ method _args]
+                                                  (case method
+                                                    :thread-api/db-sync-list-remote-graphs
+                                                    (p/resolved [{:graph-id "remote-graph-id"
+                                                                  :graph-name "leftover"
+                                                                  :graph-e2ee? true}])
+
+                                                    :thread-api/verify-and-save-e2ee-password
+                                                    (p/rejected (ex-info "invalid-e2ee-password"
+                                                                         {:code :db-sync/invalid-e2ee-password}))
+
+                                                    :thread-api/db-sync-download-graph-by-id
+                                                    (p/resolved {:ok true})
+
+                                                    (p/resolved nil)))]
+                 (p/let [result (execute-with-runtime-auth {:type :sync-download
+                                                            :repo repo
+                                                            :graph "leftover"
+                                                            :e2ee-password "wrong-password"}
+                                                           {:base-url "http://example"
+                                                            :root-dir root-dir
+                                                            :http-base "https://api.logseq.io"
+                                                            :refresh-token "refresh-token"})]
+                   (is (= :error (:status result)))
+                   (is (= :db-sync/invalid-e2ee-password (get-in result [:error :code])))
+                   (is (not (fs/existsSync graph-path))
+                       "failed download should delete the leftover canonical graph dir")
+                   (is (= [] (cli-server/list-graphs {:root-dir root-dir})))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (remove-dir! root-dir)
+                            (done)))))))
+
+(deftest test-execute-sync-download-removes-leftover-graph-on-worker-failure
+  (async done
+         (let [root-dir (temp-root-dir)
+               repo "logseq_db_leftover"
+               graph-path (node-path/join (cli-server/graphs-dir {:root-dir root-dir})
+                                          (graph-dir/repo->encoded-graph-dir-name repo))
+               create-leftover! (fn []
+                                  (fs/mkdirSync graph-path #js {:recursive true})
+                                  (fs/writeFileSync (node-path/join graph-path "db.sqlite") "")
+                                  (fs/writeFileSync (node-path/join graph-path "db-worker.lock") "lock"))]
+           (-> (p/with-redefs [cli-server/ensure-server! (fn [config _repo]
+                                                           (create-leftover!)
+                                                           (p/resolved (assoc config :base-url "http://example")))
+                               cli-server/stop-server! (fn [_config _repo]
+                                                         (p/resolved {:ok? true}))
+                               transport/invoke (fn [_ method _args]
+                                                  (case method
+                                                    :thread-api/db-sync-list-remote-graphs
+                                                    (p/resolved [{:graph-id "remote-graph-id"
+                                                                  :graph-name "leftover"
+                                                                  :graph-e2ee? false}])
+
+                                                    :thread-api/q
+                                                    (p/resolved 0)
+
+                                                    :thread-api/db-sync-download-graph-by-id
+                                                    (p/rejected (ex-info "db-sync download failed"
+                                                                         {:code :db-sync/snapshot-download-failed
+                                                                          :stage :fetch-pull}))
+
+                                                    (p/resolved nil)))]
+                 (p/let [result (execute-with-runtime-auth {:type :sync-download
+                                                            :repo repo
+                                                            :graph "leftover"}
+                                                           {:base-url "http://example"
+                                                            :root-dir root-dir
+                                                            :http-base "https://api.logseq.io"
+                                                            :refresh-token "refresh-token"})]
+                   (is (= :error (:status result)))
+                   (is (= :db-sync/snapshot-download-failed (get-in result [:error :code])))
+                   (is (not (fs/existsSync graph-path))
+                       "pre-import worker failure should delete the leftover graph dir")
+                   (is (= [] (cli-server/list-graphs {:root-dir root-dir})))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (remove-dir! root-dir)
+                            (done)))))))
+
+(deftest test-execute-sync-download-keeps-graph-dir-on-success
+  (async done
+         (let [root-dir (temp-root-dir)
+               repo "logseq_db_leftover"
+               graph-path (node-path/join (cli-server/graphs-dir {:root-dir root-dir})
+                                          (graph-dir/repo->encoded-graph-dir-name repo))
+               create-graph! (fn []
+                               (fs/mkdirSync graph-path #js {:recursive true})
+                               (fs/writeFileSync (node-path/join graph-path "db.sqlite") "imported"))]
+           (-> (p/with-redefs [cli-server/ensure-server! (fn [config _repo]
+                                                           (create-graph!)
+                                                           (p/resolved (assoc config :base-url "http://example")))
+                               cli-server/stop-server! (fn [_config _repo]
+                                                         (p/resolved {:ok? true}))
+                               transport/invoke (fn [_ method _args]
+                                                  (case method
+                                                    :thread-api/db-sync-list-remote-graphs
+                                                    (p/resolved [{:graph-id "remote-graph-id"
+                                                                  :graph-name "leftover"
+                                                                  :graph-e2ee? false}])
+
+                                                    :thread-api/q
+                                                    (p/resolved 0)
+
+                                                    :thread-api/db-sync-download-graph-by-id
+                                                    (p/resolved {:graph-id "remote-graph-id"
+                                                                 :remote-tx 9})
+
+                                                    :thread-api/db-sync-download-missing-assets
+                                                    (p/resolved {:ok true})
+
+                                                    (p/resolved nil)))]
+                 (p/let [result (execute-with-runtime-auth {:type :sync-download
+                                                            :repo repo
+                                                            :graph "leftover"}
+                                                           {:base-url "http://example"
+                                                            :root-dir root-dir
+                                                            :http-base "https://api.logseq.io"
+                                                            :refresh-token "refresh-token"})]
+                   (is (= :ok (:status result)))
+                   (is (fs/existsSync graph-path)
+                       "successful download should keep the local graph dir")
+                   (is (= ["leftover"] (cli-server/list-graphs {:root-dir root-dir})))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (remove-dir! root-dir)
+                            (done)))))))
 
 (deftest test-execute-sync-start-runtime-error-after-open
   (async done

--- a/src/test/logseq/cli/common_test.cljs
+++ b/src/test/logseq/cli/common_test.cljs
@@ -59,3 +59,18 @@
           "Unencoded Unicode graph directory should be moved to Unlinked graphs")
       (is (fs/existsSync (node-path/join unlinked-path "db.sqlite"))
           "Graph contents should be preserved after move"))))
+
+(deftest remove-graph-dir-deletes-canonical-dir-and-lock
+  (let [graphs-dir (node-helper/create-tmp-dir "remove-graph")
+        graph-name "foo/bar"
+        repo (str common-config/db-version-prefix graph-name)
+        encoded-graph-dir "foo~2Fbar"
+        graph-path (node-path/join graphs-dir encoded-graph-dir)]
+    (fs/mkdirSync graph-path #js {:recursive true})
+    (fs/writeFileSync (node-path/join graph-path "db.sqlite") "test-data")
+    (fs/writeFileSync (node-path/join graph-path "db-worker.lock") "lock")
+    (is (= graph-path (cli-common/remove-graph-dir! graphs-dir repo)))
+    (is (not (fs/existsSync graph-path))
+        "Graph directory should be deleted")
+    (is (not (fs/existsSync (node-path/join graphs-dir common-config/unlinked-graphs-dir encoded-graph-dir)))
+        "Failed-download leftovers should not be moved to Unlinked graphs")))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Failed DB graph snapshot downloads created an empty canonical local graph before import. A later retry then failed with `graph already exists`, and Desktop could open that empty leftover.

## What changed
- CLI `sync download` now deletes the leftover graph directory (including `db-worker.lock`) when this attempt created it, even if stopping the worker fails.
- Desktop/web `<rtc-download-graph!` now closes and deletes a graph created in this download attempt after any pre-import or import failure.
- Pre-existing real graphs are left in place. Successful downloads are unchanged.

## Tests
- CLI filesystem tests for leftover removal on wrong E2EE password, worker pre-import failure, stop-server timeout, and successful download.
- Desktop unit tests for leftover cleanup, skipping cleanup for pre-existing graphs, and skipping cleanup when auth fails before graph creation.

Fixes https://github.com/logseq/db-test/issues/1059

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c4ac889-7610-4111-b47e-4b960d461c28?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c4ac889-7610-4111-b47e-4b960d461c28&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

