### PR TITLE
fix: go to previous page after current page delete

### DIFF
--- a/src/main/frontend/handler/route.cljs
+++ b/src/main/frontend/handler/route.cljs
@@ -39,6 +39,22 @@
    (when pub-event? (state/pub-event! [:redirect-to-home]))
    (redirect! {:to :home})))
 
+(defn- history-length
+  []
+  (.-length js/window.history))
+
+(defn- history-go-back!
+  []
+  (.back js/window.history))
+
+(defn redirect-to-previous!
+  "Leave the current history entry by going back to the previous page/block.
+   Replaces the current entry with home when there is no previous history entry."
+  []
+  (if (> (history-length) 1)
+    (history-go-back!)
+    (redirect! {:to :home :push false})))
+
 (defn redirect-to-all-pages!
   []
   (redirect! {:to :all-pages}))

--- a/src/main/frontend/modules/outliner/pipeline.cljs
+++ b/src/main/frontend/modules/outliner/pipeline.cljs
@@ -1,6 +1,7 @@
 (ns frontend.modules.outliner.pipeline
   (:require [clojure.string :as string]
             [frontend.db.subs :as db-subs]
+            [frontend.handler.route :as route-handler]
             [frontend.handler.ui :as ui-handler]
             [frontend.state :as state]
             [frontend.util :as util]
@@ -27,6 +28,14 @@
                (and (= current-page (str block-uuid))
                     (ldb/recycled? block)))
              blocks)))
+
+(defn- leave-removed-current-page!
+  "Desktop: go to the previous page/block after the current route is deleted
+   or recycled. Mobile keeps its own stack; the header delete handler already
+   calls history.back."
+  []
+  (when-not (util/mobile?)
+    (route-handler/redirect-to-previous!)))
 
 (defn- publish-plugin-hook!
   [tx-meta {:keys [blocks deleted]}]
@@ -59,9 +68,10 @@
           (state/sidebar-remove-deleted-block! deleted-ids))
         (when-let [removed-page-ids (not-empty (concat deleted-ids recycled-ids))]
           (state/remove-pages-from-recent! removed-page-ids)))
