### PR TITLE
fix: keep graphs list usable when db-worker is nil

### DIFF
--- a/src/main/frontend/db/hooks.cljs
+++ b/src/main/frontend/db/hooks.cljs
@@ -34,15 +34,19 @@
                       {:key key :snapshot result})))
     result))
 
+(defn- snapshot-value
+  [{:keys [status value error] :as result}]
+  (case status
+    :ready value
+    (:loading :missing) nil
+    :error (if (state/db-worker-uninitialized-error? error)
+             nil
+             (throw error))
+    (throw (ex-info "Invalid renderer subscription snapshot" result))))
+
 (defn- use-external-store
   [subscribe! snapshot key]
-  (let [{:keys [status value error] :as result}
-        (use-external-store-snapshot subscribe! snapshot key)]
-    (case status
-      :ready value
-      (:loading :missing) nil
-      :error (throw error)
-      (throw (ex-info "Invalid renderer subscription snapshot" result)))))
+  (snapshot-value (use-external-store-snapshot subscribe! snapshot key)))
 
 (defn- use-external-store-projection
   [subscribe! snapshot key project]
@@ -67,14 +71,8 @@
                                     {:source source :snapshot projected})
                               projected))))
                       #js [snapshot key project])
-        {:keys [status value error] :as result}
-        (react/useSyncExternalStore subscribe get-snapshot get-snapshot)]
-    (case status
-      :ready value
-      (:loading :missing) nil
-      :error (throw error)
-      (throw (ex-info "Invalid renderer subscription snapshot"
-                      {:key key :snapshot result})))))
+        result (react/useSyncExternalStore subscribe get-snapshot get-snapshot)]
+    (snapshot-value result)))
 
 (defn use-block
   [block-uuid]
@@ -103,13 +101,7 @@
   [block-uuids]
   (when (use-block-prefetch block-uuids)
     (mapv (fn [block-uuid]
-            (let [{:keys [status value error] :as snapshot}
-                  (subs/block-snapshot block-uuid)]
-              (case status
-                :ready value
-                :missing nil
-                :error (throw error)
-                (throw (ex-info "Invalid settled block snapshot" snapshot)))))
+            (snapshot-value (subs/block-snapshot block-uuid)))
           block-uuids)))
 
 (defn use-block-projection

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -180,15 +180,16 @@
     (page-common-handler/after-page-renamed! repo data)))
 
 (defevent! :graph/sync-context []
-  (let [context {:dev? config/dev?
-                 :node-test? util/node-test?
-                 :mobile? (util/mobile?)
-                 :validate-db-options (:dev/validate-db-options (state/get-config))
-                 :importing? (:graph/importing (state/get-state))
-                 :date-formatter (state/get-date-formatter)
-                 :export-bullet-indentation (state/get-export-bullet-indentation)
-                 :preferred-format (state/get-preferred-format)}]
-    (state/<invoke-db-worker :thread-api/set-context context)))
+  (when @state/db-worker-ready?
+    (let [context {:dev? config/dev?
+                   :node-test? util/node-test?
+                   :mobile? (util/mobile?)
+                   :validate-db-options (:dev/validate-db-options (state/get-config))
+                   :importing? (:graph/importing (state/get-state))
+                   :date-formatter (state/get-date-formatter)
+                   :export-bullet-indentation (state/get-export-bullet-indentation)
+                   :preferred-format (state/get-preferred-format)}]
+      (state/<invoke-db-worker :thread-api/set-context context))))
 
 ;; Hook on a graph is ready to be shown to the user.
 ;; It's different from :graph/restored, as :graph/restored is for window reloaded

--- a/src/main/frontend/persist_db.cljs
+++ b/src/main/frontend/persist_db.cljs
@@ -321,7 +321,9 @@
       (p/let [client (<ensure-remote! repo)]
         (protocol/<list-db client))
       (p/resolved []))
-    (protocol/<list-db (get-impl))))
+    (if @state/db-worker-ready?
+      (protocol/<list-db (get-impl))
+      (p/resolved []))))
 
 (defn <unsafe-delete [repo]
   (when repo
@@ -364,7 +366,9 @@
      (if (electron-runtime?)
        (p/let [client (<ensure-remote! repo)]
          (protocol/<open-and-fetch-schema client repo opts))
-       (protocol/<open-and-fetch-schema (get-impl) repo opts)))))
+       (p/let [_ (when-not @state/db-worker-ready?
+                   (browser/start-db-worker!))]
+         (protocol/<open-and-fetch-schema (get-impl) repo opts))))))
 
 ;; FIXME: limit repo name's length and sanity
 ;; @shuyu Do we still need this?

