### PR TITLE
fix: surface encrypted graph upload decrypt errors

### DIFF
--- a/src/main/frontend/common/crypt.cljs
+++ b/src/main/frontend/common/crypt.cljs
@@ -6,10 +6,22 @@
 
 (defonce subtle (.. js/crypto -subtle))
 
-(defn- expected-crypto-operation-error?
+(defn- operation-error-label?
+  [value]
+  (= "OperationError" value))
+
+(defn expected-crypto-operation-error?
+  "WebCrypto AES-GCM/RSA-OAEP failures surface as DOMException OperationError.
+  Some runtimes put that string on `.name`; others only on `.message` or the cause.
+  Do not use `(or name cause-name)` — a truthy non-matching `.name` such as
+  `Error` would hide the OperationError on the cause."
   [e]
-  (= "OperationError" (or (some-> e .-name)
-                          (some-> e ex-cause .-name))))
+  (boolean
+   (when e
+     (or (operation-error-label? (some-> e .-name))
+         (operation-error-label? (some-> e .-message))
+         (operation-error-label? (ex-message e))
+         (expected-crypto-operation-error? (ex-cause e))))))
 
 (defn <export-aes-key
   [aes-key]
@@ -156,10 +168,11 @@
               (let [invalid-password? (expected-crypto-operation-error? e)]
                 (when-not invalid-password?
                   (log/error "decrypt-private-key" e))
-                (ex-info "decrypt-private-key"
-                         (cond-> {}
-                           invalid-password? (assoc :invalid-password? true))
-                         e))))))
+                (p/rejected
+                 (ex-info "decrypt-private-key"
+                          (cond-> {}
+                            invalid-password? (assoc :invalid-password? true))
+                          e)))))))
 
 (defn <encrypt-aes-key
   "Encrypts an AES key with a public key."

--- a/src/main/frontend/components/repo.cljs
+++ b/src/main/frontend/components/repo.cljs
@@ -53,8 +53,12 @@
 (defn- handle-cloud-graph-error!
   [error]
   (log/error :db-sync/cloud-graph-failed error)
-  (when (rtc-error/e2ee-decrypt-failed? error)
-    (notification/show! (t :encryption/wrong-password) :error false)))
+  (notification/show!
+   (if (rtc-error/e2ee-decrypt-failed? error)
+     (t :encryption/wrong-password)
+     (t :sync/something-wrong))
+   :error
+   false))
 
 (defn- graph-e2ee-enabled?
   [{:keys [url graph-e2ee?] :as graph}]

--- a/src/main/frontend/handler/events/rtc_error.cljs
+++ b/src/main/frontend/handler/events/rtc_error.cljs
@@ -35,4 +35,5 @@
   [error]
   (boolean
    (or (some e2ee-decrypt-error-codes (error-codes error))
-       (some #{"decrypt-aes-key"} (error-texts error)))))
+       (some #{"decrypt-aes-key" "decrypt-private-key" "invalid-e2ee-password"}
+             (error-texts error)))))

--- a/src/main/frontend/worker/sync/crypt.cljs
+++ b/src/main/frontend/worker/sync/crypt.cljs
@@ -567,7 +567,7 @@
                                                  :retry-error retry-error})
                                       (throw (if (invalid-e2ee-password-error? retry-error)
                                                (invalid-e2ee-password-ex retry-error)
-                                               retry-error)))))))))
+                                               retry-error))))))))
           (p/then (fn [key-material]
                     (if-let [password (when (seq @ui-password*)
                                        @ui-password*)]

--- a/src/main/frontend/worker/sync/crypt.cljs
+++ b/src/main/frontend/worker/sync/crypt.cljs
@@ -340,6 +340,21 @@
                                                  :reason :empty-ui-password}))
     password))
 
