### PR TITLE
enhance(plugin): add button action to plugin settings

### DIFF
--- a/libs/src/LSPlugin.ts
+++ b/libs/src/LSPlugin.ts
@@ -294,13 +294,22 @@ export type SimpleCommandKeybinding = {
 
 export type SettingSchemaDesc = {
   key: string
-  type: 'string' | 'number' | 'boolean' | 'enum' | 'object' | 'heading'
+  type:
+    | 'string'
+    | 'number'
+    | 'boolean'
+    | 'enum'
+    | 'object'
+    | 'heading'
+    | 'button'
   default: string | number | boolean | Array<any> | object | null
   title: string
   description: string // support markdown
   inputAs?: 'color' | 'date' | 'datetime-local' | 'range' | 'textarea'
   enumChoices?: Array<string>
   enumPicker?: 'select' | 'radio' | 'checkbox' // default: select
+  buttonText?: string // Button label. Required when type is `button`.
+  buttonAction?: string // `provideModel` method name. Required when type is `button`.
 }
 
 export type ExternalCommandType =

--- a/src/main/frontend/components/plugins.css
+++ b/src/main/frontend/components/plugins.css
@@ -545,6 +545,17 @@
           }
         }
 
+        &.as-button {
+          > .form-control {
+            flex-direction: column;
+            align-items: flex-start;
+
+            > .ui__button {
+              width: 100%;
+            }
+          }
+        }
+
         &:hover {
           background: var(--ls-tertiary-background-color);
         }

--- a/src/main/frontend/components/plugins_settings.cljs
+++ b/src/main/frontend/components/plugins_settings.cljs
@@ -103,6 +103,26 @@
    [:h2 title]
    (html-content description)])
 
+(defn invoke-button-action!
+  [pid button-action key]
+  (plugin-handler/call-plugin-user-model!
+   pid button-action [{:type "click"
+                       :dataset {:key key}}]))
+
+(hsx/defc render-item-button
+  [pid {:keys [key title buttonText buttonAction description]}]
+
+  [:div.desc-item.as-button
+   {:data-key key}
+   [:h2 [:code key] (ui/icon "caret-right") [:strong title]]
+
+   [:div.form-control
+    (when description (html-content description))
+    (shui/button {:type "button"
+                  :size :sm
+                  :on-click #(invoke-button-action! pid buttonAction key)}
+                 buttonText)]])
+
 (hsx/defc render-item-not-handled
   [s]
   [:p.text-red-500 (t :plugin/setting-not-handled s)])
@@ -186,6 +206,9 @@
 
               #{:heading}
               ^{:key key} [render-item-heading desc]
+
+              #{:button}
+              ^{:key key} [render-item-button pid desc]
 
               ^{:key key} [render-item-not-handled key])))]]
 


### PR DESCRIPTION
Adds support for buttons in plugin settings:
<img width="687" height="250" alt="image" src="https://github.com/user-attachments/assets/fee753bd-6570-4011-93e2-021094829e41" />


Example:
```
logseq.provideModel({
        showToolbarMenu: () => {
            console.log('Settings button clicker');
        }
});

logseq.useSettingsSchema([
  {
    key: 'open-toolbar',
    type: 'button',
    title: 'Toolbar',
    text: 'Open Toolbar',
    action: 'showToolbarMenu',
    description: 'Open the toolbar menu.',
  },
])
```