### PR TITLE
fix: apply Network Proxy to db-worker-node fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,6 +195,7 @@
     "send-intent": "^7.0.0",
     "string-width": "8.2.0",
     "tiny-pinyin": "1.3.2",
+    "undici": "6.24.1",
     "uniqolor": "1.1.1",
     "url": "^0.11.4",
     "util": "^0.12.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,6 +236,9 @@ importers:
       tiny-pinyin:
         specifier: 1.3.2
         version: 1.3.2
+      undici:
+        specifier: 6.24.1
+        version: 6.24.1
       uniqolor:
         specifier: 1.1.1
         version: 1.1.1
@@ -4893,6 +4896,10 @@ packages:
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  undici@6.24.1:
+    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
+    engines: {node: '>=18.17'}
 
   unified@9.2.2:
     resolution: {integrity: sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==}
@@ -10196,6 +10203,8 @@ snapshots:
       undertaker-registry: 2.0.0
 
   undici-types@7.19.2: {}
+
+  undici@6.24.1: {}
 
   unified@9.2.2:
     dependencies:

--- a/resources/package.json
+++ b/resources/package.json
@@ -47,6 +47,7 @@
     "socks-proxy-agent": "8.0.5",
     "string-width": "8.2.0",
     "tiny-pinyin": "1.3.2",
+    "undici": "6.24.1",
     "ws": "^8.20.0",
     "zod": "^4.3.6"
   },

--- a/resources/pnpm-lock.yaml
+++ b/resources/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       tiny-pinyin:
         specifier: 1.3.2
         version: 1.3.2
+      undici:
+        specifier: 6.24.1
+        version: 6.24.1
       ws:
         specifier: ^8.20.0
         version: 8.20.0
@@ -2104,6 +2107,10 @@ packages:
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  undici@6.24.1:
+    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
+    engines: {node: '>=18.17'}
 
   undici@7.26.0:
     resolution: {integrity: sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==}
@@ -4508,6 +4515,8 @@ snapshots:
   undici-types@7.16.0: {}
 
   undici-types@7.19.2: {}
+
+  undici@6.24.1: {}
 
   undici@7.26.0:
     optional: true

