### PR TITLE
fix(cli): expose recycle bin list, restore, and purge

### DIFF
--- a/cli-e2e/spec/non_sync_cases.edn
+++ b/cli-e2e/spec/non_sync_cases.edn
@@ -1177,13 +1177,109 @@
    ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json remove page --graph {{graph-arg}} --page Home"],
    :expect
    {:exit 0,
-    :stdout-json-paths {[:status] "ok", [:data :result] true}},
+    :stdout-json-paths
+    {[:status] "ok",
+     [:data :result] true,
+     [:data :recycled] true},
+    :stdout-contains ["upsert page --restore" "list recycled"]},
    :covers
    {:commands ["remove page"],
     :options
     {:global ["--config" "--graph" "--root-dir" "--output"],
      :remove ["--page"]}},
    :tags [:remove],
+   :extends :non-sync/graph-json-env}
+  {:id "remove-page-recycled-error-json",
+   :setup
+   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json upsert page --graph {{graph-arg}} --page RecycleHint >/dev/null"
+    "{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json remove page --graph {{graph-arg}} --page RecycleHint >/dev/null"],
+   :cmds
+   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json upsert page --graph {{graph-arg}} --page RecycleHint"],
+   :expect
+   {:exit 1,
+    :stdout-json-paths
+    {[:status] "error", [:error :code] "recycled-page"},
+    :stdout-contains ["upsert page --restore" "remove page --purge"]},
+   :covers
+   {:commands ["upsert page"],
+    :options
+    {:global ["--config" "--graph" "--root-dir" "--output"],
+     :upsert ["--page"]}},
+   :tags [:remove :upsert],
+   :extends :non-sync/graph-json-env}
+  {:id "list-recycled-json",
+   :setup
+   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json upsert page --graph {{graph-arg}} --page RecycleList >/dev/null"
+    "{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json remove page --graph {{graph-arg}} --page RecycleList >/dev/null"],
+   :cmds
+   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json list recycled --graph {{graph-arg}} --fields title,id --sort deleted-at --order desc --limit 20"],
+   :expect
+   {:exit 0,
+    :stdout-json-paths {[:status] "ok"},
+    :stdout-contains ["RecycleList"]},
+   :covers
+   {:commands ["list recycled"],
+    :options
+    {:global ["--config" "--graph" "--root-dir" "--output"],
+     :list ["--fields" "--sort" "--order" "--limit"]}},
+   :tags [:list :remove],
+   :extends :non-sync/graph-json-env}
+  {:id "upsert-page-restore-json",
+   :setup
+   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json upsert page --graph {{graph-arg}} --page RecycleRestore >/dev/null"
+    "{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json remove page --graph {{graph-arg}} --page RecycleRestore >/dev/null"],
+   :cmds
+   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json upsert page --graph {{graph-arg}} --page RecycleRestore --restore >/dev/null"
+    "{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json list page --graph {{graph-arg}} --fields title"],
+   :expect
+   {:exit 0,
+    :stdout-contains ["RecycleRestore"]},
+   :covers
+   {:commands ["upsert page" "list page"],
+    :options
+    {:global ["--config" "--graph" "--root-dir" "--output"],
+     :upsert ["--page" "--restore"],
+     :list ["--fields"]}},
+   :tags [:upsert :remove],
+   :extends :non-sync/graph-json-env}
+  {:id "remove-page-purge-json",
+   :setup
+   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json upsert page --graph {{graph-arg}} --page RecyclePurge >/dev/null"
+    "{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json remove page --graph {{graph-arg}} --page RecyclePurge >/dev/null"],
+   :cmds
+   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json remove page --graph {{graph-arg}} --page RecyclePurge --purge"
+    "{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json list recycled --graph {{graph-arg}} --fields title"],
+   :expect
+   {:exit 0,
+    :stdout-json-paths {[:status] "ok"},
+    :stdout-not-contains ["RecyclePurge"]},
+   :covers
+   {:commands ["remove page" "list recycled"],
+    :options
+    {:global ["--config" "--graph" "--root-dir" "--output"],
+     :remove ["--page" "--purge"],
+     :list ["--fields"]}},
+   :tags [:remove :list],
+   :extends :non-sync/graph-json-env}
+  {:id "recycled-homonym-json",
+   :setup
+   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json upsert page --graph {{graph-arg}} --page Homonym >/dev/null"
+    "{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json upsert tag --graph {{graph-arg}} --name Homonym >/dev/null"
+    "page_id=\"$({{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json query --graph {{graph-arg}} --query '[:find ?e . :where [?e :block/name \"homonym\"] (not [?e :logseq.property/deleted-at]) (not [?e :block/tags ?t] [?t :db/ident :logseq.class/Tag])]' | python3 -c 'import sys,json; print(json.load(sys.stdin)[\"data\"][\"result\"])')\"; {{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json remove page --graph {{graph-arg}} --id \"$page_id\" >/dev/null"
+    "{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json upsert page --graph {{graph-arg}} --page HomonymHost >/dev/null"],
+   :cmds
+   ["{{cli}} --root-dir {{root-dir-arg}} --config {{config-path-arg}} --output json upsert block --graph {{graph-arg}} --target-page HomonymHost --content 'link: [[Homonym]]'"],
+   :expect
+   {:exit 0,
+    :stdout-json-paths {[:status] "ok"}},
+   :covers
+   {:commands ["upsert block" "upsert tag" "query" "remove page"],
+    :options
+    {:global ["--config" "--graph" "--root-dir" "--output"],
+     :upsert ["--target-page" "--content" "--name"],
+     :query ["--query"],
+     :remove ["--id"]}},
+   :tags [:remove :upsert],
    :extends :non-sync/graph-json-env}
   {:id "graph-remove-json",
    :setup

--- a/cli-e2e/spec/non_sync_inventory.edn
+++ b/cli-e2e/spec/non_sync_inventory.edn
@@ -38,7 +38,8 @@
               "list property"
               "list task"
               "list node"
-              "list asset"]
+              "list asset"
+              "list recycled"]
    :options ["--expand"
              "--fields"
              "--limit"
@@ -91,7 +92,8 @@
              "--type"
              "--cardinality"
              "--hide"
-             "--public"]}
+             "--public"
+             "--restore"]}
 
   :remove
   {:commands ["remove block"
@@ -100,7 +102,8 @@
               "remove property"]
    :options ["--id"
              "--uuid"
-             "--name"]}
+             "--name"
+             "--purge"]}
 
   :query
   {:commands ["query"

--- a/cli/lib/add.ml
+++ b/cli/lib/add.ml
@@ -479,7 +479,29 @@ let recycled_entity value =
   Option.is_some (Edn_util.get value "logseq.property/deleted-at")
 
 let page_not_found () = Error.make Error.Page_not_found "page not found"
-let recycled_page_error () = Error.make Error.Recycled_page "page is recycled"
+
+let recycled_page_error ?name () = Error.recycled_page ?name ()
+
+let page_entities value =
+  match
+    (Edn_util.as_vector value, Edn_util.as_list value, Edn_util.as_map value)
+  with
+  | Some values, _, _ | _, Some values, _ -> values
+  | _, _, Some _ -> Vec.singleton value
+  | _ -> Vec.empty
+
+let first_page_entity values =
+  if Vec.is_empty values then None else Some (Vec.peek_front values)
+
+let choose_page_entity value =
+  let entities = page_entities value in
+  let recycled = Vec.filter recycled_entity entities in
+  let live =
+    Vec.filter (fun entity -> not (recycled_entity entity)) entities
+  in
+  match (first_page_entity live, first_page_entity recycled) with
+  | Some entity, _ -> Some entity
+  | None, entity -> entity
 
 let pull_entity config repo selector lookup =
   Transport.thread_api_pull config ~repo
@@ -591,9 +613,9 @@ let pull_created_page config repo name create_result =
 let ensure_page_entity config repo page_name =
   let open Cli_effect in
   bind (pull_pages_by_name config repo page_name page_selector) (fun result ->
-      match first_entity result with
+      match choose_page_entity result with
       | Some entity when recycled_entity entity ->
-          pure (Error (recycled_page_error ()))
+          pure (Error (recycled_page_error ~name:page_name ()))
       | Some entity -> pure (Ok entity)
       | None ->
           bind (create_page config repo page_name) (fun create_result ->

--- a/cli/lib/cli.ml
+++ b/cli/lib/cli.ml
@@ -75,7 +75,7 @@ let boolean_option = function
   | "include-built-in" | "include-journal" | "journal-only" | "include-hidden"
   | "with-properties" | "with-extends" | "with-classes" | "with-type"
   | "page-hierarchy" | "linked-references" | "ref-id-footer" | "progress"
-  | "upload-keys" ->
+  | "upload-keys" | "restore" | "purge" ->
       true
   | _ -> false
 

--- a/cli/lib/cli_parse.ml
+++ b/cli/lib/cli_parse.ml
@@ -36,7 +36,7 @@ let boolean_option = function
   | "include-built-in" | "include-journal" | "journal-only" | "include-hidden"
   | "with-properties" | "with-extends" | "with-classes" | "with-type"
   | "page-hierarchy" | "linked-references" | "ref-id-footer" | "progress"
-  | "upload-keys" | "pretty-print" ->
+  | "upload-keys" | "pretty-print" | "restore" | "purge" ->
       true
   | _ -> false
 
@@ -214,8 +214,10 @@ let allowed_options_for_path path =
   else if path2 path "list" "node" then
     Vec.append common_list_options (option_names [| "tags"; "properties" |])
   else if path2 path "list" "asset" then common_list_options
+  else if path2 path "list" "recycled" then common_list_options
   else if path2 path "remove" "block" then option_names [| "id"; "uuid" |]
-  else if path2 path "remove" "page" then option_names [| "id"; "page" |]
+  else if path2 path "remove" "page" then
+    option_names [| "id"; "page"; "purge" |]
   else if path2_any path "remove" (option_names [| "tag"; "property" |]) then
     option_names [| "id"; "name" |]
   else if path2 path "upsert" "block" then
@@ -430,6 +432,18 @@ let list_asset_sort_values =
   Vec.of_array
     [| "id"; "title"; "asset-type"; "size"; "updated-at"; "created-at" |]
 
+let list_recycled_sort_values =
+  Vec.of_array
+    [|
+      "id";
+      "title";
+      "name";
+      "uuid";
+      "deleted-at";
+      "created-at";
+      "updated-at";
+    |]
+
 let validate_list_common_values sort_values options =
   Error.bind (validate_integer_option "limit" options) (fun () ->
       Error.bind (validate_integer_option "offset" options) (fun () ->
@@ -516,6 +530,8 @@ let validate_option_values path options =
             validate_list_common_values list_node_sort_values options)
       else if path2 path "list" "asset" then
         validate_list_common_values list_asset_sort_values options
+      else if path2 path "list" "recycled" then
+        validate_list_common_values list_recycled_sort_values options
       else if path1 path "show" then validate_integer_option "level" options
       else if path1 path "completion" then
         validate_member_option "shell"
@@ -560,6 +576,7 @@ let parsed_remove_command options = function
               {
                 id = int64_option "id" options;
                 page = option_value "page" options;
+                purge = option_present "purge" options;
               }))
   | "tag" ->
       Some
@@ -756,6 +773,8 @@ let parsed_list_command options = function
                     ~default:Vec.empty;
               }))
   | "asset" -> Some (List (Parsed_asset { common = common_list_opts options }))
