### PR TITLE
fix(db): stream File-to-DB import and restore progress (db-test#1117)

### DIFF
--- a/src/main/frontend/components/imports.cljs
+++ b/src/main/frontend/components/imports.cljs
@@ -12,6 +12,7 @@
             [frontend.fs :as fs]
             [frontend.handler.assets :as assets-handler]
             [frontend.handler.db-based.import :as db-import-handler]
+            [frontend.handler.file-graph-import :as file-graph-import]
             [frontend.handler.notification :as notification]
             [frontend.handler.repo :as repo-handler]
             [frontend.handler.route :as route-handler]
@@ -336,9 +337,17 @@
         (assoc (select-keys file [:path])
                :file/content content)))))
 
-(defn- <serialize-import-files
+(defn- import-file-graph-file-meta
+  [file]
+  (select-keys file [:path :last-modified-at :fs-path]))
+
+(defn- import-files-by-path
   [files]
-  (p/all (mapv <serialize-import-file files)))
+  (into {}
+        (keep (fn [file]
+                (when-let [path (:path file)]
+                  [path file])))
+        files))
 
 (defn- write-staged-assets!
   [repo staged-assets]
@@ -367,22 +376,44 @@
    config-file]
   (state/set-state! :graph/importing :file-graph)
   (state/set-state! [:graph/importing-state :current-page] "Config files")
