### PR TITLE
fix(editor): keep new blocks visible after code block conversion

### DIFF
--- a/src/main/frontend/handler/events.cljs
+++ b/src/main/frontend/handler/events.cljs
@@ -376,6 +376,14 @@
     (p/resolved lang)
     (state/<invoke-db-worker :thread-api/get-key-value repo :logseq.kv/latest-code-lang)))
 
+(defn- refocus-upsert-type-block!
+  [source-block converted-block update-current-block?]
+  (when (or (not update-current-block?)
+            (and (nil? (state/get-state :editor/pending-new-block))
+                 (= (:block/uuid source-block)
+                    (:block/uuid (state/get-edit-block)))))
+    (editor-handler/edit-block! converted-block :max)))
+
 (defevent! :editor/upsert-type-block [[_ {:keys [block type lang update-current-block?]}]]
   (p/let [_ (when-not update-current-block?
               (editor-handler/save-current-block!))
@@ -411,7 +419,7 @@
                                 (p/let [_ (apply-requested-title! db-block)
                                         _ (turn-type! db-block)]
                                   (<get-upsert-type-block repo (:block/uuid db-block))))]
-        (js/setTimeout #(editor-handler/edit-block! converted-block :max) 100)))))
+        (js/setTimeout #(refocus-upsert-type-block! db-block converted-block update-current-block?) 100)))))
 
 (defn- editing-users-by-block
   [online-users current-user-uuid]

--- a/src/test/frontend/handler/events_test.cljs
+++ b/src/test/frontend/handler/events_test.cljs
@@ -1,7 +1,10 @@
 (ns frontend.handler.events-test
   (:require [cljs.test :refer [deftest is testing]]
             [frontend.components.rtc.download-progress :as download-progress]
+            [frontend.handler.editor :as editor-handler]
+            [frontend.handler.events :as events]
             [frontend.mobile.util :as mobile-util]
+            [frontend.state :as state]
             [logseq.shui.ui :as shui]))
 
 (deftest download-graph-progress-surface-test
@@ -25,3 +28,39 @@
         (download-progress/show! "My notes")
         (download-progress/hide!)
         (is (= [:popup :popup-hide] (mapv first @calls)))))))
+
+(deftest refocus-upsert-type-block-test
+  (let [source-id #uuid "11111111-1111-1111-1111-111111111111"
+        next-id #uuid "22222222-2222-2222-2222-222222222222"
+        source-block {:block/uuid source-id}
+        converted-block {:block/uuid source-id
+                         :logseq.property.node/display-type :code}
+        next-block {:block/uuid next-id}
+        current-block (atom source-block)
+        pending-new-block (atom nil)
+        edit-calls (atom [])]
+    (with-redefs [state/get-edit-block #(deref current-block)
+                  state/get-state (fn [key]
+                                    (when (= :editor/pending-new-block key)
+                                      @pending-new-block))
+                  editor-handler/edit-block! (fn [& args]
+                                               (swap! edit-calls conj args))]
+      (testing "an active automatic conversion keeps its normal refocus behavior"
+        (#'events/refocus-upsert-type-block! source-block converted-block true)
+        (is (= [[converted-block :max]] @edit-calls)))
+
+      (testing "a pending new block prevents the old block from reclaiming focus"
+        (reset! edit-calls [])
+        (reset! pending-new-block {:typed-text "new block text"})
+        (#'events/refocus-upsert-type-block! source-block converted-block true)
+        (is (empty? @edit-calls)))
+
+      (testing "a newer edit block makes the delayed callback stale"
+        (reset! pending-new-block nil)
+        (reset! current-block next-block)
+        (#'events/refocus-upsert-type-block! source-block converted-block true)
+        (is (empty? @edit-calls)))
+
+      (testing "explicit type insertion preserves its existing refocus behavior"
+        (#'events/refocus-upsert-type-block! source-block converted-block false)
+        (is (= [[converted-block :max]] @edit-calls))))))


### PR DESCRIPTION
## Summary

- Prevent a delayed automatic code-block conversion from moving the editor back to a block the user has already left.
- Keep newly created blocks active so their text remains visible and saved after typing four backticks and pressing Enter.
- Preserve the existing refocus behavior for active conversions and explicit type insertion.

## Root cause

`:editor/upsert-type-block` scheduled an unconditional `edit-block!` 100 ms after conversion. If Enter had already created a new block, that stale callback reclaimed focus for the converted block.

The fix only refocuses an automatic conversion while the source block is still being edited and no new block is pending.

## Verification

- `pnpm cljs:run-test -n frontend.handler.events-test` — 2 tests, 6 assertions
- `pnpm cljs:run-test -n frontend.handler.editor-test` — 81 tests, 213 assertions
- `clojure -M:clj-kondo --lint src/main/frontend/handler/events.cljs src/test/frontend/handler/events_test.cljs` — 0 errors, 0 warnings
- Manual browser verification on macOS: followed the issue steps in a local DB build, entered three blocks after the four-backtick block, and confirmed that all three remained visible and persisted after reloading the page.

## Scope

This fixes the invisible subsequent blocks described in the issue body. It does not change the macOS international-layout dead-key expansion behavior, which is tracked separately in [db-test #1021](https://github.com/logseq/db-test/issues/1021) and [logseq PR #12927](https://github.com/logseq/logseq/pull/12927).

Fixes logseq/db-test#1087