+  | "recycled" ->
+      Some (List (Parsed_recycled { common = common_list_opts options }))
   | _ -> None
 
 (* normalize_key resolves short aliases globally (-f -> fields, -e ->

--- a/cli/lib/command_id.ml
+++ b/cli/lib/command_id.ml
@@ -23,6 +23,7 @@ type t =
   | List_task
   | List_node
   | List_asset
+  | List_recycled
   | Search_block
   | Search_page
   | Search_property
@@ -99,6 +100,7 @@ let table =
       (List_task, "list-task", path [| "list"; "task" |]);
       (List_node, "list-node", path [| "list"; "node" |]);
       (List_asset, "list-asset", path [| "list"; "asset" |]);
+      (List_recycled, "list-recycled", path [| "list"; "recycled" |]);
       (Search_block, "search-block", path [| "search"; "block" |]);
       (Search_page, "search-page", path [| "search"; "page" |]);
       (Search_property, "search-property", path [| "search"; "property" |]);

--- a/cli/lib/command_registry.ml
+++ b/cli/lib/command_registry.ml
@@ -134,6 +134,18 @@ let list_asset_sort_choices =
   Vec.of_array
     [| "id"; "title"; "asset-type"; "size"; "created-at"; "updated-at" |]
 
+let list_recycled_sort_choices =
+  Vec.of_array
+    [|
+      "id";
+      "title";
+      "name";
+      "uuid";
+      "deleted-at";
+      "created-at";
+      "updated-at";
+    |]
+
 let search_result_header_order = Vec.of_array [| "id"; "ident"; "title" |]
 
 let human_table_headers_order_for_command = function
@@ -154,6 +166,7 @@ let human_table_headers_order_for_command = function
           "created-at";
           "updated-at";
         |]
+  | List_recycled -> list_recycled_sort_choices
   | Search_block | Search_page | Search_property | Search_tag ->
       search_result_header_order
   | _ -> Vec.empty
@@ -311,10 +324,16 @@ let options_for_command =
             ~multi:true;
         |]
   | List_asset -> common_list_options list_asset_sort_choices
+  | List_recycled -> common_list_options list_recycled_sort_choices
   | Remove_block -> selector_options
   | Remove_page ->
       Vec.of_array
-        [| value "id" "id" "Page id"; value "page" "page" "Page name" |]
+        [|
+          value "id" "id" "Page id";
+          value "page" "page" "Page name";
+          flag "purge"
+            "Permanently delete a recycled page instead of moving it to Recycle";
+        |]
   | Remove_tag | Remove_property ->
       Vec.of_array
         [| value "id" "id" "Entity id"; value "name" "name" "Entity name" |]
@@ -338,7 +357,9 @@ let options_for_command =
             [|
               value "id" "id" "Page id";
               value "page" "page" "Page name";
-              flag "restore" "Restore recycled page before updating";
+              flag "restore"
+                "Restore recycled page before updating. See also `list recycled` \
+                 and `remove page --purge`";
             |];
           property_update_options;
         |]

--- a/cli/lib/error.ml
+++ b/cli/lib/error.ml
@@ -292,6 +292,24 @@ let make ?hint ?(candidates = Vec.empty) ?context code message =
 
 let invalid_options message = make Invalid_options message
 
+let recycled_restore_command = function
+  | Some name -> "logseq upsert page --restore --page " ^ name
+  | None -> "logseq upsert page --restore --page <name>"
+
+let recycled_purge_command = function
+  | Some name -> "logseq remove page --purge --page " ^ name
+  | None -> "logseq remove page --purge --page <name>"
+
+let recycled_page_hint ?name () =
+  "Page is in Recycle. Restore with `"
+  ^ recycled_restore_command name
+  ^ "`. List recycled pages with `logseq list recycled`. Permanently delete with `"
+  ^ recycled_purge_command name
+  ^ "`."
+
+let recycled_page ?name () =
+  make ~hint:(recycled_page_hint ?name ()) Recycled_page "page is recycled"
+
 let missing_graph () =
   make ~hint:"Use --graph <name>" Missing_graph "graph name is required"
 

