### PR TITLE
fix: catch db-worker recovery failures during file-to-db import

### DIFF
--- a/deps/common/src/logseq/common/util.cljs
+++ b/deps/common/src/logseq/common/util.cljs
@@ -128,9 +128,11 @@
           (path-normalize)))
 
 (defn page-name-sanity-lc
-  "Sanitize the query string for a page name (mandate for :block/name)"
+  "Sanitize the query string for a page name (mandate for :block/name).
+  Returns nil for non-string input so callers do not NPE on `.toLowerCase`."
   [s]
-  (page-name-sanity (string/lower-case s)))
+  (when (string? s)
+    (page-name-sanity (string/lower-case s))))
 
 (defn safe-page-name-sanity-lc
   [s]

--- a/deps/common/test/logseq/common/util_test.cljs
+++ b/deps/common/test/logseq/common/util_test.cljs
@@ -45,3 +45,11 @@
       "[[page-name]]"
       "end-with-backslash\\"
       "\\[]{}().+*?|$^")))
+
+(deftest page-name-sanity-lc-ignores-nil-and-non-strings
+  (testing "nil and non-strings do not call toLowerCase"
+    (is (nil? (common-util/page-name-sanity-lc nil)))
+    (is (nil? (common-util/page-name-sanity-lc :page)))
+    (is (nil? (common-util/page-name-sanity-lc 1))))
+  (testing "strings still normalize"
+    (is (= "foo bar" (common-util/page-name-sanity-lc "Foo Bar")))))

--- a/deps/common/test/logseq/common/util_test.cljs
+++ b/deps/common/test/logseq/common/util_test.cljs
@@ -1,5 +1,5 @@
 (ns logseq.common.util-test
-  (:require [clojure.test :refer [deftest are testing]]
+  (:require [clojure.test :refer [deftest are testing is]]
             [logseq.common.util :as common-util]))
 
 (deftest valid-edn-keyword?

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -2366,6 +2366,20 @@
    ;; Populated as files are imported and used to drop conflicting alias declarations.
    :alias-owners (atom {})})
 
+(defn- property-title->name
+  "Property ident name from a page title. Nil titles must not call `.toLowerCase`."
+  [title]
+  (when (and (string? title) (not (string/blank? title)))
+    (keyword (string/lower-case title))))
+
+(defn- lower-case-names
+  [xs]
+  (into #{} (keep #(when (string? %) (string/lower-case %))) xs))
+
+(defn- lower-case-keywords
+  [xs]
+  (into #{} (keep #(when (string? %) (keyword (string/lower-case %)))) xs))
+
 (defn- build-tx-options [{:keys [user-options] :as options}]
   (merge
    (dissoc options :extract-options :user-options)
@@ -2395,20 +2409,6 @@
                [[:db/retract eid :block/parent]
                 [:db/retract eid :block/tags :logseq.class/Page]]))
            col)))
-
-(defn- property-title->name
-  "Property ident name from a page title. Nil titles must not call `.toLowerCase`."
-  [title]
-  (when (and (string? title) (not (string/blank? title)))
-    (keyword (string/lower-case title))))
-
-(defn- lower-case-names
-  [xs]
-  (into #{} (keep #(when (string? %) (string/lower-case %))) xs))
-
-(defn- lower-case-keywords
-  [xs]
-  (into #{} (keep #(when (string? %) (keyword (string/lower-case %)))) xs))
 
 (defn- split-pages-and-properties-tx
   "Separates new pages from new properties tx in preparation for properties to

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -2379,12 +2379,12 @@
     :custom-status-tx (atom [])
     :user-options
     (merge user-options
-           {:tag-classes (set (map string/lower-case (:tag-classes user-options)))
+           {:tag-classes (lower-case-names (:tag-classes user-options))
             :property-classes (set/difference
-                               (set (map (comp keyword string/lower-case) (:property-classes user-options)))
+                               (lower-case-keywords (:property-classes user-options))
                                file-built-in-property-names)
             :property-parent-classes (set/difference
-                                      (set (map (comp keyword string/lower-case) (:property-parent-classes user-options)))
+                                      (lower-case-keywords (:property-parent-classes user-options))
                                       file-built-in-property-names)})}))
 
 (defn- retract-parent-and-page-tag
@@ -2396,6 +2396,20 @@
                 [:db/retract eid :block/tags :logseq.class/Page]]))
            col)))
 
