### PR TITLE
enhance(plugin): add button action to plugin settings

### DIFF
--- a/libs/src/LSPlugin.ts
+++ b/libs/src/LSPlugin.ts
@@ -292,7 +292,7 @@ export type SimpleCommandKeybinding = {
   mac?: string // special for Mac OS
 }
 
-export type SettingSchemaDesc = {
+type SettingSchemaValueDesc = {
   key: string
   type: 'string' | 'number' | 'boolean' | 'enum' | 'object' | 'heading'
   default: string | number | boolean | Array<any> | object | null
@@ -302,6 +302,20 @@ export type SettingSchemaDesc = {
   enumChoices?: Array<string>
   enumPicker?: 'select' | 'radio' | 'checkbox' // default: select
 }
+
+/** A non-persisted settings action backed by a method registered with `provideModel`. */
+export type SettingSchemaButtonDesc = {
+  key: string
+  type: 'button'
+  title: string
+  text: string
+  /** The name of a method registered by this plugin with `provideModel`. */
+  action: string
+  /** Optional Markdown description. */
+  description?: string
+}
+
+export type SettingSchemaDesc = SettingSchemaValueDesc | SettingSchemaButtonDesc
 
 export type ExternalCommandType =
   | 'logseq.command/run'

--- a/src/main/frontend/components/plugins.css
+++ b/src/main/frontend/components/plugins.css
@@ -545,6 +545,17 @@
           }
         }
 
+        &.as-button {
+          > .form-control {
+            flex-direction: column;
+            align-items: flex-start;
+
+            > .ui__button {
+              width: 100%;
+            }
+          }
+        }
+
         &:hover {
           background: var(--ls-tertiary-background-color);
         }

--- a/src/main/frontend/components/plugins_settings.cljs
+++ b/src/main/frontend/components/plugins_settings.cljs
@@ -103,6 +103,26 @@
    [:h2 title]
    (html-content description)])
 
+(defn invoke-button-action!
+  [pid action key]
+  (plugin-handler/call-plugin-user-model!
+   pid action [{:type "click"
+                :dataset {:key key}}]))
+
+(hsx/defc render-item-button
+  [pid {:keys [key title text action description]}]
+
+  [:div.desc-item.as-button
+   {:data-key key}
+   [:h2 [:code key] (ui/icon "caret-right") [:strong title]]
+
+   [:div.form-control
+    (when description (html-content description))
+    (shui/button {:type "button"
+                  :size :sm
+                  :on-click #(invoke-button-action! pid action key)}
+                 text)]])
+
 (hsx/defc render-item-not-handled
   [s]
   [:p.text-red-500 (t :plugin/setting-not-handled s)])
@@ -186,6 +206,9 @@
 
               #{:heading}
               ^{:key key} [render-item-heading desc]
+
+              #{:button}
+              ^{:key key} [render-item-button pid desc]
 
               ^{:key key} [render-item-not-handled key])))]]
 


### PR DESCRIPTION
Adds support for buttons in plugin settings:
<img width="687" height="250" alt="image" src="https://github.com/user-attachments/assets/fee753bd-6570-4011-93e2-021094829e41" />


Example:
```
logseq.provideModel({
        showToolbarMenu: () => {
            console.log('Settings button clicker');
        }
});

logseq.useSettingsSchema([
  {
    key: 'open-toolbar',
    type: 'button',
    title: 'Toolbar',
    text: 'Open Toolbar',
    action: 'showToolbarMenu',
    description: 'Open the toolbar menu.',
  },
])
```