### PR TITLE
chore: restore version 2.0.1

### DIFF
--- a/src/main/frontend/version.cljs
+++ b/src/main/frontend/version.cljs
@@ -1,3 +1,3 @@
 (ns ^:no-doc frontend.version)
 
-(defonce version "2.0.2")
+(defonce version "2.0.1")


### PR DESCRIPTION
## Summary

- restore the source version to 2.0.1
- keep the query fix scheduled for the nightly channel without a version bump

## Testing

- verified the nightly version is derived from the existing source version and current date