### PR TITLE
fix(android): respect status bar safe area

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,14 @@ cljs-test-runner-out
 .lein-*
 .nrepl-*
 .DS_Store
+__pycache__/
+*.pyc
+*.pyo
+nul
+.Rhistory
+.RData
+.Rproj.user/
+.ipynb_checkpoints/
 report.html
 strings.csv
 ssl/

--- a/android/app/src/main/java/com/logseq/app/NativeTopBarPlugin.kt
+++ b/android/app/src/main/java/com/logseq/app/NativeTopBarPlugin.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
@@ -188,6 +189,7 @@ private fun TopBarContent(
   val contentTint = tint.copy(alpha = 0.8f)
 
   Surface(
+    modifier = Modifier.statusBarsPadding(),
     color = background,
     shadowElevation = 4.dp
   ) {

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -13,6 +13,10 @@ const config: CapacitorConfig = {
     androidScheme: 'http',
   },
   plugins: {
+    SystemBars: {
+      insetsHandling: 'disable',
+    },
+
     App: {
       // Logseq routes back presses through MainActivity -> JS (window.LogseqNative.onNativePop).
       // Disable @capacitor/app's built-in OnBackPressedCallback so it doesn't intercept the


### PR DESCRIPTION
## Summary
- keep Capacitor's SystemBars inset handling disabled so the safe-area plugin owns WebView insets
- apply Compose status-bar padding to the separately attached native top bar
- add standard local artifact ignores

## Verification
- reproduced the overlap on Pixel 9 Pro XL / Android 17 (API 37)
- verified corrected control bounds and successful overflow-button interaction
- verified cold relaunch, background/resume, and portrait-landscape-portrait
- verified unchanged toolbar coordinates on Android 16 (API 36)
- `android/gradlew.bat -p android assembleDebug`
- `git diff --check`

## Known unrelated check failure
- `:app:lintDebug` still reports the pre-existing `UnsafeImplicitIntentLaunch` in `UILocal.kt`; addressed separately