### PR TITLE
fix: keep Cover asset fields on view row refs

### DIFF
--- a/src/main/frontend/worker/handler/block_breadcrumb.cljs
+++ b/src/main/frontend/worker/handler/block_breadcrumb.cljs
@@ -30,6 +30,11 @@
         property-value (:logseq.property/value ref)
         property-icon (:logseq.property/icon ref)
         hide-from-node (:logseq.property.class/hide-from-node ref)
+        asset-type (:logseq.property.asset/type ref)
+        asset-width (:logseq.property.asset/width ref)
+        asset-height (:logseq.property.asset/height ref)
+        asset-resize-metadata (:logseq.property.asset/resize-metadata ref)
+        asset-external-url (:logseq.property.asset/external-url ref)
         property-value-title (when (or (:block/closed-value-property ref)
                                        (:logseq.property/created-from-property ref))
                                (:block/title ref))]
@@ -52,6 +57,13 @@
       (some? property-value) (assoc :logseq.property/value property-value)
       (some? property-icon) (assoc :logseq.property/icon property-icon)
       (some? hide-from-node) (assoc :logseq.property.class/hide-from-node hide-from-node)
+      (some? asset-type) (assoc :logseq.property.asset/type asset-type)
+      (some? asset-width) (assoc :logseq.property.asset/width asset-width)
+      (some? asset-height) (assoc :logseq.property.asset/height asset-height)
+      (some? asset-resize-metadata)
+      (assoc :logseq.property.asset/resize-metadata asset-resize-metadata)
+      (some? asset-external-url)
+      (assoc :logseq.property.asset/external-url asset-external-url)
       (some? property-value-title) (assoc :block/title property-value-title))))
 
 (defn- breadcrumb-entity

--- a/src/main/frontend/worker/plain_value.cljs
+++ b/src/main/frontend/worker/plain_value.cljs
@@ -33,6 +33,18 @@
         (assoc :logseq.property/choice-checkbox-state (:logseq.property/choice-checkbox-state entity))
         property-value-datom
         (assoc :logseq.property/value (:v property-value-datom))
+        (:logseq.property.asset/type entity)
+        (assoc :logseq.property.asset/type (:logseq.property.asset/type entity))
+        (:logseq.property.asset/width entity)
+        (assoc :logseq.property.asset/width (:logseq.property.asset/width entity))
+        (:logseq.property.asset/height entity)
+        (assoc :logseq.property.asset/height (:logseq.property.asset/height entity))
+        (:logseq.property.asset/resize-metadata entity)
+        (assoc :logseq.property.asset/resize-metadata
+               (:logseq.property.asset/resize-metadata entity))
+        (:logseq.property.asset/external-url entity)
+        (assoc :logseq.property.asset/external-url
+               (:logseq.property.asset/external-url entity))
         (:db/ident entity)
         (assoc :db/ident (:db/ident entity))))
     {:db/id value}))

--- a/src/test/frontend/components/views_test.cljs
+++ b/src/test/frontend/components/views_test.cljs
@@ -214,6 +214,42 @@
     (is (= block
            (views/gallery-card-asset-block block :block/uuid)))))
 
+(deftest gallery-and-table-cover-hydration-keeps-asset-render-fields-test
+  (let [cover-uuid #uuid "11111111-1111-1111-1111-111111111111"
+        cover {:db/id 9
+               :block/uuid cover-uuid
+               :block/title "poster"
+               :block/tags [{:db/ident :logseq.class/Asset}]
+               :logseq.property.asset/type "webp"}
+        row {:db/id 1
+             :block/uuid #uuid "22222222-2222-2222-2222-222222222222"
+             :block/title "Inception"
+             :user.property/cover cover}
+        cover-property {:db/ident :user.property/cover
+                        :block/title "Cover"
+                        :logseq.property/type :asset}
+        columns (views/build-columns
+                 {:view-parent {:db/ident :user.class/Movie}}
+                 [cover-property]
+                 {:with-object-name? false
+                  :add-tags-column? false})
+        cover-column (some #(when (= :user.property/cover (:id %)) %) columns)]
+    (is (= :asset (get-in cover-column [:property :logseq.property/type]))
+        "Cover columns keep the :asset type used by Gallery/Table.")
+    (is (= :user.property/cover
+           (#'views/gallery-asset-property-ident
+            {:logseq.property/view-for {:db/ident :user.class/Movie
+                                        :block/tags [{:db/ident :logseq.class/Tag}]}
+             :logseq.property.view/feature-type :class-objects}
+            columns)))
+    (is (= cover
+           (views/gallery-card-asset-block row :user.property/cover)))
+    (is (uuid? (:block/uuid (views/gallery-card-asset-block row :user.property/cover))))
+    (is (= "webp"
+           (:logseq.property.asset/type
+            (views/gallery-card-asset-block row :user.property/cover)))
+        "Hydrated Cover must keep the type/filename fields asset-cp needs.")))
+
 (deftest view-row-ids-flatten-only-typed-uuid-payloads-test
   (let [row-a (random-uuid)
         row-b (random-uuid)

--- a/src/test/frontend/worker/handler/block_test.cljs
+++ b/src/test/frontend/worker/handler/block_test.cljs
@@ -106,7 +106,12 @@
   (is (every? #{:db/id :block/uuid :db/ident :block/title :block/name
                 :block/tags :logseq.property/value :logseq.property/icon
                 :logseq.property.class/hide-from-node
-                :logseq.property/choice-exclusions}
+                :logseq.property/choice-exclusions
+                :logseq.property.asset/type
+                :logseq.property.asset/width
+                :logseq.property.asset/height
+                :logseq.property.asset/resize-metadata
+                :logseq.property.asset/external-url}
               (keys reference))))
 
 (deftest canonical-property-reference-values-keep-type-tags-test
@@ -560,3 +565,62 @@
         (doseq [value [blocks membership tree]]
           (is (= value
                  (-> value ldb/write-transit-str ldb/read-transit-str))))))))