+(defn- invalid-e2ee-password-error?
+  [error]
+  (or (true? (:invalid-password? (ex-data error)))
+      (= :db-sync/invalid-e2ee-password (:code (ex-data error)))
+      (= "decrypt-private-key" (ex-message error))
+      (crypt/expected-crypto-operation-error? error)))
+
+(defn- invalid-e2ee-password-ex
+  [error]
+  (if (= :db-sync/invalid-e2ee-password (:code (ex-data error)))
+    error
+    (ex-info "invalid-e2ee-password"
+             {:code :db-sync/invalid-e2ee-password}
+             error)))
+
 (defn- <verify-e2ee-password
   [password encrypted-private-key-or-str]
   (when-not (seq password)
@@ -349,11 +364,8 @@
                                   encrypted-private-key-or-str)
           private-key (-> (crypt/<decrypt-private-key password encrypted-private-key)
                           (p/catch (fn [error]
-                                     (if (true? (:invalid-password? (ex-data error)))
-                                       (p/rejected
-                                        (ex-info "invalid-e2ee-password"
-                                                 {:code :db-sync/invalid-e2ee-password}
-                                                 error))
+                                     (if (invalid-e2ee-password-error? error)
+                                       (p/rejected (invalid-e2ee-password-ex error))
                                        (p/rejected error)))))]
     private-key))
 
@@ -553,7 +565,9 @@
                                                  :graph-id graph-id
                                                  :first-error error
                                                  :retry-error retry-error})
-                                      (throw retry-error)))))))
+                                      (throw (if (invalid-e2ee-password-error? retry-error)
+                                               (invalid-e2ee-password-ex retry-error)
+                                               retry-error)))))))))
           (p/then (fn [key-material]
                     (if-let [password (when (seq @ui-password*)
                                        @ui-password*)]

--- a/src/test/frontend/common/crypt_test.cljs
+++ b/src/test/frontend/common/crypt_test.cljs
@@ -45,7 +45,7 @@
        (-> (p/do! (crypt/<decrypt-private-key "wrong-password" encrypted-private-key))
            (p/catch (fn [e]
                       (is (= "decrypt-private-key" (ex-message e)))
-                      (is (true? (:invalid-password? (ex-data e))))))))
+                      (is (true? (:invalid-password? (ex-data e)))))))
        (-> (p/let [another-rsa-key-pair (crypt/<generate-rsa-key-pair)]
              (crypt/<decrypt-aes-key (:privateKey another-rsa-key-pair) encrypted-aes-key))
            (p/catch (fn [e] (is (= "decrypt-aes-key" (ex-message e))))))))))

--- a/src/test/frontend/common/crypt_test.cljs
+++ b/src/test/frontend/common/crypt_test.cljs
@@ -1,5 +1,5 @@
 (ns frontend.common.crypt-test
-  (:require [cljs.test :as t :refer [is testing]]
+  (:require [cljs.test :as t :refer [deftest is testing]]
             [frontend.common.crypt :as crypt]
             [frontend.test.helper :as test-helper :include-macros true :refer [deftest-async]]
             [promesa.core :as p]))
@@ -43,7 +43,22 @@
 2. use wrong private-key to decrypt encrypted-aes-key above"
       (p/do!
        (-> (p/do! (crypt/<decrypt-private-key "wrong-password" encrypted-private-key))
-           (p/catch (fn [e] (is (= "decrypt-private-key" (ex-message e))))))
+           (p/catch (fn [e]
+                      (is (= "decrypt-private-key" (ex-message e)))
+                      (is (true? (:invalid-password? (ex-data e))))))))
        (-> (p/let [another-rsa-key-pair (crypt/<generate-rsa-key-pair)]
              (crypt/<decrypt-aes-key (:privateKey another-rsa-key-pair) encrypted-aes-key))
            (p/catch (fn [e] (is (= "decrypt-aes-key" (ex-message e))))))))))
