### PR TITLE
fix: keep table search mounted during view-data refetch

### DIFF
--- a/src/main/frontend/components/views.cljs
+++ b/src/main/frontend/components/views.cljs
@@ -1496,10 +1496,15 @@
                  (assoc :block.temp/refs-count (:block.temp/refs-count row)))]
     (table-row-inner table row' props option)))
 
+(defn- search-input-visible?
+  "Keep the search field open after a remount whenever a query is already present."
+  [show-input? input]
+  (or (boolean show-input?) (not (string/blank? input))))
+
 (hsx/defc search
   [input {:keys [on-change set-input!]}]
   (let [[show-input? set-show-input!] (hooks/use-state false)]
-    (if show-input?
+    (if (search-input-visible? show-input? input)
       [:div.flex.flex-row.items-center
        (shui/input
         {:placeholder (t :view.filter/type-to-search)
@@ -3088,6 +3093,12 @@
     (= :query-result view-feature-type)
     (assoc :query-row-uuids query-row-uuids)))
 
+(defn- displayed-view-data
+  "Keep the last successful view payload while a refetch is in flight.
+   Only the initial load (no previous data) should show skeletons."
+  [view-data last-view-data]
+  (or view-data last-view-data))
+
 (hsx/defc loaded-view-aux
   [view-entity {:keys [config view-feature-type query-row-uuids
                        deactivate-deferred-view!] :as option}]
@@ -3116,8 +3127,10 @@
                                                 initial-row-count)
         view-data (db-hooks/use-resource
                    [:view-data (:block/uuid view-entity) resource-context])
+        *last-view-data (hooks/use-ref nil)
+        resolved-view-data (displayed-view-data view-data (hooks/deref *last-view-data))
         query? (= view-feature-type :query-result)
-        properties (:properties view-data)
+        properties (:properties resolved-view-data)
         option (cond-> (assoc option
                               :view-parent (:logseq.property/view-for view-entity))
                  query?
@@ -3130,16 +3143,18 @@
                          (fn [collapsed?]
                            (when collapsed?
                              (deactivate-deferred-view!)))}))]
-    (if (nil? view-data)
+    (when (some? view-data)
+      (hooks/set-ref! *last-view-data view-data))
+    (if (nil? resolved-view-data)
       [:div.flex.flex-col.space-2.gap-2.my-2
        (for [idx (range 3)]
          (shui/skeleton {:key idx :class "h-6 w-full"}))]
-      (let [data (view-data->rows view-data)
+      (let [data (view-data->rows resolved-view-data)
             ignore! (fn [_])]
         [:div.flex.flex-col.gap-2
          (view-container view-entity (assoc option
-                                            :view-data view-data
-                                            :partition (:partition view-data)
+                                            :view-data resolved-view-data
+                                            :partition (:partition resolved-view-data)
                                             :data data
                                             :full-data data
                                             :filters (or filters {})
@@ -3149,11 +3164,11 @@
                                             :set-data! ignore!
                                             :set-input! set-input!
                                             :input input
-                                            :items-count (:count view-data)
+                                            :items-count (:count resolved-view-data)
                                             :group-by-property-ident group-by-property-ident
-                                            :ref-pages-count (:ref-pages-count view-data)
+                                            :ref-pages-count (:ref-pages-count resolved-view-data)
                                             :ref-matched-children-ids
-                                            (:matched-child-uuids view-data)
+                                            (:matched-child-uuids resolved-view-data)
                                             :display-type display-type))]))))
 
 (hsx/defc deferred-view-placeholder

--- a/src/test/frontend/components/views_test.cljs
+++ b/src/test/frontend/components/views_test.cljs
@@ -10,6 +10,7 @@
             [frontend.db.subs :as subs]
             [frontend.util :as util]
             [goog.object :as gobj]
+            [logseq.shui.hooks :as hooks]
             [promesa.core :as p]))
 
 (def ^:private test-graph-id "view-resource-test")
@@ -491,3 +492,101 @@
   (is (views/group-by-column? {:id :block/tags
                                :property {:logseq.property/type :class
                                           :db/cardinality :db.cardinality/many}})))
+
+(deftest displayed-view-data-keeps-last-payload-while-refetching
+  (let [previous {:partition :flat :count 2 :rows [:a :b]}
+        next {:partition :flat :count 1 :rows [:a]}]
+    (is (nil? (#'views/displayed-view-data nil nil))
+        "Initial load with no payload still shows skeletons.")
+    (is (= previous (#'views/displayed-view-data previous nil)))
+    (is (= previous (#'views/displayed-view-data nil previous))
+        "A nil refetch must keep the last successful view-data.")
+    (is (= next (#'views/displayed-view-data next previous)))))
+
+(deftest search-input-stays-visible-when-query-is-present
+  (is (false? (#'views/search-input-visible? false "")))
+  (is (false? (#'views/search-input-visible? false "   ")))
+  (is (true? (#'views/search-input-visible? true "")))
+  (is (true? (#'views/search-input-visible? false "todo"))
+      "A remounted search with a non-empty query must stay open."))
+
+(deftest table-search-renders-input-when-query-is-non-empty
+  (let [open-markup (render-static
+                     (views/search "todo" {:on-change identity :set-input! identity}))
+        closed-markup (render-static
+                       (views/search "" {:on-change identity :set-input! identity}))]
+    (is (string/includes? open-markup "Type to search")
+        "Remounting search with a typed query must keep the input mounted.")
+    (is (string/includes? open-markup "todo")
+        "The typed filter value is preserved on remount.")
+    (is (not (string/includes? closed-markup "Type to search"))
+        "An empty query still collapses back to the search button.")))
+
+(deftest loaded-view-skeletons-only-on-initial-empty-view-data
+  (let [view-entity {:block/uuid (random-uuid)
+                     :db/id 1
+                     :logseq.property.view/type
+                     {:db/ident :logseq.property.view/type.table}}
+        container-calls (atom [])]
+    (with-redefs [db-hooks/use-resource (constantly nil)
+                  views/view-container
+                  (fn [entity option]
+                    (swap! container-calls conj [entity option])
+                    [:span "view-container"])]
+      (let [markup (render-static
+                    (views/loaded-view-aux view-entity
+                                           {:view-feature-type :class-objects
+                                            :config {}}))]
+        (is (string/includes? markup "h-6 w-full")
+            "The first load with no view-data still shows skeletons.")
+        (is (empty? @container-calls)
+            "view-container must not mount before the first successful payload.")))))
+
+(deftest loaded-view-keeps-toolbar-when-view-data-refetches
+  (let [view-uuid (random-uuid)
+        view-entity {:block/uuid view-uuid
+                     :db/id 1
+                     :logseq.property.view/type
+                     {:db/ident :logseq.property.view/type.table}}
+        view-data {:partition :flat
+                   :count 1
+                   :rows [(random-uuid)]}
+        *last-view-data #js {:current nil}
+        *input #js {:current "todo"}
+        container-calls (atom [])
+        original-use-state hooks/use-state
+        render-view
+        (fn [resource]
+          (with-redefs [db-hooks/use-resource (constantly resource)
+                        hooks/use-ref (fn [_] *last-view-data)
+                        hooks/use-state
+                        (fn [value]
+                          (if (= "" value)
+                            #js [(.-current *input)
+                                 #(set! (.-current *input) %)]
+                            (original-use-state value)))
+                        views/view-container
+                        (fn [entity option]
+                          (swap! container-calls conj [entity option])
+                          [:div.view-action-search "search"])]
+            (render-static
+             (views/loaded-view-aux view-entity
+                                    {:view-feature-type :class-objects
+                                     :config {}}))))]
+    (let [loaded-markup (render-view view-data)]
+      (is (string/includes? loaded-markup "view-action-search"))
+      (is (= 1 (count @container-calls)))
+      (is (= view-data (:view-data (second (first @container-calls))))
+          "The first successful payload is passed to the toolbar.")
+      (is (= "todo" (:input (second (first @container-calls))))))
+    (reset! container-calls [])
+    (let [refetch-markup (render-view nil)]
+      (is (string/includes? refetch-markup "view-action-search")
+          "A search refetch that clears view-data must keep the toolbar mounted.")
+      (is (not (string/includes? refetch-markup "h-6 w-full"))
+          "Skeletons must not replace the toolbar during a refetch.")
+      (is (= 1 (count @container-calls)))
+      (is (= view-data (:view-data (second (first @container-calls))))
+          "The last successful view-data is kept while the refetch is in flight.")
+      (is (= "todo" (:input (second (first @container-calls))))
+          "The typed filter stays on the still-mounted search."))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [db-test#1118](https://github.com/logseq/db-test/issues/1118).

## Problem

In a DB-graph Table view, opening search and typing caused the input to unmount after the 300ms debounce. The filter still applied, but the field collapsed back to the magnifying-glass button.

`loaded-view-aux` puts `debounced-input` into `view-resource-context`. When that value changes, `use-resource` refetches and `view-data` becomes `nil`. The component then swapped the entire `view-container` (including the search toolbar) for skeletons. `search` keeps `show-input?` in local React state, so remounting reset it to `false`.

## Change

- Keep the last successful `view-data` while a refetch is in flight (stale-while-revalidate). Skeletons are used only on the initial load, when there is no previous payload.
- Keep the search input visible whenever the query is non-empty, so a remount cannot collapse a typed filter. Escape and the X button still clear the query and collapse the field.

## Test plan

- `bb dev:test -v frontend.components.views-test`
  - Initial `view-data` nil still shows skeletons and does not mount `view-container`.
  - After a successful load, a nil refetch keeps the toolbar mounted and preserves the last payload plus the typed query.
  - Search with a non-empty query stays open after remount; empty query still collapses.
- Manual: open a DB-graph Table view, click search, type several characters across the debounce. The input should stay focused/open. Escape / X should still close and clear it.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0df73657-6368-4f17-b05a-ae6605b2e43b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0df73657-6368-4f17-b05a-ae6605b2e43b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

