### PR TITLE
fix: update window title on back navigation

### DIFF
--- a/src/electron/electron/handler.cljs
+++ b/src/electron/electron/handler.cljs
@@ -540,6 +540,10 @@
 (defmethod handle :window-close [^js win]
   (.close win))
 
+(defmethod handle :set-window-title [^js win [_ title]]
+  (when (and win (string? title) (not (.isDestroyed win)))
+    (.setTitle win title)))
+
 (defmethod handle :theme-loaded [^js win]
   (.manage (windowStateKeeper) win))
 

--- a/src/main/frontend/handler/route.cljs
+++ b/src/main/frontend/handler/route.cljs
@@ -1,6 +1,7 @@
 (ns frontend.handler.route
   "Provides fns used for routing throughout the app"
   (:require [clojure.string :as string]
+            [electron.ipc :as ipc]
             [frontend.config :as config]
             [frontend.context.i18n :refer [t]]
             [frontend.date :as date]
@@ -206,12 +207,30 @@
     (<page-route-title (:name path-params))
     (p/resolved (static-title name path-params))))
 
+(defonce ^:private *page-title-update-id (atom 0))
+
+(defn- apply-page-title!
+  [title]
+  (util/set-title! title)
+  (ipc/ipc :set-window-title title))
+
 (defn update-page-title!
   [route]
-  (let [{:keys [data path-params]} route]
+  (let [update-id (swap! *page-title-update-id inc)
+        {:keys [data path-params]} route]
     (p/let [title (get-title (:name data) path-params)
-            hls? (pdf-utils/hls-file? title)]
-      (util/set-title! (if hls? (pdf-utils/fix-local-asset-pagename title) title)))))
+            hls? (pdf-utils/hls-file? title)
+            title (if hls? (pdf-utils/fix-local-asset-pagename title) title)]
+      (when (= update-id @*page-title-update-id)
+        (apply-page-title! title)
+        ;; Chromium can restore the history-entry title after popstate and
+        ;; overwrite a same-turn document.title write. Re-apply on the next
+        ;; tick so Back/Forward keep the current page title.
+        (js/setTimeout
+         (fn []
+           (when (= update-id @*page-title-update-id)
+             (apply-page-title! title)))
+         0)))))
 
 (defn update-page-label!
   [route]

--- a/src/test/frontend/handler/route_test.cljs
+++ b/src/test/frontend/handler/route_test.cljs
@@ -1,9 +1,9 @@
 (ns frontend.handler.route-test
   (:require [cljs.test :refer [async deftest is testing use-fixtures]]
+            [electron.ipc :as ipc]
             [frontend.db.conn :as conn]
             [frontend.db.utils :as db-utils]
             [frontend.date :as date]
-            [electron.ipc :as ipc]
             [frontend.handler.graph :as graph-handler]
             [frontend.handler.recent :as recent-handler]
             [frontend.handler.route :as route-handler]

--- a/src/test/frontend/handler/route_test.cljs
+++ b/src/test/frontend/handler/route_test.cljs
@@ -223,8 +223,8 @@
       (-> (p/with-redefs [ipc/ipc (fn [channel title]
                                     (when (= :set-window-title channel)
                                       (swap! window-titles conj title)))]
-            (route-handler/update-page-title! left-route)
             (p/do!
+             (do (route-handler/update-page-title! left-route) nil)
              (route-handler/update-page-title! current-route)
              (is (= "Current" (.-title document)))
              (p/resolve! left-title {:page-title "Left"})

--- a/src/test/frontend/handler/route_test.cljs
+++ b/src/test/frontend/handler/route_test.cljs
@@ -3,6 +3,7 @@
             [frontend.db.conn :as conn]
             [frontend.db.utils :as db-utils]
             [frontend.date :as date]
+            [electron.ipc :as ipc]
             [frontend.handler.graph :as graph-handler]
             [frontend.handler.recent :as recent-handler]
             [frontend.handler.route :as route-handler]
@@ -185,6 +186,87 @@
              (is (= "Page" (.-page (.-dataset (.-body document)))))
              (is (= (str (subs block-title 0 48) "...")
                     (.-title document)))))
+          (p/catch
+           (fn [error]
+             (is false (str error))))
+          (p/finally
+           (fn []
+             (state/replace-state! previous-state)
+             (reset! state/*db-worker previous-worker)
+             (set! (.-document js/global) previous-document)
+             (done)))))))
+
+(defn- page-route
+  [page-name]
+  {:data {:name :page}
+   :path-params {:name page-name}})
+
+(deftest stale-route-title-resolve-does-not-overwrite-current-page-test
+  (async done
+    (let [left-route (page-route "Left")
+          current-route (page-route "Current")
+          left-title (p/deferred)
+          document #js {:title "stale"
+                        :body #js {:dataset #js {:page ""}}}
+          previous-document (.-document js/global)
+          previous-state (state/get-state)
+          previous-worker @state/*db-worker
+          window-titles (atom [])]
+      (set! (.-document js/global) document)
+      (state/swap-state! assoc :git/current-repo "test")
+      (reset! state/*db-worker
+              (fn [_api _repo route-name]
+                (case route-name
+                  "Left" left-title
+                  "Current" (p/resolved {:page-title "Current"})
+                  (p/resolved nil))))
+      (-> (p/with-redefs [ipc/ipc (fn [channel title]
+                                    (when (= :set-window-title channel)
+                                      (swap! window-titles conj title)))]
+            (route-handler/update-page-title! left-route)
+            (p/do!
+             (route-handler/update-page-title! current-route)
+             (is (= "Current" (.-title document)))
+             (p/resolve! left-title {:page-title "Left"})
+             (p/delay 10)
+             (is (= "Current" (.-title document))
+                 "A stale Back/forward title resolve must not overwrite the current page.")
+             (is (= ["Current"] (vec (distinct @window-titles))))))
+          (p/catch
+           (fn [error]
+             (is false (str error))))
+          (p/finally
+           (fn []
+             (state/replace-state! previous-state)
+             (reset! state/*db-worker previous-worker)
+             (set! (.-document js/global) previous-document)
+             (done)))))))
+
+(deftest set-route-match-updates-title-after-back-navigation-test
+  (async done
+    (let [left-route (page-route "Left")
+          previous-route (page-route "Previous")
+          document #js {:title ""
+                        :body #js {:dataset #js {:page ""}}}
+          previous-document (.-document js/global)
+          previous-state (state/get-state)
+          previous-worker @state/*db-worker]
+      (set! (.-document js/global) document)
+      (state/swap-state! assoc :git/current-repo "test")
+      (reset! state/*db-worker
+              (fn [_api _repo route-name]
+                (p/resolved {:page-title route-name})))
+      (-> (p/do!
+           (route-handler/set-route-match! left-route)
+           (p/delay 0)
+           (is (= "Left" (.-title document)))
+           ;; popstate / history.back uses the same on-navigate -> set-route-match! path
+           (route-handler/set-route-match! previous-route)
+           (p/delay 0)
+           (is (= "Previous" (.-title document)))
+           (route-handler/set-route-match! left-route)
+           (p/delay 0)
+           (is (= "Left" (.-title document))))
           (p/catch
            (fn [error]
              (is false (str error))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes window/taskbar title staying on the previous page after Back (and Forward).

https://github.com/logseq/db-test/issues/1122

## Behavior
Click-through navigation already updated `document.title` through reitit `on-navigate` → `set-route-match!` → `update-page-title!`. Back/Forward use `history.back` / `popstate` and hit the same route match path, but title application was racy and Electron never called `BrowserWindow.setTitle`.

This change:
- Sequences async `:thread-api/get-route-title` resolves so a stale Back/Forward result cannot overwrite the current page
- Re-applies the current title on the next tick after Chromium history-title restore
- Sets the Electron window title via IPC so the taskbar matches `document.title`

## Tests
- Stale `get-route-title` resolve cannot overwrite the current page title
- `set-route-match!` (the popstate / `on-navigate` path) updates the title after Back and Forward-style navigation

Verified with `LOGSEQ_STABLE_IDENTS=1 node static/tests.js -n frontend.handler.route-test`: 5 tests, 16 assertions, 0 failures. clj-kondo on the touched files is clean.

The unsequenced title path fails the new race test (`document.title` becomes `"Left"` after a late resolve). After the generation check, the same test keeps `"Current"`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98416003-35f5-4e9f-87c8-1159fa5a4654?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98416003-35f5-4e9f-87c8-1159fa5a4654&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