--- a/cli/lib/example.ml
+++ b/cli/lib/example.ml
@@ -101,6 +101,12 @@ let default_entries =
           "logseq list asset --graph my-graph --limit 20 --sort updated-at \
            --order desc";
         |];
+      entry [| "list"; "recycled" |]
+        [|
+          "logseq list recycled --graph my-graph";
+          "logseq list recycled --graph my-graph --limit 20 --sort deleted-at \
+           --order desc";
+        |];
       entry [| "upsert"; "block" |]
         [|
           "logseq upsert block --graph my-graph --target-page Home --content \
@@ -120,6 +126,7 @@ let default_entries =
            '[\"project\"]'";
           "logseq upsert page --graph my-graph --id 999 --update-properties \
            '{:logseq.property/description \"Example\"}'";
+          "logseq upsert page --graph my-graph --page Home --restore";
         |];
       entry [| "upsert"; "task" |]
         [|
@@ -163,6 +170,7 @@ let default_entries =
         [|
           "logseq remove page --graph my-graph --page Home";
           "logseq remove page --graph my-graph --id 123";
+          "logseq remove page --graph my-graph --page Home --purge";
         |];
       entry [| "remove"; "tag" |]
         [| "logseq remove tag --graph my-graph --name project" |];

--- a/cli/lib/format_types.ml
+++ b/cli/lib/format_types.ml
@@ -290,7 +290,7 @@ let truncate_title_cell max_width value =
 
 let is_list_command = function
   | Command_id.List_page | List_tag | List_property | List_task | List_node
-  | List_asset ->
+  | List_asset | List_recycled ->
       true
   | _ -> false
 

--- a/cli/lib/list_command.ml
+++ b/cli/lib/list_command.ml
@@ -49,6 +49,7 @@ type node_opts = {
 }
 
 type asset_opts = { common : common_opts }
+type recycled_opts = { common : common_opts }
 
 type parsed =
   | Parsed_page of page_opts
@@ -57,8 +58,9 @@ type parsed =
   | Parsed_task of task_opts
   | Parsed_node of node_opts
   | Parsed_asset of asset_opts
+  | Parsed_recycled of recycled_opts
 
-type kind = Page | Tag | Property | Task | Node | Asset
+type kind = Page | Tag | Property | Task | Node | Asset | Recycled
 
 type action = {
   kind : kind;
@@ -85,6 +87,7 @@ let kind_of_parsed = function
   | Parsed_task _ -> Task
   | Parsed_node _ -> Node
   | Parsed_asset _ -> Asset
+  | Parsed_recycled _ -> Recycled
 
 let normalize_priority value =
   match String.lowercase_ascii (String.trim value) with
@@ -194,6 +197,19 @@ let asset_field_map =
          ("created-at", "block/created-at");
        |])
 
+let recycled_field_map =
+  field_map
+    (Vec.of_array
+       [|
+         ("id", "db/id");
+         ("title", "block/title");
+         ("name", "block/name");
+         ("uuid", "block/uuid");
+         ("deleted-at", "logseq.property/deleted-at");
+         ("created-at", "block/created-at");
+         ("updated-at", "block/updated-at");
+       |])
+
 let field_map_of_kind = function
   | Page -> page_field_map
   | Tag -> tag_field_map
@@ -201,6 +217,7 @@ let field_map_of_kind = function
   | Task -> task_field_map
   | Node -> node_field_map
   | Asset -> asset_field_map
+  | Recycled -> recycled_field_map
 
 let value_rank value =
   match value with
@@ -286,6 +303,7 @@ let command_id = function
   | Parsed_task _ -> List_task
   | Parsed_node _ -> List_node
   | Parsed_asset _ -> List_asset
+  | Parsed_recycled _ -> List_recycled
 
 let value_of_string_list values =
   Edn_util.vector_vec (values |> Vec.map (fun value -> Edn_util.string value))
@@ -379,6 +397,42 @@ let property_selector =
          kw "db/cardinality";
          kw "logseq.property/public?";
        |])
+
+let recycled_selector =
+  vector_vec
+    (Vec.of_array
+       [|
+         kw "db/id";
+         kw "block/uuid";
+         kw "block/name";
+         kw "block/title";
+         kw "logseq.property/deleted-at";
+         kw "block/created-at";
+         kw "block/updated-at";
+       |])
+
+let recycled_query =
+  Cli_primitive.make_datascript_query
+    ~find:
+      (Vec.singleton
+         (vector_vec
+            (Vec.of_array
+               [|
+                 list_vec
+                   (Vec.of_array [| sym "pull"; sym "?e"; recycled_selector |]);
+                 sym "...";
+               |])))
+    ~where:
+      (Vec.singleton
+         (Cli_primitive.V
+            (Edn_util.vector_t_vec
+               (Vec.of_array
+                  [|
+                    sym "?e";
+                    kw "logseq.property/deleted-at";
+                    sym "?deleted-at";
+                  |]))))
+    ()
 
 let class_query selector class_ident =
   Cli_primitive.make_datascript_query
@@ -770,7 +824,7 @@ let prepare_items kind options items =
   | Page -> Vec.map prepare_page_item items
   | Tag -> Vec.map (prepare_tag_item options) items
   | Property -> Vec.map (prepare_property_item options) items
-  | Task | Node | Asset -> items
+  | Task | Node | Asset | Recycled -> items
 
 let visible_title_fields = function
   | Node ->
@@ -779,7 +833,7 @@ let visible_title_fields = function
           Edn_util.keyword_t "block/title";
           Edn_util.keyword_t "block/page-title";
         |]
-  | Page | Tag | Property | Task | Asset ->
+  | Page | Tag | Property | Task | Asset | Recycled ->
       Vec.singleton (Edn_util.keyword_t "block/title")
 
 let normalize_visible_title_fields config repo kind items =
@@ -870,6 +924,13 @@ let options_of_parsed = function
             else Some (value_of_string_list opts.properties))
       |> Edn_util.map_vec
   | Parsed_asset opts -> Edn_util.map_vec (opts.common |> common_options)
+  | Parsed_recycled opts ->
+      let common =
+        match opts.common.sort with
+        | Some _ -> opts.common
+        | None -> { opts.common with sort = Some "deleted-at" }
+      in
+      Edn_util.map_vec (common_options common)
 
 let build ?registry:_ config _globals parsed =
   Error.bind (normalize_options parsed) (fun parsed ->
@@ -930,7 +991,12 @@ let execute_with_mode action config mode =
                       ~repo:action.repo ~options
                 | Node | Asset ->
                     Transport.thread_api_cli_list_nodes invoke_config
-                      ~repo:action.repo ~options)
+                      ~repo:action.repo ~options
+                | Recycled ->
+                    Transport.thread_api_q invoke_config ~repo:action.repo
+                      ~query:
+                        (Edn_util.vector_t_vec
+                           (Vec.singleton (query_value recycled_query))))
                 (fun value ->
                   let items =
                     match
@@ -1024,6 +1090,15 @@ let metadata () =
                 updated-at --order desc";
              |])
         List_asset "List assets";
+      meta
+        ~examples:
+          (Vec.of_array
+             [|
+               "logseq list recycled --graph my-graph";
+               "logseq list recycled --graph my-graph --limit 20 --sort \
+                deleted-at --order desc";
+             |])
+        List_recycled "List recycled pages and blocks";
     |]
 
 let execute action config =

--- a/cli/lib/remove.ml
+++ b/cli/lib/remove.ml
@@ -1,5 +1,9 @@
 type block_opts = { id_raw : string option; uuid : Cli_primitive.uuid option }
