### PR TITLE
fix(android): restore native sheet rendering and header layout

### DIFF
--- a/android/app/src/main/java/com/logseq/app/NativeBottomSheetPlugin.kt
+++ b/android/app/src/main/java/com/logseq/app/NativeBottomSheetPlugin.kt
@@ -20,6 +20,7 @@ class NativeBottomSheetPlugin : Plugin() {
     private val snapshotTag = "bottom-sheet"
     private val mainHandler = Handler(Looper.getMainLooper())
     private var dialog: BottomSheetDialog? = null
+    private var pendingPresentation: (() -> Unit)? = null
     private var awaitingContentReady = false
     private var previousParent: ViewGroup? = null
     private var previousIndex: Int = -1
@@ -42,7 +43,7 @@ class NativeBottomSheetPlugin : Plugin() {
 
         activity.runOnUiThread {
             WebViewSnapshotManager.registerWindow(activity.window)
-            if (dialog != null || awaitingContentReady) {
+            if (dialog != null || pendingPresentation != null || awaitingContentReady) {
                 call.resolve()
                 return@runOnUiThread
             }
@@ -76,16 +77,6 @@ class NativeBottomSheetPlugin : Plugin() {
             }
 
             WebViewSnapshotManager.showSnapshot(snapshotTag, webView)
-
-            // Move the WebView into the BottomSheet container
-            detachWebView(webView, ctx)
-            container!!.addView(
-                webView,
-                FrameLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.MATCH_PARENT
-                )
-            )
 
             val behavior = sheet.behavior
             val defaultHeight = call.getInt("defaultHeight", null)
@@ -122,17 +113,42 @@ class NativeBottomSheetPlugin : Plugin() {
                 container = null
             }
 
+            pendingPresentation = {
+                detachWebView(webView, ctx)
+                container!!.addView(
+                    webView,
+                    FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT
+                    )
+                )
+                sheet.show()
+                notifyListeners("state", JSObject().put("presented", true))
+                dialog = sheet
+                call.resolve()
+            }
             notifyListeners("state", JSObject().put("presenting", true))
-            sheet.show()
-            notifyListeners("state", JSObject().put("presented", true))
-            dialog = sheet
-            call.resolve()
         }
     }
 
     @PluginMethod
     fun dismiss(call: PluginCall) {
         activity?.runOnUiThread {
+            if (pendingPresentation != null) {
+                pendingPresentation = null
+                container = null
+                WebViewSnapshotManager.clearSnapshot(snapshotTag)
+                notifyListeners("state", JSObject().put("dismissing", true))
+                notifyListeners(
+                    "state",
+                    JSObject()
+                        .put("presented", false)
+                        .put("dismissing", false)
+                )
+                call.resolve()
+                return@runOnUiThread
+            }
+
             if (dialog == null) {
                 pendingRestoreWebView?.let { finishDismissal(it) }
                     ?: WebViewSnapshotManager.clearSnapshot(snapshotTag)
@@ -148,6 +164,13 @@ class NativeBottomSheetPlugin : Plugin() {
     @PluginMethod
     fun contentReady(call: PluginCall) {
         activity?.runOnUiThread {
+            pendingPresentation?.let { presentation ->
+                pendingPresentation = null
+                presentation()
+                call.resolve()
+                return@runOnUiThread
+            }
+
             val webView = pendingRestoreWebView
             if (!awaitingContentReady || webView == null) {
                 call.resolve()

--- a/android/app/src/main/java/com/logseq/app/NativeTopBarPlugin.kt
+++ b/android/app/src/main/java/com/logseq/app/NativeTopBarPlugin.kt
@@ -1,6 +1,5 @@
 package com.logseq.app
 
-import android.os.Build
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.compose.foundation.clickable
@@ -26,8 +25,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color as ComposeColor
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -44,7 +41,6 @@ import com.getcapacitor.annotation.CapacitorPlugin
 @CapacitorPlugin(name = "NativeTopBarPlugin")
 class NativeTopBarPlugin : Plugin() {
   private var topBarView: NativeTopBarView? = null
-  private var originalWebViewPaddingTop: Int? = null
 
   @PluginMethod
   fun configure(call: PluginCall) {
@@ -64,11 +60,8 @@ class NativeTopBarPlugin : Plugin() {
         tintHex?.takeIf { it.isNotBlank() }
           ?.let { NativeUiUtils.parseColor(it, LogseqTheme.current().tint) }
 
-      val webView = bridge.webView
-
       if (hidden) {
         removeBar()
-        restorePadding(webView)
         call.resolve()
         return@runOnUiThread
       }
@@ -82,9 +75,6 @@ class NativeTopBarPlugin : Plugin() {
       }
 
       bar.bind(title, titleClickable, leftButtons, rightButtons, tintColorOverride)
-      bar.post {
-        adjustWebViewPadding(webView, bar.height)
-      }
       call.resolve()
     }
   }
@@ -107,40 +97,6 @@ class NativeTopBarPlugin : Plugin() {
       root.removeView(view)
     }
     topBarView = null
-  }
-
-  private fun statusBarInset(webView: android.webkit.WebView?): Int {
-    if (webView == null) return 0
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      webView.rootWindowInsets?.getInsets(android.view.WindowInsets.Type.statusBars())?.top ?: 0
-    } else {
-      @Suppress("DEPRECATION")
-      webView.rootWindowInsets?.stableInsetTop ?: 0
-    }
-  }
-
-  private fun adjustWebViewPadding(webView: android.webkit.WebView?, barHeight: Int) {
-    if (webView == null) return
-    if (originalWebViewPaddingTop == null) {
-      originalWebViewPaddingTop = webView.paddingTop
-    }
-    val insetTop = statusBarInset(webView)
-    val target = (barHeight - insetTop).coerceAtLeast(0)
-      .takeIf { it > 0 } ?: NativeUiUtils.dp(webView.context, 56f)
-    webView.setPadding(
-      webView.paddingLeft,
-      target,
-      webView.paddingRight,
-      webView.paddingBottom
-    )
-  }
-
-  private fun restorePadding(webView: android.webkit.WebView?) {
-    if (webView == null) return
-    val original = originalWebViewPaddingTop
-    if (original != null) {
-      webView.setPadding(webView.paddingLeft, original, webView.paddingRight, webView.paddingBottom)
-    }
   }
 
   private fun parseButtons(array: JSArray?): List<ButtonSpec> {
@@ -227,21 +183,9 @@ private fun TopBarContent(
   onTap: (String) -> Unit
 ) {
   val theme by LogseqTheme.colors.collectAsState()
-  val view = LocalView.current
-  val density = LocalDensity.current
   val background = ComposeColor(theme.background)
   val tint = tintOverride?.let { ComposeColor(it) } ?: ComposeColor(theme.tint)
   val contentTint = tint.copy(alpha = 0.8f)
-  val statusBarTopPx = remember(view) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      view.rootWindowInsets?.getInsets(android.view.WindowInsets.Type.statusBars())?.top ?: 0
-    } else {
-      @Suppress("DEPRECATION")
-      view.rootWindowInsets?.stableInsetTop ?: 0
-    }
-  }
-  val statusBarTop = with(density) { statusBarTopPx.toDp() }
-  val compactTopInset = maxOf(statusBarTop, 8.dp)
 
   Surface(
     color = background,
@@ -252,7 +196,7 @@ private fun TopBarContent(
         modifier = Modifier
           .fillMaxWidth()
           .heightIn(min = 42.dp)
-          .padding(start = 12.dp, end = 8.dp, top = compactTopInset + 8.dp, bottom = 16.dp),
+          .padding(start = 12.dp, end = 8.dp, top = 16.dp, bottom = 16.dp),
         verticalAlignment = Alignment.CenterVertically
       ) {
         Row(

--- a/src/main/mobile/components/app.cljs
+++ b/src/main/mobile/components/app.cljs
@@ -346,18 +346,20 @@
   []
   (let [current-repo (rfx/use-sub [:git/current-repo])
         show-action-bar? (rfx/use-sub [:mobile/show-action-bar?])
-        [{:keys [open? content-fn opts]}] (hooks/use-atom mobile-state/*popup-data)
+        [popup-data] (hooks/use-atom mobile-state/*popup-data)
+        [popup-presenting?] (hooks/use-atom mobile-state/*popup-presenting?)
+        {:keys [open? content-fn]} popup-data
         show-popup? (and open? content-fn)
         route-match (rfx/use-sub [:route-match])]
     [:main#app-container-wrapper.ls-fold-button-on-right
-     [:div#app-container {:class (when show-popup? "invisible")}
+     [:div#app-container {:class (when (and show-popup? popup-presenting?) "invisible")}
       [:div#main-container.flex.flex-1.overflow-x-hidden
        (app current-repo route-match)]]
      (when (mobile-util/native-ios?)
        (native-graphs-bridge))
      (when show-popup?
-       [:div.ls-layer
-        (popup/popup opts content-fn)])
+       [:div.ls-layer {:class (when-not popup-presenting? "invisible")}
+        (popup/popup popup-data)])
      (editor-toolbar/mobile-bar)
      (when show-action-bar?
        (selection-toolbar/action-bar))

--- a/src/main/mobile/components/popup.cljs
+++ b/src/main/mobile/components/popup.cljs
@@ -4,6 +4,7 @@
             [frontend.state :as state]
             [frontend.ui :as ui]
             [logseq.shui.popup.core :as shui-popup]
+            [logseq.shui.hooks :as hooks]
             [logseq.shui.ui :as shui]
             [mobile.state :as mobile-state]
             [promesa.core :as p]
@@ -11,6 +12,7 @@
 
 (defonce *last-popup? (atom nil))
 (defonce *last-popup-data (atom nil))
+(defonce *pending-native-sheet-data (atom nil))
 
 (defn- popup-min-height
   [default-height]
@@ -42,6 +44,19 @@
   (when-let [^js plugin mobile-util/native-bottom-sheet]
     (.dismiss plugin #js {})))
 
+(defn present-native-sheet-after-render!
+  [data]
+  (.requestAnimationFrame
+   js/window
+   (fn []
+     (.requestAnimationFrame
+      js/window
+      (fn []
+        (when (and (identical? data @*pending-native-sheet-data)
+                   (identical? data @mobile-state/*popup-data))
+          (reset! *pending-native-sheet-data nil)
+          (present-native-sheet! data)))))))
+
 (defn- notify-native-sheet-content-ready!
   []
   (when-let [^js plugin mobile-util/native-bottom-sheet]
@@ -55,8 +70,12 @@
 
 (defn- handle-native-sheet-state!
   [^js data]
-  (let [dismissing? (.-dismissing data)]
+  (let [presenting? (or (.-presenting data) (.-presented data))
+        dismissing? (.-dismissing data)]
     (cond
+      presenting?
+      (mobile-state/set-popup-presenting! true)
+
       dismissing?
       (p/do!
        (when (some? @mobile-state/*popup-data)
@@ -64,8 +83,10 @@
          (mobile-state/set-popup! nil)
          (when-let [plugin ^js mobile-util/native-editor-toolbar]
            (.dismiss plugin)))
+       (mobile-state/set-popup-presenting! false)
        (reset! *last-popup? false)
        (reset! *last-popup-data nil)
+       (reset! *pending-native-sheet-data nil)
        (notify-native-sheet-content-ready!))
 
       :else
@@ -115,7 +136,8 @@
         (let [data {:open? true
                     :content-fn content-fn
                     :opts opts}]
-          (present-native-sheet! data)
+          (reset! *pending-native-sheet-data data)
+          (mobile-state/set-popup-presenting! false)
           (mobile-state/set-popup! data))))))
 
 (defn popup-hide!
@@ -128,14 +150,26 @@
 
     :else
     (if (and @*last-popup? (not (= (first args) :editor.commands/commands)))
-      (dismiss-native-sheet!)
+      (if (some? @*pending-native-sheet-data)
+        (do
+          (reset! *pending-native-sheet-data nil)
+          (reset! *last-popup? false)
+          (reset! *last-popup-data nil)
+          (mobile-state/set-popup-presenting! false)
+          (mobile-state/set-popup! nil))
+        (dismiss-native-sheet!))
       (apply shui-popup/hide! args))))
 
 (set! shui/popup-show! popup-show!)
 (set! shui/popup-hide! popup-hide!)
 
 (hsx/defc popup
-  [opts content-fn]
+  [{:keys [opts content-fn] :as data}]
+  (hooks/use-effect!
+   (fn []
+     (present-native-sheet-after-render! data)
+     nil)
+   [data])
   (let [title (or (:title opts) (when (string? content-fn) content-fn))
         content (if (fn? content-fn)
                   (content-fn)

--- a/src/main/mobile/components/popup.cljs
+++ b/src/main/mobile/components/popup.cljs
@@ -70,11 +70,13 @@
 
 (defn- handle-native-sheet-state!
   [^js data]
-  (let [presenting? (or (.-presenting data) (.-presented data))
+  (let [presenting? (.-presenting data)
         dismissing? (.-dismissing data)]
     (cond
       presenting?
-      (mobile-state/set-popup-presenting! true)
+      (do
+       (mobile-state/set-popup-presenting! true)
+       (notify-native-sheet-content-ready!))
 
       dismissing?
       (p/do!

--- a/src/main/mobile/state.cljs
+++ b/src/main/mobile/state.cljs
@@ -21,11 +21,16 @@
 (defn use-tab [] (hooks/use-atom *tab))
 
 (defonce *popup-data (atom nil))
+(defonce *popup-presenting? (atom false))
 (defn set-popup!
   [data]
   (reset! *popup-data data)
   (when data
     (state/pub-event! [:mobile/clear-edit])))
+
+(defn set-popup-presenting!
+  [presenting?]
+  (reset! *popup-presenting? presenting?))
 
 (defonce *flashcards-header (atom nil))
 (defn set-flashcards-header!

--- a/src/test/mobile/popup_test.cljs
+++ b/src/test/mobile/popup_test.cljs
@@ -82,3 +82,34 @@
         (reset! mobile-state/*popup-data nil)
         (reset! mobile-state/*popup-presenting? false)
         (reset! popup/*pending-native-sheet-data nil)))))
+
+(deftest native-sheet-content-ready-follows-popup-render
+  (testing "the native sheet waits until its WebView content has painted"
+    (let [original-raf (.-requestAnimationFrame js/window)
+          raf-callbacks (atom [])
+          content-ready-count (atom 0)
+          plugin #js {:contentReady (fn [_]
+                                      (swap! content-ready-count inc))}]
+      (set! (.-requestAnimationFrame js/window)
+            (fn [callback]
+              (swap! raf-callbacks conj callback)))
+      (reset! mobile-state/*popup-presenting? false)
+      (try
+        (with-redefs [mobile-util/native-bottom-sheet plugin]
+          (#'popup/handle-native-sheet-state! #js {:presenting true})
+
+          (is @mobile-state/*popup-presenting?)
+          (is (zero? @content-ready-count))
+          (is (= 1 (count @raf-callbacks)))
+
+          (when-let [first-frame (first @raf-callbacks)]
+            (first-frame)
+            (is (zero? @content-ready-count))
+            (is (= 2 (count @raf-callbacks))))
+
+          (when-let [second-frame (second @raf-callbacks)]
+            (second-frame)
+            (is (= 1 @content-ready-count))))
+        (finally
+          (set! (.-requestAnimationFrame js/window) original-raf)
+          (reset! mobile-state/*popup-presenting? false))))))

--- a/src/test/mobile/popup_test.cljs
+++ b/src/test/mobile/popup_test.cljs
@@ -1,0 +1,84 @@
+(ns mobile.popup-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [frontend.mobile.util :as mobile-util]
+            [frontend.state :as state]
+            [mobile.components.popup :as popup]
+            [mobile.state :as mobile-state]))
+
+(deftest native-sheet-is-presented-after-popup-content-renders
+  (testing "the WebView is not moved before React can render the popup"
+    (let [original-raf (.-requestAnimationFrame js/window)
+          raf-callbacks (atom [])
+          presented-data (atom [])
+          plugin #js {:present (fn [data]
+                                 (swap! presented-data conj
+                                        {:data data
+                                         :popup-data @mobile-state/*popup-data}))}]
+      (set! (.-requestAnimationFrame js/window)
+            (fn [callback]
+              (swap! raf-callbacks conj callback)))
+      (reset! mobile-state/*popup-data nil)
+      (reset! mobile-state/*popup-presenting? false)
+      (reset! popup/*pending-native-sheet-data nil)
+      (try
+        (with-redefs [mobile-util/native-bottom-sheet plugin
+                      state/pub-event! (fn [& _])]
+          (popup/popup-show! nil (fn [] [:div "Settings"]) {})
+
+          (is (some? @mobile-state/*popup-data))
+          (is (empty? @presented-data))
+          (is (empty? @raf-callbacks))
+
+          (popup/present-native-sheet-after-render!
+           @mobile-state/*popup-data)
+          (is (= 1 (count @raf-callbacks)))
+
+          (when-let [first-frame (first @raf-callbacks)]
+            (first-frame)
+            (is (empty? @presented-data))
+            (is (= 2 (count @raf-callbacks))))
+
+          (when-let [second-frame (second @raf-callbacks)]
+            (second-frame)
+            (is (= @mobile-state/*popup-data
+                   (:popup-data (first @presented-data))))))
+        (finally
+          (set! (.-requestAnimationFrame js/window) original-raf)
+          (reset! mobile-state/*popup-data nil)
+          (reset! mobile-state/*popup-presenting? false)
+          (reset! popup/*pending-native-sheet-data nil))))))
+
+(deftest cancelled-popup-is-not-presented
+  (let [original-raf (.-requestAnimationFrame js/window)
+        raf-callbacks (atom [])
+        present-count (atom 0)
+        dismiss-count (atom 0)
+        plugin #js {:present (fn [_]
+                               (swap! present-count inc))
+                    :dismiss (fn [_]
+                               (swap! dismiss-count inc))}]
+    (set! (.-requestAnimationFrame js/window)
+          (fn [callback]
+            (swap! raf-callbacks conj callback)))
+    (reset! mobile-state/*popup-data nil)
+    (reset! mobile-state/*popup-presenting? false)
+    (reset! popup/*pending-native-sheet-data nil)
+    (try
+      (with-redefs [mobile-util/native-bottom-sheet plugin
+                    state/pub-event! (fn [& _])]
+        (popup/popup-show! nil (fn [] [:div "Settings"]) {})
+        (popup/present-native-sheet-after-render!
+         @mobile-state/*popup-data)
+        (popup/popup-hide!)
+        (when-let [first-frame (first @raf-callbacks)]
+          (first-frame))
+        (when-let [second-frame (second @raf-callbacks)]
+          (second-frame))
+        (is (zero? @present-count))
+        (is (zero? @dismiss-count))
+        (is (nil? @mobile-state/*popup-data)))
+      (finally
+        (set! (.-requestAnimationFrame js/window) original-raf)
+        (reset! mobile-state/*popup-data nil)
+        (reset! mobile-state/*popup-presenting? false)
+        (reset! popup/*pending-native-sheet-data nil)))))


### PR DESCRIPTION
## Summary

- render popup content before Android reparents the WebView
- make the native bottom sheet wait for an explicit two-frame content-ready signal before presentation
- keep the graph visible until native presentation actually begins and cancel pending presentations cleanly
- remove the duplicated status-bar inset from the native header so journal content is no longer obscured

## Root cause

The settings action could call the native bottom sheet before the HSX popup content committed. Android then detached and moved the WebView immediately, allowing the sheet to capture an empty layer. Rendering before the call reduced the race but did not close it, so the native plugin now waits for an explicit content-ready handshake before moving and showing the WebView.

The native top bar had a separate layout error: `android.R.id.content` already starts below the status bar, but the Compose header added the status-bar inset again. Its attempt to compensate with WebView padding did not move the DOM viewport, leaving the journal heading under the native controls.

## Regression history

- `fe65e36f13` (`refactor: remove ui db`, 2026-07-08) introduced the graph-rendering regression seen in the nightly line; the August mobile restore commits fixed parts of startup and journal rendering.
- the empty native sheet was a latent WebView reparent race in the pre-existing Android sheet path, exposed by the newer asynchronous HSX/RFX render flow rather than missing graph data.
- the duplicated native header inset came from `62e66f30b9` (`fix(android): adjust native top bar layout and icon sizes`, 2026-05-09).

## Test plan

- `bb dev:lint-and-test`
- `bb dev:test -v mobile.popup-test` (3 tests, 16 assertions)
- `./android/gradlew -p android testDebugUnitTest assembleDebug`
- production mobile CLJS build, Capacitor sync, and Android debug APK installation
- Android API 36.1 emulator with production WebView/assets:
  - 11 cold-start settings cycles; settings rendered and graph restored after every dismissal
  - 5 repeated warm settings open/dismiss cycles
  - background/resume while the sheet is open
  - force-stop while the sheet is open, then relaunch
  - graph selector, calendar, and theme option popup checks
  - no fatal or uncaught runtime errors in the tested flows