### PR TITLE
Clear leftover closed values when a property type no longer supports them

### DIFF
--- a/deps/outliner/src/logseq/outliner/property.cljs
+++ b/deps/outliner/src/logseq/outliner/property.cljs
@@ -278,6 +278,22 @@
     (outliner-validate/validate-block-title @conn property-name property)
     (outliner-validate/validate-property-title property-name)))
 
+(defn- clear-closed-values-tx
+  "Retract leftover closed-value links when a property type no longer supports
+  them, and delete unused choice entities. The config UI hides the enum for types
+  outside closed-value-property-types, but leftover :block/closed-value-property
+  links are still enforced by validate's fix-non-closed-values!."
+  [db property]
+  (when-let [closed-values (seq (entity-plus/lookup-kv-then-entity property :property/closed-values))]
+    (let [property-id (:db/id property)
+          retract-tx (map (fn [value]
+                            [:db/retract (:db/id value) :block/closed-value-property property-id])
+                          closed-values)
+          user-closed-values (vec (remove ldb/built-in? closed-values))]
+      (concat retract-tx
+              (when (seq user-closed-values)
+                (:tx-data (outliner-core/delete-blocks db user-closed-values {})))))))
+
 (defn- update-property
   [conn db-ident property schema {:keys [property-name properties]}]
   (validate-property-name-update conn property property-name)
@@ -292,6 +308,8 @@
           (and (some? property-name) (not= property-name (:block/title property)))
           (assoc :block/title property-name
                  :block/name (common-util/page-name-sanity-lc property-name)))