-      (when (and (current-page-deleted? current-page deleted)
-                 (not (util/mobile?)))
-        (.back js/window.history))
+      (when (or (current-page-deleted? current-page deleted)
+                (and (not initial-pages?)
+                     (current-page-recycled? current-page blocks)))
+        (leave-removed-current-page!))
 
       (cond
         initial-pages?
@@ -71,9 +81,6 @@
 
         :else
         (do
-          (when (current-page-recycled? current-page blocks)
-            (.back js/window.history))
-
           (when (or (not= (:client-id tx-meta) (:client-id (state/get-state)))
                     (= :apply-template (:outliner-op tx-meta)))
             (update-editing-block-title-if-changed! blocks))

--- a/src/test/frontend/handler/route_test.cljs
+++ b/src/test/frontend/handler/route_test.cljs
@@ -19,6 +19,39 @@
   []
   (conn/get-db test-helper/test-db))
 
+(defn- with-history
+  [history f]
+  (let [original-history (.-history js/window)]
+    (set! (.-history js/window) history)
+    (try
+      (f)
+      (finally
+        (set! (.-history js/window) original-history)))))
+
+(deftest redirect-to-previous-uses-history-when-available-test
+  (let [calls (atom [])]
+    (with-history
+      #js {:length 3
+           :back (fn [] (swap! calls conj :back))}
+      (fn []
+        (with-redefs [route-handler/redirect! (fn [route]
+                                                (swap! calls conj [:redirect route]))]
+          (route-handler/redirect-to-previous!)
+          (is (= [:back] @calls)
+              "A previous history entry is restored instead of sending the user home."))))))
+
+(deftest redirect-to-previous-falls-back-to-home-without-history-test
+  (let [calls (atom [])]
+    (with-history
+      #js {:length 1
+           :back (fn [] (swap! calls conj :back))}
+      (fn []
+        (with-redefs [route-handler/redirect! (fn [route]
+                                                (swap! calls conj [:redirect route]))]
+          (route-handler/redirect-to-previous!)
+          (is (= [[:redirect {:to :home :push false}]] @calls)
+              "With no previous history entry, replace the deleted page with home."))))))
+
 (deftest default-page-route
   (let [journal-uuid (random-uuid)]
     (load-test-files

--- a/src/test/frontend/modules/outliner/pipeline_test.cljs
+++ b/src/test/frontend/modules/outliner/pipeline_test.cljs
@@ -1,8 +1,10 @@
 (ns frontend.modules.outliner.pipeline-test
   (:require [cljs.test :refer [deftest is]]
             [frontend.db.subs :as db-subs]
+            [frontend.handler.route :as route-handler]
             [frontend.modules.outliner.pipeline :as pipeline]
-            [frontend.state :as state]))
+            [frontend.state :as state]
+            [frontend.util :as util]))
 
 (deftest compact-worker-broadcast-applies-the-exact-delta-once-and-keeps-page-events-test
   (let [original-state (state/get-state)
@@ -128,5 +130,147 @@
                                 :delta delta})
         (is (= [7] (state/get-recent-pages))
             "Hard deletion removes only that page from recent history."))
+      (finally
+        (state/replace-state! original-state)))))
+
+(defn- recycled-page-delta
+  [page-uuid]
+  {:graph-id "delete-nav-test"
+   :rev 12
+   :blocks {page-uuid {:db/id 42
+                       :block/uuid page-uuid
+                       :block/tags [{:db/ident :logseq.class/Page}]
+                       :logseq.property/deleted-at 1}}
+   :deleted {}
+   :children {}
+   :affected-keys #{[:entity page-uuid]}})
+
+(defn- hard-deleted-page-delta
+  [page-uuid]
+  {:graph-id "delete-nav-test"
+   :rev 13
+   :blocks {}
+   :deleted {page-uuid {:rev 13 :db/id 42}}
+   :children {}
+   :affected-keys #{[:entity page-uuid]}})
+
+(defn- invoke-delete-hooks
+  [{:keys [current-page delta tx-meta]}]
+  (let [repo "delete-nav-test"
+        nav-calls (atom [])]
+    (with-redefs [db-subs/apply-delta! (constantly true)
+                  state/get-current-repo (constantly repo)
+                  state/get-current-page (constantly current-page)
+                  state/sidebar-remove-deleted-block! (constantly nil)
+                  state/pub-event! (constantly nil)
+                  route-handler/redirect-to-previous! (fn []
+                                                        (swap! nav-calls conj :previous))
+                  route-handler/redirect-to-home! (fn [& _]
+                                                    (swap! nav-calls conj :home))]
+      (pipeline/invoke-hooks {:repo repo
+                              :tx-meta (merge {:client-id "client"
+                                               :outliner-op :delete-page
+                                               :deleted-page "Page B"}
+                                              tx-meta)
+                              :delta delta})
+      @nav-calls)))
+
+(deftest recycling-current-page-goes-to-previous-route-test
+  (let [original-state (state/get-state)
+        page-uuid (random-uuid)]
+    (try
+      (state/replace-state! {:client-id "client"})
+      (is (= [:previous]
+             (invoke-delete-hooks
+              {:current-page (str page-uuid)
+               :delta (recycled-page-delta page-uuid)}))
+          "Deleting the current page goes back to the previous page/block, not home.")
+      (finally
+        (state/replace-state! original-state)))))
+
+(deftest recycling-other-page-does-not-navigate-test
+  (let [original-state (state/get-state)
+        page-uuid (random-uuid)]
+    (try
+      (state/replace-state! {:client-id "client"})
+      (is (= []
+             (invoke-delete-hooks
+              {:current-page (str (random-uuid))
+               :delta (recycled-page-delta page-uuid)}))
+          "Deleting a page that is not the current route must not steal navigation.")
+      (finally
+        (state/replace-state! original-state)))))
+
+(deftest hard-deleting-current-page-goes-to-previous-route-test
+  (let [original-state (state/get-state)
+        page-uuid (random-uuid)]
+    (try
+      (state/replace-state! {:client-id "client"})
+      (is (= [:previous]
+             (invoke-delete-hooks
+              {:current-page (str page-uuid)
+               :delta (hard-deleted-page-delta page-uuid)}))
+          "Permanently deleting the current page goes back to the previous page/block.")
+      (finally
+        (state/replace-state! original-state)))))
+
+(deftest hard-deleting-other-page-does-not-navigate-test
+  (let [original-state (state/get-state)
+        page-uuid (random-uuid)]
+    (try
+      (state/replace-state! {:client-id "client"})
+      (is (= []
+             (invoke-delete-hooks
+              {:current-page (str (random-uuid))
+               :delta (hard-deleted-page-delta page-uuid)}))
+          "Permanently deleting a non-current page must not steal navigation.")
+      (finally
+        (state/replace-state! original-state)))))
+
+(deftest recycling-current-page-on-mobile-does-not-navigate-test
+  (let [original-state (state/get-state)
+        page-uuid (random-uuid)]
+    (try
+      (state/replace-state! {:client-id "client"})
+      (with-redefs [util/mobile? (constantly true)]
+        (is (= []
+               (invoke-delete-hooks
+                {:current-page (str page-uuid)
+                 :delta (recycled-page-delta page-uuid)}))
+            "Mobile keeps its own stack; pipeline must not also go back."))
+      (finally
+        (state/replace-state! original-state)))))
+
+(deftest recycling-current-block-goes-to-previous-route-test
+  (let [original-state (state/get-state)
+        block-uuid (random-uuid)]
+    (try
+      (state/replace-state! {:client-id "client"})
+      (is (= [:previous]
+             (invoke-delete-hooks
+              {:current-page (str block-uuid)
+               :delta {:graph-id "delete-nav-test"
+                       :rev 14
+                       :blocks {block-uuid {:db/id 99
+                                            :block/uuid block-uuid
+                                            :logseq.property/deleted-at 1}}
+                       :deleted {}
+                       :children {}
+                       :affected-keys #{[:entity block-uuid]}}}))
+          "Deleting the focused block also returns to the previous page/block.")
+      (finally
+        (state/replace-state! original-state)))))
+
+(deftest recycling-current-page-during-initial-pages-does-not-navigate-test
+  (let [original-state (state/get-state)
+        page-uuid (random-uuid)]
+    (try
+      (state/replace-state! {:client-id "client"})
+      (is (= []
+             (invoke-delete-hooks
+              {:current-page (str page-uuid)
+               :delta (recycled-page-delta page-uuid)
+               :tx-meta {:initial-pages? true}}))
+          "Graph load must not treat recycled pages as a user delete navigation.")
       (finally
         (state/replace-state! original-state)))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes [db-test#1135](https://github.com/logseq/db-test/issues/1135).

After deleting the page (or focused block) you are viewing, Logseq now returns to the previously visited page/block in history instead of sending you home.

Deleting a page that is not the current route does not change navigation.

## Behavior

- Recycle or hard-delete of the **current** page/block → `history.back()` to the previous page/block.
- No previous history entry → replace the current entry with home (does not create today's journal).
- Delete of a **non-current** page → no navigation.
- Mobile is left to its own stack. The mobile header delete handler already calls `history.back`; the pipeline does not also go back (avoids a double pop after #13153).

## Tests

- `frontend.modules.outliner.pipeline-test` covers current vs non-current recycle/hard-delete, focused-block delete, mobile skip, and graph-load (`:initial-pages?`).
- `frontend.handler.route-test` covers history-back vs home fallback.

## Notes

#13153 already replaced the hardcoded home redirect with `history.back`. This follow-up unifies that path, adds the empty-history fallback, stops mobile double-back on recycle, and adds tests. It does not change #1137 or #1139.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3cc4318-4816-4ab0-a204-3f7eafcc03ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3cc4318-4816-4ab0-a204-3f7eafcc03ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

