### PR TITLE
fix: do not silently delete property values during graph validate

### DIFF
--- a/src/main/frontend/handler/common/developer.cljs
+++ b/src/main/frontend/handler/common/developer.cljs
@@ -82,7 +82,7 @@
     (notification/show! (t :page/not-found-warning) :warning)))
 
 (defn ^:export validate-db []
-  (state/<invoke-db-worker :thread-api/validate-db (state/get-current-repo)))
+  (state/<invoke-db-worker :thread-api/validate-db (state/get-current-repo) {:fix false}))
 
 (defn- checksum-export-file-name
   [repo]

--- a/src/main/frontend/handler/db_based/export.cljs
+++ b/src/main/frontend/handler/db_based/export.cljs
@@ -80,7 +80,8 @@
   "Run db validation before exporting EDN"
   [repo]
   (p/let [validate-result (state/<invoke-db-worker :thread-api/validate-db
-                                                   (state/get-current-repo))
+                                                   (state/get-current-repo)
+                                                   {:fix false})
           {:keys [errors]} validate-result
           _ (when (seq errors)
               (throw (ex-info "Graph validation failed" validate-result)))

--- a/src/main/frontend/worker/db/validate.cljs
+++ b/src/main/frontend/worker/db/validate.cljs
@@ -5,9 +5,12 @@
             [datascript.impl.entity :as de]
             [frontend.worker.db.migrate :as db-migrate]
             [frontend.worker.shared-service :as shared-service]
+            [lambdaisland.glogi :as log]
+            [logseq.common.util :as common-util]
             [logseq.db :as ldb]
             [logseq.db-sync.checksum :as sync-checksum]
             [logseq.db.frontend.class :as db-class]
+            [logseq.db.frontend.property.type :as db-property-type]
             [logseq.db.frontend.validate :as db-validate]))
 
 (defn- get-property-by-title
@@ -219,43 +222,68 @@
     (when (seq tx-data')
       (ldb/transact! conn tx-data'))))
 
+(defn- closed-value-type?
+  [property]
+  (contains? db-property-type/closed-value-property-types
+             (:logseq.property/type property)))
+
 (defn- fix-non-closed-values!
+  "Retract values that are not in a property's closed-value set.
+   Only runs for property types that still support closed values. Leftover closed
+   values on a Node (or other non-enum) property must not delete live values."
   [conn]
   (let [db @conn
+        now (common-util/time-ms)
         properties (->> (ldb/get-all-properties db)
-                        (filter :block/_closed-value-property))
-        tx-data (mapcat
-                 (fn [property]
-                   (let [closed-values (:block/_closed-value-property property)
-                         matches (if (every? de/entity? closed-values)
-                                   (set (map :db/id closed-values))
-                                   (set closed-values))
-                         values (d/q
-                                 '[:find ?b ?v
-                                   :in $ ?p
-                                   :where
-                                   [?b ?p ?v]]
-                                 db
-                                 (:db/ident property))]
-                     (keep
-                      (fn [[b v]]
-                        (when-not (or (matches v)
-                                      (= :logseq.property/empty-placeholder (:db/ident (d/entity db v))))
-                          [:db/retract b (:db/ident  property) v]))
-                      values)))
-                 properties)]
-    (when (seq tx-data)
-      (prn :debug :fix-non-closed-values tx-data)
-      (ldb/transact! conn tx-data {:fix-db? true}))))
+                        (filter :block/_closed-value-property)
+                        (filter closed-value-type?))
+        retract-tx (vec
+                    (mapcat
+                     (fn [property]
+                       (let [closed-values (:block/_closed-value-property property)
+                             matches (if (every? de/entity? closed-values)
+                                       (set (map :db/id closed-values))
+                                       (set closed-values))
+                             values (d/q
+                                     '[:find ?b ?v
+                                       :in $ ?p
+                                       :where
+                                       [?b ?p ?v]]
+                                     db
+                                     (:db/ident property))]
+                         (keep
+                          (fn [[b v]]
+                            (when-not (or (matches v)
+                                          (= :logseq.property/empty-placeholder (:db/ident (d/entity db v))))
+                              [:db/retract b (:db/ident property) v]))
+                          values)))
+                     properties))
+        updated-at-tx (map (fn [eid]
+                             {:db/id eid
+                              :block/updated-at now})
+                           (distinct (map second retract-tx)))
+        tx-data (concat retract-tx updated-at-tx)]
+    (when (seq retract-tx)
+      (log/info :fix-non-closed-values {:retractions retract-tx})
+      (ldb/transact! conn tx-data {:fix-db? true}))
+    retract-tx))
 
 (defn- fix-icon-wrong-type!
   [conn]
   (let [icon (d/entity @conn :logseq.property/icon)]
     (when (= :db.type/ref (:db/valueType icon))
       (let [datoms (d/datoms @conn :avet :logseq.property/icon)
-            tx-data (cons
-                     [:db/retract (:db/id icon) :db/valueType]
-                     (map (fn [d] [:db/retract (:e d) (:a d)]) datoms))]
+            now (common-util/time-ms)
+            retract-tx (map (fn [d] [:db/retract (:e d) (:a d)]) datoms)
+            tx-data (concat
+                     [[:db/retract (:db/id icon) :db/valueType]]
+                     retract-tx
+                     (map (fn [d]
+                            {:db/id (:e d)
+                             :block/updated-at now})
+                          datoms))]
+        (when (seq datoms)
+          (log/info :fix-icon-wrong-type {:retractions retract-tx}))
         (ldb/transact! conn tx-data {:fix-db? true})))))
 
 (defn- fix-extends-cardinality!
@@ -291,16 +319,49 @@
       (recur (validate-db-result @conn))
       result)))
 
