### PR TITLE
chore: bump version to 2.0.2

### DIFF
--- a/src/main/frontend/version.cljs
+++ b/src/main/frontend/version.cljs
@@ -1,3 +1,3 @@
 (ns ^:no-doc frontend.version)
 
-(defonce version "2.0.1")
+(defonce version "2.0.2")


### PR DESCRIPTION
## Summary

- bump the desktop application version to 2.0.2
- prepare the patch release containing the query crash fix from #13123

## Testing

- verified `scripts/get-pkg-version.js beta` resolves to `2.0.2`

Release follow-up for #13122