-type page_opts = { id : Cli_primitive.db_id option; page : string option }
+type page_opts = {
+  id : Cli_primitive.db_id option;
+  page : string option;
+  purge : bool;
+}
 
 type named_entity_opts = {
   id : Cli_primitive.db_id option;
@@ -26,6 +30,7 @@ type action =
       graph : Cli_primitive.graph;
       id : Cli_primitive.db_id option;
       page : string option;
+      purge : bool;
     }
   | Remove_tag of {
       repo : Cli_primitive.repo;
@@ -122,9 +127,14 @@ let build_page repo graph (opts : page_opts) =
   match (opts.id, Option.map String.trim opts.page) with
   | None, None ->
       Error (Error.make Error.Missing_page_name "page name or id is required")
-  | Some id, None -> Ok (Remove_page { repo; graph; id = Some id; page = None })
+  | Some id, None ->
+      Ok
+        (Remove_page
+           { repo; graph; id = Some id; page = None; purge = opts.purge })
   | None, Some page when page <> "" ->
-      Ok (Remove_page { repo; graph; id = None; page = Some page })
+      Ok
+        (Remove_page
+           { repo; graph; id = None; page = Some page; purge = opts.purge })
   | None, Some _ -> Error (Error.invalid_options "page must be non-empty")
   | Some _, Some _ ->
       Error (Error.invalid_options "only one of --id or --page is allowed")
@@ -202,6 +212,26 @@ let entity_selector =
 let result_value value =
   Edn_util.map_vec (Vec.of_array [| (kw "result", value) |])
 
+let recycled_result_value ~purged ~id ~name ~uuid =
+  let fields =
+    Vec.of_array
+      [|
+        (kw "result", Edn_util.bool true);
+        (kw "id", Edn_util.int64 id);
+        (kw "name", Edn_util.string name);
+        (kw "uuid", Edn_util.string uuid);
+        (kw "recycled", Edn_util.bool (not purged));
+        (kw "purged", Edn_util.bool purged);
+      |]
+  in
+  let fields =
+    if purged then fields
+    else
+      Vec.push_back fields
+        (kw "hint", Edn_util.string (Error.recycled_page_hint ~name ()))
+  in
+  Edn_util.map_vec fields
+
 let entity_result_value result id name =
   Edn_util.map_vec
     (Vec.of_array
@@ -241,6 +271,9 @@ let id_of_entity value = Edn_util.get_int64 value "db/id"
 let has_name value = Option.is_some (Edn_util.get_string value "block/name")
 let has_id value = Option.is_some (Edn_util.get_int64 value "db/id")
 
+let recycled_entity value =
+  Option.is_some (Edn_util.get value "logseq.property/deleted-at")
+
 let pull config repo selector lookup =
   Transport.thread_api_pull config ~repo
     ~selector:(Edn_util.expect_vector_t "remove pull selector" selector)
@@ -264,9 +297,44 @@ let list_named_entities config repo method_ =
       Transport.thread_api_cli_list_properties config ~repo ~options
   | method_name -> invalid_arg ("unsupported list method: " ^ method_name)
 
-let list_pages config repo =
-  list_named_entities config repo
-    (Edn_util.keyword_t "thread-api/cli-list-pages")
+let sym value = Edn_util.symbol value
+let list_vec values = Edn_util.list_vec values
+
+let query_value query =
+  Edn_util.any (Cli_primitive.datascript_query_to_edn query)
+
+let page_query =
+  Cli_primitive.make_datascript_query
+    ~find:
+      (Vec.singleton
+         (vector_vec
+            (Vec.of_array
+               [|
+                 list_vec
+                   (Vec.of_array [| sym "pull"; sym "?e"; page_selector |]);
+                 sym "...";
+               |])))
+    ~in_:
+      (Vec.of_array
+         [|
+           Melange_edn_melange.symbol "$"; Melange_edn_melange.symbol "?name";
+         |])
+    ~where:
+      (Vec.singleton
+         (Cli_primitive.V
+            (Edn_util.vector_t_vec
+               (Vec.of_array [| sym "?e"; kw "block/name"; sym "?name" |]))))
+    ()
+
+let pull_pages_by_name config repo name =
+  Transport.thread_api_q config ~repo
+    ~query:
+      (Edn_util.vector_t_vec
+         (Vec.of_array
+            [|
+              query_value page_query;
+              Edn_util.string (String.lowercase_ascii (String.trim name));
+            |]))
 
 let apply_outliner_ops config repo ops =
   Transport.thread_api_apply_outliner_ops config ~repo
@@ -310,6 +378,17 @@ let delete_page_uuid config repo uuid =
            kw "delete-page";
            Edn_util.vector_vec
              (Vec.of_array [| Edn_util.uuid uuid; Edn_util.map_vec Vec.empty |]);
+         |])
+  in
+  apply_delete_op config repo op
+
+let purge_page_uuid config repo uuid =
+  let op =
+    Edn_util.vector_vec
+      (Vec.of_array
+         [|
+           kw "recycle-delete-permanently";
+           Edn_util.vector_vec (Vec.of_array [| Edn_util.uuid uuid |]);
          |])
   in
   apply_delete_op config repo op
@@ -511,53 +590,90 @@ let execute_remove_block_ids mode invoke_config repo ids =
                     (multi_block_result ~deleted_ids ~missing_ids ~result
                        ~page_ids)))))
 
-let execute_remove_page_id mode invoke_config repo id =
+let execute_remove_page mode invoke_config repo ~purge entity =
+  let open Cli_effect in
+  let page_name = Option.value (entity_name entity) ~default:"" in
+  if not (has_id entity) then
+    pure
+      (Cli_result.error ~command:Command_id.Remove_page mode
+         (Error.make Error.Page_not_found "page not found"))
+  else
+    match (id_of_entity entity, uuid_of_entity entity) with
+    | Some id, Some uuid ->
+        let recycled = recycled_entity entity in
+        if recycled && not purge then
+          pure
+            (Cli_result.error ~command:Command_id.Remove_page mode
+               (Error.recycled_page ~name:page_name ()))
+        else
+          let recycle_effect =
+            if recycled then pure Edn_util.bool true
+            else delete_page_uuid invoke_config repo uuid
+          in
+          bind recycle_effect (fun _ ->
+              let purge_effect =
+                if purge then purge_page_uuid invoke_config repo uuid
+                else pure Edn_util.nil
+              in
+              bind purge_effect (fun _ ->
+                  pure
+                    (Cli_result.ok ~command:Command_id.Remove_page mode
+                       (Raw
+                          (recycled_result_value ~purged:purge ~id
+                             ~name:page_name ~uuid)))))
+    | _ ->
+        pure
+          (Cli_result.error ~command:Command_id.Remove_page mode
+             (Error.make Error.Page_not_found "page not found"))
+
+let select_remove_page_target ~purge name entities =
+  let live =
+    Vec.filter (fun entity -> not (recycled_entity entity)) entities
+  in
+  let recycled = Vec.filter recycled_entity entities in
+  if purge then
+    match Vec.length recycled with
+    | 1 -> Ok (Vec.nth recycled 0)
+    | n when n > 1 ->
+        Error (ambiguous_error Error.Ambiguous_page_name "page" name recycled)
+    | _ -> (
+        match Vec.length live with
+        | 1 -> Ok (Vec.nth live 0)
+        | 0 -> Error (Error.make Error.Page_not_found "page not found")
+        | _ -> Error (ambiguous_error Error.Ambiguous_page_name "page" name live)
+        )
+  else
+    match Vec.length live with
+    | 1 -> Ok (Vec.nth live 0)
+    | n when n > 1 ->
+        Error (ambiguous_error Error.Ambiguous_page_name "page" name live)
+    | _ -> (
+        match Vec.length recycled with
+        | 0 -> Error (Error.make Error.Page_not_found "page not found")
+        | _ ->
+            Error
+              (Error.recycled_page
+                 ~name:
+                   (Option.value
+                      (entity_name (Vec.nth recycled 0))
+                      ~default:name)
+                 ()))
+
+let execute_remove_page_id mode invoke_config repo ~purge id =
   let open Cli_effect in
   bind
     (pull invoke_config repo page_selector (Edn_util.int64 id))
