### PR TITLE
fix: replace hung db-worker after sleep

### DIFF
--- a/cli/lib/server_runtime.ml
+++ b/cli/lib/server_runtime.ml
@@ -367,13 +367,22 @@ let wait_for_ready config repo =
           | Some ({ status = Ready; _ } as server) -> Some server | _ -> None)
         (find_repo_server config repo))
 
-let read_lock_pid path =
+let read_lock path =
   if not (Cli_unix.file_exists path) then None
   else
     try
-      Cli_unix.read_text_file path |> Json_util.value_of_json_string
-      |> fun raw -> Edn_util.get_int raw "pid"
+      let raw =
+        Cli_unix.read_text_file path |> Json_util.value_of_json_string
+      in
+      Some
+        ( Edn_util.get_int raw "pid",
+          Edn_util.get_string raw "owner-source"
+          |> Option.map owner_source_of_string
+          |> Option.value ~default:Cli_primitive.Unknown )
     with _ -> None
+
+let read_lock_pid path =
+  match read_lock path with Some (Some pid, _) -> Some pid | _ -> None
 
 let live_lock path =
   match read_lock_pid path with Some pid -> process_alive pid | None -> false
@@ -381,6 +390,56 @@ let live_lock path =
 let owner_manageable = function
   | Cli_primitive.Cli | Cli_primitive.Unknown -> true
   | _ -> false
+
+let pid_published_in_server_list config pid =
+  read_server_list (server_list_path config)
+  |> Vec.exists (fun (entry_pid, _) -> entry_pid = pid)
+
+let remove_lock path =
+  if Cli_unix.file_exists path then
+    try Cli_unix.remove_tree path with _ -> ()
+
+let lock_process_stopped pid_opt =
+  match pid_opt with
+  | None -> true
+  | Some pid -> pid = Cli_unix.getpid () || not (process_alive pid)
+
+let force_cleanup_lock path (pid_opt, _owner) =
+  let open Cli_effect in
+  let self = Cli_unix.getpid () in
+  (match pid_opt with
+  | Some pid when pid <> self && process_alive pid -> (
+      try Cli_unix.kill pid Sys.sigterm with _ -> ())
+  | _ -> ());
+  bind
+    (wait_until_effect ~timeout_span:(Time.span_of_ms 1_000L)
+       ~interval_span:(Time.span_of_ms 100L) (fun () ->
+         pure (if lock_process_stopped pid_opt then Some () else None)))
+    (function
+      | Some () ->
+          if lock_process_stopped pid_opt then remove_lock path;
+          pure ()
+      | None ->
+          (match pid_opt with
+          | Some pid when pid <> self && process_alive pid -> (
+              try Cli_unix.kill pid Sys.sigkill with _ -> ())
+          | _ -> ());
+          bind
+            (wait_until_effect ~timeout_span:(Time.span_of_ms 1_000L)
+               ~interval_span:(Time.span_of_ms 100L) (fun () ->
+                 pure
+                   (if lock_process_stopped pid_opt then Some () else None)))
+            (fun _ ->
+              if lock_process_stopped pid_opt then remove_lock path;
+              pure ()))
+
+let maybe_replace_unhealthy_lock config path =
+  match read_lock path with
+  | Some ((Some pid, owner) as lock_info)
+    when owner_manageable owner && process_alive pid
+         && pid_published_in_server_list config pid ->
+      force_cleanup_lock path lock_info
+  | _ -> Cli_effect.pure ()
 
 let start_result_of_server repo (server : server) =
   { repo; owner_source = server.owner_source; owned = server.owned }
@@ -409,6 +468,37 @@ let wait_for_published_ready time config repo =
                        (Error.make Error.Server_start_failed
                           "db-worker-node failed to start"))))
 
