### PR TITLE
fix: stop orphaning :default property value blocks

### DIFF
--- a/deps/outliner/src/logseq/outliner/core.cljs
+++ b/deps/outliner/src/logseq/outliner/core.cljs
@@ -995,7 +995,7 @@
 
 (defn ^:api ^:large-vars/cleanup-todo delete-blocks
   "Delete blocks from the tree."
-  [db blocks _opts]
+  [db blocks {:keys [reclaim-property-value?]}]
   (let [top-level-blocks (filter-top-level-blocks db blocks)
         non-consecutive? (and (> (count top-level-blocks) 1) (seq (ldb/get-non-consecutive-blocks db top-level-blocks)))
         top-level-blocks* (get-top-level-blocks top-level-blocks non-consecutive?)
@@ -1023,7 +1023,7 @@
                                                (:db/id (:logseq.property/default-value from-property)))
                                          (not (:block/closed-value-property start-block)))]
         (cond
-          (and delete-one-block? default-value-property?)
+          (and delete-one-block? default-value-property? (not reclaim-property-value?))
           (let [datoms (d/datoms db :avet (:db/ident from-property) (:db/id start-block))
                 tx-data (map (fn [d] {:db/id (:e d)
                                       (:db/ident from-property) :logseq.property/empty-placeholder}) datoms)]

--- a/deps/outliner/src/logseq/outliner/property.cljs
+++ b/deps/outliner/src/logseq/outliner/property.cljs
@@ -182,6 +182,75 @@
      (mapcat #(direct-extends-retraction-tx-data (d/entity db %) inherited-parent-ids)
              (db-class/get-structured-children db (:db/id class))))))
 
+(defn- property-value-entities
+  [value]
+  (cond
+    (de/entity? value) [value]
+    (and (coll? value) (not (map? value)) (every? de/entity? value)) (vec value)
+    :else []))
+
+(defn- property-value-ids
+  [value]
+  (let [items (cond
+                (nil? value) []
+                (and (coll? value) (not (map? value))) value
+                :else [value])]
+    (into #{} (keep (fn [item]
+                      (cond
+                        (de/entity? item) (:db/id item)
+                        (integer? item) item))
+                    items))))
+
+(defn- property-value-referrer-ids
+  [db property-ident value-id]
+  (set (d/q '[:find [?e ...]
+              :in $ ?property-id ?value-id
+              :where
+              [?e ?property-id ?value-id]]
+            db
+            property-ident
+            value-id)))
+
+(defn- generated-property-value-block?
+  "True for a private property value block that is safe to edit or delete.
+  Pages, closed values, empty placeholder, and a property's configured default
+  value are shared and must not be reclaimed."
+  [property value]
+  (and (de/entity? value)
+       (:logseq.property/created-from-property value)
+       (not (entity-util/page? value))
+       (not (ldb/closed-value? value))
+       (not= :logseq.property/empty-placeholder (:db/ident value))
+       (not= (:db/id value) (:db/id (:logseq.property/default-value property)))))
+
+(defn- unreferenced-generated-property-value-blocks
+  "Generated property value blocks that will have no remaining property
+  referrers after `retracting-block-ids` stop pointing at them."
+  [db property values retracting-block-ids]
+  (filter
+   (fn [value]
+     (and (generated-property-value-block? property value)
+          (empty? (set/difference (property-value-referrer-ids db (:db/ident property) (:db/id value))
+                                  retracting-block-ids))))
+   values))
+
+(defn- retract-unreferenced-property-value-blocks-tx
+  [db property values retracting-block-ids]
+  (let [deleting (unreferenced-generated-property-value-blocks db property values retracting-block-ids)]
+    (when (seq deleting)
+      (:tx-data (outliner-core/delete-blocks db deleting {})))))
+
+(defn- replaced-generated-property-value-tx
+  [db block property old-value new-value replace-all-values?]
+  (when replace-all-values?
+    (retract-unreferenced-property-value-blocks-tx
+     db
+     property
+     (remove (fn [entity]
+               (contains? (property-value-ids new-value) (:db/id entity)))
+             (property-value-entities old-value))
+     #{(:db/id block)})))
+
 (defn- build-property-value-tx-data
   [conn block property-id value]
   (when (some? value)
@@ -202,7 +271,10 @@
                             (should-add-task-tag-for-property? conn block property-id)
                             (assoc :block/tags :logseq.class/Task)
                             (= :logseq.property/template-applied-to property-id)
-                            (assoc :block/tags :logseq.class/Template))]
+                            (assoc :block/tags :logseq.class/Template))
+          retract-old-value-tx (replaced-generated-property-value-tx
+                                @conn block property old-value tx-value
+                                (or (not multiple-values?) retract-multiple-values?))]
       (cond-> []
         multiple-values-empty?
         (conj [:db/retract (:db/id update-block-tx) property-id :logseq.property/empty-placeholder])
@@ -210,6 +282,8 @@
         (conj [:db/retract (:db/id update-block-tx) property-id])
         extends?
         (into (redundant-extends-retraction-tx-data @conn block value))
+        (seq retract-old-value-tx)
+        (into retract-old-value-tx)
         true
         (conj update-block-tx)))))
 