-    (fun entity ->
-      if not (has_id entity) then
-        pure
-          (Cli_result.error ~command:Command_id.Remove_page mode
-             (Error.make Error.Page_not_found "page not found"))
-      else
-        match uuid_of_entity entity with
-        | None ->
-            pure
-              (Cli_result.error ~command:Command_id.Remove_page mode
-                 (Error.make Error.Page_not_found "page not found"))
-        | Some uuid ->
-            bind (delete_page_uuid invoke_config repo uuid) (fun result ->
-                pure
-                  (Cli_result.ok ~command:Command_id.Remove_page mode
-                     (Raw (result_value result)))))
+    (execute_remove_page mode invoke_config repo ~purge)
 
-let execute_remove_page_name mode invoke_config repo name =
+let execute_remove_page_name mode invoke_config repo ~purge name =
   let open Cli_effect in
-  bind (list_pages invoke_config repo) (fun pages_value ->
-      let matches =
-        pages_value |> entities_of_value |> Vec.filter (name_matches name)
-      in
-      if Vec.is_empty matches then
-        pure
-          (Cli_result.error ~command:Command_id.Remove_page mode
-             (Error.make Error.Page_not_found "page not found"))
-      else if Vec.length matches > 1 then
-        pure
-          (Cli_result.error ~command:Command_id.Remove_page mode
-             (ambiguous_error Error.Ambiguous_page_name "page" name matches))
-      else
-        let page = Vec.nth matches 0 in
-        match uuid_of_entity page with
-        | None ->
-            pure
-              (Cli_result.error ~command:Command_id.Remove_page mode
-                 (Error.make Error.Page_not_found "page not found"))
-        | Some uuid ->
-            bind (delete_page_uuid invoke_config repo uuid) (fun result ->
-                pure
-                  (Cli_result.ok ~command:Command_id.Remove_page mode
-                     (Raw (result_value result)))))
+  bind (pull_pages_by_name invoke_config repo name) (fun pages_value ->
+      match
+        select_remove_page_target ~purge name (entities_of_value pages_value)
+      with
+      | Error err ->
+          pure (Cli_result.error ~command:Command_id.Remove_page mode err)
+      | Ok page -> execute_remove_page mode invoke_config repo ~purge page)
 
 let execute_remove_entity mode invoke_config repo ~command ~list_method
     ~not_found_code ~ambiguous_code ~label ~validate ~id ~name =
@@ -646,19 +762,20 @@ let execute_with_mode action config mode =
       pure
         (Cli_result.error ~command:Command_id.Remove_block mode
            (Error.make Error.Missing_target "block is required"))
-  | Remove_page { repo; id = Some id; _ } ->
-      bind (Server_runtime.ensure_server config repo ~create_empty_db:false)
-        (function
-        | Error err ->
-            pure (Cli_result.error ~command:Command_id.Remove_page mode err)
-        | Ok invoke_config -> execute_remove_page_id mode invoke_config repo id)
-  | Remove_page { repo; page = Some page; _ } ->
+  | Remove_page { repo; id = Some id; purge; _ } ->
       bind (Server_runtime.ensure_server config repo ~create_empty_db:false)
         (function
         | Error err ->
             pure (Cli_result.error ~command:Command_id.Remove_page mode err)
         | Ok invoke_config ->
-            execute_remove_page_name mode invoke_config repo page)
+            execute_remove_page_id mode invoke_config repo ~purge id)
+  | Remove_page { repo; page = Some page; purge; _ } ->
+      bind (Server_runtime.ensure_server config repo ~create_empty_db:false)
+        (function
+        | Error err ->
+            pure (Cli_result.error ~command:Command_id.Remove_page mode err)
+        | Ok invoke_config ->
+            execute_remove_page_name mode invoke_config repo ~purge page)
   | Remove_page _ ->
       pure
         (Cli_result.error ~command:Command_id.Remove_page mode
@@ -722,8 +839,9 @@ let metadata () =
              [|
                "logseq remove page --graph my-graph --page Home";
                "logseq remove page --graph my-graph --id 123";
+               "logseq remove page --graph my-graph --page Home --purge";
              |])
-        Remove_page "Remove page";
+        Remove_page "Remove page (moves it to Recycle unless --purge)";
       meta
         ~examples:
           (Vec.singleton "logseq remove tag --graph my-graph --name project")

--- a/cli/lib/remove.ml
+++ b/cli/lib/remove.ml
@@ -607,7 +607,7 @@ let execute_remove_page mode invoke_config repo ~purge entity =
                (Error.recycled_page ~name:page_name ()))
         else
           let recycle_effect =
-            if recycled then pure Edn_util.bool true
+            if recycled then pure (Edn_util.bool true)
             else delete_page_uuid invoke_config repo uuid
           in
           bind recycle_effect (fun _ ->

--- a/cli/lib/show.ml
+++ b/cli/lib/show.ml
@@ -380,7 +380,7 @@ let recycled_page value =
   Option.is_some (Edn_util.get value "block/name")
   && Option.is_some (Edn_util.get value "logseq.property/deleted-at")
 
-let recycled_page_error () = Error.make Error.Recycled_page "page is recycled"
+let recycled_page_error ?name () = Error.recycled_page ?name ()
 
 let ident_value value =
   Option.map strip_keyword_prefix

--- a/cli/lib/update.ml
+++ b/cli/lib/update.ml
@@ -321,7 +321,28 @@ let recycled_entity value =
   Option.is_some (Edn_util.get value "logseq.property/deleted-at")
 
 let page_not_found () = Error.make Error.Page_not_found "page not found"
-let recycled_page_error () = Error.make Error.Recycled_page "page is recycled"
+let recycled_page_error ?name () = Error.recycled_page ?name ()
+
+let page_entities value =
+  match
+    (Edn_util.as_vector value, Edn_util.as_list value, Edn_util.as_map value)
+  with
+  | Some values, _, _ | _, Some values, _ -> values
+  | _, _, Some _ -> Vec.singleton value
+  | _ -> Vec.empty
+
+let first_page_entity values =
+  if Vec.is_empty values then None else Some (Vec.peek_front values)
+
+let choose_page_entity value =
+  let entities = page_entities value in
+  let recycled = Vec.filter recycled_entity entities in
+  let live =
+    Vec.filter (fun entity -> not (recycled_entity entity)) entities
+  in
+  match (first_page_entity live, first_page_entity recycled) with
+  | Some entity, _ -> Some entity
+  | None, entity -> entity
 
 let pull invoke_config repo selector lookup =
   Transport.thread_api_pull invoke_config ~repo
@@ -382,6 +403,43 @@ let class_query selector class_ident =
 
 let tag_query selector = query_value (class_query selector "logseq.class/Tag")
 let property_query selector = class_query selector "logseq.class/Property"
+
+let page_query selector =
+  Cli_primitive.make_datascript_query
+    ~find:
+      (Vec.of_array
+         [|
+           vector_vec
+             (Vec.of_array
+                [|
+                  list_vec
+                    (Vec.of_array
+                       [| variable "pull"; variable "?e"; selector |]);
+                  variable "...";
+                |]);
+         |])
+    ~in_:
+      (Vec.of_array
+         [|
+           Melange_edn_melange.symbol "$"; Melange_edn_melange.symbol "?name";
+         |])
+    ~where:
+      (Vec.singleton
+         (Cli_primitive.V
+            (Edn_util.vector_t_vec
+               (Vec.of_array
+                  [| variable "?e"; kw "block/name"; variable "?name" |]))))
+    ()
+
+let pull_pages_by_name invoke_config repo name selector =
+  Transport.thread_api_q invoke_config ~repo
+    ~query:
+      (Edn_util.vector_t_vec
+         (Vec.of_array
+            [|
+              query_value (page_query selector);
+              Edn_util.string (normalized_page_name name);
+            |]))
 
 let first_entity value =
   match
@@ -487,19 +545,16 @@ let resolve_target invoke_config repo action =
                 (ensure_non_page entity "target must be a block"
                    Error.Invalid_target))
   | None, None, Some page ->
