### PR TITLE
fix: don't add #Task when a child class already provides it

### DIFF
--- a/deps/outliner/src/logseq/outliner/property.cljs
+++ b/deps/outliner/src/logseq/outliner/property.cljs
@@ -106,10 +106,13 @@
        boolean))
 
 (defn- should-add-task-tag-for-property?
+  "Add #Task when setting status/scheduled/deadline unless a class already
+  provides that property. Pages are not special-cased: #Page does not provide
+  task properties, so a plain page still gets #Task, while a page tagged with a
+  Task child class does not."
   [conn block property-id]
   (and (contains? #{:logseq.property/status :logseq.property/scheduled :logseq.property/deadline} property-id)
        (or (empty? (:block/tags block))
-           (ldb/internal-page? block)
            (not (block-classes-provide-property? @conn block property-id)))))
 
 (defn- class-lookup-ref?

--- a/deps/outliner/test/logseq/outliner/property_test.cljs
+++ b/deps/outliner/test/logseq/outliner/property_test.cljs
@@ -298,6 +298,38 @@
            (mapv :db/ident (:block/tags (d/entity @conn [:block/uuid project]))))
         "Doesn't add Task to block when its class provides status")))
 
+(deftest task-child-class-does-not-add-parent-task-tag
+  (let [tag-idents (fn [conn block-uuid]
+                     (set (map :db/ident (:block/tags (d/entity @conn [:block/uuid block-uuid])))))]
+    (doseq [[property-id value]
+            [[:logseq.property/status :logseq.property/status.doing]
+             [:logseq.property/scheduled 1783612800000]
+             [:logseq.property/deadline 1783699200000]]]
+      (testing (str property-id)
+        (let [conn (db-test/create-conn-with-blocks
+                    {:classes {:Work {:build/class-extends [:logseq.class/Task]}}
+                     :pages-and-blocks
+                     [{:page {:block/title "plain page"}}
+                      {:page {:block/title "work page" :build/tags [:Work]}
+                       :blocks [{:block/title "work block" :build/tags [:Work]}]}]})
+              plain-page (:block/uuid (db-test/find-page-by-title @conn "plain page"))
+              work-page (:block/uuid (db-test/find-page-by-title @conn "work page"))
+              work-block (:block/uuid (db-test/find-block-by-content @conn "work block"))]
+          (outliner-property/batch-set-property! conn [plain-page] property-id value)
+          (is (= #{:logseq.class/Task :logseq.class/Page}
+                 (tag-idents conn plain-page))
+              "Adds Task to a plain page with no Task-related class")
+
+          (outliner-property/batch-set-property! conn [work-page] property-id value)
+          (is (= #{:user.class/Work :logseq.class/Page}
+                 (tag-idents conn work-page))
+              "Does not add parent Task to a page tagged with a Task child class")
+
+          (outliner-property/batch-set-property! conn [work-block] property-id value)
+          (is (= #{:user.class/Work}
+                 (tag-idents conn work-block))
+              "Does not add parent Task to a block tagged with a Task child class"))))))
+
 (deftest batch-set-property-rejects-private-built-in-entity
   (let [conn (db-test/create-conn)
         placeholder (d/entity @conn :logseq.property/empty-placeholder)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes pages tagged with a child of `#Task` (e.g. `#Work`) incorrectly also receiving the parent `#Task` tag when status, scheduled, or deadline is set.

Fixes [db-test#1103](https://github.com/logseq/db-test/issues/1103) / [logseq#13102](https://github.com/logseq/logseq/issues/13102).

## Behavior change

Setting status / scheduled / deadline now adds `#Task` only when no existing class already provides that property.

- A page tagged with a Task child class does **not** get extra `#Task`.
- A plain page with no Task-related class still gets `#Task`.
- A block tagged with a Task child class still does **not** get extra `#Task` (already correct).

## Cause

`should-add-task-tag-for-property?` treated every internal page as needing `#Task` via `ldb/internal-page?`, skipping the class-property check that blocks already use. Pages always have `#Page`, so that short-circuit fired even when a child class already inherited the task properties.

## Tests

`logseq.outliner.property-test/task-child-class-does-not-add-parent-task-tag` covers status, scheduled, and deadline for:

- page tagged with a Task child
- plain page
- block tagged with a Task child

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7ca1d20-73aa-4d84-8c01-7b0298cc47c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7ca1d20-73aa-4d84-8c01-7b0298cc47c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