--- a/src/main/frontend/persist_db/browser.cljs
+++ b/src/main/frontend/persist_db/browser.cljs
@@ -273,8 +273,13 @@
       result))
 
   (<list-db [_this]
-    (-> (state/<invoke-db-worker :thread-api/list-db)
-        (p/catch sqlite-error-handler)))
+    (if-not @state/db-worker-ready?
+      (p/resolved [])
+      (-> (state/<invoke-db-worker :thread-api/list-db)
+          (p/catch (fn [error]
+                     (if (state/db-worker-uninitialized-error? error)
+                       []
+                       (sqlite-error-handler error)))))))
 
   (<unsafe-delete [_this repo]
     (state/<invoke-db-worker :thread-api/unsafe-unlink-db repo))
@@ -286,7 +291,10 @@
     (-> (p/let [result (state/<invoke-db-worker :thread-api/create-or-open-db repo opts)
                 _ (<sync-markdown-mirror-setting! repo)]
           result)
-        (p/catch sqlite-error-handler)))
+        (p/catch (fn [error]
+                   (if (state/db-worker-uninitialized-error? error)
+                     (p/rejected error)
+                     (sqlite-error-handler error))))))
 
   (<export-db [_this repo opts]
     (-> (if (util/electron?)

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -18,6 +18,7 @@
             [frontend.util.entity :as entity]
             [goog.dom :as gdom]
             [goog.object :as gobj]
+            [lambdaisland.glogi :as log]
             [logseq.common.config :as common-config]
             [logseq.db :as ldb]
             [logseq.shui.dialog.core :as shui-dialog]
@@ -54,8 +55,16 @@
                     :en)
                 name)))))
 
+(def db-worker-uninitialized-message
+  "db-worker has not been initialized")
+
+(defn db-worker-uninitialized-error?
+  "True when a call failed because `*db-worker` was nil."
+  [error]
+  (= db-worker-uninitialized-message (ex-message error)))
+
 (def db-worker-ready?
-  "`<invoke-db-worker` throws err if `*db-worker` not ready yet.
+  "`<invoke-db-worker` rejects if `*db-worker` is not ready yet.
   Use this atom to wait till db-worker ready."
   (let [ready? (atom (fn? @*db-worker))]
     (add-watch *db-worker ::db-worker-ready?
@@ -64,17 +73,22 @@
     ready?))
 
 (defn <invoke-db-worker
-  "invoke db-worker thread api"
+  "invoke db-worker thread api.
+
+  Always returns a promise. When the worker is missing this rejects instead of
+  throwing, so React render / RFX handlers can recover instead of hitting
+  ErrorBoundary."
   [qkw & args]
   (let [worker @*db-worker]
-    (when (nil? worker)
-      (prn :<invoke-db-worker-error qkw)
-      (throw (ex-info "db-worker has not been initialized" {})))
-    (p/let [result (apply worker qkw args)]
-      (if (or (instance? ExceptionInfo result)
-              (instance? js/Error result))
-        (p/rejected result)
-        result))))
+    (if (nil? worker)
+      (do
+        (log/warn :db-worker/not-initialized {:qkw qkw})
+        (p/rejected (ex-info db-worker-uninitialized-message {:qkw qkw})))
+      (p/let [result (apply worker qkw args)]
+        (if (or (instance? ExceptionInfo result)
+                (instance? js/Error result))
+          (p/rejected result)
+          result)))))
 
 (def ^:private export-block-text-indent-styles #{"dashes" "spaces" "no-indent"})
 

--- a/src/main/frontend/undo_redo.cljs
+++ b/src/main/frontend/undo_redo.cljs
@@ -5,7 +5,7 @@
 
 (defn- worker-not-initialized?
   [e]
-  (= "db-worker has not been initialized" (ex-message e)))
+  (state/db-worker-uninitialized-error? e))
 
 (defn- normalize-empty-result
   [result]
@@ -20,12 +20,14 @@
 
 (defn- invoke-db-worker
   [thread-api & args]
-  (try
-    (apply state/<invoke-db-worker thread-api args)
-    (catch :default e
-      (if (worker-not-initialized? e)
-        nil
-        (throw e)))))
+  (if-not @state/db-worker-ready?
+    nil
+    (try
+      (apply state/<invoke-db-worker thread-api args)
+      (catch :default e
+        (if (worker-not-initialized? e)
+          nil
+          (throw e))))))
 
 (defn clear-history!
   [repo]

--- a/src/test/frontend/components/repo_test.cljs
+++ b/src/test/frontend/components/repo_test.cljs
@@ -567,3 +567,32 @@
       (is (= [[:graph/open-new-window "logseq_db_demo"]]
              @events))
       (is (zero? @registry-reads)))))
