### PR TITLE
fix: persist table row-number column

### DIFF
--- a/deps/db/src/logseq/db/frontend/property.cljs
+++ b/deps/db/src/logseq/db/frontend/property.cljs
@@ -529,6 +529,12 @@
                                              :hide? true
                                              :public? false}}
 
+     :logseq.property.table/show-row-number? {:title "Show table row numbers"
+                                              :schema
+                                              {:type :checkbox
+                                               :hide? true
+                                               :public? false}}
+
      :logseq.property.table/ordered-columns {:title "View ordered columns"
                                              :schema
                                              {:type :coll

--- a/deps/db/src/logseq/db/frontend/schema.cljs
+++ b/deps/db/src/logseq/db/frontend/schema.cljs
@@ -30,7 +30,7 @@
          (map (juxt :major :minor)
               [(parse-schema-version x) (parse-schema-version y)])))
 
-(def version (parse-schema-version "65.33"))
+(def version (parse-schema-version "65.34"))
 
 (defn major-version
   "Return a number.

--- a/deps/db/test/logseq/db/frontend/property_test.cljs
+++ b/deps/db/test/logseq/db/frontend/property_test.cljs
@@ -75,6 +75,15 @@
     (is (= true (get-in props [property :schema :hide?])))
     (is (db-property/logseq-property? property))))
 
+(deftest table-show-row-number-built-in-property
+  (let [property (get db-property/built-in-properties :logseq.property.table/show-row-number?)]
+    (is (some? property))
+    (is (= "Show table row numbers" (:title property)))
+    (is (= :checkbox (get-in property [:schema :type])))
+    (is (= false (get-in property [:schema :public?])))
+    (is (= true (get-in property [:schema :hide?])))
+    (is (db-property/logseq-property? :logseq.property.table/show-row-number?))))
+
 (deftest assignee-built-in-property
   (let [property (get db-property/built-in-properties :logseq.property/assignee)]
     (testing "schema"

--- a/src/main/frontend/components/views.cljs
+++ b/src/main/frontend/components/views.cljs
@@ -2003,6 +2003,34 @@
          [property operator])))
    filters))
 
+(defn- table-hidden-columns
+  [view-entity columns]
+  (if-let [hidden-columns (:logseq.property.table/hidden-columns view-entity)]
+    hidden-columns
+    (when (seq (:logseq.property.table/ordered-columns view-entity))
+      (vec (set/difference (set (map :id columns))
+                           (set (:logseq.property.table/ordered-columns view-entity))
+                           #{:select :block/created-at :block/updated-at})))))
+
+(defn- table-visible-columns
+  "Restore column visibility from a view entity.
+  The # row-number column defaults to hidden and is stored separately because
+  hidden-columns only records columns the user turned off."
+  [view-entity columns]
+  (-> (if-let [hidden-columns (table-hidden-columns view-entity columns)]
+        (zipmap hidden-columns (repeat false))
+        {})
+      (assoc :id (true? (:logseq.property.table/show-row-number? view-entity)))))
+
+(defn- table-visibility-to-persist
+  [visible-columns]
+  {:hidden-columns (vec (keep (fn [[column visible?]]
+                                (when (and (false? visible?)
+                                           (not= :id column))
+                                  column))
+                              visible-columns))
+   :show-row-number? (true? (get visible-columns :id))})
+
 (defn- db-set-table-state!
   [entity {:keys [set-sorting! set-filters!]}]
   {:set-sorting!
@@ -2019,10 +2047,11 @@
         (set-filters! filters))))
    :set-visible-columns!
    (fn [columns]
-     (let [hidden-columns (vec (keep (fn [[column visible?]]
-                                       (when (false? visible?)
-                                         column)) columns))]
-       (property-handler/set-block-property! (:db/id entity) :logseq.property.table/hidden-columns hidden-columns)))
+     (let [{:keys [hidden-columns show-row-number?]} (table-visibility-to-persist columns)]
+       (db-property-handler/set-block-properties!
+        (:db/id entity)
+        {:logseq.property.table/hidden-columns hidden-columns
+         :logseq.property.table/show-row-number? show-row-number?})))
    :set-ordered-columns!
    (fn [ordered-columns]
      (let [ids (vec (remove #{:select} ordered-columns))]
@@ -2863,16 +2892,7 @@
                       (-> (remove #{:id :select} (map :id columns))
                           (conj :block/uuid :block/name)
                           vec))
-        visible-columns (-> (if-let [hidden-columns (:logseq.property.table/hidden-columns view-entity)]
-                              (zipmap hidden-columns (repeat false))
-                              ;; This case can happen for imported tables
-                              (if (seq (:logseq.property.table/ordered-columns view-entity))
-                                (zipmap (set/difference (set (map :id columns))
-                                                        (set (:logseq.property.table/ordered-columns view-entity))
-                                                        #{:select :block/created-at :block/updated-at})
-                                        (repeat false))
-                                {}))
-                            (assoc :id false))
+        visible-columns (table-visible-columns view-entity columns)
         ordered-columns (vec (concat [:select] (:logseq.property.table/ordered-columns view-entity)))
         sized-columns (:logseq.property.table/sized-columns view-entity)
         {:keys [set-sorting! set-filters! set-visible-columns! set-ordered-columns! set-sized-columns!]}

--- a/src/main/frontend/worker/db/migrate.cljs
+++ b/src/main/frontend/worker/db/migrate.cljs
@@ -162,7 +162,8 @@
                           :logseq.property.view/gallery-display-properties
                           :logseq.property.view/gallery-card-size
                           :logseq.property.view/gallery-card-width
-                          :logseq.property.view/gallery-card-height]}]])
+                          :logseq.property.view/gallery-card-height]}]
+   ["65.34" {:properties [:logseq.property.table/show-row-number?]}]])
 
 (let [[major minor] (last (sort (map (comp (juxt :major :minor) db-schema/parse-schema-version first)
                                      schema-version->updates)))]

--- a/src/test/frontend/components/views_test.cljs
+++ b/src/test/frontend/components/views_test.cljs
@@ -491,3 +491,66 @@
   (is (views/group-by-column? {:id :block/tags
                                :property {:logseq.property/type :class
                                           :db/cardinality :db.cardinality/many}})))
