### PR TITLE
fix: show graph exclusion property on tags

### DIFF
--- a/deps/db/src/logseq/db/frontend/property.cljs
+++ b/deps/db/src/logseq/db/frontend/property.cljs
@@ -425,7 +425,6 @@
      :logseq.property/exclude-from-graph-view {:title "Excluded from Graph view?"
                                                :schema
                                                {:type :checkbox
-                                                :hide? true
                                                 :view-context :page
                                                 :public? true}}
 

--- a/deps/db/src/logseq/db/frontend/schema.cljs
+++ b/deps/db/src/logseq/db/frontend/schema.cljs
@@ -30,7 +30,7 @@
          (map (juxt :major :minor)
               [(parse-schema-version x) (parse-schema-version y)])))
 
-(def version (parse-schema-version "65.33"))
+(def version (parse-schema-version "65.34"))
 
 (defn major-version
   "Return a number.

--- a/src/main/frontend/worker/db/migrate.cljs
+++ b/src/main/frontend/worker/db/migrate.cljs
@@ -120,6 +120,12 @@
              [[:db/retract (:db/id class) :block/order (:block/order class)]]))))
       [:logseq.class/Comments :logseq.class/Comment]))))
 
+(defn- show-exclude-from-graph-view-property
+  [db]
+  (when-let [property (d/entity db :logseq.property/exclude-from-graph-view)]
+    (when (:logseq.property/hide? property)
+      [[:db/retract (:db/id property) :logseq.property/hide?]])))
+
 (def schema-version->updates
   "A vec of tuples defining datascript migrations. Each tuple consists of the
    schema version integer and a migration map. A migration map can have keys of :properties, :classes
@@ -162,7 +168,8 @@
                           :logseq.property.view/gallery-display-properties
                           :logseq.property.view/gallery-card-size
                           :logseq.property.view/gallery-card-width
-                          :logseq.property.view/gallery-card-height]}]])
+                          :logseq.property.view/gallery-card-height]}]
+   ["65.34" {:fix show-exclude-from-graph-view-property}]])
 
 (let [[major minor] (last (sort (map (comp (juxt :major :minor) db-schema/parse-schema-version first)
                                      schema-version->updates)))]

--- a/src/test/frontend/worker/handler/property_test.cljs
+++ b/src/test/frontend/worker/handler/property_test.cljs
@@ -63,6 +63,23 @@
       (is (contains? full-ids :user.property/author))
       (is (not (contains? hidden-ids :user.property/author))))))
 
+(deftest display-properties-shows-graph-exclusion-on-tags
+  (let [conn (d/create-conn db-schema/schema)
+        tag-uuid #uuid "22222222-2222-2222-2222-222222222222"]
+    (d/transact! conn (sqlite-create-graph/build-db-initial-data "{}"))
+    (d/transact! conn [{:db/ident :user.class/Topic
+                        :block/title "Topic"
+                        :block/name "topic"
+                        :block/uuid tag-uuid
+                        :block/tags :logseq.class/Tag
+                        :logseq.property/exclude-from-graph-view true}])
+    (let [tag (d/entity @conn [:block/uuid tag-uuid])
+          result (worker-property/display-properties @conn tag {:page-title? true} false)
+          full-ids (set (map :property-id (:full-properties result)))
+          hidden-ids (set (map :property-id (:hidden-properties result)))]
+      (is (contains? full-ids :logseq.property/exclude-from-graph-view))
+      (is (not (contains? hidden-ids :logseq.property/exclude-from-graph-view))))))
+
 (deftest display-property-map-reflects-default-value-entity-updates
   (let [conn (d/create-conn db-schema/schema)]
     (d/transact! conn (sqlite-create-graph/build-db-initial-data "{}"))

--- a/src/test/frontend/worker/migrate_test.cljs
+++ b/src/test/frontend/worker/migrate_test.cljs
@@ -405,3 +405,21 @@
     (is (every? #(= :raw-number (:logseq.property/type (d/entity @conn %)))
                 [:logseq.property.view/gallery-card-width
                  :logseq.property.view/gallery-card-height]))))
+
+(deftest migrate-65-34-shows-exclude-from-graph-view-property
+  (let [conn (d/create-conn db-schema/schema)]
+    (d/transact! conn (sqlite-create-graph/build-db-initial-data ""))
+    (d/transact! conn [{:db/ident :logseq.kv/schema-version
+                        :kv/value {:major 65 :minor 33}}
+                       {:db/ident :logseq.property/exclude-from-graph-view
+                        :logseq.property/hide? true}])
+
+    (is (true? (:logseq.property/hide?
+                (d/entity @conn :logseq.property/exclude-from-graph-view))))
+
+    (db-migrate/migrate conn :target-version {:major 65 :minor 34})
+
+    (is (= {:major 65 :minor 34}
+           (:kv/value (d/entity @conn :logseq.kv/schema-version))))
+    (is (nil? (:logseq.property/hide?
+               (d/entity @conn :logseq.property/exclude-from-graph-view))))))


### PR DESCRIPTION
Fixes https://github.com/logseq/db-test/issues/1084

## Summary

- show `Excluded from Graph view?` on Tag pages
- retain its page-only view context so it does not appear on ordinary blocks
- migrate existing graphs to the corrected built-in property definition
- add focused rendering and migration coverage

## Verification

- `bb dev:test -v frontend.worker.handler.property-test/display-properties-shows-graph-exclusion-on-tags`
- `bb dev:test -v frontend.worker.migrate-test/migrate-65-34-shows-exclude-from-graph-view-property`
- `bb dev:test -v frontend.worker.graph-view-test/global-all-pages-graph-keeps-links-within-rendered-nodes`

