### PR TITLE
fix: include Doing pages in journal default query

### DIFF
--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -423,7 +423,8 @@
 (def db-default-config
   "Default repo config for DB graphs"
   (merge common-default-config
-         ;; The "DOING" query returns tasks with "Doing" status for recent past days
+         ;; The "DOING" query returns Doing blocks on recent journal pages,
+         ;; plus pages whose status is Doing (pages have no :block/page).
          ;; The "TODO" query returns tasks with "Todo" status for upcoming future days
          {:default-queries
           {:journals
@@ -433,10 +434,13 @@
                       :in $ ?start ?today
                       :where
                       (task ?b #{"Doing"})
-                      [?b :block/page ?p]
-                      [?p :block/journal-day ?d]
-                      [(>= ?d ?start)]
-                      [(<= ?d ?today)]]
+                      (or-join [?b ?start ?today]
+                               (and
+                                [?b :block/page ?p]
+                                [?p :block/journal-day ?d]
+                                [(>= ?d ?start)]
+                                [(<= ?d ?today)])
+                               [?b :block/name])]
              :inputs [:14d :today]
              :collapsed? true}
             {:title-key :journal.default-query/todo

--- a/src/test/frontend/db/query_custom_test.cljs
+++ b/src/test/frontend/db/query_custom_test.cljs
@@ -1,3 +1,61 @@
-(ns frontend.db.query-custom-test)
+(ns frontend.db.query-custom-test
+  (:require [cljs-time.core :as t]
+            [cljs.test :refer [deftest is testing]]
+            [frontend.state :as state]
+            [frontend.worker.handler.query :as query-handler]
+            [logseq.common.util.date-time :as date-time-util]
+            [logseq.db.test.helper :as db-test]))
 
-;; TODO: Add db graph tests
+(defn- journal-default-query
+  [title-key]
+  (->> (get-in state/db-default-config [:default-queries :journals])
+       (some #(when (= title-key (:title-key %)) %))))
+
+(defn- query-titles
+  [db query-m today]
+  (with-redefs [t/today (constantly today)]
+    (->> (query-handler/execute-custom-query
+          db
+          query-m
+          {:today-day (date-time-util/date->int today)})
+         (map (comp :block/title first))
+         set)))
+
+(deftest journal-doing-query-includes-doing-pages-and-blocks
+  (let [today (t/date-time 2026 8 28)
+        conn (db-test/create-conn-with-blocks
+              {:pages-and-blocks
+               [{:page {:block/title "Doing page"
+                        :build/properties {:logseq.property/status :logseq.property/status.doing}
+                        :build/tags [:logseq.class/Task]}}
+                {:page {:block/title "Todo page"
+                        :build/properties {:logseq.property/status :logseq.property/status.todo}
+                        :build/tags [:logseq.class/Task]}}
+                {:page {:block/title "Regular page"}
+                 :blocks [{:block/title "Doing block on regular page"
+                           :build/properties {:logseq.property/status :logseq.property/status.doing}
+                           :build/tags [:logseq.class/Task]}]}
+                {:page {:build/journal 20260820}
+                 :blocks [{:block/title "Doing block on recent journal"
+                           :build/properties {:logseq.property/status :logseq.property/status.doing}
+                           :build/tags [:logseq.class/Task]}
+                          {:block/title "Todo block on recent journal"
+                           :build/properties {:logseq.property/status :logseq.property/status.todo}
+                           :build/tags [:logseq.class/Task]}]}
+                {:page {:build/journal 20260101}
+                 :blocks [{:block/title "Doing block on old journal"
+                           :build/properties {:logseq.property/status :logseq.property/status.doing}
+                           :build/tags [:logseq.class/Task]}]}]})
+        titles (query-titles @conn (journal-default-query :journal.default-query/doing) today)]
+    (testing "Doing pages are included even though they have no :block/page"
+      (is (contains? titles "Doing page")))
+    (testing "Doing blocks on recent journal pages still match"
+      (is (contains? titles "Doing block on recent journal")))
+    (is (not (contains? titles "Todo page"))
+        "Pages with Todo status are not included")
+    (is (not (contains? titles "Todo block on recent journal"))
+        "Todo blocks are not included")
+    (is (not (contains? titles "Doing block on regular page"))
+        "Doing blocks on non-journal pages stay excluded")
+    (is (not (contains? titles "Doing block on old journal"))
+        "Doing blocks outside the recent journal window stay excluded")))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Today's Journal default Doing query required `:block/page` plus a journal-day in range. Pages have no `:block/page`, so a page with status Doing never appeared even though Doing blocks on recent journals did.

The default Doing query now matches:
- Doing blocks on journal pages in the existing 14-day window
- Pages whose status is Doing

Fixes [logseq/db-test#1124](https://github.com/logseq/db-test/issues/1124).

## Test plan

- [x] Unit test runs the product default Doing query against a DB graph and asserts:
  - a Doing page is included
  - a Doing block on a recent journal is still included
  - Todo pages/blocks, Doing blocks on non-journal pages, and Doing blocks on old journals stay excluded
- [x] `bb dev:test -v frontend.db.query-custom-test/journal-doing-query-includes-doing-pages-and-blocks` — 1 test, 6 assertions, 0 failures
- [x] `clojure -M:clj-kondo --lint` on the changed files — 0 errors, 0 warnings

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a477914c-61e5-4ff1-ade8-e279e7a3963b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a477914c-61e5-4ff1-ade8-e279e7a3963b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

