### PR TITLE
fix: do not insert nil blocks from empty tag templates

### DIFF
--- a/src/main/frontend/worker/pipeline.cljs
+++ b/src/main/frontend/worker/pipeline.cljs
@@ -109,8 +109,9 @@
                              journal-page
                              (map (fn [t] (assoc t :journal journal-page))))))
         raw-template-blocks (fn [template]
-                              (let [template-children (rest (ldb/get-block-and-children db (:block/uuid template)
-                                                                                        {:include-property-block? true}))]
+                              ;; Skip childless templates; (assoc nil ...) would create a nil-title block.
+                              (when-let [template-children (seq (rest (ldb/get-block-and-children db (:block/uuid template)
+                                                                                                  {:include-property-block? true})))]
                                 (->> (cons (assoc (first template-children)
                                                   :logseq.property/used-template (:db/id template))
                                            (rest template-children))

--- a/src/main/frontend/worker/pipeline.cljs
+++ b/src/main/frontend/worker/pipeline.cljs
@@ -110,8 +110,8 @@
                              (map (fn [t] (assoc t :journal journal-page))))))
         raw-template-blocks (fn [template]
                               ;; Skip childless templates; (assoc nil ...) would create a nil-title block.
-                              (when-let [template-children (seq (rest (ldb/get-block-and-children db (:block/uuid template)
-                                                                                                  {:include-property-block? true})))]
+                              (when-let [template-children (next (ldb/get-block-and-children db (:block/uuid template)
+                                                                                            {:include-property-block? true}))]
                                 (->> (cons (assoc (first template-children)
                                                   :logseq.property/used-template (:db/id template))
                                            (rest template-children))

--- a/src/test/frontend/worker/pipeline_test.cljs
+++ b/src/test/frontend/worker/pipeline_test.cljs
@@ -1152,3 +1152,84 @@
               "No :logseq.property.history entries are added for an imported transaction")))
       (finally
         (ldb/register-transact-pipeline-fn! identity)))))
