### PR TITLE
fix: export children of text property values

### DIFF
--- a/src/main/logseq/common/export/file.cljs
+++ b/src/main/logseq/common/export/file.cljs
@@ -39,7 +39,7 @@
                 date-time-util/default-journal-title-formatter)
             " HH:mm")))))
 
-(declare property-value->string block-properties-content)
+(declare property-value->string block-properties-content block->content)
 
 (defn- property-value-sort-key
   [db property item context]
@@ -116,14 +116,31 @@
        {:replace-block-refs? (not (:preserve-block-refs? context))})
       (property-value->string db property v context))))
 
+(defn- property-value-children-content
+  [db value-entity spaces-tabs context]
+  (when-let [children (seq (ldb/sort-by-order (:block/_parent value-entity)))]
+    (let [indent (or (:export-bullet-indentation context) "  ")
+          child-level (+ 2 (quot (count spaces-tabs) (max 1 (count indent))))]
+      (->> children
+           (map (fn [child]
+                  (block->content db (:block/uuid child) {:init-level child-level} context)))
+           (string/join "\n")
+           not-empty))))
+
 (defn- default-property-value-block-content
   [db property v spaces-tabs context]
   (let [line (str spaces-tabs "- " (property-value-block-title db property v context))
-        properties-content (when-let [id (:db/id v)]
-                             (block-properties-content db (d/entity db id) (str spaces-tabs "  ") context))]
+        value-entity (when-let [id (:db/id v)]
+                       (d/entity db id))
+        properties-content (when value-entity
+                             (block-properties-content db value-entity (str spaces-tabs "  ") context))
+        children-content (when value-entity
+                           (property-value-children-content db value-entity spaces-tabs context))]
     (cond-> line
       properties-content
-      (str "\n" properties-content))))
+      (str "\n" properties-content)
+      children-content
+      (str "\n" children-content))))
 
 (defn- property-value-blocks-content
   [db property v spaces-tabs context]

--- a/src/test/frontend/handler/export_property_test.cljs
+++ b/src/test/frontend/handler/export_property_test.cljs
@@ -2,10 +2,28 @@
   (:require [cljs-time.coerce :as tc]
             [cljs-time.core :as t]
             [cljs.test :refer [deftest is]]
+            [clojure.string :as string]
             [datascript.core :as d]
             [logseq.common.export.file :as common-file]
             [logseq.common.util.date-time :as date-time-util]
-            [logseq.db.frontend.property :as db-property]))
+            [logseq.db.frontend.property :as db-property]
+            [logseq.db.test.helper :as db-test]))
+
+(def ^:private block-export-context
+  {:export-bullet-indentation "  "
+   :export-properties-as-list-items? true
+   :export-node-property-values-as-page-refs? true
+   :export-default-property-values-as-blocks? true
+   :preserve-block-refs? true})
+
+(defn- export-page
+  [conn title]
+  (let [page (db-test/find-page-by-title @conn title)]
+    (common-file/block->content
+     @conn
+     (:block/uuid page)
+     {:include-page-properties? true}
+     block-export-context)))
 
 (deftest block-properties-content-uses-property-title-and-time-for-datetime
   (let [datetime-ms (tc/to-long (t/date-time 2026 5 14 9 30))
@@ -29,3 +47,50 @@
       (is (= (str "  deadline:: " expected-datetime "\n"
                   "  P1:: hello")
              (@#'common-file/block-properties-content nil {} "  " {}))))))
+
+(deftest default-property-value-children-are-exported
+  (let [conn (db-test/create-conn-with-blocks
+              {:properties {:user.property/notes {:logseq.property/type :default}}
+               :pages-and-blocks [{:page {:block/title "Text Prop Children"
+                                           :build/properties
+                                           {:user.property/notes
+                                            {:build/property-value :block
+                                             :block/title "page value"
+                                             :build/children [{:block/title "page value child"}]}}}
+                                   :blocks [{:block/title "body"
+                                             :build/properties
+                                             {:user.property/notes
+                                              {:build/property-value :block
+                                               :block/title "block value"
+                                               :build/children
+                                               [{:block/title "child of value"
+                                                 :build/children [{:block/title "grandchild"}]}]}}}
+                                            {:block/title "after"}]}]})]
+    (is (= (str "* notes::\n"
+                "  - page value\n"
+                "    - page value child\n"
+                "- body\n"
+                "  * notes::\n"
+                "    - block value\n"
+                "      - child of value\n"
+                "        - grandchild\n"
+                "- after")
+           (export-page conn "Text Prop Children")))))
+
+(deftest url-property-value-children-are-not-exported
+  (let [conn (db-test/create-conn-with-blocks
+              {:properties {:user.property/website {:logseq.property/type :url}}
+               :pages-and-blocks [{:page {:block/title "Url Prop Children"}
+                                   :blocks [{:block/title "body"
+                                             :build/properties
+                                             {:user.property/website
+                                              {:build/property-value :block
+                                               :block/title "https://example.com"
+                                               :build/children [{:block/title "should not appear"}]}}}
+                                            {:block/title "after"}]}]})
+        content (export-page conn "Url Prop Children")]
+    (is (= (str "- body\n"
+                "  * website:: https://example.com\n"
+                "- after")
+           content))
+    (is (not (string/includes? content "should not appear")))))

--- a/src/test/frontend/worker/markdown_mirror_test.cljs
+++ b/src/test/frontend/worker/markdown_mirror_test.cljs
@@ -579,6 +579,73 @@
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
           (p/finally done)))))
 
+(deftest page-mirror-exports-default-property-value-children-test
+  (async done
+    (let [{:keys [platform files]} (fake-platform)
+          page-uuid #uuid "33333333-3333-4333-8333-333333333342"
+          conn (db-test/create-conn-with-blocks
+                {:properties {:user.property/notes {:logseq.property/type :default}}
+                 :pages-and-blocks [{:page {:block/title "Text Prop Children"
+                                             :block/uuid page-uuid
+                                             :build/properties
+                                             {:user.property/notes
+                                              {:build/property-value :block
+                                               :block/title "page value"
+                                               :build/children [{:block/title "page value child"}]}}}
+                                     :blocks [{:block/title "body"
+                                               :build/properties
+                                               {:user.property/notes
+                                                {:build/property-value :block
+                                                 :block/title "block value"
+                                                 :build/children
+                                                 [{:block/title "child of value"
+                                                   :build/children [{:block/title "grandchild"}]}]}}}
+                                              {:block/title "after"}]}]})
+          page (db-test/find-page-by-title @conn "Text Prop Children")]
+      (-> (markdown-mirror/<mirror-page! test-repo @conn (:db/id page) {:platform platform})
+          (p/then (fn [_]
+                    (is (= (str (page-marker page-uuid) "\n"
+                                "* notes::\n"
+                                "  - page value\n"
+                                "    - page value child\n\n"
+                                "- body\n"
+                                "  * notes::\n"
+                                "    - block value\n"
+                                "      - child of value\n"
+                                "        - grandchild\n"
+                                "- after")
+                           (get @files (page-path "pages/Text Prop Children.md"))))))
+          (p/catch (fn [e] (is false (str "unexpected error: " e))))
+          (p/finally done)))))
+
+(deftest page-mirror-does-not-export-url-property-value-children-test
+  (async done
+    (let [{:keys [platform files]} (fake-platform)
+          page-uuid #uuid "33333333-3333-4333-8333-333333333343"
+          conn (db-test/create-conn-with-blocks
+                {:properties {:user.property/website {:logseq.property/type :url}}
+                 :pages-and-blocks [{:page {:block/title "Url Prop Children"
+                                             :block/uuid page-uuid}
+                                     :blocks [{:block/title "body"
+                                               :build/properties
+                                               {:user.property/website
+                                                {:build/property-value :block
+                                                 :block/title "https://example.com"
+                                                 :build/children [{:block/title "should not appear"}]}}}
+                                              {:block/title "after"}]}]})
+          page (db-test/find-page-by-title @conn "Url Prop Children")]
+      (-> (markdown-mirror/<mirror-page! test-repo @conn (:db/id page) {:platform platform})
+          (p/then (fn [_]
+                    (let [content (get @files (page-path "pages/Url Prop Children.md"))]
+                      (is (= (str (page-marker page-uuid) "\n\n"
+                                  "- body\n"
+                                  "  * website:: https://example.com\n"
+                                  "- after")
+                             content))
+                      (is (not (re-find #"should not appear" content))))))
+          (p/catch (fn [e] (is false (str "unexpected error: " e))))
+          (p/finally done)))))
+
 (deftest page-mirror-exports-page-property-values-test
   (async done
     (let [{:keys [platform files]} (fake-platform)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Children of default/text-type property values exist in the DB under the value block, but markdown file export and the derived markdown mirror only wrote the value title. The subtree was dropped.

Fixes logseq/db-test#1107.

## Cause

Default/text property values are exported as nested blocks by `default-property-value-block-content`. That helper wrote the value title (and any properties on the value) but did not walk `:block/_parent` children. URL and other non-text types stay on a single property line and are unchanged.

The markdown-mirror outline walk is not the source of the missing content: it only decorates already-exported outline blocks. The children never made it into the exported markdown.

## Change

- Recursively export children of default/text property values in `logseq.common.export.file`.
- Leave URL and other non-text property types as inline values without child export (does not address db-test#1108).

## Tests

- File export: children of a default/text property value appear under the value; URL property values with children stay inline and do not export those children.
- Markdown mirror: same coverage through `<mirror-page!`.

Verified with the production export/mirror functions:

- Pre-fix: default/text children missing (`- page value` / `- block value` only).
- Post-fix: page/block value children and grandchildren appear; URL children stay omitted.
- `frontend.handler.export-property-test` + `frontend.worker.markdown-mirror-test`: 47 tests, 76 assertions, 0 failures.
- clj-kondo on changed files: 0 errors, 0 warnings.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-309a5bd3-b80e-41e7-bf0d-fe2a30b7436c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-309a5bd3-b80e-41e7-bf0d-fe2a30b7436c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

