### PR TITLE
fix: keep first empty journal block focused

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3142,7 +3142,9 @@
           (let [top-block? (= (:db/id left-or-parent) (block-page-id block))
                 single-block? (if e (inside-of-single-block (.-target e)) false)
                 root-block? (= (:block.temp/container block) (str (:block/uuid block)))]
-            (when (and (not (and top-block? (not (string/blank? value))))
+            (when (and (not (and top-block?
+                                 (or (entity/journal? left-or-parent)
+                                     (not (string/blank? value)))))
                        (not (editor-block-preserved-on-empty-title-merge? block))
                        (not root-block?)
                        (not single-block?)

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -1236,7 +1236,7 @@
                                                    :cursor-pos 8}))))
 
 (defn- delete-block-at-zero-pos-result
-  [block]
+  [block & {:keys [left-sibling]}]
   (let [deleted? (atom false)
         stopped? (atom false)
         input #js {:value ""}
@@ -1259,7 +1259,7 @@
     (set! util/stop (fn [_] (reset! stopped? true)))
     (set! state/get-current-repo (constantly test-helper/test-db))
     (set! state/get-edit-block (constantly block))
-    (set! db-async/<get-block-sibling (fn [& _] (p/resolved nil)))
+    (set! db-async/<get-block-sibling (fn [& _] (p/resolved left-sibling)))
     (set! editor/get-state (constantly {:config {}}))
     (set! editor/delete-block-inner! (fn [_ _] (reset! deleted? true)))
     (set! util/get-prev-block-non-collapsed-non-embed (constantly nil))
@@ -1300,6 +1300,32 @@
                          :block/page {:db/id 10}})]
           (is (= {:deleted? true :stopped? true} result)))
         (p/finally done))))
+
+(deftest first-empty-journal-block-backspace-does-not-edit-the-journal-title-test
+  (async done
+    (let [journal {:db/id 10
+                   :block/uuid #uuid "00000000-0000-0000-0000-000000000010"
+                   :block/name "aug 20th, 2026"
+                   :block/title "Aug 20th, 2026"
+                   :block/tags [{:db/ident :logseq.class/Journal}]}
+          previous {:db/id 1
+                    :block/uuid #uuid "11111111-1111-1111-1111-111111111111"
+                    :block/title "previous"
+                    :block/parent journal
+                    :block/page journal}
+          empty-block {:db/id 2
+                       :block/uuid #uuid "22222222-2222-2222-2222-222222222222"
+                       :block/title ""
+                       :block/parent journal
+                       :block/page journal}]
+      (-> (p/let [first-result (delete-block-at-zero-pos-result empty-block)
+                  later-result (delete-block-at-zero-pos-result
+                                empty-block :left-sibling previous)]
+            (is (= {:deleted? false :stopped? true} first-result)
+                "Backspace must not move editing from the first empty block to a journal title.")
+            (is (= {:deleted? true :stopped? true} later-result)
+                "Backspace must preserve normal joins when a journal block has a previous block."))
+          (p/finally done)))))
 
 (deftest delete-block-when-zero-pos-keeps-the-keydown-editor-state-test
   (async done


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Prevent Backspace in the first empty block of a journal page from deleting the block and moving the editor into the journal title. Normal Backspace joins for later journal blocks remain unchanged.

## Tests

- Focused editor regression test
- Editor handler test namespace
- Renderer runtime verification pending

Fixes https://github.com/logseq/db-test/issues/1094
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2be15790-b706-4a53-a95f-8cef134b1ffc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2be15790-b706-4a53-a95f-8cef134b1ffc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

