### PR TITLE
fix: render query function hashmap without crashing

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1626,23 +1626,26 @@
           :map-inline map-inline
           :inline inline}))
 
+(hsx/defc macro-function-fallback-cp
+  [arguments]
+  [:span.warning
+   (util/format "{{function %s}}" (first arguments))])
+
 (hsx/defc macro-function-result-cp
-  [query-result arguments fallback]
+  [query-result arguments]
   (or (some-> query-result
               (block-macros/function-macro arguments)
               block-macros/function-result->hiccup)
-      fallback))
+      (macro-function-fallback-cp arguments)))
 
 (hsx/defc macro-function-cp
   [config arguments]
   (let [fallback* (hooks/use-memo #(atom nil) [])
         query-result* (or (:query-result config) fallback*)
-        [query-result] (hooks/use-atom query-result*)
-        fallback [:span.warning
-                  (util/format "{{function %s}}" (first arguments))]]
+        [query-result] (hooks/use-atom query-result*)]
     (ui/catch-error
-     fallback
-     (macro-function-result-cp query-result arguments fallback))))
+     (macro-function-fallback-cp arguments)
+     (macro-function-result-cp query-result arguments))))
 
 (def ^:private default-video-embed-width 560)
 (def ^:private min-video-embed-width 160)

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -1626,15 +1626,23 @@
           :map-inline map-inline
           :inline inline}))
 
+(hsx/defc macro-function-result-cp
+  [query-result arguments fallback]
+  (or (some-> query-result
+              (block-macros/function-macro arguments)
+              block-macros/function-result->hiccup)
+      fallback))
+
 (hsx/defc macro-function-cp
   [config arguments]
   (let [fallback* (hooks/use-memo #(atom nil) [])
         query-result* (or (:query-result config) fallback*)
-        [query-result] (hooks/use-atom query-result*)]
-    (or
-     (some-> query-result (block-macros/function-macro arguments))
-     [:span.warning
-      (util/format "{{function %s}}" (first arguments))])))
+        [query-result] (hooks/use-atom query-result*)
+        fallback [:span.warning
+                  (util/format "{{function %s}}" (first arguments))]]
+    (ui/catch-error
+     fallback
+     (macro-function-result-cp query-result arguments fallback))))
 
 (def ^:private default-video-embed-width 560)
 (def ^:private min-video-embed-width 160)

--- a/src/main/frontend/components/block/macros.cljs
+++ b/src/main/frontend/components/block/macros.cljs
@@ -1,28 +1,33 @@
 (ns frontend.components.block.macros
   "Logseq macros that render and evaluate in blocks"
-  (:require [clojure.walk :as walk]
+  (:require [clojure.string :as string]
+            [clojure.walk :as walk]
             [frontend.extensions.sci :as sci]
             [frontend.handler.common :as common-handler]
+            [frontend.util :as util]
             [goog.string :as gstring]
             [goog.string.format]
+            [lambdaisland.glogi :as log]
             [logseq.db.frontend.property :as db-property]))
 
 (defn- properties-by-name
   "Given a block from a query result, returns a map of its properties indexed by
   property idents and titles"
   [block]
-  (->> (db-property/properties block)
-       (mapcat (fn [[k v]]
-	                 ;; For now just support cardinality :one
-	                 (when-not (set? v)
-	                   (let [prop-val (if (map? v)
-	                                    (db-property/property-value-content v)
-	                                    v)
-	                         property-title (or (get-in db-property/built-in-properties [k :title])
-	                                            (name k))]
-	                     [[(keyword property-title) prop-val]
-	                      [k prop-val]]))))
-       (into {})))
+  (if-not (map? block)
+    {}
+    (->> (db-property/properties block)
+         (mapcat (fn [[k v]]
+                   ;; For now just support cardinality :one
+                   (when-not (set? v)
+                     (let [prop-val (if (map? v)
+                                      (db-property/property-value-content v)
+                                      v)
+                           property-title (or (get-in db-property/built-in-properties [k :title])
+                                              (name k))]
+                       [[(keyword property-title) prop-val]
+                        [k prop-val]]))))
+         (into {}))))
 
 (defn- normalize-query-function
   [ast* result]
@@ -57,21 +62,53 @@
          f))
      ast)))
 