+let spawn_new_server time config repo ~create_empty_db lock =
+  let open Cli_effect in
+  match resolve_script_path config with
+  | Stdlib.Error err -> pure (Stdlib.Error err)
+  | Stdlib.Ok script -> (
+      try
+        bind
+          (time "server.spawn-daemon" (fun () ->
+               spawn_server_process ~script
+                 ~root_dir:(resolve_root_dir config) ~repo ~owner_source:"cli"
+                 ~create_empty_db;
+               pure ()))
+          (fun () ->
+            bind
+              (time "server.wait-lock" (fun () -> wait_for_lock lock))
+              (function
+                | None ->
+                    pure
+                      (Stdlib.Error
+                         (Error.make Error.Server_start_timeout_orphan
+                            ("db-worker-node failed to start. Command: "
+                            ^ db_worker_command_line ~script
+                                ~root_dir:(resolve_root_dir config) ~repo
+                                ~owner_source:"cli" ~create_empty_db)))
+                | Some () -> wait_for_published_ready time config repo))
+      with exn ->
+        pure
+          (Stdlib.Error
+             (Error.make Error.Server_start_failed
+                ("failed to spawn db-worker-node: " ^ Printexc.to_string exn))))
+
 let start_server_unprofiled config repo ~create_empty_db =
   let open Cli_effect in
   let time stage f =
@@ -424,44 +514,26 @@ let start_server_unprofiled config repo ~create_empty_db =
     | None -> (
         match ensure_repo_dir config repo with
         | Stdlib.Error err -> pure (Stdlib.Error err)
-        | Stdlib.Ok _ -> (
+        | Stdlib.Ok _ ->
             let lock = lock_path ~root_dir:(resolve_root_dir config) repo in
-            if live_lock lock then wait_for_published_ready time config repo
-            else
-              match resolve_script_path config with
-              | Stdlib.Error err -> pure (Stdlib.Error err)
-              | Stdlib.Ok script -> (
-                  try
-                    bind
-                      (time "server.spawn-daemon" (fun () ->
-                           spawn_server_process ~script
-                             ~root_dir:(resolve_root_dir config) ~repo
-                             ~owner_source:"cli" ~create_empty_db;
-                           pure ()))
-                      (fun () ->
+            bind (maybe_replace_unhealthy_lock config lock) (fun () ->
+                if live_lock lock then
+                  bind (wait_for_published_ready time config repo) (function
+                    | Stdlib.Ok result -> pure (Stdlib.Ok result)
+                    | Stdlib.Error err ->
                         bind
-                          (time "server.wait-lock" (fun () ->
-                               wait_for_lock lock))
-                          (function
-                            | None ->
-                                pure
-                                  (Stdlib.Error
-                                     (Error.make
-                                        Error.Server_start_timeout_orphan
-                                        ("db-worker-node failed to start. \
-                                          Command: "
-                                        ^ db_worker_command_line ~script
-                                            ~root_dir:(resolve_root_dir config)
-                                            ~repo ~owner_source:"cli"
-                                            ~create_empty_db)))
-                            | Some () ->
-                                wait_for_published_ready time config repo))
-                  with exn ->
-                    pure
-                      (Stdlib.Error
-                         (Error.make Error.Server_start_failed
-                            ("failed to spawn db-worker-node: "
-                           ^ Printexc.to_string exn)))))))
+                          (match read_lock lock with
+                          | Some ((_, owner) as lock_info)
+                            when owner_manageable owner ->
+                              force_cleanup_lock lock lock_info
+                          | _ -> pure ())
+                          (fun () ->
+                            if live_lock lock then pure (Stdlib.Error err)
+                            else
+                              spawn_new_server time config repo ~create_empty_db
+                                lock))
+                else
+                  spawn_new_server time config repo ~create_empty_db lock)))
 
 let start_server config repo ~create_empty_db =
   Profile_types.time config.Cli_config.profile_session "server.ensure-started"
@@ -516,13 +588,31 @@ let shutdown_server server =
 
 let stop_server config repo =
   let open Cli_effect in