+
+(deftest empty-tag-template-on-asset-allows-asset-create-test
+  (testing "inserting an asset succeeds when a childless Template is applied to Asset"
+    (let [conn (db-test/create-conn-with-blocks
+                {:pages-and-blocks
+                 [{:page {:block/title "Home"}}
+                  {:page {:block/title "Templates"}
+                   :blocks [{:block/title "empty asset template"
+                             :build/tags [:logseq.class/Template]}]}]})
+          home (ldb/get-page @conn "Home")
+          template-root (db-test/find-block-by-content @conn "empty asset template")
+          asset-class (d/entity @conn :logseq.class/Asset)
+          asset-uuid (random-uuid)]
+      (ldb/transact! conn [[:db/add (:db/id template-root)
+                            :logseq.property/template-applied-to
+                            (:db/id asset-class)]])
+      (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
+      (try
+        (outliner-op/apply-ops! conn
+                                [[:insert-blocks [[{:block/uuid asset-uuid
+                                                    :block/title "ableton"
+                                                    :block/tags #{:logseq.class/Asset}
+                                                    :logseq.property.asset/type "png"
+                                                    :logseq.property.asset/size 10
+                                                    :logseq.property.asset/checksum "abc123"}]
+                                                  (:block/uuid home)
+                                                  {:outliner-op :insert-blocks
+                                                   :keep-uuid? true
+                                                   :bottom? true}]]]
+                                {})
+        (let [asset (d/entity @conn [:block/uuid asset-uuid])]
+          (is (some? asset)
+              "The asset block is stored")
+          (is (= "ableton" (:block/title asset)))
+          (is (= "png" (:logseq.property.asset/type asset)))
+          (is (contains? (set (map :db/ident (:block/tags asset))) :logseq.class/Asset))
+          (is (empty? (filter :logseq.property/used-template (:block/_parent asset)))
+              "A childless template does not invent a used-template child")
+          (is (not-any? #(nil? (:block/title %)) (:block/_parent asset))
+              "No nil-title child is created under the asset"))
+        (finally
+          (ldb/register-transact-pipeline-fn! identity)))))
+
+  (testing "a template with children still inserts them under the new asset"
+    (let [conn (db-test/create-conn-with-blocks
+                {:pages-and-blocks
+                 [{:page {:block/title "Home"}}
+                  {:page {:block/title "Templates"}
+                   :blocks [{:block/title "asset caption template"
+                             :build/tags [:logseq.class/Template]
+                             :build/children [{:block/title "caption"}]}]}]})
+          home (ldb/get-page @conn "Home")
+          template-root (db-test/find-block-by-content @conn "asset caption template")
+          asset-class (d/entity @conn :logseq.class/Asset)
+          asset-uuid (random-uuid)]
+      (ldb/transact! conn [[:db/add (:db/id template-root)
+                            :logseq.property/template-applied-to
+                            (:db/id asset-class)]])
+      (ldb/register-transact-pipeline-fn! worker-pipeline/transact-pipeline)
+      (try
+        (outliner-op/apply-ops! conn
+                                [[:insert-blocks [[{:block/uuid asset-uuid
+                                                    :block/title "ableton"
+                                                    :block/tags #{:logseq.class/Asset}
+                                                    :logseq.property.asset/type "png"
+                                                    :logseq.property.asset/size 10
+                                                    :logseq.property.asset/checksum "abc123"}]
+                                                  (:block/uuid home)
+                                                  {:outliner-op :insert-blocks
+                                                   :keep-uuid? true
+                                                   :bottom? true}]]]
+                                {})
+        (let [asset (d/entity @conn [:block/uuid asset-uuid])
+              caption (db-test/find-block-by-content @conn "caption")]
+          (is (some? asset))
+          (is (some? caption))
+          (is (= (:db/id asset) (:db/id (:block/parent caption))))
+          (is (= (:db/id template-root)
+                 (:db/id (:logseq.property/used-template caption)))))
+        (finally
+          (ldb/register-transact-pipeline-fn! identity))))))

--- a/src/test/frontend/worker/pipeline_test.cljs
+++ b/src/test/frontend/worker/pipeline_test.cljs
@@ -1225,11 +1225,13 @@
                                                    :bottom? true}]]]
                                 {})
         (let [asset (d/entity @conn [:block/uuid asset-uuid])
-              caption (db-test/find-block-by-content @conn "caption")]
+              inserted (->> (:block/_parent asset)
+                            (filter #(= "caption" (:block/title %)))
+                            first)]
           (is (some? asset))
-          (is (some? caption))
-          (is (= (:db/id asset) (:db/id (:block/parent caption))))
+          (is (some? inserted)
+              "Template children are copied under the new asset")
           (is (= (:db/id template-root)
-                 (:db/id (:logseq.property/used-template caption)))))
+                 (:db/id (:logseq.property/used-template inserted)))))
         (finally
           (ldb/register-transact-pipeline-fn! identity))))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Uploading an asset failed in a new graph once a childless Template was applied to the private `Asset` tag. Datascript rejected the transaction with `Cannot store nil as a value`, so the Assets page stayed empty while the file was already on disk.

This matches [db-test#1139](https://github.com/logseq/db-test/issues/1139). Demo graphs were unaffected because they have no template applied to Asset.

## Cause

`insert-tag-templates` copies a tag's applied-template children under the new `#Asset` block. For a childless template it did `(assoc nil :logseq.property/used-template id)`, producing a child with `:block/title nil`. The whole `insert-blocks` tx rolled back. `new-asset-block` had already written the file.

Manual apply-template already skipped empty templates (`template-children-blocks`); the tag-template pipeline did not.

## Fix

Skip childless templates in `raw-template-blocks`, matching the existing apply-template path. An empty template on Asset is now a no-op: the asset is stored and no nil-title child is created.

## Tests

- Empty Template applied to Asset: inserting an asset succeeds, no used-template / nil-title child
- Template with children applied to Asset: children still insert under the new asset

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ee92ec4-3afa-4830-8f96-f1fdc5c11011?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ee92ec4-3afa-4830-8f96-f1fdc5c11011&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