+(defn function-result->hiccup
+  "Convert a {{function}} SCI value into React-safe hiccup.
+
+  Primitives render as text. Explicit hiccup vectors are passed through.
+  Maps, sets, seqs, and other objects are pretty-printed so they cannot be
+  mounted as React children."
+  [result]
+  (cond
+    (nil? result)
+    nil
+
+    (or (string? result) (number? result))
+    [:span.function-macro-result result]
+
+    (boolean? result)
+    [:span.function-macro-result (str result)]
+
+    (and (vector? result)
+         (or (keyword? (first result))
+             (fn? (first result))
+             (:hiccup (meta result))))
+    result
+
+    :else
+    [:span.function-macro-result.whitespace-pre-wrap
+     (try
+       (string/trimr (util/pp-str result))
+       (catch :default _
+         (str result)))]))
+
 (defn function-macro
   "Provides functionality for {{function}}"
   [query-result* arguments]
-  (let [query-result (if (map? query-result*)
-                       ;; Ungroup results grouped by page in page view
-                       (mapcat val query-result*)
-                       query-result*)
-        query-result' (->> query-result
-	                           (map #(hash-map :block/properties (properties-by-name %))))
-        fn-string (-> (gstring/format "(fn [result] %s)" (first arguments))
-                      (common-handler/safe-read-string "failed to parse function")
-                      (normalize-query-function query-result')
-                      (str))
-        f (sci/eval-string fn-string)]
-    (when (fn? f)
-      (try (f query-result')
-           (catch :default e
-             (js/console.error e))))))
+  (try
+    (let [query-result (if (map? query-result*)
+                         ;; Ungroup results grouped by page in page view
+                         (mapcat val query-result*)
+                         query-result*)
+          query-result' (mapv #(hash-map :block/properties (properties-by-name %))
+                              query-result)
+          fn-string (-> (gstring/format "(fn [result] %s)" (first arguments))
+                        (common-handler/safe-read-string "failed to parse function")
+                        (normalize-query-function query-result')
+                        (str))
+          f (sci/eval-string fn-string)]
+      (when (fn? f)
+        (f query-result')))
+    (catch :default e
+      (log/error :function-macro-failed e)
+      nil)))

--- a/src/main/frontend/components/query/result.cljs
+++ b/src/main/frontend/components/query/result.cljs
@@ -47,5 +47,8 @@
 
 (defn use-query-result
   [config query]
-  (let [resource (db-hooks/use-resource [:query (query-spec config query)])]
-    (:rows resource)))
+  (let [resource (db-hooks/use-resource [:query (query-spec config query)])
+        result (:rows resource)]
+    (when-let [query-result (:query-result config)]
+      (reset! query-result result))
+    result))

--- a/src/main/frontend/components/query/result.cljs
+++ b/src/main/frontend/components/query/result.cljs
@@ -1,7 +1,8 @@
 (ns frontend.components.query.result
   "Query result related functionality for query components"
   (:require [clojure.string :as string]
-            [frontend.db.hooks :as db-hooks]))
+            [frontend.db.hooks :as db-hooks]
+            [logseq.shui.hooks :as hooks]))
 
 (defn get-group-by-page
   [{:keys [result-transform query] :as query-config}
@@ -48,7 +49,9 @@
 (defn use-query-result
   [config query]
   (let [resource (db-hooks/use-resource [:query (query-spec config query)])
-        result (:rows resource)]
-    (when-let [query-result (:query-result config)]
-      (reset! query-result result))
+        result (:rows resource)
+        query-result (:query-result config)]
+    (hooks/use-effect! #(when query-result
+                          (reset! query-result result))
+                       [query-result result])
     result))

--- a/src/test/frontend/components/block/macros_test.cljs
+++ b/src/test/frontend/components/block/macros_test.cljs
@@ -6,6 +6,7 @@
             [frontend.components.block :as block]
             [frontend.components.block.macros :as block-macros]
             [goog.object :as gobj]
+            [io.factorhouse.hsx.core :as hsx]
             [logseq.shui.hooks :as hooks]))
 
 (defn- render-static
@@ -60,6 +61,21 @@
            (block-macros/function-result->hiccup [:div "hi"])))))
 
 (deftest function-macro-hashmap-renders-as-text
+  (testing "Pretty-printed hashmap hiccup is a valid React tree"
+    (let [markup (render-static
+                  (hsx/create-element
+                   (block-macros/function-result->hiccup {1 2})))]
+      (is (string/includes? markup "1"))
+      (is (string/includes? markup "2"))))
+
+  (testing "Result component pretty-prints hashmap values"
+    (let [markup (render-static
+                  (block/macro-function-result-cp
+                   [(random-uuid)]
+                   ["(hash-map 1 2)"]))]
+      (is (string/includes? markup "1"))
+      (is (string/includes? markup "2"))))
+
   (testing "Hashmap results are pretty-printed instead of crashing React"
     (let [markup (render-function-macro [(random-uuid)] ["(hash-map 1 2)"])]
       (is (string/includes? markup "1"))
@@ -78,10 +94,11 @@
           markup (with-redefs [hooks/use-memo (fn [f _deps] (f))
                                hooks/use-atom (fn [a] [@a #(reset! a %)])]
                    (render-static
-                    [:div
-                     (block/macro-function-cp {:query-result (atom rows)}
-                                              ["(hash-map 1 2)"])
-                     (block/macro-function-cp {:query-result (atom rows)}
-                                              ["(count result)"])]))]
+                    (hsx/create-element
+                     [:div
+                      (block/macro-function-cp {:query-result (atom rows)}
+                                               ["(hash-map 1 2)"])
+                      (block/macro-function-cp {:query-result (atom rows)}
+                                               ["(count result)"])])))]
       (is (string/includes? markup "1"))
       (is (string/includes? markup "2")))))