+  let lock_path = lock_path ~root_dir:(resolve_root_dir config) repo in
   bind (find_repo_server config repo) (function
     | None when Option.is_some config.Cli_config.base_url ->
         pure (Stdlib.Ok { repo })
-    | None ->
-        pure
-          (Stdlib.Error
-             (Error.make Error.Server_not_found "server is not running"))
+    | None -> (
+        match read_lock lock_path with
+        | None ->
+            pure
+              (Stdlib.Error
+                 (Error.make Error.Server_not_found "server is not running"))
+        | Some (_, owner) when not (owner_manageable owner) ->
+            pure
+              (Stdlib.Error
+                 (Error.make Error.Server_owned_by_other
+                    "server is owned by another process"))
+        | Some lock_info ->
+            bind (force_cleanup_lock lock_path lock_info) (fun () ->
+                if live_lock lock_path then
+                  pure
+                    (Stdlib.Error
+                       (Error.make Error.Server_stop_timeout
+                          "timed out stopping server"))
+                else (
+                  remove_lock lock_path;
+                  pure (Stdlib.Ok { repo }))))
     | Some server ->
         if not (owner_manageable server.owner_source) then
           pure
@@ -532,8 +622,6 @@ let stop_server config repo =
         else
           let shutdown_timeout_span = Time.span_of_ms 5_000L in
           let shutdown_interval_span = Time.span_of_ms 200L in
-          let kill_timeout_span = Time.span_of_ms 1_000L in
-          let kill_interval_span = Time.span_of_ms 100L in
           bind (shutdown_server server) (fun _ ->
               bind
                 (wait_until_effect ~timeout_span:shutdown_timeout_span
@@ -544,23 +632,28 @@ let stop_server config repo =
                 (function
                   | Some () -> pure (Stdlib.Ok { repo })
                   | None ->
-                      (try
-                         if process_alive server.pid then
-                           Cli_unix.kill server.pid Sys.sigterm
-                       with _ -> ());
-                      bind
-                        (wait_until_effect ~timeout_span:kill_timeout_span
-                           ~interval_span:kill_interval_span (fun () ->
-                             map
-                               (function None -> Some () | Some _ -> None)
-                               (find_repo_server config repo)))
-                        (function
-                          | Some () -> pure (Stdlib.Ok { repo })
-                          | None ->
-                              pure
-                                (Stdlib.Error
-                                   (Error.make Error.Server_stop_timeout
-                                      "timed out stopping server"))))))
+                      let lock_info =
+                        match read_lock lock_path with
+                        | Some (pid_opt, owner) ->
+                            ( (match pid_opt with
+                              | Some _ -> pid_opt
+                              | None -> Some server.pid),
+                              owner )
+                        | None -> (Some server.pid, server.owner_source)
+                      in
+                      bind (force_cleanup_lock lock_path lock_info) (fun () ->
+                          if
+                            Cli_unix.file_exists lock_path
+                            && process_alive server.pid
+                            && server.pid <> Cli_unix.getpid ()
+                          then
+                            pure
+                              (Stdlib.Error
+                                 (Error.make Error.Server_stop_timeout
+                                    "timed out stopping server"))
+                          else (
+                            remove_lock lock_path;
+                            pure (Stdlib.Ok { repo }))))))
 
 let restart_server config repo =
   stop_server config repo >>= function

--- a/cli/test/cli_parity_test_cases.ml
+++ b/cli/test/cli_parity_test_cases.ml
@@ -7294,6 +7294,78 @@ let () =
         server_close server (fun[@u] () -> ());
         fail_promise (Printexc.to_string exn));
 
