### PR TITLE
fix: collapse property-only nodes

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -52,6 +52,7 @@
             [logseq.common.util.page-ref :as page-ref]
             [logseq.db :as ldb]
             [logseq.db.frontend.asset :as db-asset]
+            [logseq.db.frontend.property :as db-property]
             [logseq.graph-parser.block :as gp-block]
             [logseq.graph-parser.mldoc :as gp-mldoc]
             [logseq.graph-parser.utf8 :as utf8]
@@ -3848,8 +3849,10 @@
 
 (defn db-collapsable?
   [block & _opts]
-  (let [properties (->> (:block.temp/property-keys block)
-                        (remove #{:block/alias})
+  (let [property-keys (or (seq (:block.temp/property-keys block))
+                          (filter db-property/property? (keys block)))
+        properties (->> property-keys
+                        (remove db-property/db-attribute-properties)
                         (remove nil?))]
     (or (seq properties)
         (:logseq.property/query block))))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3853,6 +3853,7 @@
                           (filter db-property/property? (keys block)))
         properties (->> property-keys
                         (remove db-property/db-attribute-properties)
+                        (remove #{:logseq.property/created-by-ref})
                         (remove nil?))]
     (or (seq properties)
         (:logseq.property/query block))))

--- a/src/main/frontend/worker/handler/block.cljs
+++ b/src/main/frontend/worker/handler/block.cljs
@@ -135,6 +135,8 @@
                          (property-handler/display-property-map db entity-id))
                   block)]
       (cond-> (assoc block
+                     :block.temp/property-keys
+                     (property-handler/block-property-keys db entity)
                      :block.temp/positioned-properties
                      (canonical-positioned-properties-map db entity)
                      :block.temp/breadcrumb
@@ -391,15 +393,19 @@
                                                :else
                                                child-map-base)]
                                (-> child-map
-                                   (assoc :block.temp/has-children?
+                                   (assoc :block.temp/property-keys
+                                          (property-handler/block-property-keys db child)
+                                          :block.temp/has-children?
                                           (block-has-children? db (:db/id child))))))
                            children))
-          block-map-base (cond-> (merge
-                                  (property-handler/entity-direct-map db block [:db/id :db/ident :block/uuid :block/name :block/tags])
-                                  (worker-plain/entity-forward-map db block {:properties properties}))
-                           (or render-data? (empty? properties))
-                           (assoc :block/properties
-                                  (property-handler/display-properties-for-block db block)))
+          block-map-base (-> (cond-> (merge
+                                      (property-handler/entity-direct-map db block [:db/id :db/ident :block/uuid :block/name :block/tags])
+                                      (worker-plain/entity-forward-map db block {:properties properties}))
+                               (or render-data? (empty? properties))
+                               (assoc :block/properties
+                                      (property-handler/display-properties-for-block db block)))
+                             (assoc :block.temp/property-keys
+                                    (property-handler/block-property-keys db block)))
           block-map (cond
                       root-render-data?
                       (assoc-root-render-data db block block-map-base)

--- a/src/main/frontend/worker/handler/property.cljs
+++ b/src/main/frontend/worker/handler/property.cljs
@@ -734,6 +734,18 @@
                    property-id))))
        distinct))
 
+(defn block-property-keys
+  "Own property idents plus class-provided property idents."
+  [db block]
+  (let [block-id (cond
+                   (number? block) block
+                   (map? block) (:db/id block)
+                   :else (:db/id (d/entity db block)))
+        own-keys (direct-block-property-ids db block-id)
+        class-keys (map :db/ident
+                        (:classes-properties (block-class-properties db (d/entity db block-id))))]
+    (vec (distinct (concat own-keys class-keys)))))
+
 (defn- property-has-closed-values?
   [db property]
   (boolean (seq (d/datoms db :avet :block/closed-value-property (:db/id property)))))

--- a/src/main/frontend/worker/plain_value.cljs
+++ b/src/main/frontend/worker/plain_value.cljs
@@ -4,7 +4,8 @@
             [clojure.walk :as walk]
             [datascript.core :as d]
             [datascript.impl.entity :as de]
-            [logseq.db :as ldb]))
+            [logseq.db :as ldb]
+            [logseq.db.frontend.property :as db-property]))
 
 (defn- ref-value->summary
   [db value]
@@ -153,8 +154,13 @@
                         (update m a (fnil conj []) v')
                         (assoc m a v'))))
                   {:db/id (:db/id entity)}
-                  datoms)]
-      (cond-> result
+                  datoms)
+          own-property-keys (->> (d/datoms db :eavt (:db/id entity))
+                                 (map :a)
+                                 distinct
+                                 (filter db-property/property?)
+                                 vec)]
+      (cond-> (assoc result :block.temp/property-keys own-property-keys)
         raw-title
         (assoc :block/title raw-title
                :block/raw-title raw-title)

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -2575,3 +2575,34 @@
       (#'editor/enter-comments-area-node! comments-node)
       (is (= [comments-node] @selected)
           "Collapsed comments should be selected for keyboard shortcuts"))))