+
+(deftest graph-e2ee-enabled-with-nil-worker-does-not-throw
+  (async done
+         (let [previous-worker @state/*db-worker
+               e2ee-fn (some-> (resolve 'frontend.components.repo/graph-e2ee-enabled?) deref)]
+           (is (fn? e2ee-fn) "All graphs reads e2ee state through a helper")
+           (if-not e2ee-fn
+             (finish-async-test! done)
+             (do
+               (reset! state/*db-worker nil)
+               (let [sync-result (try
+                                   (with-redefs [state/get-current-repo (fn [] "logseq_db_demo")]
+                                     (e2ee-fn {:url "logseq_db_demo"}))
+                                   (catch :default e
+                                     {:threw e}))]
+                 (if (and (map? sync-result) (contains? sync-result :threw))
+                   (do
+                     (is false "All graphs must not throw when db-worker is missing.")
+                     (reset! state/*db-worker previous-worker)
+                     (finish-async-test! done))
+                   (-> sync-result
+                       (p/then (fn [_]
+                                 (is true "resolved without a worker is acceptable")))
+                       (p/catch (fn [error]
+                                  (is (state/db-worker-uninitialized-error? error)
+                                      "Failure stays in the promise instead of crashing the page.")))
+                       (p/finally (fn []
+                                    (reset! state/*db-worker previous-worker)
+                                    (finish-async-test! done)))))))))))

--- a/src/test/frontend/db/hooks_test.cljs
+++ b/src/test/frontend/db/hooks_test.cljs
@@ -3,6 +3,7 @@
             [cljs.test :refer [deftest is]]
             [frontend.db.hooks :as db-hooks]
             [frontend.db.subs :as subs]
+            [frontend.state :as state]
             [goog.object :as gobj]))
 
 (defn- with-use-sync-external-store
@@ -242,4 +243,9 @@
         (with-redefs [subs/block-snapshot (constantly {:status :error
                                                        :error error})]
           (is (thrown? js/Error
-                       (db-hooks/use-block block-uuid))))))))
+                       (db-hooks/use-block block-uuid))))
+        (with-redefs [subs/block-snapshot
+                      (constantly {:status :error
+                                   :error (ex-info state/db-worker-uninitialized-message {})})]
+          (is (nil? (db-hooks/use-block block-uuid))
+              "A missing db-worker must not throw into React ErrorBoundary."))))))

--- a/src/test/frontend/db/restore_test.cljs
+++ b/src/test/frontend/db/restore_test.cljs
@@ -95,3 +95,33 @@
              (fn []
                (state/replace-state! previous-state)
                (done))))))))
+
+(deftest restore-graph-with-nil-worker-rejects-without-throwing
+  (async done
+         (let [repo "logseq_db_restore_nil_worker"
+               previous-state (state/get-state)
+               previous-worker @state/*db-worker]
+           (reset! state/*db-worker nil)
+           (p/with-redefs [persist-db/<open-and-fetch-schema
+                           (fn [_repo _opts]
+                             (p/resolved {:schema db-schema/schema}))]
+             (let [sync-result (try
+                                 (db-restore/restore-graph! repo)
+                                 (catch :default e
+                                   {:threw e}))]
+               (if (and (map? sync-result) (contains? sync-result :threw))
+                 (do
+                   (is false "Restore must not throw into the UI when db-worker is missing.")
+                   (reset! state/*db-worker previous-worker)
+                   (state/replace-state! previous-state)
+                   (done))
+                 (-> sync-result
+                     (p/then (fn []
+                               (is false "Restore should reject when db-worker is missing.")))
+                     (p/catch (fn [error]
+                                (is (state/db-worker-uninitialized-error? error))
+                                (is (false? (boolean (state/get-state :graph/loading?))))))
+                     (p/finally (fn []
+                                  (reset! state/*db-worker previous-worker)
+                                  (state/replace-state! previous-state)
+                                  (done))))))))))

--- a/src/test/frontend/db/restore_test.cljs
+++ b/src/test/frontend/db/restore_test.cljs
@@ -20,108 +20,107 @@
           current-repos (atom [])
           reset-graphs (atom [])]
       (reset! db-conn/conns {})
-      (p/with-redefs [persist-db/<open-and-fetch-schema
-                      (fn [repo' _opts]
-                        (is (= repo repo'))
-                        (swap! calls conj [:open repo'])
-                        (p/resolved {:schema db-schema/schema}))
-                      state/pub-event!
-                      (fn [event]
-                        (swap! events conj event)
-                        (swap! calls conj [:event event])
-                        (p/resolved nil))
-                      state/set-current-repo!
-                      (fn [repo']
-                        (swap! current-repos conj repo')
-                        (swap! calls conj [:current-repo repo'])
-                        (state/swap-state! assoc :git/current-repo repo')
-                        nil)
-                      state/<invoke-db-worker
-                      (fn [api repo']
-                        (swap! calls conj [:worker api repo'])
-                        (p/resolved conflicts-by-block))
-                      state/set-sync-block-conflicts!
-                      (fn [& args]
-                        (swap! calls conj (into [:hydrate] args)))
-                      db-subs/reset-graph!
-                      (fn [repo']
-                        (swap! reset-graphs conj repo')
-                        (swap! calls conj [:reset repo']))]
-        (-> (db-restore/restore-graph! repo)
-            (p/then
-             (fn [_]
-               (is (= [repo] @current-repos))
-               (is (= [repo] @reset-graphs)
-                   "A restored worker graph must reset renderer subscriptions before rendering it.")
-               (is (= [[:graph/restored repo] [:ui/re-render-root]]
-                      @events))
-               (is (= [[:open repo]
-                       [:worker :thread-api/db-sync-get-all-block-conflicts repo]
-                       [:current-repo repo]
-                       [:reset repo]
-                       [:hydrate repo conflicts-by-block]
-                       [:event [:graph/restored repo]]
-                       [:event [:ui/re-render-root]]]
-                      @calls)
-                   "Restore hydrates all conflicts once after graph reset and before rendering.")
-               (is (empty? @db-conn/conns)
-                   "Restoring a graph must not create a renderer DataScript connection.")))
-            (p/catch
-             (fn [error]
-               (is false (str error))))
-            (p/finally
-             (fn []
-               (state/replace-state! previous-state)
-               (reset! db-conn/conns previous-conns)
-               (done))))))))
+      (-> (p/with-redefs [persist-db/<open-and-fetch-schema
+                          (fn [repo' _opts]
+                            (is (= repo repo'))
+                            (swap! calls conj [:open repo'])
+                            (p/resolved {:schema db-schema/schema}))
+                          state/pub-event!
+                          (fn [event]
+                            (swap! events conj event)
+                            (swap! calls conj [:event event])
+                            (p/resolved nil))
+                          state/set-current-repo!
+                          (fn [repo']
+                            (swap! current-repos conj repo')
+                            (swap! calls conj [:current-repo repo'])
+                            (state/swap-state! assoc :git/current-repo repo')
+                            nil)
+                          state/<invoke-db-worker
+                          (fn [api repo']
+                            (swap! calls conj [:worker api repo'])
+                            (p/resolved conflicts-by-block))
+                          state/set-sync-block-conflicts!
+                          (fn [& args]
+                            (swap! calls conj (into [:hydrate] args)))
+                          db-subs/reset-graph!
+                          (fn [repo']
+                            (swap! reset-graphs conj repo')
+                            (swap! calls conj [:reset repo']))]
+            (-> (db-restore/restore-graph! repo)
+                (p/then
+                 (fn [_]
+                   (is (= [repo] @current-repos))
+                   (is (= [repo] @reset-graphs)
+                       "A restored worker graph must reset renderer subscriptions before rendering it.")
+                   (is (= [[:graph/restored repo] [:ui/re-render-root]]
+                          @events))
+                   (is (= [[:open repo]
+                           [:worker :thread-api/db-sync-get-all-block-conflicts repo]
+                           [:current-repo repo]
+                           [:reset repo]
+                           [:hydrate repo conflicts-by-block]
+                           [:event [:graph/restored repo]]
+                           [:event [:ui/re-render-root]]]
+                          @calls)
+                       "Restore hydrates all conflicts once after graph reset and before rendering.")
+                   (is (empty? @db-conn/conns)
+                       "Restoring a graph must not create a renderer DataScript connection.")))
+                (p/catch
+                 (fn [error]
+                   (is false (str error))))))
+          (p/finally
+           (fn []
+             (state/replace-state! previous-state)
+             (reset! db-conn/conns previous-conns)
+             (done)))))))
 
 (deftest failed-restore-keeps-current-graph-and-clears-loading-test
   (async done
     (let [repo "logseq_db_restore_failure"
           previous-state (state/get-state)
           previous-repo (state/get-current-repo)]
-      (p/with-redefs [persist-db/<open-and-fetch-schema
-                      (fn [_repo _opts]
-                        (p/resolved {:schema nil}))]
-        (-> (db-restore/restore-graph! repo)
-            (p/then (fn []
-                      (is false "Restore should reject an invalid schema.")))
-            (p/catch
-             (fn [_error]
-               (is (false? (boolean (state/get-state :graph/loading?))))
-               (is (= previous-repo (state/get-current-repo))
-                   "Current repo changes only after schema validation succeeds.")))
-            (p/finally
-             (fn []
-               (state/replace-state! previous-state)
-               (done))))))))
+      (-> (p/with-redefs [persist-db/<open-and-fetch-schema
+                          (fn [_repo _opts]
+                            (p/resolved {:schema nil}))]
+            (-> (db-restore/restore-graph! repo)
+                (p/then (fn []
+                          (is false "Restore should reject an invalid schema.")))
+                (p/catch
+                 (fn [_error]
+                   (is (false? (boolean (state/get-state :graph/loading?))))
+                   (is (= previous-repo (state/get-current-repo))
+                       "Current repo changes only after schema validation succeeds.")))))
+          (p/finally
+           (fn []
+             (state/replace-state! previous-state)
+             (done)))))))
 
 (deftest restore-graph-with-nil-worker-rejects-without-throwing
   (async done
-         (let [repo "logseq_db_restore_nil_worker"
-               previous-state (state/get-state)
-               previous-worker @state/*db-worker]
-           (reset! state/*db-worker nil)
-           (p/with-redefs [persist-db/<open-and-fetch-schema
-                           (fn [_repo _opts]
-                             (p/resolved {:schema db-schema/schema}))]
-             (let [sync-result (try
-                                 (db-restore/restore-graph! repo)
-                                 (catch :default e
-                                   {:threw e}))]
-               (if (and (map? sync-result) (contains? sync-result :threw))
-                 (do
-                   (is false "Restore must not throw into the UI when db-worker is missing.")
-                   (reset! state/*db-worker previous-worker)
-                   (state/replace-state! previous-state)
-                   (done))
-                 (-> sync-result
-                     (p/then (fn []
-                               (is false "Restore should reject when db-worker is missing.")))
-                     (p/catch (fn [error]
-                                (is (state/db-worker-uninitialized-error? error))
-                                (is (false? (boolean (state/get-state :graph/loading?))))))
-                     (p/finally (fn []
-                                  (reset! state/*db-worker previous-worker)
-                                  (state/replace-state! previous-state)
-                                  (done))))))))))
+    (let [repo "logseq_db_restore_nil_worker"
+          previous-state (state/get-state)
+          previous-worker @state/*db-worker]
+      (reset! state/*db-worker nil)
+      (-> (p/with-redefs [persist-db/<open-and-fetch-schema
+                          (fn [_repo _opts]
+                            (p/resolved {:schema db-schema/schema}))]
+            (let [sync-result (try
+                                (db-restore/restore-graph! repo)
+                                (catch :default e
+                                  {:threw e}))]
+              (if (and (map? sync-result) (contains? sync-result :threw))
+                (do
+                  (is false "Restore must not throw into the UI when db-worker is missing.")
+                  (p/resolved nil))
+                (-> sync-result
+                    (p/then (fn []
+                              (is false "Restore should reject when db-worker is missing.")))
+                    (p/catch (fn [error]
+                               (is (state/db-worker-uninitialized-error? error))
+                               (is (false? (boolean (state/get-state :graph/loading?))))))))))
+          (p/finally
+           (fn []
+             (reset! state/*db-worker previous-worker)
+             (state/replace-state! previous-state)
+             (done)))))))

--- a/src/test/frontend/handler/events_test.cljs
+++ b/src/test/frontend/handler/events_test.cljs
@@ -43,12 +43,16 @@
   (let [previous-worker @state/*db-worker
         calls (atom [])
         handler (get @@#'events/event-definitions :graph/sync-context)]
-    (reset! state/*db-worker (fn [qkw context]
-                               (swap! calls conj [qkw context])
-                               nil))
+    (reset! state/*db-worker (fn [& _] nil))
     (try
-      (handler [:graph/sync-context])
-      (is (= 1 (count @calls)))
-      (is (= :thread-api/set-context (ffirst @calls)))
+      (is (true? @state/db-worker-ready?)
+          "A function worker must mark db-worker as ready.")
+      (with-redefs [state/<invoke-db-worker
+                    (fn [qkw context]
+                      (swap! calls conj [qkw context])
+                      nil)]
+        (handler [:graph/sync-context])
+        (is (= 1 (count @calls)))
+        (is (= :thread-api/set-context (ffirst @calls))))
       (finally
         (reset! state/*db-worker previous-worker)))))

--- a/src/test/frontend/handler/events_test.cljs
+++ b/src/test/frontend/handler/events_test.cljs
@@ -1,7 +1,9 @@
 (ns frontend.handler.events-test
   (:require [cljs.test :refer [deftest is testing]]
             [frontend.components.rtc.download-progress :as download-progress]
+            [frontend.handler.events :as events]
             [frontend.mobile.util :as mobile-util]
+            [frontend.state :as state]
             [logseq.shui.ui :as shui]))
 
 (deftest download-graph-progress-surface-test
@@ -25,3 +27,28 @@
         (download-progress/show! "My notes")
         (download-progress/hide!)
         (is (= [:popup :popup-hide] (mapv first @calls)))))))
+
+(deftest graph-sync-context-with-nil-worker-does-not-throw
+  (let [previous-worker @state/*db-worker
+        handler (get @#'events/event-definitions :graph/sync-context)]
+    (is (fn? handler) ":graph/sync-context should be registered")
+    (reset! state/*db-worker nil)
+    (try
+      (is (nil? (handler [:graph/sync-context]))
+          "Sync-context must no-op when the worker is missing instead of crashing All graphs.")
+      (finally
+        (reset! state/*db-worker previous-worker)))))
+
+(deftest graph-sync-context-invokes-worker-when-ready
+  (let [previous-worker @state/*db-worker
+        calls (atom [])
+        handler (get @#'events/event-definitions :graph/sync-context)]
+    (reset! state/*db-worker (fn [qkw context]
+                               (swap! calls conj [qkw context])
+                               nil))
+    (try
+      (handler [:graph/sync-context])
+      (is (= 1 (count @calls)))
+      (is (= :thread-api/set-context (ffirst @calls)))
+      (finally
+        (reset! state/*db-worker previous-worker)))))

--- a/src/test/frontend/handler/events_test.cljs
+++ b/src/test/frontend/handler/events_test.cljs
@@ -30,7 +30,7 @@
 
 (deftest graph-sync-context-with-nil-worker-does-not-throw
   (let [previous-worker @state/*db-worker
-        handler (get @#'events/event-definitions :graph/sync-context)]
+        handler (get @@#'events/event-definitions :graph/sync-context)]
     (is (fn? handler) ":graph/sync-context should be registered")
     (reset! state/*db-worker nil)
     (try
@@ -42,7 +42,7 @@
 (deftest graph-sync-context-invokes-worker-when-ready
   (let [previous-worker @state/*db-worker
         calls (atom [])
-        handler (get @#'events/event-definitions :graph/sync-context)]
+        handler (get @@#'events/event-definitions :graph/sync-context)]
     (reset! state/*db-worker (fn [qkw context]
                                (swap! calls conj [qkw context])
                                nil))

--- a/src/test/frontend/persist_db_test.cljs
+++ b/src/test/frontend/persist_db_test.cljs
@@ -1636,3 +1636,35 @@
            (fn []
              (set! state/<invoke-db-worker original-invoke)
              (done)))))))
+
+(deftest browser-list-db-with-nil-worker-returns-empty-without-throwing
+  (async done
+         (let [original-electron? util/electron?
+               original-show! notification/show!
+               notifications (atom [])]
+           (reset-runtime-state!)
+           (set! util/electron? (constantly false))
+           (set! notification/show! (fn [& args]
+                                      (swap! notifications conj args)
+                                      nil))
+           (let [sync-result (try
+                               (persist-db/<list-db)
+                               (catch :default e
+                                 {:threw e}))]
+             (if (and (map? sync-result) (contains? sync-result :threw))
+               (do
+                 (is false "Listing graphs must not throw when db-worker is missing.")
+                 (set! util/electron? original-electron?)
+                 (set! notification/show! original-show!)
+                 (done))
+               (-> sync-result
+                   (p/then (fn [repos]
+                             (is (= [] repos))
+                             (is (empty? @notifications)
+                                 "A missing worker is not a SQLite storage error.")))
+                   (p/catch (fn [e]
+                              (is false (str "unexpected error: " e))))
+                   (p/finally (fn []
+                                (set! util/electron? original-electron?)
+                                (set! notification/show! original-show!)
+                                (done)))))))))

--- a/src/test/frontend/state_test.cljs
+++ b/src/test/frontend/state_test.cljs
@@ -1,11 +1,12 @@
 (ns frontend.state-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [cljs.test :refer [async deftest is testing]]
             [frontend.rfx :as rfx]
             [frontend.state :as state]
             [frontend.util :as util]
             [frontend.util.cursor :as cursor]
             [goog.dom :as gdom]
-            [io.factorhouse.rfx.store :as store]))
+            [io.factorhouse.rfx.store :as store]
+            [promesa.core :as p]))
 
 (defn- caret-pos-when-editor-content-changes
   [initial-content updated-content new-pos]
@@ -275,3 +276,28 @@
                 state/get-selection-block-ids (constantly nil)
                 state/get-selection-direction (constantly nil)]
     (is (nil? (state/get-editor-info)))))
+
+(deftest invoke-db-worker-with-nil-worker-rejects-without-throwing
+  (async done
+         (let [previous-worker @state/*db-worker]
+           (reset! state/*db-worker nil)
+           (let [sync-result (try
+                               (state/<invoke-db-worker :thread-api/list-db)
+                               (catch :default e
+                                 {:threw e}))]
+             (if (and (map? sync-result) (contains? sync-result :threw))
+               (do
+                 (is false "A missing worker must not throw into React render.")
+                 (reset! state/*db-worker previous-worker)
+                 (done))
+               (do
+                 (is (false? @state/db-worker-ready?))
+                 (-> sync-result
+                     (p/then (fn [value]
+                               (is false (str "expected rejection, got " value))))
+                     (p/catch (fn [error]
+                                (is (state/db-worker-uninitialized-error? error))
+                                (is (= :thread-api/list-db (:qkw (ex-data error))))))
+                     (p/finally (fn []
+                                  (reset! state/*db-worker previous-worker)
+                                  (done))))))))))

--- a/src/test/frontend/undo_redo_test.cljs
+++ b/src/test/frontend/undo_redo_test.cljs
@@ -72,3 +72,16 @@
              (undo-redo/redo repo)))
       (is (nil? (undo-redo/clear-history! repo)))
       (is (empty? @calls)))))
+
+(deftest undo-redo-with-nil-worker-does-not-throw-test
+  (let [previous-worker @state/*db-worker]
+    (reset! state/*db-worker nil)
+    (try
+      (with-redefs [util/node-test? false]
+        (is (= :frontend.undo-redo/empty-undo-stack
+               (undo-redo/undo "logseq_db_missing-worker")))
+        (is (= :frontend.undo-redo/empty-redo-stack
+               (undo-redo/redo "logseq_db_missing-worker")))
+        (is (nil? (undo-redo/clear-history! "logseq_db_missing-worker"))))
+      (finally
+        (reset! state/*db-worker previous-worker)))))

--- a/src/test/frontend/undo_redo_test.cljs
+++ b/src/test/frontend/undo_redo_test.cljs
@@ -12,16 +12,21 @@
         invoke! (fn [& args]
                   (swap! calls conj (vec args))
                   (vec args))
-        repo "repo-1"]
-    (with-redefs [util/node-test? false
-                  state/<invoke-db-worker invoke!]
-      (is (= [:thread-api/undo-redo-undo repo]
-             (undo-redo/undo repo)))
-      (is (= [:thread-api/undo-redo-redo repo]
-             (undo-redo/redo repo)))
-      (is (= [[:thread-api/undo-redo-undo repo]
-              [:thread-api/undo-redo-redo repo]]
-             @calls)))))
+        repo "repo-1"
+        previous-worker @state/*db-worker]
+    (reset! state/*db-worker invoke!)
+    (try
+      (with-redefs [util/node-test? false
+                    state/<invoke-db-worker invoke!]
+        (is (= [:thread-api/undo-redo-undo repo]
+               (undo-redo/undo repo)))
+        (is (= [:thread-api/undo-redo-redo repo]
+               (undo-redo/redo repo)))
+        (is (= [[:thread-api/undo-redo-undo repo]
+                [:thread-api/undo-redo-redo repo]]
+               @calls)))
+      (finally
+        (reset! state/*db-worker previous-worker)))))
 
 (deftest clear-history-and-record-editor-info-proxy-test
   (let [calls (atom [])
@@ -32,16 +37,21 @@
         editor-info {:block-uuid (random-uuid)
                      :container-id 1
                      :start-pos 0
-                     :end-pos 3}]
-    (with-redefs [util/node-test? false
-                  state/<invoke-db-worker invoke!]
-      (is (= [:thread-api/undo-redo-clear-history repo]
-             (undo-redo/clear-history! repo)))
-      (is (= [:thread-api/undo-redo-record-editor-info repo editor-info]
-             (undo-redo/record-editor-info! repo editor-info)))
-      (is (= [[:thread-api/undo-redo-clear-history repo]
-              [:thread-api/undo-redo-record-editor-info repo editor-info]]
-             @calls)))))
+                     :end-pos 3}
+        previous-worker @state/*db-worker]
+    (reset! state/*db-worker invoke!)
+    (try
+      (with-redefs [util/node-test? false
+                    state/<invoke-db-worker invoke!]
+        (is (= [:thread-api/undo-redo-clear-history repo]
+               (undo-redo/clear-history! repo)))
+        (is (= [:thread-api/undo-redo-record-editor-info repo editor-info]
+               (undo-redo/record-editor-info! repo editor-info)))
+        (is (= [[:thread-api/undo-redo-clear-history repo]
+                [:thread-api/undo-redo-record-editor-info repo editor-info]]
+               @calls)))
+      (finally
+        (reset! state/*db-worker previous-worker)))))
 
 (deftest record-ui-state-proxy-test
   (let [calls (atom [])
@@ -49,14 +59,19 @@
                   (swap! calls conj (vec args))
                   (vec args))
         repo "repo-3"
-        ui-state-str "{:old-state {}, :new-state {:route-data {:to :page}}}"]
-    (with-redefs [util/node-test? false
-                  state/<invoke-db-worker invoke!]
-      (is (nil? (undo-redo/record-ui-state! repo nil)))
-      (is (= [:thread-api/undo-redo-record-ui-state repo ui-state-str]
-             (undo-redo/record-ui-state! repo ui-state-str)))
-      (is (= [[:thread-api/undo-redo-record-ui-state repo ui-state-str]]
-             @calls)))))
+        ui-state-str "{:old-state {}, :new-state {:route-data {:to :page}}}"
+        previous-worker @state/*db-worker]
+    (reset! state/*db-worker invoke!)
+    (try
+      (with-redefs [util/node-test? false
+                    state/<invoke-db-worker invoke!]
+        (is (nil? (undo-redo/record-ui-state! repo nil)))
+        (is (= [:thread-api/undo-redo-record-ui-state repo ui-state-str]
+               (undo-redo/record-ui-state! repo ui-state-str)))
+        (is (= [[:thread-api/undo-redo-record-ui-state repo ui-state-str]]
+               @calls)))
+      (finally
+        (reset! state/*db-worker previous-worker)))))
 
 (deftest node-test-undo-redo-does-not-call-worker-test
   (let [calls (atom [])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/logseq/db-test/issues/1077

After a failed graph open or worker recovery, `*db-worker` can be nil. `<invoke-db-worker` used to throw `db-worker has not been initialized` synchronously. Promesa `p/let` does not catch that first-binding throw, so React render, RFX, restore, and All graphs hit ErrorBoundary (“Something is wrong”) instead of a recoverable empty/error state.

## Change
- `<invoke-db-worker` always returns a promise and rejects when the worker is missing, instead of throwing.
- Browser `<list-db>` returns `[]` when the worker is not ready (no SQLite error toast / reload loop).
- `:graph/sync-context` no-ops unless the worker is ready.
- Renderer subscription hooks treat an uninitialized-worker error as empty data instead of throwing into ErrorBoundary.
- Failed restore still clears `:graph/loading?` and keeps the current graph so the graphs list remains usable.

Not in scope: db-test#1076 (import NPE), #1066/#1074 (sleep/wake reconnect), #927 (import recovery).

## Tests
- `frontend.state-test/invoke-db-worker-with-nil-worker-rejects-without-throwing`
- `frontend.persist-db-test/browser-list-db-with-nil-worker-returns-empty-without-throwing`
- `frontend.db.restore-test/restore-graph-with-nil-worker-rejects-without-throwing`
- `frontend.db.hooks-test` uninitialized worker error does not throw from `use-block`
- `frontend.handler.events-test` `:graph/sync-context` nil-worker / ready
- `frontend.undo-redo-test/undo-redo-with-nil-worker-does-not-throw-test`
- `frontend.components.repo-test/graph-e2ee-enabled-with-nil-worker-does-not-throw`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fa96c64-e9b7-43f9-b0a5-ec72eee91bfa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fa96c64-e9b7-43f9-b0a5-ec72eee91bfa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

