### PR TITLE
fix: use property idents for status and priority shortcuts

### DIFF
--- a/src/main/frontend/modules/shortcut/config.cljs
+++ b/src/main/frontend/modules/shortcut/config.cljs
@@ -274,12 +274,12 @@
    :editor/add-property-status              {:binding "p s"
                                              :selection? true
                                              :fn      (fn []
-                                                        (state/pub-event! [:editor/new-property {:property-key "Status"}]))}
+                                                        (state/pub-event! [:editor/new-property {:property-key :logseq.property/status}]))}
 
    :editor/add-property-priority            {:binding "p p"
                                              :selection? true
                                              :fn      (fn []
-                                                        (state/pub-event! [:editor/new-property {:property-key "Priority"}]))}
+                                                        (state/pub-event! [:editor/new-property {:property-key :logseq.property/priority}]))}
 
    :editor/add-property-icon                {:binding "p i"
                                              :selection? true

--- a/src/test/frontend/modules/shortcut/config_test.cljs
+++ b/src/test/frontend/modules/shortcut/config_test.cljs
@@ -3,6 +3,14 @@
             [frontend.modules.shortcut.config :as shortcut-config]
             [frontend.state :as state]))
 
+(defn- published-property-key
+  [shortcut-id]
+  (let [events* (atom [])]
+    (with-redefs [state/pub-event! (fn [event]
+                                     (swap! events* conj event))]
+      ((get-in shortcut-config/all-built-in-keyboard-shortcuts [shortcut-id :fn]))
+      (get-in @events* [0 1 :property-key]))))
+
 (deftest graph-db-save-shortcut-does-not-trigger-legacy-save-event
   (testing "mod+s in db graph sends new save-info event"
     (let [events* (atom [])]
@@ -12,3 +20,15 @@
                  [:graph/db-save :fn]))
         (is (= [[:graph/db-save-shortcut]]
                @events*))))))
+
+(deftest task-property-shortcuts-use-keyword-idents
+  (testing "status, priority, and deadline shortcuts seed built-in property idents"
+    (is (= :logseq.property/status
+           (published-property-key :editor/add-property-status))
+        "p s must use the Status ident, not the title string")
+    (is (= :logseq.property/priority
+           (published-property-key :editor/add-property-priority))
+        "p p must use the Priority ident, not the title string")
+    (is (= :logseq.property/deadline
+           (published-property-key :editor/add-property-deadline))
+        "p d remains the working keyword-ident baseline")))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--
Thank you for the pull request. Please provide a description. Screenshots and gifs are appreciated for UX enhancements, new features and bug fixes!

For bug fixes and new features, please include tests and possibly benchmarks.
-->

`p s` (Status) and `p p` (Priority) now pass built-in property idents, matching `p d` (Deadline). The property dialog only seeds closed values for keyword keys, so the title strings left those shortcuts on the name/type popup.

Fixes [logseq/db-test#1115](https://github.com/logseq/db-test/issues/1115).

## Test plan
- Unit test `frontend.modules.shortcut.config-test/task-property-shortcuts-use-keyword-idents` asserts Status, Priority, and Deadline publish keyword idents rather than title strings.
- On a block, `p s` and `p p` should open the same usable closed-value picker as `p d`.

Verified:
- Before the product change, the new test failed with `"Status"` / `"Priority"`.
- After the change: `bb dev:test -v frontend.modules.shortcut.config-test/task-property-shortcuts-use-keyword-idents` — 1 test, 3 assertions, 0 failures.
- `pnpm cljs:run-test -n frontend.modules.shortcut.config-test` — 2 tests, 4 assertions, 0 failures.
- `clj-kondo` on the two changed files — 0 errors, 0 warnings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f05d4a1-ea8c-4fa3-b1cb-0dedf1861e8f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f05d4a1-ea8c-4fa3-b1cb-0dedf1861e8f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