+
+(defn- cover-row-fixture
+  []
+  (let [conn (db-test/create-conn)
+        page-uuid #uuid "20000000-0000-0000-0000-000000000001"
+        row-uuid #uuid "20000000-0000-0000-0000-000000000002"
+        cover-uuid #uuid "20000000-0000-0000-0000-000000000003"]
+    (d/transact! conn
+                 [{:db/id -1
+                   :block/uuid page-uuid
+                   :block/tx-id 10
+                   :block/title "Movies"
+                   :block/name "movies"
+                   :block/tags :logseq.class/Page}
+                  {:db/id -2
+                   :db/ident :user.property/cover
+                   :db/valueType :db.type/ref
+                   :db/cardinality :db.cardinality/one
+                   :block/uuid #uuid "20000000-0000-0000-0000-000000000004"
+                   :block/tx-id 10
+                   :block/title "Cover"
+                   :logseq.property/type :asset
+                   :block/tags :logseq.class/Property}
+                  {:db/id -3
+                   :block/uuid cover-uuid
+                   :block/tx-id 10
+                   :block/title "poster"
+                   :block/tags :logseq.class/Asset
+                   :logseq.property.asset/type "webp"
+                   :logseq.property.asset/width 800
+                   :logseq.property.asset/height 1200
+                   :logseq.property.asset/external-url "https://example.com/poster.webp"}
+                  {:db/id -4
+                   :block/uuid row-uuid
+                   :block/tx-id 10
+                   :block/title "Inception"
+                   :block/page -1
+                   :block/parent -1
+                   :block/order "a0"
+                   :user.property/cover -3}])
+    {:conn conn
+     :row-uuid row-uuid
+     :cover-uuid cover-uuid}))
+
+(deftest canonical-cover-property-is-not-a-db-id-stub-test
+  (when-let [canonical-block (canonical-block-api)]
+    (let [{:keys [conn row-uuid cover-uuid]} (cover-row-fixture)
+          block (canonical-block @conn (d/entity @conn [:block/uuid row-uuid]))
+          cover (:user.property/cover block)]
+      (is (map? cover))
+      (is (not= {:db/id (:db/id cover)} cover)
+          "Gallery/Table Cover values must keep more than a bare db/id stub.")
+      (is (= cover-uuid (:block/uuid cover)))
+      (is (= "webp" (:logseq.property.asset/type cover)))
+      (is (= 800 (:logseq.property.asset/width cover)))
+      (is (= 1200 (:logseq.property.asset/height cover)))
+      (is (= "https://example.com/poster.webp"
+             (:logseq.property.asset/external-url cover)))
+      (assert-shallow-identity-ref cover))))

--- a/src/test/frontend/worker/plain_value_test.cljs
+++ b/src/test/frontend/worker/plain_value_test.cljs
@@ -92,6 +92,40 @@
     (is (= value-uuid (:block/uuid value)))
     (is (= "11111111-1111-1111-1111-111111111111" (:block/title value)))))
 
+(deftest asset-property-values-keep-render-fields
+  (let [conn (d/create-conn db-schema/schema)
+        asset-uuid #uuid "11111111-1111-1111-1111-111111111111"
+        host-uuid #uuid "33333333-3333-3333-3333-333333333333"]
+    (d/transact! conn (sqlite-create-graph/build-db-initial-data "{}"))
+    (d/transact! conn [{:db/id -1
+                        :db/ident :user.property/cover
+                        :block/title "Cover"
+                        :logseq.property/type :asset
+                        :db/valueType :db.type/ref
+                        :db/cardinality :db.cardinality/one
+                        :block/tags :logseq.class/Property}
+                       {:db/id -2
+                        :block/uuid asset-uuid
+                        :block/title "poster"
+                        :block/tags :logseq.class/Asset
+                        :logseq.property.asset/type "webp"
+                        :logseq.property.asset/width 640
+                        :logseq.property.asset/height 480}
+                       {:db/id -3
+                        :block/uuid host-uuid
+                        :block/title "Host"
+                        :block/name "host"
+                        :block/tags :logseq.class/Page
+                        :user.property/cover -2}])
+    (let [db @conn
+          host (d/entity db [:block/uuid host-uuid])
+          value (:user.property/cover (plain-value/entity-forward-map db host {}))]
+      (is (= asset-uuid (:block/uuid value)))
+      (is (= "webp" (:logseq.property.asset/type value)))
+      (is (= 640 (:logseq.property.asset/width value)))
+      (is (= 480 (:logseq.property.asset/height value)))
+      (is (not= {:db/id (:db/id value)} value)))))
+
 (deftest entity-forward-map-excludes-requested-attributes
   (let [[db host _target-uuid _value-uuid] (property-value-db :default {})
         result (plain-value/entity-forward-map db host {:exclude-attrs #{:block/name


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes Gallery and Table Cover images that stopped rendering after worker-backed row hydration.

Gallery and Table hydrate each row through `use-block` UUID. Worker canonical/plain ref summaries kept Cover as a shallow identity (`:db/id` plus title/uuid) and omitted the asset fields `asset-cp` needs (`:block/uuid`, `:logseq.property.asset/type`, and related render metadata). The same graph still rendered Cover on `5a23230`.

This change copies those asset render fields onto shallow Cover refs and adds tests for the worker row payload and Gallery/Table hydration.

Related: logseq/db-test#1119

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc36b11a-4253-444b-b337-bd7633dbe8d9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc36b11a-4253-444b-b337-bd7633dbe8d9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

