### PR TITLE
fix: refresh class properties when a new property is added to a tag

### DIFF
--- a/src/main/frontend/components/objects.cljs
+++ b/src/main/frontend/components/objects.cljs
@@ -4,6 +4,7 @@
             [frontend.components.views :as views]
             [frontend.context.i18n :refer [t]]
             [frontend.db.async :as db-async]
+            [frontend.db.hooks :as db-hooks]
             [frontend.handler.editor :as editor-handler]
             [frontend.state :as state]
             [logseq.db :as ldb]
@@ -110,6 +111,11 @@
   [class config]
   (let [container-key (select-keys config [:id :sidebar? :embed? :custom-query? :query :current-block :table? :block? :db/id :page-name])
         config (assoc config :container-id (or (:container-id config) (state/get-container-id container-key)))
+        ;; Subscribe to the class block reactively so that adding/removing a
+        ;; tag property re-triggers the properties fetch below instead of
+        ;; only refreshing on full remount (e.g. a page reload).
+        live-class (db-hooks/use-block (:block/uuid class))
+        class-properties (:logseq.property.class/properties live-class)
         [properties set-properties!] (hooks/use-state [])
         _ (hooks/use-effect!
            (fn []
@@ -118,7 +124,7 @@
                               (:db/id class))]
                (set-properties! (or result [])))
              nil)
-           [(:db/id class)])]
+           [(:db/id class) class-properties])]
     [:div.ml-1
      (class-objects-inner config class properties)]))
 


### PR DESCRIPTION
## Fixes logseq/db-test#1129

## Problem
In a tag's Table view, adding a new property via the "+ New property" picker doesn't show the new column until the page is refreshed. The property is saved correctly, the column list just doesn't update in place.

## Root cause
`class-objects` in `src/main/frontend/components/objects.cljs` fetches the class's property list once via `db-async/<get-class-properties` inside a `use-effect!` whose dependency array was only `[(:db/id class)]`. This only refetches when navigating to a different class, never when a property is added to the same class, so the fetched `properties` state stays stale until a full page refresh.

## Fix
Subscribe to the class block reactively with `db-hooks/use-block` and include its `:logseq.property.class/properties` in the effect's dependency vector, so adding a tag property now correctly retriggers the fetch.

## Testing
Verified manually against a fresh DB graph: the new column now appears immediately without needing a refresh.