+  test_promise
+    "CLI parity server start replaces live lock when healthz is unpublished"
+    (fun () ->
+      let root = temp_dir "logseq-cli-server-unhealthy-lock-" in
+      let worker_script = Node.Path.join [| root; "db-worker-node.js" |] in
+      let graphs_dir = Node.Path.join [| root; "graphs" |] in
+      let graph_dir = Node.Path.join [| graphs_dir; "demo" |] in
+      let lock_path = Node.Path.join [| graph_dir; "db-worker.lock" |] in
+      let server_list_path = Node.Path.join [| root; "server-list" |] in
+      let server =
+        create_server (fun[@u] req res ->
+            if req_method req = "GET" && req_url req = "/healthz" then
+              write_json res 200
+                (Printf.sprintf
+                   "{\"repo\":\"logseq_db_demo\",\"status\":\"ready\",\"host\":\"127.0.0.1\",\"pid\":%d,\"owner-source\":\"cli\",\"root-dir\":%S,\"revision\":\"test-revision\"}"
+                   (Cli_unix.getpid ()) root)
+            else write_json res 404 (error_response "not found"))
+      in
+      try
+        mkdir_p graph_dir;
+        write_file worker_script "console.log('db-worker');\n";
+        write_file lock_path
+          (Printf.sprintf
+             "{\"repo\":\"logseq_db_demo\",\"pid\":%d,\"lock-id\":\"unhealthy\",\"owner-source\":\"cli\"}"
+             (Cli_unix.getpid ()));
+        write_file server_list_path
+          (string_of_int (Cli_unix.getpid ()) ^ " 1\n");
+        start_spawn_capture ();
+        set_env "LOGSEQ_DB_WORKER_NODE_SCRIPT" worker_script;
+        Js.Promise.make (fun ~resolve ~reject ->
+            server_listen server 0 "127.0.0.1" (fun[@u] () ->
+                let port = (server_address server)##port in
+                set_spawn_capture_on_spawn ~lock_path ~server_list_path ~port;
+                let config = config ~root_dir:root ~repo:"demo" () in
+                let finish_ok () =
+                  server_close server (fun[@u] () -> (resolve pass [@u]))
+                in
+                let finish_error message =
+                  server_close server (fun[@u] () ->
+                      (reject (Failure message) [@u]))
+                in
+                Cli_effect.on_any
+                  (Server_runtime.start_server config
+                     (Cli_primitive.create_repo "logseq_db_demo")
+                     ~create_empty_db:false)
+                  (fun result ->
+                    let calls = spawn_capture_calls () in
+                    stop_spawn_capture ();
+                    unset_env "LOGSEQ_DB_WORKER_NODE_SCRIPT";
+                    remove_tree root;
+                    match result with
+                    | Error err ->
+                        finish_error
+                          ("server start failed: " ^ err.Error.message)
+                    | Ok _ -> (
+                        try
+                          expect_named_contains "spawned replacement worker"
+                            calls worker_script;
+                          finish_ok ()
+                        with exn -> finish_error (Printexc.to_string exn)))
+                  (fun exn ->
+                    stop_spawn_capture ();
+                    unset_env "LOGSEQ_DB_WORKER_NODE_SCRIPT";
+                    remove_tree root;
+                    finish_error (Printexc.to_string exn))))
+      with exn ->
+        stop_spawn_capture ();
+        unset_env "LOGSEQ_DB_WORKER_NODE_SCRIPT";
+        remove_tree root;
+        server_close server (fun[@u] () -> ());
+        fail_promise (Printexc.to_string exn));
+
   test_promise "CLI parity ensure server retries final health discovery"
     (fun () ->
       let root = temp_dir "logseq-cli-ensure-final-health-" in

--- a/src/main/logseq/cli/server.cljs
+++ b/src/main/logseq/cli/server.cljs
@@ -162,6 +162,10 @@
   [path lock]
   (daemon/cleanup-stale-lock! path lock))
 
+(defn- force-cleanup-lock!
+  [path lock]
+  (daemon/force-cleanup-lock! path lock))
+
 (defn- wait-for
   [pred-fn opts]
   (daemon/wait-for pred-fn opts))
@@ -273,6 +277,66 @@
                    :interval-ms 50})
         (p/then (fn [_] @server*)))))
 
