### PR TITLE
fix: stop CLI-owned db-worker when deleting a graph

### DIFF
--- a/docs/agent-guide/db-worker/002-desktop-db-worker-request-cap-switch-graph.md
+++ b/docs/agent-guide/db-worker/002-desktop-db-worker-request-cap-switch-graph.md
@@ -190,12 +190,12 @@ When the cap is reached, release the current Desktop remote runtime before switc
 Current available paths:
 
 - `persist-db/<close-db` closes the current remote db and calls `<stop-remote-if-current!`.
-- Electron `:deleteGraph` uses `db-worker/release-repo!`, but this also unlinks the graph and must not be reused directly.
+- Electron `:deleteGraph` uses `db-worker/delete-repo!`, which also unlinks the graph and must not be reused directly.
 - Electron `release-window!` is currently called from window close and graph-runtime lifecycle paths.
 
 Implementation options:
 
-- Add a focused IPC such as `"releaseDbWorkerRuntime"` or `"releaseDbWorkerRepo"` that calls `electron.db-worker/release-repo!` without deleting the graph.
+- Add a focused IPC such as `"releaseDbWorkerRuntime"` or `"releaseDbWorkerRepo"` that calls `electron.db-worker/ensure-repo-stopped!` with `electron.db-worker/manager` without deleting the graph.
 - Or add an internal renderer helper that uses existing close-db/stop paths if they fully release the runtime for the failed active repo.
 
 Prefer one explicit IPC if current close paths leave Electron manager state pointing at the failed repo.
@@ -285,7 +285,7 @@ If error classification is uncertain, treat it as app-level and do not increment
 1. Verify whether `remote/stop!` plus renderer state clearing is enough to make the next graph start correctly.
 2. If Electron manager state still keeps the failed graph/window association, add a dedicated IPC handler:
    - Renderer channel: `"releaseDbWorkerRuntime"` or equivalent.
-   - Main handler: calls `electron.db-worker/release-repo!` or a narrower release function.
+   - Main handler: calls `electron.db-worker/ensure-repo-stopped!` with `electron.db-worker/manager`, or a narrower release function.
    - Must not call `cli-common/unlink-graph!`.
 3. Add tests in `src/test/electron/db_worker_manager_test.cljs` or handler-level tests to prove the release path detaches the failed repo without deleting graph data.
 

--- a/docs/cli/logseq-cli.md
+++ b/docs/cli/logseq-cli.md
@@ -198,7 +198,7 @@ Server ownership behavior:
 - `server start` can return `server-start-timeout-orphan` when lock creation times out and orphan matching processes are detected.
 - Normal connection startup compares the discovered server revision with the local requester revision. Missing revision is treated as mismatch.
 - On revision mismatch, startup attempts one graceful-first restart of the exact discovered server for the same repo/root-dir, even if the stale server has a different owner source. If the replacement still reports a different revision, startup fails fast and does not return an incompatible endpoint.
-- Manual `server stop` and `server restart` keep owner protections; cross-owner stop is only used by the automatic revision-mismatch startup path after the target mismatch is proven.
+- Manual `server stop` and `server restart` keep owner protections. Automatic revision-mismatch recovery, orphan cleanup, `graph remove`, and Desktop graph deletion may stop a worker started by another owner.
 - `server list` human output includes both `OWNER` and `REVISION` columns.
 - `server list` prints a compatibility warning in human output when any server revision string is not exactly equal to the local CLI revision string.
 - `server cleanup` remains a manual maintenance command. It checks discovered servers in the current root-dir, treats `revision != local CLI revision` (including missing revision) as mismatch, and attempts graceful-first termination only for `:owner-source :cli` targets.

--- a/src/electron/electron/db_worker.cljs
+++ b/src/electron/electron/db_worker.cljs
@@ -1,5 +1,6 @@
 (ns electron.db-worker
-  (:require [logseq.cli.server :as cli-server]
+  (:require [logseq.cli.common :as cli-common]
+            [logseq.cli.server :as cli-server]
             [logseq.common.graph-dir :as graph-dir]
             [logseq.db-worker.daemon :as daemon]
             [promesa.core :as p]))
@@ -280,6 +281,27 @@
 (defn release-repo!
   [repo]
   (ensure-repo-stopped! manager repo))
+
+(defn- throw-if-stop-failed!
+  [stop-result]
+  (when-not (or (:ok? stop-result)
+                (= :server-not-found (get-in stop-result [:error :code])))
+    (throw (ex-info (get-in stop-result [:error :message] "failed to stop db-worker-node")
+                    {:code (or (get-in stop-result [:error :code]) :server-stop-failed)})))
+  stop-result)
+
+(defn delete-repo!
+  "Detach any Desktop runtime, stop a live db-worker for repo even if another
+  owner started it, then unlink the graph directory."
+  ([repo]
+   (delete-repo! manager repo))
+  ([mgr repo]
+   (p/let [_ (ensure-repo-stopped! mgr repo)
+           stop-result (cli-server/stop-server! {:owner-source :electron}
+                                                repo
+                                                {:allow-cross-owner? true})]
+     (throw-if-stop-failed! stop-result)
+     (cli-common/unlink-graph! repo))))
 
 (defn stop-all-managed!
   []

--- a/src/electron/electron/db_worker.cljs
+++ b/src/electron/electron/db_worker.cljs
@@ -278,10 +278,6 @@
   ([mgr repo window-id]
    (ensure-stopped! mgr repo window-id)))
 
-(defn release-repo!
-  [repo]
-  (ensure-repo-stopped! manager repo))
-
 (defn- throw-if-stop-failed!
   [stop-result]
   (when-not (or (:ok? stop-result)
@@ -291,16 +287,18 @@
   stop-result)
 
 (defn delete-repo!
-  "Detach any Desktop runtime, stop a live db-worker for repo even if another
-  owner started it, then unlink the graph directory."
+  "Stop a live db-worker for repo even if another owner started it, detach any
+  Desktop runtime, then unlink the graph directory."
   ([repo]
    (delete-repo! manager repo))
   ([mgr repo]
-   (p/let [_ (ensure-repo-stopped! mgr repo)
-           stop-result (cli-server/stop-server! {:owner-source :electron}
+   (p/let [stop-result (cli-server/stop-server! {:owner-source :electron}
                                                 repo
                                                 {:allow-cross-owner? true})]
      (throw-if-stop-failed! stop-result)
+     (swap! (:state mgr)
+            (fn [current]
+              (first (detach-repo current (repo-key repo)))))
      (cli-common/unlink-graph! repo))))
 
 (defn stop-all-managed!

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -31,7 +31,6 @@
             [electron.utils :as utils]
             [electron.window :as win]
             [electron.graph-switch-flow :as graph-switch-flow]
-            [logseq.cli.common :as cli-common]
             [logseq.common.config :as common-config]
             [logseq.common.graph :as common-graph]
             [logseq.common.graph-registry :as graph-registry]
@@ -227,8 +226,7 @@
 
 (defmethod handle :deleteGraph [_window [_ graph]]
   (when-let [repo (canonical-repo graph)]
-    (p/let [_ (db-worker/release-repo! repo)]
-      (cli-common/unlink-graph! repo))))
+    (db-worker/delete-repo! repo)))
 
 ;; DB related IPCs start
 

--- a/src/main/frontend/worker/db_worker_node.cljs
+++ b/src/main/frontend/worker/db_worker_node.cljs
@@ -458,8 +458,8 @@
       (.end res)
       (catch :default _)))
   (reset! *sse-clients #{})
-  (when-let [lock-path (:path @*lock-info)]
-    (db-lock/remove-lock! lock-path)))
+  (when-let [{:keys [path lock]} @*lock-info]
+    (db-lock/remove-owned-lock! path lock)))
 
 (defn- make-stop!
   [{:keys [proxy repo actual-port server stopped? on-stopped!]}]
@@ -528,8 +528,8 @@
                                               :on-stopped! on-stopped!}
                                              resolve)))
        (.on server "error" (fn [error]
-                              (when-let [lock-path (:path @*lock-info)]
-                                (db-lock/remove-lock! lock-path))
+                              (when-let [{:keys [path lock]} @*lock-info]
+                                (db-lock/remove-owned-lock! path lock))
                               (reject error)))))))
 
 (defn start-daemon!
@@ -581,8 +581,8 @@
                                      :root-dir root-dir
                                      :on-stopped! on-stopped!}))
               (p/catch (fn [e]
-                         (when-let [lock-path (:path @*lock-info)]
-                           (db-lock/remove-lock! lock-path))
+                         (when-let [{:keys [path lock]} @*lock-info]
+                           (db-lock/remove-owned-lock! path lock))
                          (throw e)))))
         (catch :default e
           (p/rejected e))))))

--- a/src/main/frontend/worker/db_worker_node_lock.cljs
+++ b/src/main/frontend/worker/db_worker_node_lock.cljs
@@ -89,23 +89,16 @@
   (when (and (seq path) (fs/existsSync path))
     (fs/unlinkSync path)))
 