+
+(deftest db-collapsable-uses-property-keys-and-class-properties-test
+  (testing "own property-keys make a childless node collapsable"
+    (is (true? (editor/db-collapsable?
+                {:block/title "o1"
+                 :block.temp/property-keys [:user.property/p1]}))))
+
+  (testing "class-provided property-keys are collapsable even without a value"
+    (is (true? (editor/db-collapsable?
+                {:block/title "o1"
+                 :block/tags [{:db/ident :user.class/c1}]
+                 :block.temp/property-keys [:user.property/p1]}))))
+
+  (testing "property idents on the worker map are used when property-keys is absent"
+    (is (true? (editor/db-collapsable?
+                {:block/title "o1"
+                 :user.property/p1 "filled"}))))
+
+  (testing "query blocks stay collapsable"
+    (is (true? (editor/db-collapsable?
+                {:block/title "query"
+                 :logseq.property/query {:block/title "q"}}))))
+
+  (testing "tags or titles alone do not make a node collapsable"
+    (is (not (editor/db-collapsable?
+              {:block/title "plain"
+               :block/tags [{:db/ident :user.class/c1}]
+               :block.temp/property-keys [:block/tags]})))
+    (is (not (editor/db-collapsable?
+              {:block/title "plain"
+               :block/tags [{:db/ident :logseq.class/Page}]})))))

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -2578,25 +2578,25 @@
 
 (deftest db-collapsable-uses-property-keys-and-class-properties-test
   (testing "own property-keys make a childless node collapsable"
-    (is (true? (editor/db-collapsable?
-                {:block/title "o1"
-                 :block.temp/property-keys [:user.property/p1]}))))
+    (is (editor/db-collapsable?
+         {:block/title "o1"
+          :block.temp/property-keys [:user.property/p1]})))
 
   (testing "class-provided property-keys are collapsable even without a value"
-    (is (true? (editor/db-collapsable?
-                {:block/title "o1"
-                 :block/tags [{:db/ident :user.class/c1}]
-                 :block.temp/property-keys [:user.property/p1]}))))
+    (is (editor/db-collapsable?
+         {:block/title "o1"
+          :block/tags [{:db/ident :user.class/c1}]
+          :block.temp/property-keys [:user.property/p1]})))
 
   (testing "property idents on the worker map are used when property-keys is absent"
-    (is (true? (editor/db-collapsable?
-                {:block/title "o1"
-                 :user.property/p1 "filled"}))))
+    (is (editor/db-collapsable?
+         {:block/title "o1"
+          :user.property/p1 "filled"})))
 
   (testing "query blocks stay collapsable"
-    (is (true? (editor/db-collapsable?
-                {:block/title "query"
-                 :logseq.property/query {:block/title "q"}}))))
+    (is (editor/db-collapsable?
+         {:block/title "query"
+          :logseq.property/query {:block/title "q"}})))
 
   (testing "tags or titles alone do not make a node collapsable"
     (is (not (editor/db-collapsable?

--- a/src/test/frontend/worker/handler/block_test.cljs
+++ b/src/test/frontend/worker/handler/block_test.cljs
@@ -2,7 +2,8 @@
   (:require [cljs.test :refer [deftest is testing]]
             [datascript.core :as d]
             [frontend.util.entity :as entity]
-            [frontend.worker.handler.block]
+            [frontend.worker.handler.block :as block-handler]
+            [frontend.worker.handler.property :as property-handler]
             [logseq.db :as ldb]
             [logseq.db.test.helper :as db-test]))
 
@@ -202,6 +203,8 @@
       (is (map? (:block.temp/positioned-properties block)))
       (is (vector? (:block.temp/breadcrumb block)))
       (is (integer? (:block.temp/refs-count block)))
+      (is (some #{:user.property/priority} (:block.temp/property-keys block))
+          "Own property idents are persisted for collapse.")
       (is (not (contains? block :block/children)))
       (is (not (contains? block :block/properties)))
       (is (not-any? #(and (keyword? %)
@@ -209,6 +212,7 @@
                     (remove #{:block.temp/order-list-index
                               :block.temp/breadcrumb
                               :block.temp/positioned-properties
+                              :block.temp/property-keys
                               :block.temp/refs-count}
                             (keys block)))))))
 
