### PR TITLE
fix: expand block macro arguments

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -79,6 +79,7 @@
             [logseq.common.path :as path]
             [logseq.common.util :as common-util]
             [logseq.common.util.block-ref :as block-ref]
+            [logseq.common.util.macro :as macro-util]
             [logseq.common.util.page-ref :as page-ref]
             [logseq.db :as ldb]
             [logseq.db.common.entity-plus :as entity-plus]
@@ -1850,6 +1851,9 @@
   (let [macro-content (or
                        (get (state/get-macros) name)
                        (get (state/get-macros) (keyword name)))
+        macro-content (if (and (seq arguments) macro-content)
+                        (macro-util/macro-subs macro-content arguments)
+                        macro-content)
         format (get-in config [:block :block/format] :markdown)]
     (render-macro config name arguments macro-content format)))
 

--- a/src/test/frontend/components/block/macros_test.cljs
+++ b/src/test/frontend/components/block/macros_test.cljs
@@ -5,6 +5,7 @@
             [clojure.string :as string]
             [frontend.components.block :as block]
             [frontend.components.block.macros :as block-macros]
+            [frontend.state :as state]
             [goog.object :as gobj]
             [io.factorhouse.hsx.core :as hsx]
             [logseq.shui.hooks :as hooks]))
@@ -102,3 +103,22 @@
                                                ["(count result)"])])))]
       (is (string/includes? markup "1"))
       (is (string/includes? markup "2")))))
+
+(defn- render-user-macro
+  [macro-name arguments]
+  (#'block/macro-cp {} {:name macro-name :arguments arguments}))
+
+(deftest user-macro-substitutes-block-arguments
+  (let [poem "Rose is $1, violet's $2. Life's ordered: Org assists you."]
+    (with-redefs [state/get-macros (constantly {"poem" poem})]
+      (testing "{{poem $1 $2}} style macros substitute arguments in block render"
+        (let [markup (pr-str (render-user-macro "poem" ["red" "blue"]))]
+          (is (string/includes? markup "Rose is red, violet's blue. Life's ordered: Org assists you."))
+          (is (not (string/includes? markup "$1")))
+          (is (not (string/includes? markup "$2")))))
+
+      (testing "a macro with no args is unchanged"
+        (let [markup (pr-str (render-user-macro "poem" []))]
+          (is (string/includes? markup poem))
+          (is (string/includes? markup "$1"))
+          (is (string/includes? markup "$2")))))))

--- a/src/test/logseq/common/util/macro_test.cljs
+++ b/src/test/logseq/common/util/macro_test.cljs
@@ -1,0 +1,18 @@
+(ns logseq.common.util.macro-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [logseq.common.util.macro :as macro-util]))
+
+(def poem
+  "Rose is $1, violet's $2. Life's ordered: Org assists you.")
+
+(deftest expand-value-if-macro-substitutes-property-arguments
+  (testing "property-value macro expansion still substitutes $1 $2"
+    (is (= "Rose is red, violet's blue. Life's ordered: Org assists you."
+           (macro-util/expand-value-if-macro
+            "{{poem red blue}}"
+            {"poem" poem}))))
+
+  (testing "a macro with no args is unchanged"
+    (is (= "{{poem}}"
+           (macro-util/expand-value-if-macro "{{poem}}" {"poem" poem})))
+    (is (= poem (macro-util/macro-subs poem [])))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Restore `$1`/`$2` substitution for user-defined block macros.

Fixes [logseq/db-test#1112](https://github.com/logseq/db-test/issues/1112) (transferred from [logseq/logseq#13114](https://github.com/logseq/logseq/issues/13114)).

## Problem

User macros in `config.edn` such as:

```clojure
:macros {"poem" "Rose is $1, violet's $2. Life's ordered: Org assists you."}
```

rendered the raw template. `{{poem red, blue}}` stayed as `Rose is $1, violet's $2...` instead of substituting arguments.

This was a regression from the og/db split: `macro-else-cp` used to call `macro-subs` when arguments were present, and that call was dropped.

## Change

`macro-else-cp` applies `macro-util/macro-subs` again before `render-macro`. A macro with no arguments is left unchanged. Property-value expansion via `expand-value-if-macro` is unchanged.

## Tests

- Block render: `{{poem $1 $2}}` style macros substitute arguments
- Property-value macro expansion still substitutes
- A macro with no args is unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3268410-96bf-4e59-8e5c-801f398c789c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3268410-96bf-4e59-8e5c-801f398c789c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

