### PR TITLE
fix: show history for non-status enable-history properties

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -3267,28 +3267,70 @@
         [:div status-title]]
        [:div (date/int->local-time-2 created-at)]])))
 
+(defn- history-scalar-label
+  [property scalar-value]
+  (if (and (number? scalar-value)
+           (contains? #{:date :datetime} (:logseq.property/type property)))
+    (date/int->local-time-2 scalar-value)
+    (str scalar-value)))
+
+(hsx/defc property-history-ref-value
+  [value-uuid]
+  (let [value (db-hooks/use-block value-uuid)]
+    (when value
+      [:div.flex.flex-row.gap-1.items-center
+       (icon-component/get-node-icon-cp value {:size 14 :color? true})
+       [:div (:block/title value)]])))
+
+(hsx/defc property-history-row
+  [{:keys [created-at property-uuid value-uuid scalar-value]}]
+  (let [property (db-hooks/use-block property-uuid)]
+    (when property
+      [:div.flex.flex-row.gap-1.items-center.text-sm.justify-between
+       [:div.flex.flex-row.gap-1.items-center
+        [:div (:block/title property)]
+        (if value-uuid
+          (property-history-ref-value value-uuid)
+          [:div (history-scalar-label property scalar-value)])]
+       [:div (date/int->local-time-2 created-at)]])))
+
+(hsx/defc property-history-item
+  [item]
+  (if (:status-uuid item)
+    (status-history-row item)
+    (property-history-row item)))
+
 (hsx/defc status-history-cp
-  [status-history]
-  (let [[sort-desc? set-sort-desc!] (hooks/use-state true)]
+  [history]
+  (let [[sort-desc? set-sort-desc!] (hooks/use-state true)
+        status-only? (every? :status-uuid history)]
     [:div.p-2.text-muted-foreground.text-sm.max-h-96
      [:div.font-medium.mb-2.flex.flex-row.gap-2.items-center
-      [:div (t :block/status-history)]
+      [:div (t (if status-only? :block/status-history :block/property-history))]
       (shui/button-ghost-icon (if sort-desc? :arrow-down :arrow-up)
                               {:title (t :block/sort-order)
                                :class "text-muted-foreground !h-4 !w-4"
                                :icon-props {:size 14}
                                :on-click #(set-sort-desc! (not sort-desc?))})]
      [:div.flex.flex-col.gap-1
-      (for [item (if sort-desc? (reverse status-history) status-history)]
-        ^{:key (str (:status-uuid item) "-" (:created-at item))}
-        (status-history-row item))]]))
+      (for [item (if sort-desc? (reverse history) history)]
+        ^{:key (str (or (:status-uuid item)
+                        (:value-uuid item)
+                        (:property-uuid item))
+                    "-" (:created-at item)
+                    "-" (:scalar-value item))}
+        (property-history-item item))]]))
 
 (hsx/defc task-spent-time-cp
   [block]
   (let [resource (db-hooks/use-resource [:block-task-time (:block/uuid block)])
         history (:history resource)
-        seconds (:seconds resource)]
-    (when (and seconds (pos? seconds))
+        seconds (:seconds resource)
+        latest-created-at (:created-at (last history))
+        label (if (and seconds (pos? seconds))
+                (clock/seconds->days:hours:minutes:seconds seconds)
+                (date/int->local-time-2 latest-created-at))]
+    (when (seq history)
       [:div.text-sm.time-spent.ml-1
        (shui/button
         {:variant :ghost
@@ -3298,7 +3340,7 @@
                      (shui/popup-show! (.-target e)
                                        (fn [] (status-history-cp history))
                                        {:align :end}))}
-        (clock/seconds->days:hours:minutes:seconds seconds))])))
+        label)]))))
 
 (defn- sync-conflict-attr-label
   [attr]
@@ -3451,8 +3493,7 @@
          [:div.block-head-wrap
           (block-title config block {:*show-query? *show-query?})])
 
-       (when (task-block? block)
-         (task-spent-time-cp block))]
+       (task-spent-time-cp block)]
 
       (block-content-inner config block ast-body plugin-slotted? collapsed? block-ref-with-title?)]]))
 

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -3340,7 +3340,7 @@
                      (shui/popup-show! (.-target e)
                                        (fn [] (status-history-cp history))
                                        {:align :end}))}
-        label)]))))
+        label)])))
 
 (defn- sync-conflict-attr-label
   [attr]

--- a/src/main/frontend/worker/handler/query.cljs
+++ b/src/main/frontend/worker/handler/query.cljs
@@ -46,52 +46,80 @@
                (d/pull @conn selector)
                (common-initial-data/with-parent @conn)))))
 
