### PR TITLE
Fix table sort priority when selecting an existing column

### DIFF
--- a/deps/shui/src/logseq/shui/table/core.cljc
+++ b/deps/shui/src/logseq/shui/table/core.cljc
@@ -80,13 +80,10 @@
 (defn- column-set-sorting!
   [column set-sorting! sorting asc?]
   (let [id (:id column)
-        existing-column (some (fn [item] (when (= (:id item) id) item)) sorting)
-        value (->> (if existing-column
-                     (if (nil? asc?)
-                       (remove (fn [item] (= (:id item) id)) sorting)
-                       (map (fn [item] (if (= (:id item) id) (assoc item :asc? asc?) item)) sorting))
-                     (when-not (nil? asc?)
-                       (into [{:id id :asc? asc?}] sorting)))
+        without-column (remove (fn [item] (= (:id item) id)) sorting)
+        value (->> (if (nil? asc?)
+                     without-column
+                     (into [{:id id :asc? asc?}] without-column))
                    (remove nil?)
                    vec)]
     (set-sorting! value)

--- a/src/test/logseq/shui/table/core_test.cljs
+++ b/src/test/logseq/shui/table/core_test.cljs
@@ -1,0 +1,28 @@
+(ns logseq.shui.table.core-test
+  (:require [cljs.test :refer [deftest is]]
+            [logseq.shui.table.core :as table]))
+
+(deftest selecting-an-existing-sort-promotes-it-test
+  (let [sorting [{:id :block/title :asc? true}
+                 {:id :block/updated-at :asc? false}]
+        persisted-sorting (atom nil)
+        table-option (table/table-option
+                      {:data []
+                       :columns [{:id :block/title}
+                                 {:id :block/updated-at}]
+                       :state {:sorting sorting
+                               :row-selection {}
+                               :visible-columns {}}
+                       :data-fns {:set-sorting! #(reset! persisted-sorting %)
+                                  :set-visible-columns! (fn [_])
+                                  :set-row-selection! (fn [_])}})
+        result ((:column-set-sorting! table-option)
+                sorting
+                {:id :block/updated-at}
+                true)
+        expected [{:id :block/updated-at :asc? true}
+                  {:id :block/title :asc? true}]]
+    (is (= expected result))
+    (is (= expected @persisted-sorting))
+    (is (= [:block/updated-at :block/title]
+           (mapv :id result)))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/logseq/db-test/issues/1100

## Summary
- promote the most recently selected table column to the primary sort
- preserve remaining sort criteria as secondary sorts
- add a focused regression test for selecting an existing secondary sort
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-485cf638-a795-4d4f-b1d4-2dd7bbb93644?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-485cf638-a795-4d4f-b1d4-2dd7bbb93644&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