@@ -451,6 +525,32 @@
           property-id
           raw-value))))
 
+(defn- exclusive-generated-property-value-block?
+  [db property block value]
+  (and (some? block)
+       (generated-property-value-block? property value)
+       (= #{(:db/id block)} (property-value-referrer-ids db (:db/ident property) (:db/id value)))))
+
+(defn- reuse-or-create-default-url-property-value
+  "Reuse this block's exclusive :default/:url value block when possible so string
+  updates edit in place instead of minting orphans. Mint a new value block when
+  the current value is shared or missing."
+  [conn property property-id v block-id]
+  (throw-error-if-invalid-new-property-value @conn property v)
+  (let [block (when block-id (d/entity @conn block-id))
+        existing (when block (get block property-id))]
+    (if (exclusive-generated-property-value-block? @conn property block existing)
+      (do
+        (when (not= v (db-property/property-value-content existing))
+          (ldb/transact! conn
+                         [(outliner-core/block-with-updated-at
+                           {:db/id (:db/id existing)
+                            :block/title v})]
+                         {:outliner-op :save-block}))
+        (:db/id existing))
+      (let [v-uuid (create-property-text-block! conn block-id property-id v {:set-block-property? false})]
+        (:db/id (d/entity @conn [:block/uuid v-uuid]))))))
+
 (defn- find-or-create-property-value
   "Find or create a property value. Only to be used with properties that have ref types"
   [conn property-id v block-id]
@@ -467,9 +567,7 @@
       (and default-or-url?
            ;; FIXME: remove this when :logseq.property/order-list-type updated to closed values
            (not= property-id :logseq.property/order-list-type))
-      (let [_ (throw-error-if-invalid-new-property-value @conn property v)
-            v-uuid (create-property-text-block! conn block-id property-id v {:set-block-property? false})]
-        (:db/id (d/entity @conn [:block/uuid v-uuid])))
+      (reuse-or-create-default-url-property-value conn property property-id v block-id)
 
       :else
       (or (get-property-value-eid @conn property-id v)
@@ -614,37 +712,11 @@
         (let [txs (mapcat
                    (fn [block]
                      (let [value (get block property-id)
-                           entities (cond
-                                      (de/entity? value) [value]
-                                      (and (sequential? value) (every? de/entity? value)) value
-                                      :else nil)
-                           deleting-entities (filter
-                                              (fn [value]
-                                                (let [value-referrers*
-                                                      (d/q '[:find [?e ...]
-                                                             :in $ ?property-id ?value-id
-                                                             :where
-                                                             [?e ?property-id ?value-id]]
-                                                           @conn
-                                                           (:db/ident property)
-                                                           (:db/id value))
-                                                      value-referrers
-                                                      (cond
-                                                        (nil? value-referrers*)
-                                                        #{}
-
-                                                        (coll? value-referrers*)
-                                                        (set value-referrers*)
-
-                                                        :else
-                                                        #{value-referrers*})]
-                                                  (and
-                                                   (:logseq.property/created-from-property value)
-                                                   (not (or (entity-util/page? value) (ldb/closed-value? value)))
-                                                   (empty? (set/difference value-referrers block-id-set)))))
-                                              entities)
-                           retract-blocks-tx (when (seq deleting-entities)
-                                               (:tx-data (outliner-core/delete-blocks @conn deleting-entities {})))]
+                           retract-blocks-tx (retract-unreferenced-property-value-blocks-tx
+                                              @conn
+                                              property
+                                              (property-value-entities value)
+                                              block-id-set)]
                        (concat
                         [[:db/retract (:db/id block) (:db/ident property)]]
                         retract-blocks-tx)))

--- a/deps/outliner/src/logseq/outliner/property.cljs
+++ b/deps/outliner/src/logseq/outliner/property.cljs
@@ -238,7 +238,7 @@
   [db property values retracting-block-ids]
   (let [deleting (unreferenced-generated-property-value-blocks db property values retracting-block-ids)]
     (when (seq deleting)
-      (:tx-data (outliner-core/delete-blocks db deleting {})))))
+      (:tx-data (outliner-core/delete-blocks db deleting {:reclaim-property-value? true})))))
 
 (defn- replaced-generated-property-value-tx
   [db block property old-value new-value replace-all-values?]
@@ -809,54 +809,58 @@
    (throw-error-if-read-only-property property-id)
    (if (nil? v)
      (batch-remove-property! conn block-ids property-id options)
-     (let [block-eids (map ->eid block-ids)
-           _ (throw-error-if-batch-alias-targets block-eids property-id)
-           _ (validate-batch-set-property conn block-eids property-id v)
-           property (d/entity @conn property-id)
-           _ (when (nil? property)
-               (throw (ex-info (str "Property " property-id " doesn't exist yet") {:property-id property-id})))
-           property-type (get property :logseq.property/type :default)
-           many? (= :db.cardinality/many (:db/cardinality property))
-           entity-id? (and (:entity-id? options) (number? v))
-           ref? (contains? db-property-type/all-ref-property-types property-type)
-           extends? (= property-id :logseq.property.class/extends)
-           default-url-not-closed? (and (contains? #{:default :url} property-type)
-                                        (not extends?)
-                                        (not (seq (entity-plus/lookup-kv-then-entity property :property/closed-values))))
-           v' (cond
-                extends?
-                (normalize-extends-value @conn v)
+     (ldb/batch-transact-with-temp-conn!
+      conn
+      {:outliner-op :batch-set-property}
+      (fn [conn]
+        (let [block-eids (map ->eid block-ids)
+              _ (throw-error-if-batch-alias-targets block-eids property-id)
+              _ (validate-batch-set-property conn block-eids property-id v)
+              property (d/entity @conn property-id)
+              _ (when (nil? property)
+                  (throw (ex-info (str "Property " property-id " doesn't exist yet") {:property-id property-id})))
+              property-type (get property :logseq.property/type :default)
+              many? (= :db.cardinality/many (:db/cardinality property))
+              entity-id? (and (:entity-id? options) (number? v))
+              ref? (contains? db-property-type/all-ref-property-types property-type)
+              extends? (= property-id :logseq.property.class/extends)
+              default-url-not-closed? (and (contains? #{:default :url} property-type)
+                                           (not extends?)
+                                           (not (seq (entity-plus/lookup-kv-then-entity property :property/closed-values))))
+              v' (cond
+                   extends?
+                   (normalize-extends-value @conn v)
 
-                (and ref? (not entity-id?))
-                (if default-url-not-closed?
-                  (normalize-and-validate-default-url-property-values conn property v many?)
-                  (convert-ref-property-values conn property-id v property-type {:many? many?}))
+                   (and ref? (not entity-id?))
+                   (if default-url-not-closed?
+                     (normalize-and-validate-default-url-property-values conn property v many?)
+                     (convert-ref-property-values conn property-id v property-type {:many? many?}))
 
-                :else
-                v)
-           _ (when (nil? v')
-               (throw (ex-info "Property value must be not nil" {:v v})))
-           txs (doall
-                (mapcat
-                 (fn [eid]
-                   (if-let [block (d/entity @conn eid)]
-                     (let [v' (if (and default-url-not-closed?
-                                       (not (and (keyword? v) entity-id?)))
-                                (convert-ref-property-values conn property-id v' property-type
-                                                             {:many? many?
-                                                              :block-id (:db/id block)})
-                                v')]
-                       (throw-error-if-self-value block v' ref?)
-                       (throw-error-if-invalid-property-value @conn property v')
-                       (when (= property-id :block/alias)
-                         (doseq [alias-id (if (coll? v') v' [v'])]
-                           (when (number? alias-id)
-                             (throw-error-if-invalid-alias @conn block alias-id))))
-                       (build-property-value-tx-data conn block property-id v'))
-                     (js/console.error "Skipping setting a block's property because the block id could not be found:" eid)))
-                 block-eids))]
-       (when (seq txs)
-         (ldb/transact! conn txs {:outliner-op :batch-set-property}))))))
+                   :else
+                   v)
+              _ (when (nil? v')
+                  (throw (ex-info "Property value must be not nil" {:v v})))
+              txs (doall
+                   (mapcat
+                    (fn [eid]
+                      (if-let [block (d/entity @conn eid)]
+                        (let [v' (if (and default-url-not-closed?
+                                          (not (and (keyword? v) entity-id?)))
+                                   (convert-ref-property-values conn property-id v' property-type
+                                                                {:many? many?
+                                                                 :block-id (:db/id block)})
+                                   v')]
+                          (throw-error-if-self-value block v' ref?)
+                          (throw-error-if-invalid-property-value @conn property v')
+                          (when (= property-id :block/alias)
+                            (doseq [alias-id (if (coll? v') v' [v'])]
+                              (when (number? alias-id)
+                                (throw-error-if-invalid-alias @conn block alias-id))))
+                          (build-property-value-tx-data conn block property-id v'))
+                        (js/console.error "Skipping setting a block's property because the block id could not be found:" eid)))
+                    block-eids))]
+          (when (seq txs)
+            (ldb/transact! conn txs {:outliner-op :batch-set-property}))))))))
 
 (defn remove-block-property!
   [conn eid property-id]
@@ -1049,13 +1053,21 @@
              (doseq [block-eid block-eids]
                (when-let [block (d/entity @conn block-eid)]
                  (let [current-val (get block property-id)
-                       fv (first current-val)]
+                       fv (first current-val)
+                       removed-value (some (fn [value]
+                                             (when (or (= property-value value)
+                                                       (= property-value (:db/id value)))
+                                               value))
+                                           current-val)]
                    (if (and (= 1 (count current-val))
                             (or (= property-value fv)
                                 (= property-value (:db/id fv))))
                      (remove-block-property! conn (:db/id block) property-id)
                      (ldb/transact! conn
-                                    [[:db/retract (:db/id block) property-id property-value]]
+                                    (concat
+                                     [[:db/retract (:db/id block) property-id property-value]]
+                                     (retract-unreferenced-property-value-blocks-tx
+                                      @conn property (property-value-entities removed-value) #{(:db/id block)}))
                                     {:outliner-op :save-block}))))))))))))
 
 (defn delete-property-value!

--- a/deps/outliner/test/logseq/outliner/property_test.cljs
+++ b/deps/outliner/test/logseq/outliner/property_test.cljs
@@ -7,6 +7,19 @@
             [logseq.outliner.core :as outliner-core]
             [logseq.outliner.property :as outliner-property]))
 
+(defn- created-from-property-children
+  [db parent-id]
+  (map (fn [id]
+         (let [e (d/entity db id)]
+           {:db/id id
+            :title (db-property/property-value-content e)}))
+       (d/q '[:find [?c ...]
+              :in $ ?parent
+              :where
+              [?c :block/parent ?parent]
+              [?c :logseq.property/created-from-property]]
+            db parent-id)))
+
 (deftest upsert-property!
   (testing "Creates a property"
     (let [conn (db-test/create-conn-with-blocks [])
@@ -189,17 +202,149 @@
           "New block has property set")
       (is (= property-value (:user.property/checkbox (db-test/find-block-by-content @conn "b2")))))))
 
+(deftest default-property-string-updates-do-not-orphan-value-blocks
+  (testing "set-block-property! reuses the exclusive value block across successive string updates"
+    (let [conn (db-test/create-conn-with-blocks
+                {:properties {:note {:logseq.property/type :default}}
+                 :pages-and-blocks [{:page {:block/title "page1"}
+                                     :blocks [{:block/title "host"}]}]})
+          host-id (:db/id (db-test/find-block-by-content @conn "host"))]
+      (outliner-property/set-block-property! conn host-id :user.property/note "first value")
+      (let [first-value-id (:db/id (:user.property/note (d/entity @conn host-id)))]
+        (outliner-property/set-block-property! conn host-id :user.property/note "second value")
+        (outliner-property/set-block-property! conn host-id :user.property/note "third value")
+        (let [host (d/entity @conn host-id)
+              children (created-from-property-children @conn host-id)
+              current (:user.property/note host)]
+          (is (= 1 (count children))
+              "Only the current value block remains as a child")
+          (is (= first-value-id (:db/id current))
+              "The original value block is edited in place")
+          (is (= "third value" (db-property/property-value-content current)))
+          (is (= [{:db/id first-value-id :title "third value"}] children))))))
+
+  (testing "batch-set-property! reclaims previous :default values"
+    (let [conn (db-test/create-conn-with-blocks
+                {:properties {:note {:logseq.property/type :default}}
+                 :pages-and-blocks [{:page {:block/title "page1"}
+                                     :blocks [{:block/title "host"}]}]})
+          host-uuid (:block/uuid (db-test/find-block-by-content @conn "host"))
+          host-id (:db/id (d/entity @conn [:block/uuid host-uuid]))]
+      (outliner-property/batch-set-property! conn [host-uuid] :user.property/note "first value")
+      (outliner-property/batch-set-property! conn [host-uuid] :user.property/note "second value")
+      (outliner-property/batch-set-property! conn [host-uuid] :user.property/note "third value")
+      (let [host (d/entity @conn host-id)
+            children (created-from-property-children @conn host-id)
+            current (:user.property/note host)]
+        (is (= 1 (count children)))
+        (is (= "third value" (db-property/property-value-content current)))
+        (is (= (:db/id current) (:db/id (first children)))))))
+
+  (testing "in-place title edits keep the same value block"
+    (let [conn (db-test/create-conn-with-blocks
+                {:properties {:note {:logseq.property/type :default}}
+                 :pages-and-blocks [{:page {:block/title "page1"}
+                                     :blocks [{:block/title "host"}]}]})
+          host-id (:db/id (db-test/find-block-by-content @conn "host"))]
+      (outliner-property/set-block-property! conn host-id :user.property/note "first value")
+      (let [value (:user.property/note (d/entity @conn host-id))
+            value-id (:db/id value)]
+        (ldb/transact! conn [(outliner-core/block-with-updated-at
+                              {:db/id value-id
+                               :block/title "edited in place"})])
+        (let [host (d/entity @conn host-id)
+              children (created-from-property-children @conn host-id)
+              current (:user.property/note host)]
+          (is (= value-id (:db/id current)))
+          (is (= "edited in place" (db-property/property-value-content current)))
+          (is (= 1 (count children)))))))
+
+  (testing "replacing with another entity reclaims the previous exclusive value block"
+    (let [conn (db-test/create-conn-with-blocks
+                {:properties {:note {:logseq.property/type :default}}
+                 :pages-and-blocks [{:page {:block/title "page1"}
+                                     :blocks [{:block/title "host-a"}
+                                              {:block/title "host-b"}]}]})
+          host-a-id (:db/id (db-test/find-block-by-content @conn "host-a"))
+          host-b-id (:db/id (db-test/find-block-by-content @conn "host-b"))]
+      (outliner-property/set-block-property! conn host-a-id :user.property/note "a value")
+      (outliner-property/set-block-property! conn host-b-id :user.property/note "b value")
+      (let [a-value-id (:db/id (:user.property/note (d/entity @conn host-a-id)))
+            b-value-id (:db/id (:user.property/note (d/entity @conn host-b-id)))]
+        (outliner-property/set-block-property! conn host-a-id :user.property/note b-value-id)
+        (is (nil? (d/entity @conn a-value-id))
+            "Unreferenced previous value block is deleted")
+        (is (some? (d/entity @conn b-value-id)))
+        (is (= b-value-id (:db/id (:user.property/note (d/entity @conn host-a-id)))))
+        (is (= b-value-id (:db/id (:user.property/note (d/entity @conn host-b-id)))))
+        (is (= 0 (count (created-from-property-children @conn host-a-id))))
+        (is (= 1 (count (created-from-property-children @conn host-b-id)))))))
+
+  (testing "url string updates also leave a single value block"
+    (let [conn (db-test/create-conn-with-blocks
+                {:properties {:homepage {:logseq.property/type :url}}
+                 :pages-and-blocks [{:page {:block/title "page1"}
+                                     :blocks [{:block/title "host"}]}]})
+          host-id (:db/id (db-test/find-block-by-content @conn "host"))]
+      (outliner-property/set-block-property! conn host-id :user.property/homepage "https://example.com/one")
+      (outliner-property/set-block-property! conn host-id :user.property/homepage "https://example.com/two")
+      (outliner-property/set-block-property! conn host-id :user.property/homepage "https://example.com/three")
+      (let [children (created-from-property-children @conn host-id)
+            current (:user.property/homepage (d/entity @conn host-id))]
+        (is (= 1 (count children)))
+        (is (= "https://example.com/three" (db-property/property-value-content current))))))
+
+  (testing "updating one block does not reclaim another block's value"
+    (let [conn (db-test/create-conn-with-blocks
+                {:properties {:note {:logseq.property/type :default}}
+                 :pages-and-blocks [{:page {:block/title "page1"}
+                                     :blocks [{:block/title "host-a"}
+                                              {:block/title "host-b"}]}]})
+          host-a-id (:db/id (db-test/find-block-by-content @conn "host-a"))
+          host-b-id (:db/id (db-test/find-block-by-content @conn "host-b"))]
+      (outliner-property/set-block-property! conn host-a-id :user.property/note "a1")
+      (outliner-property/set-block-property! conn host-b-id :user.property/note "b1")
+      (outliner-property/set-block-property! conn host-a-id :user.property/note "a2")
+      (is (= "a2" (db-property/property-value-content (:user.property/note (d/entity @conn host-a-id)))))
+      (is (= "b1" (db-property/property-value-content (:user.property/note (d/entity @conn host-b-id)))))
+      (is (= 1 (count (created-from-property-children @conn host-a-id))))
+      (is (= 1 (count (created-from-property-children @conn host-b-id))))))
+
+  (testing "many default values: add keeps existing, replace reclaims unused"
+    (let [conn (db-test/create-conn-with-blocks
+                {:properties {:notes {:logseq.property/type :default
+                                      :db/cardinality :db.cardinality/many}}
+                 :pages-and-blocks [{:page {:block/title "page1"}
+                                     :blocks [{:block/title "host"}]}]})
+          host-id (:db/id (db-test/find-block-by-content @conn "host"))
+          host-uuid (:block/uuid (d/entity @conn host-id))]
+      (outliner-property/batch-set-property! conn [host-uuid] :user.property/notes "Step 1")
+      (outliner-property/batch-set-property! conn [host-uuid] :user.property/notes "Step 2")
+      (is (= #{"Step 1" "Step 2"}
+             (->> (:user.property/notes (d/entity @conn host-id))
+                  (map db-property/property-value-content)
+                  set)))
+      (is (= 2 (count (created-from-property-children @conn host-id))))
+      (outliner-property/batch-set-property! conn [host-uuid] :user.property/notes ["Step 3"])
+      (is (= #{"Step 3"}
+             (->> (:user.property/notes (d/entity @conn host-id))
+                  (map db-property/property-value-content)
+                  set)))
+      (is (= 1 (count (created-from-property-children @conn host-id)))))))
+
 (deftest remove-block-property!
   (let [conn (db-test/create-conn-with-blocks
               [{:page {:block/title "page1"}
                 :blocks [{:block/title "b1" :build/properties {:default "foo"}}]}])
         block (db-test/find-block-by-content @conn "b1")
+        value-id (:db/id (:user.property/default block))
         _ (assert (:user.property/default block))
         ;; Use same args as outliner.op
         _ (outliner-property/remove-block-property! conn [:block/uuid (:block/uuid block)] :user.property/default)
         updated-block (db-test/find-block-by-content @conn "b1")]
     (is (some? updated-block))
-    (is (nil? (:user.property/default updated-block)) "Block property is deleted")))
+    (is (nil? (:user.property/default updated-block)) "Block property is deleted")
+    (is (nil? (d/entity @conn value-id)) "Unreferenced value block is reclaimed")))
 
 (deftest batch-set-property!
   (testing "Set built-in property values for multiple blocks"

--- a/deps/outliner/test/logseq/outliner/property_test.cljs
+++ b/deps/outliner/test/logseq/outliner/property_test.cljs
@@ -240,6 +240,30 @@
         (is (= "third value" (db-property/property-value-content current)))
         (is (= (:db/id current) (:db/id (first children)))))))
 
+  (testing "batch-set-property! updates reused value blocks atomically"
+    (let [conn (db-test/create-conn-with-blocks
+                {:properties {:note {:logseq.property/type :default}}
+                 :pages-and-blocks [{:page {:block/title "page1"}
+                                     :blocks [{:block/title "host-a"}
+                                              {:block/title "host-b"}]}]})
+          host-uuids (mapv #(-> (db-test/find-block-by-content @conn %)
+                                :block/uuid)
+                           ["host-a" "host-b"])
+          tx-reports (atom [])]
+      (outliner-property/batch-set-property! conn host-uuids :user.property/note "first value")
+      (d/listen! conn ::capture-batch-default-update #(swap! tx-reports conj %))
+      (try
+        (outliner-property/batch-set-property! conn host-uuids :user.property/note "second value")
+        (is (= 1 (count @tx-reports))
+            "The batch update is committed as one transaction")
+        (is (= ["second value" "second value"]
+               (mapv #(-> (d/entity @conn [:block/uuid %])
+                          :user.property/note
+                          db-property/property-value-content)
+                     host-uuids)))
+        (finally
+          (d/unlisten! conn ::capture-batch-default-update)))))
+
   (testing "in-place title edits keep the same value block"
     (let [conn (db-test/create-conn-with-blocks
                 {:properties {:note {:logseq.property/type :default}}
@@ -279,6 +303,40 @@
         (is (= b-value-id (:db/id (:user.property/note (d/entity @conn host-b-id)))))
         (is (= 0 (count (created-from-property-children @conn host-a-id))))
         (is (= 1 (count (created-from-property-children @conn host-b-id)))))))
+
+  (testing "configured property defaults do not prevent reclaiming custom values"
+    (let [conn (db-test/create-conn-with-blocks
+                {:properties {:note {:logseq.property/type :default}}
+                 :pages-and-blocks [{:page {:block/title "page1"}
+                                     :blocks [{:block/title "default-source"}
+                                              {:block/title "host"}
+                                              {:block/title "replacement-source"}]}]})
+          default-source-id (:db/id (db-test/find-block-by-content @conn "default-source"))
+          host-id (:db/id (db-test/find-block-by-content @conn "host"))
+          replacement-source-id (:db/id (db-test/find-block-by-content @conn "replacement-source"))
+          property-id (:db/id (d/entity @conn :user.property/note))]
+      (outliner-property/set-block-property! conn default-source-id :user.property/note "default value")
+      (let [default-value-id (:db/id (:user.property/note (d/entity @conn default-source-id)))]
+        (ldb/transact! conn [{:db/id property-id
+                              :logseq.property/default-value default-value-id}])
+        (outliner-property/set-block-property! conn host-id :user.property/note "old custom value")
+        (outliner-property/set-block-property! conn replacement-source-id :user.property/note "replacement value")
+        (let [old-value-id (:db/id (:user.property/note (d/entity @conn host-id)))
+              replacement-value-id (:db/id (:user.property/note (d/entity @conn replacement-source-id)))]
+          (outliner-property/set-block-property! conn host-id :user.property/note replacement-value-id)
+          (is (nil? (d/entity @conn old-value-id))
+              "The replaced custom value block is reclaimed")
+          (is (some? (d/entity @conn default-value-id))
+              "The configured default value is preserved")
+          (is (= replacement-value-id
+                 (:db/id (:user.property/note (d/entity @conn host-id)))))
+          (is (empty? (created-from-property-children @conn host-id)))
+          (outliner-property/set-block-property! conn host-id :user.property/note default-value-id)
+          (outliner-property/remove-block-property! conn host-id :user.property/note)
+          (is (= :logseq.property/empty-placeholder
+                 (:db/ident (:user.property/note (d/entity @conn host-id)))))
+          (is (some? (d/entity @conn default-value-id))
+              "Removing a configured default replaces it with the placeholder")))))
 
   (testing "url string updates also leave a single value block"
     (let [conn (db-test/create-conn-with-blocks
@@ -331,6 +389,27 @@
                   (map db-property/property-value-content)
                   set)))
       (is (= 1 (count (created-from-property-children @conn host-id)))))))
+
+(deftest delete-one-of-many-generated-property-values
+  (testing "deleting one of many default values reclaims its value block"
+    (let [conn (db-test/create-conn-with-blocks
+                {:properties {:notes {:logseq.property/type :default
+                                      :db/cardinality :db.cardinality/many}}
+                 :pages-and-blocks [{:page {:block/title "page1"}
+                                     :blocks [{:block/title "host"}]}]})
+          host-id (:db/id (db-test/find-block-by-content @conn "host"))]
+      (outliner-property/batch-set-property! conn [host-id] :user.property/notes "Step 1")
+      (outliner-property/batch-set-property! conn [host-id] :user.property/notes "Step 2")
+      (let [step-1 (some #(when (= "Step 1" (db-property/property-value-content %)) %)
+                         (:user.property/notes (d/entity @conn host-id)))]
+        (outliner-property/delete-property-value! conn host-id :user.property/notes (:db/id step-1))
+        (is (nil? (d/entity @conn (:db/id step-1)))
+            "The removed value block is reclaimed")
+        (is (= #{"Step 2"}
+               (->> (:user.property/notes (d/entity @conn host-id))
+                    (map db-property/property-value-content)
+                    set)))
+        (is (= 1 (count (created-from-property-children @conn host-id))))))))
 
 (deftest remove-block-property!
   (let [conn (db-test/create-conn-with-blocks
@@ -474,6 +553,25 @@
          js/Error
          #"Can't remove required"
          (outliner-property/batch-remove-property! conn [(:db/id (d/entity @conn :user.class/C1))] :logseq.property.class/extends)))))
+
+(deftest batch-remove-generated-property-values
+  (let [conn (db-test/create-conn-with-blocks
+              {:properties {:note {:logseq.property/type :default}}
+               :pages-and-blocks [{:page {:block/title "page1"}
+                                   :blocks [{:block/title "host-a"}
+                                            {:block/title "host-b"}]}]})
+        host-ids (mapv #(-> (db-test/find-block-by-content @conn %) :db/id)
+                       ["host-a" "host-b"])]
+    (outliner-property/batch-set-property! conn host-ids :user.property/note "value")
+    (let [value-ids (mapv #(-> (d/entity @conn %)
+                               :user.property/note
+                               :db/id)
+                          host-ids)]
+      (outliner-property/batch-remove-property! conn host-ids :user.property/note)
+      (is (every? nil? (map #(get (d/entity @conn %) :user.property/note) host-ids)))
+      (is (every? nil? (map #(d/entity @conn %) value-ids))
+          "Batch removal reclaims generated value blocks")
+      (is (every? empty? (map #(created-from-property-children @conn %) host-ids))))))
 
 (deftest batch-remove-property-rejects-private-built-in-entity
   (let [conn (db-test/create-conn)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updating a cardinality-one `:default` or `:url` property with a new string used to mint a new value block and only retract the old attribute ref. The previous value block stayed as an invisible child of the host (`:logseq.property/created-from-property`, unreferenced), so each edit accumulated another orphan.

This change does two things in the outliner set/batch-set path:

- Reuse the host's exclusive generated value block and edit its title in place when the current value is not shared.
- Reclaim unreferenced generated value blocks when the property is replaced with a different entity, matching `batch-remove-property!`.

Shared values (closed values, pages, empty placeholder, a property's configured default value, and values still referenced by other blocks) are left alone. UI in-place title edits of the existing value block are unchanged.

Fixes https://github.com/logseq/db-test/issues/1073

## Tests
- Added `default-property-string-updates-do-not-orphan-value-blocks` covering `set-block-property!`, `batch-set-property!`, in-place title edits, entity replacement, `:url`, independent hosts, and many-cardinality add vs replace.
- `remove-block-property!` now asserts the unreferenced value block is deleted.
- `deps/outliner` unit tests: 100 tests, 370 assertions, 0 failures.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5b01f94-7085-4002-83f1-c0eb9c3def64?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5b01f94-7085-4002-83f1-c0eb9c3def64&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