--- a/src/test/frontend/components/block/macros_test.cljs
+++ b/src/test/frontend/components/block/macros_test.cljs
@@ -1,0 +1,87 @@
+(ns frontend.components.block.macros-test
+  (:require ["react" :as react]
+            ["react-dom/server" :as react-dom-server]
+            [cljs.test :refer [deftest is testing]]
+            [clojure.string :as string]
+            [frontend.components.block :as block]
+            [frontend.components.block.macros :as block-macros]
+            [goog.object :as gobj]
+            [logseq.shui.hooks :as hooks]))
+
+(defn- render-static
+  [element]
+  (let [previous-react (gobj/get js/globalThis "React")]
+    (gobj/set js/globalThis "React" react)
+    (try
+      (.renderToStaticMarkup react-dom-server element)
+      (finally
+        (if (some? previous-react)
+          (gobj/set js/globalThis "React" previous-react)
+          (js-delete js/globalThis "React"))))))
+
+(defn- render-function-macro
+  [query-result arguments]
+  (with-redefs [hooks/use-memo (fn [f _deps] (f))
+                hooks/use-atom (fn [a] [@a #(reset! a %)])]
+    (render-static
+     (block/macro-function-cp {:query-result (atom query-result)}
+                              arguments))))
+
+(deftest function-macro-evaluates-hash-map-and-result
+  (testing "{{function (hash-map 1 2)}} returns a CLJS map"
+    (is (= {1 2}
+           (block-macros/function-macro
+            [(random-uuid)]
+            ["(hash-map 1 2)"]))))
+
+  (testing "{{function result}} returns a collection, not a React child"
+    (let [result (block-macros/function-macro
+                  [(random-uuid) (random-uuid)]
+                  ["result"])]
+      (is (seq result))
+      (is (every? map? result)))))
+
+(deftest function-result-hiccup-is-react-safe
+  (testing "Maps and other collections become printable text"
+    (let [hiccup (block-macros/function-result->hiccup {1 2})]
+      (is (vector? hiccup))
+      (is (string? (last hiccup)))
+      (is (string/includes? (last hiccup) "1"))
+      (is (string/includes? (last hiccup) "2"))))
+
+  (testing "Scalar values stay renderable"
+    (is (= [:span.function-macro-result 3]
+           (block-macros/function-result->hiccup 3)))
+    (is (= [:span.function-macro-result "ok"]
+           (block-macros/function-result->hiccup "ok"))))
+
+  (testing "Hiccup vectors are left intact"
+    (is (= [:div "hi"]
+           (block-macros/function-result->hiccup [:div "hi"])))))
+
+(deftest function-macro-hashmap-renders-as-text
+  (testing "Hashmap results are pretty-printed instead of crashing React"
+    (let [markup (render-function-macro [(random-uuid)] ["(hash-map 1 2)"])]
+      (is (string/includes? markup "1"))
+      (is (string/includes? markup "2"))))
+
+  (testing "Query result collections are pretty-printed instead of crashing React"
+    (let [markup (render-function-macro [(random-uuid)] ["result"])]
+      (is (string/includes? markup ":block/properties"))))
+
+  (testing "Scalar results still render"
+    (let [markup (render-function-macro [(random-uuid) (random-uuid)] ["(count result)"])]
+      (is (string/includes? markup "2"))))
+
+  (testing "A hashmap function does not prevent a sibling function from rendering"
+    (let [rows [(random-uuid) (random-uuid)]
+          markup (with-redefs [hooks/use-memo (fn [f _deps] (f))
+                               hooks/use-atom (fn [a] [@a #(reset! a %)])]
+                   (render-static
+                    [:div
+                     (block/macro-function-cp {:query-result (atom rows)}
+                                              ["(hash-map 1 2)"])
+                     (block/macro-function-cp {:query-result (atom rows)}
+                                              ["(count result)"])]))]
+      (is (string/includes? markup "1"))
+      (is (string/includes? markup "2")))))

--- a/src/test/frontend/components/query/result_test.cljs
+++ b/src/test/frontend/components/query/result_test.cljs
@@ -57,3 +57,17 @@
                 :today-day 20260721
                 :current-block-uuid current-block-uuid}]]
              @resource-keys)))))