+
+(deftest expected-crypto-operation-error-detects-runtime-shapes-test
+  (let [named (js/DOMException. "The operation failed for an operation-specific reason"
+                                "OperationError")
+        message-only (js/DOMException. "OperationError")
+        wrapped (ex-info "decrypt-private-key" {} named)
+        wrapped-message-only (ex-info "decrypt-private-key" {} message-only)]
+    (is (true? (crypt/expected-crypto-operation-error? named)))
+    (is (true? (crypt/expected-crypto-operation-error? message-only)))
+    (is (true? (crypt/expected-crypto-operation-error? wrapped)))
+    (is (true? (crypt/expected-crypto-operation-error? wrapped-message-only)))
+    (is (false? (crypt/expected-crypto-operation-error?
+                 (ex-info "decrypt-private-key" {} (js/Error. "TypeError")))))))

--- a/src/test/frontend/components/repo_test.cljs
+++ b/src/test/frontend/components/repo_test.cljs
@@ -5,6 +5,8 @@
             [frontend.handler.db-based.sync :as rtc-handler]
             [frontend.handler.graph :as graph-handler]
             [frontend.handler.repo :as repo-handler]
+            [frontend.context.i18n :as i18n]
+            [frontend.handler.notification :as notification]
             [frontend.handler.user :as user-handler]
             [frontend.state :as state]
             [frontend.mobile.util :as mobile-util]
@@ -114,6 +116,46 @@
                            (finish-async-test! done)))
                  (p/catch (fn [error]
                             (is false (str error))
+                            (finish-async-test! done))))))))
+
+(deftest upload-local-graph-shows-error-when-decrypt-private-key-fails-test
+  (async done
+         (let [upload-fn (some-> (resolve 'frontend.components.repo/upload-local-graph-with-confirm!) deref)
+               shown (atom [])]
+           (if-not upload-fn
+             (do
+               (is false "missing upload-local-graph-with-confirm!")
+               (finish-async-test! done))
+             (-> (p/with-redefs [shui/dialog-confirm! (fn [_content _opts]
+                                                        (p/resolved nil))
+                                 rtc-handler/<rtc-upload-graph! (fn [_repo _graph-e2ee?]
+                                                                  (p/rejected
+                                                                   (ex-info "decrypt-private-key"
+                                                                            {}
+                                                                            (js/DOMException. "OperationError" "OperationError"))))
+                                 state/get-current-repo (fn []
+                                                          "logseq_db_demo")
+                                 rtc-indicator/on-upload-finished-task (fn [f]
+                                                                         (f))
+                                 util/mobile? (fn [] false)
+                                 shui/popup-show! (fn [& _] nil)
+                                 shui/popup-hide! (fn [& _] nil)
+                                 i18n/t (fn [key & _args] key)
+                                 notification/show! (fn [content status persist?]
+                                                      (swap! shown conj {:content content
+                                                                         :status status
+                                                                         :persist? persist?}))]
+                   (upload-fn {:url "logseq_db_demo"
+                               :graph-e2ee? true}))
+                 (p/then (fn [_]
+                           (is false "expected upload decrypt failure")
+                           (finish-async-test! done)))
+                 (p/catch (fn [error]
+                            (is (= "decrypt-private-key" (ex-message error)))
+                            (is (= [{:content :encryption/wrong-password
+                                     :status :error
+                                     :persist? false}]
+                                   @shown))
                             (finish-async-test! done))))))))
 
 (deftest upload-local-graph-switches-before-uploading-non-current-graph-test
@@ -228,6 +270,36 @@
                  (p/catch (fn [error]
                             (is false (str error))
                             (finish-async-test! done))))))))