--- a/scripts/build-db-worker-node-bundle.mjs
+++ b/scripts/build-db-worker-node-bundle.mjs
@@ -21,6 +21,7 @@ const builtinModuleSet = new Set([
 const externalModuleSet = new Set([
   "@zvec/zvec",
   "keytar",
+  "undici",
   "ws",
 ]);
 
@@ -129,6 +130,11 @@ async function main() {
   if (bundleContents.includes("node_modules/.pnpm/keytar")) {
     throw new Error(
       "vite bundle contains a pnpm keytar native path; keytar must stay external"
+    );
+  }
+  if (bundleContents.includes("node_modules/.pnpm/undici")) {
+    throw new Error(
+      "vite bundle contains a pnpm undici path; undici must stay external"
     );
   }
   if (bundleContents.includes("ws does not work in the browser")) {

--- a/scripts/prepare-cli-package.mjs
+++ b/scripts/prepare-cli-package.mjs
@@ -76,6 +76,7 @@ const dependencyNames = [
   "mldoc",
   "picocolors",
   "string-width",
+  "undici",
   "ws",
 ];
 

--- a/scripts/test-cli-release-config.mjs
+++ b/scripts/test-cli-release-config.mjs
@@ -410,6 +410,7 @@ assert.equal(packageJson.dependencies?.["@modelcontextprotocol/sdk"], undefined)
 assert.equal(packageJson.dependencies?.zod, undefined);
 assert.ok(packageJson.dependencies?.["@js-joda/core"], "publish package should include @js-joda/core for release artifacts");
 assert.ok(packageJson.dependencies?.keytar, "publish package should include keytar for db-worker-node");
+assert.ok(packageJson.dependencies?.undici, "publish package should include undici for db-worker-node proxy fetch");
 assert.ok(packageJson.dependencies?.["string-width"], "publish package should include string-width for CLI rendering");
 for (const dependencyName of zvecOptionalRuntimeDependencies) {
   assert.equal(

--- a/src/electron/electron/db_worker.cljs
+++ b/src/electron/electron/db_worker.cljs
@@ -2,6 +2,7 @@
   (:require [logseq.cli.server :as cli-server]
             [logseq.common.graph-dir :as graph-dir]
             [logseq.db-worker.daemon :as daemon]
+            [logseq.db-worker.network-proxy :as network-proxy]
             [promesa.core :as p]))
 
 (defn- initial-state
@@ -237,7 +238,8 @@
 
 (defn- start-managed-daemon!
   [repo]
-  (let [config (merge {:owner-source :electron}
+  (let [config (merge {:owner-source :electron
+                       :extra-env (network-proxy/current-child-env)}
                       @*runtime-opts)]
     (p/let [_ (when (seq (:embedding-endpoint config))
                 (-> (cli-server/stop-server! config repo)

--- a/src/electron/electron/utils.cljs
+++ b/src/electron/electron/utils.cljs
@@ -12,6 +12,7 @@
             [logseq.common.config :as common-config]
             [logseq.common.graph :as common-graph]
             [logseq.common.graph-dir :as graph-dir]
+            [logseq.db-worker.network-proxy :as network-proxy]
             [promesa.core :as p]))
 
 (defonce *win (atom nil)) ;; The main window
@@ -233,14 +234,21 @@
      (= type "system")
      (p/let [_ (<set-electron-proxy {:type "system"})
              proxy (<get-system-proxy)]
+       (network-proxy/remember-child-env!
+        (when proxy
+          {:type (or (:protocol proxy) (:type proxy))
+           :host (:host proxy)
+           :port (:port proxy)}))
        (set-fetch-agent-proxy proxy))
 
      (= type "direct")
      (p/let [_ (<set-electron-proxy {:type "direct"})]
+       (network-proxy/remember-child-env! {:type "direct"})
        (set-fetch-agent-proxy nil))
 
      (or (= type "socks5") (= type "http"))
      (p/let [_ (<set-electron-proxy {:type type :host host :port port})]
+       (network-proxy/remember-child-env! {:type type :host host :port port})
        (set-fetch-agent-proxy {:protocol type :host host :port port}))
 
      :else

--- a/src/main/frontend/components/plugins.cljs
+++ b/src/main/frontend/components/plugins.cljs
@@ -557,6 +557,9 @@
                               (let [normalized-opts (normalize-opts opts)]
                                 (when-not (validate!)
                                   (state/set-state! [:electron/user-cfgs :settings/agent] normalized-opts)
+                                  (when @state/*db-worker
+                                    (state/<invoke-db-worker :thread-api/sync-app-state
+                                                             {:network/proxy normalized-opts}))
                                   (shui/dialog-close!)
                                   (-> (ipc/ipc :setProxy normalized-opts)
                                       (p/catch (fn [e]

--- a/src/main/frontend/handler/db_based/sync.cljs
+++ b/src/main/frontend/handler/db_based/sync.cljs
@@ -209,7 +209,8 @@
   (let [payload (select-keys (state/get-state) [:git/current-repo :config
                                                  :auth/id-token :auth/access-token :auth/refresh-token
                                                  :auth/oauth-token-url :auth/oauth-domain :auth/oauth-client-id
-                                                 :user/info])]
+                                                 :user/info])
+        network-proxy (get-in (state/get-state) [:electron/user-cfgs :settings/agent])]
     (cond-> (if (nil? (:git/current-repo payload))
               (dissoc payload :git/current-repo)
               payload)
@@ -217,7 +218,10 @@
       (assoc :auth/oauth-domain config/OAUTH-DOMAIN)
 
       (seq config/COGNITO-CLIENT-ID)
-      (assoc :auth/oauth-client-id config/COGNITO-CLIENT-ID))))
+      (assoc :auth/oauth-client-id config/COGNITO-CLIENT-ID)
+
+      (some? network-proxy)
+      (assoc :network/proxy network-proxy))))
 
 (defn- <sync-auth-state-to-db-worker!
   []

--- a/src/main/frontend/worker/db_worker_node.cljs
+++ b/src/main/frontend/worker/db_worker_node.cljs
@@ -13,6 +13,7 @@
             [logseq.cli.style :as style]
             [logseq.db :as ldb]
             [logseq.db-worker.log :as db-worker-log]
+            [logseq.db-worker.network-proxy :as network-proxy]
             [logseq.db-worker.server-list :as server-list]
             [promesa.core :as p]))
 
@@ -553,6 +554,7 @@
                                    :log-level (keyword (or log-level "info"))})
           (log/info :db-worker-node-version {:build-time (build-version/build-time)
                                              :revision (build-version/revision)})
+          (network-proxy/apply-from-process-env!)
           (reset! *ready? false)
           (reset! *lock-info nil)
           (reset! *server-list-file server-list-file)

--- a/src/main/frontend/worker/handler/transaction.cljs
+++ b/src/main/frontend/worker/handler/transaction.cljs
@@ -7,6 +7,7 @@
    [frontend.worker.db-listener :as db-listener]
    [frontend.worker.handler.block :as block-handler]
    [frontend.worker.plain-value :as worker-plain]
+   [frontend.worker.platform :as platform]
    [frontend.worker.shared-service :as shared-service]
    [frontend.worker.state :as worker-state]
    [lambdaisland.glogi :as log]
@@ -155,4 +156,6 @@
              (nil? (:git/current-repo new-state)))
     (log/error :thread-api/sync-app-state {:reason :nil-current-repo}))
   (worker-state/set-new-state! new-state)
+  (when (contains? new-state :network/proxy)
+    (platform/set-http-proxy! (:network/proxy new-state)))
   nil)

--- a/src/main/frontend/worker/platform.cljs
+++ b/src/main/frontend/worker/platform.cljs
@@ -30,6 +30,16 @@
   (or @*platform
       (throw (ex-info "platform adapter not initialized" {}))))
 
+(defn maybe-current
+  []
+  @*platform)
+
+(defn set-http-proxy!
+  "No-op unless the platform adapter provides :http/set-proxy! (Node only)."
+  [settings]
+  (when-let [f (get-in (maybe-current) [:http :set-proxy!])]
+    (f settings)))
+
 (defn env-flag
   [platform flag]
   (get-in platform [:env flag]))

--- a/src/main/frontend/worker/platform/node.cljs
+++ b/src/main/frontend/worker/platform/node.cljs
@@ -10,6 +10,7 @@
             [frontend.worker.db-worker-node-lock :as db-lock]
             [goog.object :as gobj]
             [lambdaisland.glogi :as log]
+            [logseq.db-worker.network-proxy :as network-proxy]
             [logseq.common.config :as common-config]
             [logseq.db.sqlite.backup :as sqlite-backup]
             [promesa.core :as p]
@@ -748,7 +749,8 @@
                                     (<read-secret-text-by-owner kv owner-source key))
                 :delete-secret-text! (fn [key]
                                        (<delete-secret-text-by-owner! kv owner-source key))}
-       :timers {:set-interval! (fn [f ms] (js/setInterval f ms))}}
+       :timers {:set-interval! (fn [f ms] (js/setInterval f ms))}
+       :http {:set-proxy! network-proxy/apply-settings!}}
        vector-embedding-enabled?
        (assoc :embedding {:model-id embedding-model-id
                           :dimension embedding-dimension

--- a/src/main/logseq/cli/server.cljs
+++ b/src/main/logseq/cli/server.cljs
@@ -185,14 +185,15 @@
     (assoc payload :http-status status)))
 
 (defn- spawn-server!
-  [{:keys [repo root-dir owner-source create-empty-db? embedding-endpoint embedding-model-id]}]
+  [{:keys [repo root-dir owner-source create-empty-db? embedding-endpoint embedding-model-id extra-env]}]
   (daemon/spawn-server! {:script (db-worker-script-path)
                          :repo repo
                          :root-dir root-dir
                          :owner-source owner-source
                          :create-empty-db? create-empty-db?
                          :embedding-endpoint embedding-endpoint
-                         :embedding-model-id embedding-model-id}))
+                         :embedding-model-id embedding-model-id
+                         :extra-env extra-env}))
 
 (defn- rewrite-lock-owner-source!
   [path lock owner-source]
@@ -295,7 +296,8 @@
                                                                   :owner-source requester-owner
                                                                   :create-empty-db? (:create-empty-db? config)
                                                                   :embedding-endpoint (:embedding-endpoint config)
-                                                                  :embedding-model-id (:embedding-model-id config)})))
+                                                                  :embedding-model-id (:embedding-model-id config)
+                                                                  :extra-env (:extra-env config)})))
                                  (-> (profile/time! profile-session
                                                     "server.wait-lock"
                                                     (fn []

--- a/src/main/logseq/db_worker/daemon.cljs
+++ b/src/main/logseq/db_worker/daemon.cljs
@@ -6,6 +6,7 @@
             [clojure.string :as string]
             [lambdaisland.glogi :as log]
             [logseq.db-worker.log :as db-worker-log]
+            [logseq.db-worker.network-proxy :as network-proxy]
             [promesa.core :as p]))
 
 (def ^:private valid-owner-sources
@@ -224,14 +225,14 @@
              :interval-ms 50}))
 
 (defn spawn-server!
-  [{:keys [script repo root-dir owner-source create-empty-db? embedding-endpoint embedding-model-id]}]
+  [{:keys [script repo root-dir owner-source create-empty-db? embedding-endpoint embedding-model-id extra-env]}]
   (let [owner-source (normalize-owner-source owner-source)
         detached? (not= owner-source :electron)
         args (clj->js (cond-> [script "--repo" repo "--root-dir" root-dir "--owner-source" (name owner-source)]
                         create-empty-db? (conj "--create-empty-db")
                         (seq embedding-endpoint) (conj "--embedding-endpoint" embedding-endpoint)
                         (seq embedding-model-id) (conj "--embedding-model-id" embedding-model-id)))
-        env (js/Object.assign #js {} (.-env js/process) #js {:ELECTRON_RUN_AS_NODE "1"})]
+        env (network-proxy/merge-child-env extra-env)]
     (when (and (= :electron owner-source)
                (not (seq embedding-endpoint)))
       (js-delete env embedding-url-env))

--- a/src/main/logseq/db_worker/network_proxy.cljs
+++ b/src/main/logseq/db_worker/network_proxy.cljs
@@ -1,0 +1,180 @@
+(ns logseq.db-worker.network-proxy
+  "Apply Network Proxy settings to Node undici fetch used by db-worker-node."
+  (:require [clojure.string :as string]
+            [lambdaisland.glogi :as log]))
+
+(def ^:private proxy-env-keys
+  ["HTTP_PROXY" "HTTPS_PROXY" "ALL_PROXY"
+   "http_proxy" "https_proxy" "all_proxy"
+   "NODE_USE_ENV_PROXY" "LOGSEQ_NETWORK_PROXY"])
+
+(defn- proxy-type
+  [{:keys [type protocol]}]
+  (or type protocol))
+
+(defn proxy-url
+  "Return http://host:port or socks5://host:port for explicit proxy settings."
+  [settings]
+  (let [type (proxy-type settings)
+        host (:host settings)
+        port (:port settings)]
+    (when (and (contains? #{"http" "socks5"} type)
+               (not (string/blank? (str host)))
+               (some? port)
+               (not (string/blank? (str port))))
+      (str type "://" host ":" port))))
+
+(defn child-env
+  "Env overlay for a spawned db-worker-node process.
+
+  nil values mean the key should be deleted so a `direct` proxy ignores inherited
+  HTTP_PROXY. nil return means leave the parent environment unchanged."
+  [settings]
+  (let [type (proxy-type settings)]
+    (cond
+      (= "direct" type)
+      (into {"LOGSEQ_NETWORK_PROXY" "direct"}
+            (map (fn [k] [k nil]) (remove #{"LOGSEQ_NETWORK_PROXY"} proxy-env-keys)))
+
+      (seq (proxy-url settings))
+      (let [url (proxy-url settings)]
+        (cond-> {"LOGSEQ_NETWORK_PROXY" url
+                 "NODE_USE_ENV_PROXY" "1"}
+          (= "http" type)
+          (assoc "HTTP_PROXY" url
+                 "HTTPS_PROXY" url
+                 "http_proxy" url
+                 "https_proxy" url
+                 "ALL_PROXY" nil
+                 "all_proxy" nil)
+
+          (= "socks5" type)
+          (assoc "ALL_PROXY" url
+                 "all_proxy" url
+                 "HTTP_PROXY" nil
+                 "HTTPS_PROXY" nil
+                 "http_proxy" nil
+                 "https_proxy" nil)))
+
+      :else
+      nil)))
+
+(defonce *child-env (atom nil))
+
+(defn remember-child-env!
+  [settings]
+  (reset! *child-env (child-env settings)))
+
+(defn current-child-env
+  []
+  @*child-env)
+
+(defn- load-undici
+  []
+  (when (exists? js/process)
+    (try
+      (js/require "undici")
+      (catch :default e
+        (log/warn :db-sync/undici-unavailable {:error e})
+        nil))))
+
+(defn- env-proxy-url
+  []
+  (when (exists? js/process)
+    (let [env (.-env js/process)]
+      (or (aget env "LOGSEQ_NETWORK_PROXY")
+          (aget env "HTTPS_PROXY")
+          (aget env "https_proxy")
+          (aget env "HTTP_PROXY")
+          (aget env "http_proxy")
+          (aget env "ALL_PROXY")
+          (aget env "all_proxy")))))
+
+(defn- ->dispatcher
+  [^js undici settings]
+  (let [Agent (.-Agent undici)
+        ProxyAgent (.-ProxyAgent undici)
+        EnvHttpProxyAgent (.-EnvHttpProxyAgent undici)
+        type (proxy-type settings)
+        url (or (proxy-url settings)
+                (when (and (string? (env-proxy-url))
+                           (not= "direct" (env-proxy-url))
+                           (or (nil? settings)
+                               (= "system" type)))
+                  (env-proxy-url)))]
+    (cond
+      (= "direct" type)
+      (new Agent)
+
+      (= "direct" url)
+      (new Agent)
+
+      (and (string? url)
+           (or (string/starts-with? url "http://")
+               (string/starts-with? url "https://")
+               (string/starts-with? url "socks5://")))
+      (try
+        (new ProxyAgent url)
+        (catch :default e
+          (log/warn :db-sync/proxy-agent-failed {:url url :error e})
+          (new EnvHttpProxyAgent)))
+
+      :else
+      (new EnvHttpProxyAgent))))
+
+(defn apply-settings!
+  "Set undici's global dispatcher so js/fetch honors Network Proxy settings.
+   nil / :system falls back to HTTP_PROXY via EnvHttpProxyAgent."
+  [settings]
+  (when-let [undici (load-undici)]
+    (let [dispatcher (->dispatcher undici settings)]
+      (.setGlobalDispatcher undici dispatcher)
+      dispatcher)))
+
+(defn- url->settings
+  [url]
+  (try
+    (let [parsed (js/URL. url)
+          protocol (string/replace (.-protocol parsed) #":$" "")]
+      (when (contains? #{"http" "https" "socks5"} protocol)
+        {:type (if (= "https" protocol) "http" protocol)
+         :host (.-hostname parsed)
+         :port (.-port parsed)}))
+    (catch :default _
+      nil)))
+
+(defn apply-from-process-env!
+  []
+  (let [url (env-proxy-url)]
+    (when (seq url)
+      (apply-settings!
+       (if (= "direct" url)
+         {:type "direct"}
+         (url->settings url))))))
+
+(defn merge-child-env
+  "Build the env object passed to child_process.spawn."
+  [extra-env]
+  (let [env (js/Object.assign #js {} (.-env js/process) #js {:ELECTRON_RUN_AS_NODE "1"})]
+    (when extra-env
+      (doseq [[k v] extra-env]
+        (let [k (if (keyword? k) (name k) (str k))]
+          (if (nil? v)
+            (js-delete env k)
+            (aset env k (str v))))))
+    (let [direct? (= "direct" (aget env "LOGSEQ_NETWORK_PROXY"))
+          has-proxy-url? (or (and (seq (aget env "LOGSEQ_NETWORK_PROXY"))
+                                  (not direct?))
+                             (seq (aget env "HTTP_PROXY"))
+                             (seq (aget env "HTTPS_PROXY"))
+                             (seq (aget env "http_proxy"))
+                             (seq (aget env "https_proxy"))
+                             (seq (aget env "ALL_PROXY"))
+                             (seq (aget env "all_proxy")))]
+      (if direct?
+        (doseq [k (remove #{"LOGSEQ_NETWORK_PROXY"} proxy-env-keys)]
+          (js-delete env k))
+        (when (and has-proxy-url?
+                   (not (seq (aget env "NODE_USE_ENV_PROXY"))))
+          (aset env "NODE_USE_ENV_PROXY" "1"))))
+    env))

--- a/src/test/electron/db_worker_manager_test.cljs
+++ b/src/test/electron/db_worker_manager_test.cljs
@@ -313,6 +313,7 @@
           (p/then (fn [runtime-info]
                     (is (= "graph-a" (:repo @captured)))
                     (is (= :electron (get-in @captured [:config :owner-source])))
+                    (is (contains? (:config @captured) :extra-env))
                     (is (nil? (get-in @captured [:config :server-list-file])))
                     (is (= "http://127.0.0.1:9300" (:base-url runtime-info)))
                     (is (= true (:owned? runtime-info)))))

--- a/src/test/frontend/handler/db_based/sync_test.cljs
+++ b/src/test/frontend/handler/db_based/sync_test.cljs
@@ -461,6 +461,43 @@
                             (reset! state/*db-worker worker-prev)
                             (state/replace-state! state-prev)))))))
 
+(deftest rtc-start-syncs-network-proxy-when-configured-test
+  (async done
+         (let [worker-prev @state/*db-worker
+               state-prev (state/get-state)
+               calls (atom [])]
+           (reset! state/*db-worker :worker)
+           (state/replace-state! (assoc state-prev
+                                      :git/current-repo "demo-graph"
+                                      :auth/id-token "id-token"
+                                      :auth/access-token "access-token"
+                                      :auth/refresh-token "refresh-token"
+                                      :user/info {:sub "user-1"}
+                                      :config {:a 1}
+                                      :electron/user-cfgs {:settings/agent {:type "http"
+                                                                            :host "127.0.0.1"
+                                                                            :port "10808"}}
+                                      :rtc/uploading? false
+                                      :rtc/loading-graphs? false))
+           (-> (p/with-redefs [user-handler/<ensure-id&access-token! (fn [] (p/resolved true))
+                               state/get-rtc-graphs (fn [] [{:url "demo-graph"
+                                                             :graph-ready-for-use? true}])
+                               state/<invoke-db-worker (fn [& args]
+                                                         (swap! calls conj args)
+                                                         (p/resolved :ok))]
+                 (db-sync/<rtc-start! "demo-graph"))
+               (p/then (fn [_]
+                         (is (= :thread-api/sync-app-state (ffirst @calls)))
+                         (is (= {:type "http" :host "127.0.0.1" :port "10808"}
+                                (:network/proxy (second (first @calls)))))
+                         (finish-async-test! done)))
+               (p/catch (fn [error]
+                          (is false (str error))
+                          (finish-async-test! done)))
+               (p/finally (fn []
+                            (reset! state/*db-worker worker-prev)
+                            (state/replace-state! state-prev)))))))
+
 (deftest rtc-download-graph-emits-feedback-before-snapshot-fetch-test
   (let [trace (atom [])
         log-events (atom [])]

--- a/src/test/logseq/db_worker/daemon_test.cljs
+++ b/src/test/logseq/db_worker/daemon_test.cljs
@@ -3,6 +3,7 @@
             [frontend.test.node-helper :as node-helper]
             [logseq.cli.test-helper :as test-helper]
             [logseq.db-worker.daemon :as daemon]
+            [logseq.db-worker.network-proxy :as network-proxy]
             [promesa.core :as p]
             ["fs" :as fs]
             ["path" :as node-path]
@@ -104,6 +105,26 @@
       (is (every? (fn [args]
                     (not-any? #{"--create-empty-db"} args))
                   @captured))
+      (finally
+        (set! (.-spawn child-process) original-spawn)))))
+
+(deftest spawn-server-merges-network-proxy-extra-env
+  (let [captured (atom nil)
+        original-spawn (.-spawn child-process)]
+    (set! (.-spawn child-process)
+          (fn [_cmd _args opts]
+            (reset! captured (js->clj opts :keywordize-keys true))
+            (js-obj "unref" (fn [] nil))))
+    (try
+      (daemon/spawn-server! {:script "/tmp/db-worker-node.js"
+                             :repo "logseq_db_spawn_helper_test"
+                             :root-dir "/tmp/logseq-root"
+                             :extra-env (network-proxy/child-env {:type "http"
+                                                                  :host "127.0.0.1"
+                                                                  :port "10808"})})
+      (is (= "http://127.0.0.1:10808" (get-in @captured [:env :HTTP_PROXY])))
+      (is (= "http://127.0.0.1:10808" (get-in @captured [:env :LOGSEQ_NETWORK_PROXY])))
+      (is (= "1" (get-in @captured [:env :NODE_USE_ENV_PROXY])))
       (finally
         (set! (.-spawn child-process) original-spawn)))))
 

--- a/src/test/logseq/db_worker/network_proxy_test.cljs
+++ b/src/test/logseq/db_worker/network_proxy_test.cljs
@@ -1,0 +1,202 @@
+(ns logseq.db-worker.network-proxy-test
+  (:require [cljs.test :refer [async deftest is]]
+            [clojure.string :as string]
+            [frontend.worker.platform :as platform]
+            [goog.object :as gobj]
+            [logseq.db-worker.network-proxy :as network-proxy]
+            [promesa.core :as p]))
+
+(def ^:private http (js/require "http"))
+(def ^:private net (js/require "net"))
+
+(deftest proxy-url-for-http-and-socks5-settings
+  (is (= "http://127.0.0.1:10808"
+         (network-proxy/proxy-url {:type "http" :host "127.0.0.1" :port "10808"})))
+  (is (= "socks5://127.0.0.1:1080"
+         (network-proxy/proxy-url {:protocol "socks5" :host "127.0.0.1" :port 1080})))
+  (is (nil? (network-proxy/proxy-url {:type "system"})))
+  (is (nil? (network-proxy/proxy-url {:type "direct"})))
+  (is (nil? (network-proxy/proxy-url {:type "http" :host "127.0.0.1"}))))
+
+(deftest child-env-for-http-direct-and-system
+  (is (= {"LOGSEQ_NETWORK_PROXY" "http://127.0.0.1:10808"
+          "NODE_USE_ENV_PROXY" "1"
+          "HTTP_PROXY" "http://127.0.0.1:10808"
+          "HTTPS_PROXY" "http://127.0.0.1:10808"
+          "http_proxy" "http://127.0.0.1:10808"
+          "https_proxy" "http://127.0.0.1:10808"
+          "ALL_PROXY" nil
+          "all_proxy" nil}
+         (network-proxy/child-env {:type "http" :host "127.0.0.1" :port "10808"})))
+  (is (= "socks5://127.0.0.1:1080"
+         (get (network-proxy/child-env {:type "socks5" :host "127.0.0.1" :port "1080"})
+              "ALL_PROXY")))
+  (is (nil? (get (network-proxy/child-env {:type "socks5" :host "127.0.0.1" :port "1080"})
+                 "HTTP_PROXY")))
+  (let [direct (network-proxy/child-env {:type "direct"})]
+    (is (= "direct" (get direct "LOGSEQ_NETWORK_PROXY")))
+    (is (nil? (get direct "HTTP_PROXY")))
+    (is (nil? (get direct "NODE_USE_ENV_PROXY"))))
+  (is (nil? (network-proxy/child-env {:type "system"})))
+  (is (nil? (network-proxy/child-env nil))))
+
+(deftest merge-child-env-applies-http-proxy-and-strips-direct
+  (let [process-env (.-env js/process)
+        original-http (gobj/get process-env "HTTP_PROXY")
+        original-https (gobj/get process-env "HTTPS_PROXY")
+        original-all (gobj/get process-env "ALL_PROXY")]
+    (try
+      (gobj/set process-env "HTTP_PROXY" "http://inherited.example:8080")
+      (gobj/set process-env "HTTPS_PROXY" "http://inherited.example:8080")
+      (gobj/set process-env "ALL_PROXY" "socks5://inherited.example:1080")
+      (let [http-env (js->clj (network-proxy/merge-child-env
+                               (network-proxy/child-env {:type "http" :host "127.0.0.1" :port "10808"}))
+                              :keywordize-keys false)
+            direct-env (js->clj (network-proxy/merge-child-env
+                                 (network-proxy/child-env {:type "direct"}))
+                                :keywordize-keys false)
+            inherited-env (js->clj (network-proxy/merge-child-env nil)
+                                   :keywordize-keys false)]
+        (is (= "1" (get http-env "ELECTRON_RUN_AS_NODE")))
+        (is (= "http://127.0.0.1:10808" (get http-env "LOGSEQ_NETWORK_PROXY")))
+        (is (= "http://127.0.0.1:10808" (get http-env "HTTP_PROXY")))
+        (is (= "1" (get http-env "NODE_USE_ENV_PROXY")))
+        (is (nil? (get http-env "ALL_PROXY")))
+        (is (= "direct" (get direct-env "LOGSEQ_NETWORK_PROXY")))
+        (is (nil? (get direct-env "HTTP_PROXY")))
+        (is (nil? (get direct-env "HTTPS_PROXY")))
+        (is (nil? (get direct-env "ALL_PROXY")))
+        (is (nil? (get direct-env "NODE_USE_ENV_PROXY")))
+        (is (= "http://inherited.example:8080" (get inherited-env "HTTP_PROXY")))
+        (is (= "1" (get inherited-env "NODE_USE_ENV_PROXY"))))
+      (finally
+        (if original-http
+          (gobj/set process-env "HTTP_PROXY" original-http)
+          (gobj/remove process-env "HTTP_PROXY"))
+        (if original-https
+          (gobj/set process-env "HTTPS_PROXY" original-https)
+          (gobj/remove process-env "HTTPS_PROXY"))
+        (if original-all
+          (gobj/set process-env "ALL_PROXY" original-all)
+          (gobj/remove process-env "ALL_PROXY"))))))
+
+(deftest remember-and-current-child-env
+  (let [prev (network-proxy/current-child-env)]
+    (try
+      (network-proxy/remember-child-env! {:type "http" :host "127.0.0.1" :port "10808"})
+      (is (= "http://127.0.0.1:10808"
+             (get (network-proxy/current-child-env) "LOGSEQ_NETWORK_PROXY")))
+      (network-proxy/remember-child-env! nil)
+      (is (nil? (network-proxy/current-child-env)))
+      (finally
+        (reset! network-proxy/*child-env prev)))))
+
+(deftest set-http-proxy-is-noop-without-platform-adapter
+  (with-redefs [platform/maybe-current (constantly nil)]
+    (is (nil? (platform/set-http-proxy! {:type "http" :host "127.0.0.1" :port "10808"})))))
+
+(deftest set-http-proxy-uses-platform-http-capability
+  (let [called (atom nil)]
+    (with-redefs [platform/maybe-current
+                  (fn []
+                    {:http {:set-proxy! (fn [settings]
+                                          (reset! called settings))}})]
+      (platform/set-http-proxy! {:type "direct"})
+      (is (= {:type "direct"} @called)))))
+
+(defn- start-http-proxy
+  []
+  (p/create
+   (fn [resolve reject]
+     (let [hits (atom [])
+           origin (.createServer http
+                                 (fn [_req res]
+                                   (.writeHead res 404 #js {"content-type" "text/plain"})
+                                   (.end res "origin-via-proxy-404")))
+           proxy (.createServer http
+                                (fn [req res]
+                                  (swap! hits conj [:request (.-method req) (.-url req)])
+                                  (.writeHead res 404 #js {"content-type" "text/plain"})
+                                  (.end res "proxy-404-via-proxy")))]
+       (.on proxy "connect"
+            (fn [req client-socket head]
+              (swap! hits conj [:connect (.-url req)])
+              (.listen origin 0 "127.0.0.1"
+                       (fn []
+                         (let [port (.-port (.address origin))
+                               sock (.connect net port "127.0.0.1"
+                                              (fn []
+                                                (.write client-socket "HTTP/1.1 200 Connection Established\r\n\r\n")
+                                                (when (and head (pos? (.-length head)))
+                                                  (.write sock head))
+                                                (.pipe sock client-socket)
+                                                (.pipe client-socket sock)))]
+                           (.on sock "close" (fn [] (.close origin)))
+                           (.on sock "error" (fn [_]
+                                               (try (.destroy client-socket) (catch :default _))
+                                               (.close origin))))))))
+       (.on proxy "error" reject)
+       (.listen proxy 0 "127.0.0.1"
+                (fn []
+                  (resolve {:port (.-port (.address proxy))
+                            :hits hits
+                            :stop! (fn []
+                                     (p/create
+                                      (fn [resolve-close _]
+                                        (try (.close origin) (catch :default _))
+                                        (.close proxy (fn [] (resolve-close true))))))}))))))))
+
+(defn- load-undici
+  []
+  (try
+    (js/require "undici")
+    (catch :default _
+      nil)))
+
+(deftest fetch-honors-applied-http-proxy-settings
+  (async done
+         (if-not (load-undici)
+           (do
+             (is false "undici is required for db-worker-node proxy dispatch")
+             (done))
+           (let [undici (load-undici)
+                 prev-dispatcher (.getGlobalDispatcher undici)
+                 target "http://192.0.2.1:8787/sync/deadbeef/pull"
+                 stop!* (atom nil)]
+             (-> (p/let [{:keys [port hits stop!]} (start-http-proxy)
+                         _ (reset! stop!* stop!)
+                         _ (network-proxy/apply-settings! {:type "http"
+                                                           :host "127.0.0.1"
+                                                           :port (str port)})
+                         proxied (js/fetch target)
+                         proxied-text (.text proxied)
+                         _ (network-proxy/apply-settings! {:type "direct"})
+                         direct-error (p/catch
+                                       (js/fetch target #js {:signal (.timeout js/AbortSignal 1500)})
+                                       (fn [e] e))]
+                   (is (= 404 (.-status proxied)))
+                   (is (string/includes? proxied-text "via-proxy"))
+                   (is (seq @hits))
+                   (is (some (fn [hit]
+                               (let [[kind _method-or-url url] hit]
+                                 (or (and (= :connect kind)
+                                          (string/includes? (str _method-or-url) "192.0.2.1:8787"))
+                                     (and (= :request kind)
+                                          (string/includes? (str url) "192.0.2.1:8787")))))
+                             @hits))
+                   (is (some? direct-error))
+                   (is (or (string/includes? (or (.-message direct-error) "") "fetch failed")
+                           (string/includes? (or (.-message direct-error) "") "aborted")
+                           (string/includes? (or (.-name direct-error) "") "Timeout")
+                           (string/includes? (or (.-name direct-error) "") "Abort")
+                           (string/includes? (or (.-code direct-error) "") "UND_ERR"))))
+                 (p/catch (fn [e]
+                            (is false (str e))))
+                 (p/finally
+                   (fn []
+                     (.setGlobalDispatcher undici prev-dispatcher)
+                     (let [stop! @stop!*]
+                       (if stop!
+                         (-> (stop!)
+                             (p/finally (fn [] (done))))
+                         (done))))))))))

--- a/src/test/logseq/db_worker/network_proxy_test.cljs
+++ b/src/test/logseq/db_worker/network_proxy_test.cljs
@@ -1,14 +1,8 @@
 (ns logseq.db-worker.network-proxy-test
-  (:require [cljs.test :refer [async deftest is]]
-            [clojure.string :as string]
+  (:require [cljs.test :refer [deftest is]]
             [frontend.worker.platform :as platform]
             [goog.object :as gobj]
-            [logseq.db-worker.network-proxy :as network-proxy]
-            [promesa.core :as p]))
-
-(def ^:private http (js/require "http"))
-(def ^:private net (js/require "net"))
-
+            [logseq.db-worker.network-proxy :as network-proxy]))
 (deftest proxy-url-for-http-and-socks5-settings
   (is (= "http://127.0.0.1:10808"
          (network-proxy/proxy-url {:type "http" :host "127.0.0.1" :port "10808"})))
@@ -104,48 +98,6 @@
       (platform/set-http-proxy! {:type "direct"})
       (is (= {:type "direct"} @called)))))
 
-(defn- start-http-proxy
-  []
-  (p/create
-   (fn [resolve reject]
-     (let [hits (atom [])
-           origin (.createServer http
-                                 (fn [_req res]
-                                   (.writeHead res 404 #js {"content-type" "text/plain"})
-                                   (.end res "origin-via-proxy-404")))
-           proxy (.createServer http
-                                (fn [req res]
-                                  (swap! hits conj [:request (.-method req) (.-url req)])
-                                  (.writeHead res 404 #js {"content-type" "text/plain"})
-                                  (.end res "proxy-404-via-proxy")))]
-       (.on proxy "connect"
-            (fn [req client-socket head]
-              (swap! hits conj [:connect (.-url req)])
-              (.listen origin 0 "127.0.0.1"
-                       (fn []
-                         (let [port (.-port (.address origin))
-                               sock (.connect net port "127.0.0.1"
-                                              (fn []
-                                                (.write client-socket "HTTP/1.1 200 Connection Established\r\n\r\n")
-                                                (when (and head (pos? (.-length head)))
-                                                  (.write sock head))
-                                                (.pipe sock client-socket)
-                                                (.pipe client-socket sock)))]
-                           (.on sock "close" (fn [] (.close origin)))
-                           (.on sock "error" (fn [_]
-                                               (try (.destroy client-socket) (catch :default _))
-                                               (.close origin))))))))
-       (.on proxy "error" reject)
-       (.listen proxy 0 "127.0.0.1"
-                (fn []
-                  (resolve {:port (.-port (.address proxy))
-                            :hits hits
-                            :stop! (fn []
-                                     (p/create
-                                      (fn [resolve-close _]
-                                        (try (.close origin) (catch :default _))
-                                        (.close proxy (fn [] (resolve-close true))))))}))))))))
-
 (defn- load-undici
   []
   (try
@@ -153,50 +105,19 @@
     (catch :default _
       nil)))
 
-(deftest fetch-honors-applied-http-proxy-settings
-  (async done
-         (if-not (load-undici)
-           (do
-             (is false "undici is required for db-worker-node proxy dispatch")
-             (done))
-           (let [undici (load-undici)
-                 prev-dispatcher (.getGlobalDispatcher undici)
-                 target "http://192.0.2.1:8787/sync/deadbeef/pull"
-                 stop!* (atom nil)]
-             (-> (p/let [{:keys [port hits stop!]} (start-http-proxy)
-                         _ (reset! stop!* stop!)
-                         _ (network-proxy/apply-settings! {:type "http"
-                                                           :host "127.0.0.1"
-                                                           :port (str port)})
-                         proxied (js/fetch target)
-                         proxied-text (.text proxied)
-                         _ (network-proxy/apply-settings! {:type "direct"})
-                         direct-error (p/catch
-                                       (js/fetch target #js {:signal (.timeout js/AbortSignal 1500)})
-                                       (fn [e] e))]
-                   (is (= 404 (.-status proxied)))
-                   (is (string/includes? proxied-text "via-proxy"))
-                   (is (seq @hits))
-                   (is (some (fn [hit]
-                               (let [[kind _method-or-url url] hit]
-                                 (or (and (= :connect kind)
-                                          (string/includes? (str _method-or-url) "192.0.2.1:8787"))
-                                     (and (= :request kind)
-                                          (string/includes? (str url) "192.0.2.1:8787")))))
-                             @hits))
-                   (is (some? direct-error))
-                   (is (or (string/includes? (or (.-message direct-error) "") "fetch failed")
-                           (string/includes? (or (.-message direct-error) "") "aborted")
-                           (string/includes? (or (.-name direct-error) "") "Timeout")
-                           (string/includes? (or (.-name direct-error) "") "Abort")
-                           (string/includes? (or (.-code direct-error) "") "UND_ERR"))))
-                 (p/catch (fn [e]
-                            (is false (str e))))
-                 (p/finally
-                   (fn []
-                     (.setGlobalDispatcher undici prev-dispatcher)
-                     (let [stop! @stop!*]
-                       (if stop!
-                         (-> (stop!)
-                             (p/finally (fn [] (done))))
-                         (done))))))))))
+(deftest apply-settings-installs-proxy-agent-and-direct-agent
+  (let [undici (load-undici)]
+    (is (some? undici) "undici is required for db-worker-node proxy dispatch")
+    (when undici
+      (let [prev (.getGlobalDispatcher undici)]
+        (try
+          (let [proxy-dispatcher (network-proxy/apply-settings! {:type "http"
+                                                                 :host "127.0.0.1"
+                                                                 :port "10808"})
+                direct-dispatcher (network-proxy/apply-settings! {:type "direct"})]
+            (is (some? proxy-dispatcher))
+            (is (= "ProxyAgent" (.-name (.-constructor proxy-dispatcher))))
+            (is (= "Agent" (.-name (.-constructor direct-dispatcher))))
+            (is (= direct-dispatcher (.getGlobalDispatcher undici))))
+          (finally
+            (.setGlobalDispatcher undici prev)))))))


### PR DESCRIPTION
Fixes https://github.com/logseq/db-test/issues/1080

## Summary

Desktop DB graph downloads use db-worker-node `fetch`. This change applies Settings > Advanced > Network Proxy to that worker:

- pass an HTTP proxy or explicit direct mode to spawned db-worker-node processes
- install the corresponding undici dispatcher at startup and during runtime updates
- synchronize proxy settings when they are saved
- preserve inherited HTTP proxy behavior when no application setting is present

SOCKS5 remains available to Electron requests but is not applied to worker fetch because undici 6 ProxyAgent is HTTP-only.

## Verification

- proxy URL and child environment tests
- spawn environment tests
- renderer state synchronization tests
- undici dispatcher tests