+
+(deftest use-query-result-shares-rows-with-function-macro-atom-test
+  (let [rows [(random-uuid)]
+        query-result (atom :unset)
+        current-block-uuid (random-uuid)]
+    (with-redefs [db-hooks/use-resource (fn [_] {:rows rows})]
+      (is (= rows
+             (query-result/use-query-result
+              {:dsl-query? true
+               :query-result query-result
+               :current-block-uuid current-block-uuid}
+              {:query "(task TODO)"})))
+      (is (= rows @query-result)
+          "Child {{function}} blocks read this atom from shared block config."))))

--- a/src/test/frontend/components/query/result_test.cljs
+++ b/src/test/frontend/components/query/result_test.cljs
@@ -1,7 +1,8 @@
 (ns frontend.components.query.result-test
   (:require [cljs.test :refer [deftest is]]
             [frontend.components.query.result :as query-result]
-            [frontend.db.hooks :as db-hooks]))
+            [frontend.db.hooks :as db-hooks]
+            [logseq.shui.hooks :as hooks]))
 
 (deftest custom-query-subscribes-to-serialized-worker-resources-test
   (let [current-block-uuid (random-uuid)
@@ -26,7 +27,8 @@
                     (swap! resource-keys conj resource-key)
                     {:rows [(if (= :dsl (get-in resource-key [1 :kind]))
                               dsl-row-uuid
-                              datalog-row-uuid)]})]
+                              datalog-row-uuid)]})
+                  hooks/use-effect! (fn [& _args])]
       (is (= [dsl-row-uuid]
              (query-result/use-query-result
               {:dsl-query? true
@@ -58,16 +60,24 @@
                 :current-block-uuid current-block-uuid}]]
              @resource-keys)))))
 
-(deftest use-query-result-shares-rows-with-function-macro-atom-test
+(deftest use-query-result-shares-rows-after-render-test
   (let [rows [(random-uuid)]
         query-result (atom :unset)
+        effect (atom nil)
         current-block-uuid (random-uuid)]
-    (with-redefs [db-hooks/use-resource (fn [_] {:rows rows})]
+    (with-redefs [db-hooks/use-resource (fn [_] {:rows rows})
+                  hooks/use-effect! (fn [setup-fn deps]
+                                      (reset! effect [setup-fn deps]))]
       (is (= rows
              (query-result/use-query-result
               {:dsl-query? true
                :query-result query-result
                :current-block-uuid current-block-uuid}
               {:query "(task TODO)"})))
+      (is (= :unset @query-result)
+          "Rendering must not update consumers of the shared atom.")
+      (is (= [query-result rows] (second @effect)))
+      (when-let [setup-fn (first @effect)]
+        (setup-fn))
       (is (= rows @query-result)
           "Child {{function}} blocks read this atom from shared block config."))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
{{function}} results that are maps or other collections were passed through as React children, which crashes the page with React error 31.

This change pretty-prints those values (same idea as query table `pp-str`), evaluates and renders each function inside a block-level error boundary that returns React elements (not raw hiccup), and restores writing query rows into the shared `:query-result` atom so `{{function result}}` under a query actually evaluates.

Fixes https://github.com/logseq/db-test/issues/1079

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d97d792a-30d1-4f6d-936e-4391590248e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d97d792a-30d1-4f6d-936e-4391590248e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