-(defn same-lock-identity?
-  [a b]
-  (boolean
-   (and (number? (:pid a))
-        (number? (:pid b))
-        (= (:pid a) (:pid b))
-        (let [id-a (:lock-id a)
-              id-b (:lock-id b)]
-          (or (not (seq id-a))
-              (not (seq id-b))
-              (= id-a id-b))))))
-
 (defn remove-owned-lock!
   [path expected]
   (when (and (seq path) expected (fs/existsSync path))
-    (let [current (read-lock path)]
-      (when (same-lock-identity? current expected)
+    (let [{:keys [pid lock-id]} expected
+          current (read-lock path)]
+      (when (and (number? pid)
+                 (= pid (:pid current))
+                 (if (seq lock-id)
+                   (= lock-id (:lock-id current))
+                   true))
         (fs/unlinkSync path)))))
 
 (defn create-lock!

--- a/src/main/frontend/worker/db_worker_node_lock.cljs
+++ b/src/main/frontend/worker/db_worker_node_lock.cljs
@@ -89,6 +89,25 @@
   (when (and (seq path) (fs/existsSync path))
     (fs/unlinkSync path)))
 
+(defn same-lock-identity?
+  [a b]
+  (boolean
+   (and (number? (:pid a))
+        (number? (:pid b))
+        (= (:pid a) (:pid b))
+        (let [id-a (:lock-id a)
+              id-b (:lock-id b)]
+          (or (not (seq id-a))
+              (not (seq id-b))
+              (= id-a id-b))))))
+
+(defn remove-owned-lock!
+  [path expected]
+  (when (and (seq path) expected (fs/existsSync path))
+    (let [current (read-lock path)]
+      (when (same-lock-identity? current expected)
+        (fs/unlinkSync path)))))
+
 (defn create-lock!
   [{:keys [root-dir repo owner-source]}]
   (p/create
@@ -100,7 +119,7 @@
          (when (and existing (contains? #{:alive :no-permission} (pid-status (:pid existing))))
            (throw (ex-info "graph already locked" {:code :repo-locked :lock existing})))
          (when (and existing (= :not-found (pid-status (:pid existing))))
-           (remove-lock! path))
+           (remove-owned-lock! path existing))
          (fs/mkdirSync (node-path/dirname path) #js {:recursive true})
          (let [fd (fs/openSync path "wx")
                lock {:repo repo

--- a/src/main/logseq/cli/command/graph.cljs
+++ b/src/main/logseq/cli/command/graph.cljs
@@ -476,7 +476,7 @@
 
 (defn execute-graph-remove
   [action config]
-  (-> (p/let [stop-result (cli-server/stop-server! config (:repo action))
+  (-> (p/let [stop-result (cli-server/stop-server! config (:repo action) {:allow-cross-owner? true})
               _ (when-not (or (:ok? stop-result)
                               (= :server-not-found (get-in stop-result [:error :code])))
                   (throw (ex-info (get-in stop-result [:error :message] "failed to stop server")

--- a/src/main/logseq/cli/format.cljs
+++ b/src/main/logseq/cli/format.cljs
@@ -207,6 +207,7 @@
     :ambiguous-property-name "Retry with --id <property-id>"
     :root-dir-permission "Check filesystem permissions or set LOGSEQ_CLI_ROOT_DIR"
     :server-owned-by-other "Retry from the process owner that started the server"
+    :server-stop-timeout "Stop the lingering db-worker-node process manually, then retry"
     :server-start-timeout-orphan "Check and stop lingering db-worker-node processes, then retry"
     :server-revision-mismatch "Logseq will restart revision-mismatched db-worker-node servers automatically; retry after stopping any lingering server manually"
     :server-revision-mismatch-restart-failed "Logseq tried to restart a revision-mismatched db-worker-node server and failed. Stop the server manually, then retry"

--- a/src/main/logseq/cli/server.cljs
+++ b/src/main/logseq/cli/server.cljs
@@ -222,6 +222,11 @@
        (filter #(same-root-dir? config %))
        vec))
 
+(defn- same-pid?
+  [a b]
+  (and (number? (:pid a))
+       (= (:pid a) (:pid b))))
+
 (defn- repo-server
   [config servers repo]
   (first (filter #(graph-dir/same-repo? repo (:repo %))
@@ -304,7 +309,7 @@
                              replacement-lock? (boolean (and published
                                                              (nil? lock)
                                                              current-lock
-                                                             (not (daemon/same-lock-identity? current-lock published))))
+                                                             (not (same-pid? current-lock published))))
                              orphaned? (boolean (and published
                                                      (nil? lock)
                                                      (not replacement-lock?)))
@@ -356,7 +361,7 @@
                                     lock)
                              repo-server' (if (and published
                                                    (or (nil? lock)
-                                                       (daemon/same-lock-identity? lock published)))
+                                                       (same-pid? lock published)))
                                             published
                                             (-> (profile/time! profile-session
                                                                "server.wait-publish"
@@ -443,28 +448,16 @@
   (or (nil? pid)
       (not (contains? #{:alive :no-permission} (pid-status pid)))))
 
-(defn- expected-lock-identity
-  [lock server]
-  {:pid (or (:pid lock) (:pid server))
-   :lock-id (or (:lock-id lock) (:lock-id server))})
-
 (defn- server-considered-stopped?
   [path server expected-lock]
   (let [current (read-lock path)
-        expected (expected-lock-identity expected-lock server)]
-    (cond
-      (and current (not (daemon/same-lock-identity? current expected)))
-      true
-
-      (daemon/same-lock-identity? current expected)
-      false
-
-      :else
+        target-pid (:pid server)]
+    (if current
+      (not= (:pid current) target-pid)
       (or (some? expected-lock)
-          (let [pid (:pid server)]
-            (or (nil? pid)
-                (= pid (.-pid js/process))
-                (server-pid-gone? pid)))))))
+          (nil? target-pid)
+          (= target-pid (.-pid js/process))
+          (server-pid-gone? target-pid)))))
 
 (defn- unpublish-server!
   [config {:keys [pid port]}]
@@ -485,7 +478,7 @@
   [config repo path server]
   (let [expected-lock (read-lock path)]
     (if (and expected-lock
-             (not (daemon/same-lock-identity? expected-lock server)))
+             (not (same-pid? expected-lock server)))
       (p/resolved {:ok? true
                    :data {:repo repo}})
       (-> (p/let [_ (shutdown! server)
@@ -508,7 +501,7 @@
                             :data {:repo repo}}))
                  (p/catch (fn [_]
                             (when (server-pid-gone? (:pid server))
-                              (daemon/remove-owned-lock! path (expected-lock-identity expected-lock server))
+                              (daemon/remove-owned-lock! path (or expected-lock server))
                               (unpublish-server! config server))
                             (if (server-considered-stopped? path server expected-lock)
                               {:ok? true

--- a/src/main/logseq/cli/server.cljs
+++ b/src/main/logseq/cli/server.cljs
@@ -229,12 +229,11 @@
 
 (defn- repo-server-matching-lock
   [config servers repo lock]
-  (let [pid (:pid lock)
-        candidates (servers-for-config config servers)]
+  (let [pid (:pid lock)]
     (if (number? pid)
       (first (filter #(and (graph-dir/same-repo? repo (:repo %))
                            (= pid (:pid %)))
-                     candidates))
+                     (servers-for-config config servers)))
       (repo-server config servers repo))))
 
 (declare stop-server!)
@@ -329,7 +328,6 @@
 
                                          :else
                                          published)
-                             lock lock-after-orphan
                              _ (when (and (not published) (not (fs/existsSync path)))
                                  (profile/time! profile-session
                                                 "server.spawn-daemon"

--- a/src/main/logseq/cli/server.cljs
+++ b/src/main/logseq/cli/server.cljs
@@ -150,10 +150,6 @@
   [path]
   (daemon/read-lock path))
 
-(defn- remove-lock!
-  [path]
-  (daemon/remove-lock! path))
-
 (defn- http-request
   [opts]
   (daemon/http-request opts))
@@ -231,6 +227,16 @@
   (first (filter #(graph-dir/same-repo? repo (:repo %))
                  (servers-for-config config servers))))
 
+(defn- repo-server-matching-lock
+  [config servers repo lock]
+  (let [pid (:pid lock)
+        candidates (servers-for-config config servers)]
+    (if (number? pid)
+      (first (filter #(and (graph-dir/same-repo? repo (:repo %))
+                           (= pid (:pid %)))
+                     candidates))
+      (repo-server config servers repo))))
+
 (declare stop-server!)
 
 (def ^:private server-discovery-timeout-ms 30000)
@@ -264,16 +270,20 @@
            vec))))
 
 (defn- wait-for-discovered-server
-  [config repo]
-  (let [server* (atom nil)]
-    (-> (wait-for (fn []
-                    (p/let [servers (discover-servers config)
-                            server (repo-server config servers repo)]
-                      (reset! server* server)
-                      (some? server)))
-                  {:timeout-ms server-discovery-timeout-ms
-                   :interval-ms 50})
-        (p/then (fn [_] @server*)))))
+  ([config repo]
+   (wait-for-discovered-server config repo nil))
+  ([config repo expected-pid]
+   (let [server* (atom nil)]
+     (-> (wait-for (fn []
+                     (p/let [servers (discover-servers config)
+                             server (if (number? expected-pid)
+                                      (repo-server-matching-lock config servers repo {:pid expected-pid})
+                                      (repo-server config servers repo))]
+                       (reset! server* server)
+                       (some? server)))
+                   {:timeout-ms server-discovery-timeout-ms
+                    :interval-ms 50})
+         (p/then (fn [_] @server*))))))
 
 (defn- ensure-server-started-once!
   [config repo]
@@ -286,23 +296,41 @@
                      (ensure-repo-dir! root-dir repo)
                      (p/let [existing (read-lock path)
                              _ (cleanup-stale-lock! path existing)
+                             lock (read-lock path)
                              discovered (discover-servers config)
-                             discovered-repo-server (repo-server config discovered repo)
-                             orphaned? (boolean (and discovered-repo-server
-                                                     (nil? existing)
-                                                     (not (fs/existsSync path))))
+                             published (if lock
+                                         (repo-server-matching-lock config discovered repo lock)
+                                         (repo-server config discovered repo))
+                             current-lock (read-lock path)
+                             replacement-lock? (boolean (and published
+                                                             (nil? lock)
+                                                             current-lock
+                                                             (not (daemon/same-lock-identity? current-lock published))))
+                             orphaned? (boolean (and published
+                                                     (nil? lock)
+                                                     (not replacement-lock?)))
                              _ (when orphaned?
                                  (p/let [stop-result (stop-server! config repo
                                                                   {:allow-cross-owner? true
-                                                                   :target-server discovered-repo-server})]
+                                                                   :target-server published})]
                                    (when-not (:ok? stop-result)
                                      (throw (ex-info "db-worker-node failed to stop orphaned server"
                                                      {:code :server-start-failed
                                                       :repo repo
                                                       :stop-error (:error stop-result)})))))
-                             discovered-repo-server (when-not orphaned?
-                                                      discovered-repo-server)
-                             _ (when (and (not discovered-repo-server) (not (fs/existsSync path)))
+                             lock-after-orphan (read-lock path)
+                             published (cond
+                                         (and lock-after-orphan (or orphaned? replacement-lock?))
+                                         (p/let [discovered (discover-servers config)]
+                                           (repo-server-matching-lock config discovered repo lock-after-orphan))
+
+                                         (or orphaned? replacement-lock?)
+                                         nil
+
+                                         :else
+                                         published)
+                             lock lock-after-orphan
+                             _ (when (and (not published) (not (fs/existsSync path)))
                                  (profile/time! profile-session
                                                 "server.spawn-daemon"
                                                 (fn []
@@ -328,12 +356,14 @@
                                            (= :unknown (lock-owner-source lock)))
                                     (rewrite-lock-owner-source! path lock :cli)
                                     lock)
-                             repo-server' (if discovered-repo-server
-                                            discovered-repo-server
+                             repo-server' (if (and published
+                                                   (or (nil? lock)
+                                                       (daemon/same-lock-identity? lock published)))
+                                            published
                                             (-> (profile/time! profile-session
                                                                "server.wait-publish"
                                                                (fn []
-                                                                 (wait-for-discovered-server config repo)))
+                                                                 (wait-for-discovered-server config repo (:pid lock))))
                                                 (p/catch (fn [e]
                                                            (if (= :timeout (:code (ex-data e)))
                                                              (throw (ex-info "db-worker-node failed to publish health"
@@ -415,14 +445,28 @@
   (or (nil? pid)
       (not (contains? #{:alive :no-permission} (pid-status pid)))))
 
+(defn- expected-lock-identity
+  [lock server]
+  {:pid (or (:pid lock) (:pid server))
+   :lock-id (or (:lock-id lock) (:lock-id server))})
+
 (defn- server-considered-stopped?
-  [path server lock-existed?]
-  (and (not (fs/existsSync path))
-       (or lock-existed?
-           (let [pid (:pid server)]
-             (or (nil? pid)
-                 (= pid (.-pid js/process))
-                 (server-pid-gone? pid))))))
+  [path server expected-lock]
+  (let [current (read-lock path)
+        expected (expected-lock-identity expected-lock server)]
+    (cond
+      (and current (not (daemon/same-lock-identity? current expected)))
+      true
+
+      (daemon/same-lock-identity? current expected)
+      false
+
+      :else
+      (or (some? expected-lock)
+          (let [pid (:pid server)]
+            (or (nil? pid)
+                (= pid (.-pid js/process))
+                (server-pid-gone? pid)))))))
 
 (defn- unpublish-server!
   [config {:keys [pid port]}]
@@ -433,43 +477,47 @@
                                  [{:pid pid :port port}])))
 
 (defn- wait-until-stopped
-  [path server lock-existed?]
+  [path server expected-lock]
   (wait-for (fn []
-              (p/resolved (server-considered-stopped? path server lock-existed?)))
+              (p/resolved (server-considered-stopped? path server expected-lock)))
             {:timeout-ms 5000
              :interval-ms 200}))
 
 (defn- stop-discovered-server!
   [config repo path server]
-  (let [lock-existed? (fs/existsSync path)]
-    (-> (p/let [_ (shutdown! server)
-                _ (wait-until-stopped path server lock-existed?)]
-          (unpublish-server! config server)
-          {:ok? true
-           :data {:repo repo}})
-        (p/catch
-         (fn [_]
-           (when (and (= :alive (pid-status (:pid server)))
-                      (not= (:pid server) (.-pid js/process)))
-             (try
-               (.kill js/process (:pid server) "SIGTERM")
-               (catch :default e
-                 (log/warn :cli-server-stop-sigterm-failed e))))
-           (-> (wait-until-stopped path server lock-existed?)
-               (p/then (fn [_]
-                         (unpublish-server! config server)
-                         {:ok? true
-                          :data {:repo repo}}))
-               (p/catch (fn [_]
-                          (when (server-pid-gone? (:pid server))
-                            (remove-lock! path)
-                            (unpublish-server! config server))
-                          (if (server-considered-stopped? path server lock-existed?)
-                            {:ok? true
-                             :data {:repo repo}}
-                            {:ok? false
-                             :error {:code :server-stop-timeout
-                                     :message "timed out stopping server"}})))))))))
+  (let [expected-lock (read-lock path)]
+    (if (and expected-lock
+             (not (daemon/same-lock-identity? expected-lock server)))
+      (p/resolved {:ok? true
+                   :data {:repo repo}})
+      (-> (p/let [_ (shutdown! server)
+                  _ (wait-until-stopped path server expected-lock)]
+            (unpublish-server! config server)
+            {:ok? true
+             :data {:repo repo}})
+          (p/catch
+           (fn [_]
+             (when (and (= :alive (pid-status (:pid server)))
+                        (not= (:pid server) (.-pid js/process)))
+               (try
+                 (.kill js/process (:pid server) "SIGTERM")
+                 (catch :default e
+                   (log/warn :cli-server-stop-sigterm-failed e))))
+             (-> (wait-until-stopped path server expected-lock)
+                 (p/then (fn [_]
+                           (unpublish-server! config server)
+                           {:ok? true
+                            :data {:repo repo}}))
+                 (p/catch (fn [_]
+                            (when (server-pid-gone? (:pid server))
+                              (daemon/remove-owned-lock! path (expected-lock-identity expected-lock server))
+                              (unpublish-server! config server))
+                            (if (server-considered-stopped? path server expected-lock)
+                              {:ok? true
+                               :data {:repo repo}}
+                              {:ok? false
+                               :error {:code :server-stop-timeout
+                                       :message "timed out stopping server"}}))))))))))
 
 (defn- stop-server-target!
   [config repo {:keys [allow-cross-owner? target-server]}]
@@ -485,7 +533,9 @@
       (p/let [server (if target-server
                        target-server
                        (p/let [servers (discover-servers config)]
-                         (repo-server config servers repo)))]
+                         (or (when lock
+                               (repo-server-matching-lock config servers repo lock))
+                             (repo-server config servers repo))))]
         (if-not server
           (if (and (pos-int? (:pid lock))
                    (contains? #{:alive :no-permission} (pid-status (:pid lock))))

--- a/src/main/logseq/cli/server.cljs
+++ b/src/main/logseq/cli/server.cljs
@@ -292,9 +292,10 @@
                                                      (nil? existing)
                                                      (not (fs/existsSync path))))
                              _ (when orphaned?
-                                 (p/let [stop-result (stop-server! config repo {:allow-cross-owner? true})]
-                                   (when-not (or (:ok? stop-result)
-                                                 (= :server-not-found (get-in stop-result [:error :code])))
+                                 (p/let [stop-result (stop-server! config repo
+                                                                  {:allow-cross-owner? true
+                                                                   :target-server discovered-repo-server})]
+                                   (when-not (:ok? stop-result)
                                      (throw (ex-info "db-worker-node failed to stop orphaned server"
                                                      {:code :server-start-failed
                                                       :repo repo
@@ -415,12 +416,13 @@
       (not (contains? #{:alive :no-permission} (pid-status pid)))))
 
 (defn- server-considered-stopped?
-  [path server]
+  [path server lock-existed?]
   (and (not (fs/existsSync path))
-       (let [pid (:pid server)]
-         (or (nil? pid)
-             (= pid (.-pid js/process))
-             (server-pid-gone? pid)))))
+       (or lock-existed?
+           (let [pid (:pid server)]
+             (or (nil? pid)
+                 (= pid (.-pid js/process))
+                 (server-pid-gone? pid))))))
 
 (defn- unpublish-server!
   [config {:keys [pid port]}]
@@ -431,42 +433,43 @@
                                  [{:pid pid :port port}])))
 
 (defn- wait-until-stopped
-  [path server]
+  [path server lock-existed?]
   (wait-for (fn []
-              (p/resolved (server-considered-stopped? path server)))
+              (p/resolved (server-considered-stopped? path server lock-existed?)))
             {:timeout-ms 5000
              :interval-ms 200}))
 
 (defn- stop-discovered-server!
   [config repo path server]
-  (-> (p/let [_ (shutdown! server)
-              _ (wait-until-stopped path server)]
-        (unpublish-server! config server)
-        {:ok? true
-         :data {:repo repo}})
-      (p/catch
-       (fn [_]
-         (when (and (= :alive (pid-status (:pid server)))
-                    (not= (:pid server) (.-pid js/process)))
-           (try
-             (.kill js/process (:pid server) "SIGTERM")
-             (catch :default e
-               (log/warn :cli-server-stop-sigterm-failed e))))
-         (-> (wait-until-stopped path server)
-             (p/then (fn [_]
-                       (unpublish-server! config server)
-                       {:ok? true
-                        :data {:repo repo}}))
-             (p/catch (fn [_]
-                        (when (server-pid-gone? (:pid server))
-                          (remove-lock! path)
-                          (unpublish-server! config server))
-                        (if (server-considered-stopped? path server)
-                          {:ok? true
-                           :data {:repo repo}}
-                          {:ok? false
-                           :error {:code :server-stop-timeout
-                                   :message "timed out stopping server"}}))))))))
+  (let [lock-existed? (fs/existsSync path)]
+    (-> (p/let [_ (shutdown! server)
+                _ (wait-until-stopped path server lock-existed?)]
+          (unpublish-server! config server)
+          {:ok? true
+           :data {:repo repo}})
+        (p/catch
+         (fn [_]
+           (when (and (= :alive (pid-status (:pid server)))
+                      (not= (:pid server) (.-pid js/process)))
+             (try
+               (.kill js/process (:pid server) "SIGTERM")
+               (catch :default e
+                 (log/warn :cli-server-stop-sigterm-failed e))))
+           (-> (wait-until-stopped path server lock-existed?)
+               (p/then (fn [_]
+                         (unpublish-server! config server)
+                         {:ok? true
+                          :data {:repo repo}}))
+               (p/catch (fn [_]
+                          (when (server-pid-gone? (:pid server))
+                            (remove-lock! path)
+                            (unpublish-server! config server))
+                          (if (server-considered-stopped? path server lock-existed?)
+                            {:ok? true
+                             :data {:repo repo}}
+                            {:ok? false
+                             :error {:code :server-stop-timeout
+                                     :message "timed out stopping server"}})))))))))
 
 (defn- stop-server-target!
   [config repo {:keys [allow-cross-owner? target-server]}]
@@ -484,9 +487,16 @@
                        (p/let [servers (discover-servers config)]
                          (repo-server config servers repo)))]
         (if-not server
-          {:ok? false
-           :error {:code :server-not-found
-                   :message "server is not running"}}
+          (if (and (pos-int? (:pid lock))
+                   (contains? #{:alive :no-permission} (pid-status (:pid lock))))
+            {:ok? false
+             :error {:code :server-stop-timeout
+                     :message "server process is alive but not reachable"
+                     :repo repo
+                     :pid (:pid lock)}}
+            {:ok? false
+             :error {:code :server-not-found
+                     :message "server is not running"}})
           (let [server-owner (or lock-owner
                                  (normalize-owner-source (:owner-source server)))]
             (if-not (or allow-cross-owner?

--- a/src/main/logseq/cli/server.cljs
+++ b/src/main/logseq/cli/server.cljs
@@ -289,6 +289,7 @@
                              discovered (discover-servers config)
                              discovered-repo-server (repo-server config discovered repo)
                              orphaned? (boolean (and discovered-repo-server
+                                                     (nil? existing)
                                                      (not (fs/existsSync path))))
                              _ (when orphaned?
                                  (p/let [stop-result (stop-server! config repo {:allow-cross-owner? true})]
@@ -413,18 +414,26 @@
   (or (nil? pid)
       (not (contains? #{:alive :no-permission} (pid-status pid)))))
 
+(defn- server-considered-stopped?
+  [path server]
+  (and (not (fs/existsSync path))
+       (let [pid (:pid server)]
+         (or (nil? pid)
+             (= pid (.-pid js/process))
+             (server-pid-gone? pid)))))
+
 (defn- unpublish-server!
   [config {:keys [pid port]}]
-  (when (and (pos-int? pid) (pos-int? port))
+  (when (and (pos-int? pid)
+             (pos-int? port)
+             (not= pid (.-pid js/process)))
     (server-list/remove-entries! (server-list-path config)
                                  [{:pid pid :port port}])))
 
 (defn- wait-until-stopped
   [path server]
   (wait-for (fn []
-              (p/resolved
-               (and (not (fs/existsSync path))
-                    (server-pid-gone? (:pid server)))))
+              (p/resolved (server-considered-stopped? path server)))
             {:timeout-ms 5000
              :interval-ms 200}))
 
@@ -452,8 +461,7 @@
                         (when (server-pid-gone? (:pid server))
                           (remove-lock! path)
                           (unpublish-server! config server))
-                        (if (and (not (fs/existsSync path))
-                                 (server-pid-gone? (:pid server)))
+                        (if (server-considered-stopped? path server)
                           {:ok? true
                            :data {:repo repo}}
                           {:ok? false

--- a/src/main/logseq/cli/server.cljs
+++ b/src/main/logseq/cli/server.cljs
@@ -231,6 +231,8 @@
   (first (filter #(graph-dir/same-repo? repo (:repo %))
                  (servers-for-config config servers))))
 
+(declare stop-server!)
+
 (def ^:private server-discovery-timeout-ms 30000)
 
 (defn discover-servers
@@ -286,6 +288,18 @@
                              _ (cleanup-stale-lock! path existing)
                              discovered (discover-servers config)
                              discovered-repo-server (repo-server config discovered repo)
+                             orphaned? (boolean (and discovered-repo-server
+                                                     (not (fs/existsSync path))))
+                             _ (when orphaned?
+                                 (p/let [stop-result (stop-server! config repo {:allow-cross-owner? true})]
+                                   (when-not (or (:ok? stop-result)
+                                                 (= :server-not-found (get-in stop-result [:error :code])))
+                                     (throw (ex-info "db-worker-node failed to stop orphaned server"
+                                                     {:code :server-start-failed
+                                                      :repo repo
+                                                      :stop-error (:error stop-result)})))))
+                             discovered-repo-server (when-not orphaned?
+                                                      discovered-repo-server)
                              _ (when (and (not discovered-repo-server) (not (fs/existsSync path)))
                                  (profile/time! profile-session
                                                 "server.spawn-daemon"
@@ -394,55 +408,89 @@
                                           :timeout-ms 1000})]
     (= 200 status)))
 
+(defn- server-pid-gone?
+  [pid]
+  (or (nil? pid)
+      (not (contains? #{:alive :no-permission} (pid-status pid)))))
+
+(defn- unpublish-server!
+  [config {:keys [pid port]}]
+  (when (and (pos-int? pid) (pos-int? port))
+    (server-list/remove-entries! (server-list-path config)
+                                 [{:pid pid :port port}])))
+
+(defn- wait-until-stopped
+  [path server]
+  (wait-for (fn []
+              (p/resolved
+               (and (not (fs/existsSync path))
+                    (server-pid-gone? (:pid server)))))
+            {:timeout-ms 5000
+             :interval-ms 200}))
+
+(defn- stop-discovered-server!
+  [config repo path server]
+  (-> (p/let [_ (shutdown! server)
+              _ (wait-until-stopped path server)]
+        (unpublish-server! config server)
+        {:ok? true
+         :data {:repo repo}})
+      (p/catch
+       (fn [_]
+         (when (and (= :alive (pid-status (:pid server)))
+                    (not= (:pid server) (.-pid js/process)))
+           (try
+             (.kill js/process (:pid server) "SIGTERM")
+             (catch :default e
+               (log/warn :cli-server-stop-sigterm-failed e))))
+         (-> (wait-until-stopped path server)
+             (p/then (fn [_]
+                       (unpublish-server! config server)
+                       {:ok? true
+                        :data {:repo repo}}))
+             (p/catch (fn [_]
+                        (when (server-pid-gone? (:pid server))
+                          (remove-lock! path)
+                          (unpublish-server! config server))
+                        (if (and (not (fs/existsSync path))
+                                 (server-pid-gone? (:pid server)))
+                          {:ok? true
+                           :data {:repo repo}}
+                          {:ok? false
+                           :error {:code :server-stop-timeout
+                                   :message "timed out stopping server"}}))))))))
+
 (defn- stop-server-target!
   [config repo {:keys [allow-cross-owner? target-server]}]
   (let [requester-owner (requester-owner-source config)
         root-dir (resolve-root-dir config)
         path (lock-path root-dir repo)
-        lock (read-lock path)]
-    (if-not lock
-      (p/resolved {:ok? false
-                   :error {:code :server-not-found
-                           :message "server is not running"}})
-      (let [lock-owner (lock-owner-source lock)]
-        (if-not (or allow-cross-owner?
-                    (owner-manageable? requester-owner lock-owner))
-          (p/resolved (owner-mismatch-error repo requester-owner lock-owner))
-          (p/let [server (if target-server
-                           target-server
-                           (p/let [servers (discover-servers config)]
-                             (repo-server config servers repo)))]
-            (if-not server
-              {:ok? false
-               :error {:code :server-not-found
-                       :message "server is not running"}}
-              (-> (p/let [_ (shutdown! server)]
-                    (wait-for (fn []
-                                (p/resolved (not (fs/existsSync path))))
-                              {:timeout-ms 5000
-                               :interval-ms 200})
-                    {:ok? true
-                     :data {:repo repo}})
-                  (p/catch
-                   (fn [_]
-                     (when (and (= :alive (pid-status (:pid server)))
-                                (not= (:pid server) (.-pid js/process)))
-                       (try
-                         (.kill js/process (:pid server) "SIGTERM")
-                         (catch :default e
-                           (log/warn :cli-server-stop-sigterm-failed e))))
-                     (when (= :not-found (pid-status (:pid server)))
-                       (remove-lock! path))
-                     (if (fs/existsSync path)
-                       {:ok? false
-                        :error {:code :server-stop-timeout
-                                :message "timed out stopping server"}}
-                       {:ok? true
-                        :data {:repo repo}})))))))))))
+        lock (read-lock path)
+        lock-owner (when lock (lock-owner-source lock))]
+    (if (and lock
+             (not allow-cross-owner?)
+             (not (owner-manageable? requester-owner lock-owner)))
+      (p/resolved (owner-mismatch-error repo requester-owner lock-owner))
+      (p/let [server (if target-server
+                       target-server
+                       (p/let [servers (discover-servers config)]
+                         (repo-server config servers repo)))]
+        (if-not server
+          {:ok? false
+           :error {:code :server-not-found
+                   :message "server is not running"}}
+          (let [server-owner (or lock-owner
+                                 (normalize-owner-source (:owner-source server)))]
+            (if-not (or allow-cross-owner?
+                        (owner-manageable? requester-owner server-owner))
+              (owner-mismatch-error repo requester-owner server-owner)
+              (stop-discovered-server! config repo path server))))))))
 
 (defn stop-server!
-  [config repo]
-  (stop-server-target! config repo {:allow-cross-owner? false}))
+  ([config repo]
+   (stop-server! config repo nil))
+  ([config repo opts]
+   (stop-server-target! config repo (merge {:allow-cross-owner? false} opts))))
 
 (defn- stop-version-mismatched-server!
   [config repo server]

--- a/src/main/logseq/db_worker/daemon.cljs
+++ b/src/main/logseq/db_worker/daemon.cljs
@@ -47,23 +47,16 @@
   (when (and (seq path) (fs/existsSync path))
     (fs/unlinkSync path)))
 
-(defn same-lock-identity?
-  [a b]
-  (boolean
-   (and (number? (:pid a))
-        (number? (:pid b))
-        (= (:pid a) (:pid b))
-        (let [id-a (:lock-id a)
-              id-b (:lock-id b)]
-          (or (not (seq id-a))
-              (not (seq id-b))
-              (= id-a id-b))))))
-
 (defn remove-owned-lock!
   [path expected]
   (when (and (seq path) expected (fs/existsSync path))
-    (let [current (read-lock path)]
-      (when (same-lock-identity? current expected)
+    (let [{:keys [pid lock-id]} expected
+          current (read-lock path)]
+      (when (and (number? pid)
+                 (= pid (:pid current))
+                 (if (seq lock-id)
+                   (= lock-id (:lock-id current))
+                   true))
         (fs/unlinkSync path)))))
 
 (defn http-request

--- a/src/main/logseq/db_worker/daemon.cljs
+++ b/src/main/logseq/db_worker/daemon.cljs
@@ -47,6 +47,25 @@
   (when (and (seq path) (fs/existsSync path))
     (fs/unlinkSync path)))
 
+(defn same-lock-identity?
+  [a b]
+  (boolean
+   (and (number? (:pid a))
+        (number? (:pid b))
+        (= (:pid a) (:pid b))
+        (let [id-a (:lock-id a)
+              id-b (:lock-id b)]
+          (or (not (seq id-a))
+              (not (seq id-b))
+              (= id-a id-b))))))
+
+(defn remove-owned-lock!
+  [path expected]
+  (when (and (seq path) expected (fs/existsSync path))
+    (let [current (read-lock path)]
+      (when (same-lock-identity? current expected)
+        (fs/unlinkSync path)))))
+
 (defn http-request
   [{:keys [method host port path headers body timeout-ms]}]
   (p/create
@@ -182,13 +201,13 @@
 
     (= :not-found (pid-status (:pid lock)))
     (do
-      (remove-lock! path)
+      (remove-owned-lock! path lock)
       (p/resolved nil))
 
     (not (valid-lock? lock))
     (-> (stop-stale-process! lock)
         (p/then (fn [_]
-                  (remove-lock! path)
+                  (remove-owned-lock! path lock)
                   nil)))
 
     :else

--- a/src/test/electron/db_worker_manager_test.cljs
+++ b/src/test/electron/db_worker_manager_test.cljs
@@ -394,9 +394,9 @@
                      (is false (str "unexpected error: " e))))
           (p/finally (fn [] (done)))))))
 
-(deftest delete-repo-does-not-unlink-when-force-stop-fails
+(deftest delete-repo-unlinks-when-worker-is-already-stopped
   (async done
-    (let [graphs-dir (node-helper/create-tmp-dir "delete-repo-stop-failed")
+    (let [graphs-dir (node-helper/create-tmp-dir "delete-repo-stopped")
           repo "logseq_db_demo"
           graph-path (node-path/join graphs-dir "demo")
           manager (db-worker/create-manager
@@ -407,13 +407,45 @@
       (-> (p/with-redefs [common-graph/get-default-graphs-dir (fn [] graphs-dir)
                           cli-server/stop-server! (fn [_config _repo _opts]
                                                     (p/resolved {:ok? false
+                                                                 :error {:code :server-not-found
+                                                                         :message "server is not running"}}))]
+            (db-worker/delete-repo! manager repo))
+          (p/then (fn [_]
+                    (is (not (fs/existsSync graph-path)))
+                    (is (fs/existsSync (node-path/join graphs-dir
+                                                       common-config/unlinked-graphs-dir
+                                                       "demo"
+                                                       "db.sqlite")))))
+          (p/catch (fn [e]
+                     (is false (str "unexpected error: " e))))
+          (p/finally (fn [] (done)))))))
+
+(deftest delete-repo-does-not-unlink-when-force-stop-fails
+  (async done
+    (let [graphs-dir (node-helper/create-tmp-dir "delete-repo-stop-failed")
+          repo "logseq_db_demo"
+          graph-path (node-path/join graphs-dir "demo")
+          state-before-delete (atom nil)
+          manager (db-worker/create-manager
+                   {:start-daemon! (fn [repo]
+                                     (p/resolved (assoc (runtime repo) :owned? false)))
+                    :stop-daemon! (fn [_] (p/resolved true))})]
+      (fs/mkdirSync graph-path #js {:recursive true})
+      (fs/writeFileSync (node-path/join graph-path "db.sqlite") "data")
+      (-> (p/with-redefs [common-graph/get-default-graphs-dir (fn [] graphs-dir)
+                          cli-server/stop-server! (fn [_config _repo _opts]
+                                                    (p/resolved {:ok? false
                                                                  :error {:code :server-stop-timeout
                                                                          :message "timed out stopping server"}}))]
-            (db-worker/delete-repo! manager repo))
+            (p/let [_ (db-worker/ensure-started! manager repo :window-1)
+                    _ (reset! state-before-delete @(:state manager))]
+              (db-worker/delete-repo! manager repo)))
           (p/then (fn [_]
                     (is false "delete-repo! should fail closed when stop fails")))
           (p/catch (fn [e]
                      (is (= :server-stop-timeout (:code (ex-data e))))
                      (is (fs/existsSync graph-path)
-                         "Live graph dir must not be moved if the worker could not be stopped")))
+                         "Live graph dir must not be moved if the worker could not be stopped")
+                     (is (= @state-before-delete @(:state manager))
+                         "Desktop must keep tracking the runtime when deletion aborts")))
           (p/finally (fn [] (done)))))))

--- a/src/test/electron/db_worker_manager_test.cljs
+++ b/src/test/electron/db_worker_manager_test.cljs
@@ -1,7 +1,12 @@
 (ns electron.db-worker-manager-test
-  (:require [cljs.test :refer [async deftest is]]
+  (:require ["fs-extra" :as fs]
+            ["path" :as node-path]
+            [cljs.test :refer [async deftest is]]
             [electron.db-worker :as db-worker]
+            [frontend.test.node-helper :as node-helper]
             [logseq.cli.server :as cli-server]
+            [logseq.common.config :as common-config]
+            [logseq.common.graph :as common-graph]
             [promesa.core :as p]))
 
 (defn- runtime
@@ -319,3 +324,96 @@
           (p/catch (fn [e]
                      (is false (str "unexpected error: " e))))
           (p/finally (fn [] (done)))))))
+
+(deftest delete-repo-stops-unowned-runtime-then-unlinks
+  (async done
+    (let [graphs-dir (node-helper/create-tmp-dir "delete-repo-unowned")
+          repo "logseq_db_demo"
+          graph-path (node-path/join graphs-dir "demo")
+          unlinked-path (node-path/join graphs-dir common-config/unlinked-graphs-dir "demo")
+          daemon-stop-calls (atom [])
+          server-stop-calls (atom [])
+          manager (db-worker/create-manager
+                   {:start-daemon! (fn [repo]
+                                     (p/resolved (assoc (runtime repo) :owned? false)))
+                    :stop-daemon! (fn [rt]
+                                    (swap! daemon-stop-calls conj (:repo rt))
+                                    (p/resolved true))})]
+      (fs/mkdirSync graph-path #js {:recursive true})
+      (fs/writeFileSync (node-path/join graph-path "db.sqlite") "data")
+      (fs/writeFileSync (node-path/join graph-path "db-worker.lock") "{\"pid\":4242}")
+      (-> (p/with-redefs [common-graph/get-default-graphs-dir (fn [] graphs-dir)
+                          cli-server/stop-server! (fn [config repo opts]
+                                                    (swap! server-stop-calls conj {:config config
+                                                                                   :repo repo
+                                                                                   :opts opts})
+                                                    (p/resolved {:ok? true}))]
+            (p/let [_ (db-worker/ensure-started! manager repo :window-1)
+                    unlinked (db-worker/delete-repo! manager repo)
+                    state @(:state manager)]
+              (is (empty? @daemon-stop-calls)
+                  "Window-scoped skip of CLI-owned runtimes should still apply")
+              (is (= 1 (count @server-stop-calls)))
+              (is (= repo (:repo (first @server-stop-calls))))
+              (is (= :electron (get-in (first @server-stop-calls) [:config :owner-source])))
+              (is (true? (get-in (first @server-stop-calls) [:opts :allow-cross-owner?])))
+              (is (= unlinked-path unlinked))
+              (is (not (fs/existsSync graph-path)))
+              (is (fs/existsSync (node-path/join unlinked-path "db.sqlite")))
+              (is (nil? (get-in state [:repos repo])))
+              (is (nil? (get-in state [:window->repo :window-1])))))
+          (p/catch (fn [e]
+                     (is false (str "unexpected error: " e))))
+          (p/finally (fn [] (done)))))))
+
+(deftest delete-repo-stops-published-server-even-when-desktop-never-attached
+  (async done
+    (let [graphs-dir (node-helper/create-tmp-dir "delete-repo-unattached")
+          repo "logseq_db_demo"
+          graph-path (node-path/join graphs-dir "demo")
+          server-stop-calls (atom [])
+          manager (db-worker/create-manager
+                   {:start-daemon! (fn [repo] (p/resolved (runtime repo)))
+                    :stop-daemon! (fn [_] (p/resolved true))})]
+      (fs/mkdirSync graph-path #js {:recursive true})
+      (fs/writeFileSync (node-path/join graph-path "db.sqlite") "data")
+      (-> (p/with-redefs [common-graph/get-default-graphs-dir (fn [] graphs-dir)
+                          cli-server/stop-server! (fn [_config repo opts]
+                                                    (swap! server-stop-calls conj {:repo repo
+                                                                                   :opts opts})
+                                                    (p/resolved {:ok? true}))]
+            (p/let [_ (db-worker/delete-repo! manager repo)]
+              (is (= [{:repo repo :opts {:allow-cross-owner? true}}]
+                     @server-stop-calls))
+              (is (not (fs/existsSync graph-path)))
+              (is (fs/existsSync (node-path/join graphs-dir
+                                                 common-config/unlinked-graphs-dir
+                                                 "demo"
+                                                 "db.sqlite")))))
+          (p/catch (fn [e]
+                     (is false (str "unexpected error: " e))))
+          (p/finally (fn [] (done)))))))
+
+(deftest delete-repo-does-not-unlink-when-force-stop-fails
+  (async done
+    (let [graphs-dir (node-helper/create-tmp-dir "delete-repo-stop-failed")
+          repo "logseq_db_demo"
+          graph-path (node-path/join graphs-dir "demo")
+          manager (db-worker/create-manager
+                   {:start-daemon! (fn [repo] (p/resolved (runtime repo)))
+                    :stop-daemon! (fn [_] (p/resolved true))})]
+      (fs/mkdirSync graph-path #js {:recursive true})
+      (fs/writeFileSync (node-path/join graph-path "db.sqlite") "data")
+      (-> (p/with-redefs [common-graph/get-default-graphs-dir (fn [] graphs-dir)
+                          cli-server/stop-server! (fn [_config _repo _opts]
+                                                    (p/resolved {:ok? false
+                                                                 :error {:code :server-stop-timeout
+                                                                         :message "timed out stopping server"}}))]
+            (db-worker/delete-repo! manager repo))
+          (p/then (fn [_]
+                    (is false "delete-repo! should fail closed when stop fails")))
+          (p/catch (fn [e]
+                     (is (= :server-stop-timeout (:code (ex-data e))))
+                     (is (fs/existsSync graph-path)
+                         "Live graph dir must not be moved if the worker could not be stopped")))
+          (p/finally (fn [] (done))))))))

--- a/src/test/electron/db_worker_manager_test.cljs
+++ b/src/test/electron/db_worker_manager_test.cljs
@@ -416,4 +416,4 @@
                      (is (= :server-stop-timeout (:code (ex-data e))))
                      (is (fs/existsSync graph-path)
                          "Live graph dir must not be moved if the worker could not be stopped")))
-          (p/finally (fn [] (done))))))))
+          (p/finally (fn [] (done)))))))

--- a/src/test/frontend/worker/db_worker_node_lock_test.cljs
+++ b/src/test/frontend/worker/db_worker_node_lock_test.cljs
@@ -114,3 +114,36 @@
           (p/finally (fn []
                        (db-lock/remove-lock! path)
                        (done)))))))
+
+(deftest remove-owned-lock-deletes-matching-identity
+  (let [root-dir (node-helper/create-tmp-dir "db-worker-node-lock-owned")
+        repo (str "logseq_db_lock_owned_" (subs (str (random-uuid)) 0 8))
+        path (db-lock/lock-path root-dir repo)
+        lock {:repo repo
+              :pid 4242
+              :lock-id "owned-lock"
+              :owner-source :cli}]
+    (fs/mkdirSync (node-path/dirname path) #js {:recursive true})
+    (fs/writeFileSync path (js/JSON.stringify (clj->js lock)))
+    (db-lock/remove-owned-lock! path lock)
+    (is (not (fs/existsSync path)))))
+
+(deftest remove-owned-lock-keeps-mismatched-pid-or-lock-id
+  (let [root-dir (node-helper/create-tmp-dir "db-worker-node-lock-owned-mismatch")
+        repo (str "logseq_db_lock_owned_mismatch_" (subs (str (random-uuid)) 0 8))
+        path (db-lock/lock-path root-dir repo)
+        current {:repo repo
+                 :pid 4242
+                 :lock-id "new-lock"
+                 :owner-source :electron}]
+    (fs/mkdirSync (node-path/dirname path) #js {:recursive true})
+    (fs/writeFileSync path (js/JSON.stringify (clj->js current)))
+    (db-lock/remove-owned-lock! path {:repo repo
+                                      :pid 1111
+                                      :lock-id "old-lock"})
+    (is (fs/existsSync path))
+    (db-lock/remove-owned-lock! path {:repo repo
+                                      :pid 4242
+                                      :lock-id "old-lock"})
+    (is (fs/existsSync path))
+    (is (= "new-lock" (:lock-id (db-lock/read-lock path))))))

--- a/src/test/logseq/cli/command/graph_test.cljs
+++ b/src/test/logseq/cli/command/graph_test.cljs
@@ -533,3 +533,28 @@
                (p/catch (fn [e]
                           (is false (str "unexpected error: " e))))
                (p/finally done)))))
+
+(deftest test-execute-graph-remove-does-not-unlink-when-worker-is-live
+  (async done
+         (let [root-dir (node-helper/create-tmp-dir "cli-graph-remove-live-worker")
+               graphs-dir (cli-server/graphs-dir {:root-dir root-dir})
+               repo "logseq_db_demo"
+               graph-path (node-path/join graphs-dir "demo")]
+           (fs/mkdirSync graph-path #js {:recursive true})
+           (fs/writeFileSync (node-path/join graph-path "db.sqlite") "data")
+           (-> (p/with-redefs [cli-server/stop-server!
+                               (fn [_config _repo _opts]
+                                 (p/resolved {:ok? false
+                                              :error {:code :server-stop-timeout
+                                                      :message "server process is alive but not reachable"}}))]
+                 (graph-command/execute-graph-remove
+                  {:type :graph-remove
+                   :repo repo
+                   :graph "demo"}
+                  {:root-dir root-dir}))
+               (p/then (fn [_]
+                         (is false "graph remove should fail while the worker is alive")))
+               (p/catch (fn [error]
+                          (is (= :server-stop-timeout (:code (ex-data error))))
+                          (is (fs/existsSync graph-path))))
+               (p/finally done)))))

--- a/src/test/logseq/cli/command/graph_test.cljs
+++ b/src/test/logseq/cli/command/graph_test.cljs
@@ -500,3 +500,36 @@
                (p/catch (fn [e]
                           (is false (str "unexpected error: " e))))
                (p/finally done)))))
+
+(deftest test-execute-graph-remove-stops-cross-owner-runtime-then-unlinks
+  (async done
+         (let [root-dir (node-helper/create-tmp-dir "cli-graph-remove-force-stop")
+               graphs-dir (cli-server/graphs-dir {:root-dir root-dir})
+               repo "logseq_db_demo"
+               graph-path (node-path/join graphs-dir "demo")
+               stop-calls (atom [])]
+           (fs/mkdirSync graph-path #js {:recursive true})
+           (fs/writeFileSync (node-path/join graph-path "db.sqlite") "data")
+           (-> (p/with-redefs [cli-server/stop-server! (fn [config repo opts]
+                                                         (swap! stop-calls conj {:config config
+                                                                                 :repo repo
+                                                                                 :opts opts})
+                                                         (p/resolved {:ok? true}))]
+                 (p/let [result (graph-command/execute-graph-remove
+                                 {:type :graph-remove
+                                  :repo repo
+                                  :graph "demo"}
+                                 {:root-dir root-dir})]
+                   (is (= :ok (:status result)))
+                   (is (= [{:config {:root-dir root-dir}
+                            :repo repo
+                            :opts {:allow-cross-owner? true}}]
+                          @stop-calls))
+                   (is (not (fs/existsSync graph-path)))
+                   (is (fs/existsSync (node-path/join graphs-dir
+                                                      "Unlinked graphs"
+                                                      "demo"
+                                                      "db.sqlite")))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))

--- a/src/test/logseq/cli/server_test.cljs
+++ b/src/test/logseq/cli/server_test.cljs
@@ -1244,6 +1244,39 @@
                           (is false (str "unexpected error: " e))))
                (p/finally done)))))
 
+(deftest stop-server-accepts-removed-lock-while-process-exits
+  (async done
+         (let [root-dir (node-helper/create-tmp-dir "cli-server-graceful-stop")
+               repo (str "logseq_db_graceful_stop_" (subs (str (random-uuid)) 0 8))
+               lock-file (cli-server/lock-path root-dir repo)
+               server {:repo repo
+                       :host "127.0.0.1"
+                       :port 9104
+                       :pid 424242
+                       :owner-source :cli
+                       :status :ready
+                       :root-dir root-dir}]
+           (fs/mkdirSync (node-path/dirname lock-file) #js {:recursive true})
+           (fs/writeFileSync lock-file
+                             (js/JSON.stringify
+                              (clj->js (select-keys server [:repo :host :port :pid :owner-source]))))
+           (-> (p/with-redefs [cli-server/discover-servers (fn [_] (p/resolved [server]))
+                               daemon/http-request (fn [_]
+                                                     (fs/unlinkSync lock-file)
+                                                     (p/resolved {:status 200 :body ""}))
+                               daemon/pid-status (fn [_] :no-permission)
+                               daemon/wait-for (fn [pred-fn _]
+                                                 (p/let [stopped? (pred-fn)]
+                                                   (if stopped?
+                                                     true
+                                                     (p/rejected (js/Error. "not stopped")))))]
+                 (cli-server/stop-server! {:root-dir root-dir} repo))
+               (p/then (fn [result]
+                         (is (true? (:ok? result)))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
 (deftest stop-server-stops-discovered-server-when-canonical-lock-missing
   (async done
          (let [root-dir (node-helper/create-tmp-dir "cli-server-missing-lock-stop")
@@ -1278,6 +1311,82 @@
                                          (.toString (fs/readFileSync server-list-file) "utf8"))
                                        "")
                                    "424242 9104")))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
+(deftest stop-server-denies-cross-owner-with-missing-lock
+  (async done
+         (let [root-dir (node-helper/create-tmp-dir "cli-server-missing-lock-owner")
+               repo (str "logseq_db_missing_lock_owner_" (subs (str (random-uuid)) 0 8))
+               server {:repo repo
+                       :host "127.0.0.1"
+                       :port 9105
+                       :pid 424242
+                       :owner-source :cli
+                       :status :ready
+                       :root-dir root-dir}]
+           (-> (p/with-redefs [cli-server/discover-servers (fn [_] (p/resolved [server]))]
+                 (cli-server/stop-server! {:root-dir root-dir
+                                           :owner-source :electron}
+                                          repo))
+               (p/then (fn [result]
+                         (is (false? (:ok? result)))
+                         (is (= :server-owned-by-other
+                                (get-in result [:error :code])))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
+(deftest stop-server-times-out-when-shutdown-and-sigterm-do-not-stop-worker
+  (async done
+         (let [root-dir (node-helper/create-tmp-dir "cli-server-stop-timeout")
+               repo (str "logseq_db_stop_timeout_" (subs (str (random-uuid)) 0 8))
+               lock-file (cli-server/lock-path root-dir repo)
+               server {:repo repo
+                       :host "127.0.0.1"
+                       :port 9106
+                       :pid (.-pid js/process)
+                       :owner-source :cli
+                       :status :ready
+                       :root-dir root-dir}]
+           (fs/mkdirSync (node-path/dirname lock-file) #js {:recursive true})
+           (fs/writeFileSync lock-file
+                             (js/JSON.stringify
+                              (clj->js (select-keys server [:repo :host :port :pid :owner-source]))))
+           (-> (p/with-redefs [cli-server/discover-servers (fn [_] (p/resolved [server]))
+                               daemon/http-request (fn [_]
+                                                     (p/rejected (js/Error. "shutdown failed")))
+                               daemon/wait-for (fn [_ _]
+                                                 (p/rejected (js/Error. "not stopped")))]
+                 (cli-server/stop-server! {:root-dir root-dir} repo))
+               (p/then (fn [result]
+                         (is (false? (:ok? result)))
+                         (is (= :server-stop-timeout
+                                (get-in result [:error :code])))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
+(deftest stop-server-fails-closed-for-live-undiscoverable-lock
+  (async done
+         (let [root-dir (node-helper/create-tmp-dir "cli-server-undiscoverable")
+               repo (str "logseq_db_undiscoverable_" (subs (str (random-uuid)) 0 8))
+               lock-file (cli-server/lock-path root-dir repo)
+               lock {:repo repo
+                     :host "127.0.0.1"
+                     :port 9105
+                     :pid 424242
+                     :owner-source :cli}]
+           (fs/mkdirSync (node-path/dirname lock-file) #js {:recursive true})
+           (fs/writeFileSync lock-file (js/JSON.stringify (clj->js lock)))
+           (-> (p/with-redefs [cli-server/discover-servers (fn [_] (p/resolved []))
+                               daemon/pid-status (fn [_] :alive)]
+                 (cli-server/stop-server! {:root-dir root-dir} repo))
+               (p/then (fn [result]
+                         (is (false? (:ok? result)))
+                         (is (= :server-stop-timeout
+                                (get-in result [:error :code])))))
                (p/catch (fn [e]
                           (is false (str "unexpected error: " e))))
                (p/finally done)))))
@@ -1335,9 +1444,42 @@
                          (is (= 1 (count @stop-calls)))
                          (is (= repo (:repo (first @stop-calls))))
                          (is (true? (get-in (first @stop-calls) [:opts :allow-cross-owner?])))
+                         (is (= orphan (get-in (first @stop-calls) [:opts :target-server])))
                          (is (= 1 @spawn-calls))
                          (is (= "http://127.0.0.1:9411" (:base-url config)))
                          (is (true? (:owned? config)))))
                (p/catch (fn [e]
                           (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
+(deftest ensure-server-does-not-spawn-when-orphan-stop-fails
+  (async done
+         (let [root-dir (node-helper/create-tmp-dir "cli-server-orphan-stop-failed")
+               repo (str "logseq_db_orphan_stop_failed_" (subs (str (random-uuid)) 0 8))
+               spawn-calls (atom 0)
+               orphan {:repo repo
+                       :host "127.0.0.1"
+                       :port 9412
+                       :pid 94121
+                       :owner-source :cli
+                       :revision (version/revision)
+                       :status :ready}]
+           (-> (p/with-redefs [daemon/read-lock (fn [_] nil)
+                               daemon/cleanup-stale-lock! (fn [_ _] (p/resolved nil))
+                               cli-server/discover-servers (fn [_] (p/resolved [orphan]))
+                               cli-server/stop-server! (fn [_config _repo _opts]
+                                                         (p/resolved {:ok? false
+                                                                      :error {:code :server-stop-timeout
+                                                                              :message "timed out stopping server"}}))
+                               daemon/spawn-server! (fn [_]
+                                                      (swap! spawn-calls inc)
+                                                      nil)]
+                 (cli-server/ensure-server! {:root-dir root-dir
+                                             :owner-source :electron}
+                                            repo))
+               (p/then (fn [_]
+                         (is false "ensure-server! should reject when orphan stop fails")))
+               (p/catch (fn [error]
+                          (is (= :server-start-failed (:code (ex-data error))))
+                          (is (zero? @spawn-calls))))
                (p/finally done)))))

--- a/src/test/logseq/cli/server_test.cljs
+++ b/src/test/logseq/cli/server_test.cljs
@@ -647,12 +647,9 @@
                      :host "127.0.0.1"
                      :port 9301
                      :owner-source :cli}
-               read-lock-calls (atom 0)
                discover-calls (atom 0)]
            (-> (p/with-redefs [daemon/read-lock (fn [_]
-                                                  (if (= 1 (swap! read-lock-calls inc))
-                                                    nil
-                                                    lock))
+                                                  (when @captured lock))
                                daemon/cleanup-stale-lock! (fn [_ _] (p/resolved nil))
                                daemon/spawn-server! (fn [opts]
                                                       (reset! captured opts)
@@ -688,7 +685,7 @@
          (let [root-dir (node-helper/create-tmp-dir "cli-server-profile")
                repo (str "logseq_db_profile_" (subs (str (random-uuid)) 0 8))
                session (profile/create-session true)
-               read-lock-calls (atom 0)
+               spawned? (atom false)
                discover-calls (atom 0)
                lock {:repo repo
                      :pid (.-pid js/process)
@@ -696,11 +693,11 @@
                      :port 9310
                      :owner-source :cli}]
            (-> (p/with-redefs [daemon/read-lock (fn [_]
-                                                  (if (= 1 (swap! read-lock-calls inc))
-                                                    nil
-                                                    lock))
+                                                  (when @spawned? lock))
                                daemon/cleanup-stale-lock! (fn [_ _] (p/resolved nil))
-                               daemon/spawn-server! (fn [_] nil)
+                               daemon/spawn-server! (fn [_]
+                                                      (reset! spawned? true)
+                                                      nil)
                                daemon/wait-for-lock (fn [_] (p/resolved true))
                                cli-server/discover-servers (fn [_]
                                                             (p/resolved (if (= 1 (swap! discover-calls inc))
@@ -953,7 +950,7 @@
                lock-file (cli-server/lock-path root-dir-b repo)
                request* (atom nil)
                lock {:repo repo
-                     :pid (.-pid js/process)
+                     :pid 4002
                      :lock-id "stop-lock"
                      :owner-source :cli}]
            (fs/mkdirSync (node-path/dirname lock-file) #js {:recursive true})
@@ -1397,7 +1394,6 @@
                repo (str "logseq_db_orphan_lock_" (subs (str (random-uuid)) 0 8))
                stop-calls (atom [])
                spawn-calls (atom 0)
-               read-lock-calls (atom 0)
                discover-calls (atom 0)
                lock {:repo repo
                      :pid (.-pid js/process)
@@ -1418,8 +1414,7 @@
                         :revision (version/revision)
                         :status :ready}]
            (-> (p/with-redefs [daemon/read-lock (fn [_]
-                                                  (if (= 1 (swap! read-lock-calls inc))
-                                                    nil
+                                                  (when (pos? @spawn-calls)
                                                     lock))
                                daemon/cleanup-stale-lock! (fn [_ _] (p/resolved nil))
                                cli-server/stop-server! (fn [config repo opts]
@@ -1482,4 +1477,164 @@
                (p/catch (fn [error]
                           (is (= :server-start-failed (:code (ex-data error))))
                           (is (zero? @spawn-calls))))
+               (p/finally done)))))
+
+(deftest ensure-server-recovers-orphan-after-cleanup-deletes-lock
+  (async done
+         (let [root-dir (node-helper/create-tmp-dir "cli-server-cleanup-orphan")
+               repo (str "logseq_db_cleanup_orphan_" (subs (str (random-uuid)) 0 8))
+               lock-file (cli-server/lock-path root-dir repo)
+               stop-calls (atom [])
+               spawn-calls (atom 0)
+               discover-calls (atom 0)
+               started-lock {:repo repo
+                             :pid (.-pid js/process)
+                             :lock-id "started-lock"
+                             :owner-source :electron}
+               orphan {:repo repo
+                       :host "127.0.0.1"
+                       :port 9413
+                       :pid 94131
+                       :owner-source :cli
+                       :revision (version/revision)
+                       :status :ready}
+               started {:repo repo
+                        :host "127.0.0.1"
+                        :port 9414
+                        :pid (.-pid js/process)
+                        :owner-source :electron
+                        :revision (version/revision)
+                        :status :ready}]
+           (fs/mkdirSync (node-path/dirname lock-file) #js {:recursive true})
+           (fs/writeFileSync lock-file
+                             (js/JSON.stringify
+                              (clj->js {:repo repo
+                                        :pid (.-pid js/process)
+                                        :owner-source :cli})))
+           (-> (p/with-redefs [cli-server/stop-server! (fn [config repo opts]
+                                                         (swap! stop-calls conj {:config config
+                                                                                 :repo repo
+                                                                                 :opts opts})
+                                                         (p/resolved {:ok? true}))
+                               daemon/spawn-server! (fn [_]
+                                                      (swap! spawn-calls inc)
+                                                      (fs/writeFileSync lock-file (js/JSON.stringify (clj->js started-lock)))
+                                                      nil)
+                               daemon/wait-for-lock (fn [_] (p/resolved true))
+                               cli-server/discover-servers (fn [_]
+                                                            (p/resolved
+                                                             (if (= 1 (swap! discover-calls inc))
+                                                               [orphan]
+                                                               [started])))
+                               daemon/wait-for-ready (fn [_] (p/resolved true))]
+                 (cli-server/ensure-server! {:root-dir root-dir
+                                             :owner-source :electron}
+                                            repo))
+               (p/then (fn [config]
+                         (is (= 1 (count @stop-calls)))
+                         (is (= orphan (get-in (first @stop-calls) [:opts :target-server])))
+                         (is (= 1 @spawn-calls))
+                         (is (= "http://127.0.0.1:9414" (:base-url config)))
+                         (is (true? (:owned? config)))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
+(deftest ensure-server-rediscovers-when-replacement-lock-appears-before-orphan-stop
+  (async done
+         (let [root-dir (node-helper/create-tmp-dir "cli-server-orphan-replacement")
+               repo (str "logseq_db_orphan_replacement_" (subs (str (random-uuid)) 0 8))
+               lock-file (cli-server/lock-path root-dir repo)
+               stop-calls (atom [])
+               spawn-calls (atom 0)
+               discover-calls (atom 0)
+               shutdown-calls (atom 0)
+               replacement-lock {:repo repo
+                                 :pid (.-pid js/process)
+                                 :lock-id "replacement-lock"
+                                 :owner-source :electron}
+               orphan {:repo repo
+                       :host "127.0.0.1"
+                       :port 9415
+                       :pid 94151
+                       :owner-source :cli
+                       :revision (version/revision)
+                       :status :ready}
+               started {:repo repo
+                        :host "127.0.0.1"
+                        :port 9416
+                        :pid (.-pid js/process)
+                        :owner-source :electron
+                        :revision (version/revision)
+                        :status :ready}]
+           (-> (p/with-redefs [cli-server/discover-servers (fn [_]
+                                                            (let [n (swap! discover-calls inc)]
+                                                              (when (= 1 n)
+                                                                (fs/mkdirSync (node-path/dirname lock-file) #js {:recursive true})
+                                                                (fs/writeFileSync lock-file (js/JSON.stringify (clj->js replacement-lock))))
+                                                              (p/resolved (if (= 1 n) [orphan] [started]))))
+                               daemon/spawn-server! (fn [_]
+                                                      (swap! spawn-calls inc)
+                                                      nil)
+                               daemon/http-request (fn [opts]
+                                                     (swap! shutdown-calls inc)
+                                                     (swap! stop-calls conj opts)
+                                                     (p/resolved {:status 200 :body ""}))
+                               daemon/wait-for-ready (fn [_] (p/resolved true))]
+                 (cli-server/ensure-server! {:root-dir root-dir
+                                             :owner-source :electron}
+                                            repo))
+               (p/then (fn [config]
+                         (is (zero? @spawn-calls))
+                         (is (zero? @shutdown-calls))
+                         (is (fs/existsSync lock-file))
+                         (is (= "replacement-lock"
+                                (:lock-id (daemon/read-lock lock-file))))
+                         (is (= "http://127.0.0.1:9416" (:base-url config)))
+                         (is (true? (:owned? config)))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
+(deftest stop-server-does-not-delete-replacement-lock-created-during-shutdown
+  (async done
+         (let [root-dir (node-helper/create-tmp-dir "cli-server-stop-replacement")
+               repo (str "logseq_db_stop_replacement_" (subs (str (random-uuid)) 0 8))
+               lock-file (cli-server/lock-path root-dir repo)
+               replacement-lock {:repo repo
+                                 :pid (.-pid js/process)
+                                 :lock-id "replacement-during-stop"
+                                 :owner-source :electron}
+               orphan {:repo repo
+                       :host "127.0.0.1"
+                       :port 9417
+                       :pid 94171
+                       :owner-source :cli
+                       :status :ready
+                       :root-dir root-dir}]
+           (-> (p/with-redefs [cli-server/discover-servers (fn [_] (p/resolved [orphan]))
+                               daemon/http-request (fn [_]
+                                                     (fs/mkdirSync (node-path/dirname lock-file) #js {:recursive true})
+                                                     (fs/writeFileSync lock-file (js/JSON.stringify (clj->js replacement-lock)))
+                                                     (p/resolved {:status 200 :body ""}))
+                               daemon/pid-status (fn [pid]
+                                                   (if (= pid (:pid orphan))
+                                                     :not-found
+                                                     :alive))
+                               daemon/wait-for (fn [pred-fn _]
+                                                 (p/let [stopped? (pred-fn)]
+                                                   (if stopped?
+                                                     true
+                                                     (p/rejected (js/Error. "not stopped")))))]
+                 (cli-server/stop-server! {:root-dir root-dir
+                                           :owner-source :electron}
+                                          repo
+                                          {:allow-cross-owner? true}))
+               (p/then (fn [result]
+                         (is (true? (:ok? result)))
+                         (is (fs/existsSync lock-file))
+                         (is (= "replacement-during-stop"
+                                (:lock-id (daemon/read-lock lock-file))))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
                (p/finally done)))))

--- a/src/test/logseq/cli/server_test.cljs
+++ b/src/test/logseq/cli/server_test.cljs
@@ -1545,7 +1545,6 @@
          (let [root-dir (node-helper/create-tmp-dir "cli-server-orphan-replacement")
                repo (str "logseq_db_orphan_replacement_" (subs (str (random-uuid)) 0 8))
                lock-file (cli-server/lock-path root-dir repo)
-               stop-calls (atom [])
                spawn-calls (atom 0)
                discover-calls (atom 0)
                shutdown-calls (atom 0)
@@ -1576,9 +1575,8 @@
                                daemon/spawn-server! (fn [_]
                                                       (swap! spawn-calls inc)
                                                       nil)
-                               daemon/http-request (fn [opts]
+                               daemon/http-request (fn [_]
                                                      (swap! shutdown-calls inc)
-                                                     (swap! stop-calls conj opts)
                                                      (p/resolved {:status 200 :body ""}))
                                daemon/wait-for-ready (fn [_] (p/resolved true))]
                  (cli-server/ensure-server! {:root-dir root-dir

--- a/src/test/logseq/cli/server_test.cljs
+++ b/src/test/logseq/cli/server_test.cljs
@@ -1204,3 +1204,140 @@
         (is (= "yy y" (:legacy-graph-name legacy-item)))
         (is (= "yy y" (:target-graph-dir legacy-item)))
         (is (= true (:conflict? legacy-item)))))))
+
+(deftest stop-server-allows-cross-owner-when-requested
+  (async done
+         (let [root-dir (node-helper/create-tmp-dir "cli-server-force-stop")
+               repo (str "logseq_db_force_stop_" (subs (str (random-uuid)) 0 8))
+               lock-file (cli-server/lock-path root-dir repo)
+               request* (atom nil)
+               lock {:repo repo
+                     :pid (.-pid js/process)
+                     :host "127.0.0.1"
+                     :port 9103
+                     :owner-source :cli}]
+           (fs/mkdirSync (node-path/dirname lock-file) #js {:recursive true})
+           (fs/writeFileSync lock-file (js/JSON.stringify (clj->js lock)))
+           (-> (p/with-redefs [cli-server/discover-servers (fn [_]
+                                                            (p/resolved [{:repo repo
+                                                                          :host "127.0.0.1"
+                                                                          :port 9103
+                                                                          :pid (.-pid js/process)
+                                                                          :owner-source :cli
+                                                                          :revision nil
+                                                                          :status :ready
+                                                                          :root-dir root-dir}]))
+                               daemon/http-request (fn [opts]
+                                                     (reset! request* opts)
+                                                     (p/resolved {:status 200 :body ""}))
+                               daemon/wait-for (fn [_ _] (p/resolved true))
+                               daemon/pid-status (fn [_] :not-found)]
+                 (cli-server/stop-server! {:root-dir root-dir
+                                           :owner-source :electron}
+                                          repo
+                                          {:allow-cross-owner? true}))
+               (p/then (fn [result]
+                         (is (= true (:ok? result)))
+                         (is (= "/v1/shutdown" (:path @request*)))
+                         (is (= 9103 (:port @request*)))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
+(deftest stop-server-stops-discovered-server-when-canonical-lock-missing
+  (async done
+         (let [root-dir (node-helper/create-tmp-dir "cli-server-missing-lock-stop")
+               repo (str "logseq_db_missing_lock_stop_" (subs (str (random-uuid)) 0 8))
+               request* (atom nil)
+               server-list-file (cli-config/server-list-path root-dir)]
+           (fs/writeFileSync server-list-file "424242 9104\n")
+           (-> (p/with-redefs [cli-server/discover-servers (fn [_]
+                                                            (p/resolved [{:repo repo
+                                                                          :host "127.0.0.1"
+                                                                          :port 9104
+                                                                          :pid 424242
+                                                                          :owner-source :cli
+                                                                          :revision nil
+                                                                          :status :ready
+                                                                          :root-dir root-dir}]))
+                               daemon/http-request (fn [opts]
+                                                     (reset! request* opts)
+                                                     (p/resolved {:status 200 :body ""}))
+                               daemon/wait-for (fn [_ _] (p/resolved true))
+                               daemon/pid-status (fn [_] :not-found)]
+                 (cli-server/stop-server! {:root-dir root-dir
+                                           :owner-source :electron}
+                                          repo
+                                          {:allow-cross-owner? true}))
+               (p/then (fn [result]
+                         (is (= true (:ok? result)))
+                         (is (= "/v1/shutdown" (:path @request*)))
+                         (is (= 9104 (:port @request*)))
+                         (is (not (string/includes?
+                                   (or (when (fs/existsSync server-list-file)
+                                         (.toString (fs/readFileSync server-list-file) "utf8"))
+                                       "")
+                                   "424242 9104")))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
+(deftest ensure-server-stops-orphaned-published-server-then-spawns
+  (async done
+         (let [root-dir (node-helper/create-tmp-dir "cli-server-orphan-lock")
+               repo (str "logseq_db_orphan_lock_" (subs (str (random-uuid)) 0 8))
+               stop-calls (atom [])
+               spawn-calls (atom 0)
+               read-lock-calls (atom 0)
+               discover-calls (atom 0)
+               lock {:repo repo
+                     :pid (.-pid js/process)
+                     :lock-id "new-lock"
+                     :owner-source :electron}
+               orphan {:repo repo
+                       :host "127.0.0.1"
+                       :port 9410
+                       :pid 94101
+                       :owner-source :cli
+                       :revision (version/revision)
+                       :status :ready}
+               started {:repo repo
+                        :host "127.0.0.1"
+                        :port 9411
+                        :pid (.-pid js/process)
+                        :owner-source :electron
+                        :revision (version/revision)
+                        :status :ready}]
+           (-> (p/with-redefs [daemon/read-lock (fn [_]
+                                                  (if (= 1 (swap! read-lock-calls inc))
+                                                    nil
+                                                    lock))
+                               daemon/cleanup-stale-lock! (fn [_ _] (p/resolved nil))
+                               cli-server/stop-server! (fn [config repo opts]
+                                                         (swap! stop-calls conj {:config config
+                                                                                 :repo repo
+                                                                                 :opts opts})
+                                                         (p/resolved {:ok? true}))
+                               daemon/spawn-server! (fn [_]
+                                                      (swap! spawn-calls inc)
+                                                      nil)
+                               daemon/wait-for-lock (fn [_] (p/resolved true))
+                               cli-server/discover-servers (fn [_]
+                                                            (p/resolved
+                                                             (if (= 1 (swap! discover-calls inc))
+                                                               [orphan]
+                                                               [started])))
+                               daemon/wait-for-ready (fn [_] (p/resolved true))]
+                 (cli-server/ensure-server! {:root-dir root-dir
+                                             :owner-source :electron}
+                                            repo))
+               (p/then (fn [config]
+                         (is (= 1 (count @stop-calls)))
+                         (is (= repo (:repo (first @stop-calls))))
+                         (is (true? (get-in (first @stop-calls) [:opts :allow-cross-owner?])))
+                         (is (= 1 @spawn-calls))
+                         (is (= "http://127.0.0.1:9411" (:base-url config)))
+                         (is (true? (:owned? config)))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))

--- a/src/test/logseq/db_worker/daemon_test.cljs
+++ b/src/test/logseq/db_worker/daemon_test.cljs
@@ -125,6 +125,58 @@
                      (is false (str "unexpected error: " e))
                      (done)))))))
 
+(deftest cleanup-stale-lock-does-not-remove-replacement-lock
+  (async done
+    (let [root-dir (node-helper/create-tmp-dir "db-worker-daemon-replacement")
+          repo (str "logseq_db_helper_replacement_" (subs (str (random-uuid)) 0 8))
+          path (node-path/join root-dir "db-worker.lock")
+          stale-lock {:repo repo
+                      :pid 999999999
+                      :lock-id "stale-lock"
+                      :owner-source :cli}
+          replacement-lock {:repo repo
+                            :pid (.-pid js/process)
+                            :lock-id "replacement-lock"
+                            :owner-source :electron}]
+      (fs/mkdirSync root-dir #js {:recursive true})
+      (fs/writeFileSync path (js/JSON.stringify (clj->js replacement-lock)))
+      (-> (p/let [_ (daemon/cleanup-stale-lock! path stale-lock)]
+            (is (fs/existsSync path))
+            (is (= "replacement-lock" (:lock-id (daemon/read-lock path))))
+            (done))
+          (p/catch (fn [e]
+                     (is false (str "unexpected error: " e))
+                     (done)))))))
+
+(deftest remove-owned-lock-deletes-matching-identity
+  (let [root-dir (node-helper/create-tmp-dir "db-worker-daemon-owned-lock")
+        path (node-path/join root-dir "db-worker.lock")
+        lock {:repo "logseq_db_owned"
+              :pid 4242
+              :lock-id "owned-lock"
+              :owner-source :cli}]
+    (fs/mkdirSync root-dir #js {:recursive true})
+    (fs/writeFileSync path (js/JSON.stringify (clj->js lock)))
+    (daemon/remove-owned-lock! path lock)
+    (is (not (fs/existsSync path)))))
+
+(deftest remove-owned-lock-keeps-mismatched-identity
+  (let [root-dir (node-helper/create-tmp-dir "db-worker-daemon-owned-mismatch")
+        path (node-path/join root-dir "db-worker.lock")
+        current {:repo "logseq_db_owned"
+                 :pid 4242
+                 :lock-id "new-lock"
+                 :owner-source :electron}
+        expected {:repo "logseq_db_owned"
+                  :pid 1111
+                  :lock-id "old-lock"
+                  :owner-source :cli}]
+    (fs/mkdirSync root-dir #js {:recursive true})
+    (fs/writeFileSync path (js/JSON.stringify (clj->js current)))
+    (daemon/remove-owned-lock! path expected)
+    (is (fs/existsSync path))
+    (is (= "new-lock" (:lock-id (daemon/read-lock path))))))
+
 (deftest terminate-process-uses-platform-appropriate-stop-command
   (async done
     (let [terminate-process! (fn [pid force?]


### PR DESCRIPTION
Fixes https://github.com/logseq/db-test/issues/1060

Desktop and CLI graph deletion could leave a CLI-owned db-worker published after the graph directory and canonical lock were removed. Reopening the same graph then reused an orphaned server and failed because its lock was missing.

## Changes
- Stop live db-workers across owners before deleting a graph, and abort deletion if shutdown fails.
- Recover from published workers whose canonical lock is missing by stopping the orphan before spawning a replacement.
- Match discovered workers to lock ownership and preserve replacement locks created during shutdown or stale-lock cleanup.
- Remove lock files only when their PID and lock identity still belong to the worker performing cleanup.

## Tests
- `bb dev:test -v logseq.cli.server-test` — 47 tests, 155 assertions
- `pnpm cljs:run-test -v frontend.worker.db-worker-node-lock-test` — 10 tests, 26 assertions
- `pnpm cljs:run-test -v logseq.db-worker.daemon-test` — 11 tests, 31 assertions
- `bb lint:large-vars`
- CLI E2E build preflight was attempted locally but could not build because the local opam switch lacks `melange-edn-melange` and `rrbvec`; CI will run with the configured dependencies.