### PR TITLE
Preserve asset alt text during File-to-DB import

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -1431,11 +1431,14 @@
 
 (defn- update-asset-links-in-block-title [block-title asset-name-to-uuids ignored-assets]
   (reduce (fn [acc [asset-name asset-uuid]]
-            (let [new-title (string/replace acc
-                                            (re-pattern (str "!?\\[[^\\]]*?\\]\\([^\\)]*?"
-                                                             (common-util/escape-regex-chars asset-name)
-                                                             "\\)(\\{[^}]*\\})?"))
-                                            (page-ref/->page-ref asset-uuid))]
+            (let [new-title (string/replace
+                             acc
+                             (re-pattern (str "(!?)\\[([^\\]]*?)\\]\\([^\\)]*?"
+                                              (common-util/escape-regex-chars asset-name)
+                                              "\\)(\\{[^}]*\\})?"))
+                             (fn [[_ image-prefix label]]
+                               (str image-prefix "[" label "]("
+                                    (page-ref/->page-ref asset-uuid) ")")))]
               (when (string/includes? new-title asset-name)
                 (swap! ignored-assets conj
                        {:reason "Some asset links were not updated to block references"

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -1431,15 +1431,17 @@
 
 (defn- update-asset-links-in-block-title [block-title asset-name-to-uuids ignored-assets]
   (reduce (fn [acc [asset-name asset-uuid]]
-            (let [new-title (string/replace
+            (let [asset-link-pattern
+                  (re-pattern (str "(!?)\\[([^\\]]*?)\\]\\([^\\)]*?"
+                                   (common-util/escape-regex-chars asset-name)
+                                   "\\)(\\{[^}]*\\})?"))
+                  new-title (string/replace
                              acc
-                             (re-pattern (str "(!?)\\[([^\\]]*?)\\]\\([^\\)]*?"
-                                              (common-util/escape-regex-chars asset-name)
-                                              "\\)(\\{[^}]*\\})?"))
+                             asset-link-pattern
                              (fn [[_ image-prefix label]]
                                (str image-prefix "[" label "]("
                                     (page-ref/->page-ref asset-uuid) ")")))]
-              (when (string/includes? new-title asset-name)
+              (when (re-find asset-link-pattern new-title)
                 (swap! ignored-assets conj
                        {:reason "Some asset links were not updated to block references"
                         :path asset-name

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -838,6 +838,14 @@ abc
      "assets/paper.pdf"]
     "Read [the paper]([[UUID]])"))
 
+(deftest asset-path-in-alt-text-is-not-ignored
+  (let [ignored-assets (atom [])
+        title "![assets/foo.png](assets/foo.png)"]
+    (is (= "![assets/foo.png]([[UUID]])"
+           (@#'gp-exporter/update-asset-links-in-block-title
+            title {"assets/foo.png" "UUID"} ignored-assets)))
+    (is (empty? @ignored-assets))))
+
 (deftest-async import-asset-link-preserves-alt-text
   (p/let [graph-dir (write-temp-file-graph
                      {"logseq/config.edn" "{}"

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -821,17 +821,42 @@ abc
     ;; Standard image link with metadata
     ["![greg-popovich-thumbs-up.png](../assets/greg-popovich-thumbs-up_1704749687791_0.png){:height 288, :width 100} says pop"
      "assets/greg-popovich-thumbs-up_1704749687791_0.png"]
-    "[[UUID]] says pop"
+    "![greg-popovich-thumbs-up.png]([[UUID]]) says pop"
 
     ;; Image link with no metadata
     ["![some-title](../assets/CleanShot_2022-10-12_at_15.53.20@2x_1665561216083_0.png)"
      "assets/CleanShot_2022-10-12_at_15.53.20@2x_1665561216083_0.png"]
-    "[[UUID]]"
+    "![some-title]([[UUID]])"
 
     ;; 2nd link
     ["[[FIRST UUID]] and ![dino!](assets/subdir/partydino.gif)"
      "assets/subdir/partydino.gif"]
-    "[[FIRST UUID]] and [[UUID]]"))
+    "[[FIRST UUID]] and ![dino!]([[UUID]])"
+
+    ;; File link
+    ["Read [the paper](../assets/paper.pdf)"
+     "assets/paper.pdf"]
+    "Read [the paper]([[UUID]])"))
+
+(deftest-async import-asset-link-preserves-alt-text
+  (p/let [graph-dir (write-temp-file-graph
+                     {"logseq/config.edn" "{}"
+                      "pages/assets.md" "- ![some alt](../assets/foo.png)\n"
+                      "assets/foo.png" "png"})
+          conn (db-test/create-conn)
+          _ (db-pipeline/add-listener conn)
+          {:keys [import-state]} (import-file-graph-to-db graph-dir conn {})
+          asset (db-test/find-block-by-content @conn "foo")
+          source-block (db-test/find-block-by-content @conn #"some alt")]
+    (is (some? asset) "Asset is imported")
+    (is (= (str "![some alt]("
+                (page-ref/->page-ref (:block/uuid asset))
+                ")")
+           (:block/title source-block))
+        "Asset reference keeps its original alt text")
+    (is (empty? @(:ignored-assets import-state)) "No assets are ignored")
+    (is (empty? (:errors (db-validate/validate-local-db! @conn)))
+        "Imported graph validates")))
 
 (deftest-async import-missing-local-pdf-asset-link-is-ignored-quietly
   (let [graph-dir (write-temp-file-graph

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -261,7 +261,8 @@
         (merge
          (cond-> {:loading "lazy"
                   :referrerPolicy "no-referrer"
-                  :src src'}
+                  :src src'
+                  :alt title}
            (not gallery-view?)
            (assoc :title title))
          metadata)]
@@ -1129,7 +1130,9 @@
 
 (hsx/defc asset-cp
   [config block]
-  (let [asset-type (:logseq.property.asset/type block)
+  (let [title (block-asset/link-title block (:asset-link-title config))
+        full-text (:ref-full-text config)
+        asset-type (:logseq.property.asset/type block)
         file (block-asset/asset-file-name block)
         file-exists?* (hooks/use-memo #(atom nil) [(:block/uuid block) asset-type])
         requested?* (hooks/use-memo #(atom false) [(:block/uuid block)])
@@ -1191,10 +1194,10 @@
                   (asset-link (cond-> (assoc config :asset-block block)
                                 (not gallery-image?)
                                 (assoc :image-placeholder img-placeholder))
-                              (:block/title block)
+                              title
                               href
                               img-metadata
-                              nil)
+                              full-text)
                   (and (not gallery-image?)
                        (block-asset/show-missing-file-warning? block file-exists?))
                   (missing-asset-file
@@ -1261,7 +1264,7 @@
     (when-not (and (:db/id block) (= (:db/id block) (:db/id (:block config))))
       (cond
         (and asset? (img-audio-video? block))
-        (asset-cp config block)
+        (asset-cp (assoc config :asset-link-title (:label config')) block)
 
         (and (string? uuid-or-title) (string/ends-with? uuid-or-title ".excalidraw"))
         [:div.draw {:on-click (fn [e]
@@ -1559,7 +1562,7 @@
       (let [label* (if (seq (mldoc/plain->text label)) label nil)]
         (if (and (string? page) (string/blank? page))
           [:span (ref/->page-ref page)]
-          (page-reference config page label*)))
+          (page-reference (assoc config :ref-full-text full_text) page label*)))
 
       ["Embed_data" src]
       (image-link config url src nil metadata full_text)

--- a/src/main/frontend/components/block/asset.cljs
+++ b/src/main/frontend/components/block/asset.cljs
@@ -34,6 +34,13 @@
   (cond-> (str (:block/title asset-block))
     ext (str "." (name ext))))
 
+(defn link-title
+  "Uses a reference label when present, otherwise the asset's title."
+  [asset-block label]
+  (if (nil? label)
+    (:block/title asset-block)
+    label))
+
 (defn asset-file-name
   [asset-block]
   (str (:block/uuid asset-block) "." (:logseq.property.asset/type asset-block)))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1722,9 +1722,9 @@
           _ (or block (throw (ex-info (str block-id " not exists")
                                       {:block-id block-id})))
           text (:block/title block)
-          content (if asset-block
-                    (string/replace text (ref/->page-ref (:block/uuid asset-block)) "")
-                    (string/replace text full-text ""))]
+          content (if full-text
+                    (string/replace text full-text "")
+                    (string/replace text (ref/->page-ref (:block/uuid asset-block)) ""))]
     (save-block! repo block content)
     (when (and local? delete-local?)
       (when asset-block

--- a/src/test/frontend/components/block/asset_test.cljs
+++ b/src/test/frontend/components/block/asset_test.cljs
@@ -17,6 +17,13 @@
             {:block/title "test"}
             :pdf)))))
 
+(deftest link-title-test
+  (let [asset {:block/title "file-name"}]
+    (testing "uses an asset reference label"
+      (is (= "some alt" (block-asset/link-title asset "some alt"))))
+    (testing "falls back to the asset title without a reference label"
+      (is (= "file-name" (block-asset/link-title asset nil))))))
+
 (deftest asset-relative-path-test
   (testing "builds the graph-relative asset file path from an asset block"
     (let [asset-uuid (random-uuid)]


### PR DESCRIPTION
Fixes https://github.com/logseq/db-test/issues/1081

## Summary

- preserve image alt text and file-link labels when replacing File graph asset URLs with DB asset references
- render imported asset references with their per-reference labels and image alt attributes
- remove labeled asset references correctly from their source blocks
- cover link rewriting, ignored-asset reporting, and the File-to-DB import path

## Verification

- `pnpm test` in `deps/graph-parser`
- `bb dev:test -v frontend.components.block.asset-test/link-title-test`
- `bb dev:lint-and-test`

