### PR TITLE
fix(worker): allow a missing :block/order on a direct child

### DIFF
--- a/src/main/frontend/worker/handler/block.cljs
+++ b/src/main/frontend/worker/handler/block.cljs
@@ -215,7 +215,11 @@
                      (fail-render-read! "Invalid direct-child UUID"
                                         {:parent-uuid parent-uuid
                                          :block-uuid child-uuid}))
-                   (when-not (string? order)
+                   ;; :block/order is {:optional true} for pages in
+                   ;; normal-page, so a parented page may legitimately have
+                   ;; none. Sort those first, matching ldb/sort-by-order,
+                   ;; rather than failing the whole membership read.
+                   (when-not (or (nil? order) (string? order))
                      (fail-render-read! "Invalid direct-child order"
                                         {:parent-uuid parent-uuid
                                          :block-uuid child-uuid

--- a/src/test/frontend/worker/handler/block_test.cljs
+++ b/src/test/frontend/worker/handler/block_test.cljs
@@ -546,6 +546,65 @@
       (is (thrown? js/Error
                    (direct-children-membership @conn page-uuid))))))
 
+(deftest direct-children-membership-allows-missing-child-order-test
+  (when-let [direct-children-membership
+             (direct-children-membership-api)]
+    (let [conn (db-test/create-conn)
+          page-uuid (random-uuid)
+          ordered-uuid (random-uuid)
+          orderless-uuid (random-uuid)]
+      ;; :block/order is {:optional true} for pages in normal-page, so a
+      ;; parented page may legitimately carry none. It must not fail the
+      ;; whole membership read for its siblings.
+      (d/transact! conn
+                   [{:db/id -1
+                     :block/uuid page-uuid
+                     :block/tx-id 11
+                     :block/title "Parent"
+                     :block/name "parent"
+                     :block/tags :logseq.class/Page}
+                    {:block/uuid ordered-uuid
+                     :block/tx-id 11
+                     :block/title "Ordered child"
+                     :block/page -1
+                     :block/parent -1
+                     :block/order "a0"}
+                    {:db/id -2
+                     :block/uuid orderless-uuid
+                     :block/tx-id 11
+                     :block/title "Child page without order"
+                     :block/name "child page without order"
+                     :block/tags :logseq.class/Page
+                     :block/parent -1}])
+      (let [response (direct-children-membership @conn page-uuid)]
+        (is (= 2 (count (:items response)))
+            "the order-less child does not remove its siblings")
+        (is (= [[orderless-uuid nil] [ordered-uuid "a0"]]
+               (:items response))
+            "a nil order sorts first, matching ldb/sort-by-order")))))
+
+(deftest direct-children-membership-rejects-non-string-child-order-test
+  (when-let [direct-children-membership
+             (direct-children-membership-api)]
+    (let [conn (db-test/create-conn)
+          page-uuid (random-uuid)]
+      ;; Absent is legal; a non-string value is still a real defect.
+      (d/transact! conn
+                   [{:db/id -1
+                     :block/uuid page-uuid
+                     :block/tx-id 11
+                     :block/title "Parent"
+                     :block/name "parent"
+                     :block/tags :logseq.class/Page}
+                    {:block/uuid (random-uuid)
+                     :block/tx-id 11
+                     :block/title "Child"
+                     :block/page -1
+                     :block/parent -1
+                     :block/order 42}])
+      (is (thrown? js/Error
+                   (direct-children-membership @conn page-uuid))))))
+
 (deftest canonical-block-snapshots-are-transit-safe-pure-results-test
   (let [canonical-blocks (canonical-blocks-api)
         direct-children-membership (direct-children-membership-api)


### PR DESCRIPTION
### Why this is a PR and not an issue

Filing it as a patch because a patch is the most specific statement of the
problem I can make — it names the exact line, the exact value, and what I think
should happen instead, with tests that pin both halves.

**Please close it without ceremony if it isn't useful.** I'm not looking to
defend this. If the guard is deliberate, if this area is mid-rewrite, or if you'd
rather solve it a different way, throwing it away costs me nothing and the
report below still stands on its own. I'd rather hand you something concrete and
disposable than something vague you have to interrogate.

---

## What happens

Opening a page whose open subtree contains a direct child with no `:block/order`
fails the whole page:

```
POST http://127.0.0.1:PORT/v1/invoke  500 (Internal Server Error)
Error: Invalid direct-child order
```

The throw is in `direct-children-membership`
(`src/main/frontend/worker/handler/block.cljs:219`), reaches the renderer as a
500 from the worker, and is caught by the React ErrorBoundary — so the user gets
"Something went wrong" and the app is unusable until relaunch.

Because `open-block-tree` calls `direct-children-membership` recursively, the
page that fails can be far above the block that causes it. On the graph where I
hit this, one page four levels down made the top-level **Library** page
impossible to open.

## Why I think the rejected value is legal

`:block/order` is `{:optional true}` for pages:

```clojure
;; deps/db/src/logseq/db/frontend/malli_schema.cljs
(def normal-page
  (vec (concat
    [:map {:error/path ["normal-page"]}
     [:block/journal-day {:optional true} :int]
     [:block/parent      {:optional true} :int]
     [:block/order       {:optional true} block-order]]   ; :308
    page-attrs page-or-block-attrs)))

(def block-attrs                                          ; :406
  [[:block/title  :string]
   [:block/parent :int]
   [:block/order  block-order]                            ; required — normal blocks
   …])
```

It is required for *normal blocks* and optional for *pages*. The block in
question is a page (`:block/name`, tagged `:logseq.class/Page`) nested under
another page, which this graph does for its own hierarchy.

Corroborating that reading:

- `logseq graph validate` scoped to the page returns
  `{:pages_scanned 1, :blocks_scanned 4, :findings []}`.
- The pre-worker-refactor build (rev `9a11243`) renders the same graph fine.
  Only the post-refactor build (rev `71db2e3`) fails.
- The page's attribute set is otherwise identical to a sibling page that renders
  — same tags, same parent, same shape. The order is the only difference.

## Why the guard doesn't seem load-bearing

The very next expression is `(sort-by second)`, and `cljs.core/compare` already
orders `nil` ahead of any string. That is exactly what `ldb/sort-by-order` — a
bare `(sort-by :block/order blocks)` — relies on everywhere else in the tree.
So the surrounding code already tolerates what this guard rejects.

The patch accepts `nil` and lets it sort first, while still rejecting a
non-string value, which would be a real defect:

```clojure
(when-not (or (nil? order) (string? order))
  (fail-render-read! "Invalid direct-child order" …))
```

## Tests

- `direct-children-membership-allows-missing-child-order-test` — an order-less
  child no longer removes its siblings from the result, and sorts first.
- `direct-children-membership-rejects-non-string-child-order-test` — a numeric
  order still throws.

Verified against `master` by reverting the one-line source change and rerunning
the namespace: the first test errors with the same message seen in the wild,

```
ERROR in (direct-children-membership-allows-missing-child-order-test)
#error {:message "Invalid direct-child order", :block-order nil}
  at frontend/worker/handler/block.cljs:218
```

and passes with it. Full namespace: 16 tests, 100 assertions, 0 failures.

No regressions across every `frontend.worker.*` and `frontend.db.*` namespace —
1071 tests, 4989 assertions, 0 failures, 0 errors.

## Deliberately not in this PR

Three things I noticed but didn't touch, because they're design calls that are
yours to make:

1. **Whether these guards should throw at all.** There are ten `fail-render-read!`
   sites in this file. Failing an entire page's read because one child is odd is
   a large blast radius for a render path; skipping the child and rendering the
   rest is the other obvious design. I only changed the predicate.
2. **Whether the UI should name the failing block.** The `ex-info` already carries
   `:parent-uuid`, `:block-uuid` and `:block-order`, and none of it reaches the
   user. "Invalid direct-child order" alone is hard to act on.
3. **Whether there should be a repair path.** On the affected build I could not
   fix the block from anywhere: the UI can't render the page that holds it,
   `logseq upsert block` refuses page sources with `invalid-source: source must
   be a non-page block`, and `logseq.Editor.moveBlock` silently no-ops on a page
   (returns `null`, changes nothing, raises nothing — the same call on a normal
   block works). I repaired it by dragging the page in an older build. That
   silent `moveBlock` no-op may be worth its own issue; say the word and I'll
   open one.

## What I could not determine

What wrote a page with no `:block/order` in the first place. It was created
2026-08-02; the graph's `client-ops` log only begins 2026-08-07, so it can't be
inspected. Every ordinary write path I can test on the current build assigns an
order correctly — creating a page under a parent, and even recycling one. So I
can't tell you whether there's an upstream write bug here or a one-off from an
older build. If that origin matters more to you than the read-path behaviour,
I'm happy to dig further.

## Environment

Logseq DB graph, desktop macOS arm64, app 2.0.1, build rev `71db2e3`.
Not reproducible on rev `9a11243`. Present on `master` at `047acf36ee`.