@@ -560,3 +564,38 @@
         (doseq [value [blocks membership tree]]
           (is (= value
                  (-> value ldb/write-transit-str ldb/read-transit-str))))))))
+
+(deftest block-property-keys-include-own-and-class-properties-test
+  (let [conn (db-test/create-conn-with-blocks
+              {:classes {:c1 {:build/class-properties [:p1]}}
+               :properties {:own {:logseq.property/type :default}}
+               :pages-and-blocks
+               [{:page {:block/title "Page"}
+                 :blocks [{:block/title "with-own"
+                           :build/properties {:own "v"}}
+                          {:block/title "with-class"
+                           :build/tags [:c1]}
+                          {:block/title "plain"}]}]})
+        db @conn
+        with-own (db-test/find-block-by-content db "with-own")
+        with-class (db-test/find-block-by-content db "with-class")
+        plain (db-test/find-block-by-content db "plain")
+        own-map (:block (block-handler/get-block-and-children db (:db/id with-own) {:children? false}))
+        class-map (:block (block-handler/get-block-and-children db (:db/id with-class) {:children? false}))
+        plain-map (:block (block-handler/get-block-and-children db (:db/id plain) {:children? false}))]
+    (is (some #{:user.property/own} (property-handler/block-property-keys db with-own)))
+    (is (some #{:user.property/p1} (property-handler/block-property-keys db with-class))
+        "Class-provided properties are included even when the node has no own value.")
+    (is (not-any? #{:user.property/own :user.property/p1}
+                  (property-handler/block-property-keys db plain)))
+    (is (some #{:user.property/own} (:block.temp/property-keys own-map)))
+    (is (some #{:user.property/p1} (:block.temp/property-keys class-map)))
+    (is (not-any? #{:user.property/own :user.property/p1}
+                  (:block.temp/property-keys plain-map)))
+    (when-let [canonical-block (canonical-block-api)]
+      (d/transact! conn [{:db/id (:db/id with-class)
+                          :block/tx-id 1}])
+      (is (some #{:user.property/p1}
+                (:block.temp/property-keys
+                 (canonical-block @conn (d/entity @conn (:db/id with-class)))))
+          "Canonical renderer maps persist class-provided property keys."))))

--- a/src/test/frontend/worker/handler/render_resource_test.cljs
+++ b/src/test/frontend/worker/handler/render_resource_test.cljs
@@ -521,7 +521,8 @@
   (is (every? #{:block.temp/positioned-properties
                 :block.temp/breadcrumb
                 :block.temp/refs-count
-                :block.temp/order-list-index}
+                :block.temp/order-list-index
+                :block.temp/property-keys}
               (filter #(= "block.temp" (namespace %)) (keys block))))
   (doseq [reference (concat (keep block [:block/page :block/parent])
                             (:block/refs block)

--- a/src/test/frontend/worker/plain_value_test.cljs
+++ b/src/test/frontend/worker/plain_value_test.cljs
@@ -100,6 +100,12 @@
     (is (not (contains? result :user.property/related)))
     (is (= "Host" (:block/title result)))))
 
+(deftest entity-forward-map-includes-own-property-keys
+  (let [[db host _target-uuid _value-uuid] (property-value-db :default {})
+        result (plain-value/entity-forward-map db host {})]
+    (is (some #{:user.property/related} (:block.temp/property-keys result))
+        "Own property idents are persisted so renderer collapse can see them.")))
+
 (deftest get-block-display-properties-use-resolved-node-values
   (let [[db host target-uuid _value-uuid]
         (property-value-db :node {:block/name "target"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/logseq/db-test/issues/1116

After the UI db removal, `db-collapsable?` only looked at `:block.temp/property-keys`, but worker block maps never set that field. Nodes that only had properties (or class-provided properties) and no children could no longer be collapsed.

## Change
- Persist own and class-provided property idents on worker block maps (`canonical-block`, `get-block-and-children`, `entity-forward-map`).
- Restore `db-collapsable?` to use those keys, ignore db-attribute properties such as tags, and treat query blocks as collapsable.
- Nodes with neither children nor user/class properties stay uncollapsable.

## Tests
- `db-collapsable?` covers property-keys, class-provided properties, query blocks, and tag-only nodes.
- Worker tests cover own `property-keys` on `entity-forward-map` / `canonical-block` and class-provided keys on `get-block-and-children`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73d05870-df27-49ce-9d39-1cebab886241?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73d05870-df27-49ce-9d39-1cebab886241&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

