### PR TITLE
fix(editor): don't pass nil edit content to subs in autocompletes

### DIFF
--- a/deps/common/src/logseq/common/util.cljs
+++ b/deps/common/src/logseq/common/util.cljs
@@ -49,12 +49,17 @@
     (not (re-find #"[#\t\r\n]+" tag-name))))
 
 (defn safe-subs
+  "Like `subs`, but clamps out-of-range indices and returns \"\" for a non-string
+  `s` instead of throwing. `subs` is a bare `.substring` passthrough, so a nil
+  `s` otherwise raises \"Cannot read properties of null\"."
   ([s start]
    (let [c (count s)]
      (safe-subs s start c)))
   ([s start end]
-   (let [c (count s)]
-     (subs s (min c start) (min c end)))))
+   (if (string? s)
+     (let [c (count s)]
+       (subs s (min c start) (min c end)))
+     "")))
 
 (defn wrapped-by
   [v start end]

--- a/deps/common/test/logseq/common/util_test.cljs
+++ b/deps/common/test/logseq/common/util_test.cljs
@@ -45,3 +45,24 @@
       "[[page-name]]"
       "end-with-backslash\\"
       "\\[]{}().+*?|$^")))
+
+(deftest safe-subs
+  (testing "behaves like subs for in-range indices"
+    (are [args y]
+         (= (apply common-util/safe-subs args) y)
+      ["hello" 1 3] "el"
+      ["hello" 2]   "llo"
+      ["hello" 0 5] "hello"))
+  (testing "clamps out-of-range indices instead of throwing"
+    (are [args y]
+         (= (apply common-util/safe-subs args) y)
+      ["hello" 0 99]  "hello"
+      ["hello" 99 99] ""
+      ["hello" 99]    ""))
+  (testing "returns \"\" for a non-string instead of throwing"
+    (are [args y]
+         (= (apply common-util/safe-subs args) y)
+      [nil 0 0] ""
+      [nil 0 5] ""
+      [nil 0]   ""
+      [42 0 1]  "")))

--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -353,7 +353,7 @@
         q (or
            selected-text
            (when (>= (count edit-content) current-pos)
-             (subs edit-content pos current-pos)))]
+             (common-util/safe-subs edit-content pos current-pos)))]
     (when input
       (let [embed? (= action "Block embed")
             page (when embed? (page-ref/get-page-name edit-content))
@@ -392,7 +392,7 @@
       (let [current-pos (cursor/pos input)
             q (or
                (when (>= (count edit-content) current-pos)
-                 (subs edit-content pos current-pos))
+                 (common-util/safe-subs edit-content pos current-pos))
                "")]
         (template-search-aux id q)))))
 


### PR DESCRIPTION
Fixes the renderer crash reported in logseq/db-test#1086, and the mis-named helper behind it.

## The crash

`block-search` reads edit content from a subscription keyed on the current edit
block:

```clojure
(defn- use-current-edit-content []
  (rfx/use-sub [:editor/content (:block/uuid (state/get-edit-block))]))
```

That yields `nil` once there is no edit block. Backspace at position 0 deletes
the block being edited (`handler/editor.cljs:3184`), and
`close-autocomplete-if-outside` never clears `:block-search` — it admits the
action in its `contains?` set and excludes it in the same `and` — so the
component renders again with no edit block behind it.

The condition in front of the `subs` call doesn't guard that case:

```clojure
(when (>= (count edit-content) current-pos)
  (subs edit-content pos current-pos))
```

`(count nil)` is `0`, so with the caret at 0 the guard passes and
`cljs.core/subs` — a bare `.substring` passthrough — throws
`Cannot read properties of null (reading 'substring')`. The error boundary
catches it and replaces the app with "Something went wrong".

`template-search` carries the same pattern.

## `safe-subs` wasn't a fix for these sites either

The obvious repair is to route both call sites through `common-util/safe-subs`,
which is what `page-search` already does two functions above. But `safe-subs`
clamps indices and then calls `subs` on whatever it was given:

```clojure
([s start end]
 (let [c (count s)]
   (subs s (min c start) (min c end))))
```

`(safe-subs nil 0 0)` throws the identical error, so `page-search` is not
actually protected today — it only looks protected. Of the four callers of
`use-current-edit-content`, only `code-block-mode-picker` is safe, because it
coerces with `(or … "")`.

So this guards `safe-subs` itself, which covers all 21 of its call sites, and
then routes the two raw `subs` calls through it.

## Why `""` and not `nil`

Returning `nil` would leave `commands.cljs:421` throwing one frame later, in
`(string/index-of (safe-subs …) end-pattern)`. `""` is absorbed cleanly by every
call site: the `(str …)` sites, the `(= "]]" …)` comparisons, `string/blank?`,
`take-while`, and `string/index-of` alike.

I've kept the existing range conditions at both call sites rather than dropping
them as redundant. They aren't purely redundant — they change behaviour when
`current-pos` exceeds the content length, which is reachable here because
`editor-on-change!` debounces content updates by 50 ms while `:block-search` is
active. Keeping them makes this a nil-safety change and nothing more, and
matches the shape `page-search` already uses.

## Testing

`safe-subs` had no test coverage. Added some, including the nil cases:

```
cd deps/common && clojure -M:test
Ran 18 tests containing 102 assertions.
0 failures, 0 errors.
```

Reverting only the `safe-subs` change and re-running gives 4 errors, failing on
the same `TypeError: Cannot read properties of null (reading 'substring')` seen
in the wild — so the tests do pin this specific bug.

I have not run the full application suite; I don't have the pnpm/shadow-cljs
toolchain set up locally. The `editor.cljs` half is a two-symbol swap to a
function already required in that namespace.

## What this does not address

`#13047` also notes the dead condition in `close-autocomplete-if-outside`:
`:block-search` cannot satisfy that `and`, so the autocomplete is never closed
by it, which is what keeps the component mounted long enough to see the `nil`.
That needs someone to decide which half was intended, so I've left it alone
here.

Also worth stating plainly: the crash is real and its stack trace resolved
cleanly through the shipped source map, but I was not able to reproduce it on
demand afterwards — consistent with the 50 ms debounce window. The fix stands on
the source reading rather than on a replay, and the `safe-subs` half is
verifiable independently of the crash entirely.

Drafted with Claude Code; reviewed and tested by me.
