### PR TITLE
fix: restore macOS Command+M minimize and create missing global config.edn

### DIFF
--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -212,10 +212,10 @@
 (defn- window-menu-os-items
   "OS window roles. Minimize is always present so macOS Command+M is
    handled by Electron's minimize role instead of being omitted."
-  [mac?]
+  [macos?]
   (concat
    [{:role "minimize"}]
-   (when-not mac?
+   (when-not macos?
      [{:role "zoom"}
       ;; Disable Control+W shortcut
       {:role "close"

--- a/src/electron/electron/core.cljs
+++ b/src/electron/electron/core.cljs
@@ -209,6 +209,18 @@
          (.removeHandler ipcMain call-app-channel)
          (.removeHandler ipcMain call-win-channel))))
 
+(defn- window-menu-os-items
+  "OS window roles. Minimize is always present so macOS Command+M is
+   handled by Electron's minimize role instead of being omitted."
+  [mac?]
+  (concat
+   [{:role "minimize"}]
+   (when-not mac?
+     [{:role "zoom"}
+      ;; Disable Control+W shortcut
+      {:role "close"
+       :accelerator false}])))
+
 (defn- set-app-menu! []
   (let [about-fn (fn []
                    (.showMessageBox dialog (clj->js {:title "Logseq"
@@ -244,12 +256,7 @@
                        {:role "windowMenu"
                         :submenu
                         (concat
-                          (when-not mac?
-                            [{:role "minimize"}
-                             {:role "zoom"}
-                             ;; Disable Control+W shortcut
-                             {:role "close"
-                              :accelerator false}])
+                          (window-menu-os-items mac?)
                           [{:label "Always on Top"
                             :type "checkbox"
                             :click (fn [^js menuItem ^js browserWindow]

--- a/src/main/frontend/handler/global_config.cljs
+++ b/src/main/frontend/handler/global_config.cljs
@@ -62,9 +62,12 @@
                             (nil? v))
                      (rewrite/dissoc result (first ks))
                      (rewrite/assoc-in result ks v))
-        new-str-content (str new-result)]
-    (fs/write-file! (global-config-path) new-str-content)
-    (state/set-global-config! (rewrite/sexpr new-result) new-str-content)))
+        new-str-content (str new-result)
+        write-p (p/do!
+                 (fs/mkdir-if-not-exists (global-config-dir))
+                 (fs/write-file! (global-config-path) new-str-content))]
+    (state/set-global-config! (rewrite/sexpr new-result) new-str-content)
+    write-p))
 
 (defn start
   "This component has three responsibilities on start:
@@ -75,8 +78,10 @@
   (-> (p/do!
        (p/let [root-dir' (ipc/ipc "getLogseqDotDirRoot")]
          (reset! root-dir root-dir'))
-       (restore-global-config!)
-       (create-global-config-file-if-not-exists repo))
+       ;; Create first: restore reads the file and fails (aborting start)
+       ;; on a fresh install when config/config.edn does not exist yet.
+       (create-global-config-file-if-not-exists repo)
+       (restore-global-config!))
       (p/timeout 6000)
       (p/catch (fn [e]
                  (js/console.error "cannot start global-config" e)))))

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -36,8 +36,8 @@
 
 (defn- publish-open-dialog-default-binding
   "macOS Command+M minimizes the window; do not steal it for publish."
-  [mac?]
-  (if mac? [] "mod+m"))
+  [macos?]
+  (if macos? [] "mod+m"))
 
 ;; TODO: Namespace all-default-keyboard-shortcuts keys with `:command` e.g.
 ;; `:command.date-picker/complete`. They are namespaced in translation but

--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -34,6 +34,11 @@
     (js/setTimeout #(route-handler/go-to-search! mode) 128)
     (route-handler/go-to-search! mode)))
 
+(defn- publish-open-dialog-default-binding
+  "macOS Command+M minimizes the window; do not steal it for publish."
+  [mac?]
+  (if mac? [] "mod+m"))
+
 ;; TODO: Namespace all-default-keyboard-shortcuts keys with `:command` e.g.
 ;; `:command.date-picker/complete`. They are namespaced in translation but
 ;; almost everywhere else they are not which could cause needless conflicts
@@ -377,7 +382,7 @@
                                              :inactive (not (util/electron?))
                                              :binding "mod+s"}
 
-   :publish/open-dialog                     {:binding "mod+m"
+   :publish/open-dialog                     {:binding (publish-open-dialog-default-binding mac?)
                                              :inactive config/publishing?
                                              :fn      #(state/pub-event! [:publish/open-dialog])}
 

--- a/src/test/frontend/handler/global_config_test.cljs
+++ b/src/test/frontend/handler/global_config_test.cljs
@@ -1,0 +1,67 @@
+(ns frontend.handler.global-config-test
+  (:require ["fs" :as fs-node]
+            ["fs/promises" :as fsp]
+            ["path" :as node-path]
+            [clojure.edn :as edn]
+            [cljs.test :refer [is]]
+            [frontend.fs :as fs]
+            [frontend.handler.global-config :as global-config-handler]
+            [frontend.state :as state]
+            [frontend.test.helper :as test-helper :include-macros true :refer [deftest-async]]
+            [frontend.test.node-fixtures :as node-fixtures]
+            [frontend.test.node-helper :as test-node-helper]
+            [promesa.core :as p]))
+
+(defn- create-fresh-global-root
+  "Temp ~/.logseq-style root with no config/ directory."
+  []
+  (let [root-dir (node-path/resolve (test-node-helper/create-tmp-dir))]
+    (reset! global-config-handler/root-dir root-dir)
+    root-dir))
+
+(defn- delete-global-root
+  [root-dir]
+  (reset! global-config-handler/root-dir nil)
+  (when (and root-dir (fs-node/existsSync root-dir))
+    (fs-node/rmSync root-dir #js {:recursive true :force true})))
+
+(deftest-async set-global-config-kv-creates-missing-config-edn
+  {:before (node-fixtures/setup-get-fs!)
+   :after (node-fixtures/restore-get-fs!)}
+  (let [root-dir (create-fresh-global-root)
+        previous-state (state/get-state)
+        config-dir (global-config-handler/global-config-dir)
+        config-path (global-config-handler/global-config-path)]
+    (p/with-redefs [fs/write-file! (fn [path content]
+                                     (fsp/writeFile path content))]
+      (-> (p/do!
+           (is (false? (fs-node/existsSync config-dir))
+               "fresh install has no global config dir")
+           (global-config-handler/set-global-config-kv!
+            :shortcuts {:publish/open-dialog []})
+           (is (true? (fs-node/existsSync config-path))
+               "write creates missing config/config.edn")
+           (is (= {:publish/open-dialog []}
+                  (:shortcuts (edn/read-string (str (fs-node/readFileSync config-path)))))))
+          (p/finally
+            (fn []
+              (state/replace-state! previous-state)
+              (delete-global-root root-dir)))))))
+
+(deftest-async create-then-restore-global-config-on-fresh-install
+  {:before (node-fixtures/setup-get-fs!)
+   :after (node-fixtures/restore-get-fs!)}
+  (let [root-dir (create-fresh-global-root)
+        previous-state (state/get-state)
+        config-path (global-config-handler/global-config-path)]
+    (-> (p/do!
+         (#'global-config-handler/create-global-config-file-if-not-exists nil)
+         (global-config-handler/restore-global-config!)
+         (is (true? (fs-node/existsSync config-path))
+             "start create-before-restore writes the default file")
+         (is (map? (state/get-global-config))
+             "restore loads the newly created file"))
+        (p/finally
+          (fn []
+            (state/replace-state! previous-state)
+            (delete-global-root root-dir))))))

--- a/src/test/frontend/modules/shortcut/config_test.cljs
+++ b/src/test/frontend/modules/shortcut/config_test.cljs
@@ -1,7 +1,8 @@
 (ns frontend.modules.shortcut.config-test
   (:require [cljs.test :refer [deftest is testing]]
             [frontend.modules.shortcut.config :as shortcut-config]
-            [frontend.state :as state]))
+            [frontend.state :as state]
+            [frontend.util :as util]))
 
 (deftest graph-db-save-shortcut-does-not-trigger-legacy-save-event
   (testing "mod+s in db graph sends new save-info event"
@@ -12,3 +13,14 @@
                  [:graph/db-save :fn]))
         (is (= [[:graph/db-save-shortcut]]
                @events*))))))
+
+(deftest publish-open-dialog-does-not-steal-mac-minimize
+  (let [default-binding #'shortcut-config/publish-open-dialog-default-binding]
+    (testing "macOS leaves Command+M unbound so the system can minimize"
+      (is (= [] (default-binding true))))
+    (testing "non-Mac keeps Ctrl+M as the publish default"
+      (is (= "mod+m" (default-binding false))))
+    (testing "built-in shortcut uses the platform default"
+      (is (= (default-binding util/mac?)
+             (get-in shortcut-config/all-built-in-keyboard-shortcuts
+                     [:publish/open-dialog :binding]))))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes Command+M not minimizing the Logseq window on macOS, and the ENOENT when clearing that keybind on a fresh install.

Fixes https://github.com/logseq/db-test/issues/1113
Fixes https://github.com/logseq/logseq/issues/13113

## What changed

- `:publish/open-dialog` no longer defaults to `mod+m` on macOS, so Command+M is not stolen from the OS. Non-Mac keeps `Ctrl+M`.
- Electron's Window menu now includes `{:role "minimize"}` on macOS, which is the system Command+M minimize action.
- Global config start creates `config/config.edn` before restoring it.
- `set-global-config-kv!` creates the missing `config/` directory before writing, so clearing a keybind on a fresh install no longer ENOENTs.

## Tests

- Unit coverage for the Mac/non-Mac publish default binding.
- Unit coverage for writing global `config.edn` when the file and parent directory are missing, and for create-then-restore on a fresh install.

Electron menu/role behavior is not e2e-tested here (Linux CI cannot fire macOS Command+M).

## How to verify on macOS

1. Fresh Logseq DB install (or a profile with no custom shortcuts).
2. Focus the Logseq window and press Command+M. The window should minimize to the Dock.
3. Settings → keybinds: Command+M should not be owned by "Open publish dialog for current page".
4. Clear any keybind (Backspace). It should persist without a write error on missing `config/config.edn`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33b97943-c8fd-41c5-af95-43ad165b5c53?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33b97943-c8fd-41c5-af95-43ad165b5c53&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

