### PR TITLE
test: cover shift-selected page deletion

### DIFF
--- a/src/test/frontend/components/views_test.cljs
+++ b/src/test/frontend/components/views_test.cljs
@@ -6,8 +6,11 @@
             [datascript.impl.entity :as de]
             [frontend.components.property.value :as property-value]
             [frontend.components.views :as views]
+            [frontend.db.async :as db-async]
             [frontend.db.hooks :as db-hooks]
             [frontend.db.subs :as subs]
+            [frontend.db.transact :as db-transact]
+            [frontend.state :as state]
             [frontend.util :as util]
             [goog.object :as gobj]
             [promesa.core :as p]))
@@ -137,6 +140,40 @@
   (is (= :view/all
          (#'views/default-view-title-key :all-pages)))
   (is (nil? (#'views/default-view-title-key :query-result))))
+
+(deftest all-pages-delete-hydrates-entire-selected-id-range-test
+  (async done
+         (let [repo "test-repo"
+               selected-ids (mapv (fn [_] (random-uuid)) (range 5))
+               pages (mapv (fn [idx block-uuid]
+                             {:db/id (inc idx)
+                              :block/uuid block-uuid
+                              :block/title (str "Page " (inc idx))
+                              :block/tags [{:db/ident :logseq.class/Page}]})
+                           (range)
+                           selected-ids)
+               fetch-call (atom nil)
+               published-event (atom nil)
+               cleared-selection (atom nil)
+               table {:data-fns {:set-row-selection! #(reset! cleared-selection %)}}]
+           (finish-async!
+            done
+            (p/with-redefs [state/get-current-repo (constantly repo)
+                            db-async/<get-blocks
+                            (fn [actual-repo actual-ids opts]
+                              (reset! fetch-call [actual-repo (vec actual-ids) opts])
+                              (p/resolved (mapv (fn [page] {:block page}) pages)))
+                            state/pub-event! #(reset! published-event %)
+                            db-transact/apply-outliner-ops (fn [& _] (p/resolved nil))]
+              (p/let [_ (#'views/on-delete-rows nil :all-pages table selected-ids)
+                      [event dialog-pages clear-selection!] @published-event]
+                (is (= [repo selected-ids {:children? false}] @fetch-call))
+                (is (= :page/show-delete-dialog event))
+                (is (= pages (vec dialog-pages)))
+                (is (= ["Page 1" "Page 2" "Page 3" "Page 4" "Page 5"]
+                       (mapv :block/title dialog-pages)))
+                (clear-selection!)
+                (is (= {} @cleared-selection))))))))
 
 (deftest built-in-many-properties-use-datascript-cardinality
   (is (= :db.cardinality/many


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Product fix

The range-selection product fix already landed in https://github.com/logseq/logseq/pull/12892 via https://github.com/logseq/logseq/commit/bc7783b32de3ef6278198b17c2f9ff84e264c10d.

That commit updated `table-row-id` to prefer `:block/uuid` and used the normalized row ID for the table and gallery anchor/range lookups. This matches the UUID-backed table `:data` introduced by the worker-backed UI refactor. Current master was manually verified by Shift-clicking five contiguous pages: all five became selected, appeared in the confirmation dialog, and were deleted.

## This PR

This PR is regression coverage only; it is not presented as the product fix. It verifies that deleting a selected page range bulk-hydrates every selected ID before opening the confirmation dialog, passes all page titles to the dialog, and clears selection on completion.

## Testing

- `bb dev:test -v frontend.components.views-test/all-pages-delete-hydrates-entire-selected-id-range-test`
- `bb dev:lint-and-test`
- manually selected five contiguous pages with Shift-click, confirmed all five appeared in the dialog, and deleted all five

[shift_select_delete_full_page_range.mp4](https://cursor.com/agents/bc-6fd5086b-fb93-4c67-97d8-6bacdc8552ee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshift_select_delete_full_page_range.mp4)

Related: https://github.com/logseq/db-test/issues/1096

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fd5086b-fb93-4c67-97d8-6bacdc8552ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fd5086b-fb93-4c67-97d8-6bacdc8552ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

