### PR TITLE
fix: query page references in text properties

### DIFF
--- a/src/main/frontend/worker/query_dsl.cljs
+++ b/src/main/frontend/worker/query_dsl.cljs
@@ -368,28 +368,42 @@
                           (or (:block/title value)
                               (:logseq.property/value value)))
                         (:logseq.property/scalar-default-value property))
-        default-value? (and (some? v') (= default-value v'))
-        rule (if private-property?
-               (cond
-                 (and ref-type? default-value?)
-                 :private-ref-property-with-default
-                 ref-type?
-                 :private-ref-property
-                 default-value?
-                 :private-scalar-property-with-default
-                 :else
-                 :private-scalar-property)
-               (cond
-                 (and ref-type? default-value?)
-                 :ref-property-with-default
-                 ref-type?
-                 :ref-property
-                 default-value?
-                 :scalar-property-with-default
-                 :else
-                 :scalar-property))]
-    {:query (list (symbol (name rule)) '?b k v')
-     :rules [rule]}))
+        get-rule (fn [value]
+                   (let [default-value? (and (some? value) (= default-value value))]
+                     (if private-property?
+                       (cond
+                         (and ref-type? default-value?)
+                         :private-ref-property-with-default
+                         ref-type?
+                         :private-ref-property
+                         default-value?
+                         :private-scalar-property-with-default
+                         :else
+                         :private-scalar-property)
+                       (cond
+                         (and ref-type? default-value?)
+                         :ref-property-with-default
+                         ref-type?
+                         :ref-property
+                         default-value?
+                         :scalar-property-with-default
+                         :else
+                         :scalar-property))))
+        rule (get-rule v')
+        raw-page-ref-value (when (and (= :default (:logseq.property/type property))
+                                      (page-ref/page-ref? (str v)))
+                             (str v))
+        raw-page-ref-rule (when raw-page-ref-value (get-rule raw-page-ref-value))
+        rule-clause (fn [rule value]
+                      (list (symbol (name rule)) '?b k value))]
+    {:query (if raw-page-ref-value
+              (list 'or
+                    (rule-clause rule v')
+                    (rule-clause raw-page-ref-rule raw-page-ref-value))
+              (rule-clause rule v'))
+     :rules (cond-> [rule]
+              (and raw-page-ref-rule (not= rule raw-page-ref-rule))
+              (conj raw-page-ref-rule))}))
 
 (defn- build-property-one-arg
   [e {:keys [private-property?]}]

--- a/src/test/frontend/db/query_dsl_test.cljs
+++ b/src/test/frontend/db/query_dsl_test.cljs
@@ -233,6 +233,31 @@
     (test-helper/with-config {}
       (block-property-queries-test))))
 
+(deftest default-property-page-ref-text-query
+  (load-test-files
+   {:properties
+    {:mixed {:logseq.property/type :default
+             :db/cardinality :db.cardinality/many}}
+    :pages-and-blocks
+    [{:page {:block/title "Equivalent Value"}
+      :blocks [{:block/title "plain holder"
+                :build/properties {:mixed "Equivalent Value"}}
+               {:block/title "page-ref holder"
+                :build/properties {:mixed "[[Equivalent Value]]"}}]}]})
+
+  (is (= #{"plain holder" "page-ref holder"}
+         (set (map :block/title
+                   (dsl-query "(property mixed [[Equivalent Value]])"))))
+      "Page-ref text values and equivalent plain text values both match")
+  (is (= ["plain holder"]
+         (map :block/title
+              (dsl-query "(property mixed \"Equivalent Value\")")))
+      "Plain text filtering keeps exact-match behavior")
+  (is (= #{"plain holder" "page-ref holder"}
+         (set (map :block/title
+                   (dsl-query "(property mixed)"))))
+      "Unbound property values keep matching all values"))
+
 (deftest db-only-block-property-queries
   (load-test-files
    {:properties


### PR DESCRIPTION
Fixes https://github.com/logseq/db-test/issues/1085

## Summary

- match page-reference-shaped values stored in Text properties by normalized and raw forms
- preserve exact matching for ordinary plain-text filters
- add focused query DSL coverage for mixed Text values

## Verification

- `bb dev:test -v frontend.db.query-dsl-test/default-property-page-ref-text-query`
- `bb dev:test -v frontend.db.query-dsl-test`
- `bb dev:lint-and-test`