+
+(deftest handle-cloud-graph-error-shows-wrong-password-for-decrypt-private-key-test
+  (let [shown (atom [])]
+    (with-redefs [i18n/t (fn [key & _args] key)
+                  notification/show! (fn [content status persist?]
+                                       (swap! shown conj {:content content
+                                                          :status status
+                                                          :persist? persist?}))]
+      (#'repo/handle-cloud-graph-error!
+       (ex-info "decrypt-private-key"
+                {}
+                (js/DOMException. "OperationError" "OperationError")))
+      (is (= [{:content :encryption/wrong-password
+               :status :error
+               :persist? false}]
+             @shown)))))
+
+(deftest handle-cloud-graph-error-shows-generic-error-for-other-failures-test
+  (let [shown (atom [])]
+    (with-redefs [i18n/t (fn [key & _args] key)
+                  notification/show! (fn [content status persist?]
+                                       (swap! shown conj {:content content
+                                                          :status status
+                                                          :persist? persist?}))]
+      (#'repo/handle-cloud-graph-error!
+       (ex-info "db-sync missing base" {:repo "logseq_db_demo"}))
+      (is (= [{:content :sync/something-wrong
+               :status :error
+               :persist? false}]
+             @shown)))))
 
 (deftest upload-local-graph-hides-mobile-popup-when-upload-errors-test
   (async done

--- a/src/test/frontend/handler/events/rtc_error_test.cljs
+++ b/src/test/frontend/handler/events/rtc_error_test.cljs
@@ -19,3 +19,18 @@
        (rtc-error/e2ee-decrypt-failed?
         (ex-info "db-sync download failed"
                  {:error-message "snapshot download failed"})))))
+
+(deftest e2ee-decrypt-failed-detects-decrypt-private-key-test
+  (is (true?
+       (rtc-error/e2ee-decrypt-failed?
+        (ex-info "decrypt-private-key" {}))))
+  (is (true?
+       (rtc-error/e2ee-decrypt-failed?
+        (ex-info "db-sync upload failed"
+                 {:error (ex-info "decrypt-private-key"
+                                  {}
+                                  (js/DOMException. "OperationError" "OperationError"))}))))
+  (is (true?
+       (rtc-error/e2ee-decrypt-failed?
+        (ex-info "invalid-e2ee-password"
+                 {:code :db-sync/invalid-e2ee-password})))))

--- a/src/test/frontend/worker/sync/crypt_test.cljs
+++ b/src/test/frontend/worker/sync/crypt_test.cljs
@@ -524,7 +524,7 @@
                (p/then (fn [_]
                          (is false "expected verify failure")))
                (p/catch (fn [e]
-                          (is (= "decrypt-private-key" (ex-message e)))
+                          (is (= :db-sync/invalid-e2ee-password (:code (ex-data e))))
                           (is (zero? @save-calls))))
                (p/finally done)))))
 
@@ -850,13 +850,72 @@
                (p/then (fn [_]
                          (is false "expected decrypt-private-key failure")))
                (p/catch (fn [e]
-                          (is (= "decrypt-private-key" (ex-message e)))
+                          (is (= :db-sync/invalid-e2ee-password (:code (ex-data e))))
                           (is (= [{:action :native-get-e2ee-password
                                    :payload {:key "logseq-encrypted-password"}}
                                   {:action :request-e2ee-password
                                    :payload {:reason :decrypt-user-rsa-private-key}}]
                                  @ui-calls))
                           (is (empty? @save-calls))))