+(defn- property-title->name
+  "Property ident name from a page title. Nil titles must not call `.toLowerCase`."
+  [title]
+  (when (and (string? title) (not (string/blank? title)))
+    (keyword (string/lower-case title))))
+
+(defn- lower-case-names
+  [xs]
+  (into #{} (keep #(when (string? %) (string/lower-case %))) xs))
+
+(defn- lower-case-keywords
+  [xs]
+  (into #{} (keep #(when (string? %) (keyword (string/lower-case %)))) xs))
+
 (defn- split-pages-and-properties-tx
   "Separates new pages from new properties tx in preparation for properties to
   be transacted separately. Also builds property pages tx and converts existing
@@ -2405,22 +2419,22 @@
         ;; _ (when (seq new-properties) (prn :new-properties new-properties))
         [properties-tx pages-tx'] ((juxt filter remove)
                                    #(contains? new-properties (keyword (:block/name %))) pages-tx)
-        property-pages-tx (map (fn [{block-uuid :block/uuid :block/keys [title]}]
-                                 (let [property-name (keyword (string/lower-case title))
-                                       db-ident (get-ident @(:all-idents import-state) property-name)
-                                       upstream-property (get upstream-properties property-name)]
-                                   (sqlite-util/build-new-property
-                                    db-ident
-                                    ;; Tweak new properties that have upstream changes in flight to behave like
-                                    ;; existing properties i.e. they should be defined by the upstream property
-                                    (if (and upstream-property
-                                             (#{:date :node} (:from-type upstream-property))
-                                             (= :default (get-in upstream-property [:schema :logseq.property/type])))
-                                      ;; Assumes :many for :date and :node like infer-property-schema-and-get-property-change
-                                      {:logseq.property/type (:from-type upstream-property) :db/cardinality :many}
-                                      (get-property-schema @(:property-schemas import-state) property-name))
-                                    {:title title :block-uuid block-uuid})))
-                               properties-tx)
+        property-pages-tx (keep (fn [{block-uuid :block/uuid :block/keys [title]}]
+                                  (when-let [property-name (property-title->name title)]
+                                    (let [db-ident (get-ident @(:all-idents import-state) property-name)
+                                          upstream-property (get upstream-properties property-name)]
+                                      (sqlite-util/build-new-property
+                                       db-ident
+                                       ;; Tweak new properties that have upstream changes in flight to behave like
+                                       ;; existing properties i.e. they should be defined by the upstream property
+                                       (if (and upstream-property
+                                                (#{:date :node} (:from-type upstream-property))
+                                                (= :default (get-in upstream-property [:schema :logseq.property/type])))
+                                         ;; Assumes :many for :date and :node like infer-property-schema-and-get-property-change
+                                         {:logseq.property/type (:from-type upstream-property) :db/cardinality :many}
+                                         (get-property-schema @(:property-schemas import-state) property-name))
+                                       {:title title :block-uuid block-uuid}))))
+                                properties-tx)
         converted-property-pages-tx
         (map (fn [kw-name]
                (let [existing-page-uuid (get existing-pages (name kw-name))
@@ -2700,7 +2714,10 @@
         ;; returning val results in smoother ui updates
         m)
       (p/catch (fn [error]
-                 (notify-user {:msg (str "Import failed on " (pr-str path) " with error:\n" (.-message error))
+                 (notify-user {:msg (str "Import failed on " (pr-str path) " with error:\n"
+                                         (or (ex-message error)
+                                             (some-> error .-message)
+                                             (str error)))
                                :level :error
                                :ex-data {:path path :error error}})
                  (throw error)))))

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -2482,3 +2482,14 @@ abc
             "root's alias pointing to mid dropped: mid already owns aliases")
         (is (some #(= :alias/alias-owns-aliases (:reason %)) @ignored-props)
             "alias-owns-aliases reason recorded")))))
+
+(deftest property-title->name-skips-nil-and-blank
+  (let [property-title->name (some-> (resolve 'logseq.graph-parser.exporter/property-title->name)
+                                     deref)]
+    (is (fn? property-title->name))
+    (when (fn? property-title->name)
+      (is (nil? (property-title->name nil)))
+      (is (nil? (property-title->name 1)))
+      (is (nil? (property-title->name "")))
+      (is (nil? (property-title->name "   ")))
+      (is (= :priority (property-title->name "Priority"))))))

--- a/src/main/frontend/components/imports.cljs
+++ b/src/main/frontend/components/imports.cljs
@@ -319,6 +319,47 @@
         (log/error :import-error ex-data)))
     (notification/show! msg :warning false)))
 
+(defn- error-message
+  [error]
+  (or (ex-message error)
+      (some-> error .-message)
+      (str error)))
+
+(defn- worker-unavailable-error?
+  [error]
+  (let [msg (error-message error)
+        {:keys [status code]} (ex-data error)]
+    (or (state/db-worker-uninitialized-error? error)
+        (= "db-worker has not been initialized" msg)
+        (contains? #{:server-unavailable :db-worker-unavailable :connection-refused
+                     :fetch-failed :network-error}
+                   code)
+        (= 0 status))))
+
+(defn abort-file-graph-import!
+  "Clear File-to-DB import UI and report a caught error. Idempotent if import is not running."
+  [{:keys [error reason]}]
+  (when (state/get-state :graph/importing)
+    (let [msg (some-> error error-message)
+          display (if (or (= reason :db-worker-runtime-recovered)
+                          (worker-unavailable-error? error))
+                    (t :import/file-to-db-interrupted)
+                    (t :import/file-to-db-error (or msg (str error))))]
+      (log/error :import-error {:error error :reason reason :message msg})
+      (notification/show! display :error)
+      (state/set-state! :graph/importing nil)
+      (state/set-state! :graph/importing-state nil)))
+  nil)
+
+(defn- <invoke-import-file-graph
+  [repo config-file files options]
+  (-> (state/<wait-for-db-worker)
+      (p/then (fn [_]
+                (try
+                  (state/<invoke-db-worker :thread-api/import-file-graph repo config-file files options)
+                  (catch :default e
+                    (p/rejected e)))))))
+
 (defn- <serialize-import-file
   [file]
   (let [^js file-object (:file-object file)]
@@ -367,22 +408,24 @@
    config-file]
   (state/set-state! :graph/importing :file-graph)
   (state/set-state! [:graph/importing-state :current-page] "Config files")
-  (p/let [start-time (t/now)
-          _ (repo-handler/new-db! graph-name {:file-graph-import? true})
-          repo (state/get-current-repo)
-          serialized-files (<serialize-import-files *files)
-          serialized-config-file (first (filter #(= (:path %) (:path config-file)) serialized-files))
-          options (build-file-graph-worker-options user-options config/config-default-content)
-          import-result (state/<invoke-db-worker :thread-api/import-file-graph repo serialized-config-file serialized-files options)
-          _ (doseq [notification (:notifications import-result)]
-              (show-notification notification))
-          _ (write-staged-assets! repo (:staged-assets import-result))]
-    (log/info :import-file-graph {:msg (str "Import finished in " (/ (t/in-millis (t/interval start-time (t/now))) 1000) " seconds")})
-    (state/set-state! :graph/importing nil)
-    (state/set-state! :graph/importing-state nil)
-    (validate-imported-data import-result)
-    (state/pub-event! [:graph/ready (state/get-current-repo)])
-    (finished-cb)))
+  (-> (p/let [start-time (t/now)
+              _ (repo-handler/new-db! graph-name {:file-graph-import? true})
+              repo (state/get-current-repo)
+              serialized-files (<serialize-import-files *files)
+              serialized-config-file (first (filter #(= (:path %) (:path config-file)) serialized-files))
+              options (build-file-graph-worker-options user-options config/config-default-content)
+              import-result (<invoke-import-file-graph repo serialized-config-file serialized-files options)
+              _ (doseq [notification (:notifications import-result)]
+                  (show-notification notification))
+              _ (write-staged-assets! repo (:staged-assets import-result))]
+        (log/info :import-file-graph {:msg (str "Import finished in " (/ (t/in-millis (t/interval start-time (t/now))) 1000) " seconds")})
+        (state/set-state! :graph/importing nil)
+        (state/set-state! :graph/importing-state nil)
+        (validate-imported-data import-result)
+        (state/pub-event! [:graph/ready (state/get-current-repo)])
+        (finished-cb))
+      (p/catch (fn [error]
+                 (abort-file-graph-import! {:error error})))))
 
 (defn import-file-to-db-handler
   "Import from a graph folder as a DB-based graph"
@@ -441,12 +484,16 @@
   [importing?]
   (hooks/use-effect!
    (fn []
-     (when (and importing? (not (shui-dialog/get-dialog :import-indicator)))
+     (cond
+       (and importing? (not (shui-dialog/get-dialog :import-indicator)))
        (shui/dialog-open! indicator-progress
                           {:id :import-indicator
                            :content-props
                            {:onPointerDownOutside #(.preventDefault %)
-                            :onOpenAutoFocus #(.preventDefault %)}})))
+                            :onOpenAutoFocus #(.preventDefault %)}})
+
+       (and (not importing?) (shui-dialog/get-dialog :import-indicator))
+       (shui/dialog-close! :import-indicator)))
    [importing?])
   [:<>])
 

--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -8,6 +8,7 @@
             [cljs-time.core :as t]
             [clojure.string :as string]
             [frontend.commands :as commands]
+            [frontend.components.imports :as imports]
             [frontend.components.rtc.download-progress :as download-progress]
             [frontend.config :as config]
             [frontend.context.i18n :refer [t]]
@@ -188,7 +189,12 @@
                  :date-formatter (state/get-date-formatter)
                  :export-bullet-indentation (state/get-export-bullet-indentation)
                  :preferred-format (state/get-preferred-format)}]
-    (state/<invoke-db-worker :thread-api/set-context context)))
+    (when (fn? @state/*db-worker)
+      (state/<invoke-db-worker :thread-api/set-context context))))
+
+(defevent! :graph/abort-file-to-db-import
+  [[_ payload]]
+  (imports/abort-file-graph-import! payload))
 
 ;; Hook on a graph is ready to be shown to the user.
 ;; It's different from :graph/restored, as :graph/restored is for window reloaded

--- a/src/main/frontend/persist_db.cljs
+++ b/src/main/frontend/persist_db.cljs
@@ -135,7 +135,10 @@
                               :reason :release-skipped)))))
       (p/then (fn [client]
                 (when client
-                  (log/info :event :db-worker-runtime-recovered :repo repo))))
+                  (log/info :event :db-worker-runtime-recovered :repo repo)
+                  (when (state/get-state :graph/importing)
+                    (state/pub-event! [:graph/abort-file-to-db-import
+                                       {:reason :db-worker-runtime-recovered}])))))
       (p/catch (fn [error]
                  (log/error :event :db-worker-runtime-recovery-failed
                             :repo repo

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -63,13 +63,61 @@
                  (reset! ready? (fn? worker))))
     ready?))
 
+(def ^:private db-worker-ready-timeout-ms 20000)
+
+(defn db-worker-uninitialized-error
+  ([]
+   (db-worker-uninitialized-error {}))
+  ([data]
+   (ex-info "db-worker has not been initialized" data)))
+
+(defn db-worker-uninitialized-error?
+  [error]
+  (= "db-worker has not been initialized" (ex-message error)))
+
+(defn <wait-for-db-worker
+  "Resolve when `*db-worker` is a function. Reject with an uninitialized error
+  if the worker is still missing after `timeout-ms` (default 20s)."
+  ([]
+   (<wait-for-db-worker db-worker-ready-timeout-ms))
+  ([timeout-ms]
+   (if (fn? @*db-worker)
+     (p/resolved true)
+     (let [ready (p/deferred)
+           watch-key (keyword (str "wait-db-worker-" (random-uuid)))
+           timeout-id (atom nil)
+           finished? (atom false)
+           finish! (fn [ok? error]
+                     (when (compare-and-set! finished? false true)
+                       (when-let [id @timeout-id]
+                         (js/clearTimeout id)
+                         (reset! timeout-id nil))
+                       (remove-watch *db-worker watch-key)
+                       (if ok?
+                         (p/resolve! ready true)
+                         (p/reject! ready error))))]
+       (add-watch *db-worker watch-key
+                  (fn [_ _ _ worker]
+                    (when (fn? worker)
+                      (finish! true nil))))
+       (reset! timeout-id
+               (js/setTimeout
+                (fn []
+                  (when-not (fn? @*db-worker)
+                    (finish! false (db-worker-uninitialized-error {:timeout-ms timeout-ms}))))
+                timeout-ms))
+       ;; Worker may become ready between the initial check and add-watch.
+       (when (fn? @*db-worker)
+         (finish! true nil))
+       ready))))
+
 (defn <invoke-db-worker
   "invoke db-worker thread api"
   [qkw & args]
   (let [worker @*db-worker]
     (when (nil? worker)
       (prn :<invoke-db-worker-error qkw)
-      (throw (ex-info "db-worker has not been initialized" {})))
+      (throw (db-worker-uninitialized-error)))
     (p/let [result (apply worker qkw args)]
       (if (or (instance? ExceptionInfo result)
               (instance? js/Error result))

--- a/src/main/frontend/undo_redo.cljs
+++ b/src/main/frontend/undo_redo.cljs
@@ -5,7 +5,7 @@
 
 (defn- worker-not-initialized?
   [e]
-  (= "db-worker has not been initialized" (ex-message e)))
+  (state/db-worker-uninitialized-error? e))
 
 (defn- normalize-empty-result
   [result]

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -924,6 +924,8 @@
  :import/extract-inline-code-snippets "Extract inline code snippets as child blocks"
  :import/file-finished "Import finished!"
  :import/file-to-db-desc "Import a file-based Logseq graph folder into a new DB graph"
+ :import/file-to-db-error "File-to-DB import failed: {1}"
+ :import/file-to-db-interrupted "Import stopped because the database worker restarted. Please try the import again."
  :import/file-to-db-title "File to DB graph"
  :import/graph-name-conflict "Please specify another name as another graph with this name already exists!"
  :import/graph-name-placeholder "Graph name"

--- a/src/resources/dicts/zh-cn.edn
+++ b/src/resources/dicts/zh-cn.edn
@@ -924,6 +924,8 @@
  :import/extract-inline-code-snippets "将行内代码片段提取为子块"
  :import/file-finished "导入完成！"
  :import/file-to-db-desc "将基于文件的 Logseq 知识库文件夹导入到新的 DB 知识库"
+ :import/file-to-db-error "文件到 DB 导入失败：{1}"
+ :import/file-to-db-interrupted "导入已停止，因为数据库 worker 已重启。请重新导入。"
  :import/file-to-db-title "文件到 DB 知识库"
  :import/graph-name-conflict "已存在同名图谱，请指定其他名称！"
  :import/graph-name-placeholder "图谱名称"

--- a/src/test/frontend/components/imports_test.cljs
+++ b/src/test/frontend/components/imports_test.cljs
@@ -1,8 +1,10 @@
 (ns frontend.components.imports-test
   (:require [cljs.test :refer [async deftest is]]
             [frontend.config :as config]
-            [frontend.components.imports]
+            [frontend.components.imports :as imports]
             [frontend.fs :as fs]
+            [frontend.handler.notification :as notification]
+            [frontend.state :as state]
             [logseq.db :as ldb]
             [promesa.core :as p]))
 
@@ -54,6 +56,49 @@
                           (p/resolve! write :written))
                       _ (p/delay 0)]
                 (is (true? @completed?)))))
+          (p/catch (fn [error]
+                     (is false (str error))))
+          (p/finally done)))))
+
+(deftest abort-file-graph-import-reports-uninitialized-worker-as-import-error
+  (let [original-state (state/get-state)
+        notifications (atom [])]
+    (try
+      (state/replace-state! (assoc original-state
+                                  :graph/importing :file-graph
+                                  :graph/importing-state {:current-page "pages/A.md"}))
+      (with-redefs [notification/show! (fn [content status]
+                                         (swap! notifications conj [content status]))]
+        (imports/abort-file-graph-import!
+         {:error (state/db-worker-uninitialized-error)})
+        (is (nil? (state/get-state :graph/importing)))
+        (is (nil? (state/get-state :graph/importing-state)))
+        (is (= 1 (count @notifications)))
+        (is (= :error (second (first @notifications))))
+        (imports/abort-file-graph-import!
+         {:error (state/db-worker-uninitialized-error)})
+        (is (= 1 (count @notifications))
+            "Abort is idempotent once importing is cleared"))
+      (finally
+        (state/replace-state! original-state)))))
+
+(deftest invoke-import-file-graph-converts-sync-uninitialized-throw-to-rejected-promise
+  (async done
+    (let [invoke-import (some-> (resolve 'frontend.components.imports/<invoke-import-file-graph)
+                                deref)]
+      (is (fn? invoke-import))
+      (-> (p/with-redefs [state/<wait-for-db-worker (fn [] (p/resolved true))
+                          state/<invoke-db-worker
+                          (fn [& _]
+                            (throw (state/db-worker-uninitialized-error)))]
+            (-> (invoke-import "repo" {:path "logseq/config.edn"} [] {})
+                (p/then (fn [_] {:status :resolved}))
+                (p/catch (fn [error]
+                           {:status :rejected
+                            :message (ex-message error)}))))
+          (p/then (fn [result]
+                    (is (= :rejected (:status result)))
+                    (is (= "db-worker has not been initialized" (:message result)))))
           (p/catch (fn [error]
                      (is false (str error))))
           (p/finally done)))))

--- a/src/test/frontend/persist_db_test.cljs
+++ b/src/test/frontend/persist_db_test.cljs
@@ -1333,6 +1333,8 @@
                             (set! notification/show! original-notification-show!)
                             (reset-runtime-state!)
                             (done)))))))
+
+(deftest electron-list-db-runtime-recovery-does-not-release-fresh-same-repo-runtime
   (async done
          (let [recovery! #'persist-db/<trigger-db-worker-runtime-recovery!
                ipc-calls (atom [])

--- a/src/test/frontend/persist_db_test.cljs
+++ b/src/test/frontend/persist_db_test.cljs
@@ -1261,7 +1261,78 @@
                             (reset-runtime-state!)
                             (done)))))))
 
-(deftest electron-list-db-runtime-recovery-does-not-release-fresh-same-repo-runtime
+(deftest electron-runtime-recovery-aborts-in-progress-file-graph-import
+  (async done
+         (let [recovery! #'persist-db/<trigger-db-worker-runtime-recovery!
+               ipc-calls (atom [])
+               start-calls (atom [])
+               stop-calls (atom [])
+               events (atom [])
+               notifications (atom [])
+               session-id "session-a"
+               wrapped-worker (fn [& _] nil)
+               old-client (->FakeRemote "logseq_db_graph_a" (fn [& _] nil))
+               new-client (->FakeRemote "logseq_db_graph_a" wrapped-worker)
+               original-state (state/get-state)
+               original-ipc ipc/ipc
+               original-start! remote/start!
+               original-stop! remote/stop!
+               original-pub-event! state/pub-event!
+               original-notification-show! notification/show!]
+           (reset-runtime-state!)
+           (state/replace-state! (assoc original-state
+                                       :git/current-repo "logseq_db_graph_a"
+                                       :graph/importing :file-graph
+                                       :graph/importing-state {:current-page "pages/A.md"}))
+           (reset! persist-db/remote-db old-client)
+           (reset! persist-db/remote-repo "logseq_db_graph_a")
+           (reset! persist-db/remote-runtime-state {:repo "logseq_db_graph_a"
+                                                    :client old-client
+                                                    :session-id session-id
+                                                    :request-failures 1
+                                                    :recovery-triggered? true})
+           (set! ipc/ipc (fn [channel repo]
+                           (swap! ipc-calls conj [channel repo])
+                           (case channel
+                             "db-worker-runtime"
+                             (p/resolved {:base-url "http://127.0.0.1:9101"
+                                          :auth-token nil
+                                          :repo repo})
+
+                             (p/resolved nil))))
+           (set! remote/start! (fn [{:keys [repo]}]
+                                 (swap! start-calls conj repo)
+                                 new-client))
+           (set! remote/stop! (fn [client]
+                                (swap! stop-calls conj (:repo client))
+                                (p/resolved true)))
+           (set! state/pub-event! (fn [event]
+                                    (swap! events conj event)
+                                    (p/resolved true)))
+           (set! notification/show! (fn [content status]
+                                      (swap! notifications conj [content status])
+                                      nil))
+           (-> (p/let [_ (recovery! "logseq_db_graph_a" old-client session-id)
+                       _ (p/delay 0)]
+                 (is (= [["releaseDbWorkerRuntime" "logseq_db_graph_a"]
+                         ["db-worker-runtime" "logseq_db_graph_a"]]
+                        @ipc-calls))
+                 (is (= [[:graph/abort-file-to-db-import
+                          {:reason :db-worker-runtime-recovered}]]
+                        @events))
+                 (is (= :file-graph (state/get-state :graph/importing))
+                     "Event handler owns clearing import state; recovery only publishes abort"))
+               (p/catch (fn [e]
+                          (is false (str "unexpected error: " e))))
+               (p/finally (fn []
+                            (state/replace-state! original-state)
+                            (set! ipc/ipc original-ipc)
+                            (set! remote/start! original-start!)
+                            (set! remote/stop! original-stop!)
+                            (set! state/pub-event! original-pub-event!)
+                            (set! notification/show! original-notification-show!)
+                            (reset-runtime-state!)
+                            (done)))))))
   (async done
          (let [recovery! #'persist-db/<trigger-db-worker-runtime-recovery!
                ipc-calls (atom [])
@@ -1516,6 +1587,52 @@
                        (set! util/electron? original-electron?)
                        (set! remote/invoke! original-invoke!)
                        (set! remote/stop! original-stop!)
+                       (done)))))))
+
+(deftest invoke-db-worker-after-clear-remote-runtime-throws
+  (let [original-worker @state/*db-worker]
+    (try
+      (#'persist-db/clear-remote-runtime!)
+      (is (nil? @state/*db-worker))
+      (try
+        (state/<invoke-db-worker :thread-api/list-db)
+        (is false "expected uninitialized throw")
+        (catch :default e
+          (is (state/db-worker-uninitialized-error? e))))
+      (finally
+        (reset! state/*db-worker original-worker)))))
+
+(deftest wait-for-db-worker-resolves-when-worker-is-installed
+  (async done
+    (let [original-worker @state/*db-worker]
+      (reset! state/*db-worker nil)
+      (let [waiting (state/<wait-for-db-worker 200)]
+        (js/setTimeout
+         (fn []
+           (reset! state/*db-worker (fn [& _] :ready)))
+         20)
+        (-> waiting
+            (p/then (fn [result]
+                      (is (true? result))
+                      (is (fn? @state/*db-worker))))
+            (p/catch (fn [error]
+                       (is false (str error))))
+            (p/finally (fn []
+                         (reset! state/*db-worker original-worker)
+                         (done))))))))
+
+(deftest wait-for-db-worker-times-out-when-still-nil
+  (async done
+    (let [original-worker @state/*db-worker]
+      (reset! state/*db-worker nil)
+      (-> (state/<wait-for-db-worker 30)
+          (p/then (fn [_]
+                    (is false "expected timeout")))
+          (p/catch (fn [error]
+                     (is (state/db-worker-uninitialized-error? error))
+                     (is (= 30 (:timeout-ms (ex-data error))))))
+          (p/finally (fn []
+                       (reset! state/*db-worker original-worker)
                        (done)))))))
 
 (deftest start-db-worker-skips-in-node-test-runtime

--- a/src/test/frontend/util_test.cljs
+++ b/src/test/frontend/util_test.cljs
@@ -71,3 +71,11 @@
       (is (= @actual-ops 4))
       (is (= (m+ 3 5) 8))
       (is (= @actual-ops 4)))))
+
+(deftest page-name-sanity-lc-ignores-nil-and-non-strings
+  (testing "nil and non-strings do not throw on toLowerCase"
+    (is (nil? (util/page-name-sanity-lc nil)))
+    (is (nil? (util/page-name-sanity-lc :page)))
+    (is (nil? (util/page-name-sanity-lc 1))))
+  (testing "strings still normalize"
+    (is (= "foo bar" (util/page-name-sanity-lc "Foo Bar")))))


### PR DESCRIPTION
Fixes https://github.com/logseq/db-test/issues/1076

## Summary

- wait for a recovered db-worker before invoking File-to-DB import
- convert synchronous worker initialization failures into rejected promises
- abort File-to-DB import state and show a useful error after recovery failure
- avoid worker invocations while the worker is unavailable
- validate imported property titles before normalization
- improve per-file import error reporting

The import is stopped after worker recovery; resumable imports remain separate work.

## Verification

- recovery and worker wait tests
- File-to-DB abort and rejection tests
- page name validation tests
- graph parser property title tests

