### PR TITLE
fix: preserve quoted page references in queries

### DIFF
--- a/deps/db/src/logseq/db/frontend/query_dsl.cljs
+++ b/deps/db/src/logseq/db/frontend/query_dsl.cljs
@@ -13,11 +13,13 @@
   (if (common-util/wrapped-by-quotes? s)
     s
     (let [quoted-page-ref
-          (fn [matches]
-            (let [match' (string/replace (second matches) "#" tag-placeholder)]
-              (str "\"" page-ref/left-brackets match' page-ref/right-brackets "\"")))]
+          (fn [[match page-name]]
+            (if (some? page-name)
+              (let [page-name' (string/replace page-name "#" tag-placeholder)]
+                (str "\"" page-ref/left-brackets page-name' page-ref/right-brackets "\""))
+              match))]
       (some-> s
-              (string/replace #"\"?\[\[(.*?)\]\]\"?" quoted-page-ref)
+              (string/replace #"\"(?:\\.|[^\"\\])*\"|\[\[(.*?)\]\]" quoted-page-ref)
               (string/replace #"\(between ([^\)]+)\)"
                               (fn [[_ x]]
                                 (->> (string/split x #" ")

--- a/src/test/frontend/db/query_dsl_test.cljs
+++ b/src/test/frontend/db/query_dsl_test.cljs
@@ -157,7 +157,10 @@
       "(and \"for #clojure\")"
 
       "(and \"for #clojure\" #foo)"
-      "(and \"for #clojure\" #tag foo)")))
+      "(and \"for #clojure\" #tag foo)"
+
+      "(and [[outside]] (property prop \"2 [[6a8ead3b-a450-4916-a7e2-d16d0d2b59fd]]\"))"
+      "(and \"[[outside]]\" (property prop \"2 [[6a8ead3b-a450-4916-a7e2-d16d0d2b59fd]]\"))")))
 
 (defn- testable-content
   "Only test :block/title up to page-ref to make tests readable"
@@ -175,6 +178,7 @@
               {:block/title "b3"
                :build/properties {:prop-d #{[:build/page {:block/title "no-space-link"}]}
                                   :prop-c #{[:build/page {:block/title "page a"}] [:build/page {:block/title "page b"}] [:build/page {:block/title "page c"}]}
+                                  :prop-linked-title #{[:build/page {:block/title "2 [[6a8ead3b-a450-4916-a7e2-d16d0d2b59fd]]"}]}
                                   :prop-linked-num #{[:build/page {:block/title "3000"}]}}}
               {:block/title "b4", :build/properties {:prop-d #{[:build/page {:block/title "nada"}]}}}]}])
 
@@ -217,6 +221,11 @@
          (map (comp first string/split-lines :block/title)
               (dsl-query "(property prop-linked-num 3000)")))
       "Blocks have property with integer page value")
+
+  (is (= ["b3"]
+         (map (comp first string/split-lines :block/title)
+              (dsl-query "(and (property prop-linked-title \"2 [[6a8ead3b-a450-4916-a7e2-d16d0d2b59fd]]\"))")))
+      "Page-reference syntax in quoted property values remains literal")
 
   (is (= ["b3"]
          (map (comp first string/split-lines :block/title)


### PR DESCRIPTION
## Summary

- preserve page-reference syntax inside quoted query values
- continue transforming page references used as query clauses
- add preprocessing and database-query regression coverage

## Testing

- `pnpm cljs:run-test -n frontend.db.query-dsl-test` (22 tests, 101 assertions)
- reproduced the reader exception against the attached issue database before the fix
- reopened the attached database after a full runtime restart and verified the persisted query returns its result

Closes #13122