### PR TITLE
Fix inherited tag icons on page references

### DIFF
--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -126,9 +126,6 @@
                                      :i18n-key :electron/write-file-error
                                      :i18n-args [path error-message]})))))))
 
-(defmethod handle :appendDebugLog [_window [_ path payload]]
-  (fs/appendFileSync path payload))
-
 (defmethod handle :rename [_window [_ old-path new-path]]
   (logger/info ::rename "from" old-path "to" new-path)
   (fs/renameSync old-path new-path))

--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -126,6 +126,9 @@
                                      :i18n-key :electron/write-file-error
                                      :i18n-args [path error-message]})))))))
 
+(defmethod handle :appendDebugLog [_window [_ path payload]]
+  (fs/appendFileSync path payload))
+
 (defmethod handle :rename [_window [_ old-path new-path]]
   (logger/info ::rename "from" old-path "to" new-path)
   (fs/renameSync old-path new-path))

--- a/src/main/frontend/components/icon.cljs
+++ b/src/main/frontend/components/icon.cljs
@@ -6,7 +6,6 @@
             [camel-snake-kebab.core :as csk]
             [cljs-bean.core :as bean]
             [clojure.string :as string]
-            [electron.ipc :as ipc]
             [frontend.config :as config]
             [frontend.context.i18n :refer [t]]
             [frontend.search :as search]
@@ -24,24 +23,6 @@
             [io.factorhouse.hsx.core :as hsx]))
 
 (defonce emojis (vals (bean/->clj (gobj/get emoji-data "emojis"))))