+
+(deftest table-visible-columns-default-hides-row-number
+  (is (= false
+         (:id (#'views/table-visible-columns {} [{:id :block/title}])))))
+
+(deftest table-visible-columns-restores-row-number-and-hidden-columns
+  (let [columns [{:id :select}
+                 {:id :id}
+                 {:id :block/title}
+                 {:id :user.property/status}
+                 {:id :block/created-at}]
+        view {:logseq.property.table/hidden-columns [:user.property/status]
+              :logseq.property.table/show-row-number? true}
+        visible (#'views/table-visible-columns view columns)]
+    (is (true? (:id visible)))
+    (is (false? (:user.property/status visible)))
+    (is (nil? (:block/title visible)))))
+
+(deftest table-visible-columns-keeps-row-number-hidden-when-flag-is-false
+  (is (= false
+         (:id (#'views/table-visible-columns
+               {:logseq.property.table/show-row-number? false}
+               [{:id :id}])))))
+
+(deftest table-visible-columns-hides-imported-columns-not-in-ordered-columns
+  (let [columns [{:id :select}
+                 {:id :id}
+                 {:id :block/title}
+                 {:id :user.property/status}
+                 {:id :block/created-at}
+                 {:id :block/updated-at}]
+        view {:logseq.property.table/ordered-columns [:block/title]}
+        visible (#'views/table-visible-columns view columns)]
+    (is (false? (:id visible)))
+    (is (false? (:user.property/status visible)))
+    (is (nil? (:block/title visible)))
+    (is (nil? (:block/created-at visible)))
+    (is (nil? (:block/updated-at visible)))))
+
+(deftest table-visibility-to-persist-saves-row-number-separately
+  (is (= {:hidden-columns [:user.property/status]
+          :show-row-number? true}
+         (#'views/table-visibility-to-persist
+          {:id true
+           :user.property/status false
+           :block/title true})))
+  (is (= {:hidden-columns []
+          :show-row-number? false}
+         (#'views/table-visibility-to-persist {:id false}))))
+
+(deftest table-row-number-visibility-round-trips-across-remount
+  (let [columns [{:id :select} {:id :id} {:id :block/title} {:id :user.property/status}]
+        persisted (#'views/table-visibility-to-persist
+                   {:id true
+                    :user.property/status false})
+        remounted (#'views/table-visible-columns
+                   {:logseq.property.table/hidden-columns (:hidden-columns persisted)
+                    :logseq.property.table/show-row-number? (:show-row-number? persisted)}
+                   columns)]
+    (is (true? (:show-row-number? persisted)))
+    (is (= [:user.property/status] (:hidden-columns persisted)))
+    (is (true? (:id remounted)))
+    (is (false? (:user.property/status remounted)))))

--- a/src/test/frontend/worker/migrate_test.cljs
+++ b/src/test/frontend/worker/migrate_test.cljs
@@ -405,3 +405,21 @@
     (is (every? #(= :raw-number (:logseq.property/type (d/entity @conn %)))
                 [:logseq.property.view/gallery-card-width
                  :logseq.property.view/gallery-card-height]))))
+
+(deftest migrate-65-34-adds-table-show-row-number-property
+  (let [conn (d/create-conn db-schema/schema)]
+    (d/transact! conn [{:db/ident :logseq.kv/schema-version
+                        :kv/value {:major 65 :minor 33}}])
+
+    (is (nil? (d/entity @conn :logseq.property.table/show-row-number?)))
+
+    (let [result (db-migrate/migrate conn :target-version {:major 65 :minor 34})]
+      (is (= {:major 65 :minor 34}
+             (:kv/value (d/entity @conn :logseq.kv/schema-version))))
+      (let [property (d/entity @conn :logseq.property.table/show-row-number?)]
+        (is (some? property))
+        (is (= "Show table row numbers" (:block/title property)))
+        (is (= :checkbox (:logseq.property/type property))))
+      (is (some #(= {:properties [:logseq.property.table/show-row-number?]}
+                    (:migrate-updates %))
+                (:upgrade-result-coll result))))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the Table View `#` row-number column resetting after switching views or leaving a page.

## Problem

Enabling `#` only updated in-memory column visibility. Remount always hid `#` again (`:id false`), and `set-visible-columns!` only persisted hidden columns. Because `#` is hidden by default, “shown” was never stored.

## Fix

- Persist `#` visibility as `:logseq.property.table/show-row-number?` on the view.
- Restore that flag when rebuilding `visible-columns`.
- Keep existing hidden-column persistence for other columns.

## Tests

- Persist and restore of `#` across a remount.
- Other hidden columns still persist.
- Default remains hidden.
- Schema migration adds the new property.

Related: [db-test#1123](https://github.com/logseq/db-test/issues/1123)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78175696-190a-4f63-9651-653d2be0172a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78175696-190a-4f63-9651-653d2be0172a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