-      bind
-        (pull invoke_config repo page_selector
-           (vector_vec
-              (Vec.of_array
-                 [|
-                   kw "block/name"; Edn_util.string (normalized_page_name page);
-                 |])))
-        (fun entity ->
-          match id_of_entity entity with
+      bind (pull_pages_by_name invoke_config repo page page_selector)
+        (fun result ->
+          match choose_page_entity result with
           | None -> pure (Error (page_not_found ()))
-          | Some _ when recycled_entity entity ->
-              pure (Error (recycled_page_error ()))
-          | Some _ -> pure (Ok entity))
+          | Some entity when recycled_entity entity ->
+              pure (Error (recycled_page_error ~name:page ()))
+          | Some entity -> (
+              match id_of_entity entity with
+              | None -> pure (Error (page_not_found ()))
+              | Some _ -> pure (Ok entity)))
   | None, None, None ->
       pure (Error (Error.make Error.Missing_target "target is required"))
 

--- a/cli/lib/upsert.ml
+++ b/cli/lib/upsert.ml
@@ -1540,7 +1540,33 @@ let recycled_entity value =
   Option.is_some (Edn_util.get value "logseq.property/deleted-at")
 
 let page_not_found () = Error.make Error.Page_not_found "page not found"
-let recycled_page_error () = Error.make Error.Recycled_page "page is recycled"
+let recycled_page_error ?name () = Error.recycled_page ?name ()
+
+let page_entities value =
+  match
+    (Edn_util.as_vector value, Edn_util.as_list value, Edn_util.as_map value)
+  with
+  | Some values, _, _ | _, Some values, _ -> values
+  | _, _, Some _ -> Vec.singleton value
+  | _ -> Vec.empty
+
+let first_page_entity values =
+  if Vec.is_empty values then None else Some (Vec.peek_front values)
+
+let choose_page_entity ?(prefer_recycled = false) value =
+  let entities = page_entities value in
+  let recycled = Vec.filter recycled_entity entities in
+  let live =
+    Vec.filter (fun entity -> not (recycled_entity entity)) entities
+  in
+  if prefer_recycled then
+    match (first_page_entity recycled, first_page_entity live) with
+    | Some entity, _ -> Some entity
+    | None, entity -> entity
+  else
+    match (first_page_entity live, first_page_entity recycled) with
+    | Some entity, _ -> Some entity
+    | None, entity -> entity
 
 let resolve_tag_id invoke_config repo tag =
   let open Cli_effect in
@@ -2692,13 +2718,13 @@ let execute_create_page mode invoke_config repo name restore plan =
   let open Cli_effect in
   bind (pull_pages_by_name invoke_config repo name page_selector)
     (fun existing ->
-      match first_entity existing with
+      match choose_page_entity ~prefer_recycled:restore existing with
       | Some page -> (
           let recycled = recycled_entity page in
           if recycled && not restore then
             pure
               (Cli_result.error ~command:Command_id.Upsert_page mode
-                 (recycled_page_error ()))
+                 (recycled_page_error ~name ()))
           else
             match (id_of_entity page, uuid_of_entity page) with
             | Some id, Some uuid ->
@@ -2707,7 +2733,7 @@ let execute_create_page mode invoke_config repo name restore plan =
             | Some _, None when recycled ->
                 pure
                   (Cli_result.error ~command:Command_id.Upsert_page mode
-                     (recycled_page_error ()))
+                     (recycled_page_error ~name ()))
             | Some id, None -> pure (ok_page_ids mode (Vec.singleton id))
             | _ ->
                 pure
@@ -2741,7 +2767,7 @@ let execute_update_page mode invoke_config repo id restore plan =
       | Some _ when recycled_entity entity && not restore ->
           pure
             (Cli_result.error ~command:Command_id.Upsert_page mode
-               (recycled_page_error ()))
+               (recycled_page_error ?name:(name_of_entity entity) ()))
       | Some id -> (
           let recycled = recycled_entity entity in
           match uuid_of_entity entity with
@@ -2751,7 +2777,7 @@ let execute_update_page mode invoke_config repo id restore plan =
           | None when recycled ->
               pure
                 (Cli_result.error ~command:Command_id.Upsert_page mode
-                   (recycled_page_error ()))
+                   (recycled_page_error ?name:(name_of_entity entity) ()))
           | None -> pure (ok_page_ids mode (Vec.singleton id))))
 
 let update_plan_empty (plan : Property.update_plan) =

--- a/cli/spec/cli/command_id.mli
+++ b/cli/spec/cli/command_id.mli
@@ -23,6 +23,7 @@ type t =
   | List_task
   | List_node
   | List_asset
+  | List_recycled
   | Search_block
   | Search_page
   | Search_property

--- a/cli/spec/commands/list_command.mli
+++ b/cli/spec/commands/list_command.mli
@@ -49,6 +49,7 @@ type node_opts = {
 }
 
 type asset_opts = { common : common_opts }
+type recycled_opts = { common : common_opts }
 
 type parsed =
   | Parsed_page of page_opts
@@ -57,8 +58,9 @@ type parsed =
   | Parsed_task of task_opts
   | Parsed_node of node_opts
   | Parsed_asset of asset_opts
+  | Parsed_recycled of recycled_opts
 