+               (p/finally (fn []
+                            (reset! worker-state/*state old-state)
+                            (done)))))))
+
+(deftest preflight-upload-operation-error-is-not-silent-cache-miss-test
+  (async done
+         (let [old-state @worker-state/*state
+               get-pair-calls (atom 0)
+               clear-cache-calls (atom 0)
+               load-graph-ids (atom [])
+               ui-calls (atom [])
+               orig-load @#'sync-crypt/<load-user-rsa-key-material]
+           (reset! worker-state/*state (assoc old-state :auth/refresh-token "current-refresh-token"))
+           (-> (p/with-redefs [sync-crypt/e2ee-base (fn [] "https://api.logseq.io")
+                               sync-crypt/<resolve-user-uuid (fn []
+                                                               (p/resolved "user-1"))
+                               sync-crypt/<get-user-rsa-key-pair-raw
+                               (fn [_base]
+                                 (swap! get-pair-calls inc)
+                                 (p/resolved {:public-key "public-key"
+                                              :encrypted-private-key "encrypted-private-key"}))
+                               sync-crypt/<clear-user-rsa-key-pair-cache!
+                               (fn [_base _user-id]
+                                 (swap! clear-cache-calls inc)
+                                 (p/resolved nil))
+                               sync-crypt/<import-public-key (fn [_public-key]
+                                                               (p/resolved :public-key))
+                               sync-crypt/<load-user-rsa-key-material
+                               (fn [base user-id graph-id]
+                                 (swap! load-graph-ids conj graph-id)
+                                 (orig-load base user-id graph-id))
+                               platform/current (fn [] {:env {:runtime :node
+                                                              :owner-source :electron}})
+                               platform/read-secret-text (fn [_platform' _key]
+                                                           (p/resolved "stored-password"))
+                               ldb/read-transit-str identity
+                               crypt/<decrypt-text-by-text-password
+                               (fn [_refresh-token _data]
+                                 (p/rejected (ex-info "decrypt-text-by-text-password" {})))
+                               crypt/<decrypt-private-key
+                               (fn [_password _encrypted-private-key]
+                                 (p/rejected (ex-info "decrypt-private-key"
+                                                      {}
+                                                      (js/DOMException. "OperationError" "OperationError"))))
+                               ui-request/<request
+                               (fn [action payload & _opts]
+                                 (swap! ui-calls conj {:action action :payload payload})
+                                 (p/resolved {:password "typed-password"}))]
+                 (sync-crypt/<preflight-upload-e2ee! "logseq_db_demo" true))
+               (p/then (fn [_]
+                         (is false "expected preflight decrypt failure")))
+               (p/catch (fn [error]
+                          (is (= :db-sync/invalid-e2ee-password (:code (ex-data error))))
+                          (is (= [nil] @load-graph-ids))
+                          (is (= 2 @get-pair-calls))
+                          (is (= 1 @clear-cache-calls))
+                          (is (= [{:action :request-e2ee-password
+                                   :payload {:reason :decrypt-user-rsa-private-key}}]
+                                 @ui-calls))))
                (p/finally (fn []
                             (reset! worker-state/*state old-state)
                             (done)))))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes encrypted first-upload in the web app failing with only a worker console log and no UI error ([db-test#1128](https://github.com/logseq/db-test/issues/1128)).

## Problem

Uploading a local graph with encryption (`app.logseq`: cloud icon → Use encryption → type password twice) failed silently. The worker logged:

```
[frontend.worker.sync.crypt] {:db-sync/user-rsa-key-cache-invalid
 {:graph-id nil
  :first-error #error {:message "decrypt-private-key", :data {},
                       :cause DOMException OperationError}
  :retry-error #error {:message "decrypt-private-key", ...}}}
```

`upload-graph!` → `<preflight-upload-e2ee!` loads RSA material with `graph-id` nil. A WebCrypto `OperationError` from `decrypt-private-key` was treated as an RSA cache miss, retried, then rethrown without `:db-sync/invalid-e2ee-password`. The UI only notified for that code / `decrypt-aes-key`, so the user saw nothing.

## Change

- Detect `OperationError` on the error, its message, and its cause (a truthy non-matching `.name` such as `Error` no longer hides the cause).
- Reject `decrypt-private-key` failures instead of resolving with an `ex-info` value.
- Map `decrypt-private-key` / `OperationError` to `:db-sync/invalid-e2ee-password` after the cache retry so the error is user-facing, not a silent cache miss.
- Treat `decrypt-private-key` and `invalid-e2ee-password` as E2EE decrypt failures in the UI.
- Always show a notification on cloud graph create/upload failure: wrong password for E2EE decrypt errors, otherwise the existing generic sync error.

## Tests

- Preflight with `graph-id` nil + `OperationError` rejects with `:db-sync/invalid-e2ee-password` (one cache retry, not swallowed).
- OperationError detector covers named, message-only, and wrapped DOMExceptions.
- UI: `decrypt-private-key` shows the wrong-password notification; other upload errors show the generic sync error.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5e705b9-76ea-482c-93d9-0a1406bbf928?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5e705b9-76ea-482c-93d9-0a1406bbf928&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

