### PR TITLE
fix: prevent Enter from splitting page titles

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2592,6 +2592,8 @@
   [el]
   (some? (dom/closest el ".block-editor")))
 
+(declare escape-editing)
+
 (defn keydown-new-block-handler [^js e]
   (let [target (when e (.-target e))
         state (cond-> (get-state)
@@ -2603,11 +2605,21 @@
               (inside-of-editor-block target))
       (if (pending-new-block?)
         (when e (.preventDefault e))
-        (if (or (state/doc-mode-enter-for-new-line?) (inside-of-single-block (:node state)))
-          (keydown-new-line)
-          (do
-            (when e (.preventDefault e))
-            (keydown-new-block state)))))))
+        (let [new-line? (or (state/doc-mode-enter-for-new-line?)
+                            (inside-of-single-block (:node state)))]
+          (cond
+            (get-in state [:config :page-title?])
+            (do
+              (when e (.preventDefault e))
+              (escape-editing))
+
+            new-line?
+            (keydown-new-line)
+
+            :else
+            (do
+              (when e (.preventDefault e))
+              (keydown-new-block state))))))))
 
 (defn keydown-new-line-handler [e]
   (let [state (get-state)]

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -179,6 +179,32 @@
              @captured-state)
           "Enter must use the textarea that received the keydown event."))))
 
+(deftest enter-on-page-title-saves-and-exits-instead-of-splitting-test
+  (let [target #js {:value "Alpha Beta Gamma"
+                    :selectionStart 5}
+        calls (atom [])
+        event #js {:target target
+                   :preventDefault (fn []
+                                     (swap! calls conj :prevent-default))}]
+    (with-redefs [editor/get-state (constantly {:block {:db/id 1
+                                                        :block/uuid #uuid "11111111-1111-1111-1111-111111111111"
+                                                        :block/title "Alpha Beta Gamma"}
+                                                :config {:page-title? true}
+                                                :node target
+                                                :value "Alpha Beta Gamma"
+                                                :pos 5})
+                  editor/inside-of-editor-block (constantly true)
+                  editor/pending-new-block? (constantly false)
+                  state/doc-mode-enter-for-new-line? (constantly false)
+                  editor/inside-of-single-block (constantly false)
+                  editor/escape-editing (fn [& _args]
+                                          (swap! calls conj :escape-editing))
+                  editor/keydown-new-block (fn [_state]
+                                             (swap! calls conj :new-block))]
+      (editor/keydown-new-block-handler event)
+      (is (= [:prevent-default :escape-editing] @calls)
+          "Enter on a page title must save and exit without splitting the page entity."))))
+
 (deftest keydown-new-block-keeps-the-keydown-editor-state-test
   (let [block {:db/id 1
                :block/uuid #uuid "11111111-1111-1111-1111-111111111111"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- save and exit page-title editing when Enter is pressed
- prevent trailing title text from becoming a new child block
- add focused editor coverage for the page-title Enter path

## Testing
- `bb dev:test -v frontend.handler.editor-test/enter-on-page-title-saves-and-exits-instead-of-splitting-test`
- `pnpm cljs:run-test -v frontend.handler.editor-test` (78 tests, 208 assertions)
- `bb dev:lint-and-test`
- manually verified in the renderer that Enter after “Alpha” preserves “Alpha Beta Gamma Fixed”, exits editing, and creates no trailing-text block

[page_title_enter_fix_clean_demo.mp4](https://cursor.com/agents/bc-fefd425a-395c-47d6-9459-4dd9216c9d17/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpage_title_enter_fix_clean_demo.mp4)

Fixes https://github.com/logseq/db-test/issues/1095

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fefd425a-395c-47d6-9459-4dd9216c9d17?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fefd425a-395c-47d6-9459-4dd9216c9d17&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

