### PR TITLE
fix(import): preserve file and journal mention timestamps

### DIFF
--- a/deps/common/src/logseq/common/util.cljs
+++ b/deps/common/src/logseq/common/util.cljs
@@ -255,6 +255,17 @@
   []
   (tc/to-long (t/now)))
 
+(defn timestamp-ms
+  "Coerce a Date or epoch-ms number to a positive ms timestamp.
+   Treats missing values and non-positive times (e.g. Linux epoch-0 birthtime) as absent."
+  [value]
+  (let [ms (cond
+             (number? value) value
+             (instance? js/Date value) (.getTime value)
+             :else nil)]
+    (when (and (number? ms) (pos? ms) (js/isFinite ms))
+      ms)))
+
 (defn get-page-title
   [page]
   (or (:block/title page)

--- a/deps/common/test/logseq/common/util_test.cljs
+++ b/deps/common/test/logseq/common/util_test.cljs
@@ -1,5 +1,5 @@
 (ns logseq.common.util-test
-  (:require [clojure.test :refer [deftest are testing]]
+  (:require [clojure.test :refer [deftest are testing is]]
             [logseq.common.util :as common-util]))
 
 (deftest valid-edn-keyword?
@@ -66,3 +66,17 @@
       [nil 0 5] ""
       [nil 0]   ""
       [42 0 1]  "")))
+
+(deftest timestamp-ms
+  (testing "keeps positive epoch-ms numbers"
+    (is (= 1577934245000 (common-util/timestamp-ms 1577934245000))))
+  (testing "reads Date.getTime"
+    (is (= 1577934245000 (common-util/timestamp-ms (js/Date. "2020-01-02T03:04:05.000Z")))))
+  (testing "treats missing and non-positive values as absent"
+    (are [x] (nil? (common-util/timestamp-ms x))
+      nil
+      0
+      -1
+      (js/Date. 0)
+      "2020-01-02T03:04:05.000Z"
+      js/NaN)))

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -2234,11 +2234,14 @@
        (into {})))
 
 (defn- existing-page-uuid
-  "Uuid for a page already in this import or already in the db."
+  "Uuid for a page already in this import or already imported into the db.
+   Ignore built-in pages so names like alias do not collide with the schema."
   [db all-existing-page-uuids page-name]
   (or (get all-existing-page-uuids page-name)
       (when page-name
-        (:block/uuid (ldb/get-page db page-name)))))
+        (when-let [page (ldb/get-page db page-name)]
+          (when-not (ldb/built-in? page)
+            (:block/uuid page))))))
 
 (defn- journal-file-title
   [path]

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -46,9 +46,15 @@
   "Add updated-at or created-at timestamps if they doesn't exist"
   ([block]
    (add-missing-timestamps block nil))
-  ([block {:keys [file-created-at file-updated-at]}]
-   (let [updated-at (or file-updated-at (common-util/time-ms))
-         created-at (or file-created-at updated-at)
+  ([block {:keys [file-created-at file-updated-at current-journal-created-at]}]
+   (let [ref-from-journal? (and current-journal-created-at
+                                (nil? (:block/created-at block)))
+         updated-at (if ref-from-journal?
+                      current-journal-created-at
+                      (or file-updated-at (common-util/time-ms)))
+         created-at (if ref-from-journal?
+                      current-journal-created-at
+                      (or file-created-at updated-at))
          block (cond-> block
                  (nil? (:block/updated-at block))
                  (assoc :block/updated-at updated-at)
@@ -2776,8 +2782,11 @@
   (p/let [options (assoc *options :notify-user notify-user :log-fn log-fn :file file)
           {:keys [pages blocks]} (extract-pages-and-blocks @conn file content options)
           {:keys [blocks preserve-empty-properties-uuids]} (handle-template-blocks blocks)
+          journal-created-ats (build-journal-created-ats pages)
           tx-options (merge (build-tx-options options)
-                            {:journal-created-ats (build-journal-created-ats pages)
+                            {:journal-created-ats journal-created-ats
+                             :current-journal-created-at (when (= 1 (count journal-created-ats))
+                                                           (first (vals journal-created-ats)))
                              :preserve-empty-property-block-uuids preserve-empty-properties-uuids})
           old-properties (keys @(get-in options [:import-state :property-schemas]))
           ;; Build page and block txs
@@ -2850,10 +2859,10 @@
               content (<read-file file)
               stat (when (fn? <get-file-stat)
                      (<get-file-stat (or (:fs-path file) path)))
-              created-at (or (:file-created-at file)
-                             (some-> (or (:birthtime stat) (some-> ^js stat .-birthtime)) .getTime))
-              modified-at (or (:file-updated-at file)
-                              (some-> (or (:mtime stat) (some-> ^js stat .-mtime) (:last-modified-at file)) .getTime))
+              created-at (or (common-util/timestamp-ms (:file-created-at file))
+                             (common-util/timestamp-ms (or (:birthtime stat) (some-> ^js stat .-birthtime))))
+              modified-at (or (common-util/timestamp-ms (:file-updated-at file))
+                              (common-util/timestamp-ms (or (:mtime stat) (some-> ^js stat .-mtime) (:last-modified-at file))))
               m {:file/path path :file/content content}
               export-options (cond-> (dissoc options :set-ui-state :<export-file)
                                created-at (assoc :file-created-at created-at)

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -46,13 +46,16 @@
   "Add updated-at or created-at timestamps if they doesn't exist.
    File-backed pages always use the file's birthtime/mtime when those exist,
    including when the page was first mentioned from a journal.
+   Journal pages and their blocks keep the journal day, not filesystem times.
    Reference-only pages created from a journal keep the journal date, even when
    extract already stamped them with import time."
   ([block]
    (add-missing-timestamps block nil))
   ([block {:keys [file-created-at file-updated-at current-journal-created-at]}]
    (let [file-page? (::file-page? block)
-         file-times? (and file-page? (or file-created-at file-updated-at))
+         file-times? (and file-page?
+                          (not (:block/journal-day block))
+                          (or file-created-at file-updated-at))
          journal-ref-page? (and current-journal-created-at
                                 (:block/name block)
                                 (not (:block/journal-day block))
@@ -2276,7 +2279,9 @@
 (defn- build-existing-page
   [m db page-uuid {:keys [page-names-to-uuids] :as per-file-state} {:keys [notify-user import-state file-created-at file-updated-at] :as options}]
   (let [file-page? (::file-page? m)
-        file-times? (and file-page? (or file-created-at file-updated-at))
+        file-times? (and file-page?
+                         (not (:block/journal-day m))
+                         (or file-created-at file-updated-at))
         m (cond-> (dissoc m ::file-page?)
             file-times?
             (assoc :block/created-at (or file-created-at file-updated-at)
@@ -2428,13 +2433,14 @@
                                           (not (:block/file %))))
                             ;; remove file path relative. Re-apply file stats after
                             ;; with-ref-pages, which merges refs over the file page.
-                            (map #(let [file-page? (boolean (:block/file %))]
+                            (map #(let [file-page? (boolean (:block/file %))
+                                        apply-file-times? (and file-page? (not (:block/journal-day %)))]
                                     (cond-> (dissoc % :block/file)
                                       file-page?
                                       (assoc ::file-page? true)
-                                      (and file-page? file-page-created-at)
+                                      (and apply-file-times? file-page-created-at)
                                       (assoc :block/created-at file-page-created-at)
-                                      (and file-page? file-page-updated-at)
+                                      (and apply-file-times? file-page-updated-at)
                                       (assoc :block/updated-at file-page-updated-at)))))
                        ;; sanitize alias declarations before transacting
                        (sanitize-page-aliases-for-import! (:alias-owners import-state)
@@ -2725,7 +2731,8 @@
                   (update :pages (fn [pages]
                                    (map (fn [page]
                                           (let [page (dissoc page :block.temp/original-page-name)]
-                                            (if (:block/file page)
+                                            (if (and (:block/file page)
+                                                     (not (:block/journal-day page)))
                                               (with-file-timestamps page)
                                               page)))
                                         pages)))

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -2242,8 +2242,9 @@
   [m db page-uuid {:keys [page-names-to-uuids] :as per-file-state} {:keys [notify-user import-state] :as options}]
   (let [file-page? (::file-page? m)
         m (dissoc m ::file-page?)
-        ;; These attributes are not allowed to be transacted because they must not change across files
-        disallowed-attributes [:block/name :block/uuid :block/format :block/title :block/journal-day]
+        ;; These attributes are ignored by default because they must not change across files
+        disallowed-attributes [:block/name :block/uuid :block/format :block/title :block/journal-day
+                               :block/created-at :block/updated-at]
         allowed-attributes (cond-> (into [:block/tags :block/alias :block/parent :logseq.property.class/extends :db/ident]
                                         (keep #(when (db-malli-schema/user-property? (key %)) (key %))
                                               m))

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -51,7 +51,8 @@
   ([block {:keys [file-created-at file-updated-at current-journal-created-at]}]
    (let [journal-ref-page? (and current-journal-created-at
                                 (:block/name block)
-                                (not (:block/journal-day block)))
+                                (not (:block/journal-day block))
+                                (not (::file-page? block)))
          updated-at (cond
                       journal-ref-page? current-journal-created-at
                       file-updated-at file-updated-at
@@ -2185,7 +2186,8 @@
         (journal-created-ats (:block/name m))
         (assoc :block/created-at (journal-created-ats (:block/name m))))
       (add-missing-timestamps options)
-      (update-page-tags db user-options per-file-state all-idents)))
+      (update-page-tags db user-options per-file-state all-idents)
+      (dissoc ::file-page?)))
 
 (defn- get-page-parents
   "Like ldb/get-page-parents but using all-existing-page-uuids"
@@ -2231,6 +2233,13 @@
     (second (re-find #"(?:^|/)journals/(\d{4}_\d{2}_\d{2})\.(?:md|markdown|org)$"
                      normalized-path))))
 
+(defn- journal-file-created-at
+  "Created-at for pages first mentioned in this journal file, from the filename day."
+  [file]
+  (when-let [journal-title (journal-file-title file)]
+    (when-let [journal-day (date-time-util/journal-title->int journal-title ["yyyy_MM_dd"])]
+      (date-time-util/journal-day->ms journal-day))))
+
 (defn- journal-page-name-uuid-entries
   [{:keys [path]}]
   (when-let [journal-title (journal-file-title path)]
@@ -2249,7 +2258,7 @@
          (into {} (mapcat journal-page-name-uuid-entries) doc-files)))
 
 (defn- build-existing-page
-  [m db page-uuid {:keys [page-names-to-uuids] :as per-file-state} {:keys [notify-user import-state] :as options}]
+  [m db page-uuid {:keys [page-names-to-uuids] :as per-file-state} {:keys [notify-user import-state file-created-at file-updated-at] :as options}]
   (let [file-page? (::file-page? m)
         m (dissoc m ::file-page?)
         ;; These attributes are ignored by default because they must not change across files
@@ -2258,7 +2267,8 @@
         allowed-attributes (cond-> (into [:block/tags :block/alias :block/parent :logseq.property.class/extends :db/ident]
                                         (keep #(when (db-malli-schema/user-property? (key %)) (key %))
                                               m))
-                             file-page?
+                             ;; Only overwrite first-mention timestamps when this file has real stats.
+                             (and file-page? (or file-created-at file-updated-at))
                              (into [:block/created-at :block/updated-at]))
         block-changes (select-keys m allowed-attributes)]
     (when-let [ignored-attrs (not-empty (apply dissoc m (into disallowed-attributes allowed-attributes)))]
@@ -2430,7 +2440,7 @@
                                                 ;; TODO: Enable this when it's valid for all test graphs because
                                                 ;; pages with properties must be built or else properties-tx is invalid
                                                 #_(seq properties-tx))
-                                        (build-new-page-or-class (dissoc m ::original-name ::original-title ::file-page?)
+                                        (build-new-page-or-class (dissoc m ::original-name ::original-title)
                                                                  @conn per-file-state (:all-idents import-state) options)))]
                            ;;  (when-not ret (println "Skipped page tx for" (pr-str (:block/title m))))
                            page))
@@ -2680,9 +2690,11 @@
         (cond (contains? #{:org :markdown :md} format)
               (-> (extract/extract file content extract-options')
                   (update :pages (fn [pages]
-                                   (map #(-> %
-                                             (dissoc :block.temp/original-page-name)
-                                             with-file-timestamps)
+                                   (map (fn [page]
+                                          (let [page (dissoc page :block.temp/original-page-name)]
+                                            (if (:block/file page)
+                                              (with-file-timestamps page)
+                                              page)))
                                         pages)))
                   (update :blocks (fn [blocks]
                                     (fix-extracted-block-tags-and-refs
@@ -2790,8 +2802,7 @@
           journal-created-ats (build-journal-created-ats pages)
           tx-options (merge (build-tx-options options)
                             {:journal-created-ats journal-created-ats
-                             :current-journal-created-at (when (= 1 (count journal-created-ats))
-                                                           (first (vals journal-created-ats)))
+                             :current-journal-created-at (journal-file-created-at file)
                              :preserve-empty-property-block-uuids preserve-empty-properties-uuids})
           old-properties (keys @(get-in options [:import-state :property-schemas]))
           ;; Build page and block txs

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -2442,12 +2442,17 @@
         all-pages (map #(modify-page-tx % all-existing-page-uuids) all-pages*)
         existing-uuid #(existing-page-uuid @conn all-existing-page-uuids
                                            (or (::original-name %) (:block/name %)))
+        db-existing-page-uuids (->> all-pages
+                                    (keep (fn [page]
+                                            (when-let [page-uuid (existing-uuid page)]
+                                              [(or (::original-name page) (:block/name page)) page-uuid])))
+                                    (into {}))
         all-new-page-uuids (->> all-pages
                                 (remove existing-uuid)
                                 (map (juxt (some-fn ::original-name :block/name) :block/uuid))
                                 (into {}))
         ;; Stateful because new page uuids can occur via tags
-        page-names-to-uuids (atom (merge all-existing-page-uuids all-new-page-uuids journal-page-name-uuids))
+        page-names-to-uuids (atom (merge all-existing-page-uuids db-existing-page-uuids all-new-page-uuids journal-page-name-uuids))
         per-file-state {:page-names-to-uuids page-names-to-uuids
                         :classes-tx (:classes-tx options)}
         all-pages-m (mapv #(handle-page-properties % @conn per-file-state all-pages options)

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -44,27 +44,33 @@
 
 (defn- add-missing-timestamps
   "Add updated-at or created-at timestamps if they doesn't exist.
+   File-backed pages always use the file's birthtime/mtime when those exist,
+   including when the page was first mentioned from a journal.
    Reference-only pages created from a journal keep the journal date, even when
    extract already stamped them with import time."
   ([block]
    (add-missing-timestamps block nil))
   ([block {:keys [file-created-at file-updated-at current-journal-created-at]}]
-   (let [journal-ref-page? (and current-journal-created-at
+   (let [file-page? (::file-page? block)
+         file-times? (and file-page? (or file-created-at file-updated-at))
+         journal-ref-page? (and current-journal-created-at
                                 (:block/name block)
                                 (not (:block/journal-day block))
-                                (not (::file-page? block)))
+                                (not file-page?))
          updated-at (cond
+                      file-times? (or file-updated-at file-created-at)
                       journal-ref-page? current-journal-created-at
                       file-updated-at file-updated-at
                       :else (common-util/time-ms))
          created-at (cond
+                      file-times? (or file-created-at file-updated-at)
                       journal-ref-page? current-journal-created-at
                       file-created-at file-created-at
                       :else updated-at)]
      (cond-> block
-       (or journal-ref-page? (nil? (:block/updated-at block)))
+       (or file-times? journal-ref-page? (nil? (:block/updated-at block)))
        (assoc :block/updated-at updated-at)
-       (or journal-ref-page? (nil? (:block/created-at block)))
+       (or file-times? journal-ref-page? (nil? (:block/created-at block)))
        (assoc :block/created-at created-at)))))
 
 (defn- build-new-namespace-page [block]
@@ -2227,6 +2233,13 @@
                                    (select-keys p [:block/name :block/tags])))))))
        (into {})))
 
+(defn- existing-page-uuid
+  "Uuid for a page already in this import or already in the db."
+  [db all-existing-page-uuids page-name]
+  (or (get all-existing-page-uuids page-name)
+      (when page-name
+        (:block/uuid (ldb/get-page db page-name)))))
+
 (defn- journal-file-title
   [path]
   (let [normalized-path (some-> path str (string/replace "\\" "/") string/lower-case)]
@@ -2260,15 +2273,19 @@
 (defn- build-existing-page
   [m db page-uuid {:keys [page-names-to-uuids] :as per-file-state} {:keys [notify-user import-state file-created-at file-updated-at] :as options}]
   (let [file-page? (::file-page? m)
-        m (dissoc m ::file-page?)
+        file-times? (and file-page? (or file-created-at file-updated-at))
+        m (cond-> (dissoc m ::file-page?)
+            file-times?
+            (assoc :block/created-at (or file-created-at file-updated-at)
+                   :block/updated-at (or file-updated-at file-created-at)))
         ;; These attributes are ignored by default because they must not change across files
         disallowed-attributes [:block/name :block/uuid :block/format :block/title :block/journal-day
                                :block/created-at :block/updated-at]
         allowed-attributes (cond-> (into [:block/tags :block/alias :block/parent :logseq.property.class/extends :db/ident]
                                         (keep #(when (db-malli-schema/user-property? (key %)) (key %))
                                               m))
-                             ;; Only overwrite first-mention timestamps when this file has real stats.
-                             (and file-page? (or file-created-at file-updated-at))
+                             ;; File stats replace first-mention / journal dates.
+                             file-times?
                              (into [:block/created-at :block/updated-at]))
         block-changes (select-keys m allowed-attributes)]
     (when-let [ignored-attrs (not-empty (apply dissoc m (into disallowed-attributes allowed-attributes)))]
@@ -2394,9 +2411,11 @@
   "Given all the pages and blocks parsed from a file, return a map containing
   all pages to be transacted, pages' properties and additional
   data for subsequent steps"
-  [conn pages blocks {:keys [import-state user-options]
+  [conn pages blocks {:keys [import-state user-options file-created-at file-updated-at]
                       :as options}]
   (let [journal-page-name-uuids @(:journal-page-name-uuids import-state)
+        file-page-created-at (or file-created-at file-updated-at)
+        file-page-updated-at (or file-updated-at file-created-at)
         all-pages* (-> (->> (extract/with-ref-pages pages blocks)
                             (remove #(and (not (:block/file %))
                                           (contains? journal-page-name-uuids (:block/name %))))
@@ -2404,10 +2423,16 @@
                             (remove #(and (contains? (into (:property-classes user-options) (:property-parent-classes user-options))
                                                      (keyword (:block/name %)))
                                           (not (:block/file %))))
-                            ;; remove file path relative
-                            (map #(cond-> (dissoc % :block/file)
-                                    (:block/file %)
-                                    (assoc ::file-page? true))))
+                            ;; remove file path relative. Re-apply file stats after
+                            ;; with-ref-pages, which merges refs over the file page.
+                            (map #(let [file-page? (boolean (:block/file %))]
+                                    (cond-> (dissoc % :block/file)
+                                      file-page?
+                                      (assoc ::file-page? true)
+                                      (and file-page? file-page-created-at)
+                                      (assoc :block/created-at file-page-created-at)
+                                      (and file-page? file-page-updated-at)
+                                      (assoc :block/updated-at file-page-updated-at)))))
                        ;; sanitize alias declarations before transacting
                        (sanitize-page-aliases-for-import! (:alias-owners import-state)
                                                           (:ignored-properties import-state)))
@@ -2415,8 +2440,10 @@
         all-existing-page-uuids (get-all-existing-page-uuids @(:classes-from-property-parents import-state)
                                                              @(:all-existing-page-uuids import-state))
         all-pages (map #(modify-page-tx % all-existing-page-uuids) all-pages*)
+        existing-uuid #(existing-page-uuid @conn all-existing-page-uuids
+                                           (or (::original-name %) (:block/name %)))
         all-new-page-uuids (->> all-pages
-                                (remove #(all-existing-page-uuids (or (::original-name %) (:block/name %))))
+                                (remove existing-uuid)
                                 (map (juxt (some-fn ::original-name :block/name) :block/uuid))
                                 (into {}))
         ;; Stateful because new page uuids can occur via tags
@@ -2426,9 +2453,7 @@
         all-pages-m (mapv #(handle-page-properties % @conn per-file-state all-pages options)
                           all-pages)
         pages-tx (keep (fn [{m :block _properties-tx :properties-tx}]
-                         (let [page (if-let [page-uuid (if (::original-name m)
-                                                         (all-existing-page-uuids (::original-name m))
-                                                         (all-existing-page-uuids (:block/name m)))]
+                         (let [page (if-let [page-uuid (existing-uuid m)]
                                       (build-existing-page (dissoc m ::original-name ::original-title) @conn page-uuid per-file-state options)
                                       (when (or (ldb/class? m)
                                                 ;; Don't build a new page if it overwrites an existing class

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -2875,10 +2875,13 @@
               content (<read-file file)
               stat (when (fn? <get-file-stat)
                      (<get-file-stat (or (:fs-path file) path)))
-              created-at (or (common-util/timestamp-ms (:file-created-at file))
-                             (common-util/timestamp-ms (or (:birthtime stat) (some-> ^js stat .-birthtime))))
+              ;; Prefer birthtime when it is a real time. Fall back to mtime when
+              ;; birthtime is missing or invalid (e.g. epoch-0 on ext4).
               modified-at (or (common-util/timestamp-ms (:file-updated-at file))
                               (common-util/timestamp-ms (or (:mtime stat) (some-> ^js stat .-mtime) (:last-modified-at file))))
+              created-at (or (common-util/timestamp-ms (:file-created-at file))
+                             (common-util/timestamp-ms (or (:birthtime stat) (some-> ^js stat .-birthtime)))
+                             modified-at)
               m {:file/path path :file/content content}
               export-options (cond-> (dissoc options :set-ui-state :<export-file)
                                created-at (assoc :file-created-at created-at)

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -2233,7 +2233,7 @@
                                    (select-keys p [:block/name :block/tags])))))))
        (into {})))
 
-(defn- existing-page-uuid
+(defn- lookup-imported-page-uuid
   "Uuid for a page already in this import or already imported into the db.
    Ignore built-in pages so names like alias do not collide with the schema."
   [db all-existing-page-uuids page-name]
@@ -2443,8 +2443,8 @@
         all-existing-page-uuids (get-all-existing-page-uuids @(:classes-from-property-parents import-state)
                                                              @(:all-existing-page-uuids import-state))
         all-pages (map #(modify-page-tx % all-existing-page-uuids) all-pages*)
-        existing-uuid #(existing-page-uuid @conn all-existing-page-uuids
-                                           (or (::original-name %) (:block/name %)))
+        existing-uuid #(lookup-imported-page-uuid @conn all-existing-page-uuids
+                                                  (or (::original-name %) (:block/name %)))
         db-existing-page-uuids (->> all-pages
                                     (keep (fn [page]
                                             (when-let [page-uuid (existing-uuid page)]
@@ -2814,6 +2814,13 @@
   [ref]
   {:block/uuid (second ref)})
 
+(defn- file-graph-tx-options
+  [options pages file preserve-empty-properties-uuids]
+  (merge (build-tx-options options)
+         {:journal-created-ats (build-journal-created-ats pages)
+          :current-journal-created-at (journal-file-created-at file)
+          :preserve-empty-property-block-uuids preserve-empty-properties-uuids}))
+
 (defn <add-file-to-db-graph
   "Parse file and save parsed data to the given db graph. Options available:
 
@@ -2832,11 +2839,7 @@
   (p/let [options (assoc *options :notify-user notify-user :log-fn log-fn :file file)
           {:keys [pages blocks]} (extract-pages-and-blocks @conn file content options)
           {:keys [blocks preserve-empty-properties-uuids]} (handle-template-blocks blocks)
-          journal-created-ats (build-journal-created-ats pages)
-          tx-options (merge (build-tx-options options)
-                            {:journal-created-ats journal-created-ats
-                             :current-journal-created-at (journal-file-created-at file)
-                             :preserve-empty-property-block-uuids preserve-empty-properties-uuids})
+          tx-options (file-graph-tx-options options pages file preserve-empty-properties-uuids)
           old-properties (keys @(get-in options [:import-state :property-schemas]))
           ;; Build page and block txs
           {:keys [pages-tx page-properties-tx per-file-state existing-pages]} (build-pages-tx conn pages blocks tx-options)

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -43,24 +43,28 @@
             [promesa.core :as p]))
 
 (defn- add-missing-timestamps
-  "Add updated-at or created-at timestamps if they doesn't exist"
+  "Add updated-at or created-at timestamps if they doesn't exist.
+   Reference-only pages created from a journal keep the journal date, even when
+   extract already stamped them with import time."
   ([block]
    (add-missing-timestamps block nil))
   ([block {:keys [file-created-at file-updated-at current-journal-created-at]}]
-   (let [ref-from-journal? (and current-journal-created-at
-                                (nil? (:block/created-at block)))
-         updated-at (if ref-from-journal?
-                      current-journal-created-at
-                      (or file-updated-at (common-util/time-ms)))
-         created-at (if ref-from-journal?
-                      current-journal-created-at
-                      (or file-created-at updated-at))
-         block (cond-> block
-                 (nil? (:block/updated-at block))
-                 (assoc :block/updated-at updated-at)
-                 (nil? (:block/created-at block))
-                 (assoc :block/created-at created-at))]
-     block)))
+   (let [journal-ref-page? (and current-journal-created-at
+                                (:block/name block)
+                                (not (:block/journal-day block)))
+         updated-at (cond
+                      journal-ref-page? current-journal-created-at
+                      file-updated-at file-updated-at
+                      :else (common-util/time-ms))
+         created-at (cond
+                      journal-ref-page? current-journal-created-at
+                      file-created-at file-created-at
+                      :else updated-at)]
+     (cond-> block
+       (or journal-ref-page? (nil? (:block/updated-at block)))
+       (assoc :block/updated-at updated-at)
+       (or journal-ref-page? (nil? (:block/created-at block)))
+       (assoc :block/created-at created-at)))))
 
 (defn- build-new-namespace-page [block]
   (let [new-title (ns-util/get-last-part (:block/title block))]
@@ -2659,7 +2663,8 @@
         journal-file? (some? (journal-file-title file))
         with-file-timestamps (fn [node]
                                (cond-> node
-                                 file-created-at (assoc :block/created-at file-created-at)
+                                 (or file-created-at file-updated-at)
+                                 (assoc :block/created-at (or file-created-at file-updated-at))
                                  file-updated-at (assoc :block/updated-at file-updated-at)))
         extract-options' (merge {:block-pattern (get-block-pattern format)
                                  :date-formatter "MMM do, yyyy"

--- a/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
+++ b/deps/graph-parser/src/logseq/graph_parser/exporter.cljs
@@ -2240,12 +2240,15 @@
 
 (defn- build-existing-page
   [m db page-uuid {:keys [page-names-to-uuids] :as per-file-state} {:keys [notify-user import-state] :as options}]
-  (let [;; These attributes are not allowed to be transacted because they must not change across files
-        disallowed-attributes [:block/name :block/uuid :block/format :block/title :block/journal-day
-                               :block/created-at :block/updated-at]
-        allowed-attributes (into [:block/tags :block/alias :block/parent :logseq.property.class/extends :db/ident]
-                                 (keep #(when (db-malli-schema/user-property? (key %)) (key %))
-                                       m))
+  (let [file-page? (::file-page? m)
+        m (dissoc m ::file-page?)
+        ;; These attributes are not allowed to be transacted because they must not change across files
+        disallowed-attributes [:block/name :block/uuid :block/format :block/title :block/journal-day]
+        allowed-attributes (cond-> (into [:block/tags :block/alias :block/parent :logseq.property.class/extends :db/ident]
+                                        (keep #(when (db-malli-schema/user-property? (key %)) (key %))
+                                              m))
+                             file-page?
+                             (into [:block/created-at :block/updated-at]))
         block-changes (select-keys m allowed-attributes)]
     (when-let [ignored-attrs (not-empty (apply dissoc m (into disallowed-attributes allowed-attributes)))]
       (notify-user {:msg (str "Import ignored the following attributes on page " (pr-str (:block/title m)) ": "
@@ -2381,7 +2384,9 @@
                                                      (keyword (:block/name %)))
                                           (not (:block/file %))))
                             ;; remove file path relative
-                            (map #(dissoc % :block/file)))
+                            (map #(cond-> (dissoc % :block/file)
+                                    (:block/file %)
+                                    (assoc ::file-page? true))))
                        ;; sanitize alias declarations before transacting
                        (sanitize-page-aliases-for-import! (:alias-owners import-state)
                                                           (:ignored-properties import-state)))
@@ -2414,7 +2419,7 @@
                                                 ;; TODO: Enable this when it's valid for all test graphs because
                                                 ;; pages with properties must be built or else properties-tx is invalid
                                                 #_(seq properties-tx))
-                                        (build-new-page-or-class (dissoc m ::original-name ::original-title)
+                                        (build-new-page-or-class (dissoc m ::original-name ::original-title ::file-page?)
                                                                  @conn per-file-state (:all-idents import-state) options)))]
                            ;;  (when-not ret (println "Skipped page tx for" (pr-str (:block/title m))))
                            page))
@@ -2844,12 +2849,14 @@
               content (<read-file file)
               stat (when (fn? <get-file-stat)
                      (<get-file-stat (or (:fs-path file) path)))
-              created-at (or (:birthtime stat) (some-> ^js stat .-birthtime))
-              modified-at (or (:mtime stat) (some-> ^js stat .-mtime) (:last-modified-at file))
+              created-at (or (:file-created-at file)
+                             (some-> (or (:birthtime stat) (some-> ^js stat .-birthtime)) .getTime))
+              modified-at (or (:file-updated-at file)
+                              (some-> (or (:mtime stat) (some-> ^js stat .-mtime) (:last-modified-at file)) .getTime))
               m {:file/path path :file/content content}
               export-options (cond-> (dissoc options :set-ui-state :<export-file)
-                               created-at (assoc :file-created-at (.getTime created-at))
-                               modified-at (assoc :file-updated-at (.getTime modified-at)))
+                               created-at (assoc :file-created-at created-at)
+                               modified-at (assoc :file-updated-at modified-at))
               _ (<export-file conn m export-options)]
         ;; returning val results in smoother ui updates
         m)

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -795,22 +795,27 @@ abc
 (defn- export-in-memory-doc-files
   "Import in-memory file maps. `path->stat` is a path-> {:birthtime :mtime} map.
    Pass `:file-created-at` / `:file-updated-at` on a file map to simulate the UI
-   worker path, where `<get-file-stat` is unavailable."
-  [files path->stat]
-  (p/let [conn (db-test/create-conn)
-          _ (db-pipeline/add-listener conn)
-          doc-options (gp-exporter/build-doc-options
-                       {:macros {} :file/name-format :triple-lowbar}
-                       (merge default-export-options
-                              {:user-options {:convert-all-tags? false}
-                               :<get-file-stat (fn [path] (get path->stat path))
-                               :<export-file (fn [conn' file-map opts]
-                                               (gp-exporter/<add-file-to-db-graph
-                                                conn' (:file/path file-map) (:file/content file-map) opts))}))
-          _ (gp-exporter/export-doc-files conn files
-                                          #(p/resolved (:content %))
-                                          doc-options)]
-    conn))
+   worker path, where `<get-file-stat` is unavailable.
+   Pass an existing `conn` to import more files into the same graph."
+  ([files path->stat]
+   (export-in-memory-doc-files files path->stat nil))
+  ([files path->stat conn]
+   (p/let [existing-conn? (some? conn)
+           conn (or conn (db-test/create-conn))
+           _ (when-not existing-conn?
+               (db-pipeline/add-listener conn))
+           doc-options (gp-exporter/build-doc-options
+                        {:macros {} :file/name-format :triple-lowbar}
+                        (merge default-export-options
+                               {:user-options {:convert-all-tags? false}
+                                :<get-file-stat (fn [path] (get path->stat path))
+                                :<export-file (fn [conn' file-map opts]
+                                                (gp-exporter/<add-file-to-db-graph
+                                                 conn' (:file/path file-map) (:file/content file-map) opts))}))
+           _ (gp-exporter/export-doc-files conn files
+                                           #(p/resolved (:content %))
+                                           doc-options)]
+     conn)))
 
 (deftest-async export-doc-files-preserves-filesystem-timestamps
   (let [created-at (js/Date. "2020-01-02T03:04:05.000Z")
@@ -941,6 +946,33 @@ abc
                   {(:path file) {:mtime modified-at}})
             page (ldb/get-page @conn "mtime-only")]
       (is (= (.getTime modified-at) (:block/created-at page) (:block/updated-at page)))
+      (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
+
+(deftest-async export-doc-files-uses-file-mtime-when-journal-mentions-page
+  (let [journal-day-ms (date-time-util/journal-day->ms 20240308)
+        modified-at (js/Date. "2021-06-07T08:09:10.000Z")
+        mention {:path "journals/2024_03_08.md" :content "- [[Mtime Page]]\n"}
+        file {:path "pages/Mtime Page.md" :content "- see [[Mtime Page]]\n"}]
+    (p/let [conn (export-in-memory-doc-files
+                  [mention file]
+                  {(:path file) {:mtime modified-at}})
+            page (ldb/get-page @conn "mtime page")]
+      (is (= (.getTime modified-at) (:block/created-at page) (:block/updated-at page)))
+      (is (not= journal-day-ms (:block/created-at page)))
+      (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
+
+(deftest-async export-doc-files-keeps-existing-file-timestamps-when-journal-mentions-page
+  (let [created-at (js/Date. "2020-01-02T03:04:05.000Z")
+        modified-at (js/Date. "2021-06-07T08:09:10.000Z")
+        file {:path "pages/Existing File.md" :content "- existing file\n"}
+        mention {:path "journals/2024_03_08.md" :content "- [[Existing File]]\n"}]
+    (p/let [conn (export-in-memory-doc-files
+                  [file]
+                  {(:path file) {:birthtime created-at :mtime modified-at}})
+            _ (export-in-memory-doc-files [mention] {} conn)
+            page (ldb/get-page @conn "existing file")]
+      (is (= (.getTime created-at) (:block/created-at page)))
+      (is (= (.getTime modified-at) (:block/updated-at page)))
       (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
 
 (deftest-async export-doc-file-accepts-numeric-last-modified-at

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -862,7 +862,7 @@ abc
         modified-at (js/Date. "2025-03-02T03:31:18.000Z")
         mention {:path "journals/2024_01_01.md" :content "- [[schlafe]]\n"}
         file {:path "pages/Schlaf.md"
-              :content "alias:: schlafe, schlafen, geschlafen, Schlafrhythmus, wach\n\n- ## Probleme\n"}]
+              :content "alias:: schlafe, schlafen, geschlafen, Schlafrhythmus, wach\n\n- ## Problems\n"}]
     (p/let [conn (export-in-memory-doc-files
                   [mention file]
                   {(:path file) {:birthtime created-at :mtime modified-at}})

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -861,9 +861,13 @@ abc
     (p/let [conn (export-in-memory-doc-files
                   [mention file]
                   {(:path file) {:birthtime created-at :mtime modified-at}})
-            page (ldb/get-page @conn "schlaf")]
+            page (ldb/get-page @conn "schlaf")
+            alias-page (ldb/get-page @conn "schlafe")]
       (is (= (.getTime created-at) (:block/created-at page)))
       (is (= (.getTime modified-at) (:block/updated-at page)))
+      (is (= #{"schlafe" "schlafen" "geschlafen" "schlafrhythmus" "wach"}
+             (set (map :block/name (:block/alias page)))))
+      (is (= (:db/id page) (:db/id (ldb/get-alias-source-page @conn (:db/id alias-page)))))
       (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
 
 (deftest-async export-doc-files-uses-first-journal-mention-for-fileless-pages

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -794,21 +794,25 @@ abc
 
 (deftest-async export-doc-files-preserves-filesystem-timestamps
   (let [created-at (js/Date. "2020-01-02T03:04:05.000Z")
-        modified-at (js/Date. "2021-06-07T08:09:10.000Z")]
-    (p/let [file (write-temp-graph-file "pages/timestamps.md" "- timestamped\n")
-            conn (db-test/create-conn)
+        modified-at (js/Date. "2021-06-07T08:09:10.000Z")
+        source-file {:path "pages/A.md" :content "- [[Timestamps]]\n"}
+        file {:path "pages/timestamps.md" :content "- timestamped\n"}]
+    (p/let [conn (db-test/create-conn)
             _ (db-pipeline/add-listener conn)
             doc-options (gp-exporter/build-doc-options
                          {:macros {} :file/name-format :triple-lowbar}
                          (merge default-export-options
                                 {:user-options {:convert-all-tags? false}
-                                 :<get-file-stat (fn [_]
-                                                   {:birthtime created-at
-                                                    :mtime modified-at})
+                                 :<get-file-stat (fn [path]
+                                                   (when (= path (:path file))
+                                                     {:birthtime created-at
+                                                      :mtime modified-at}))
                                  :<export-file (fn [conn' file-map opts]
                                                  (gp-exporter/<add-file-to-db-graph
                                                   conn' (:file/path file-map) (:file/content file-map) opts))}))
-            _ (gp-exporter/export-doc-files conn [{:path file}] <read-file doc-options)
+            _ (gp-exporter/export-doc-files conn [source-file file]
+                                            #(p/resolved (:content %))
+                                            doc-options)
             page (ldb/get-page @conn "timestamps")
             block (db-test/find-block-by-content @conn "timestamped")]
       (is (= (.getTime created-at) (:block/created-at page) (:block/created-at block)))

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -933,6 +933,16 @@ abc
       (is (= (.getTime modified-at) (:block/created-at page) (:block/updated-at page)))
       (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
 
+(deftest-async export-doc-file-uses-mtime-when-birthtime-missing
+  (let [modified-at (js/Date. "2021-06-07T08:09:10.000Z")
+        file {:path "pages/mtime-only.md" :content "- mtime only\n"}]
+    (p/let [conn (export-in-memory-doc-files
+                  [file]
+                  {(:path file) {:mtime modified-at}})
+            page (ldb/get-page @conn "mtime-only")]
+      (is (= (.getTime modified-at) (:block/created-at page) (:block/updated-at page)))
+      (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
+
 (deftest-async export-doc-file-accepts-numeric-last-modified-at
   (let [modified-at (.getTime (js/Date. "2021-06-07T08:09:10.000Z"))
         file {:path "pages/numeric.md"

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -792,31 +792,109 @@ abc
        (catch :default e
          (assert-failure e))))))
 
+(defn- export-in-memory-doc-files
+  "Import in-memory file maps. `path->stat` is a path-> {:birthtime :mtime} map.
+   Pass `:file-created-at` / `:file-updated-at` on a file map to simulate the UI
+   worker path, where `<get-file-stat` is unavailable."
+  [files path->stat]
+  (p/let [conn (db-test/create-conn)
+          _ (db-pipeline/add-listener conn)
+          doc-options (gp-exporter/build-doc-options
+                       {:macros {} :file/name-format :triple-lowbar}
+                       (merge default-export-options
+                              {:user-options {:convert-all-tags? false}
+                               :<get-file-stat (fn [path] (get path->stat path))
+                               :<export-file (fn [conn' file-map opts]
+                                               (gp-exporter/<add-file-to-db-graph
+                                                conn' (:file/path file-map) (:file/content file-map) opts))}))
+          _ (gp-exporter/export-doc-files conn files
+                                          #(p/resolved (:content %))
+                                          doc-options)]
+    conn))
+
 (deftest-async export-doc-files-preserves-filesystem-timestamps
   (let [created-at (js/Date. "2020-01-02T03:04:05.000Z")
         modified-at (js/Date. "2021-06-07T08:09:10.000Z")
         source-file {:path "pages/A.md" :content "- [[Timestamps]]\n"}
         file {:path "pages/timestamps.md" :content "- timestamped\n"}]
-    (p/let [conn (db-test/create-conn)
-            _ (db-pipeline/add-listener conn)
-            doc-options (gp-exporter/build-doc-options
-                         {:macros {} :file/name-format :triple-lowbar}
-                         (merge default-export-options
-                                {:user-options {:convert-all-tags? false}
-                                 :<get-file-stat (fn [path]
-                                                   (when (= path (:path file))
-                                                     {:birthtime created-at
-                                                      :mtime modified-at}))
-                                 :<export-file (fn [conn' file-map opts]
-                                                 (gp-exporter/<add-file-to-db-graph
-                                                  conn' (:file/path file-map) (:file/content file-map) opts))}))
-            _ (gp-exporter/export-doc-files conn [source-file file]
-                                            #(p/resolved (:content %))
-                                            doc-options)
+    (p/let [conn (export-in-memory-doc-files
+                  [source-file file]
+                  {(:path file) {:birthtime created-at :mtime modified-at}})
             page (ldb/get-page @conn "timestamps")
             block (db-test/find-block-by-content @conn "timestamped")]
       (is (= (.getTime created-at) (:block/created-at page) (:block/created-at block)))
       (is (= (.getTime modified-at) (:block/updated-at page) (:block/updated-at block)))
+      (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
+
+(deftest-async export-doc-files-uses-serialized-file-timestamps-without-stat
+  (let [created-at (.getTime (js/Date. "2020-01-02T03:04:05.000Z"))
+        modified-at (.getTime (js/Date. "2021-06-07T08:09:10.000Z"))
+        file {:path "pages/sport.md"
+              :content "alias:: sportlich\n"
+              :file-created-at created-at
+              :file-updated-at modified-at}]
+    (p/let [conn (export-in-memory-doc-files [file] {})
+            page (ldb/get-page @conn "sport")]
+      (is (= created-at (:block/created-at page)))
+      (is (= modified-at (:block/updated-at page)))
+      (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
+
+(deftest-async export-doc-files-preserves-alias-only-page-file-timestamps
+  (let [created-at (js/Date. "2024-03-09T19:03:41.000Z")
+        modified-at (js/Date. "2024-03-08T21:19:12.000Z")
+        mention {:path "journals/2024_01_01.md" :content "- [[Sport]]\n"}
+        file {:path "pages/Sport.md" :content "alias:: sportlich\n"}]
+    (p/let [conn (export-in-memory-doc-files
+                  [mention file]
+                  {(:path file) {:birthtime created-at :mtime modified-at}})
+            page (ldb/get-page @conn "sport")]
+      (is (= (.getTime created-at) (:block/created-at page)))
+      (is (= (.getTime modified-at) (:block/updated-at page)))
+      (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
+
+(deftest-async export-doc-files-preserves-multi-alias-page-file-timestamps
+  (let [created-at (js/Date. "2025-01-03T13:45:32.000Z")
+        modified-at (js/Date. "2025-03-02T03:31:18.000Z")
+        mention {:path "journals/2024_01_01.md" :content "- [[schlafe]]\n"}
+        file {:path "pages/Schlaf.md"
+              :content "alias:: schlafe, schlafen, geschlafen, Schlafrhythmus, wach\n\n- ## Probleme\n"}]
+    (p/let [conn (export-in-memory-doc-files
+                  [mention file]
+                  {(:path file) {:birthtime created-at :mtime modified-at}})
+            page (ldb/get-page @conn "schlaf")]
+      (is (= (.getTime created-at) (:block/created-at page)))
+      (is (= (.getTime modified-at) (:block/updated-at page)))
+      (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
+
+(deftest-async export-doc-files-uses-first-journal-mention-for-fileless-pages
+  (let [journal-day 20240308
+        expected (date-time-util/journal-day->ms journal-day)
+        journal {:path "journals/2024_03_08.md" :content "- first mention [[Referenced Only]]\n"}
+        later {:path "journals/2024_06_01.md" :content "- later mention [[Referenced Only]]\n"}]
+    (p/let [conn (export-in-memory-doc-files [journal later] {})
+            page (ldb/get-page @conn "referenced only")]
+      (is (= expected (:block/created-at page)))
+      (is (= expected (:block/updated-at page)))
+      (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
+
+(deftest-async export-doc-file-ignores-epoch-zero-birthtime
+  (let [modified-at (js/Date. "2021-06-07T08:09:10.000Z")
+        file {:path "pages/epoch.md" :content "- epoch birth\n"}]
+    (p/let [conn (export-in-memory-doc-files
+                  [file]
+                  {(:path file) {:birthtime (js/Date. 0) :mtime modified-at}})
+            page (ldb/get-page @conn "epoch")]
+      (is (= (.getTime modified-at) (:block/created-at page) (:block/updated-at page)))
+      (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
+
+(deftest-async export-doc-file-accepts-numeric-last-modified-at
+  (let [modified-at (.getTime (js/Date. "2021-06-07T08:09:10.000Z"))
+        file {:path "pages/numeric.md"
+              :content "- numeric mtime\n"
+              :last-modified-at modified-at}]
+    (p/let [conn (export-in-memory-doc-files [file] {})
+            page (ldb/get-page @conn "numeric")]
+      (is (= modified-at (:block/created-at page) (:block/updated-at page)))
       (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
 
 (deftest update-asset-links-in-block-title

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -898,6 +898,20 @@ abc
       (is (= expected (:block/created-at page) (:block/updated-at page)))
       (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
 
+(deftest-async export-doc-files-keeps-journal-page-created-at-on-journal-day
+  (let [expected (date-time-util/journal-day->ms 20240308)
+        modified-at (js/Date. "2025-08-02T00:00:00.000Z")
+        journal {:path "journals/2024_03_08.md" :content "- journal block\n"}]
+    (p/let [conn (export-in-memory-doc-files
+                  [journal]
+                  {(:path journal) {:mtime modified-at}})
+            page (db-test/find-page-by-title @conn "Mar 8th, 2024")
+            block (db-test/find-block-by-content @conn "journal block")]
+      (is (= expected (:block/created-at page)))
+      (is (= expected (:block/created-at block)))
+      (is (not= (.getTime modified-at) (:block/created-at page)))
+      (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
+
 (deftest-async export-doc-files-keeps-journal-day-when-journal-mentions-another-date
   (let [expected (date-time-util/journal-day->ms 20240308)
         journal {:path "journals/2024_03_08.md"

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -877,6 +877,48 @@ abc
       (is (= expected (:block/updated-at page)))
       (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
 
+(deftest-async export-doc-files-keeps-journal-day-when-journal-has-file-stats
+  (let [expected (date-time-util/journal-day->ms 20240308)
+        file-created-at (js/Date. "2025-08-01T00:00:00.000Z")
+        file-updated-at (js/Date. "2025-08-02T00:00:00.000Z")
+        journal {:path "journals/2024_03_08.md" :content "- first mention [[Referenced Only]]\n"}]
+    (p/let [conn (export-in-memory-doc-files
+                  [journal]
+                  {(:path journal) {:birthtime file-created-at :mtime file-updated-at}})
+            page (ldb/get-page @conn "referenced only")]
+      (is (= expected (:block/created-at page) (:block/updated-at page)))
+      (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
+
+(deftest-async export-doc-files-keeps-journal-day-when-journal-mentions-another-date
+  (let [expected (date-time-util/journal-day->ms 20240308)
+        journal {:path "journals/2024_03_08.md"
+                 :content "- first mention [[Referenced Only]] [[Mar 9th, 2024]]\n"}]
+    (p/let [conn (export-in-memory-doc-files [journal] {})
+            page (ldb/get-page @conn "referenced only")]
+      (is (= expected (:block/created-at page) (:block/updated-at page)))
+      (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
+
+(deftest-async export-doc-files-keeps-file-timestamps-when-page-mentions-one-journal
+  (let [created-at (js/Date. "2020-01-02T03:04:05.000Z")
+        modified-at (js/Date. "2021-06-07T08:09:10.000Z")
+        file {:path "pages/foo.md" :content "- [[Mar 8th, 2024]]\n"}]
+    (p/let [conn (export-in-memory-doc-files
+                  [file]
+                  {(:path file) {:birthtime created-at :mtime modified-at}})
+            page (ldb/get-page @conn "foo")]
+      (is (= (.getTime created-at) (:block/created-at page)))
+      (is (= (.getTime modified-at) (:block/updated-at page)))
+      (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
+
+(deftest-async export-doc-files-keeps-journal-mention-when-later-file-has-no-stats
+  (let [expected (date-time-util/journal-day->ms 20240308)
+        mention {:path "journals/2024_03_08.md" :content "- [[Later File]]\n"}
+        file {:path "pages/Later File.md" :content "- later file\n"}]
+    (p/let [conn (export-in-memory-doc-files [mention file] {})
+            page (ldb/get-page @conn "later file")]
+      (is (= expected (:block/created-at page) (:block/updated-at page)))
+      (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
+
 (deftest-async export-doc-file-ignores-epoch-zero-birthtime
   (let [modified-at (js/Date. "2021-06-07T08:09:10.000Z")
         file {:path "pages/epoch.md" :content "- epoch birth\n"}]

--- a/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
+++ b/deps/graph-parser/test/logseq/graph_parser/exporter_test.cljs
@@ -792,13 +792,13 @@ abc
        (catch :default e
          (assert-failure e))))))
 
-(defn- export-in-memory-doc-files
+(defn- <export-in-memory-doc-files
   "Import in-memory file maps. `path->stat` is a path-> {:birthtime :mtime} map.
    Pass `:file-created-at` / `:file-updated-at` on a file map to simulate the UI
    worker path, where `<get-file-stat` is unavailable.
    Pass an existing `conn` to import more files into the same graph."
   ([files path->stat]
-   (export-in-memory-doc-files files path->stat nil))
+   (<export-in-memory-doc-files files path->stat nil))
   ([files path->stat conn]
    (p/let [existing-conn? (some? conn)
            conn (or conn (db-test/create-conn))
@@ -822,7 +822,7 @@ abc
         modified-at (js/Date. "2021-06-07T08:09:10.000Z")
         source-file {:path "pages/A.md" :content "- [[Timestamps]]\n"}
         file {:path "pages/timestamps.md" :content "- timestamped\n"}]
-    (p/let [conn (export-in-memory-doc-files
+    (p/let [conn (<export-in-memory-doc-files
                   [source-file file]
                   {(:path file) {:birthtime created-at :mtime modified-at}})
             page (ldb/get-page @conn "timestamps")
@@ -838,7 +838,7 @@ abc
               :content "alias:: sportlich\n"
               :file-created-at created-at
               :file-updated-at modified-at}]
-    (p/let [conn (export-in-memory-doc-files [file] {})
+    (p/let [conn (<export-in-memory-doc-files [file] {})
             page (ldb/get-page @conn "sport")]
       (is (= created-at (:block/created-at page)))
       (is (= modified-at (:block/updated-at page)))
@@ -849,7 +849,7 @@ abc
         modified-at (js/Date. "2024-03-08T21:19:12.000Z")
         mention {:path "journals/2024_01_01.md" :content "- [[Sport]]\n"}
         file {:path "pages/Sport.md" :content "alias:: sportlich\n"}]
-    (p/let [conn (export-in-memory-doc-files
+    (p/let [conn (<export-in-memory-doc-files
                   [mention file]
                   {(:path file) {:birthtime created-at :mtime modified-at}})
             page (ldb/get-page @conn "sport")]
@@ -863,7 +863,7 @@ abc
         mention {:path "journals/2024_01_01.md" :content "- [[schlafe]]\n"}
         file {:path "pages/Schlaf.md"
               :content "alias:: schlafe, schlafen, geschlafen, Schlafrhythmus, wach\n\n- ## Problems\n"}]
-    (p/let [conn (export-in-memory-doc-files
+    (p/let [conn (<export-in-memory-doc-files
                   [mention file]
                   {(:path file) {:birthtime created-at :mtime modified-at}})
             page (ldb/get-page @conn "schlaf")
@@ -880,7 +880,7 @@ abc
         expected (date-time-util/journal-day->ms journal-day)
         journal {:path "journals/2024_03_08.md" :content "- first mention [[Referenced Only]]\n"}
         later {:path "journals/2024_06_01.md" :content "- later mention [[Referenced Only]]\n"}]
-    (p/let [conn (export-in-memory-doc-files [journal later] {})
+    (p/let [conn (<export-in-memory-doc-files [journal later] {})
             page (ldb/get-page @conn "referenced only")]
       (is (= expected (:block/created-at page)))
       (is (= expected (:block/updated-at page)))
@@ -891,7 +891,7 @@ abc
         file-created-at (js/Date. "2025-08-01T00:00:00.000Z")
         file-updated-at (js/Date. "2025-08-02T00:00:00.000Z")
         journal {:path "journals/2024_03_08.md" :content "- first mention [[Referenced Only]]\n"}]
-    (p/let [conn (export-in-memory-doc-files
+    (p/let [conn (<export-in-memory-doc-files
                   [journal]
                   {(:path journal) {:birthtime file-created-at :mtime file-updated-at}})
             page (ldb/get-page @conn "referenced only")]
@@ -902,7 +902,7 @@ abc
   (let [expected (date-time-util/journal-day->ms 20240308)
         modified-at (js/Date. "2025-08-02T00:00:00.000Z")
         journal {:path "journals/2024_03_08.md" :content "- journal block\n"}]
-    (p/let [conn (export-in-memory-doc-files
+    (p/let [conn (<export-in-memory-doc-files
                   [journal]
                   {(:path journal) {:mtime modified-at}})
             page (db-test/find-page-by-title @conn "Mar 8th, 2024")
@@ -916,7 +916,7 @@ abc
   (let [expected (date-time-util/journal-day->ms 20240308)
         journal {:path "journals/2024_03_08.md"
                  :content "- first mention [[Referenced Only]] [[Mar 9th, 2024]]\n"}]
-    (p/let [conn (export-in-memory-doc-files [journal] {})
+    (p/let [conn (<export-in-memory-doc-files [journal] {})
             page (ldb/get-page @conn "referenced only")]
       (is (= expected (:block/created-at page) (:block/updated-at page)))
       (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
@@ -925,7 +925,7 @@ abc
   (let [created-at (js/Date. "2020-01-02T03:04:05.000Z")
         modified-at (js/Date. "2021-06-07T08:09:10.000Z")
         file {:path "pages/foo.md" :content "- [[Mar 8th, 2024]]\n"}]
-    (p/let [conn (export-in-memory-doc-files
+    (p/let [conn (<export-in-memory-doc-files
                   [file]
                   {(:path file) {:birthtime created-at :mtime modified-at}})
             page (ldb/get-page @conn "foo")]
@@ -937,7 +937,7 @@ abc
   (let [expected (date-time-util/journal-day->ms 20240308)
         mention {:path "journals/2024_03_08.md" :content "- [[Later File]]\n"}
         file {:path "pages/Later File.md" :content "- later file\n"}]
-    (p/let [conn (export-in-memory-doc-files [mention file] {})
+    (p/let [conn (<export-in-memory-doc-files [mention file] {})
             page (ldb/get-page @conn "later file")]
       (is (= expected (:block/created-at page) (:block/updated-at page)))
       (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))
@@ -945,7 +945,7 @@ abc
 (deftest-async export-doc-file-ignores-epoch-zero-birthtime
   (let [modified-at (js/Date. "2021-06-07T08:09:10.000Z")
         file {:path "pages/epoch.md" :content "- epoch birth\n"}]
-    (p/let [conn (export-in-memory-doc-files
+    (p/let [conn (<export-in-memory-doc-files
                   [file]
                   {(:path file) {:birthtime (js/Date. 0) :mtime modified-at}})
             page (ldb/get-page @conn "epoch")]
@@ -955,7 +955,7 @@ abc
 (deftest-async export-doc-file-uses-mtime-when-birthtime-missing
   (let [modified-at (js/Date. "2021-06-07T08:09:10.000Z")
         file {:path "pages/mtime-only.md" :content "- mtime only\n"}]
-    (p/let [conn (export-in-memory-doc-files
+    (p/let [conn (<export-in-memory-doc-files
                   [file]
                   {(:path file) {:mtime modified-at}})
             page (ldb/get-page @conn "mtime-only")]
@@ -967,7 +967,7 @@ abc
         modified-at (js/Date. "2021-06-07T08:09:10.000Z")
         mention {:path "journals/2024_03_08.md" :content "- [[Mtime Page]]\n"}
         file {:path "pages/Mtime Page.md" :content "- see [[Mtime Page]]\n"}]
-    (p/let [conn (export-in-memory-doc-files
+    (p/let [conn (<export-in-memory-doc-files
                   [mention file]
                   {(:path file) {:mtime modified-at}})
             page (ldb/get-page @conn "mtime page")]
@@ -980,10 +980,10 @@ abc
         modified-at (js/Date. "2021-06-07T08:09:10.000Z")
         file {:path "pages/Existing File.md" :content "- existing file\n"}
         mention {:path "journals/2024_03_08.md" :content "- [[Existing File]]\n"}]
-    (p/let [conn (export-in-memory-doc-files
+    (p/let [conn (<export-in-memory-doc-files
                   [file]
                   {(:path file) {:birthtime created-at :mtime modified-at}})
-            _ (export-in-memory-doc-files [mention] {} conn)
+            _ (<export-in-memory-doc-files [mention] {} conn)
             page (ldb/get-page @conn "existing file")]
       (is (= (.getTime created-at) (:block/created-at page)))
       (is (= (.getTime modified-at) (:block/updated-at page)))
@@ -994,7 +994,7 @@ abc
         file {:path "pages/numeric.md"
               :content "- numeric mtime\n"
               :last-modified-at modified-at}]
-    (p/let [conn (export-in-memory-doc-files [file] {})
+    (p/let [conn (<export-in-memory-doc-files [file] {})
             page (ldb/get-page @conn "numeric")]
       (is (= modified-at (:block/created-at page) (:block/updated-at page)))
       (is (empty? (:errors (db-validate/validate-local-db! @conn)))))))

--- a/src/main/frontend/components/imports.cljs
+++ b/src/main/frontend/components/imports.cljs
@@ -323,7 +323,10 @@
 (defn- <file-timestamps
   [{:keys [fs-path last-modified-at]}]
   (p/let [stat (when (and fs-path (util/electron?) (path/absolute? fs-path))
-                  (ipc/ipc :stat fs-path))]
+                  (p/catch (ipc/ipc :stat fs-path)
+                           (fn [error]
+                             (log/warn :import-file-stat-failed {:path fs-path :error error})
+                             nil)))]
     (cond-> {}
       (:birthtime stat)
       (assoc :file-created-at (.getTime (:birthtime stat)))

--- a/src/main/frontend/components/imports.cljs
+++ b/src/main/frontend/components/imports.cljs
@@ -322,14 +322,16 @@
     (notification/show! msg :warning false)))
 
 (defn- <file-timestamps
+  "Prefer birthtime when present. Fall back to mtime / File.lastModified."
   [{:keys [fs-path last-modified-at]}]
   (p/let [stat (when (and fs-path (util/electron?) (path/absolute? fs-path))
                   (p/catch (ipc/ipc :stat fs-path)
                            (fn [error]
                              (log/warn :import-file-stat-failed {:path fs-path :error error})
                              nil)))
-          created-at (common-util/timestamp-ms (:birthtime stat))
-          updated-at (common-util/timestamp-ms (or (:mtime stat) last-modified-at))]
+          updated-at (common-util/timestamp-ms (or (:mtime stat) last-modified-at))
+          created-at (or (common-util/timestamp-ms (:birthtime stat))
+                         updated-at)]
     (cond-> {}
       created-at
       (assoc :file-created-at created-at)

--- a/src/main/frontend/components/imports.cljs
+++ b/src/main/frontend/components/imports.cljs
@@ -25,6 +25,7 @@
             [lambdaisland.glogi :as log]
             [logseq.common.config :as common-config]
             [logseq.common.path :as path]
+            [logseq.common.util :as common-util]
             [logseq.shui.dialog.core :as shui-dialog]
             [logseq.shui.form.core :as form-core]
             [logseq.shui.hooks :as hooks]
@@ -326,12 +327,14 @@
                   (p/catch (ipc/ipc :stat fs-path)
                            (fn [error]
                              (log/warn :import-file-stat-failed {:path fs-path :error error})
-                             nil)))]
+                             nil)))
+          created-at (common-util/timestamp-ms (:birthtime stat))
+          updated-at (common-util/timestamp-ms (or (:mtime stat) last-modified-at))]
     (cond-> {}
-      (:birthtime stat)
-      (assoc :file-created-at (.getTime (:birthtime stat)))
-      (or (:mtime stat) last-modified-at)
-      (assoc :file-updated-at (.getTime (or (:mtime stat) last-modified-at))))))
+      created-at
+      (assoc :file-created-at created-at)
+      updated-at
+      (assoc :file-updated-at updated-at))))
 
 (defn- <serialize-import-file
   [file]

--- a/src/main/frontend/components/imports.cljs
+++ b/src/main/frontend/components/imports.cljs
@@ -4,6 +4,7 @@
             [cljs-time.core :as t]
             [cljs.pprint :as pprint]
             [clojure.string :as string]
+            [electron.ipc :as ipc]
             [frontend.components.onboarding.setups :as setups]
             [frontend.components.repo :as repo]
             [frontend.components.svg :as svg]
@@ -319,6 +320,16 @@
         (log/error :import-error ex-data)))
     (notification/show! msg :warning false)))
 
+(defn- <file-timestamps
+  [{:keys [fs-path last-modified-at]}]
+  (p/let [stat (when (and fs-path (util/electron?) (path/absolute? fs-path))
+                  (ipc/ipc :stat fs-path))]
+    (cond-> {}
+      (:birthtime stat)
+      (assoc :file-created-at (.getTime (:birthtime stat)))
+      (or (:mtime stat) last-modified-at)
+      (assoc :file-updated-at (.getTime (or (:mtime stat) last-modified-at))))))
+
 (defn- <serialize-import-file
   [file]
   (let [^js file-object (:file-object file)]
@@ -332,9 +343,11 @@
           (assoc (select-keys file [:path])
                  :asset/payload (js/Uint8Array. buffer)
                  :asset/size (.-size file-object))))
-      (p/let [content (.text file-object)]
-        (assoc (select-keys file [:path])
-               :file/content content)))))
+      (p/let [content (.text file-object)
+              timestamps (<file-timestamps file)]
+        (merge (select-keys file [:path])
+               timestamps
+               {:file/content content})))))
 
 (defn- <serialize-import-files
   [files]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
related to https://github.com/logseq/db-test/issues/1047

Builds on https://github.com/logseq/logseq/pull/13032 so file-to-DB import keeps source timestamps instead of the import time.

## Behavior change

- File-backed pages prefer filesystem birthtime for created-at when it is a real positive time.
- Missing or invalid birthtime (including Linux ext4 epoch-0) falls back to mtime / `File.lastModified`.
- A page that already has file timestamps keeps those times when a journal later mentions it.
- Journal pages and their blocks keep the journal day, even when the journal file has filesystem stats.
- UI import serializes those timestamps onto each file before the worker runs (`<get-file-stat` is nil in the worker).
- When a page is first created as a reference and later imported from its own file, that file's created/updated timestamps overwrite the first-mention timestamps only when real file stats exist.
- Pages that only exist because they were linked from a journal use that journal file's date, even if the journal also links another date or has filesystem timestamps.
- File-backed pages that mention a journal date keep their own filesystem timestamps.

## Tests

Reproduced the db-test#1047 conversation cases plus review regressions in `deps/graph-parser` nbb tests.

OG IndexedDB created/updated columns (discussed on the issue) are not imported. Those values are not stored in the file graph.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a058ca-ea4c-78c1-b295-82fa88b4a745?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a058ca-ea4c-78c1-b295-82fa88b4a745&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