-
-(defn- debug-icon-summary
-  [icon']
-  (if (map? icon')
-    (select-keys icon' [:type :id :color])
-    icon'))
-
-(defn- debug-log!
-  [hypothesis-id location message data]
-  (ipc/ipc "appendDebugLog"
-           "/opt/cursor/logs/debug.log"
-           (str (js/JSON.stringify
-                 (clj->js {:hypothesisId hypothesis-id
-                           :location location
-                           :message message
-                           :data data
-                           :timestamp (.now js/Date)}))
-                "\n")))
 
 (defn icon
   [icon' & [opts]]
@@ -74,87 +55,32 @@
 
 (defn get-node-icon
   [node-entity {:keys [ignore-current-icon?]
-                :or {ignore-current-icon? false}
-                :as opts}]
-  ;; #region agent log
-  (debug-log! "B" "frontend.components.icon/get-node-icon:entry"
-              "get-node-icon input"
-              {:db-id (:db/id node-entity)
-               :opts (select-keys opts [:ignore-current-icon? :not-text-or-page? :link?])
-               :tag-count (count (:block/tags node-entity))
-               :entity-keys (mapv str (keys node-entity))})
-  ;; #endregion
-  (let [own-icon (when-not ignore-current-icon?
-                   (get node-entity :logseq.property/icon))
-        asset-type (:logseq.property.asset/type node-entity)
-        sorted-tags (sort-by :db/id (:block/tags node-entity))
-        first-tag-icon (some :logseq.property/icon sorted-tags)
-        class? (boolean (entity/class? node-entity))
-        property? (boolean (entity/property? node-entity))
-        page? (boolean (entity/page? node-entity))
-        result (or own-icon
-                   (cond
-                     class?
-                     "hash"
-                     property?
-                     "letter-p"
-                     page?
-                     "file"
-                     (= asset-type "pdf")
-                     "book"
-                     (some? first-tag-icon)
-                     first-tag-icon
-                     :else
-                     "point-filled"))]
-    ;; #region agent log
-    (debug-log! "A,B,D" "frontend.components.icon/get-node-icon:candidates"
-                "icon candidates before precedence"
-                {:db-id (:db/id node-entity)
-                 :own-icon (debug-icon-summary own-icon)
-                 :asset-type asset-type
-                 :class? class?
-                 :property? property?
-                 :page? page?
-                 :tags (mapv (fn [tag]
-                               {:db-id (:db/id tag)
-                                :ident (some-> (:db/ident tag) str)
-                                :icon (debug-icon-summary (:logseq.property/icon tag))})
-                             sorted-tags)
-                 :first-tag-icon (debug-icon-summary first-tag-icon)})
-    ;; #endregion
-    ;; #region agent log
-    (debug-log! "A,D" "frontend.components.icon/get-node-icon:exit"
-                "selected node icon"
-                {:db-id (:db/id node-entity)
-                 :result (debug-icon-summary result)})
-    ;; #endregion
-    result))
+                :or {ignore-current-icon? false}}]
+  (or (when-not ignore-current-icon?
+        (get node-entity :logseq.property/icon))
+      (let [asset-type (:logseq.property.asset/type node-entity)
+            first-tag-icon (some :logseq.property/icon (sort-by :db/id (:block/tags node-entity)))]
+        (cond
+          (entity/class? node-entity)
+          "hash"
+          (entity/property? node-entity)
+          "letter-p"
+          (= asset-type "pdf")
+          "book"
+          (some? first-tag-icon)
+          first-tag-icon
+          (entity/page? node-entity)
+          "file"
+          :else
+          "point-filled"))))
 
 (defn get-node-icon-cp
   [node-entity opts]
   (let [opts' (merge {:size 14} opts)
         node-icon (if (:link? opts)
                     "arrow-narrow-right"
-                    (get-node-icon node-entity opts))
-        suppressed? (or (string/blank? node-icon)
-                        (and (contains? #{"point-filled" "letter-p" "hash" "file"} node-icon)
-                             (:not-text-or-page? opts)))]
-    ;; #region agent log
-    (debug-log! "C" "frontend.components.icon/get-node-icon-cp:selection"
-                "component received selected icon"
-                {:db-id (:db/id node-entity)
-                 :node-icon (debug-icon-summary node-icon)
-                 :not-text-or-page? (:not-text-or-page? opts)
-                 :link? (:link? opts)})
-    ;; #endregion
-    ;; #region agent log
-    (debug-log! "C" "frontend.components.icon/get-node-icon-cp:branch"
-                "component suppression branch"
-                {:db-id (:db/id node-entity)
-                 :suppressed? (boolean suppressed?)
-                 :fallback-icon? (contains? #{"point-filled" "letter-p" "hash" "file"} node-icon)})
-    ;; #endregion
-    (when-not suppressed?
+                    (get-node-icon node-entity opts))]
+    (when-not (or (string/blank? node-icon) (and (contains? #{"point-filled" "letter-p" "hash" "file"} node-icon) (:not-text-or-page? opts)))
       [:div.icon-cp-container.flex.items-center
        (merge {:style {:color (or (:color node-icon) "inherit")}}
               (select-keys opts [:class]))

--- a/src/main/frontend/components/icon.cljs
+++ b/src/main/frontend/components/icon.cljs
@@ -6,6 +6,7 @@
             [camel-snake-kebab.core :as csk]
             [cljs-bean.core :as bean]
             [clojure.string :as string]
+            [electron.ipc :as ipc]
             [frontend.config :as config]
             [frontend.context.i18n :refer [t]]
             [frontend.search :as search]
@@ -23,6 +24,24 @@
             [io.factorhouse.hsx.core :as hsx]))
 
 (defonce emojis (vals (bean/->clj (gobj/get emoji-data "emojis"))))
+
+(defn- debug-icon-summary
+  [icon']
+  (if (map? icon')
+    (select-keys icon' [:type :id :color])
+    icon'))
+
+(defn- debug-log!
+  [hypothesis-id location message data]
+  (ipc/ipc "appendDebugLog"
+           "/opt/cursor/logs/debug.log"
+           (str (js/JSON.stringify
+                 (clj->js {:hypothesisId hypothesis-id
+                           :location location
+                           :message message
+                           :data data
+                           :timestamp (.now js/Date)}))
+                "\n")))
 
 (defn icon
   [icon' & [opts]]
@@ -55,32 +74,87 @@
 
 (defn get-node-icon
   [node-entity {:keys [ignore-current-icon?]
-                :or {ignore-current-icon? false}}]
-  (or (when-not ignore-current-icon?
-        (get node-entity :logseq.property/icon))
-      (let [asset-type (:logseq.property.asset/type node-entity)
-            first-tag-icon (some :logseq.property/icon (sort-by :db/id (:block/tags node-entity)))]
-        (cond
-          (entity/class? node-entity)
-          "hash"
-          (entity/property? node-entity)
-          "letter-p"
-          (entity/page? node-entity)
-          "file"
-          (= asset-type "pdf")
-          "book"
-          (some? first-tag-icon)
-          first-tag-icon
-          :else
-          "point-filled"))))
+                :or {ignore-current-icon? false}
+                :as opts}]
+  ;; #region agent log
+  (debug-log! "B" "frontend.components.icon/get-node-icon:entry"
+              "get-node-icon input"
+              {:db-id (:db/id node-entity)
+               :opts (select-keys opts [:ignore-current-icon? :not-text-or-page? :link?])
+               :tag-count (count (:block/tags node-entity))
+               :entity-keys (mapv str (keys node-entity))})
+  ;; #endregion
+  (let [own-icon (when-not ignore-current-icon?
+                   (get node-entity :logseq.property/icon))
+        asset-type (:logseq.property.asset/type node-entity)
+        sorted-tags (sort-by :db/id (:block/tags node-entity))
+        first-tag-icon (some :logseq.property/icon sorted-tags)
+        class? (boolean (entity/class? node-entity))
+        property? (boolean (entity/property? node-entity))
+        page? (boolean (entity/page? node-entity))
+        result (or own-icon
+                   (cond
+                     class?
+                     "hash"
+                     property?
+                     "letter-p"
+                     page?
+                     "file"
+                     (= asset-type "pdf")
+                     "book"
+                     (some? first-tag-icon)
+                     first-tag-icon
+                     :else
+                     "point-filled"))]
+    ;; #region agent log
+    (debug-log! "A,B,D" "frontend.components.icon/get-node-icon:candidates"
+                "icon candidates before precedence"
+                {:db-id (:db/id node-entity)
+                 :own-icon (debug-icon-summary own-icon)
+                 :asset-type asset-type
+                 :class? class?
+                 :property? property?
+                 :page? page?
+                 :tags (mapv (fn [tag]
+                               {:db-id (:db/id tag)
+                                :ident (some-> (:db/ident tag) str)
+                                :icon (debug-icon-summary (:logseq.property/icon tag))})
+                             sorted-tags)
+                 :first-tag-icon (debug-icon-summary first-tag-icon)})
+    ;; #endregion
+    ;; #region agent log
+    (debug-log! "A,D" "frontend.components.icon/get-node-icon:exit"
+                "selected node icon"
+                {:db-id (:db/id node-entity)
+                 :result (debug-icon-summary result)})
+    ;; #endregion
+    result))
 
 (defn get-node-icon-cp
   [node-entity opts]
   (let [opts' (merge {:size 14} opts)
         node-icon (if (:link? opts)
                     "arrow-narrow-right"
-                    (get-node-icon node-entity opts))]
-    (when-not (or (string/blank? node-icon) (and (contains? #{"point-filled" "letter-p" "hash" "file"} node-icon) (:not-text-or-page? opts)))
+                    (get-node-icon node-entity opts))
+        suppressed? (or (string/blank? node-icon)
+                        (and (contains? #{"point-filled" "letter-p" "hash" "file"} node-icon)
+                             (:not-text-or-page? opts)))]
+    ;; #region agent log
+    (debug-log! "C" "frontend.components.icon/get-node-icon-cp:selection"
+                "component received selected icon"
+                {:db-id (:db/id node-entity)
+                 :node-icon (debug-icon-summary node-icon)
+                 :not-text-or-page? (:not-text-or-page? opts)
+                 :link? (:link? opts)})
+    ;; #endregion
+    ;; #region agent log
+    (debug-log! "C" "frontend.components.icon/get-node-icon-cp:branch"
+                "component suppression branch"
+                {:db-id (:db/id node-entity)
+                 :suppressed? (boolean suppressed?)
+                 :fallback-icon? (contains? #{"point-filled" "letter-p" "hash" "file"} node-icon)})
+    ;; #endregion
+    (when-not suppressed?
       [:div.icon-cp-container.flex.items-center
        (merge {:style {:color (or (:color node-icon) "inherit")}}
               (select-keys opts [:class]))

--- a/src/test/frontend/components/icon_test.cljs
+++ b/src/test/frontend/components/icon_test.cljs
@@ -7,27 +7,40 @@
         tag-icon {:type :tabler-icon :id "rocket" :color "#ff0000"}
         tag {:db/id 2
              :db/ident :user.class/project
-             :logseq.property/icon tag-icon}]
+             :logseq.property/icon tag-icon}
+        page-tag {:db/id 3 :db/ident :logseq.class/Page}
+        class-tag {:db/id 4 :db/ident :logseq.class/Tag}
+        property-tag {:db/id 5 :db/ident :logseq.class/Property}
+        tagged-page {:db/id 1
+                     :block/name "tagged-page"
+                     :block/tags [tag page-tag]}]
     (testing "the node's own icon wins"
       (is (= own-icon
+             (icon/get-node-icon (assoc tagged-page :logseq.property/icon own-icon)
+                                 {}))))
+    (testing "an inherited tag icon wins over generic block and page fallbacks"
+      (is (= tag-icon
+             (icon/get-node-icon {:db/id 1 :block/tags [tag]} {})))
+      (is (= tag-icon
+             (icon/get-node-icon tagged-page {})))
+      (is (some? (icon/get-node-icon-cp tagged-page {:not-text-or-page? true}))))
+    (testing "a PDF asset icon wins over an inherited tag icon"
+      (is (= "book"
              (icon/get-node-icon {:db/id 1
                                   :block/tags [tag]
-                                  :logseq.property/icon own-icon}
+                                  :logseq.property.asset/type "pdf"}
                                  {}))))
-    (testing "an inherited tag icon is retained for ordinary blocks"
-      (is (= tag-icon
-             (icon/get-node-icon {:db/id 1 :block/tags [tag]} {}))))
     (testing "page, class, and property fallbacks stay deterministic"
       (is (= "file"
              (icon/get-node-icon {:db/id 1
                                   :block/name "page"
-                                  :block/tags [{:db/ident :logseq.class/Page}]}
+                                  :block/tags [page-tag]}
                                  {})))
       (is (= "hash"
              (icon/get-node-icon {:db/id 1
-                                  :block/tags [{:db/ident :logseq.class/Tag}]}
+                                  :block/tags [tag class-tag]}
                                  {})))
       (is (= "letter-p"
              (icon/get-node-icon {:db/id 1
-                                  :block/tags [{:db/ident :logseq.class/Property}]}
+                                  :block/tags [tag property-tag]}
                                  {}))))))


### PR DESCRIPTION
Fixes https://github.com/logseq/db-test/issues/1082

## Summary

- resolve inherited tag icons before the generic page fallback
- preserve explicit icons, class and property fallbacks, and PDF asset icons
- add focused coverage for page-reference rendering and icon precedence

## Verification

- `bb dev:test -v frontend.components.icon-test/node-icon-precedence-matches-sidebar-and-command-results-test`
- `bb dev:lint-and-test`

