### PR TITLE
fix: expose queried assets in table and gallery views

### DIFF
--- a/deps/db/src/logseq/db/common/view.cljs
+++ b/deps/db/src/logseq/db/common/view.cljs
@@ -520,7 +520,10 @@
                        (when (= 'pull (first expr))
                          (last expr))))]
     (if (and (seq properties) (not= properties ['*]))
-      properties
+      (cond-> properties
+        (and (some entity-util/asset? entities)
+             (not (some #{:logseq.property.asset/type} properties)))
+        (conj :logseq.property.asset/type))
       (distinct (mapcat keys entities)))))
 
 (defn- linked-references-page-list-view-data

--- a/deps/db/test/logseq/db/common/view_test.cljs
+++ b/deps/db/test/logseq/db/common/view_test.cljs
@@ -62,6 +62,27 @@
         titles (map (fn [id] (:block/title (d/entity @conn id))) ids)]
     (is (= ["alpha" "beta" "gamma"] titles))))
 
+(deftest get-view-data-query-assets-include-asset-type-property-test
+  (let [conn (db-test/create-conn-with-blocks
+              {:pages-and-blocks
+               [{:page {:block/title "image.png"
+                        :build/tags [:logseq.class/Asset]
+                        :build/properties {:logseq.property.asset/type "png"
+                                           :logseq.property.asset/size 1
+                                           :logseq.property.asset/checksum "checksum"}}}]})
+        asset-id (d/q '[:find ?e .
+                        :where [?e :block/title "image.png"]]
+                      @conn)
+        view-id (create-view-id conn :query-result)
+        query '[:find (pull ?b [:block/title])
+                :where [?b :logseq.property.asset/type]]
+        result (db-view/get-view-data @conn view-id
+                                      {:view-feature-type :query-result
+                                       :query query
+                                       :query-entity-ids [asset-id]})]
+    (is (= [:block/title :logseq.property.asset/type]
+           (:properties result)))))
+
 (deftest get-view-data-class-objects-sort-keeps-rows-with-missing-sort-value-test
   (let [conn (db-test/create-conn-with-blocks
               {:classes {:Topic {:block/title "Topic"}}

--- a/src/main/frontend/components/objects.cljs
+++ b/src/main/frontend/components/objects.cljs
@@ -7,7 +7,6 @@
             [frontend.handler.editor :as editor-handler]
             [frontend.state :as state]
             [logseq.db :as ldb]
-            [logseq.db.frontend.property :as db-property]
             [logseq.shui.hooks :as hooks]
             [logseq.shui.ui :as shui]
             [promesa.core :as p]
@@ -22,38 +21,16 @@
     (editor-handler/edit-block! block 0 {:container-id :unknown-container})
     block))
 
-(defn- build-asset-file-column
-  [config]
-  {:id :file
-   :name (t :file/label)
-   :type :string
-   :header views/header-cp
-   :cell (fn [_table row _column]
-           (when-let [asset-cp (state/get-component :block/asset-cp)]
-             [:div.block-content.overflow-hidden
-              {:style {:max-height 30}}
-              (asset-cp (assoc config :disable-resize? true) row)]))
-   :disable-hide? true})
-
 (defn build-class-object-columns
   [config class properties]
   (let [properties' (remove nil? properties)
         columns* (views/build-columns (assoc config :view-parent class)
                                       properties'
                                       {:add-tags-column? true
-                                       :add-page-column? true})
-        columns (cond
-                  (= (:db/ident class) :logseq.class/Pdf-annotation)
-                  (remove #(contains? #{:logseq.property/ls-type} (:id %)) columns*)
-                  (= (:db/ident class) :logseq.class/Asset)
-                  (remove #(contains? #{:logseq.property.asset/checksum} (:id %)) columns*)
-                  :else
-                  columns*)]
-    (if (= (:db/ident class) :logseq.class/Asset)
-      ;; Insert in front of tag's properties
-      (let [[before-cols after-cols] (split-with #(not (db-property/logseq-property? (:id %))) columns)]
-        (concat before-cols [(build-asset-file-column config)] after-cols))
-      columns)))
+                                       :add-page-column? true})]
+    (if (= (:db/ident class) :logseq.class/Pdf-annotation)
+      (remove #(contains? #{:logseq.property/ls-type} (:id %)) columns*)
+      columns*)))
 
 (defn build-property-object-columns
   [config property properties]

--- a/src/main/frontend/components/views.cljs
+++ b/src/main/frontend/components/views.cljs
@@ -579,7 +579,7 @@
              (when-let [page-cp (state/get-component :block/page-cp)]
                (page-cp {:disable-preview? true} page))))})
 