-  (p/let [start-time (t/now)
-          _ (repo-handler/new-db! graph-name {:file-graph-import? true})
-          repo (state/get-current-repo)
-          serialized-files (<serialize-import-files *files)
-          serialized-config-file (first (filter #(= (:path %) (:path config-file)) serialized-files))
-          options (build-file-graph-worker-options user-options config/config-default-content)
-          import-result (state/<invoke-db-worker :thread-api/import-file-graph repo serialized-config-file serialized-files options)
-          _ (doseq [notification (:notifications import-result)]
-              (show-notification notification))
-          _ (write-staged-assets! repo (:staged-assets import-result))]
-    (log/info :import-file-graph {:msg (str "Import finished in " (/ (t/in-millis (t/interval start-time (t/now))) 1000) " seconds")})
-    (state/set-state! :graph/importing nil)
-    (state/set-state! :graph/importing-state nil)
-    (validate-imported-data import-result)
-    (state/pub-event! [:graph/ready (state/get-current-repo)])
-    (finished-cb)))
+  (let [files-by-path (import-files-by-path *files)]
+    (file-graph-import/set-file-graph-import-session!
+     {:<read-file (fn [path]
+                    (if-let [file (get files-by-path path)]
+                      (<serialize-import-file file)
+                      (p/rejected (ex-info "import file not found"
+                                           {:code :import-file-not-found
+                                            :path path}))))
+      :<write-staged-asset (fn [repo asset]
+                             (write-staged-assets! repo [asset]))
+      :pending-asset-writes (atom [])}))
+  (-> (p/let [start-time (t/now)
+              _ (repo-handler/new-db! graph-name {:file-graph-import? true})
+              repo (state/get-current-repo)
+              serialized-config-file (<serialize-import-file config-file)
+              file-metas (mapv import-file-graph-file-meta *files)
+              options (build-file-graph-worker-options user-options config/config-default-content)
+              assets-dir (path/path-join (config/get-repo-dir repo) common-config/local-assets-dir)
+              _ (fs/mkdir-if-not-exists assets-dir)
+              import-result (state/<invoke-db-worker :thread-api/import-file-graph repo serialized-config-file file-metas options)
+              _ (doseq [notification (:notifications import-result)]
+                  (show-notification notification))
+              _ (file-graph-import/<await-file-graph-import-asset-writes!)
+              leftover-assets (filter :payload (:staged-assets import-result))
+              _ (write-staged-assets! repo leftover-assets)]
+        (log/info :import-file-graph {:msg (str "Import finished in " (/ (t/in-millis (t/interval start-time (t/now))) 1000) " seconds")})
+        (state/set-state! :graph/importing nil)
+        (state/set-state! :graph/importing-state nil)
+        (validate-imported-data import-result)
+        (state/pub-event! [:graph/ready (state/get-current-repo)])
+        (finished-cb))
+      (p/catch (fn [e]
+                 (log/error :import-file-graph {:error e})
+                 (notification/show! (t :import/unexpected-error (or (ex-message e) (str e))) :error)
+                 (state/set-state! :graph/importing nil)
+                 (state/set-state! :graph/importing-state nil)))
+      (p/finally (fn []
+                   (file-graph-import/clear-file-graph-import-session!)))))
 
 (defn import-file-to-db-handler
   "Import from a graph folder as a DB-based graph"

--- a/src/main/frontend/handler/file_graph_import.cljs
+++ b/src/main/frontend/handler/file_graph_import.cljs
@@ -1,0 +1,38 @@
+(ns frontend.handler.file-graph-import
+  "Renderer-side session for streaming File-to-DB imports."
+  (:require [promesa.core :as p]))
+
+(defonce ^:private *file-graph-import-session (atom nil))
+
+(defn set-file-graph-import-session!
+  [session]
+  (reset! *file-graph-import-session session))
+
+(defn clear-file-graph-import-session!
+  []
+  (reset! *file-graph-import-session nil))
+
+(defn <read-file-graph-import-file
+  [path]
+  (if-let [reader (:<read-file @*file-graph-import-session)]
+    (reader path)
+    (p/rejected (ex-info "no file-graph import session"
+                         {:code :missing-import-session
+                          :path path}))))
+
+(defn <write-file-graph-import-staged-asset!
+  [repo asset]
+  (if-let [writer (:<write-staged-asset @*file-graph-import-session)]
+    (let [write (writer repo asset)]
+      (when-let [pending (:pending-asset-writes @*file-graph-import-session)]
+        (swap! pending conj write))
+      write)
+    (p/resolved nil)))
+
+(defn <await-file-graph-import-asset-writes!
+  []
+  (if-let [pending (:pending-asset-writes @*file-graph-import-session)]
+    (p/let [_ (p/all @pending)]
+      (reset! pending [])
+      nil)
+    (p/resolved nil)))

--- a/src/main/frontend/handler/worker.cljs
+++ b/src/main/frontend/handler/worker.cljs
@@ -6,6 +6,7 @@
             [frontend.common.crypt :as crypt]
             [frontend.context.i18n :as i18n]
             [frontend.handler.e2ee :as e2ee-handler]
+            [frontend.handler.file-graph-import :as file-graph-import]
             [frontend.handler.notification :as notification]
             [frontend.state :as state]
             [lambdaisland.glogi :as log]
@@ -60,6 +61,12 @@
 (defmethod handle :thread-api/search-index-build-progress [_ _worker args]
   (when-let [f (get @thread-api/*thread-apis :thread-api/search-index-build-progress)]
     (apply f args)))
+
+(defmethod handle :set-ui-state [_ _worker [path value]]
+  (state/set-state! path value))
+
+(defmethod handle :import-staged-asset [_ _worker {:keys [repo asset]}]
+  (file-graph-import/<write-file-graph-import-staged-asset! repo asset))
 
 (defmethod handle :sync-db-changes [_ _worker data]
   (state/pub-event! [:db/sync-changes data]))
@@ -152,6 +159,15 @@
           (p/resolved {:supported? false})
           (p/let [_ (e2ee-handler/<native-delete-secret! key)]
             {:supported? true}))))
+
+    :read-import-file
+    (let [path (:path payload)]
+      (if-not (string? path)
+        (p/rejected (ex-info "invalid read-import-file payload"
+                             {:code :invalid-ui-action-payload
+                              :action action
+                              :payload payload}))
+        (file-graph-import/<read-file-graph-import-file path)))
 
     (p/rejected (ex-info "unsupported db-worker ui action"
                          {:code :unsupported-ui-action

--- a/src/main/frontend/worker/db_core.cljs
+++ b/src/main/frontend/worker/db_core.cljs
@@ -39,6 +39,7 @@
    [frontend.worker.sync.crypt :as sync-crypt]
    [frontend.worker.sync.download :as sync-download]
    [frontend.worker.thread-atom]
+   [frontend.worker.ui-request :as ui-request]
    [frontend.worker.undo-redo :as worker-undo-redo]
    [goog.functions :as gfun]
    [lambdaisland.glogi :as log]
@@ -221,11 +222,34 @@
                [k (if (satisfies? IDeref v) @v v)]))
         import-state))
 
-(defn- file-content
+(def ^:private import-file-read-timeout-ms (* 5 60 1000))
+
+(defn- file-text-content
   [file]
-  (or (:file/content file)
-      (:content file)
-      ""))
+  (or (when (string? (:file/content file))
+        (:file/content file))
+      (when (string? (:content file))
+        (:content file))))
+
+(defn- import-file-meta
+  [file]
+  (select-keys file [:path :last-modified-at :fs-path]))
+
+(defn- index-import-files
+  [files]
+  (into {}
+        (keep (fn [file]
+                (when-let [path (:path file)]
+                  [path file])))
+        files))
+
+(defn- take-indexed-import-file!
+  [*files-by-path path]
+  (when (and *files-by-path path)
+    (let [file (get @*files-by-path path)]
+      (when file
+        (swap! *files-by-path dissoc path))
+      file)))
 
 (defn- import-file-payload
   [payload]
@@ -242,28 +266,70 @@
     :else
     nil))
 
+(defn- <request-import-file
+  [file]
+  (ui-request/<request :read-import-file
+                       {:path (:path file)}
+                       {:timeout-ms import-file-read-timeout-ms
+                        :hint "import-file-graph"}))
+
+(defn- <read-import-file
+  [*files-by-path file]
+  (let [indexed (take-indexed-import-file! *files-by-path (:path file))
+        inline (or (file-text-content file)
+                   (file-text-content indexed))]
+    (if (some? inline)
+      (p/resolved inline)
+      (p/let [resolved (<request-import-file file)]
+        (or (file-text-content resolved) "")))))
+
+(defn- <resolve-import-asset-file
+  [*files-by-path file]
+  (let [indexed (take-indexed-import-file! *files-by-path (:path file))]
+    (cond
+      (some? (import-file-payload (:asset/payload file)))
+      (p/resolved file)
+
+      (some? (import-file-payload (:asset/payload indexed)))
+      (p/resolved indexed)
+
+      :else
+      (<request-import-file file))))
+
+(defn- publish-import-ui-state!
+  [path value]
+  (shared-service/broadcast-to-clients! :set-ui-state [path value]))
+
+(defn- publish-staged-import-asset!
+  [repo asset]
+  (shared-service/broadcast-to-clients! :import-staged-asset {:repo repo
+                                                             :asset asset}))
+
 (defn- <read-and-stage-import-asset
-  [file assets buffer-handler staged-assets]
-  (when-let [payload (some-> file :asset/payload import-file-payload)]
-    (let [buffer (.-buffer payload)
-          asset-type (db-asset/asset-path->type (:path file))
-          asset-id (d/squuid)
-          asset-name (some-> (:path file) gp-exporter/asset-path->name)
-          size (or (:asset/size file) (.-byteLength payload))]
-      (p/let [checksum (db-asset/<get-file-array-buffer-checksum buffer)
-              {:keys [with-edn-content pdf-annotation?]} (buffer-handler payload)
-              asset-data (with-edn-content
-                           {:size size
-                            :type asset-type
-                            :path (:path file)
-                            :checksum checksum
-                            :asset-id asset-id})]
-        (swap! assets assoc asset-name asset-data)
-        (when-not pdf-annotation?
-          (swap! staged-assets conj {:path (:path file)
-                                     :asset-id asset-id
-                                     :asset-type asset-type
-                                     :payload payload}))))))
+  [repo file assets buffer-handler staged-assets *files-by-path]
+  (p/let [file' (<resolve-import-asset-file *files-by-path file)]
+    (when-let [payload (some-> file' :asset/payload import-file-payload)]
+      (let [buffer (.-buffer payload)
+            asset-type (db-asset/asset-path->type (:path file'))
+            asset-id (d/squuid)
+            asset-name (some-> (:path file') gp-exporter/asset-path->name)
+            size (or (:asset/size file') (.-byteLength payload))]
+        (p/let [checksum (db-asset/<get-file-array-buffer-checksum buffer)
+                {:keys [with-edn-content pdf-annotation?]} (buffer-handler payload)
+                asset-data (with-edn-content
+                             {:size size
+                              :type asset-type
+                              :path (:path file')
+                              :checksum checksum
+                              :asset-id asset-id})]
+          (swap! assets assoc asset-name asset-data)
+          (when-not pdf-annotation?
+            (let [staged {:path (:path file')
+                          :asset-id asset-id
+                          :asset-type asset-type
+                          :payload payload}]
+              (publish-staged-import-asset! repo staged)
+              (swap! staged-assets conj (dissoc staged :payload)))))))))
 
 (defn- finalize-import-render-revisions!
   [conn]
@@ -288,16 +354,29 @@
   (when-let [conn (worker-state/get-datascript-conn repo)]
     (let [notifications (atom [])
           staged-assets (atom [])
+          *files-by-path (atom (index-import-files (cond-> (vec files)
+                                                     (and (map? config-file) (:path config-file))
+                                                     (conj config-file))))
+          files-meta (mapv import-file-meta files)
+          config-meta (import-file-meta config-file)
+          set-ui-state (if (fn? (:set-ui-state opts))
+                         (:set-ui-state opts)
+                         publish-import-ui-state!)
+          <read-file (if (fn? (:<read-file opts))
+                       (:<read-file opts)
+                       (fn [file]
+                         (<read-import-file *files-by-path file)))
           options (-> opts
+                      (dissoc :set-ui-state :<read-file)
                       (assoc :notify-user #(swap! notifications conj %)
                              :log-fn (fn [& args]
                                        (log/info :import-file-graph {:args args}))
-                             :<read-file (fn [file] (p/resolved (file-content file)))
+                             :set-ui-state set-ui-state
+                             :<read-file <read-file
                              :<get-file-stat (constantly nil)
                              :<read-and-copy-asset (fn [file assets buffer-handler]
-                                                     (<read-and-stage-import-asset file assets buffer-handler staged-assets)))
-                      (dissoc :set-ui-state))]
-      (p/let [result (gp-exporter/export-file-graph conn conn config-file files options)
+                                                     (<read-and-stage-import-asset repo file assets buffer-handler staged-assets *files-by-path))))]
+      (p/let [result (gp-exporter/export-file-graph conn conn config-meta files-meta options)
               _ (finalize-import-render-revisions! conn)
               validation (worker-db-validate/validate-db conn :fix false)]
         {:files (:files result)
@@ -915,7 +994,9 @@
          :log
          :add-repo
          :rtc-log
-         :rtc-sync-state])))
+         :rtc-sync-state
+         :set-ui-state
+         :import-staged-asset])))
 
 (defn- <init-service!
   [graph start-opts]

--- a/src/test/frontend/components/imports_test.cljs
+++ b/src/test/frontend/components/imports_test.cljs
@@ -18,7 +18,27 @@
                                    "{:meta/version 1}")]
         (is (= options (-> options ldb/write-transit-str ldb/read-transit-str)))
         (is (= #{"Project" "Area"} (get-in options [:user-options :tag-classes])))
-        (is (not (contains? options :notify-user)))))))
+        (is (not (contains? options :notify-user)))
+        (is (not (contains? options :set-ui-state)))))))
+
+(deftest file-graph-import-file-metas-omit-file-contents-test
+  (let [file-meta (some-> (resolve 'frontend.components.imports/import-file-graph-file-meta)
+                          deref)]
+    (is (fn? file-meta))
+    (when (fn? file-meta)
+      (let [meta (file-meta {:path "pages/Home.md"
+                             :last-modified-at 1
+                             :fs-path "/tmp/graph/pages/Home.md"
+                             :file/content "- should not cross the worker boundary"
+                             :asset/payload (js/Uint8Array. 4)
+                             :file-object :renderer-only})]
+        (is (= {:path "pages/Home.md"
+                :last-modified-at 1
+                :fs-path "/tmp/graph/pages/Home.md"}
+               meta))
+        (is (not (contains? meta :file/content)))
+        (is (not (contains? meta :asset/payload)))
+        (is (not (contains? meta :file-object)))))))
 
 (deftest staged-assets-wait-for-directory-and-all-writes-test
   (async done

--- a/src/test/frontend/handler/worker_test.cljs
+++ b/src/test/frontend/handler/worker_test.cljs
@@ -1,5 +1,6 @@
 (ns frontend.handler.worker-test
   (:require [cljs.test :refer [async deftest is]]
+            [frontend.handler.file-graph-import :as file-graph-import]
             [frontend.handler.worker :as worker-handler]
             [frontend.state :as state]
             [promesa.core :as p]))
@@ -112,3 +113,60 @@
             (p/catch (fn [error]
                        (is nil (str "unexpected error: " error))
                        (done))))))))
+
+(deftest db-worker-ui-request-read-import-file-resolves-session-file-test
+  (async done
+    (let [calls (atom [])
+          wrapped-worker (fn [qkw & args]
+                           (swap! calls conj [qkw args])
+                           (p/resolved {:ok true}))]
+      (file-graph-import/set-file-graph-import-session!
+       {:<read-file (fn [path]
+                      (p/resolved {:path path
+                                   :file/content "- streamed"}))})
+      (-> (worker-handler/handle :db-worker/ui-request
+                                 wrapped-worker
+                                 {:request-id "req-import"
+                                  :action :read-import-file
+                                  :payload {:path "pages/Home.md"}})
+          (p/then (fn [_]
+                    (is (= [[:thread-api/resolve-ui-request
+                             ["req-import" {:path "pages/Home.md"
+                                            :file/content "- streamed"}]]]
+                           @calls))))
+          (p/catch (fn [error]
+                     (is nil (str "unexpected error: " error))))
+          (p/finally (fn []
+                       (file-graph-import/clear-file-graph-import-session!)
+                       (done)))))))
+
+(deftest set-ui-state-updates-importing-progress-test
+  (let [updates (atom [])]
+    (with-redefs [state/set-state! (fn [path value]
+                                     (swap! updates conj [path value]))]
+      (worker-handler/handle :set-ui-state nil [[:graph/importing-state :current-page] "pages/Home.md"])
+      (is (= [[[:graph/importing-state :current-page] "pages/Home.md"]]
+             @updates)))))
+
+(deftest import-staged-asset-writes-through-import-session-test
+  (async done
+    (let [writes (atom [])]
+      (file-graph-import/set-file-graph-import-session!
+       {:<write-staged-asset (fn [repo asset]
+                               (swap! writes conj [repo asset])
+                               (p/resolved :written))
+        :pending-asset-writes (atom [])})
+      (-> (p/do
+            (worker-handler/handle :import-staged-asset
+                                   nil
+                                   {:repo "test-repo"
+                                    :asset {:asset-id "one" :asset-type "png"}})
+            (file-graph-import/<await-file-graph-import-asset-writes!))
+          (p/then (fn [_]
+                    (is (= [["test-repo" {:asset-id "one" :asset-type "png"}]]
+                           @writes))))
+          (p/catch (fn [error]
+                     (is nil (str "unexpected error: " error))))
+          (p/finally (fn []
+                       (file-graph-import/clear-file-graph-import-session!)
+                       (done)))))))

--- a/src/test/frontend/worker/db_core_test.cljs
+++ b/src/test/frontend/worker/db_core_test.cljs
@@ -1692,7 +1692,9 @@
     (is (contains? types "log"))
     (is (contains? types "add-repo"))
     (is (contains? types "rtc-log"))
-    (is (contains? types "rtc-sync-state"))))
+    (is (contains? types "rtc-sync-state"))
+    (is (contains? types "set-ui-state"))
+    (is (contains? types "import-staged-asset"))))
 
 ;; ---- init-core! tests ----
 
@@ -2610,6 +2612,137 @@
                             (:block/uuid (block-handler/canonical-block @conn entity))))
                      (is (contains? published-block-uuids (:block/uuid entity))
                          "Live file imports must publish complete canonical replacements.")))
+                 (p/catch
+                  (fn [error]
+                    (is false (str error))))
+                 (p/finally (fn []
+                              (reset! ldb/*transact-pipeline-fn pipeline-before)
+                              (done))))))))))
+
+(deftest import-file-graph-streams-files-and-reports-progress
+  (async done
+         (restoring-worker-state
+          (fn []
+            (let [import-file-graph! (get @thread-api/*thread-apis :thread-api/import-file-graph)
+                  conn (d/create-conn db-schema/schema)
+                  pipeline-before @ldb/*transact-pipeline-fn
+                  ui-state (atom [])
+                  in-flight (atom 0)
+                  max-in-flight (atom 0)
+                  contents {"logseq/config.edn" "{}"
+                            "pages/Home.md" "- imported home"
+                            "pages/Projects.md" "- imported projects"}
+                  config-file {:path "logseq/config.edn"}
+                  files [{:path "logseq/config.edn"}
+                         {:path "pages/Home.md"}
+                         {:path "pages/Projects.md"}]]
+              (is (fn? import-file-graph!))
+              (d/transact! conn (sqlite-create-graph/build-db-initial-data "{}"))
+              (reset! worker-state/*datascript-conns {test-repo conn})
+              (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
+              (p/with-redefs
+                [db-sync/update-local-sync-checksum! (fn [& _] nil)
+                 db-sync/handle-local-tx! (fn [& _] nil)
+                 shared-service/broadcast-to-clients! (fn [& _] nil)]
+                (db-listener/listen-db-changes! test-repo conn
+                                                :handler-keys [:sync-db-to-main-thread])
+                (->
+                 (p/let [result (import-file-graph!
+                                 test-repo
+                                 config-file
+                                 files
+                                 {:user-options {}
+                                  :set-ui-state (fn [path value]
+                                                  (swap! ui-state conj [path value]))
+                                  :<read-file (fn [file]
+                                                (swap! in-flight inc)
+                                                (swap! max-in-flight max @in-flight)
+                                                (p/let [_ (p/delay 0)]
+                                                  (swap! in-flight dec)
+                                                  (get contents (:path file))))})
+                         home (some->> (d/q '[:find [?e ...]
+                                              :where [?e :block/name "home"]]
+                                            @conn)
+                                       first
+                                       (d/entity @conn))
+                         projects (some->> (d/q '[:find [?e ...]
+                                                  :where [?e :block/name "projects"]]
+                                                @conn)
+                                           first
+                                           (d/entity @conn))
+                         home-block (db-test/find-block-by-content @conn "imported home")
+                         project-block (db-test/find-block-by-content @conn "imported projects")
+                         current-pages (into []
+                                             (keep (fn [[path value]]
+                                                     (when (= path [:graph/importing-state :current-page])
+                                                       value)))
+                                             @ui-state)
+                         totals (into []
+                                      (keep (fn [[path value]]
+                                              (when (= path [:graph/importing-state :total])
+                                                value)))
+                                      @ui-state)
+                         indexes (into []
+                                       (keep (fn [[path value]]
+                                               (when (= path [:graph/importing-state :current-idx])
+                                                 value)))
+                                       @ui-state)]
+                   (is (= #{"pages/Home.md" "pages/Projects.md" "logseq/config.edn"}
+                          (set (map :path (:files result)))))
+                   (is (every? #(not (contains? % :file/content)) (:files result))
+                       "Worker must not keep document contents on the returned file list.")
+                   (is (= "Home" (:block/title home)))
+                   (is (= "Projects" (:block/title projects)))
+                   (is (= "imported home" (:block/title home-block)))
+                   (is (= "imported projects" (:block/title project-block)))
+                   (is (= 1 @max-in-flight)
+                       "Import must read one file at a time instead of preloading the graph.")
+                   (is (= [2] totals))
+                   (is (= [1 2] indexes))
+                   (is (some #(= % "pages/Home.md") current-pages))
+                   (is (some #(= % "pages/Projects.md") current-pages)))
+                 (p/catch
+                  (fn [error]
+                    (is false (str error))))
+                 (p/finally (fn []
+                              (reset! ldb/*transact-pipeline-fn pipeline-before)
+                              (done))))))))))
+
+(deftest import-file-graph-publishes-progress-when-set-ui-state-is-not-supplied
+  (async done
+         (restoring-worker-state
+          (fn []
+            (let [import-file-graph! (get @thread-api/*thread-apis :thread-api/import-file-graph)
+                  conn (d/create-conn db-schema/schema)
+                  pipeline-before @ldb/*transact-pipeline-fn
+                  broadcasts (atom [])
+                  config-file {:path "logseq/config.edn"
+                               :file/content "{}"}
+                  files [config-file
+                         {:path "pages/Home.md"
+                          :file/content "- imported block"}]]
+              (d/transact! conn (sqlite-create-graph/build-db-initial-data "{}"))
+              (reset! worker-state/*datascript-conns {test-repo conn})
+              (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
+              (p/with-redefs
+                [db-sync/update-local-sync-checksum! (fn [& _] nil)
+                 db-sync/handle-local-tx! (fn [& _] nil)
+                 shared-service/broadcast-to-clients!
+                 (fn [event payload]
+                   (swap! broadcasts conj [event payload]))]
+                (db-listener/listen-db-changes! test-repo conn
+                                                :handler-keys [:sync-db-to-main-thread])
+                (->
+                 (p/let [_ (import-file-graph! test-repo config-file files {:user-options {}})
+                         ui-events (filter #(= :set-ui-state (first %)) @broadcasts)
+                         pages (into []
+                                     (keep (fn [[_ [path value]]]
+                                             (when (= path [:graph/importing-state :current-page])
+                                               value)))
+                                     ui-events)]
+                   (is (seq ui-events)
+                       "Default import progress must broadcast set-ui-state instead of discarding it.")
+                   (is (some #(= % "pages/Home.md") pages)))
                  (p/catch
                   (fn [error]
                     (is false (str error))))

--- a/src/test/frontend/worker/db_core_test.cljs
+++ b/src/test/frontend/worker/db_core_test.cljs
@@ -2566,189 +2566,189 @@
 
 (deftest import-file-graph-imports-documents-into-worker-conn
   (async done
-         (restoring-worker-state
-          (fn []
-            (let [import-file-graph! (get @thread-api/*thread-apis :thread-api/import-file-graph)
-                  conn (d/create-conn db-schema/schema)
-                  pipeline-before @ldb/*transact-pipeline-fn
-                  renderer-payloads (atom [])
-                  config-file {:path "logseq/config.edn"
-                               :file/content "{}"}
-                  files [config-file
-                         {:path "pages/Home.md"
-                          :file/content "- imported block"}]]
-              (is (fn? import-file-graph!))
-              (d/transact! conn (sqlite-create-graph/build-db-initial-data "{}"))
-              (reset! worker-state/*datascript-conns {test-repo conn})
-              (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
-              (p/with-redefs
-                [db-sync/update-local-sync-checksum! (fn [& _] nil)
-                 db-sync/handle-local-tx! (fn [& _] nil)
-                 shared-service/broadcast-to-clients!
-                 (fn [event payload]
-                   (when (= :sync-db-changes event)
-                     (swap! renderer-payloads conj payload)))]
-                (db-listener/listen-db-changes! test-repo conn
-                                                :handler-keys [:sync-db-to-main-thread])
-                (->
-                 (p/let [result (import-file-graph! test-repo config-file files {:user-options {}})
-                         page (some->> (d/q '[:find [?e ...]
-                                               :where [?e :block/name "home"]]
-                                             @conn)
-                                             first
-                                        (d/entity @conn))
-                         block (db-test/find-block-by-content @conn "imported block")
-                         published-block-uuids
-                         (into #{}
-                               (mapcat #(keys (get-in % [:delta :blocks])))
-                               @renderer-payloads)]
-                   (is (= #{"pages/Home.md" "logseq/config.edn"}
-                          (set (map :path (:files result)))))
-                   (is (= "Home" (:block/title page)))
-                   (is (= "imported block" (:block/title block)))
-                   (doseq [entity [page block]]
-                     (is (nat-int? (:block/tx-id entity)))
-                     (is (= (:block/uuid entity)
-                            (:block/uuid (block-handler/canonical-block @conn entity))))
-                     (is (contains? published-block-uuids (:block/uuid entity))
-                         "Live file imports must publish complete canonical replacements.")))
-                 (p/catch
-                  (fn [error]
-                    (is false (str error))))
-                 (p/finally (fn []
-                              (reset! ldb/*transact-pipeline-fn pipeline-before)
-                              (done))))))))))
+         (-> (restoring-worker-state
+              (fn []
+                (let [import-file-graph! (get @thread-api/*thread-apis :thread-api/import-file-graph)
+                      conn (d/create-conn db-schema/schema)
+                      pipeline-before @ldb/*transact-pipeline-fn
+                      renderer-payloads (atom [])
+                      config-file {:path "logseq/config.edn"
+                                   :file/content "{}"}
+                      files [config-file
+                             {:path "pages/Home.md"
+                              :file/content "- imported block"}]]
+                  (is (fn? import-file-graph!))
+                  (d/transact! conn (sqlite-create-graph/build-db-initial-data "{}"))
+                  (reset! worker-state/*datascript-conns {test-repo conn})
+                  (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
+                  (p/with-redefs
+                    [db-sync/update-local-sync-checksum! (fn [& _] nil)
+                     db-sync/handle-local-tx! (fn [& _] nil)
+                     shared-service/broadcast-to-clients!
+                     (fn [event payload]
+                       (when (= :sync-db-changes event)
+                         (swap! renderer-payloads conj payload)))]
+                    (db-listener/listen-db-changes! test-repo conn
+                                                    :handler-keys [:sync-db-to-main-thread])
+                    (->
+                     (p/let [result (import-file-graph! test-repo config-file files {:user-options {}})
+                             page (some->> (d/q '[:find [?e ...]
+                                                   :where [?e :block/name "home"]]
+                                                 @conn)
+                                                 first
+                                            (d/entity @conn))
+                             block (db-test/find-block-by-content @conn "imported block")
+                             published-block-uuids
+                             (into #{}
+                                   (mapcat #(keys (get-in % [:delta :blocks])))
+                                   @renderer-payloads)]
+                       (is (= #{"pages/Home.md" "logseq/config.edn"}
+                              (set (map :path (:files result)))))
+                       (is (= "Home" (:block/title page)))
+                       (is (= "imported block" (:block/title block)))
+                       (doseq [entity [page block]]
+                         (is (nat-int? (:block/tx-id entity)))
+                         (is (= (:block/uuid entity)
+                                (:block/uuid (block-handler/canonical-block @conn entity))))
+                         (is (contains? published-block-uuids (:block/uuid entity))
+                             "Live file imports must publish complete canonical replacements.")))
+                     (p/catch
+                      (fn [error]
+                        (is false (str error))))
+                     (p/finally (fn []
+                                  (reset! ldb/*transact-pipeline-fn pipeline-before))))))))
+             (p/finally (fn [] (done))))))
 
 (deftest import-file-graph-streams-files-and-reports-progress
   (async done
-         (restoring-worker-state
-          (fn []
-            (let [import-file-graph! (get @thread-api/*thread-apis :thread-api/import-file-graph)
-                  conn (d/create-conn db-schema/schema)
-                  pipeline-before @ldb/*transact-pipeline-fn
-                  ui-state (atom [])
-                  in-flight (atom 0)
-                  max-in-flight (atom 0)
-                  contents {"logseq/config.edn" "{}"
-                            "pages/Home.md" "- imported home"
-                            "pages/Projects.md" "- imported projects"}
-                  config-file {:path "logseq/config.edn"}
-                  files [{:path "logseq/config.edn"}
-                         {:path "pages/Home.md"}
-                         {:path "pages/Projects.md"}]]
-              (is (fn? import-file-graph!))
-              (d/transact! conn (sqlite-create-graph/build-db-initial-data "{}"))
-              (reset! worker-state/*datascript-conns {test-repo conn})
-              (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
-              (p/with-redefs
-                [db-sync/update-local-sync-checksum! (fn [& _] nil)
-                 db-sync/handle-local-tx! (fn [& _] nil)
-                 shared-service/broadcast-to-clients! (fn [& _] nil)]
-                (db-listener/listen-db-changes! test-repo conn
-                                                :handler-keys [:sync-db-to-main-thread])
-                (->
-                 (p/let [result (import-file-graph!
-                                 test-repo
-                                 config-file
-                                 files
-                                 {:user-options {}
-                                  :set-ui-state (fn [path value]
-                                                  (swap! ui-state conj [path value]))
-                                  :<read-file (fn [file]
-                                                (swap! in-flight inc)
-                                                (swap! max-in-flight max @in-flight)
-                                                (p/let [_ (p/delay 0)]
-                                                  (swap! in-flight dec)
-                                                  (get contents (:path file))))})
-                         home (some->> (d/q '[:find [?e ...]
-                                              :where [?e :block/name "home"]]
-                                            @conn)
-                                       first
-                                       (d/entity @conn))
-                         projects (some->> (d/q '[:find [?e ...]
-                                                  :where [?e :block/name "projects"]]
+         (-> (restoring-worker-state
+              (fn []
+                (let [import-file-graph! (get @thread-api/*thread-apis :thread-api/import-file-graph)
+                      conn (d/create-conn db-schema/schema)
+                      pipeline-before @ldb/*transact-pipeline-fn
+                      ui-state (atom [])
+                      in-flight (atom 0)
+                      max-in-flight (atom 0)
+                      contents {"logseq/config.edn" "{}"
+                                "pages/Home.md" "- imported home"
+                                "pages/Projects.md" "- imported projects"}
+                      config-file {:path "logseq/config.edn"}
+                      files [{:path "logseq/config.edn"}
+                             {:path "pages/Home.md"}
+                             {:path "pages/Projects.md"}]]
+                  (is (fn? import-file-graph!))
+                  (d/transact! conn (sqlite-create-graph/build-db-initial-data "{}"))
+                  (reset! worker-state/*datascript-conns {test-repo conn})
+                  (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
+                  (p/with-redefs
+                    [db-sync/update-local-sync-checksum! (fn [& _] nil)
+                     db-sync/handle-local-tx! (fn [& _] nil)
+                     shared-service/broadcast-to-clients! (fn [& _] nil)]
+                    (db-listener/listen-db-changes! test-repo conn
+                                                    :handler-keys [:sync-db-to-main-thread])
+                    (->
+                     (p/let [result (import-file-graph!
+                                     test-repo
+                                     config-file
+                                     files
+                                     {:user-options {}
+                                      :set-ui-state (fn [path value]
+                                                      (swap! ui-state conj [path value]))
+                                      :<read-file (fn [file]
+                                                    (swap! in-flight inc)
+                                                    (swap! max-in-flight max @in-flight)
+                                                    (p/let [_ (p/delay 0)]
+                                                      (swap! in-flight dec)
+                                                      (get contents (:path file))))})
+                             home (some->> (d/q '[:find [?e ...]
+                                                  :where [?e :block/name "home"]]
                                                 @conn)
                                            first
                                            (d/entity @conn))
-                         home-block (db-test/find-block-by-content @conn "imported home")
-                         project-block (db-test/find-block-by-content @conn "imported projects")
-                         current-pages (into []
-                                             (keep (fn [[path value]]
-                                                     (when (= path [:graph/importing-state :current-page])
-                                                       value)))
-                                             @ui-state)
-                         totals (into []
-                                      (keep (fn [[path value]]
-                                              (when (= path [:graph/importing-state :total])
-                                                value)))
-                                      @ui-state)
-                         indexes (into []
-                                       (keep (fn [[path value]]
-                                               (when (= path [:graph/importing-state :current-idx])
-                                                 value)))
-                                       @ui-state)]
-                   (is (= #{"pages/Home.md" "pages/Projects.md" "logseq/config.edn"}
-                          (set (map :path (:files result)))))
-                   (is (every? #(not (contains? % :file/content)) (:files result))
-                       "Worker must not keep document contents on the returned file list.")
-                   (is (= "Home" (:block/title home)))
-                   (is (= "Projects" (:block/title projects)))
-                   (is (= "imported home" (:block/title home-block)))
-                   (is (= "imported projects" (:block/title project-block)))
-                   (is (= 1 @max-in-flight)
-                       "Import must read one file at a time instead of preloading the graph.")
-                   (is (= [2] totals))
-                   (is (= [1 2] indexes))
-                   (is (some #(= % "pages/Home.md") current-pages))
-                   (is (some #(= % "pages/Projects.md") current-pages)))
-                 (p/catch
-                  (fn [error]
-                    (is false (str error))))
-                 (p/finally (fn []
-                              (reset! ldb/*transact-pipeline-fn pipeline-before)
-                              (done))))))))))
+                             projects (some->> (d/q '[:find [?e ...]
+                                                      :where [?e :block/name "projects"]]
+                                                    @conn)
+                                               first
+                                               (d/entity @conn))
+                             home-block (db-test/find-block-by-content @conn "imported home")
+                             project-block (db-test/find-block-by-content @conn "imported projects")
+                             current-pages (into []
+                                                 (keep (fn [[path value]]
+                                                         (when (= path [:graph/importing-state :current-page])
+                                                           value)))
+                                                 @ui-state)
+                             totals (into []
+                                          (keep (fn [[path value]]
+                                                  (when (= path [:graph/importing-state :total])
+                                                    value)))
+                                          @ui-state)
+                             indexes (into []
+                                           (keep (fn [[path value]]
+                                                   (when (= path [:graph/importing-state :current-idx])
+                                                     value)))
+                                           @ui-state)]
+                       (is (= #{"pages/Home.md" "pages/Projects.md" "logseq/config.edn"}
+                              (set (map :path (:files result)))))
+                       (is (every? #(not (contains? % :file/content)) (:files result))
+                           "Worker must not keep document contents on the returned file list.")
+                       (is (= "Home" (:block/title home)))
+                       (is (= "Projects" (:block/title projects)))
+                       (is (= "imported home" (:block/title home-block)))
+                       (is (= "imported projects" (:block/title project-block)))
+                       (is (= 1 @max-in-flight)
+                           "Import must read one file at a time instead of preloading the graph.")
+                       (is (= [2] totals))
+                       (is (= [1 2] indexes))
+                       (is (some #(= % "pages/Home.md") current-pages))
+                       (is (some #(= % "pages/Projects.md") current-pages)))
+                     (p/catch
+                      (fn [error]
+                        (is false (str error))))
+                     (p/finally (fn []
+                                  (reset! ldb/*transact-pipeline-fn pipeline-before))))))))
+             (p/finally (fn [] (done))))))
 
 (deftest import-file-graph-publishes-progress-when-set-ui-state-is-not-supplied
   (async done
-         (restoring-worker-state
-          (fn []
-            (let [import-file-graph! (get @thread-api/*thread-apis :thread-api/import-file-graph)
-                  conn (d/create-conn db-schema/schema)
-                  pipeline-before @ldb/*transact-pipeline-fn
-                  broadcasts (atom [])
-                  config-file {:path "logseq/config.edn"
-                               :file/content "{}"}
-                  files [config-file
-                         {:path "pages/Home.md"
-                          :file/content "- imported block"}]]
-              (d/transact! conn (sqlite-create-graph/build-db-initial-data "{}"))
-              (reset! worker-state/*datascript-conns {test-repo conn})
-              (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
-              (p/with-redefs
-                [db-sync/update-local-sync-checksum! (fn [& _] nil)
-                 db-sync/handle-local-tx! (fn [& _] nil)
-                 shared-service/broadcast-to-clients!
-                 (fn [event payload]
-                   (swap! broadcasts conj [event payload]))]
-                (db-listener/listen-db-changes! test-repo conn
-                                                :handler-keys [:sync-db-to-main-thread])
-                (->
-                 (p/let [_ (import-file-graph! test-repo config-file files {:user-options {}})
-                         ui-events (filter #(= :set-ui-state (first %)) @broadcasts)
-                         pages (into []
-                                     (keep (fn [[_ [path value]]]
-                                             (when (= path [:graph/importing-state :current-page])
-                                               value)))
-                                     ui-events)]
-                   (is (seq ui-events)
-                       "Default import progress must broadcast set-ui-state instead of discarding it.")
-                   (is (some #(= % "pages/Home.md") pages)))
-                 (p/catch
-                  (fn [error]
-                    (is false (str error))))
-                 (p/finally (fn []
-                              (reset! ldb/*transact-pipeline-fn pipeline-before)
-                              (done))))))))))
+         (-> (restoring-worker-state
+              (fn []
+                (let [import-file-graph! (get @thread-api/*thread-apis :thread-api/import-file-graph)
+                      conn (d/create-conn db-schema/schema)
+                      pipeline-before @ldb/*transact-pipeline-fn
+                      broadcasts (atom [])
+                      config-file {:path "logseq/config.edn"
+                                   :file/content "{}"}
+                      files [config-file
+                             {:path "pages/Home.md"
+                              :file/content "- imported block"}]]
+                  (d/transact! conn (sqlite-create-graph/build-db-initial-data "{}"))
+                  (reset! worker-state/*datascript-conns {test-repo conn})
+                  (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
+                  (p/with-redefs
+                    [db-sync/update-local-sync-checksum! (fn [& _] nil)
+                     db-sync/handle-local-tx! (fn [& _] nil)
+                     shared-service/broadcast-to-clients!
+                     (fn [event payload]
+                       (swap! broadcasts conj [event payload]))]
+                    (db-listener/listen-db-changes! test-repo conn
+                                                    :handler-keys [:sync-db-to-main-thread])
+                    (->
+                     (p/let [_ (import-file-graph! test-repo config-file files {:user-options {}})
+                             ui-events (filter #(= :set-ui-state (first %)) @broadcasts)
+                             pages (into []
+                                         (keep (fn [[_ [path value]]]
+                                                 (when (= path [:graph/importing-state :current-page])
+                                                   value)))
+                                         ui-events)]
+                       (is (seq ui-events)
+                           "Default import progress must broadcast set-ui-state instead of discarding it.")
+                       (is (some #(= % "pages/Home.md") pages)))
+                     (p/catch
+                      (fn [error]
+                        (is false (str error))))
+                     (p/finally (fn []
+                                  (reset! ldb/*transact-pipeline-fn pipeline-before))))))))
+             (p/finally (fn [] (done))))))
 
 (deftest get-date-scheduled-or-deadlines-filters-sorts-and-groups-worker-results
   (restoring-worker-state


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes File-to-DB graph import OOM and the stuck "importing config" / "Config files" progress indicator reported in https://github.com/logseq/db-test/issues/1117.

## Root cause

After the UI-DB-to-worker refactor, File-to-DB import:

1. Preloaded every markdown `.text` and asset `arrayBuffer` in the renderer via `p/all`.
2. Sent that entire payload in a single `:thread-api/import-file-graph` invoke.
3. Discarded exporter `:set-ui-state` in the worker (`dissoc :set-ui-state`), so the indicator never advanced past "Config files".

The renderer and worker then both held the full graph (plus structured-clone copies) until V8 hit ~1.3GB and crashed.

## What changed

- Renderer sends file metadata only (path / timestamps). File content is streamed on demand through a worker UI request when the exporter reads the next file.
- Worker indexes preloaded content if present, then drops each file after it is read so `:file/content` maps are not kept for the whole import.
- Exporter `set-ui-state` is broadcast to the renderer so progress shows the current file and idx/total.
- Staged assets are published and written incrementally instead of returning every payload in the final worker result.

Config parsing, tag/property class options, notifications, staged assets, and validation are unchanged.

## Test plan

- [x] `import-file-graph-imports-documents-into-worker-conn` still imports a preloaded payload.
- [x] `import-file-graph-streams-files-and-reports-progress` imports metadata-only files one at a time and records per-file `set-ui-state`.
- [x] `import-file-graph-publishes-progress-when-set-ui-state-is-not-supplied` asserts default progress is broadcast, not discarded.
- [x] Renderer metadata helper omits `:file/content` / asset payloads.
- [x] Worker handler covers `:read-import-file`, `:set-ui-state`, and incremental staged-asset writes.
- [x] Ran targeted cljs tests: 4 worker import assertions suites (34 assertions) and 10 imports/handler tests (34 assertions), all green.
- [ ] Manual: File → Import → File to DB Graph on a large OG graph; progress should advance past Config files and complete without worker OOM.

[Targeted cljs test results](https://cursor.com/agents/bc-2e71c82a-d72e-4c3b-81d0-3fcbebf74990/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffile-to-db-import-tests.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e71c82a-d72e-4c3b-81d0-3fcbebf74990?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e71c82a-d72e-4c3b-81d0-3fcbebf74990&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

