### PR TITLE
fix(plugin): custom uuid not working in createTag

### DIFF
--- a/src/main/logseq/api/db_based.cljs
+++ b/src/main/logseq/api/db_based.cljs
@@ -239,9 +239,11 @@
              (throw (ex-info "Tag title shouldn't include forward slash" {:title title})))
            (p/let [opts (bean/->clj opts)
                    class-ident-namespace (api-block/resolve-class-prefix-for-db this)
-                   opts' (assoc opts
-                                :redirect? false
-                                :class-ident-namespace class-ident-namespace)
+                    opts' (cond-> (assoc opts
+                                         :redirect? false
+                                         :class-ident-namespace class-ident-namespace)
+                            (string? (:uuid opts))
+                            (update :uuid uuid))
                    tag-properties (:tagProperties opts)
                    tag (db-page-handler/<create-class! title opts')
                    properties (when (seq tag-properties)

--- a/src/main/logseq/api/db_based.cljs
+++ b/src/main/logseq/api/db_based.cljs
@@ -17,6 +17,7 @@
             [frontend.util.entity :as entity]
             [goog.object :as gobj]
             [logseq.api.block :as api-block]
+            [logseq.common.util :as common-util]
             [logseq.db :as ldb]
             [logseq.graph-parser.text :as text]
             [logseq.outliner.core :as outliner-core]
@@ -239,9 +240,11 @@
              (throw (ex-info "Tag title shouldn't include forward slash" {:title title})))
            (p/let [opts (bean/->clj opts)
                    class-ident-namespace (api-block/resolve-class-prefix-for-db this)
-                   opts' (assoc opts
-                                :redirect? false
-                                :class-ident-namespace class-ident-namespace)
+                   opts' (cond-> (assoc opts
+                                        :redirect? false
+                                        :class-ident-namespace class-ident-namespace)
+                           (common-util/uuid-string? (:uuid opts))
+                           (update :uuid uuid))
                    tag-properties (:tagProperties opts)
                    tag (db-page-handler/<create-class! title opts')
                    properties (when (seq tag-properties)


### PR DESCRIPTION
Fixes the following (uuid not being respected):
```
await logseq.Editor.createTag(this.args.tagName, {
    uuid: '6a891284-eb1e-4a45-9338-bcb48e1d4ebd'
});
```