+(defn- published-pid?
+  [config pid]
+  (and (number? pid)
+       (some #(= pid (:pid %))
+             (server-list/read-entries (server-list-path config)))))
+
+(defn- spawn-daemon-and-wait-lock!
+  [config repo path requester-owner profile-session]
+  (let [root-dir (resolve-root-dir config)]
+    (profile/time! profile-session
+                   "server.spawn-daemon"
+                   (fn []
+                     (spawn-server! {:repo repo
+                                     :root-dir root-dir
+                                     :owner-source requester-owner
+                                     :create-empty-db? (:create-empty-db? config)
+                                     :embedding-endpoint (:embedding-endpoint config)
+                                     :embedding-model-id (:embedding-model-id config)})))
+    (-> (profile/time! profile-session
+                       "server.wait-lock"
+                       (fn []
+                         (wait-for-lock path)))
+        (p/catch (fn [e]
+                   (if (= :timeout (:code (ex-data e)))
+                     (throw (ex-info "db-worker-node failed to create lock"
+                                     {:code :server-start-timeout-orphan
+                                      :repo repo}))
+                     (throw e)))))))
+
+(defn- replace-unhealthy-lock!
+  [repo path lock]
+  (log/info :cli-server-replace-unhealthy-lock
+            {:repo repo
+             :pid (:pid lock)
+             :reason :live-pid-http-unhealthy})
+  (force-cleanup-lock! path lock))
+
+(defn- wait-for-published-server!
+  [config repo path requester-owner profile-session]
+  (-> (profile/time! profile-session
+                     "server.wait-publish"
+                     (fn []
+                       (wait-for-discovered-server config repo)))
+      (p/catch (fn [e]
+                 (if (= :timeout (:code (ex-data e)))
+                   (p/let [lock (read-lock path)]
+                     (if (and lock
+                              (owner-manageable? requester-owner
+                                                 (lock-owner-source lock)))
+                       (p/let [_ (replace-unhealthy-lock! repo path lock)
+                               _ (when-not (fs/existsSync path)
+                                   (spawn-daemon-and-wait-lock! config repo path
+                                                                requester-owner profile-session))]
+                         (profile/time! profile-session
+                                        "server.wait-publish"
+                                        (fn []
+                                          (wait-for-discovered-server config repo))))
+                       (throw e)))
+                   (throw e))))))
+
 (defn- ensure-server-started-once!
   [config repo]
   (let [root-dir (resolve-root-dir config)
@@ -286,38 +350,28 @@
                              _ (cleanup-stale-lock! path existing)
                              discovered (discover-servers config)
                              discovered-repo-server (repo-server config discovered repo)
-                             _ (when (and (not discovered-repo-server) (not (fs/existsSync path)))
-                                 (profile/time! profile-session
-                                                "server.spawn-daemon"
-                                                (fn []
-                                                  (spawn-server! {:repo repo
-                                                                  :root-dir root-dir
-                                                                  :owner-source requester-owner
-                                                                  :create-empty-db? (:create-empty-db? config)
-                                                                  :embedding-endpoint (:embedding-endpoint config)
-                                                                  :embedding-model-id (:embedding-model-id config)})))
-                                 (-> (profile/time! profile-session
-                                                    "server.wait-lock"
-                                                    (fn []
-                                                      (wait-for-lock path)))
-                                     (p/catch (fn [e]
-                                                (if (= :timeout (:code (ex-data e)))
-                                                  (throw (ex-info "db-worker-node failed to create lock"
-                                                                  {:code :server-start-timeout-orphan
-                                                                   :repo repo}))
-                                                  (throw e))))))
+                             existing (read-lock path)
+                             _ (when (and (not discovered-repo-server)
+                                          existing
+                                          (published-pid? config (:pid existing))
+                                          (owner-manageable? requester-owner
+                                                             (lock-owner-source existing)))
+                                 (replace-unhealthy-lock! repo path existing))
+                             _ (when (and (not discovered-repo-server)
+                                          (not (fs/existsSync path)))
+                                 (spawn-daemon-and-wait-lock! config repo path
+                                                              requester-owner profile-session))
                              lock (read-lock path)
                              lock (if (and lock
                                            (= :cli requester-owner)
                                            (= :unknown (lock-owner-source lock)))
                                     (rewrite-lock-owner-source! path lock :cli)
                                     lock)
-                             repo-server' (if discovered-repo-server
+                             repo-server' (if (and discovered-repo-server
+                                                   (fs/existsSync path))
                                             discovered-repo-server
-                                            (-> (profile/time! profile-session
-                                                               "server.wait-publish"
-                                                               (fn []
-                                                                 (wait-for-discovered-server config repo)))
+                                            (-> (wait-for-published-server!
+                                                 config repo path requester-owner profile-session)
                                                 (p/catch (fn [e]
                                                            (if (= :timeout (:code (ex-data e)))
                                                              (throw (ex-info "db-worker-node failed to publish health"
@@ -411,11 +465,22 @@
           (p/let [server (if target-server
                            target-server
                            (p/let [servers (discover-servers config)]
-                             (repo-server config servers repo)))]
+                             (repo-server config servers repo)))
+                  stop-lock (cond-> lock
+                              server (assoc :pid (:pid server)))]
             (if-not server
-              {:ok? false
-               :error {:code :server-not-found
-                       :message "server is not running"}}
+              (p/let [_ (force-cleanup-lock! path stop-lock)]
+                (if (and (fs/existsSync path)
+                         (contains? #{:alive :no-permission} (pid-status (:pid stop-lock)))
+                         (not= (:pid stop-lock) (.-pid js/process)))
+                  {:ok? false
+                   :error {:code :server-stop-timeout
+                           :message "timed out stopping server"}}
+                  (do
+                    (when (fs/existsSync path)
+                      (remove-lock! path))
+                    {:ok? true
+                     :data {:repo repo}})))
               (-> (p/let [_ (shutdown! server)]
                     (wait-for (fn []
                                 (p/resolved (not (fs/existsSync path))))
@@ -425,20 +490,13 @@
                      :data {:repo repo}})
                   (p/catch
                    (fn [_]
-                     (when (and (= :alive (pid-status (:pid server)))
-                                (not= (:pid server) (.-pid js/process)))
-                       (try
-                         (.kill js/process (:pid server) "SIGTERM")
-                         (catch :default e
-                           (log/warn :cli-server-stop-sigterm-failed e))))
-                     (when (= :not-found (pid-status (:pid server)))
-                       (remove-lock! path))
-                     (if (fs/existsSync path)
-                       {:ok? false
-                        :error {:code :server-stop-timeout
-                                :message "timed out stopping server"}}
-                       {:ok? true
-                        :data {:repo repo}})))))))))))
+                     (p/let [_ (force-cleanup-lock! path stop-lock)]
+                       (if (fs/existsSync path)
+                         {:ok? false
+                          :error {:code :server-stop-timeout
+                                  :message "timed out stopping server"}}
+                         {:ok? true
+                          :data {:repo repo}}))))))))))))
 
 (defn stop-server!
   [config repo]

--- a/src/main/logseq/db_worker/daemon.cljs
+++ b/src/main/logseq/db_worker/daemon.cljs
@@ -194,6 +194,23 @@
     :else
     (p/resolved nil)))
 
