### PR TITLE
Fix UI #1135: redirect to previous page instead of home on page delete

### DIFF
--- a/src/main/frontend/modules/outliner/pipeline.cljs
+++ b/src/main/frontend/modules/outliner/pipeline.cljs
@@ -62,7 +62,7 @@
           (state/remove-pages-from-recent! removed-page-ids)))
       (when (and (current-page-deleted? current-page deleted)
                  (not (util/mobile?)))
-        (route-handler/redirect-to-home!))
+        (.back js/window.history))
 
       (cond
         initial-pages?
@@ -73,7 +73,7 @@
         :else
         (do
           (when (current-page-recycled? current-page blocks)
-            (route-handler/redirect! {:to :home :push false}))
+            (.back js/window.history))
 
           (when (or (not= (:client-id tx-meta) (:client-id (state/get-state)))
                     (= :apply-template (:outliner-op tx-meta)))

--- a/src/main/frontend/modules/outliner/pipeline.cljs
+++ b/src/main/frontend/modules/outliner/pipeline.cljs
@@ -1,7 +1,6 @@
 (ns frontend.modules.outliner.pipeline
   (:require [clojure.string :as string]
             [frontend.db.subs :as db-subs]
-            [frontend.handler.route :as route-handler]
             [frontend.handler.ui :as ui-handler]
             [frontend.state :as state]
             [frontend.util :as util]


### PR DESCRIPTION
## Description
Fixes [db-test#1135](https://github.com/logseq/db-test/issues/1135).

Currently, when a user deletes a page they are viewing, they are unexpectedly redirected to the home screen (or all-journals). This disrupts the user's workflow. 

This PR updates `pipeline.cljs` to use `(.back js/window.history)` instead of a hardcoded redirect to `:home`, dropping the user back onto their previously visited page or block.

## Notes
* **Tested on:** Local Web/Desktop builds. 
* **Mobile Routing:** Since mobile uses native navigation stacks, the `(not (util/mobile?))` condition was preserved, leaving the mobile native routing completely intact.