-type kind = Page | Tag | Property | Task | Node | Asset
+type kind = Page | Tag | Property | Task | Node | Asset | Recycled
 
 type action = {
   kind : kind;

--- a/cli/spec/commands/remove.mli
+++ b/cli/spec/commands/remove.mli
@@ -1,5 +1,9 @@
 type block_opts = { id_raw : string option; uuid : Cli_primitive.uuid option }
-type page_opts = { id : Cli_primitive.db_id option; page : string option }
+type page_opts = {
+  id : Cli_primitive.db_id option;
+  page : string option;
+  purge : bool;
+}
 
 type named_entity_opts = {
   id : Cli_primitive.db_id option;
@@ -26,6 +30,7 @@ type action =
       graph : Cli_primitive.graph;
       id : Cli_primitive.db_id option;
       page : string option;
+      purge : bool;
     }
   | Remove_tag of {
       repo : Cli_primitive.repo;

--- a/cli/spec/core/error.mli
+++ b/cli/spec/core/error.mli
@@ -167,6 +167,8 @@ val make :
   t
 
 val invalid_options : string -> t
+val recycled_page_hint : ?name:string -> unit -> string
+val recycled_page : ?name:string -> unit -> t
 val missing_graph : unit -> t
 val missing_repo : string -> t
 val missing_target : string -> t

--- a/cli/test/cli_parity_test_cases.ml
+++ b/cli/test/cli_parity_test_cases.ml
@@ -3449,22 +3449,14 @@ let () =
   test_promise "CLI parity upsert block update rejects recycled target page"
     (fun () ->
       let apply_called = ref false in
-      let pull_count = ref 0 in
       let server =
         invoke_server (fun body ->
-            if Js.String.includes ~search:"thread-api/pull" body then (
-              incr pull_count;
-              match !pull_count with
-              | 1 ->
-                  "[\"^ \
-                   \",\"~:db/id\",207,\"~:block/uuid\",\"~u00000000-0000-4000-8000-000000000207\",\"~:block/title\",\"Source\"]"
-              | 2 ->
-                  "[\"^ \
-                   \",\"~:db/id\",50,\"~:block/uuid\",\"~u00000000-0000-4000-8000-000000000050\",\"~:block/name\",\"home\",\"~:block/title\",\"Home\",\"~:logseq.property/deleted-at\",1712000000000]"
-              | _ ->
-                  fail_test
-                    (Printf.sprintf "unexpected pull %d: %s" !pull_count body);
-                  "")
+            if Js.String.includes ~search:"thread-api/q" body then
+              "[[\"^ \
+               \",\"~:db/id\",50,\"~:block/uuid\",\"~u00000000-0000-4000-8000-000000000050\",\"~:block/name\",\"home\",\"~:block/title\",\"Home\",\"~:logseq.property/deleted-at\",1712000000000]]"
+            else if Js.String.includes ~search:"thread-api/pull" body then
+              "[\"^ \
+               \",\"~:db/id\",207,\"~:block/uuid\",\"~u00000000-0000-4000-8000-000000000207\",\"~:block/title\",\"Source\"]"
             else if
               Js.String.includes ~search:"thread-api/apply-outliner-ops" body
             then (

--- a/cli/test/cli_parity_test_cases.ml
+++ b/cli/test/cli_parity_test_cases.ml
@@ -1881,6 +1881,41 @@ let () =
                (expect_some "asset order" opts.common.order))
       | _ -> fail_test "expected list asset");
 
+  test "CLI parity parse supports list recycled and remove page purge"
+    (fun () ->
+      let request =
+        expect_parse_ok "list recycled parse"
+          [|
+            "list";
+            "recycled";
+            "--limit";
+            "20";
+            "--sort";
+            "deleted-at";
+            "--order";
+            "desc";
+          |]
+      in
+      (match request.command with
+      | Cli_request.List (List_command.Parsed_recycled opts) ->
+          expect_int "recycled limit" 20
+            (expect_some "recycled limit" opts.common.limit);
+          expect_equal "recycled sort" "deleted-at"
+            (expect_some "recycled sort" opts.common.sort);
+          expect_equal "recycled order" "desc"
+            (List_command.string_of_order
+               (expect_some "recycled order" opts.common.order))
+      | _ -> fail_test "expected list recycled");
+      let purge =
+        expect_parse_ok "remove page purge"
+          [| "remove"; "page"; "--page"; "Home"; "--purge" |]
+      in
+      match purge.command with
+      | Cli_request.Remove (Remove.Parsed_page opts) ->
+          expect_equal "purge page" "Home" (expect_some "purge page" opts.page);
+          expect_bool "purge flag" true opts.purge
+      | _ -> fail_test "expected remove page purge");
+
   test "CLI parity list rejects old name fields for tag and property" (fun () ->
       expect_parse_error_code "list tag old name field" ":invalid-options"
         [| "list"; "tag"; "--fields"; "name,properties" |];
@@ -2464,7 +2499,8 @@ let () =
         "only one of --id or --page is allowed"
         (expect_some "invalid"
            (Remove.invalid_options
-              (Remove.Parsed_page { id = Some 1L; page = Some "Home" })));
+              (Remove.Parsed_page
+                 { id = Some 1L; page = Some "Home"; purge = false })));
       expect_equal "remove tag blank" "name must be non-empty"
         (expect_some "invalid"
            (Remove.invalid_options
@@ -2506,7 +2542,8 @@ let () =
       let page =
         expect_ok "remove page by title"
           (Remove.build (config ~repo:"demo" ()) (Global_opts.create ())
-             (Remove.Parsed_page { id = None; page = Some " Home " }))
+             (Remove.Parsed_page
+                { id = None; page = Some " Home "; purge = false }))
       in
       (match page with
       | Remove.Remove_page { page = Some page; id = None; _ } ->
@@ -2528,12 +2565,12 @@ let () =
            (Remove.Parsed_block { id_raw = None; uuid = None }));
       expect_error_code "remove page missing" "missing-page-name"
         (Remove.build (config ~repo:"demo" ()) (Global_opts.create ())
-           (Remove.Parsed_page { id = None; page = None })));
+           (Remove.Parsed_page { id = None; page = None; purge = false })));
 
   test_promise "CLI parity remove page unwraps apply result map" (fun () ->
       let server =
         invoke_server (fun body ->
-            if Js.String.includes ~search:"thread-api/cli-list-pages" body then
+            if Js.String.includes ~search:"thread-api/q" body then
               "[[\"^ \
                \",\"~:db/id\",190,\"~:block/title\",\"Home\",\"~:block/name\",\"home\",\"~:block/uuid\",\"~u00000000-0000-4000-8000-000000000190\"]]"
             else if
@@ -2550,6 +2587,7 @@ let () =
                 graph = Cli_config.repo_to_graph repo;
                 id = None;
                 page = Some "Home";
+                purge = false;
               }
           in
           let cfg =
@@ -2567,6 +2605,100 @@ let () =
           expect_bool "remove page result" true
             (expect_some "remove page result bool"
                (Edn_util.get_bool data "result"));
+          expect_bool "remove page recycled" true
+            (expect_some "remove page recycled bool"
+               (Edn_util.get_bool data "recycled"));
+          expect_named_contains "remove page restore hint"
+            (expect_some "remove page hint" (Edn_util.get_string data "hint"))
+            "upsert page --restore";
+          Js.Promise.resolve pass));
+
+  test_promise "CLI parity remove page purge permanently deletes recycled page"
+    (fun () ->
+      let apply_calls = ref Vec.empty in
+      let server =
+        invoke_server (fun body ->
+            if Js.String.includes ~search:"thread-api/q" body then
+              "[[\"^ \
+               \",\"~:db/id\",190,\"~:block/title\",\"Home\",\"~:block/name\",\"home\",\"~:block/uuid\",\"~u00000000-0000-4000-8000-000000000190\",\"~:logseq.property/deleted-at\",1712000000000]]"
+            else if
+              Js.String.includes ~search:"thread-api/apply-outliner-ops" body
+            then (
+              apply_calls := Vec.push_back !apply_calls body;
+              "[\"^ \",\"~:result\",true]")
+            else "null")
+      in
+      with_server server (fun base_url ->
+          let repo = Cli_primitive.create_repo "demo" in
+          let action =
+            Remove.Remove_page
+              {
+                repo;
+                graph = Cli_config.repo_to_graph repo;
+                id = None;
+                page = Some "Home";
+                purge = true;
+              }
+          in
+          let cfg =
+            {
+              (config ~repo:"demo" ()) with
+              Cli_config.base_url = Some base_url;
+            }
+          in
+          let* result =
+            effect_to_promise
+              (execute_with_output Remove.execute action cfg Output.Mode.Json)
+          in
+          expect_bool "purge ok" false (Cli_result.is_error result);
+          let data = expect_some "purge data" (Cli_result.data_value result) in
+          expect_bool "purge flag" true
+            (expect_some "purged bool" (Edn_util.get_bool data "purged"));
+          expect_bool "not recycled after purge" false
+            (expect_some "recycled after purge"
+               (Edn_util.get_bool data "recycled"));
+          expect_int "purge apply calls" 1 (Vec.length !apply_calls);
+          expect_named_contains "purge op"
+            (Vec.nth !apply_calls 0) "recycle-delete-permanently";
+          Js.Promise.resolve pass));
+
+  test_promise "CLI parity list recycled returns deleted pages" (fun () ->
+      let server =
+        invoke_server (fun body ->
+            if Js.String.includes ~search:"thread-api/q" body then
+              "[[\"^ \
+               \",\"~:db/id\",190,\"~:block/title\",\"Home\",\"~:block/name\",\"home\",\"~:block/uuid\",\"~u00000000-0000-4000-8000-000000000190\",\"~:logseq.property/deleted-at\",1712000000000]]"
+            else "null")
+      in
+      with_server server (fun base_url ->
+          let cfg =
+            {
+              (config ~repo:"demo" ()) with
+              Cli_config.base_url = Some base_url;
+            }
+          in
+          let action =
+            expect_ok "list recycled build"
+              (List_command.build cfg (Global_opts.create ())
+                 (List_command.Parsed_recycled { common = empty_common_opts }))
+          in
+          let* result =
+            effect_to_promise
+              (execute_with_output List_command.execute action cfg
+                 Output.Mode.Json)
+          in
+          expect_bool "list recycled ok" false (Cli_result.is_error result);
+          let data =
+            expect_some "recycled list data" (Cli_result.data_value result)
+          in
+          let items =
+            expect_some "recycled items"
+              (Option.bind (Edn_util.get data "items") Edn_util.as_seq)
+          in
+          expect_int "recycled count" 1 (Vec.length items);
+          expect_equal "recycled title" "Home"
+            (expect_some "recycled title"
+               (Edn_util.get_string (Vec.peek_front items) "block/title"));
           Js.Promise.resolve pass));
 
   test_promise "CLI parity remove block rejects page entities before delete"
