### PR TITLE
test: cover scalar custom query rendering

### DIFF
--- a/src/test/frontend/components/query_test.cljs
+++ b/src/test/frontend/components/query_test.cljs
@@ -1,6 +1,7 @@
 (ns frontend.components.query-test
   (:require ["react" :as react]
             ["react-dom/server" :as react-dom-server]
+            [clojure.string :as string]
             [cljs.test :refer [deftest is]]
             [frontend.components.query :as query]
             [frontend.components.query.result :as query-result]
@@ -42,6 +43,16 @@
   (let [repo-config {:default-queries {:journals []}}]
     (is (true? (#'query/resolve-built-in-query? repo-config true {:title "TODO"})))
     (is (false? (#'query/resolve-built-in-query? repo-config false {:title "TODO"})))))
+
+(deftest scalar-custom-query-results-render-as-list-test
+  (let [html (render-static
+              (query/custom-query-inner
+               {:built-in-query? false}
+               {:query '[:find ?b]}
+               {:current-block {:block/uuid (random-uuid)}
+                :result [42]
+                :group-by-page? false}))]
+    (is (string/includes? html "<li>42</li>"))))
 
 (deftest built-in-block-query-preserves-default-page-grouping-test
   (let [captured-options (atom nil)


### PR DESCRIPTION
## Summary

- add frontend regression coverage for scalar custom-query results
- verify scalar values render through the generic list path
- make no production behavior changes

## Context

[logseq/db-test#1089](https://github.com/logseq/db-test/issues/1089) (formerly `logseq/logseq#12951`) reported that an advanced query returning a raw scalar could fail during rendering and leave the query error state visible until a reload.

On the current `master`, the query-resource pipeline preserves scalar tuples, and `custom-query-inner` renders non-UUID results as a generic list. This test records that renderer contract with a scalar result so the earlier result shape does not regress into a render failure.

This PR only covers the current scalar-result rendering path; it does not change the general error-boundary behavior.

## Testing

- `bb dev:test -v frontend.components.query-test/scalar-custom-query-results-render-as-list-test`
- `bb dev:lint-and-test`

Related to logseq/db-test#1089.