### PR TITLE
fix: update side menu and settings language immediately upon switching (#12893)

### DIFF
--- a/src/main/frontend/components/left_sidebar.cljs
+++ b/src/main/frontend/components/left_sidebar.cljs
@@ -327,7 +327,8 @@
 
 (hsx/defc sidebar-favorites-loaded
   []
-  (let [favorite-entities (db-hooks/use-resource [:favorites])]
+  (let [_preferred-language (rfx/use-sub [:preferred-language])
+        favorite-entities (db-hooks/use-resource [:favorites])]
     (sidebar-content-group
      [:a.wrap-th
       [:strong.flex-1 (t :sidebar.left/favorites)]]
@@ -358,7 +359,8 @@
 
 (hsx/defc sidebar-recent-pages-loaded
   []
-  (let [current-repo (rfx/use-sub [:git/current-repo])
+  (let [_preferred-language (rfx/use-sub [:preferred-language])
+        current-repo (rfx/use-sub [:git/current-repo])
         recent-page-ids (vec (rfx/use-sub [:ui/recent-pages current-repo]))
         pages (db-hooks/use-resource [:recent-pages recent-page-ids])]
        (sidebar-content-group

--- a/src/main/frontend/components/settings.cljs
+++ b/src/main/frontend/components/settings.cljs
@@ -346,7 +346,8 @@
 
 (hsx/defc theme-modes-row
   [t]
-  (let [theme (rfx/use-sub [:ui/theme])
+  (let [_preferred-language (rfx/use-sub [:preferred-language])
+        theme (rfx/use-sub [:ui/theme])
         dark? (= "dark" theme)
         system-theme? (rfx/use-sub [:ui/system-theme?])
         switch-theme (if dark? "light" "dark")
@@ -371,7 +372,8 @@
 
 (hsx/defc accent-color-row
   [_in-modal?]
-  (let [color-accent (rfx/use-sub [:ui/radix-color])
+  (let [_preferred-language (rfx/use-sub [:preferred-language])
+        color-accent (rfx/use-sub [:ui/radix-color])
         color-label (fn [color]
                       (case color
                         :none [:p {:style {:max-width "300px"}}
@@ -1445,6 +1447,7 @@
 (hsx/defc ^:large-vars/cleanup-todo settings
   [_active-tab]
   (let [current-repo (rfx/use-sub [:git/current-repo])
+        _preferred-language (rfx/use-sub [:preferred-language])
         _installed-plugins (rfx/use-sub [:plugin/installed-plugins])
         plugins-of-settings (and config/lsp-enabled? (seq (plugin-handler/get-enabled-plugins-if-setting-schema)))
         *active (hooks/use-memo #(atom DEFAULT-ACTIVE-TAB-STATE) [])


### PR DESCRIPTION
**Description**
Fixes #12893 

**What Happened?**
When switching the system language, the translation function `(t "...")` was not dynamically updating the UI text for elements like the side menu ("Favorites", "Recent") and settings sections ("Theme", "Colors") until the panel was manually closed and reopened.

**What Changed?**
Added the missing `_preferred-language (rfx/use-sub [:preferred-language])` subscriptions to the `left_sidebar` and `settings` components. This ensures that these UI elements successfully listen to the global language state and re-render reactively when the user switches locales.

**Checks**
- [x] The PR is ready for review.
- [x] The PR has no merge conflicts.
- [x] I have enabled "allow edits from maintainers".