### PR TITLE
fix: report invalid-block repairs during graph validation

### DIFF
--- a/src/main/frontend/worker/db/validate.cljs
+++ b/src/main/frontend/worker/db/validate.cljs
@@ -5,6 +5,7 @@
             [datascript.impl.entity :as de]
             [frontend.worker.db.migrate :as db-migrate]
             [frontend.worker.shared-service :as shared-service]
+            [lambdaisland.glogi :as log]
             [logseq.db :as ldb]
             [logseq.db-sync.checksum :as sync-checksum]
             [logseq.db.frontend.class :as db-class]
@@ -31,6 +32,70 @@
   (and (= dispatch-key :normal-page)
        (nil? (:block/updated-at entity))
        (int? (:block/created-at entity))))
+
+(defn- tx-op-type
+  [op]
+  (cond
+    (vector? op) (first op)
+    (map? op) :map
+    :else :other))
+
+(defn- tx-op->db-id
+  [db op]
+  (let [id (cond
+             (and (vector? op) (#{:db/retract :db/add :db/retractEntity} (first op)))
+             (second op)
+             (map? op)
+             (or (:db/id op) (:db/ident op)))]
+    (or (:db/id (when id (d/entity db id))) id)))
+
+(defn- entity-repair-identity
+  [db entity-id]
+  (let [entity (when entity-id (d/entity db entity-id))
+        eid (or (:db/id entity) entity-id)]
+    (cond-> {:db/id eid}
+      (:block/uuid entity) (assoc :block/uuid (:block/uuid entity))
+      (string? (:block/title entity)) (assoc :block/title (:block/title entity))
+      (:db/ident entity) (assoc :db/ident (:db/ident entity)))))
+
+(defn- summarize-fix-tx-data
+  [db tx-data]
+  (->> tx-data
+       (group-by (fn [op] (tx-op->db-id db op)))
+       (keep (fn [[eid ops]]
+               (when eid
+                 (let [retract-entity? (boolean (some #(= :db/retractEntity (tx-op-type %)) ops))
+                       retracted-attrs (->> ops
+                                            (filter #(= :db/retract (tx-op-type %)))
+                                            (map #(nth % 2))
+                                            distinct
+                                            vec)
+                       added-attrs (->> ops
+                                        (filter #(= :db/add (tx-op-type %)))
+                                        (map #(nth % 2))
+                                        distinct
+                                        vec)
+                       map-attrs (->> ops
+                                      (filter map?)
+                                      (mapcat keys)
+                                      (remove #{:db/id :db/ident})
+                                      distinct
+                                      vec)]
+                   (merge (entity-repair-identity db eid)
+                          {:retract-entity? retract-entity?
+                           :retracted-attrs retracted-attrs
+                           :added-attrs (into added-attrs map-attrs)})))))
+       vec))
+
+(defn- log-invalid-block-repairs!
+  [repairs]
+  (doseq [repair repairs]
+    (log/info :db-validate/repair repair))
+  (when (seq repairs)
+    (shared-service/broadcast-to-clients! :log
+                                          [:db-validate :info
+                                           {:msg "Repaired invalid blocks"
+                                            :repairs repairs}])))
 
 (defn- ^:large-vars/cleanup-todo fix-invalid-blocks!
   [conn errors]
@@ -189,8 +254,13 @@
         tx-data (concat fix-tx-data
                         class-as-properties)]
     (when (seq tx-data)
-      (let [tx-report (ldb/transact! conn tx-data {:fix-db? true})]
-        (seq (:tx-data tx-report))))))
+      (let [repairs (summarize-fix-tx-data db tx-data)
+            tx-report (ldb/transact! conn tx-data {:fix-db? true})]
+        (when (seq (:tx-data tx-report))
+          (let [repairs' (vec (or (seq repairs)
+                                  [{:tx-data (vec tx-data)}]))]
+            (log-invalid-block-repairs! repairs')
+            repairs'))))))
 
 (defn- fix-num-prefix-db-idents!
   "Fix invalid db/ident keywords for both classes and properties"
@@ -279,17 +349,20 @@
 (defn- log-validation-errors!
   [errors]
   (doseq [error errors]
-    (prn :debug
-         :entity (:entity error)
-         :error (dissoc error :entity))))
+    (log/debug :db-validate/error {:entity (:entity error)
+                                   :error (dissoc error :entity)})))
 
 (defn- validate-and-fix-invalid-blocks!
   [conn]
-  (loop [{:keys [errors] :as result} (validate-db-result @conn)]
+  (loop [{:keys [errors] :as result} (validate-db-result @conn)
+         repairs []]
     (log-validation-errors! errors)
-    (if (and (seq errors) (fix-invalid-blocks! conn errors))
-      (recur (validate-db-result @conn))
-      result)))
+    (let [round-repairs (when (seq errors)
+                          (fix-invalid-blocks! conn errors))]
+      (if (seq round-repairs)
+        (recur (validate-db-result @conn) (into repairs round-repairs))
+        (cond-> result
+          (seq repairs) (assoc :repairs repairs))))))
 
 (defn validate-db
   [conn & {:keys [fix] :or {fix true}}]
@@ -300,7 +373,7 @@
     (fix-non-closed-values! conn)
     (fix-num-prefix-db-idents! conn))
 
-  (let [{:keys [errors datom-count entities invalid-entity-ids]}
+  (let [{:keys [errors datom-count entities invalid-entity-ids repairs]}
         (if fix
           (validate-and-fix-invalid-blocks! conn)
           (let [{:keys [errors] :as result} (validate-db-result @conn)]
@@ -309,7 +382,8 @@
         db @conn
         counts (assoc (db-validate/graph-counts db entities) :datoms datom-count)]
 
-    (if errors
+    (cond
+      (seq errors)
       (do
         (shared-service/broadcast-to-clients! :log [:db-invalid :error
                                                     {:msg "Validation errors"
@@ -320,12 +394,21 @@
                                                       " Attempting to fix invalid blocks. Run validation again to see if they were fixed."))
                                                :warning false]))
 
+      (seq repairs)
       (shared-service/broadcast-to-clients! :notification
-                                            [(str "Your graph is valid! " counts)
-                                             :success false]))
-    (merge {:errors errors
-            :invalid-entity-ids invalid-entity-ids}
-           counts)))
+                                            [nil :success false nil nil
+                                             {:i18n-key :graph.validation/repaired-blocks
+                                              :i18n-args [(str (count repairs)) (str counts)]}])
+
+      :else
+      (shared-service/broadcast-to-clients! :notification
+                                            [nil :success false nil nil
+                                             {:i18n-key :graph.validation/valid
+                                              :i18n-args [(str counts)]}]))
+    (cond-> (merge {:errors errors
+                    :invalid-entity-ids invalid-entity-ids}
+                   counts)
+      (seq repairs) (assoc :repairs repairs))))
 
 (defn recompute-checksum-diagnostics
   [_repo conn {:keys [local-checksum remote-checksum] :as _sync-diagnostics}]

--- a/src/main/logseq/cli/command/graph.cljs
+++ b/src/main/logseq/cli/command/graph.cljs
@@ -422,7 +422,8 @@
     {:status :error
      :error {:code :graph-validation-failed
              :message (format-validation-errors (:errors result))}
-     :data {:errors (:errors result)}}
+     :data (cond-> {:errors (:errors result)}
+             (seq (:repairs result)) (assoc :repairs (:repairs result)))}
     {:status :ok :data {:result result}}))
 
 (defn execute-invoke

--- a/src/main/logseq/cli/format.cljs
+++ b/src/main/logseq/cli/format.cljs
@@ -970,16 +970,54 @@
                 (str "  Sync upload: " (if (contains? stages :upload) "ok" "-"))
                 (str "  Sync start: " (if (contains? stages :start) "ok" "-"))]))
 
+(defn- format-repair-action
+  [{:keys [retract-entity? retracted-attrs added-attrs]}]
+  (->> [(when retract-entity? "deleted entity")
+        (when (seq retracted-attrs)
+          (str "retracted " (string/join ", " retracted-attrs)))
+        (when (seq added-attrs)
+          (str "added " (string/join ", " added-attrs)))]
+       (remove nil?)
+       (string/join "; ")))
+
+(defn- format-repair
+  [{:keys [db/id block/uuid block/title db/ident] :as repair}]
+  (let [label (or (some-> ident str)
+                  (when (seq title) (pr-str title))
+                  (some-> uuid str)
+                  (str "#" id))
+        action (format-repair-action repair)]
+    (str "  " label (when (seq action) (str " — " action)))))
+
+(defn- format-graph-validate
+  [graph data]
+  (let [repairs (get-in data [:result :repairs])
+        header (str "Validated graph " (pr-str graph))]
+    (if (seq repairs)
+      (str header "\n"
+           "Repaired "
+           (cli-humanize/format-count (count repairs))
+           " invalid "
+           (cli-humanize/pluralize-noun (count repairs) "block")
+           ":\n"
+           (string/join "\n" (map format-repair repairs)))
+      header)))
+
 (defn- format-graph-action
   [command {:keys [graph]} data]
-  (if (and (= command :graph-create)
-           (map? (:stages data)))
+  (cond
+    (and (= command :graph-create)
+         (map? (:stages data)))
     (format-graph-create-enable-sync data)
+
+    (= command :graph-validate)
+    (format-graph-validate graph data)
+
+    :else
     (let [verb (case command
                  :graph-create "Created"
                  :graph-switch "Switched to"
                  :graph-remove "Removed"
-                 :graph-validate "Validated"
                  "Updated")]
       (str verb " graph " (pr-str graph)))))
 

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -814,6 +814,7 @@
  :graph.validation/config-unused-in-db-graphs-warning "is not used in DB graphs."
  :graph.validation/invalid-blocks-detected "Validation detected {1} invalid block(s). These blocks may be buggy. Attempting to fix invalid blocks. Run validation again to see if they were fixed."
  :graph.validation/name-reserved-characters-warning "Graph name can't contain following reserved characters:"
+ :graph.validation/repaired-blocks "Repaired {1} invalid block(s). Your graph is now valid! {2}"
  :graph.validation/reserved-character-asterisk "asterisk"
  :graph.validation/reserved-character-backslash "backslash"
  :graph.validation/reserved-character-colon "colon"

--- a/src/resources/dicts/zh-cn.edn
+++ b/src/resources/dicts/zh-cn.edn
@@ -814,6 +814,7 @@
  :graph.validation/config-unused-in-db-graphs-warning "在 DB 图谱中不会使用。"
  :graph.validation/invalid-blocks-detected "验证发现 {1} 个无效块。这些块可能存在问题。正在尝试修复无效块。请再次运行验证以检查它们是否已被修复。"
  :graph.validation/name-reserved-characters-warning "知识库名称不能包含以下保留字符："
+ :graph.validation/repaired-blocks "已修复 {1} 个无效块。你的图谱现在有效！{2}"
  :graph.validation/reserved-character-asterisk "星号"
  :graph.validation/reserved-character-backslash "反斜杠"
  :graph.validation/reserved-character-colon "冒号"

--- a/src/test/frontend/worker/db_validate_test.cljs
+++ b/src/test/frontend/worker/db_validate_test.cljs
@@ -1,5 +1,6 @@
 (ns frontend.worker.db-validate-test
   (:require [cljs.test :refer [deftest is]]
+            [clojure.string :as string]
             [datascript.core :as d]
             [frontend.worker.db.validate :as worker-db-validate]
             [frontend.worker.pipeline :as worker-pipeline]
@@ -34,6 +35,7 @@
         (is (= expected-counts (select-keys result (keys expected-counts))))
         (is (not (contains? result :counts)))
         (is (not (contains? result :datom-count)))
+        (is (not (contains? result :repairs)))
         (is (every? number? (map result (keys expected-counts))))))))
 
 (deftest validate-db-repairs-block-missing-uuid
@@ -59,8 +61,17 @@
                       "block")]
     (is (seq (:errors (db-validate/validate-db @conn))))
     (with-redefs [shared-service/broadcast-to-clients! (fn [& _args] nil)]
-      (with-transact-pipeline #(worker-db-validate/validate-db conn))
-      (let [repaired-block (d/entity @conn block-id)]
+      (let [result (with-transact-pipeline #(worker-db-validate/validate-db conn))
+            repaired-block (d/entity @conn block-id)
+            uuid-repair (some (fn [repair]
+                                (when (and (= block-id (:db/id repair))
+                                           (some #{:block/uuid} (:added-attrs repair)))
+                                  repair))
+                              (:repairs result))]
+        (is (empty? (:errors result)))
+        (is (seq (:repairs result))
+            "A successful repair must be reported, not only empty :errors.")
+        (is (some? uuid-repair))
         (is (uuid? (:block/uuid repaired-block)))
         (is (nat-int? (:block/tx-id repaired-block))
             "A live repair must make the repaired block canonically readable.")
@@ -103,6 +114,8 @@
             property (d/entity @conn :logseq.property.class/extends)
             class (d/entity @conn class-id)]
         (is (empty? (:errors result)))
+        (is (seq (:repairs result))
+            "A successful repair must be reported, not only empty :errors.")
         (doseq [entity [journal property class]]
           (is (not= 1 (:block/tx-id entity))
               (str "Every canonical entity changed by a live repair receives a new revision: "
@@ -112,3 +125,64 @@
         (is (nil? (:logseq.property.class/extends property)))
         (is (nil? (:kv/value class)))
         (is (empty? (:errors (worker-db-validate/validate-db conn))))))))
+
+(deftest validate-db-reports-repairs-for-legacy-block-attrs
+  (let [conn (create-db-graph-conn)
+        page-id (get (:tempids
+                      (d/transact! conn [{:db/id "page"
+                                          :block/uuid (random-uuid)
+                                          :block/created-at 1
+                                          :block/updated-at 1
+                                          :block/name "test page"
+                                          :block/title "Test Page"
+                                          :block/tags :logseq.class/Page}]))
+                     "page")
+        block-uuid (random-uuid)
+        block-id (get (:tempids
+                       (d/transact! conn [{:db/id "block"
+                                           :block/uuid block-uuid
+                                           :block/created-at 1
+                                           :block/updated-at 2
+                                           :block/page page-id
+                                           :block/parent page-id
+                                           :block/order "a0"
+                                           :block/title "legacy"
+                                           :block/pre-block? true}]))
+                      "block")
+        broadcasts (atom [])]
+    (is (seq (:errors (db-validate/validate-db @conn))))
+    (with-redefs [shared-service/broadcast-to-clients!
+                  (fn [& args] (swap! broadcasts conj (vec args)))]
+      (let [result (with-transact-pipeline #(worker-db-validate/validate-db conn))
+            matching-repair (some (fn [repair]
+                                    (when (and (= block-id (:db/id repair))
+                                               (some #{:block/pre-block?} (:retracted-attrs repair)))
+                                      repair))
+                                  (:repairs result))
+            notifications (filter (fn [call] (= :notification (first call))) @broadcasts)
+            logs (filter (fn [call] (= :log (first call))) @broadcasts)
+            notification-extra (some (fn [[_ payload]]
+                                       (nth payload 5 nil))
+                                     notifications)]
+        (is (empty? (:errors result)))
+        (is (seq (:repairs result))
+            "A successful repair must be reported, not only empty :errors.")
+        (is (some? matching-repair))
+        (is (= block-uuid (:block/uuid matching-repair)))
+        (is (false? (:retract-entity? matching-repair)))
+        (is (nil? (:block/pre-block? (d/entity @conn block-id))))
+        (is (= :graph.validation/repaired-blocks (:i18n-key notification-extra))
+            "GUI notification must report the repair instead of only 'Your graph is valid!'.")
+        (is (not-any? (fn [[_ payload]]
+                        (let [extra (nth payload 5 nil)
+                              content (first payload)]
+                          (or (= :graph.validation/valid (:i18n-key extra))
+                              (and (string? content)
+                                   (string/includes? content "Your graph is valid!")))))
+                      notifications))
+        (is (some (fn [[_ [name level data]]]
+                    (and (= :db-validate name)
+                         (= :info level)
+                         (seq (:repairs data))))
+                  logs)
+            "Repair logs must be visible at info, not only debug error dumps.")))))

--- a/src/test/logseq/cli/command/graph_test.cljs
+++ b/src/test/logseq/cli/command/graph_test.cljs
@@ -18,12 +18,18 @@
   (let [graph-validate-result #'graph-command/graph-validate-result
         invalid-result (graph-validate-result {:errors [{:entity {:db/id 1}
                                                          :errors {:foo ["bad"]}}]})
-        valid-result (graph-validate-result {:errors nil :datom-count 10})]
+        valid-result (graph-validate-result {:errors nil :datom-count 10})
+        repaired-result (graph-validate-result {:errors nil
+                                                :repairs [{:db/id 12
+                                                           :retracted-attrs [:block/pre-block?]}]})]
     (is (= :error (:status invalid-result)))
     (is (= :graph-validation-failed (get-in invalid-result [:error :code])))
     (is (string/includes? (get-in invalid-result [:error :message])
                           "Found 1 entity with errors:"))
-    (is (= :ok (:status valid-result)))))
+    (is (= :ok (:status valid-result)))
+    (is (= :ok (:status repaired-result)))
+    (is (= [{:db/id 12 :retracted-attrs [:block/pre-block?]}]
+           (get-in repaired-result [:data :result :repairs])))))
 
 (deftest test-graph-validate-result-formats-large-error-count
   (let [graph-validate-result #'graph-command/graph-validate-result

--- a/src/test/logseq/cli/format_test.cljs
+++ b/src/test/logseq/cli/format_test.cljs
@@ -101,6 +101,20 @@
                                         :data {:result {:errors nil}}}
                                        {:output-format nil})]
       (is (= "Validated graph \"foo\"" result))))
+  (testing "graph validation success with repairs prints a repair summary"
+    (let [result (format/format-result {:status :ok
+                                        :command :graph-validate
+                                        :context {:graph "foo"}
+                                        :data {:result {:errors nil
+                                                        :repairs [{:db/id 12
+                                                                   :block/title "legacy"
+                                                                   :retract-entity? false
+                                                                   :retracted-attrs [:block/pre-block?]
+                                                                   :added-attrs []}]}}}
+                                       {:output-format nil})]
+      (is (string/includes? result "Validated graph \"foo\""))
+      (is (string/includes? result "Repaired 1 invalid block"))
+      (is (string/includes? result "retracted :block/pre-block?"))))
   (testing "graph validation error prints validation details without extra prefix"
     (let [result (format/format-result {:status :error
                                         :command :graph-validate


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

GUI "Validate graph" runs `validate-db` with default `fix true`. The sixth pass, `validate-and-fix-invalid-blocks!` / `fix-invalid-blocks!`, retracts invalid attributes and entities without logging the repair. Validation errors were printed at debug; after a successful repair the loop returned the last round, so the UI reported `:errors nil` / "Your graph is valid!" as if nothing happened.

This is independent of db-test#1068 (the five `when fix` passes).

Fixes https://github.com/logseq/db-test/issues/1067

## Change

When `fix-invalid-blocks!` mutates the graph:

- Log each repair at info (`:db-validate/repair`) with entity identity, retracted attributes, added attributes, and `retract-entity?`.
- Broadcast an info log to clients with the full repair list.
- Include a non-empty `:repairs` vector on the `validate-db` result even when final `:errors` is nil.
- Show a dedicated GUI notification (`:graph.validation/repaired-blocks`) instead of only "Your graph is valid!".
- Print a repair summary from `logseq graph validate --fix` human output; JSON/EDN already carry `:repairs` on the result.

The five `when fix` passes are unchanged.

## Tests

- Existing validate repair tests now assert a non-empty `:repairs` summary, not only empty `:errors`.
- New test: a `:block/pre-block?` repair is returned, notified via `:graph.validation/repaired-blocks`, and logged at info.
- CLI format/result tests cover the human repair summary.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23f72058-bba8-475d-b0c1-2120433964d6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23f72058-bba8-475d-b0c1-2120433964d6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

