### PR TITLE
fix: configure mobile HTTPS dev server

### DIFF
--- a/docs/develop-logseq-on-mobile.md
+++ b/docs/develop-logseq-on-mobile.md
@@ -60,7 +60,7 @@ or, you can run `bb release:ios-app` to do those steps with one command.
 
 ## Set up development environment
 ### Build the development app
-- Run `pnpm install && pnpm mobile-watch` from the logseq project root directory in terminal.
+- Run `pnpm install && LOGSEQ_SHADOW_HTTPS=true pnpm mobile-watch` from the logseq project root directory in terminal.
 - Run `LOGSEQ_APP_SERVER_URL=https://your-local-ip-address:3002/mobile/ pnpm exec cap sync android` in another terminal.
 - Run `pnpm exec cap run android` to install app into your device.
 

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -3,13 +3,13 @@
  :nrepl {:port 8701}
  :source-paths ["src/main" "src/electron" "src/resources"]
 
- ;; :ssl {:enabled #shadow/env ["LOGSEQ_SHADOW_HTTPS" :as :bool :default false]
- ;;       :keystore "ssl/mobile-dev/keystore.jks"
- ;;       :password "shadow-cljs"}
+ :ssl {:enabled #shadow/env ["LOGSEQ_SHADOW_HTTPS" :as :bool :default false]
+       :keystore "ssl/mobile-dev/keystore.jks"
+       :password "shadow-cljs"}
 
  ;; "." for /static
  :dev-http {3001 ["static" "."]
-            3002 "static/mobile"}
+            3002 ["static" "."]}
 
  :js-options {:js-package-dirs ["node_modules"]}
 


### PR DESCRIPTION
## Summary

- restore Shadow CLJS's opt-in SSL configuration used by the mobile development tasks
- serve port 3002 from both `static` and the project root so `/mobile/` and `/static/mobile/js` both resolve
- document `LOGSEQ_SHADOW_HTTPS=true` for the manual Android development workflow

## Problem

`bb dev:android-app` creates a local development certificate, starts `pnpm mobile-watch` with `LOGSEQ_SHADOW_HTTPS=true`, and configures Capacitor with an HTTPS development URL. However, the Shadow CLJS SSL configuration was commented out, so port 3002 continued serving HTTP and the Android WebView failed with TLS protocol errors.

Port 3002 also used `static/mobile` as its only document root while the configured URL points to `/mobile/`. This made `/mobile/` return 404. Keeping the `/mobile/` URL is necessary because `cljs:mobile-watch` emits runtime module URLs under `/static/mobile/js`; changing the Capacitor URL to `/` loads the index but leaves those runtime modules unresolved.

Using the same document roots as port 3001 makes both paths available while keeping HTTPS opt-in through `LOGSEQ_SHADOW_HTTPS`.

## Verification

- `git diff --check`
- `bb -cp scripts/src:scripts/test -m logseq.tasks.dev-mobile-test`
- verified resolved Shadow CLJS config with `LOGSEQ_SHADOW_HTTPS=true` and `false`
- ran `LOGSEQ_SHADOW_HTTPS=true pnpm mobile-watch` (mobile build: 4,463 files, 0 warnings)
- built the Android debug APK successfully with `./gradlew assembleDebug`
- cold-started the APK on a Pixel 9 emulator: the mobile runtime initialized, Shadow CLJS connected, the splash screen hid, and the Demo graph became visible

The shared iOS task uses the same HTTPS server configuration, but iOS was not manually verified.

Fixes #13010