### PR TITLE
chore: upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -78,7 +78,7 @@ jobs:
             ${{ runner.os }}-pnpm-
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/build-desktop-release.yml
+++ b/.github/workflows/build-desktop-release.yml
@@ -98,7 +98,7 @@ jobs:
             ${{ runner.os }}-pnpm-
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/build-ios-release.yml
+++ b/.github/workflows/build-ios-release.yml
@@ -43,7 +43,7 @@ jobs:
           version: 10.33.0
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
@@ -118,7 +118,7 @@ jobs:
             cli/pnpm-lock.yaml
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
@@ -169,7 +169,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
@@ -229,7 +229,7 @@ jobs:
             scripts/pnpm-lock.yaml
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/cli-sync-stress.yml
+++ b/.github/workflows/cli-sync-stress.yml
@@ -62,7 +62,7 @@ jobs:
             deps/db-sync/pnpm-lock.yaml
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/clj-e2e.yml
+++ b/.github/workflows/clj-e2e.yml
@@ -47,7 +47,7 @@ jobs:
             pnpm-lock.yaml
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
@@ -144,7 +144,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/clj-rtc-e2e.yml
+++ b/.github/workflows/clj-rtc-e2e.yml
@@ -48,7 +48,7 @@ jobs:
             pnpm-lock.yaml
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
@@ -124,7 +124,7 @@ jobs:
           version: 10.33.0
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/deploy-and-branch.yml
+++ b/.github/workflows/deploy-and-branch.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: "zulu"
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/deploy-db-test-pages.yml
+++ b/.github/workflows/deploy-db-test-pages.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: "zulu"
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/deploy-sync-test.yml
+++ b/.github/workflows/deploy-sync-test.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: "zulu"
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/deps-cli.yml
+++ b/.github/workflows/deps-cli.yml
@@ -90,7 +90,7 @@ jobs:
             cli/pnpm-lock.yaml
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
@@ -154,7 +154,7 @@ jobs:
             cli/pnpm-lock.yaml
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/deps-common.yml
+++ b/.github/workflows/deps-common.yml
@@ -47,7 +47,7 @@ jobs:
           cache-dependency-path: deps/common/pnpm-lock.yaml
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/deps-db-sync.yml
+++ b/.github/workflows/deps-db-sync.yml
@@ -54,7 +54,7 @@ jobs:
           cache-dependency-path: deps/db-sync/pnpm-lock.yaml
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/deps-db.yml
+++ b/.github/workflows/deps-db.yml
@@ -51,7 +51,7 @@ jobs:
           cache-dependency-path: deps/db/pnpm-lock.yaml
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/deps-graph-parser.yml
+++ b/.github/workflows/deps-graph-parser.yml
@@ -55,7 +55,7 @@ jobs:
           cache-dependency-path: deps/graph-parser/pnpm-lock.yaml
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/deps-outliner.yml
+++ b/.github/workflows/deps-outliner.yml
@@ -57,7 +57,7 @@ jobs:
           cache-dependency-path: deps/outliner/pnpm-lock.yaml
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/deps-publish.yml
+++ b/.github/workflows/deps-publish.yml
@@ -56,7 +56,7 @@ jobs:
           cache-dependency-path: deps/publish/pnpm-lock.yaml
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
@@ -94,7 +94,7 @@ jobs:
           cache-dependency-path: deps/publish/pnpm-lock.yaml
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
@@ -120,7 +120,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/deps-publishing.yml
+++ b/.github/workflows/deps-publishing.yml
@@ -55,7 +55,7 @@ jobs:
           cache-dependency-path: deps/publishing/pnpm-lock.yaml
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
@@ -85,7 +85,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}


### PR DESCRIPTION
## Summary

Upgrade all active GitHub workflow references from `actions/setup-java@v4` to `@v6`.

## Validation

- `git diff --check`
- Verified no setup-java references older than v6 remain in active workflows

Tests were not run because this only updates the CI action version.