-(defn- block-status-history
+(defn- history-item
+  [db history-id created-at property-id]
+  (let [property (d/entity db property-id)
+        history (d/entity db history-id)
+        ref-value (:logseq.property.history/ref-value history)
+        scalar-value (:logseq.property.history/scalar-value history)]
+    (cond-> {:db/id history-id
+             :block/created-at created-at
+             :logseq.property.history/property-ident (:db/ident property)}
+      (:block/uuid property)
+      (assoc :logseq.property.history/property-uuid (:block/uuid property)
+             :logseq.property.history/property-title (:block/title property))
+      ref-value
+      (assoc :logseq.property.history/ref-value-ident (:db/ident ref-value)
+             :logseq.property.history/ref-value-uuid (:block/uuid ref-value)
+             :logseq.property.history/ref-value-title (:block/title ref-value))
+      (some? scalar-value)
+      (assoc :logseq.property.history/scalar-value scalar-value))))
+
+(defn- block-property-history
   [db block-id]
-  (->> (d/q '[:find ?history ?created-at ?status
+  (->> (d/q '[:find ?history ?created-at ?property
               :in $ ?block-id
               :where
               [?history :logseq.property.history/block ?block-id]
-              [?history :logseq.property.history/property :logseq.property/status]
-              [?history :logseq.property.history/ref-value ?status]
+              [?history :logseq.property.history/property ?property]
               [?history :block/created-at ?created-at]]
             db
             block-id)
-       (map (fn [[history-id created-at status-id]]
-              (let [status (d/entity db status-id)]
-                {:db/id history-id
-                 :block/created-at created-at
-                 :logseq.property.history/property-ident :logseq.property/status
-                 :logseq.property.history/ref-value-ident (:db/ident status)
-                 :logseq.property.history/ref-value-uuid (:block/uuid status)
-                 :logseq.property.history/ref-value-title (:block/title status)})))
-       (sort-by :block/created-at)))
+       (map (fn [[history-id created-at property-id]]
+              (history-item db history-id created-at property-id)))
+       (sort-by :block/created-at)
+       vec))
+
+(defn- block-status-history
+  [history]
+  (filterv (fn [item]
+             (and (= :logseq.property/status
+                     (:logseq.property.history/property-ident item))
+                  (:logseq.property.history/ref-value-ident item)))
+           history))
+
+(defn- status-spent-seconds
+  [status-history now-ms]
+  (loop [[last-item item & others] status-history
+         time 0]
+    (if item
+      (let [last-status (:logseq.property.history/ref-value-ident last-item)
+            this-status (:logseq.property.history/ref-value-ident item)]
+        (if (and (= this-status :logseq.property/status.doing)
+                 (empty? others))
+          (-> (+ time (- now-ms (:block/created-at item)))
+              (quot 1000))
+          (let [time' (if (or
+                           (= last-status :logseq.property/status.doing)
+                           (and
+                            (not (contains? #{:logseq.property/status.canceled
+                                              :logseq.property/status.backlog
+                                              :logseq.property/status.done} last-status))
+                            (= this-status :logseq.property/status.done)))
+                        (+ time (- (:block/created-at item) (:block/created-at last-item)))
+                        time)]
+            (recur (cons item others) time'))))
+      (quot time 1000))))
 
 (defn task-spent-time
   [db block-id now-ms]
-  (let [status-history (block-status-history db block-id)]
-    (when (seq status-history)
-      (let [time (loop [[last-item item & others] status-history
-                        time 0]
-                   (if item
-                     (let [last-status (:logseq.property.history/ref-value-ident last-item)
-                           this-status (:logseq.property.history/ref-value-ident item)]
-                       (if (and (= this-status :logseq.property/status.doing)
-                                (empty? others))
-                         (-> (+ time (- now-ms (:block/created-at item)))
-                             (quot 1000))
-                         (let [time' (if (or
-                                          (= last-status :logseq.property/status.doing)
-                                          (and
-                                           (not (contains? #{:logseq.property/status.canceled
-                                                             :logseq.property/status.backlog
-                                                             :logseq.property/status.done} last-status))
-                                           (= this-status :logseq.property/status.done)))
-                                       (+ time (- (:block/created-at item) (:block/created-at last-item)))
-                                       time)]
-                           (recur (cons item others) time'))))
-                     (quot time 1000)))]
-        [(vec status-history) time]))))
+  (let [history (block-property-history db block-id)]
+    (when (seq history)
+      (let [status-history (block-status-history history)
+            time (if (seq status-history)
+                   (status-spent-seconds status-history now-ms)
+                   0)]
+        [history time]))))
 
 (def-thread-api :thread-api/task-spent-time
   [repo block-id]

--- a/src/main/frontend/worker/handler/query.cljs
+++ b/src/main/frontend/worker/handler/query.cljs
@@ -46,12 +46,16 @@
                (d/pull @conn selector)
                (common-initial-data/with-parent @conn)))))
 
