### PR TITLE
Update linking page mirrors when a page is renamed

### DIFF
--- a/src/main/frontend/worker/markdown_mirror.cljs
+++ b/src/main/frontend/worker/markdown_mirror.cljs
@@ -122,14 +122,25 @@
       (and (:block/parent entity) (ldb/page? (:block/parent entity))) (:db/id (:block/parent entity))
       (some-> entity :block/parent :block/page) (:db/id (:block/page (:block/parent entity))))))
 
+(defn- referring-page-ids
+  "Page ids of blocks that reference `page-eid` via :block/refs."
+  [db page-eid]
+  (keep (fn [ref-block]
+          (page-id-for-entity db (:db/id ref-block)))
+        (:block/_refs (d/entity db page-eid))))
+
 (defn affected-page-ids
   [{:keys [db-before db-after tx-data]}]
   (->> tx-data
-       (mapcat (fn [{:keys [e a v]}]
+       (mapcat (fn [{:keys [e a v added]}]
                  (cond-> [(page-id-for-entity db-before e)
                           (page-id-for-entity db-after e)]
                    (= a :block/page)
-                   (conj v))))
+                   (conj v)
+                   (and added
+                        (#{:block/title :block/name} a)
+                        (some-> (d/entity db-after e) ldb/page?))
+                   (into (referring-page-ids db-after e)))))
        (remove nil?)
        set))
 

--- a/src/test/frontend/worker/markdown_mirror_test.cljs
+++ b/src/test/frontend/worker/markdown_mirror_test.cljs
@@ -150,6 +150,22 @@
     (is (= #{(:db/id page)}
            (markdown-mirror/affected-page-ids tx-report)))))
 
+(deftest affected-page-ids-includes-linking-pages-on-page-rename-test
+  (let [conn (db-test/create-conn-with-blocks
+              {:pages-and-blocks [{:page {:block/title "TargetOld"}
+                                   :blocks [{:block/title "target"}]}
+                                  {:page {:block/title "Source"}
+                                   :blocks [{:block/title "See [[TargetOld]]"}]}]})
+        target (db-test/find-page-by-title @conn "TargetOld")
+        source (db-test/find-page-by-title @conn "Source")
+        tx-report (d/with @conn [{:db/id (:db/id target)
+                                  :block/title "TargetNew"
+                                  :block/name "targetnew"}])]
+    (is (contains? (set (map :db/id (:block/refs (first-block source))))
+                   (:db/id target)))
+    (is (= #{(:db/id target) (:db/id source)}
+           (markdown-mirror/affected-page-ids tx-report)))))
+
 (deftest block-db-id-comments-are-not-written-to-block-lines-test
   (async done
     (let [{:keys [platform files]} (fake-platform)
@@ -966,6 +982,36 @@
                                 "- body")
                            (get @files (page-path "pages/New Name.md"))))
                     (is (nil? (get @files old-path)))))
+          (p/catch (fn [e] (is false (str "unexpected error: " e))))
+          (p/finally done)))))
+
+(deftest rename-updates-linking-page-mirror-test
+  (async done
+    (let [{:keys [platform files]} (fake-platform)
+          conn (db-test/create-conn-with-blocks
+                {:pages-and-blocks [{:page {:block/title "TargetOld"}
+                                     :blocks [{:block/title "target"}]}
+                                    {:page {:block/title "Source"}
+                                     :blocks [{:block/title "See [[TargetOld]]"}]}]})
+          source (db-test/find-page-by-title @conn "Source")
+          target (db-test/find-page-by-title @conn "TargetOld")]
+      (markdown-mirror/set-enabled! test-repo true)
+      (-> (markdown-mirror/<mirror-page! test-repo @conn (:db/id source) {:platform platform})
+          (p/then (fn [_]
+                    (is (= (str (page-marker (:block/uuid source)) "\n\n"
+                                "- See [[TargetOld]]")
+                           (get @files (page-path "pages/Source.md"))))
+                    (let [tx-report (d/with @conn [{:db/id (:db/id target)
+                                                    :block/title "TargetNew"
+                                                    :block/name "targetnew"}])
+                          _ (d/reset-conn! conn (:db-after tx-report))]
+                      (markdown-mirror/<handle-tx-report! test-repo conn tx-report {:platform platform}))))
+          (p/then (fn [_]
+                    (let [content (get @files (page-path "pages/Source.md"))]
+                      (is (= (str (page-marker (:block/uuid source)) "\n\n"
+                                  "- See [[TargetNew]]")
+                             content))
+                      (is (not (re-find #"\[\[TargetOld\]\]" content)))))))
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
           (p/finally done)))))
 

--- a/src/test/frontend/worker/markdown_mirror_test.cljs
+++ b/src/test/frontend/worker/markdown_mirror_test.cljs
@@ -1011,7 +1011,7 @@
                       (is (= (str (page-marker (:block/uuid source)) "\n\n"
                                   "- See [[TargetNew]]")
                              content))
-                      (is (not (re-find #"\[\[TargetOld\]\]" content)))))))
+                      (is (not (re-find #"\[\[TargetOld\]\]" content))))))
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
           (p/finally done)))))
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a page is renamed, Markdown mirrors of pages that link to it kept stale `[[Old Name]]` wiki links until a manual regenerate or an edit of the linking page.

`affected-page-ids` only queued the pages of entities in `tx-data`. `:rename-page` only updates the renamed page's `:block/title` / `:block/name`. Linking blocks store `[[uuid]]` and do not change, so their pages were never remirrored. Export already resolves those UUIDs to the current title, so remirroring the linking page is enough.

This change also queues pages of blocks that reference the renamed page via `:block/_refs` when a **page** entity's title or name is added. Regular block title edits are unchanged.

Fixes https://github.com/logseq/db-test/issues/1132

## Test plan

- [x] `affected-page-ids` includes both the renamed page and the linking page
- [x] After rename + `<handle-tx-report!`, Source.md contains `[[TargetNew]]` and not `[[TargetOld]]`
- [x] Existing rename path cleanup tests remain green

## Test evidence

`LOGSEQ_STABLE_IDENTS=1 node static/tests.js -n frontend.worker.markdown-mirror-test`

```
Ran 46 tests containing 77 assertions.
0 failures, 0 errors.
```

Focused rename cases:

```
Ran 4 tests containing 10 assertions.
0 failures, 0 errors.
```

Includes `affected-page-ids-includes-linking-pages-on-page-rename-test`, `rename-updates-linking-page-mirror-test`, `rename-removes-old-mirror-path-test`, and `rename-with-unchanged-content-removes-old-mirror-path-test`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f08e685c-e190-415b-8d02-ed3106787ef1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f08e685c-e190-415b-8d02-ed3106787ef1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

