### PR TITLE
perf(import): parse markdown with parse_outline_only

### DIFF
--- a/deps/graph-parser/src/logseq/graph_parser/extract.cljc
+++ b/deps/graph-parser/src/logseq/graph_parser/extract.cljc
@@ -281,9 +281,7 @@
     {}
     (let [format (common-util/get-format file-path)
           _ (when verbose (println "Parsing start: " file-path))
-          ast (gp-mldoc/->edn content (gp-mldoc/default-config format
-                                        ;; {:parse_outline_only? true}
-                                                               ))]
+          ast (gp-mldoc/->edn content (gp-mldoc/default-config format {:parse_outline_only? true}))]
       (when verbose (println "Parsing finished: " file-path))
       (let [first-block (ffirst ast)
             properties (let [properties (and (gp-property/properties-ast? first-block)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Experiment: file-to-db import with mldoc `parse_outline_only`. **Do not merge.**

## Change

`extract/extract` now passes `{:parse_outline_only? true}` into mldoc.

npm still pins `mldoc@1.5.9` (nothing newer is published). Benches used a local js_of_ocaml build of [logseq/mldoc#145](https://github.com/logseq/mldoc/pull/145) (`1973758`), not 1.5.9.

## Movies-400 (nbb in-memory, no search)

| Run | mldoc | outline | wall | parse ms/file | pages |
| --- | --- | --- | ---: | ---: | ---: |
| baseline | 1.5.9 | off | 21.0s | 19.7 | 6065 |
| prior | #145 JS | off | 21.6s | 15.6 | 6065 |
| this | #145 JS | on | 19.1s | 15.3 | 6065 |

Outline-only does not beat #145 full parse. Extract + transact dominate; `parseJson` is already ~0.2 ms/file on this corpus.

## Tests

graph-parser exporter tests fail. Outline mode drops heading Plain text (`- TODO todo item` → empty title), drops quotes, and crashes generated-graph import (`No uuid found for page name "generated-page"`). `extract-blocks-for-headings` expected `["a" "b" "c"]`, got `["" "" "a\n- b\n- c"]`.

File-to-db import needs full parse. Leave this branch as a measurement only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1097ea5-46bd-4119-884e-8d07449c3a5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1097ea5-46bd-4119-884e-8d07449c3a5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