+        new-type (:logseq.property/type changed-property-attrs)
+        old-type (:logseq.property/type property)
         property-tx-data
         (cond-> []
           (seq changed-property-attrs)
@@ -305,6 +323,10 @@
                    (seq (entity-plus/lookup-kv-then-entity property :property/closed-values))))
           (concat (update-datascript-schema property schema)))
         tx-data (concat property-tx-data
+                        (when (and new-type
+                                   (contains? db-property-type/closed-value-property-types old-type)
+                                   (not (contains? db-property-type/closed-value-property-types new-type)))
+                          (clear-closed-values-tx @conn property))
                         (when (seq properties)
                           (mapcat
                            (fn [[property-id v]]

--- a/deps/outliner/src/logseq/outliner/property.cljs
+++ b/deps/outliner/src/logseq/outliner/property.cljs
@@ -278,21 +278,24 @@
     (outliner-validate/validate-block-title @conn property-name property)
     (outliner-validate/validate-property-title property-name)))
 
-(defn- clear-closed-values-tx
-  "Retract leftover closed-value links when a property type no longer supports
-  them, and delete unused choice entities. The config UI hides the enum for types
+(defn- closed-values-tx-for-unsupported-type
+  "When type changes away from a closed-value type, retract leftover enum links
+  and delete unused choice entities. The config UI hides the enum for types
   outside closed-value-property-types, but leftover :block/closed-value-property
   links are still enforced by validate's fix-non-closed-values!."
-  [db property]
-  (when-let [closed-values (seq (entity-plus/lookup-kv-then-entity property :property/closed-values))]
-    (let [property-id (:db/id property)
-          retract-tx (map (fn [value]
-                            [:db/retract (:db/id value) :block/closed-value-property property-id])
-                          closed-values)
-          user-closed-values (vec (remove ldb/built-in? closed-values))]
-      (concat retract-tx
-              (when (seq user-closed-values)
-                (:tx-data (outliner-core/delete-blocks db user-closed-values {})))))))
+  [db property new-type]
+  (when (and new-type
+             (contains? db-property-type/closed-value-property-types (:logseq.property/type property))
+             (not (contains? db-property-type/closed-value-property-types new-type)))
+    (when-let [closed-values (seq (entity-plus/lookup-kv-then-entity property :property/closed-values))]
+      (let [property-id (:db/id property)
+            retract-tx (map (fn [value]
+                              [:db/retract (:db/id value) :block/closed-value-property property-id])
+                            closed-values)
+            user-closed-values (vec (remove ldb/built-in? closed-values))]
+        (concat retract-tx
+                (when (seq user-closed-values)
+                  (:tx-data (outliner-core/delete-blocks db user-closed-values {}))))))))
 
 (defn- update-property
   [conn db-ident property schema {:keys [property-name properties]}]
@@ -308,8 +311,6 @@
           (and (some? property-name) (not= property-name (:block/title property)))
           (assoc :block/title property-name
                  :block/name (common-util/page-name-sanity-lc property-name)))
-        new-type (:logseq.property/type changed-property-attrs)
-        old-type (:logseq.property/type property)
         property-tx-data
         (cond-> []
           (seq changed-property-attrs)
@@ -323,10 +324,8 @@
                    (seq (entity-plus/lookup-kv-then-entity property :property/closed-values))))
           (concat (update-datascript-schema property schema)))
         tx-data (concat property-tx-data
-                        (when (and new-type
-                                   (contains? db-property-type/closed-value-property-types old-type)
-                                   (not (contains? db-property-type/closed-value-property-types new-type)))
-                          (clear-closed-values-tx @conn property))
+                        (closed-values-tx-for-unsupported-type
+                         @conn property (:logseq.property/type changed-property-attrs))
                         (when (seq properties)
                           (mapcat
                            (fn [[property-id v]]

--- a/deps/outliner/test/logseq/outliner/property_test.cljs
+++ b/deps/outliner/test/logseq/outliner/property_test.cljs
@@ -60,6 +60,50 @@
       (outliner-property/upsert-property! conn :user.property/empty-prop {:logseq.property/type :number} {})
       (is (= :number (:logseq.property/type (d/entity @conn :user.property/empty-prop)))))))
 
+(deftest upsert-property-clears-closed-values-when-type-no-longer-supports-them
+  (testing "Text property with closed values -> Node retracts leftover enum"
+    (let [raster-uuid (random-uuid)
+          vector-uuid (random-uuid)
+          conn (db-test/create-conn-with-blocks
+                {:properties {:fig-source {:logseq.property/type :default
+                                           :build/closed-values [{:uuid raster-uuid :value "raster"}
+                                                                 {:uuid vector-uuid :value "vector"}]}}})
+          property (d/entity @conn :user.property/fig-source)]
+      (is (= :default (:logseq.property/type property)))
+      (is (= #{"raster" "vector"}
+             (set (map db-property/closed-value-content (:block/_closed-value-property property)))))
+      (outliner-property/upsert-property! conn :user.property/fig-source {:logseq.property/type :node} {})
+      (let [property' (d/entity @conn :user.property/fig-source)]
+        (is (= :node (:logseq.property/type property')))
+        (is (empty? (:block/_closed-value-property property'))
+            "Closed-value links are retracted so validate cannot still enforce them")
+        (is (nil? (d/entity @conn [:block/uuid raster-uuid])))
+        (is (nil? (d/entity @conn [:block/uuid vector-uuid]))))))
+
+  (testing "Text property with closed values -> Date also clears the enum"
+    (let [closed-uuid (random-uuid)
+          conn (db-test/create-conn-with-blocks
+                {:properties {:due-label {:logseq.property/type :default
+                                          :build/closed-values [{:uuid closed-uuid :value "today"}]}}})]
+      (outliner-property/upsert-property! conn :user.property/due-label {:logseq.property/type :date} {})
+      (let [property (d/entity @conn :user.property/due-label)]
+        (is (= :date (:logseq.property/type property)))
+        (is (empty? (:block/_closed-value-property property)))
+        (is (nil? (d/entity @conn [:block/uuid closed-uuid]))))))
+
+  (testing "Changing among closed-value types keeps the enum"
+    (let [closed-uuid (random-uuid)
+          conn (db-test/create-conn-with-blocks
+                {:properties {:status {:logseq.property/type :default
+                                       :build/closed-values [{:uuid closed-uuid :value "open"}]}}})]
+      (outliner-property/upsert-property! conn :user.property/status {:logseq.property/type :number} {})
+      (let [property (d/entity @conn :user.property/status)
+            closed-value (d/entity @conn [:block/uuid closed-uuid])]
+        (is (= :number (:logseq.property/type property)))
+        (is (some? closed-value))
+        (is (= #{(:db/id property)}
+               (set (map :db/id (:block/closed-value-property closed-value)))))))))
+
 (deftest convert-property-input-string
   (testing "Convert property input string according to its schema type"
     (let [test-uuid (random-uuid)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/logseq/db-test/issues/1069

## Problem

Changing a Text (or Number/URL) property that has closed values to Node — or any type outside `closed-value-property-types` — updated `:logseq.property/type` but left `:block/closed-value-property` links in place.

The property config UI only shows the enum for `#{:default :number :url}`, so those leftover choices became invisible. `fix-non-closed-values!` still treated them as the allowed set and could retract live values that were not in that leftover enum.

This is independent of db-test#1068 (Validate graph silently deleting those leftover-enum values).

## Change

`update-property` now retracts `:block/closed-value-property` and deletes the unused choice entities when the type changes away from a closed-value type.

The UI type picker and CLI `--type` both go through `upsert-property!` → `update-property`, so both paths get the cleanup.

Changing among closed-value types (Text/Number/URL) still keeps the enum.

## Tests

Added `upsert-property-clears-closed-values-when-type-no-longer-supports-them`:

- Text + closed values → Node clears the enum
- Text + closed values → Date also clears
- Text + closed values → Number keeps the enum

Pre-fix, the new test failed with leftover closed-value entities still linked (`{:db/id 192}` / `{:db/id 193}`). After the fix:

- `pnpm exec nbb-logseq -cp test -m nextjournal.test-runner -n logseq.outliner.property-test` — 29 tests, 104 assertions, 0 failures
- full outliner nbb suite `-e long` — 100 tests, 355 assertions, 0 failures

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcf3aa2a-7a42-4c0d-877e-573e292252ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcf3aa2a-7a42-4c0d-877e-573e292252ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

