### PR TITLE
Fix built-in page reference autocomplete

### DIFF
--- a/src/main/frontend/components/editor.cljs
+++ b/src/main/frontend/components/editor.cljs
@@ -211,6 +211,7 @@
                                 :friendly-title (t :page.convert/page-to-tag-action q)} classes)
                          classes))
                              (editor-handler/<get-matched-blocks q {:nlp-pages? true
+                                                                    :built-in? true
                                                                     :page-only? false}))]
       (set-exact-page! block)
       (set-matched-pages! result))))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -1981,10 +1981,10 @@
         (search/fuzzy-search classes q {:extract-fn :block/title})))))
 
 (defn <get-matched-blocks
-  "Return matched blocks that are not built-in"
-  [q & [{:keys [nlp-pages? page-only?]}]]
+  "Return matched blocks, optionally including public built-ins"
+  [q & [{:keys [nlp-pages? page-only? built-in?]}]]
   (p/let [block (state/get-edit-block)
-          result (search/block-search (state/get-current-repo) q {:built-in? false
+          result (search/block-search (state/get-current-repo) q {:built-in? (boolean built-in?)
                                                                   :limit 20
                                                                   :search-limit 100
                                                                   :enable-snippet? false

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -18,6 +18,7 @@
             [frontend.handler.route :as route-handler]
             [frontend.mobile.util :as mobile-util]
             [frontend.modules.outliner.op :as frontend-outliner-op]
+            [frontend.search :as search]
             [frontend.state :as state]
             [frontend.test.helper :as test-helper]
             [frontend.util :as util]
@@ -1048,6 +1049,36 @@
                        (set! db-async/<get-all-classes original-<get-all-classes)
                        (state/set-state! :editor/block nil)
                        (done)))))))
+
+(deftest page-search-includes-public-built-ins
+  (async done
+    (let [matched-pages (atom nil)
+          search-options (atom nil)
+          task {:db/id 1
+                :block/uuid #uuid "11111111-1111-1111-1111-111111111111"
+                :block/title "Task"
+                :logseq.property/built-in? true}
+          original-<get-block db-async/<get-block
+          original-block-search search/block-search]
+      (set! db-async/<get-block (fn [& _args] (p/resolved nil)))
+      (set! search/block-search
+            (fn [_repo _query options]
+              (reset! search-options options)
+              (p/resolved [task])))
+      (-> (#'editor-component/search-pages "Ta" false #(reset! matched-pages %) (fn [_]))
+          (p/then
+           (fn []
+             (is (true? (:built-in? @search-options))
+                 "Page reference search should request the same public built-ins as Cmd+K")
+             (is (= ["Task"] (mapv :block/title @matched-pages)))))
+          (p/catch
+           (fn [error]
+             (is false (str error))))
+          (p/finally
+           (fn []
+             (set! db-async/<get-block original-<get-block)
+             (set! search/block-search original-block-search)
+             (done)))))))
 
 (deftest tag-search-does-not-convert-class-aliases
   (async done

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -1070,7 +1070,7 @@
            (fn []
              (is (true? (:built-in? @search-options))
                  "Page reference search should request the same public built-ins as Cmd+K")
-             (is (= ["Task"] (mapv :block/title @matched-pages)))))
+             (is (some #(= "Task" (:block/title %)) @matched-pages))))
           (p/catch
            (fn [error]
              (is false (str error))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- include public built-in pages, tags, and properties in `[[` autocomplete
- retain the existing private built-in filtering used by Cmd+K
- keep block-reference autocomplete unchanged
- add focused coverage for the page-search option flow

## Testing
- `bb dev:test -v frontend.handler.editor-test/page-search-includes-public-built-ins`
- `clojure -M:clj-kondo --lint src/main/frontend/components/editor.cljs src/main/frontend/handler/editor.cljs src/test/frontend/handler/editor_test.cljs --cache false`
- live `:app` renderer probe: `Ta` includes `Task`, `Sta` includes `Status`, and private `Property type` remains excluded

Fixes https://github.com/logseq/db-test/issues/1091
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7e6ff23-d26e-4eae-b05c-e2851196d111?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7e6ff23-d26e-4eae-b05c-e2851196d111&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