-(defn validate-db
-  [conn & {:keys [fix] :or {fix true}}]
-  (when fix
-    (fix-extends-cardinality! conn)
-    (fix-icon-wrong-type! conn)
-    (db-migrate/ensure-built-in-data-exists! conn)
-    (fix-non-closed-values! conn)
-    (fix-num-prefix-db-idents! conn))
+(defn- notify-validation-result!
+  [{:keys [errors fix retracted-property-values counts]}]
+  (cond
+    (seq errors)
+    (do
+      (shared-service/broadcast-to-clients! :log [:db-invalid :error
+                                                  {:msg "Validation errors"
+                                                   :errors errors}])
+      (shared-service/broadcast-to-clients!
+       :notification
+       [nil :warning false nil nil
+        {:i18n-key (if fix
+                     :graph.validation/invalid-blocks-detected
+                     :graph.validation/invalid-blocks-found)
+         :i18n-args [(str (count errors))]}]))
 
-  (let [{:keys [errors datom-count entities invalid-entity-ids]}
+    (pos? retracted-property-values)
+    (shared-service/broadcast-to-clients!
+     :notification
+     [nil :warning false nil nil
+      {:i18n-key :graph.validation/values-retracted
+       :i18n-args [(str retracted-property-values)]}])
+
+    :else
+    (shared-service/broadcast-to-clients!
+     :notification
+     [nil :success false nil nil
+      {:i18n-key :graph.validation/valid
+       :i18n-args [(pr-str counts)]}])))
+
+(defn validate-db
+  [conn & {:keys [fix] :or {fix false}}]
+  (let [retracted-property-values
+        (if fix
+          (do
+            (fix-extends-cardinality! conn)
+            (fix-icon-wrong-type! conn)
+            (db-migrate/ensure-built-in-data-exists! conn)
+            (let [retractions (fix-non-closed-values! conn)]
+              (fix-num-prefix-db-idents! conn)
+              (count retractions)))
+          0)
+        {:keys [errors datom-count entities invalid-entity-ids]}
         (if fix
           (validate-and-fix-invalid-blocks! conn)
           (let [{:keys [errors] :as result} (validate-db-result @conn)]
@@ -308,23 +369,14 @@
             result))
         db @conn
         counts (assoc (db-validate/graph-counts db entities) :datoms datom-count)]
-
-    (if errors
-      (do
-        (shared-service/broadcast-to-clients! :log [:db-invalid :error
-                                                    {:msg "Validation errors"
-                                                     :errors errors}])
-        (shared-service/broadcast-to-clients! :notification
-                                              [(str "Validation detected " (count errors) " invalid block(s). These blocks may be buggy."
-                                                    (when fix
-                                                      " Attempting to fix invalid blocks. Run validation again to see if they were fixed."))
-                                               :warning false]))
-
-      (shared-service/broadcast-to-clients! :notification
-                                            [(str "Your graph is valid! " counts)
-                                             :success false]))
+    (notify-validation-result!
+     {:errors errors
+      :fix fix
+      :retracted-property-values retracted-property-values
+      :counts counts})
     (merge {:errors errors
-            :invalid-entity-ids invalid-entity-ids}
+            :invalid-entity-ids invalid-entity-ids
+            :retracted-property-values retracted-property-values}
            counts)))
 
 (defn recompute-checksum-diagnostics

--- a/src/main/frontend/worker/handler/export.cljs
+++ b/src/main/frontend/worker/handler/export.cljs
@@ -39,7 +39,7 @@
 (def-thread-api :thread-api/validate-db
   [repo & [opts]]
   (when-let [conn (worker-state/get-datascript-conn repo)]
-    (worker-db-validate/validate-db conn opts)))
+    (worker-db-validate/validate-db conn (or opts {}))))
 
 (defn- checksum-diagnostics
   [repo]

--- a/src/main/logseq/cli/format.cljs
+++ b/src/main/logseq/cli/format.cljs
@@ -980,8 +980,16 @@
                  :graph-switch "Switched to"
                  :graph-remove "Removed"
                  :graph-validate "Validated"
-                 "Updated")]
-      (str verb " graph " (pr-str graph)))))
+                 "Updated")
+          base (str verb " graph " (pr-str graph))
+          retracted (get-in data [:result :retracted-property-values])]
+      (if (and (= command :graph-validate) (pos? (or retracted 0)))
+        (str base ". Retracted "
+             (cli-humanize/format-count-with-noun retracted "property value")
+             " that "
+             (if (= 1 retracted) "was" "were")
+             " not in a property's closed values.")
+        base))))
 
 (defn- quote-cli-arg
   [value]

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -813,6 +813,7 @@
  :graph.validation/config-property-pages-enabled-warning "is not used in DB graphs as all properties have pages."
  :graph.validation/config-unused-in-db-graphs-warning "is not used in DB graphs."
  :graph.validation/invalid-blocks-detected "Validation detected {1} invalid block(s). These blocks may be buggy. Attempting to fix invalid blocks. Run validation again to see if they were fixed."
+ :graph.validation/invalid-blocks-found "Validation detected {1} invalid block(s). These blocks may be buggy."
  :graph.validation/name-reserved-characters-warning "Graph name can't contain following reserved characters:"
  :graph.validation/reserved-character-asterisk "asterisk"
  :graph.validation/reserved-character-backslash "backslash"
@@ -826,6 +827,7 @@
  :graph.validation/reserved-character-plus "plus"
  :graph.validation/reserved-character-question-mark "question mark"
  :graph.validation/valid "Your graph is valid! {1}"
+ :graph.validation/values-retracted "Validation removed {1} property value(s) that were not in a property's closed values."
 
  :header/go-back "Go back"
  :header/go-forward "Go forward"

--- a/src/resources/dicts/zh-cn.edn
+++ b/src/resources/dicts/zh-cn.edn
@@ -813,6 +813,7 @@
  :graph.validation/config-property-pages-enabled-warning "在 DB 图谱中不会使用，因为所有属性都有页面。"
  :graph.validation/config-unused-in-db-graphs-warning "在 DB 图谱中不会使用。"
  :graph.validation/invalid-blocks-detected "验证发现 {1} 个无效块。这些块可能存在问题。正在尝试修复无效块。请再次运行验证以检查它们是否已被修复。"
+ :graph.validation/invalid-blocks-found "验证发现 {1} 个无效块。这些块可能存在问题。"
  :graph.validation/name-reserved-characters-warning "知识库名称不能包含以下保留字符："
  :graph.validation/reserved-character-asterisk "星号"
  :graph.validation/reserved-character-backslash "反斜杠"
@@ -826,6 +827,7 @@
  :graph.validation/reserved-character-plus "加号"
  :graph.validation/reserved-character-question-mark "问号"
  :graph.validation/valid "你的图谱有效！{1}"
+ :graph.validation/values-retracted "验证已移除 {1} 个不在属性可选值中的属性值。"
 
  :header/go-back "后退"
  :header/go-forward "前进"

--- a/src/test/frontend/worker/db_validate_test.cljs
+++ b/src/test/frontend/worker/db_validate_test.cljs
@@ -1,5 +1,5 @@
 (ns frontend.worker.db-validate-test
-  (:require [cljs.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is testing]]
             [datascript.core :as d]
             [frontend.worker.db.validate :as worker-db-validate]
             [frontend.worker.pipeline :as worker-pipeline]
@@ -7,7 +7,8 @@
             [logseq.db :as ldb]
             [logseq.db.frontend.schema :as db-schema]
             [logseq.db.frontend.validate :as db-validate]
-            [logseq.db.sqlite.create-graph :as sqlite-create-graph]))
+            [logseq.db.sqlite.create-graph :as sqlite-create-graph]
+            [logseq.db.test.helper :as db-test]))
 
 (defn- create-db-graph-conn
   []
@@ -59,7 +60,7 @@
                       "block")]
     (is (seq (:errors (db-validate/validate-db @conn))))
     (with-redefs [shared-service/broadcast-to-clients! (fn [& _args] nil)]
-      (with-transact-pipeline #(worker-db-validate/validate-db conn))
+      (with-transact-pipeline #(worker-db-validate/validate-db conn :fix true))
       (let [repaired-block (d/entity @conn block-id)]
         (is (uuid? (:block/uuid repaired-block)))
         (is (nat-int? (:block/tx-id repaired-block))
@@ -98,7 +99,7 @@
                        [:db/add class-id :block/tx-id 1]])
     (is (= 3 (count (:errors (db-validate/validate-db @conn)))))
     (with-redefs [shared-service/broadcast-to-clients! (fn [& _args] nil)]
-      (let [result (with-transact-pipeline #(worker-db-validate/validate-db conn))
+      (let [result (with-transact-pipeline #(worker-db-validate/validate-db conn :fix true))
             journal (d/entity @conn journal-id)
             property (d/entity @conn :logseq.property.class/extends)
             class (d/entity @conn class-id)]
@@ -112,3 +113,98 @@
         (is (nil? (:logseq.property.class/extends property)))
         (is (nil? (:kv/value class)))
         (is (empty? (:errors (worker-db-validate/validate-db conn))))))))
+
+(defn- fig-source-value-id
+  [db block-id]
+  (:db/id (:user.property/fig-source (d/entity db block-id))))
+
+(defn- create-node-property-with-orphaned-closed-values
+  "Text property with leftover closed values after a type change to Node, plus a live Node value."
+  []
+  (let [conn (db-test/create-conn-with-blocks
+              {:properties {:fig-source {:logseq.property/type :default
+                                         :build/closed-values [{:value "raster"}
+                                                               {:value "vector"}]}}
+               :pages-and-blocks
+               [{:page {:block/title "some-node-page"}}
+                {:page {:block/title "page 1"}
+                 :blocks [{:block/title "target block"}]}]})
+        property (d/entity @conn :user.property/fig-source)
+        node-page (db-test/find-page-by-title @conn "some-node-page")
+        block (db-test/find-block-by-content @conn "target block")]
+    (d/transact! conn [{:db/id (:db/id property)
+                        :logseq.property/type :node}])
+    (d/transact! conn [[:db/add (:db/id block) :user.property/fig-source (:db/id node-page)]])
+    {:conn conn
+     :block-id (:db/id block)
+     :node-page-id (:db/id node-page)
+     :updated-at (:block/updated-at (d/entity @conn (:db/id block)))}))
+
+(deftest validate-db-preserves-node-value-when-property-has-orphaned-closed-values
+  (let [{:keys [conn block-id node-page-id updated-at]} (create-node-property-with-orphaned-closed-values)
+        property (d/entity @conn :user.property/fig-source)]
+    (is (= :node (:logseq.property/type property)))
+    (is (seq (:block/_closed-value-property property))
+        "Leftover closed values remain after the type change.")
+    (is (= node-page-id (fig-source-value-id @conn block-id)))
+    (with-redefs [shared-service/broadcast-to-clients! (fn [& _args] nil)]
+      (testing "validate without --fix does not mutate"
+        (let [result (worker-db-validate/validate-db conn)
+              block (d/entity @conn block-id)]
+          (is (empty? (:errors result)))
+          (is (= node-page-id (fig-source-value-id @conn block-id))
+              "GUI default validate must not drop a live Node value")
+          (is (= updated-at (:block/updated-at block)))
+          (is (zero? (or (:retracted-property-values result) 0)))))
+      (testing "validate with --fix still keeps a valid Node value"
+        (let [result (with-transact-pipeline
+                       #(worker-db-validate/validate-db conn :fix true))
+              block (d/entity @conn block-id)]
+          (is (empty? (:errors result)))
+          (is (= node-page-id (fig-source-value-id @conn block-id))
+              "--fix must not silently drop a valid Node value")
+          (is (zero? (or (:retracted-property-values result) 0)))
+          (is (= updated-at (:block/updated-at block))))))))
+
+(deftest validate-db-reports-closed-value-retractions-when-fixing
+  (let [conn (db-test/create-conn-with-blocks
+              {:properties {:status {:logseq.property/type :default
+                                     :build/closed-values [{:value "Todo"}
+                                                           {:value "Doing"}]}}
+               :pages-and-blocks
+               [{:page {:block/title "some-node-page"}}
+                {:page {:block/title "page 1"}
+                 :blocks [{:block/title "target block"}]}]})
+        block (db-test/find-block-by-content @conn "target block")
+        node-page (db-test/find-page-by-title @conn "some-node-page")
+        _ (d/transact! conn [[:db/add (:db/id block) :user.property/status (:db/id node-page)]])
+        original-updated-at (:block/updated-at (d/entity @conn (:db/id block)))
+        notifications (atom [])]
+    (is (= (:db/id node-page)
+           (:db/id (:user.property/status (d/entity @conn (:db/id block))))))
+    (with-redefs [shared-service/broadcast-to-clients!
+                  (fn [type' payload]
+                    (when (= type' :notification)
+                      (swap! notifications conj payload)))]
+      (testing "without --fix the out-of-enum value is left in place"
+        (let [result (worker-db-validate/validate-db conn :fix false)]
+          (is (= (:db/id node-page)
+                 (:db/id (:user.property/status (d/entity @conn (:db/id block))))))
+          (is (zero? (or (:retracted-property-values result) 0)))
+          (is (= original-updated-at
+                 (:block/updated-at (d/entity @conn (:db/id block)))))))
+      (testing "with --fix the out-of-enum value is retracted, stamped, and reported"
+        (reset! notifications [])
+        (let [result (with-transact-pipeline
+                       #(worker-db-validate/validate-db conn :fix true))
+              block' (d/entity @conn (:db/id block))
+              notification (first @notifications)]
+          (is (nil? (:user.property/status block')))
+          (is (pos? (:retracted-property-values result)))
+          (is (> (:block/updated-at block') original-updated-at))
+          (is (nat-int? (:block/tx-id block')))
+          (is (= :graph.validation/values-retracted
+                 (get-in notification [5 :i18n-key]))
+              "Retractions must not be reported as a silent valid graph")
+          (is (not= :graph.validation/valid
+                    (get-in notification [5 :i18n-key]))))))))

--- a/src/test/logseq/cli/command/graph_test.cljs
+++ b/src/test/logseq/cli/command/graph_test.cljs
@@ -18,12 +18,17 @@
   (let [graph-validate-result #'graph-command/graph-validate-result
         invalid-result (graph-validate-result {:errors [{:entity {:db/id 1}
                                                          :errors {:foo ["bad"]}}]})
-        valid-result (graph-validate-result {:errors nil :datom-count 10})]
+        valid-result (graph-validate-result {:errors nil :datom-count 10})
+        retracted-result (graph-validate-result {:errors nil
+                                                 :datom-count 10
+                                                 :retracted-property-values 2})]
     (is (= :error (:status invalid-result)))
     (is (= :graph-validation-failed (get-in invalid-result [:error :code])))
     (is (string/includes? (get-in invalid-result [:error :message])
                           "Found 1 entity with errors:"))
-    (is (= :ok (:status valid-result)))))
+    (is (= :ok (:status valid-result)))
+    (is (= :ok (:status retracted-result)))
+    (is (= 2 (get-in retracted-result [:data :result :retracted-property-values])))))
 
 (deftest test-graph-validate-result-formats-large-error-count
   (let [graph-validate-result #'graph-command/graph-validate-result

--- a/src/test/logseq/cli/format_test.cljs
+++ b/src/test/logseq/cli/format_test.cljs
@@ -101,6 +101,22 @@
                                         :data {:result {:errors nil}}}
                                        {:output-format nil})]
       (is (= "Validated graph \"foo\"" result))))
+  (testing "graph validation success mentions retracted property values"
+    (let [result (format/format-result {:status :ok
+                                        :command :graph-validate
+                                        :context {:graph "foo"}
+                                        :data {:result {:errors nil
+                                                        :retracted-property-values 2}}}
+                                       {:output-format nil})]
+      (is (= "Validated graph \"foo\". Retracted 2 property values that were not in a property's closed values." result))))
+  (testing "graph validation success mentions a single retracted property value"
+    (let [result (format/format-result {:status :ok
+                                        :command :graph-validate
+                                        :context {:graph "foo"}
+                                        :data {:result {:errors nil
+                                                        :retracted-property-values 1}}}
+                                       {:output-format nil})]
+      (is (= "Validated graph \"foo\". Retracted 1 property value that was not in a property's closed values." result))))
   (testing "graph validation error prints validation details without extra prefix"
     (let [result (format/format-result {:status :error
                                         :command :graph-validate


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
GUI Validate graph (and EDN export) called `validate-db` with no opts, so `fix` defaulted to true. `fix-non-closed-values!` then retracted any property value not in leftover `:block/_closed-value-property` entities, including live Node values after a type change. Retractions were logged only at debug, did not bump `:block/updated-at`, and the UI still reported "Your graph is valid!".

## Changes
- Default `fix` to false so GUI Validate and EDN export are read-only, matching CLI `graph validate` without `--fix`.
- `fix-non-closed-values!` only retracts on property types that still support closed values (`:default`, `:number`, `:url`). Leftover closed values on a Node property no longer delete a live Node value, even with `--fix`.
- Legitimate retractions are logged at info, stamp `:block/updated-at`, and are returned as `:retracted-property-values`. The notification/CLI report mentions them instead of claiming the graph is valid with no deletions.

## Tests
- `validate-db-preserves-node-value-when-property-has-orphaned-closed-values`
- `validate-db-reports-closed-value-retractions-when-fixing`
- CLI format coverage for retracted property values

Fixes https://github.com/logseq/db-test/issues/1068

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-feae3ef4-2e24-466a-8064-b877cc860c59?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-feae3ef4-2e24-466a-8064-b877cc860c59&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

