### PR TITLE
fix: avoid restoring stale editor title on backspace

### DIFF
--- a/clj-e2e/test/logseq/e2e/outliner_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/outliner_basic_test.clj
@@ -315,6 +315,17 @@
         (util/wait-timeout 500)
         (is (= immediate (editor-state)))))))
 
+(deftest held-backspace-does-not-duplicate-merged-content-test
+  (testing "Repeated Backspace cannot merge the same block twice"
+    (p/new-page "held backspace merge")
+    (b/new-blocks ["Foo" "" "Foo" "" "Foo" ""])
+    (util/repeat-keyboard 75 "Backspace")
+    (util/wait-timeout 500)
+    (let [editor-content (util/get-edit-content)
+          block-contents (util/get-page-blocks-contents)]
+      (is (not= "FooFoo" editor-content))
+      (is (not-any? #{"FooFoo"} block-contents)))))
+
 (deftest rapid-retype-before-enter-keeps-the-edit-test
   (testing "Backspace, retype, and Enter keep the retyped content"
     (b/open-last-block)

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -993,8 +993,10 @@
                      (block-handler/outliner-tx-meta prev-block))
               :editor/edit-block-fn
               (fn [_rows]
-                (edit-block! current-block 0 {:save-code-editor? false
-                                              :skip-load? true})))
+                (edit-block! (current-block-with-title current-block new-content)
+                             0
+                             {:save-code-editor? false
+                              :skip-load? true})))
        (when-not (= (block-parent-id block) (block-parent-id prev-block))
          (outliner-op/move-blocks! [block] prev-block {:sibling? true}))
        (delete-block-aux! prev-block))

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -1427,6 +1427,39 @@
                         "Delete must use the editor state captured by its keydown.")))
           (p/finally done)))))
 
+(deftest repeated-backspace-does-not-restore-erased-current-title-test
+  (let [current {:db/id 2
+                 :block/uuid #uuid "22222222-2222-2222-2222-222222222222"
+                 :block/title "Foo"
+                 :block/raw-title "Foo"
+                 :block/parent {:db/id 10}}
+        previous {:db/id 1
+                  :block/uuid #uuid "11111111-1111-1111-1111-111111111111"
+                  :block/title ""
+                  :block/parent {:db/id 20}}
+        tx-meta (atom nil)
+        edited (atom nil)]
+    (with-redefs [db-transact/apply-outliner-ops (fn [_ _ opts]
+                                                    (reset! tx-meta opts))
+                  frontend-outliner-op/move-blocks! (fn [& _] :move)
+                  editor/delete-block-aux! (fn [& _] :delete)
+                  editor/edit-block! (fn [block pos opts]
+                                       (reset! edited [block pos opts]))]
+      (#'editor/delete-block-with-previous!
+       {:block current
+        :current-block current
+        :prev-block previous
+        :new-content ""
+        :input-empty? true
+        :delete-concat? false})
+      ((:editor/edit-block-fn @tx-meta) [])
+      (is (= [(assoc current :block/title "" :block/raw-title "")
+              0
+              {:save-code-editor? false
+               :skip-load? true}]
+             @edited)
+          "Deleting an empty predecessor must not restore the erased mounted title."))))
+
 (deftest insert-block-saves-current-block-before-switching-editor-test
   (let [current-id #uuid "11111111-1111-1111-1111-111111111111"
         next-id #uuid "22222222-2222-2222-2222-222222222222"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/logseq/db-test/issues/1093

When deleting an empty predecessor, refocus the current block with the content captured by the Backspace operation instead of its stale mounted title. This prevents repeated Backspace operations from restoring and concatenating text twice.

Tests:
- focused editor callback regression test
- clj-e2e repeated Backspace regression test
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4251c366-c4f4-47ad-b453-30e984bbea48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4251c366-c4f4-47ad-b453-30e984bbea48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

