### PR TITLE
fix(editor): resolve embed placeholder from DOM and await cut before clearing selection

### DIFF
--- a/src/main/frontend/handler/block.cljs
+++ b/src/main/frontend/handler/block.cljs
@@ -123,14 +123,22 @@
                                          block)
                                 pos opts)))))))
 
-(defn- get-original-block-by-dom
+(defn- node-original-block
+  "Read the original (linking) block off a rendered `ls-block` node.
+  A block rendered through :block/link carries the linked block's uuid as
+  `blockid` and the linking block's own uuid as `originalblockid`."
   [node]
   (when-let [id (some-> node
-                        (.-parentNode)
-                        (util/rec-get-node "ls-block")
                         (dom/attr "originalblockid")
                         uuid)]
     {:block/uuid id}))
+
+(defn- get-original-block-by-dom
+  [node]
+  (some-> node
+          (.-parentNode)
+          (util/rec-get-node "ls-block")
+          node-original-block))
 
 (defn- get-original-block
   "Get the original block from the current editing block or selected blocks"
@@ -147,7 +155,7 @@
          (remove nil?)
          (keep #(when-let [id (dom/attr % "blockid")]
                   (when (= (uuid id) (:block/uuid linked-block))
-                    (:original-block linked-block))))
+                    (node-original-block %))))
          ;; FIXME: what if there're multiple same blocks in the selection
          first)))
 

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3599,8 +3599,8 @@
 (defn- cut-blocks-and-clear-selections!
   [copy?]
   (when-not (:active? (state/get-state :ui/find-in-page))
-    (cut-selection-blocks copy?)
-    (clear-selection!)))
+    (p/do! (cut-selection-blocks copy?)
+           (clear-selection!))))
 
 (defn shortcut-copy-selection
   [e]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3583,8 +3583,8 @@
 (defn- cut-blocks-and-clear-selections!
   [copy?]
   (when-not (:active? (state/get-state :ui/find-in-page))
-    (cut-selection-blocks copy?)
-    (clear-selection!)))
+    (p/do! (cut-selection-blocks copy?)
+           (clear-selection!))))
 
 (defn shortcut-copy-selection
   [e]


### PR DESCRIPTION
Fixes logseq/db-test#1105.

Deleting a Node embed through block selection destroys the embed's target — a block
with its whole subtree, or every block on an embedded page — and leaves the embed in
place. Both halves of this were introduced by `fe65e36f13` "refactor: remove ui db",
and both changes here restore what that commit displaced.

### 1. The placeholder lookup could never succeed

`get-original-block` maps a linked-render row back to its linking block. Before the
worker migration both of its branches read `originalblockid` off the DOM and resolved
it with `db/entity`. When the UI-side DataScript db was removed the selection branch
was replaced with `(:original-block linked-block)` — a key assigned in render config
(`components/block.cljs`, `linked-block-row`), never a datom, on an entity loaded via
`db-async/<get-blocks`. It is unconditionally `nil`.

`2256b4cb7f` "fix: improve outliner editor responsiveness" restored the *editing*
branch six days later, reading the attribute and returning `{:block/uuid id}` without
`db/entity`. This applies that same pattern to the selection branch, which was missed.

### 2. A synchronous call site became asynchronous without an await

The same commit turned `cut-selection-blocks` from synchronous into a `p/let` over
`db-async/<get-blocks`, but left its caller unchanged:

```clojure
(cut-selection-blocks copy?)   ; now returns a pending promise
(clear-selection!)             ; still runs immediately
```

`clear-selection!` empties the selection before the continuation reaches
`get-original-block`, which reads live selection state. Awaiting closes it. This is
why the behaviour was timing-dependent — the same gesture could pass once and fail
afterwards.

### Verification

Built from source and exercised through the real desktop UI, both by injected input
(CDP `Input.dispatchMouseEvent` / `dispatchKeyEvent`, traversing the normal hit-test
and handler path) and by hand. Outcomes read from the graph's `client-ops` store
(`forward_outliner_ops`), never from the UI. Fixture restored from a backup before
every trial.

Six embed shapes — block with content, block with children, empty block, empty page,
page with blocks, embed-of-embed chain — across three gestures:

| gesture | before | after |
|---|---|---|
| right-click bullet → <kbd>Delete</kbd> | target destroyed | placeholder only |
| right-click bullet → <kbd>Cmd</kbd>+<kbd>X</kbd> | target destroyed | placeholder only |
| right-click bullet → menu "Delete selected blocks" | target destroyed | placeholder only |

The empty-target cases matter as controls: the op names the *placeholder*, rather
than producing a no-op that merely looks clean.

### Known gaps

- The context menu's **Cut** item is a separate defect and is not addressed here —
  see logseq/db-test#1104. It predates the worker migration.
- On embed-of-embed chains this removes the inner placeholder rather than the outer
  one, because `linked-block-row` recurses and the innermost `:original-block` wins.
  No data is lost, but it is not quite right.
- `:embed?` and `:page-embed?` are read in `components/block.cljs` and set nowhere in
  `src/main/frontend`, so `data-transclude` never applies to node embeds. Left alone;
  possibly vestigial.