@@ -2949,9 +3081,56 @@ let () =
           (match result.Cli_result.error with
           | Some err ->
               expect_equal "upsert recycled code" "recycled-page"
-                (Error.code_to_string err.Error.code)
+                (Error.code_to_string err.Error.code);
+              expect_named_contains "upsert recycled restore hint"
+                (expect_some "upsert recycled hint" err.Error.hint)
+                "upsert page --restore"
           | None -> fail_test "expected upsert error");
           expect_bool "no ops applied" false !apply_called;
+          Js.Promise.resolve pass));
+
+  test_promise
+    "CLI parity upsert page prefers live homonym over recycled page" (fun () ->
+      let apply_called = ref false in
+      let server =
+        invoke_server (fun body ->
+            if Js.String.includes ~search:"thread-api/q" body then
+              "[[\"^ \
+               \",\"~:db/id\",50,\"~:block/uuid\",\"~u00000000-0000-4000-8000-000000000050\",\"~:block/name\",\"home\",\"~:block/title\",\"Home\",\"~:logseq.property/deleted-at\",1712000000000],[\"^ \
+               \",\"~:db/id\",51,\"~:block/uuid\",\"~u00000000-0000-4000-8000-000000000051\",\"~:block/name\",\"home\",\"~:block/title\",\"Home\"]]"
+            else if
+              Js.String.includes ~search:"thread-api/apply-outliner-ops" body
+            then (
+              apply_called := true;
+              "true")
+            else "null")
+      in
+      with_server server (fun base_url ->
+          let repo = Cli_primitive.create_repo "demo" in
+          let cfg =
+            {
+              (config ~repo:"demo" ()) with
+              Cli_config.base_url = Some base_url;
+            }
+          in
+          let action =
+            Upsert.Upsert_page
+              {
+                repo;
+                graph = Cli_config.repo_to_graph repo;
+                mode = Upsert.Create;
+                id = None;
+                page = Some "Home";
+                restore = false;
+                plan = Property.empty_update_plan;
+              }
+          in
+          let* result =
+            effect_to_promise
+              (execute_with_output Upsert.execute action cfg Output.Mode.Json)
+          in
+          expect_bool "live homonym ok" false (Cli_result.is_error result);
+          expect_bool "live homonym does not restore" false !apply_called;
           Js.Promise.resolve pass));
 
   test_promise "CLI parity upsert page update rejects recycled page by default"
@@ -3214,9 +3393,57 @@ let () =
           (match result.Cli_result.error with
           | Some err ->
               expect_equal "upsert block create recycled code" "recycled-page"
-                (Error.code_to_string err.Error.code)
+                (Error.code_to_string err.Error.code);
+              expect_named_contains "upsert block recycled restore hint"
+                (expect_some "upsert block recycled hint" err.Error.hint)
+                "upsert page --restore"
           | None -> fail_test "expected upsert block create error");
           expect_bool "no create ops applied" false !apply_called;
+          Js.Promise.resolve pass));
+
+  test_promise
+    "CLI parity upsert block create prefers live homonym over recycled page"
+    (fun () ->
+      let server =
+        invoke_server (fun body ->
+            if Js.String.includes ~search:"thread-api/q" body then
+              "[[\"^ \
+               \",\"~:db/id\",50,\"~:block/uuid\",\"~u00000000-0000-4000-8000-000000000050\",\"~:block/name\",\"home\",\"~:block/title\",\"Home\",\"~:logseq.property/deleted-at\",1712000000000],[\"^ \
+               \",\"~:db/id\",51,\"~:block/uuid\",\"~u00000000-0000-4000-8000-000000000051\",\"~:block/name\",\"home\",\"~:block/title\",\"Home\"]]"
+            else if
+              Js.String.includes ~search:"thread-api/apply-outliner-ops" body
+            then "true"
+            else "null")
+      in
+      with_server server (fun base_url ->
+          let repo = Cli_primitive.create_repo "demo" in
+          let cfg =
+            {
+              (config ~repo:"demo" ()) with
+              Cli_config.base_url = Some base_url;
+            }
+          in
+          let action =
+            Upsert.Upsert_block
+              (Upsert.Block_create
+                 {
+                   repo;
+                   graph = Cli_config.repo_to_graph repo;
+                   target = Upsert.Target_page "Home";
+                   pos = Block.Last_child;
+                   status = None;
+                   tags = Vec.empty;
+                   properties = Vec.empty;
+                   blocks = Vec.singleton (Block.make ~title:"Child" ());
+                   update_plan = Property.empty_update_plan;
+                 })
+          in
+          let* result =
+            effect_to_promise
+              (execute_with_output Upsert.execute action cfg Output.Mode.Json)
+          in
+          expect_bool "block create live homonym ok" false
+            (Cli_result.is_error result);
           Js.Promise.resolve pass));
 
   test_promise "CLI parity upsert block update rejects recycled target page"
@@ -5941,6 +6168,7 @@ let () =
         "Usage: logseq list <subcommand> [options]";
       expect_named_contains "list page command" list_help "list page";
       expect_named_contains "list asset command" list_help "list asset";
+      expect_named_contains "list recycled command" list_help "list recycled";
       expect_named_not_contains "list command options suffix" list_help
         "list page [options]";
       let backup_help = run_cli [| "graph"; "backup" |] in


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`logseq remove page` soft-recycles a page, but the CLI returned raw `true`, hid recycled entities from `list`/`search`, and later `upsert` failed with `recycled-page` / `"page is recycled"` with no restore hint. A recycled homonym could also shadow a live page or tag with the same `:block/name`.

This change makes the recycle bin inspectable and recoverable from the CLI:

- `remove page` reports that the page was recycled, including restore/purge hints.
- `recycled-page` errors mention `upsert page --restore`, `list recycled`, and `remove page --purge`.
- `list recycled` lists recycled pages and blocks.
- `remove page --purge` permanently deletes a recycled page (recycles first if it is still live).
- Page lookup prefers a live homonym over a recycled row with the same name.

`upsert page --restore` already existed; this makes it discoverable from the error path.

## Test plan

- CLI unit tests (`cd cli && npm test`): 241 passed, including parse `list recycled` / `--purge`, recycle result + restore hint, list recycled, purge, live-homonym preference, recycled-page restore hint.
- CLI e2e (`bb -f cli-e2e/bb.edn test --skip-build --case …`): `remove-page-json`, `remove-page-recycled-error-json`, `list-recycled-json`, `upsert-page-restore-json`, `remove-page-purge-json`, `recycled-homonym-json` all passed.

Fixes https://github.com/logseq/db-test/issues/1063

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4bdb9f17-6ced-4775-8907-ab3b069700d1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4bdb9f17-6ced-4775-8907-ab3b069700d1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