-(defn- property-ident
+(defn- property->ident
   [property]
   (cond
     (keyword? property) property
@@ -590,7 +590,7 @@
   [config properties]
   (or (= :logseq.class/Asset (:db/ident (:view-parent config)))
       (some (fn [property]
-              (= :logseq.property.asset/type (property-ident property)))
+              (= :logseq.property.asset/type (property->ident property)))
             properties)))
 
 (defn- asset-file-column

--- a/src/main/frontend/components/views.cljs
+++ b/src/main/frontend/components/views.cljs
@@ -579,6 +579,44 @@
              (when-let [page-cp (state/get-component :block/page-cp)]
                (page-cp {:disable-preview? true} page))))})
 
+(defn- property-ident
+  [property]
+  (cond
+    (keyword? property) property
+    (map? property) (or (:db/ident property) (:id property))
+    :else nil))
+
+(defn- include-asset-file-column?
+  [config properties]
+  (or (= :logseq.class/Asset (:db/ident (:view-parent config)))
+      (some (fn [property]
+              (= :logseq.property.asset/type (property-ident property)))
+            properties)))
+
+(defn- asset-file-column
+  [config]
+  {:id :file
+   :name (t :file/label)
+   :type :string
+   :header header-cp
+   :cell (fn [_table row _column]
+           (when (ldb/asset? row)
+             (when-let [asset-cp (state/get-component :block/asset-cp)]
+               [:div.block-content.overflow-hidden
+                {:style {:max-height 30}}
+                (asset-cp (assoc config :disable-resize? true) row)])))
+   :disable-hide? true})
+
+(defn- maybe-add-asset-file-column
+  [config properties columns]
+  (if (and (include-asset-file-column? config properties)
+           (not (some #(= :file (:id %)) columns)))
+    (let [[before-cols after-cols] (split-with #(not (and (keyword? (:id %))
+                                                          (db-property/logseq-property? (:id %))))
+                                               columns)]
+      (concat before-cols [(asset-file-column config)] after-cols))
+    columns))
+
 (defn build-columns
   [config properties & {:keys [with-object-name? with-id? add-tags-column? add-page-column? advanced-query?]
                         :or {with-object-name? true
@@ -671,7 +709,8 @@
               :cell timestamp-cell-cp})
            (when add-page-column?
              (page-column))])
-         (remove nil?))))
+         (remove nil?)
+         (maybe-add-asset-file-column config properties))))
 
 (defn sort-columns
   [columns ordered-column-ids]
@@ -2228,19 +2267,22 @@
         ->entity (fn [value]
                    (cond
                      (map? value) value
-                     :else value))]
-    (cond
-      (= :block/uuid asset-property-ident)
-      block
+                     :else value))
+        from-property (cond
+                        (= :block/uuid asset-property-ident)
+                        block
 
-      (set? asset-value)
-      (some ->entity asset-value)
+                        (set? asset-value)
+                        (some ->entity asset-value)
 
-      (sequential? asset-value)
-      (some ->entity asset-value)
+                        (sequential? asset-value)
+                        (some ->entity asset-value)
 
-      :else
-      (->entity asset-value))))
+                        :else
+                        (->entity asset-value))]
+    (or from-property
+        (when (ldb/asset? block)
+          block))))
 
 (hsx/defc gallery-card-item
   [table view-entity block config {:keys [asset-property-ident display-property-idents]}]
@@ -2860,7 +2902,9 @@
    *scroller-ref]
   (let [journals? (:journals? config)
         option (assoc option* :properties
-                      (-> (remove #{:id :select} (map :id columns))
+                      (-> (remove #{:id :select :file} (map :id columns))
+                          (cond-> (some #(= :file (:id %)) columns)
+                            (conj :logseq.property.asset/type))
                           (conj :block/uuid :block/name)
                           vec))
         visible-columns (-> (if-let [hidden-columns (:logseq.property.table/hidden-columns view-entity)]

--- a/src/test/frontend/components/views_test.cljs
+++ b/src/test/frontend/components/views_test.cljs
@@ -8,6 +8,7 @@
             [frontend.components.views :as views]
             [frontend.db.hooks :as db-hooks]
             [frontend.db.subs :as subs]
+            [frontend.state :as state]
             [frontend.util :as util]
             [goog.object :as gobj]
             [promesa.core :as p]))
@@ -213,6 +214,92 @@
                :block/uuid #uuid "11111111-1111-1111-1111-111111111111"}]
     (is (= block
            (views/gallery-card-asset-block block :block/uuid)))))
+
+(deftest gallery-card-asset-block-should-use-queried-asset-row
+  "Query / table / gallery have no type=:asset property on uploaded assets.
+   When the row itself is an Asset, treat it as the gallery media."
+  (let [asset {:db/id 193
+               :block/title "uploaded.png"
+               :block/uuid #uuid "22222222-2222-2222-2222-222222222222"
+               :logseq.property.asset/type "png"
+               :logseq.property.asset/size 1024}
+        page {:db/id 10
+              :block/title "A page"
+              :block/uuid #uuid "33333333-3333-3333-3333-333333333333"}
+        cover {:db/id 20
+               :block/title "cover.png"
+               :logseq.property.asset/type "png"}]
+    (is (= asset
+           (views/gallery-card-asset-block asset nil))
+        "A queried Asset row with no asset property still resolves to itself.")
+    (is (nil? (views/gallery-card-asset-block page nil))
+        "Non-asset query rows do not become gallery media.")
+    (is (= cover
+           (views/gallery-card-asset-block (assoc page :user.property/cover cover)
+                                           :user.property/cover))
+        "An explicit type=:asset property still wins over the row.")))
+
+(deftest gallery-asset-property-ident-still-uses-uuid-for-asset-tag-page
+  (is (= :block/uuid
+         (#'views/gallery-asset-property-ident
+          {:logseq.property/view-for {:db/ident :logseq.class/Asset}
+           :logseq.property.view/feature-type :class-objects}
+          [])))
+  (is (nil? (#'views/gallery-asset-property-ident
+             {:logseq.property.view/feature-type :query-result}
+             [{:id :logseq.property.asset/type :logseq.property/type :default}]))
+      "Query views without a type=:asset column keep the row-as-asset gallery fallback."))
+
+(deftest asset-file-column-renders-only-asset-rows
+  (let [calls (atom [])
+        columns (views/build-columns {} [:logseq.property.asset/type] {:add-tags-column? false})
+        file-column (some #(when (= :file (:id %)) %) columns)
+        asset {:logseq.property.asset/type "png" :block/title "uploaded.png"}
+        page {:block/title "A page"}]
+    (with-redefs [state/get-component
+                  (fn [k]
+                    (when (= k :block/asset-cp)
+                      (fn [config row]
+                        (swap! calls conj [config row])
+                        [:div "asset"])))]
+      ((:cell file-column) nil asset nil)
+      ((:cell file-column) nil page nil)
+      (is (= [asset] (map second @calls))
+          "The File column renders the row itself only when it is an Asset."))))
+
+(deftest build-columns-should-expose-file-column-for-assets
+  (let [asset-type-property {:db/ident :logseq.property.asset/type
+                             :block/title "Type"
+                             :logseq.property/type :default}
+        asset-size-property {:db/ident :logseq.property.asset/size
+                             :block/title "Size"
+                             :logseq.property/type :number}
+        query-columns (views/build-columns {}
+                                           [:logseq.property.asset/type
+                                            :logseq.property.asset/size
+                                            :logseq.property.asset/checksum]
+                                           {:add-tags-column? false})
+        class-columns (views/build-columns {:view-parent {:db/ident :logseq.class/Asset}}
+                                           [asset-type-property asset-size-property]
+                                           {:add-tags-column? true
+                                            :add-page-column? true})
+        other-columns (views/build-columns {}
+                                           [{:db/ident :logseq.property/status
+                                             :block/title "Status"
+                                             :logseq.property/type :default}]
+                                           {:add-tags-column? false})]
+    (is (some #(= :file (:id %)) query-columns)
+        "Query columns include File when results have Asset type/size.")
+    (is (some #(= :file (:id %)) class-columns)
+        "The #Asset tag page still exposes a File column.")
+    (is (not (some #(= :file (:id %)) other-columns))
+        "Unrelated tables do not gain a File column.")
+    (is (= :file
+           (->> class-columns
+                (drop-while #(not (contains? #{:file :logseq.property.asset/type} (:id %))))
+                first
+                :id))
+        "File is inserted before Asset class properties.")))
 
 (deftest view-row-ids-flatten-only-typed-uuid-payloads-test
   (let [row-a (random-uuid)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Uploaded Asset entities only have type/size/checksum. Query table and gallery looked for a `type=:asset` property (or `:block/uuid` only on the `#Asset` tag page), so a query that returned assets showed no image and no File column.

This treats a query/table/gallery row that is itself an Asset as the asset, matching the `#Asset` tag page:

- Gallery renders the row media when there is no `type=:asset` property
- Table adds the existing File column when results include Asset type (or the view parent is `#Asset`)
- The `#Asset` tag page still uses `:block/uuid` / File as before
- Mixed query rows that are not assets stay empty in File/gallery media

Fixes https://github.com/logseq/db-test/issues/1062
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-838e5929-5549-4117-9e82-7f69d3a1081c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-838e5929-5549-4117-9e82-7f69d3a1081c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