+(defn force-cleanup-lock!
+  "Stop a lock's process even when the pid is still alive, then remove the lock
+  once the process is gone. Used when HTTP is dead/hung after sleep/wake."
+  [path lock]
+  (cond
+    (nil? lock)
+    (p/resolved nil)
+
+    :else
+    (-> (stop-stale-process! lock)
+        (p/then (fn [_]
+                  (when (or (nil? (:pid lock))
+                            (= (:pid lock) (.-pid js/process))
+                            (process-stopped? (:pid lock)))
+                    (remove-lock! path))
+                  nil)))))
+
 (defn wait-for
   [pred-fn {:keys [timeout-ms interval-ms]
             :or {timeout-ms 8000

--- a/src/test/logseq/cli/server_test.cljs
+++ b/src/test/logseq/cli/server_test.cljs
@@ -447,25 +447,95 @@
                           (is false (str "unexpected error: " e))))
                (p/finally done)))))
 
-(deftest ensure-server-repairs-stale-lock
+(deftest stop-server-kills-undiscovered-live-lock
   (async done
-         (let [root-dir (node-helper/create-tmp-dir "cli-server")
-               repo (str "logseq_db_stale_" (subs (str (random-uuid)) 0 8))
-               path (cli-server/lock-path root-dir repo)
-               cleanup-stale-lock! #'cli-server/cleanup-stale-lock!
+         (let [root-dir (node-helper/create-tmp-dir "cli-server-stop-unhealthy")
+               repo (str "logseq_db_stop_unhealthy_" (subs (str (random-uuid)) 0 8))
+               lock-file (cli-server/lock-path root-dir repo)
+               pid 424242
                lock {:repo repo
-                     :pid (.-pid js/process)
-                     :host "127.0.0.1"
-                     :port 0
-                     :startedAt (.toISOString (js/Date.))}]
-           (fs/mkdirSync (node-path/dirname path) #js {:recursive true})
-           (fs/writeFileSync path (js/JSON.stringify (clj->js lock)))
-           (-> (p/let [_ (cleanup-stale-lock! path lock)]
-                 (is (not (fs/existsSync path)))
-                 (done))
+                     :pid pid
+                     :lock-id "unhealthy-stop-lock"
+                     :owner-source :cli}
+               cleanup-calls (atom [])]
+           (fs/mkdirSync (node-path/dirname lock-file) #js {:recursive true})
+           (fs/writeFileSync lock-file (js/JSON.stringify (clj->js lock)))
+           (-> (p/with-redefs [cli-server/discover-servers (fn [_] (p/resolved []))
+                               daemon/force-cleanup-lock! (fn [path lock']
+                                                            (swap! cleanup-calls conj lock')
+                                                            (when (fs/existsSync path)
+                                                              (fs/unlinkSync path))
+                                                            (p/resolved nil))]
+                 (cli-server/stop-server! {:root-dir root-dir
+                                           :owner-source :cli}
+                                          repo))
+               (p/then (fn [result]
+                         (is (= true (:ok? result)))
+                         (is (= 1 (count @cleanup-calls)))
+                         (is (= pid (:pid (first @cleanup-calls))))
+                         (is (not (fs/existsSync lock-file)))))
                (p/catch (fn [e]
-                          (is false (str "unexpected error: " e))
-                          (done)))))))
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
+
+(deftest start-server-replaces-unhealthy-published-lock
+  (async done
+         (let [root-dir (node-helper/create-tmp-dir "cli-server-start-unhealthy")
+               repo (str "logseq_db_start_unhealthy_" (subs (str (random-uuid)) 0 8))
+               lock-file (cli-server/lock-path root-dir repo)
+               server-list-file (cli-config/server-list-path root-dir)
+               pid 424242
+               port 65534
+               lock {:repo repo
+                     :pid pid
+                     :lock-id "unhealthy-start-lock"
+                     :owner-source :cli}
+               replacement-lock {:repo repo
+                                 :pid (.-pid js/process)
+                                 :lock-id "replacement-lock"
+                                 :owner-source :cli}
+               spawn-calls (atom 0)
+               cleanup-calls (atom [])]
+           (fs/mkdirSync (node-path/dirname lock-file) #js {:recursive true})
+           (fs/writeFileSync lock-file (js/JSON.stringify (clj->js lock)))
+           (fs/writeFileSync server-list-file (str pid " " port "\n"))
+           (-> (p/with-redefs [                               daemon/pid-status (fn [_] :alive)
+                               daemon/force-cleanup-lock! (fn [path lock']
+                                                            (swap! cleanup-calls conj lock')
+                                                            (when (fs/existsSync path)
+                                                              (fs/unlinkSync path))
+                                                            (p/resolved nil))
+                               daemon/spawn-server! (fn [_]
+                                                      (swap! spawn-calls inc)
+                                                      (fs/writeFileSync lock-file
+                                                                        (js/JSON.stringify (clj->js replacement-lock)))
+                                                      nil)
+                               daemon/wait-for-lock (fn [_] (p/resolved true))
+                               cli-server/discover-servers (fn [_]
+                                                            (p/resolved
+                                                             (if (pos? @spawn-calls)
+                                                               [{:repo repo
+                                                                 :host "127.0.0.1"
+                                                                 :port 9330
+                                                                 :pid (.-pid js/process)
+                                                                 :owner-source :cli
+                                                                 :revision (version/revision)
+                                                                 :status :ready
+                                                                 :root-dir root-dir}]
+                                                               [])))
+                               daemon/wait-for-ready (fn [_] (p/resolved true))]
+                 (cli-server/start-server! {:root-dir root-dir
+                                            :owner-source :cli
+                                            :expected-revision (version/revision)}
+                                           repo))
+               (p/then (fn [result]
+                         (is (= true (:ok? result)))
+                         (is (= 1 (count @cleanup-calls)))
+                         (is (= pid (:pid (first @cleanup-calls))))
+                         (is (= 1 @spawn-calls))))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally done)))))
 
 (deftest ensure-server-reuses-existing-running-daemon-lock
   (async done

--- a/src/test/logseq/db_worker/daemon_test.cljs
+++ b/src/test/logseq/db_worker/daemon_test.cljs
@@ -125,6 +125,59 @@
                      (is false (str "unexpected error: " e))
                      (done)))))))
 
+(deftest cleanup-stale-lock-keeps-live-valid-lock
+  (async done
+    (let [root-dir (node-helper/create-tmp-dir "db-worker-daemon-live-lock")
+          repo (str "logseq_db_helper_live_" (subs (str (random-uuid)) 0 8))
+          path (node-path/join root-dir "db-worker.lock")
+          child (.spawn child-process "node" #js ["-e" "setInterval(() => {}, 1000)"]
+                        #js {:stdio "ignore"})
+          pid (.-pid child)
+          lock {:repo repo
+                :pid pid
+                :lock-id "live-valid-lock"
+                :owner-source :cli}]
+      (.on child "exit" (fn [_code _signal] nil))
+      (fs/writeFileSync path (js/JSON.stringify (clj->js lock)))
+      (-> (p/let [_ (daemon/cleanup-stale-lock! path lock)]
+            (is (fs/existsSync path) "live valid lock must be kept")
+            (is (= :alive (daemon/pid-status pid))))
+          (p/catch (fn [e]
+                     (is false (str "unexpected error: " e))))
+          (p/finally (fn []
+                       (try
+                         (.kill child "SIGKILL")
+                         (catch :default _))
+                       (done)))))))
+
+(deftest force-cleanup-lock-kills-frozen-process-and-removes-lock
+  (async done
+    (let [root-dir (node-helper/create-tmp-dir "db-worker-daemon-frozen-lock")
+          repo (str "logseq_db_helper_frozen_" (subs (str (random-uuid)) 0 8))
+          path (node-path/join root-dir "db-worker.lock")
+          child (.spawn child-process "node" #js ["-e" "setInterval(() => {}, 1000)"]
+                        #js {:stdio "ignore"})
+          pid (.-pid child)
+          lock {:repo repo
+                :pid pid
+                :lock-id "frozen-lock"
+                :owner-source :cli}]
+      (.on child "exit" (fn [_code _signal] nil))
+      (fs/writeFileSync path (js/JSON.stringify (clj->js lock)))
+      (when (not= "win32" (.-platform js/process))
+        (.kill js/process pid "SIGSTOP"))
+      (-> (p/let [_ (daemon/force-cleanup-lock! path lock)]
+            (is (not (fs/existsSync path)) "unhealthy lock must be removed")
+            (is (not= :alive (daemon/pid-status pid))
+                "frozen pid must be killed so a new worker can start"))
+          (p/catch (fn [e]
+                     (is false (str "unexpected error: " e))))
+          (p/finally (fn []
+                       (try
+                         (.kill child "SIGKILL")
+                         (catch :default _))
+                       (done)))))))
+
 (deftest terminate-process-uses-platform-appropriate-stop-command
   (async done
     (let [terminate-process! (fn [pid force?]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/logseq/db-test/issues/1066

Also covers closed duplicate https://github.com/logseq/db-test/issues/1074 (same toast on macOS/Ubuntu/Win11).

## Problem

After sleep/wake, the db-worker-node pid can still be alive while HTTP is hung. Recovery calls release then start, but:

- `stop-server!` discovered the worker via `/healthz`, so a frozen process returned `server-not-found` and was not killed
- the lock stayed in place
- start skipped spawn because pid-status was `:alive`
- discovery then timed out and the app showed `:graph/db-worker-recovery-failed-error`

PR 12744 only added same-graph recovery. It did not treat a live-but-unhealthy lock as stale, so 2.0.1 still shows the toast.

## Change

Treat a live-but-unhealthy worker (pid alive, healthz hang/fail, already published in `server-list`) as stale:

- kill it (SIGTERM then SIGKILL / Windows `taskkill`)
- drop the lock
- spawn a new runtime

The reconnect toast is only shown when a replacement worker cannot start. Healthy stop/start is unchanged: a ready `/healthz` response is still reused, and 503 starting is still waited on rather than killed.

The same replacement logic is applied in the Electron/cljs daemon path (the desktop toast) and the Melange CLI `server start`/`stop` path.

## Tests

- `force-cleanup-lock-kills-frozen-process-and-removes-lock` (SIGSTOP'd child)
- `cleanup-stale-lock-keeps-live-valid-lock`
- `stop-server-kills-undiscovered-live-lock`
- `start-server-replaces-unhealthy-published-lock`
- CLI parity: start replaces a live lock when healthz is unpublished

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f52c0964-4588-490e-acdd-0213aff1f040?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f52c0964-4588-490e-acdd-0213aff1f040&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