+(defn- history-ref-entity
+  [db history-id]
+  (when-let [value (:v (first (d/datoms db :eavt history-id :logseq.property.history/ref-value)))]
+    (d/entity db value)))
+
 (defn- history-item
   [db history-id created-at property-id]
   (let [property (d/entity db property-id)
-        history (d/entity db history-id)
-        ref-value (:logseq.property.history/ref-value history)
-        scalar-value (:logseq.property.history/scalar-value history)]
+        ref-value (history-ref-entity db history-id)
+        scalar-value (:v (first (d/datoms db :eavt history-id :logseq.property.history/scalar-value)))]
     (cond-> {:db/id history-id
              :block/created-at created-at
              :logseq.property.history/property-ident (:db/ident property)}

--- a/src/main/frontend/worker/handler/render_resource/basic.cljs
+++ b/src/main/frontend/worker/handler/render_resource/basic.cljs
@@ -219,6 +219,30 @@
           (mapv #(common/require-uuid! :comment-thread-uuid
                                 (:block/uuid %))))]))
 
+(defn- history-resource-item
+  [item]
+  (let [status? (= :logseq.property/status
+                   (:logseq.property.history/property-ident item))
+        ref-value-uuid (:logseq.property.history/ref-value-uuid item)]
+    (cond-> {:created-at (:block/created-at item)}
+      status?
+      (assoc :status-uuid
+             (common/require-uuid!
+              :status-uuid
+              ref-value-uuid))
+      (not status?)
+      (assoc :property-ident (:logseq.property.history/property-ident item)
+             :property-uuid
+             (common/require-uuid!
+              :property-uuid
+              (:logseq.property.history/property-uuid item)))
+      (and (not status?) (uuid? ref-value-uuid))
+      (assoc :value-uuid
+             (common/require-uuid! :history-value-uuid ref-value-uuid))
+      (and (not status?)
+           (contains? item :logseq.property.history/scalar-value))
+      (assoc :scalar-value (:logseq.property.history/scalar-value item)))))
+
 (defn- block-task-time
   [db resource-key _runtime]
   (let [block-uuid (second resource-key)
@@ -228,14 +252,7 @@
                                            (common-util/time-ms))
             [[] 0])]
     [#{[:task-time block-uuid]}
-     {:history
-      (mapv (fn [item]
-              {:created-at (:block/created-at item)
-               :status-uuid
-               (common/require-uuid!
-                :status-uuid
-                (:logseq.property.history/ref-value-uuid item))})
-            history)
+     {:history (mapv history-resource-item history)
       :seconds seconds}]))
 
 (defn- route-block

--- a/src/resources/dicts/en.edn
+++ b/src/resources/dicts/en.edn
@@ -132,6 +132,7 @@
  :block/open-block-references "Open block references"
  :block/practice "Practice"
  :block/practice-cards "Practice cards"
+ :block/property-history "Property history"
  :block/remove-tag "Remove tag"
  :block/remove-this-tag "Remove this tag"
  :block/render-error "Block Render Error:"

--- a/src/resources/dicts/zh-cn.edn
+++ b/src/resources/dicts/zh-cn.edn
@@ -132,6 +132,7 @@
  :block/open-block-references "打开块引用"
  :block/practice "练习"
  :block/practice-cards "练习卡片"
+ :block/property-history "属性历史"
  :block/remove-tag "移除标签"
  :block/remove-this-tag "移除此标签"
  :block/render-error "块渲染错误："

--- a/src/test/frontend/worker/db_core_test.cljs
+++ b/src/test/frontend/worker/db_core_test.cljs
@@ -2106,6 +2106,58 @@
          (is (not-any? #(contains? % :logseq.property.history/ref-value) history))
          (is (not-any? #(contains? % :logseq.property.history/property) history))))))))
 
+(deftest task-spent-time-includes-non-status-property-history
+  (restoring-worker-state
+   (fn []
+     (let [spent-time! (get-thread-api :thread-api/task-spent-time)
+           conn (d/create-conn task-spent-time-schema)
+           block-uuid #uuid "11111111-1111-1111-1111-111111111111"]
+       (d/transact! conn [{:db/ident :logseq.property/status}
+                          {:db/ident :logseq.property/status.doing
+                           :block/title "Doing"}
+                          {:db/ident :logseq.property/status.done
+                           :block/title "Done"}
+                          {:db/ident :logseq.property/priority}
+                          {:db/ident :logseq.property/priority.high
+                           :block/title "High"}
+                          {:block/uuid block-uuid
+                           :block/title "task"}])
+       (reset! worker-state/*datascript-conns {test-repo conn})
+       (let [block-id (ffirst (d/q '[:find ?b
+                                     :in $ ?uuid
+                                     :where [?b :block/uuid ?uuid]]
+                                   @conn
+                                   block-uuid))]
+         (d/transact! conn [{:block/created-at 1000
+                             :logseq.property.history/block block-id
+                             :logseq.property.history/property :logseq.property/status
+                             :logseq.property.history/ref-value :logseq.property/status.doing}
+                            {:block/created-at 2500
+                             :logseq.property.history/block block-id
+                             :logseq.property.history/property :logseq.property/priority
+                             :logseq.property.history/ref-value :logseq.property/priority.high}
+                            {:block/created-at 4000
+                             :logseq.property.history/block block-id
+                             :logseq.property.history/property :logseq.property/status
+                             :logseq.property.history/ref-value :logseq.property/status.done}])
+         (let [[history seconds] (spent-time! test-repo block-id)]
+           (is (= 3 seconds)
+               "Status spent time is unchanged when other enable-history properties are present")
+           (is (= [{:created-at 1000
+                    :property-ident :logseq.property/status
+                    :status-ident :logseq.property/status.doing}
+                   {:created-at 2500
+                    :property-ident :logseq.property/priority
+                    :status-ident :logseq.property/priority.high}
+                   {:created-at 4000
+                    :property-ident :logseq.property/status
+                    :status-ident :logseq.property/status.done}]
+                  (mapv (fn [item]
+                          {:created-at (:block/created-at item)
+                           :property-ident (:logseq.property.history/property-ident item)
+                           :status-ident (:logseq.property.history/ref-value-ident item)})
+                        history)))))))))
+
 (deftest get-display-properties-keeps-other-position-properties-for-page-properties
   (restoring-worker-state
    (fn []

--- a/src/test/frontend/worker/handler/render_resource_test.cljs
+++ b/src/test/frontend/worker/handler/render_resource_test.cljs
@@ -1447,6 +1447,60 @@
                                 {:history [] :seconds 0}
                                 response))))
 
+(deftest block-task-time-resource-includes-non-status-property-history-test
+  (when-let [api (render-resource-api)]
+    (let [{:keys [conn journal-child-b]} (render-resource-fixture)
+          tracked-property-uuid (random-uuid)
+          history-uuid (random-uuid)
+          priority-history-uuid (random-uuid)
+          priority-uuid (:block/uuid (d/entity @conn :logseq.property/priority))
+          high-uuid (:block/uuid (d/entity @conn :logseq.property/priority.high))]
+      (d/transact! conn
+                   [{:db/id -200
+                     :db/ident :user.property/tracked
+                     :block/uuid tracked-property-uuid
+                     :block/tx-id 21
+                     :block/title "Tracked"
+                     :block/tags :logseq.class/Property
+                     :logseq.property/type :default
+                     :logseq.property/enable-history? true}
+                    {:db/id [:block/uuid journal-child-b]
+                     :block/tx-id 21
+                     :user.property/tracked "alpha"
+                     :logseq.property/priority :logseq.property/priority.high}
+                    {:block/uuid history-uuid
+                     :block/tx-id 21
+                     :block/created-at 5000
+                     :logseq.property.history/block [:block/uuid journal-child-b]
+                     :logseq.property.history/property :user.property/tracked
+                     :logseq.property.history/scalar-value "alpha"}
+                    {:block/uuid priority-history-uuid
+                     :block/tx-id 21
+                     :block/created-at 8000
+                     :logseq.property.history/block [:block/uuid journal-child-b]
+                     :logseq.property.history/property :logseq.property/priority
+                     :logseq.property.history/ref-value :logseq.property/priority.high}])
+      (let [resource-key [:block-task-time journal-child-b]
+            response (call-resource api conn resource-key)]
+        (assert-resource-envelope
+         @conn
+         resource-key
+         #{[:task-time journal-child-b]}
+         {:history [{:created-at 5000
+                     :property-ident :user.property/tracked
+                     :property-uuid tracked-property-uuid
+                     :scalar-value "alpha"}
+                    {:created-at 8000
+                     :property-ident :logseq.property/priority
+                     :property-uuid priority-uuid
+                     :value-uuid high-uuid}]
+          :seconds 0}
+         response)
+        (is (not-any? :status-uuid (get-in response [:value :history]))
+            "Non-status history is displayed without the Status-only payload")
+        (is (= 8000 (:created-at (last (get-in response [:value :history]))))
+            "The node timestamp uses the latest enable-history change")))))
+
 (deftest route-block-resource-watches-the-page-lookup-and-resolved-entities-test
   (when-let [api (render-resource-api)]
     (let [{:keys [conn page route-heading]} (render-resource-fixture)

--- a/src/test/frontend/worker/pipeline_test.cljs
+++ b/src/test/frontend/worker/pipeline_test.cljs
@@ -1152,3 +1152,42 @@
               "No :logseq.property.history entries are added for an imported transaction")))
       (finally
         (ldb/register-transact-pipeline-fn! identity)))))
+
+(deftest enable-history-records-non-status-property-test
+  (let [conn (db-test/create-conn-with-blocks
+              {:properties {:user.property/tracked {:logseq.property/type :checkbox
+                                                    :build/properties {:logseq.property/enable-history? true}}
+                            :user.property/untracked {:logseq.property/type :checkbox}}
+               :pages-and-blocks [{:page {:block/title "page1"}
+                                   :blocks [{:block/title "history node"}]}]})
+        block (db-test/find-block-by-content @conn "history node")
+        history-for (fn [property-ident]
+                      (d/q '[:find [?e ...]
+                             :in $ ?block ?property
+                             :where
+                             [?e :logseq.property.history/block ?block]
+                             [?e :logseq.property.history/property ?property]]
+                           @conn
+                           (:db/id block)
+                           property-ident))]
+    (is (true? (:logseq.property/enable-history? (d/entity @conn :user.property/tracked))))
+    (is (not (true? (:logseq.property/enable-history? (d/entity @conn :user.property/untracked)))))
+    (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
+    (try
+      (ldb/transact! conn [[:db/add (:db/id block)
+                            :user.property/tracked true]
+                           [:db/add (:db/id block)
+                            :user.property/untracked true]
+                           [:db/add (:db/id block)
+                            :logseq.property/priority :logseq.property/priority.high]])
+      (is (= 1 (count (history-for :user.property/tracked)))
+          "A non-status property with enable-history records a history row")
+      (is (= [true]
+             (mapv :logseq.property.history/scalar-value
+                   (map #(d/entity @conn %) (history-for :user.property/tracked)))))
+      (is (empty? (history-for :user.property/untracked))
+          "A property without enable-history stays hidden from history")
+      (is (= 1 (count (history-for :logseq.property/priority)))
+          "Built-in Priority records history because enable-history is on")
+      (finally
+        (ldb/register-transact-pipeline-fn! identity)))))

--- a/src/test/frontend/worker/pipeline_test.cljs
+++ b/src/test/frontend/worker/pipeline_test.cljs
@@ -1166,7 +1166,8 @@
                              :in $ ?block ?property
                              :where
                              [?e :logseq.property.history/block ?block]
-                             [?e :logseq.property.history/property ?property]]
+                             [?e :logseq.property.history/property ?prop]
+                             [?prop :db/ident ?property]]
                            @conn
                            (:db/id block)
                            property-ident))]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Enabling `enable property history` on a property had no visible effect except for Status. History rows were already recorded for other properties (including built-in Priority), but the node UI only queried and rendered Status history via spent-time.

Fixes logseq/db-test#1120.

## Change

- Query all property-history rows for a node, not only Status.
- Keep Status spent-time calculation and the existing Status history popup.
- When enable-history is on and a non-status property changes, show a timestamp next to the node. Clicking it opens property history.
- Properties without enable-history are still not recorded, so they stay hidden.

## Tests

- Recording: custom enable-history property and Priority write history rows; a property without enable-history does not.
- Display: the block task-time resource returns non-status history (timestamp + property/value payload) with `seconds` 0, and mixed Status + Priority history still reports Status spent time.
- `frontend.worker.pipeline-test` + `frontend.worker.handler.render-resource-test`: 103 tests, 750 assertions, 0 failures.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9afa809f-95e9-46b9-9d9a-cf0e25cf8973?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9afa809f-95e9-46b9-9d9a-cf0e25cf8973&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

