### PR TITLE
fix: restore spell check after Linux restart

### DIFF
--- a/src/electron/electron/spell_check.cljs
+++ b/src/electron/electron/spell_check.cljs
@@ -1,110 +1,15 @@
-(ns electron.spell-check
-  (:require [clojure.string :as string]))
-
-(def hunspell-dictionary-download-url
-  "https://redirector.gvt1.com/edgedl/chrome/dict/")
+(ns electron.spell-check)
 
 (defn session-spellcheck-enabled?
   [value]
   (not= false value))
 
-(defn window-web-preferences
-  [config-value]
-  {:spellcheck (session-spellcheck-enabled? config-value)})
-
-(defn- normalize-language
-  [language]
-  (when (string? language)
-    (let [normalized (string/replace language "_" "-")]
-      (when (seq normalized)
-        normalized))))
-
-(defn- language-prefix
-  [language]
-  (some-> language normalize-language (string/split #"-") first))
-
-(defn hunspell-languages
-  "Choose hunspell language codes that Electron will accept.
-   Prefer already-configured languages, then the OS/app locale, then en-US."
-  [current-languages available-languages fallback-language]
-  (let [available (filterv seq available-languages)
-        available-set (set available)
-        current (filterv available-set current-languages)
-        fallback (normalize-language fallback-language)
-        prefixed (when-let [prefix (language-prefix fallback)]
-                   (filterv #(= prefix (language-prefix %)) available))]
-    (cond
-      (seq current) current
-      (and fallback (contains? available-set fallback)) [fallback]
-      (seq prefixed) [(first prefixed)]
-      (contains? available-set "en-US") ["en-US"]
-      (seq available) [(first available)]
-      :else [])))
-
-(defn- spellchecker-languages
-  [^js session]
-  (if (fn? (.-getSpellCheckerLanguages session))
-    (vec (js->clj (.getSpellCheckerLanguages session)))
-    []))
-
-(defn- available-spellchecker-languages
-  [^js session]
-  (vec (js->clj (or (.-availableSpellCheckerLanguages session) #js []))))
-
-(defn- hunspell-platform?
-  []
-  (contains? #{"linux" "win32"} (.-platform js/process)))
-
-(defn- linux-platform?
-  []
-  (= "linux" (.-platform js/process)))
-
-(defn- app-locale
-  []
-  (try
-    (some-> (js/require "electron") .-app .getLocale)
-    (catch :default _
-      nil)))
-
-(defn apply-session-spellcheck!
-  "Apply spellcheck to an Electron session.
-
-  On hunspell platforms (Linux/Windows), enabling also restores a dictionary
-  download URL and language list so a persisted disabled or empty-dictionary
-  session can recover. Linux additionally resets languages to work around
-  Electron 40+ failing to initialize cached .bdic files."
-  ([session enabled?]
-   (apply-session-spellcheck! session enabled? nil))
-  ([^js session enabled? {:keys [hunspell? reinit-hunspell? fallback-language dictionary-download-url]
-                          :or {hunspell? false
-                               reinit-hunspell? false
-                               dictionary-download-url hunspell-dictionary-download-url}}]
-   (when session
-     (when (and enabled? hunspell?)
-       (when (fn? (.-setSpellCheckerDictionaryDownloadURL session))
-         (.setSpellCheckerDictionaryDownloadURL session dictionary-download-url))
-       (let [current (spellchecker-languages session)
-             available (available-spellchecker-languages session)
-             languages (hunspell-languages current available fallback-language)]
-         (when (and (fn? (.-setSpellCheckerLanguages session)) (seq languages))
-           (if reinit-hunspell?
-             (do (.setSpellCheckerLanguages session #js [])
-                 (.setSpellCheckerLanguages session (clj->js languages)))
-             (when (empty? current)
-               (.setSpellCheckerLanguages session (clj->js languages)))))))
-     (.setSpellCheckerEnabled session enabled?))
-   session))
+(defn startup-spellcheck-states
+  [linux? enabled?]
+  [(if (and linux? enabled?) false enabled?) enabled?])
 
 (defn apply-window-spellcheck!
-  ([win enabled?]
-   (apply-window-spellcheck! win enabled? nil))
-  ([^js win enabled? opts]
-   (when-let [^js session (some-> win .-webContents .-session)]
-     (apply-session-spellcheck!
-      session
-      enabled?
-      (merge {:hunspell? (hunspell-platform?)
-              :reinit-hunspell? (linux-platform?)
-              :fallback-language (app-locale)}
-             opts)))
-   win))
+  [^js win enabled?]
+  (when-let [^js session (some-> win .-webContents .-session)]
+    (.setSpellCheckerEnabled session enabled?))
+  win)

--- a/src/electron/electron/spell_check.cljs
+++ b/src/electron/electron/spell_check.cljs
@@ -1,11 +1,110 @@
-(ns electron.spell-check)
+(ns electron.spell-check
+  (:require [clojure.string :as string]))
+
+(def hunspell-dictionary-download-url
+  "https://redirector.gvt1.com/edgedl/chrome/dict/")
 
 (defn session-spellcheck-enabled?
   [value]
   (not= false value))
 
+(defn window-web-preferences
+  [config-value]
+  {:spellcheck (session-spellcheck-enabled? config-value)})
+
+(defn- normalize-language
+  [language]
+  (when (string? language)
+    (let [normalized (string/replace language "_" "-")]
+      (when (seq normalized)
+        normalized))))
+
+(defn- language-prefix
+  [language]
+  (some-> language normalize-language (string/split #"-") first))
+
+(defn hunspell-languages
+  "Choose hunspell language codes that Electron will accept.
+   Prefer already-configured languages, then the OS/app locale, then en-US."
+  [current-languages available-languages fallback-language]
+  (let [available (filterv seq available-languages)
+        available-set (set available)
+        current (filterv available-set current-languages)
+        fallback (normalize-language fallback-language)
+        prefixed (when-let [prefix (language-prefix fallback)]
+                   (filterv #(= prefix (language-prefix %)) available))]
+    (cond
+      (seq current) current
+      (and fallback (contains? available-set fallback)) [fallback]
+      (seq prefixed) [(first prefixed)]
+      (contains? available-set "en-US") ["en-US"]
+      (seq available) [(first available)]
+      :else [])))
+
+(defn- spellchecker-languages
+  [^js session]
+  (if (fn? (.-getSpellCheckerLanguages session))
+    (vec (js->clj (.getSpellCheckerLanguages session)))
+    []))
+
+(defn- available-spellchecker-languages
+  [^js session]
+  (vec (js->clj (or (.-availableSpellCheckerLanguages session) #js []))))
+
+(defn- hunspell-platform?
+  []
+  (contains? #{"linux" "win32"} (.-platform js/process)))
+
+(defn- linux-platform?
+  []
+  (= "linux" (.-platform js/process)))
+
+(defn- app-locale
+  []
+  (try
+    (some-> (js/require "electron") .-app .getLocale)
+    (catch :default _
+      nil)))
+
+(defn apply-session-spellcheck!
+  "Apply spellcheck to an Electron session.
+
+  On hunspell platforms (Linux/Windows), enabling also restores a dictionary
+  download URL and language list so a persisted disabled or empty-dictionary
+  session can recover. Linux additionally resets languages to work around
+  Electron 40+ failing to initialize cached .bdic files."
+  ([session enabled?]
+   (apply-session-spellcheck! session enabled? nil))
+  ([^js session enabled? {:keys [hunspell? reinit-hunspell? fallback-language dictionary-download-url]
+                          :or {hunspell? false
+                               reinit-hunspell? false
+                               dictionary-download-url hunspell-dictionary-download-url}}]
+   (when session
+     (when (and enabled? hunspell?)
+       (when (fn? (.-setSpellCheckerDictionaryDownloadURL session))
+         (.setSpellCheckerDictionaryDownloadURL session dictionary-download-url))
+       (let [current (spellchecker-languages session)
+             available (available-spellchecker-languages session)
+             languages (hunspell-languages current available fallback-language)]
+         (when (and (fn? (.-setSpellCheckerLanguages session)) (seq languages))
+           (if reinit-hunspell?
+             (do (.setSpellCheckerLanguages session #js [])
+                 (.setSpellCheckerLanguages session (clj->js languages)))
+             (when (empty? current)
+               (.setSpellCheckerLanguages session (clj->js languages)))))))
+     (.setSpellCheckerEnabled session enabled?))
+   session))
+
 (defn apply-window-spellcheck!
-  [^js win enabled?]
-  (when-let [^js session (some-> win .-webContents .-session)]
-    (.setSpellCheckerEnabled session enabled?))
-  win)
+  ([win enabled?]
+   (apply-window-spellcheck! win enabled? nil))
+  ([^js win enabled? opts]
+   (when-let [^js session (some-> win .-webContents .-session)]
+     (apply-session-spellcheck!
+      session
+      enabled?
+      (merge {:hunspell? (hunspell-platform?)
+              :reinit-hunspell? (linux-platform?)
+              :fallback-language (app-locale)}
+             opts)))
+   win))

--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -33,6 +33,8 @@
    (let [win-state (windowStateKeeper (clj->js {:defaultWidth 980 :defaultHeight 700}))
          native-titlebar? (cfgs/get-item :window/native-titlebar?)
          url (if graph (str url "#/?graph=" graph) url)
+         spell-check-cfg (cfgs/get-item :spell-check)
+         spell-check-enabled? (spell-check/session-spellcheck-enabled? spell-check-cfg)
          win-opts  (cond->
                     {:backgroundColor      "#fff" ; SEE https://www.electronjs.org/docs/latest/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do
                      :width                (.-width win-state)
@@ -43,25 +45,25 @@
                      :autoHideMenuBar      (not mac?)
                      :show                 false
                      :webPreferences
-                     {:plugins                 true        ; pdf
-                      :nodeIntegration         false
-                      :nodeIntegrationInWorker false
-                      :nativeWindowOpen        true
-                      :sandbox                 false
-                      :webSecurity             (not dev?)
-                      :contextIsolation        true
-                       ;; Remove OverlayScrollbars and transition `.scrollbar-spacing`
-                       ;; to use `scollbar-gutter` after the feature is implemented in browsers.
-                      :enableBlinkFeatures     'OverlayScrollbars'
-                      :preload                 (node-path/join js/__dirname "js/preload.js")}}
+                     (merge {:plugins                 true        ; pdf
+                             :nodeIntegration         false
+                             :nodeIntegrationInWorker false
+                             :nativeWindowOpen        true
+                             :sandbox                 false
+                             :webSecurity             (not dev?)
+                             :contextIsolation        true
+                              ;; Remove OverlayScrollbars and transition `.scrollbar-spacing`
+                              ;; to use `scollbar-gutter` after the feature is implemented in browsers.
+                             :enableBlinkFeatures     'OverlayScrollbars'
+                             :preload                 (node-path/join js/__dirname "js/preload.js")}
+                            (spell-check/window-web-preferences spell-check-cfg))}
 
                      (seq opts)
                      (merge opts)
 
                      linux?
                      (assoc :icon (node-path/join js/__dirname "icons/logseq.png")))
-         win       (BrowserWindow. (clj->js win-opts))
-         spell-check-enabled? (spell-check/session-spellcheck-enabled? (cfgs/get-item :spell-check))]
+         win       (BrowserWindow. (clj->js win-opts))]
      (spell-check/apply-window-spellcheck! win spell-check-enabled?)
      (.onBeforeSendHeaders (.. session -defaultSession -webRequest)
                            (clj->js {:urls (array "*://*.youtube.com/*")})
@@ -74,8 +76,13 @@
                                (callback (bean/->js
                                           {:cancel         false
                                            :requestHeaders headers})))))
-     ;; Show window as soon as it's ready
-     (.once win "ready-to-show" #(.show win))
+     ;; Show window as soon as it's ready. Re-apply spellcheck after the
+     ;; session is ready so Linux hunspell can recover cached dictionaries.
+     (.once win "ready-to-show"
+            (fn []
+              (when spell-check-enabled?
+                (spell-check/apply-window-spellcheck! win true))
+              (.show win)))
      (.loadURL win url)
      ;;(when dev? (.. win -webContents (openDevTools)))
      win)))

--- a/src/electron/electron/window.cljs
+++ b/src/electron/electron/window.cljs
@@ -35,6 +35,8 @@
          url (if graph (str url "#/?graph=" graph) url)
          spell-check-cfg (cfgs/get-item :spell-check)
          spell-check-enabled? (spell-check/session-spellcheck-enabled? spell-check-cfg)
+         [initial-spell-check-enabled? ready-spell-check-enabled?]
+         (spell-check/startup-spellcheck-states linux? spell-check-enabled?)
          win-opts  (cond->
                     {:backgroundColor      "#fff" ; SEE https://www.electronjs.org/docs/latest/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do
                      :width                (.-width win-state)
@@ -45,18 +47,17 @@
                      :autoHideMenuBar      (not mac?)
                      :show                 false
                      :webPreferences
-                     (merge {:plugins                 true        ; pdf
-                             :nodeIntegration         false
-                             :nodeIntegrationInWorker false
-                             :nativeWindowOpen        true
-                             :sandbox                 false
-                             :webSecurity             (not dev?)
-                             :contextIsolation        true
-                              ;; Remove OverlayScrollbars and transition `.scrollbar-spacing`
-                              ;; to use `scollbar-gutter` after the feature is implemented in browsers.
-                             :enableBlinkFeatures     'OverlayScrollbars'
-                             :preload                 (node-path/join js/__dirname "js/preload.js")}
-                            (spell-check/window-web-preferences spell-check-cfg))}
+                     {:plugins                 true        ; pdf
+                      :nodeIntegration         false
+                      :nodeIntegrationInWorker false
+                      :nativeWindowOpen        true
+                      :sandbox                 false
+                      :webSecurity             (not dev?)
+                      :contextIsolation        true
+                       ;; Remove OverlayScrollbars and transition `.scrollbar-spacing`
+                       ;; to use `scollbar-gutter` after the feature is implemented in browsers.
+                      :enableBlinkFeatures     'OverlayScrollbars'
+                      :preload                 (node-path/join js/__dirname "js/preload.js")}}
 
                      (seq opts)
                      (merge opts)
@@ -64,7 +65,7 @@
                      linux?
                      (assoc :icon (node-path/join js/__dirname "icons/logseq.png")))
          win       (BrowserWindow. (clj->js win-opts))]
-     (spell-check/apply-window-spellcheck! win spell-check-enabled?)
+     (spell-check/apply-window-spellcheck! win initial-spell-check-enabled?)
      (.onBeforeSendHeaders (.. session -defaultSession -webRequest)
                            (clj->js {:urls (array "*://*.youtube.com/*")})
                            (fn [^js details callback]
@@ -76,12 +77,11 @@
                                (callback (bean/->js
                                           {:cancel         false
                                            :requestHeaders headers})))))
-     ;; Show window as soon as it's ready. Re-apply spellcheck after the
-     ;; session is ready so Linux hunspell can recover cached dictionaries.
+     ;; Keep spellcheck disabled until ready-to-show on Linux to avoid the
+     ;; Electron 40+ cached dictionary initialization race (#50327).
      (.once win "ready-to-show"
             (fn []
-              (when spell-check-enabled?
-                (spell-check/apply-window-spellcheck! win true))
+              (spell-check/apply-window-spellcheck! win ready-spell-check-enabled?)
               (.show win)))
      (.loadURL win url)
      ;;(when dev? (.. win -webContents (openDevTools)))

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -288,7 +288,8 @@
 
 (hsx/defc switch-spell-check-row
   [t]
-  (let [enabled? (rfx/use-sub [:electron/user-cfgs :spell-check])]
+  ;; Match electron.spell-check/session-spellcheck-enabled?: nil defaults to on.
+  (let [enabled? (not= false (rfx/use-sub [:electron/user-cfgs :spell-check]))]
     [:div.it.sm:grid.sm:grid-cols-3.sm:gap-4.sm:items-center
      [:label.block.text-sm.font-medium.leading-5.opacity-70
       (t :settings.editor/spell-checker)]

--- a/src/test/electron/spell_check_test.cljs
+++ b/src/test/electron/spell_check_test.cljs
@@ -104,6 +104,15 @@
       (is (= [[] ["en-GB"]] (:language-calls @state)))
       (is (true? (:enabled @state)))))
 
+  (testing "Linux reinit resets existing languages so cached dictionaries reload"
+    (let [{:keys [session state]} (mock-session {:languages ["en-US"]})]
+      (spell-check/apply-session-spellcheck!
+       session true
+       {:hunspell? true
+        :reinit-hunspell? true
+        :fallback-language "en-US"})
+      (is (= [[] ["en-US"]] (:language-calls @state)))))
+
   (testing "enabling on Windows fills an empty language list without resetting an existing one"
     (let [{:keys [session state]} (mock-session {:languages []})]
       (spell-check/apply-session-spellcheck!
@@ -121,6 +130,7 @@
       (is (= [] (:language-calls @state)))
       (is (= ["fr"] (:languages @state)))))
 
+  (testing "disabling only toggles the session flag and keeps hunspell languages"
     (let [{:keys [session state]} (mock-session {:enabled true :languages ["en-US"]})]
       (spell-check/apply-session-spellcheck!
        session false

--- a/src/test/electron/spell_check_test.cljs
+++ b/src/test/electron/spell_check_test.cljs
@@ -2,64 +2,19 @@
   (:require [cljs.test :refer [deftest is testing]]
             [electron.spell-check :as spell-check]))
 
-(defn- mock-session
-  [{:keys [enabled languages available]
-    :or {enabled true
-         languages []
-         available ["en-US" "en-GB" "fr"]}}]
-  (let [state (atom {:enabled enabled
-                     :languages languages
-                     :download-url nil
-                     :language-calls []
-                     :enabled-calls []})
-        session (js-obj)]
-    (aset session "availableSpellCheckerLanguages" (clj->js available))
-    (aset session "getSpellCheckerLanguages"
-          (fn []
-            (clj->js (:languages @state))))
-    (aset session "setSpellCheckerLanguages"
-          (fn [languages]
-            (let [languages (js->clj languages)]
-              (swap! state (fn [s]
-                             (-> s
-                                 (assoc :languages languages)
-                                 (update :language-calls conj languages)))))))
-    (aset session "setSpellCheckerDictionaryDownloadURL"
-          (fn [url]
-            (swap! state assoc :download-url url)))
-    (aset session "setSpellCheckerEnabled"
-          (fn [enabled?]
-            (swap! state (fn [s]
-                           (-> s
-                               (assoc :enabled enabled?)
-                               (update :enabled-calls conj enabled?))))))
-    {:session session
-     :state state}))
-
 (deftest session-spellcheck-enabled?-test
   (testing "defaults to enabled unless the stored config is explicitly false"
     (is (true? (spell-check/session-spellcheck-enabled? nil)))
     (is (true? (spell-check/session-spellcheck-enabled? true)))
     (is (false? (spell-check/session-spellcheck-enabled? false)))))
 
-(deftest window-web-preferences-test
-  (testing "window create prefs enable spellcheck for nil and true, and disable only for false"
-    (is (= {:spellcheck true} (spell-check/window-web-preferences nil)))
-    (is (= {:spellcheck true} (spell-check/window-web-preferences true)))
-    (is (= {:spellcheck false} (spell-check/window-web-preferences false)))))
-
-(deftest hunspell-languages-test
-  (testing "keeps currently configured languages that hunspell still supports"
-    (is (= ["fr"] (spell-check/hunspell-languages ["fr"] ["en-US" "fr"] "en-US"))))
-  (testing "uses the fallback locale when the persisted language list is empty"
-    (is (= ["en-GB"] (spell-check/hunspell-languages [] ["en-GB" "fr"] "en-GB"))))
-  (testing "maps a locale prefix onto an available hunspell language"
-    (is (= ["en-GB"] (spell-check/hunspell-languages [] ["en-GB" "fr"] "en")))
-    (is (= ["en-US"] (spell-check/hunspell-languages [] ["en-US" "fr"] "en_US"))))
-  (testing "falls back to en-US, then the first available language"
-    (is (= ["en-US"] (spell-check/hunspell-languages [] ["fr" "en-US"] nil)))
-    (is (= ["fr"] (spell-check/hunspell-languages [] ["fr" "de"] nil)))
-    (is (= [] (spell-check/hunspell-languages [] [] "en-US")))))
+(deftest startup-spellcheck-states-test
+  (testing "Linux keeps spellcheck disabled until the window is ready"
+    (is (= [false true] (spell-check/startup-spellcheck-states true true)))
+    (is (= [false false] (spell-check/startup-spellcheck-states true false))))
+  (testing "other platforms apply the configured state directly"
+    (is (= [true true] (spell-check/startup-spellcheck-states false true)))
+    (is (= [false false] (spell-check/startup-spellcheck-states false false)))))
 
 (deftest apply-window-spellcheck!-test
   (testing "updates the BrowserWindow session spell checker state"
@@ -72,72 +27,7 @@
               (swap! calls conj enabled?)
               (aset session "spellCheckerEnabled" enabled?)))
 
-      (spell-check/apply-window-spellcheck! win false {:hunspell? false})
+      (spell-check/apply-window-spellcheck! win false)
 
       (is (= [false] @calls))
       (is (false? (.-spellCheckerEnabled session))))))
-
-(deftest apply-session-spellcheck!-hunspell-test
-  (testing "enabling on Linux restores the dictionary URL, languages, and enabled flag"
-    (let [{:keys [session state]} (mock-session {:enabled false :languages []})
-          win (js-obj "webContents" (js-obj "session" session))]
-      (spell-check/apply-window-spellcheck!
-       win true
-       {:hunspell? true
-        :reinit-hunspell? true
-        :fallback-language "en-US"})
-      (is (true? (:enabled @state)))
-      (is (= [true] (:enabled-calls @state)))
-      (is (= spell-check/hunspell-dictionary-download-url (:download-url @state)))
-      (is (= [[] ["en-US"]] (:language-calls @state)))
-      (is (= ["en-US"] (:languages @state)))))
-
-  (testing "enabling after a persisted empty dictionary uses the fallback locale"
-    (let [{:keys [session state]} (mock-session {:enabled false
-                                                 :languages []
-                                                 :available ["en-GB" "fr"]})]
-      (spell-check/apply-session-spellcheck!
-       session true
-       {:hunspell? true
-        :reinit-hunspell? true
-        :fallback-language "en-GB"})
-      (is (= [[] ["en-GB"]] (:language-calls @state)))
-      (is (true? (:enabled @state)))))
-
-  (testing "Linux reinit resets existing languages so cached dictionaries reload"
-    (let [{:keys [session state]} (mock-session {:languages ["en-US"]})]
-      (spell-check/apply-session-spellcheck!
-       session true
-       {:hunspell? true
-        :reinit-hunspell? true
-        :fallback-language "en-US"})
-      (is (= [[] ["en-US"]] (:language-calls @state)))))
-
-  (testing "enabling on Windows fills an empty language list without resetting an existing one"
-    (let [{:keys [session state]} (mock-session {:languages []})]
-      (spell-check/apply-session-spellcheck!
-       session true
-       {:hunspell? true
-        :reinit-hunspell? false
-        :fallback-language "en-US"})
-      (is (= [["en-US"]] (:language-calls @state))))
-    (let [{:keys [session state]} (mock-session {:languages ["fr"]})]
-      (spell-check/apply-session-spellcheck!
-       session true
-       {:hunspell? true
-        :reinit-hunspell? false
-        :fallback-language "en-US"})
-      (is (= [] (:language-calls @state)))
-      (is (= ["fr"] (:languages @state)))))
-
-  (testing "disabling only toggles the session flag and keeps hunspell languages"
-    (let [{:keys [session state]} (mock-session {:enabled true :languages ["en-US"]})]
-      (spell-check/apply-session-spellcheck!
-       session false
-       {:hunspell? true
-        :reinit-hunspell? true
-        :fallback-language "en-US"})
-      (is (= [false] (:enabled-calls @state)))
-      (is (nil? (:download-url @state)))
-      (is (= [] (:language-calls @state)))
-      (is (= ["en-US"] (:languages @state))))))

--- a/src/test/electron/spell_check_test.cljs
+++ b/src/test/electron/spell_check_test.cljs
@@ -1,22 +1,65 @@
 (ns electron.spell-check-test
   (:require [cljs.test :refer [deftest is testing]]
-            [electron.spell-check]))
+            [electron.spell-check :as spell-check]))
 
-(defn- session-spellcheck-enabled?
-  [value]
-  (when-let [f (resolve 'electron.spell-check/session-spellcheck-enabled?)]
-    (f value)))
-
-(defn- apply-window-spellcheck!
-  [win enabled?]
-  (when-let [f (resolve 'electron.spell-check/apply-window-spellcheck!)]
-    (f win enabled?)))
+(defn- mock-session
+  [{:keys [enabled languages available]
+    :or {enabled true
+         languages []
+         available ["en-US" "en-GB" "fr"]}}]
+  (let [state (atom {:enabled enabled
+                     :languages languages
+                     :download-url nil
+                     :language-calls []
+                     :enabled-calls []})
+        session (js-obj)]
+    (aset session "availableSpellCheckerLanguages" (clj->js available))
+    (aset session "getSpellCheckerLanguages"
+          (fn []
+            (clj->js (:languages @state))))
+    (aset session "setSpellCheckerLanguages"
+          (fn [languages]
+            (let [languages (js->clj languages)]
+              (swap! state (fn [s]
+                             (-> s
+                                 (assoc :languages languages)
+                                 (update :language-calls conj languages)))))))
+    (aset session "setSpellCheckerDictionaryDownloadURL"
+          (fn [url]
+            (swap! state assoc :download-url url)))
+    (aset session "setSpellCheckerEnabled"
+          (fn [enabled?]
+            (swap! state (fn [s]
+                           (-> s
+                               (assoc :enabled enabled?)
+                               (update :enabled-calls conj enabled?))))))
+    {:session session
+     :state state}))
 
 (deftest session-spellcheck-enabled?-test
   (testing "defaults to enabled unless the stored config is explicitly false"
-    (is (true? (session-spellcheck-enabled? nil)))
-    (is (true? (session-spellcheck-enabled? true)))
-    (is (false? (session-spellcheck-enabled? false)))))
+    (is (true? (spell-check/session-spellcheck-enabled? nil)))
+    (is (true? (spell-check/session-spellcheck-enabled? true)))
+    (is (false? (spell-check/session-spellcheck-enabled? false)))))
+
+(deftest window-web-preferences-test
+  (testing "window create prefs enable spellcheck for nil and true, and disable only for false"
+    (is (= {:spellcheck true} (spell-check/window-web-preferences nil)))
+    (is (= {:spellcheck true} (spell-check/window-web-preferences true)))
+    (is (= {:spellcheck false} (spell-check/window-web-preferences false)))))
+
+(deftest hunspell-languages-test
+  (testing "keeps currently configured languages that hunspell still supports"
+    (is (= ["fr"] (spell-check/hunspell-languages ["fr"] ["en-US" "fr"] "en-US"))))
+  (testing "uses the fallback locale when the persisted language list is empty"
+    (is (= ["en-GB"] (spell-check/hunspell-languages [] ["en-GB" "fr"] "en-GB"))))
+  (testing "maps a locale prefix onto an available hunspell language"
+    (is (= ["en-GB"] (spell-check/hunspell-languages [] ["en-GB" "fr"] "en")))
+    (is (= ["en-US"] (spell-check/hunspell-languages [] ["en-US" "fr"] "en_US"))))
+  (testing "falls back to en-US, then the first available language"
+    (is (= ["en-US"] (spell-check/hunspell-languages [] ["fr" "en-US"] nil)))
+    (is (= ["fr"] (spell-check/hunspell-languages [] ["fr" "de"] nil)))
+    (is (= [] (spell-check/hunspell-languages [] [] "en-US")))))
 
 (deftest apply-window-spellcheck!-test
   (testing "updates the BrowserWindow session spell checker state"
@@ -29,7 +72,62 @@
               (swap! calls conj enabled?)
               (aset session "spellCheckerEnabled" enabled?)))
 
-      (apply-window-spellcheck! win false)
+      (spell-check/apply-window-spellcheck! win false {:hunspell? false})
 
       (is (= [false] @calls))
       (is (false? (.-spellCheckerEnabled session))))))
+
+(deftest apply-session-spellcheck!-hunspell-test
+  (testing "enabling on Linux restores the dictionary URL, languages, and enabled flag"
+    (let [{:keys [session state]} (mock-session {:enabled false :languages []})
+          win (js-obj "webContents" (js-obj "session" session))]
+      (spell-check/apply-window-spellcheck!
+       win true
+       {:hunspell? true
+        :reinit-hunspell? true
+        :fallback-language "en-US"})
+      (is (true? (:enabled @state)))
+      (is (= [true] (:enabled-calls @state)))
+      (is (= spell-check/hunspell-dictionary-download-url (:download-url @state)))
+      (is (= [[] ["en-US"]] (:language-calls @state)))
+      (is (= ["en-US"] (:languages @state)))))
+
+  (testing "enabling after a persisted empty dictionary uses the fallback locale"
+    (let [{:keys [session state]} (mock-session {:enabled false
+                                                 :languages []
+                                                 :available ["en-GB" "fr"]})]
+      (spell-check/apply-session-spellcheck!
+       session true
+       {:hunspell? true
+        :reinit-hunspell? true
+        :fallback-language "en-GB"})
+      (is (= [[] ["en-GB"]] (:language-calls @state)))
+      (is (true? (:enabled @state)))))
+
+  (testing "enabling on Windows fills an empty language list without resetting an existing one"
+    (let [{:keys [session state]} (mock-session {:languages []})]
+      (spell-check/apply-session-spellcheck!
+       session true
+       {:hunspell? true
+        :reinit-hunspell? false
+        :fallback-language "en-US"})
+      (is (= [["en-US"]] (:language-calls @state))))
+    (let [{:keys [session state]} (mock-session {:languages ["fr"]})]
+      (spell-check/apply-session-spellcheck!
+       session true
+       {:hunspell? true
+        :reinit-hunspell? false
+        :fallback-language "en-US"})
+      (is (= [] (:language-calls @state)))
+      (is (= ["fr"] (:languages @state)))))
+
+    (let [{:keys [session state]} (mock-session {:enabled true :languages ["en-US"]})]
+      (spell-check/apply-session-spellcheck!
+       session false
+       {:hunspell? true
+        :reinit-hunspell? true
+        :fallback-language "en-US"})
+      (is (= [false] (:enabled-calls @state)))
+      (is (nil? (:download-url @state)))
+      (is (= [] (:language-calls @state)))
+      (is (= ["en-US"] (:languages @state))))))


### PR DESCRIPTION
Fixes https://github.com/logseq/db-test/issues/1072

Spell check on Linux could work on the first launch but fail after restart with a cached dictionary. The Settings toggle also showed Off when `:spell-check` was absent, even though the Electron session treated that value as enabled.

## Root cause

Logseq uses Electron 42.3.0, which is affected by electron/electron#50327: on Linux, spell check must remain disabled during startup and be enabled after the window is ready when a cached dictionary exists.

Creating a window with `webPreferences.spellcheck: false` is not used because Electron cannot dynamically re-enable spell checking in that window.

## Changes

- Treat absent `:spell-check` as enabled in Settings, matching the Electron session behavior.
- On Linux, disable session spell check before loading and restore the configured state at `ready-to-show`.
- Keep the existing session-level toggle path for runtime On/Off changes.
- Leave dictionary download, locale selection, and spell checker languages to Electron.

## Testing

- `bb dev:test -v electron.spell-check-test`
- 3 tests, 9 assertions, 0 failures.