### PR TITLE
fix: mirror the Contents page to markdown

### DIFF
--- a/src/main/frontend/worker/markdown_mirror.cljs
+++ b/src/main/frontend/worker/markdown_mirror.cljs
@@ -531,10 +531,16 @@
    (block-content db (:block/uuid page) {:include-page-properties? true} options)
    options))
 
+(defn- contents-page?
+  "The Contents page is created as built-in but holds ordinary user blocks."
+  [page]
+  (= "contents" (:block/name page)))
+
 (defn- mirrorable-page?
   [page]
   (and (ldb/page? page)
-       (not (ldb/built-in? page))
+       (or (not (ldb/built-in? page))
+           (contents-page? page))
        (not (ldb/property? page))
        (not (ldb/hidden? page))
        (not (:logseq.property.user/email page))))

--- a/src/test/frontend/worker/markdown_mirror_test.cljs
+++ b/src/test/frontend/worker/markdown_mirror_test.cljs
@@ -48,6 +48,14 @@
 (defn- first-block [page]
   (-> page :block/_page first))
 
+(defn- add-child-block!
+  [conn page title]
+  (d/transact! conn [{:block/uuid (random-uuid)
+                      :block/title title
+                      :block/page (:db/id page)
+                      :block/parent (:db/id page)
+                      :block/order "a0"}]))
+
 (defn- <mirror-repo!
   [& args]
   (if-let [f (resolve 'frontend.worker.markdown-mirror/<mirror-repo!)]
@@ -787,7 +795,12 @@
                                   "- class")
                              (get @files (page-path "pages/Project.md")))))
                     (is (nil? (get @files (page-path "pages/Built In.md"))))
-                    (is (nil? (get @files (page-path "pages/rating.md"))))))
+                    (is (nil? (get @files (page-path "pages/rating.md"))))
+                    (is (nil? (get @files (page-path "pages/Library.md"))))
+                    (is (nil? (get @files (page-path "pages/Quick add.md"))))
+                    (let [contents (db-test/find-page-by-title @conn "Contents")]
+                      (is (true? (ldb/built-in? contents)))
+                      (is (some? (get @files (page-path "pages/Contents.md")))))))
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
           (p/finally done)))))
 
@@ -1070,3 +1083,110 @@
                     (is (empty? @writes))))
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
           (p/finally done)))))
+
+(deftest contents-page-is-mirrored-despite-built-in-flag-test
+  (async done
+    (let [{:keys [platform files writes]} (fake-platform)
+          conn (db-test/create-conn-with-blocks
+                {:pages-and-blocks [{:page {:block/title "Page A"}
+                                     :blocks [{:block/title "alpha"}]}]})
+          contents (db-test/find-page-by-title @conn "Contents")
+          _ (add-child-block! conn contents "sidebar notes")]
+      (is (true? (ldb/built-in? contents)))
+      (is (false? (ldb/hidden? contents)))
+      (-> (markdown-mirror/<mirror-page! test-repo @conn (:db/id contents) {:platform platform})
+          (p/then (fn [result]
+                    (let [path (page-path "pages/Contents.md")
+                          content (str (page-marker (:block/uuid contents)) "\n\n"
+                                       "- sidebar notes")]
+                      (is (= :written (:status result)))
+                      (is (= content (get @files path)))
+                      (is (= [[path content]] @writes)))))
+          (p/catch (fn [e] (is false (str "unexpected error: " e))))
+          (p/finally done)))))
+
+(deftest internal-built-in-and-hidden-pages-are-not-mirrored-test
+  (async done
+    (let [{:keys [platform files writes]} (fake-platform)
+          conn (db-test/create-conn-with-blocks
+                {:properties {:rating {:logseq.property/type :default}}
+                 :pages-and-blocks [{:page {:block/title "Hidden User"
+                                            :build/properties {:logseq.property/hide? true}}
+                                     :blocks [{:block/title "secret"}]}]})
+          library (db-test/find-page-by-title @conn "Library")
+          quick-add (db-test/find-page-by-title @conn "Quick add")
+          recycle (db-test/find-page-by-title @conn "Recycle")
+          hidden-user (db-test/find-page-by-title @conn "Hidden User")
+          rating (db-test/find-page-by-title @conn "rating")]
+      (is (true? (ldb/built-in? library)))
+      (is (true? (ldb/built-in? quick-add)))
+      (is (true? (ldb/hidden? quick-add)))
+      (is (true? (ldb/hidden? recycle)))
+      (is (true? (ldb/hidden? hidden-user)))
+      (is (true? (ldb/property? rating)))
+      (-> (p/all [(markdown-mirror/<mirror-page! test-repo @conn (:db/id library) {:platform platform})
+                  (markdown-mirror/<mirror-page! test-repo @conn (:db/id quick-add) {:platform platform})
+                  (markdown-mirror/<mirror-page! test-repo @conn (:db/id recycle) {:platform platform})
+                  (markdown-mirror/<mirror-page! test-repo @conn (:db/id hidden-user) {:platform platform})
+                  (markdown-mirror/<mirror-page! test-repo @conn (:db/id rating) {:platform platform})])
+          (p/then (fn [results]
+                    (is (every? (fn [result]
+                                  (and (= :skipped (:status result))
+                                       (= :excluded-page (:reason result))))
+                                results))
+                    (is (empty? @writes))
+                    (is (nil? (get @files (page-path "pages/Library.md"))))
+                    (is (nil? (get @files (page-path "pages/Quick add.md"))))
+                    (is (nil? (get @files (page-path "pages/Recycle.md"))))
+                    (is (nil? (get @files (page-path "pages/Hidden User.md"))))
+                    (is (nil? (get @files (page-path "pages/rating.md"))))))
+          (p/catch (fn [e] (is false (str "unexpected error: " e))))
+          (p/finally done)))))
+
+(deftest contents-page-edit-updates-mirror-without-deleting-test
+  (async done
+    (let [{:keys [platform files deletes]} (fake-platform)
+          conn (db-test/create-conn-with-blocks
+                {:pages-and-blocks [{:page {:block/title "Page A"}
+                                     :blocks [{:block/title "alpha"}]}]})
+          contents (db-test/find-page-by-title @conn "Contents")
+          _ (add-child-block! conn contents "before")
+          block (db-test/find-block-by-content @conn "before")
+          path (page-path "pages/Contents.md")
+          _ (swap! files assoc path (str (page-marker (:block/uuid contents)) "\n\n"
+                                         "- before"))
+          tx-report (d/with @conn [{:db/id (:db/id block)
+                                    :block/title "after"}])
+          _ (d/reset-conn! conn (:db-after tx-report))]
+      (markdown-mirror/set-enabled! test-repo true)
+      (-> (markdown-mirror/<handle-tx-report! test-repo conn tx-report {:platform platform})
+          (p/then (fn [_]
+                    (is (empty? @deletes))
+                    (is (= (str (page-marker (:block/uuid contents)) "\n\n"
+                                "- after")
+                           (get @files path)))))
+          (p/catch (fn [e] (is false (str "unexpected error: " e))))
+          (p/finally done)))))
+
+(deftest unrelated-page-tx-does-not-delete-contents-mirror-test
+  (async done
+    (let [{:keys [platform files deletes]} (fake-platform)
+          conn (db-test/create-conn-with-blocks
+                {:pages-and-blocks [{:page {:block/title "Page A"}
+                                     :blocks [{:block/title "before"}]}]})
+          contents (db-test/find-page-by-title @conn "Contents")
+          page (db-test/find-page-by-title @conn "Page A")
+          block (first-block page)
+          contents-path (page-path "pages/Contents.md")
+          contents-content (str (page-marker (:block/uuid contents)) "\n\n"
+                                "- sidebar notes")
+          _ (swap! files assoc contents-path contents-content)
+          tx-report (d/with @conn [{:db/id (:db/id block)
+                                    :block/title "after"}])]
+      (markdown-mirror/set-enabled! test-repo true)
+      (-> (markdown-mirror/<handle-tx-report! test-repo conn tx-report {:platform platform})
+          (p/then (fn [_]
+                    (is (not (some #{contents-path} @deletes)))
+                    (is (= contents-content (get @files contents-path)))))
+          (p/catch (fn [e] (is false (str "unexpected error: " e))))
+          (p/finally done))))))

--- a/src/test/frontend/worker/markdown_mirror_test.cljs
+++ b/src/test/frontend/worker/markdown_mirror_test.cljs
@@ -1189,4 +1189,4 @@
                     (is (not (some #{contents-path} @deletes)))
                     (is (= contents-content (get @files contents-path)))))
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
-          (p/finally done))))))
+          (p/finally done)))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes logseq/db-test#1144

## Root cause

`mirrorable-page?` excluded every page with `:logseq.property/built-in? true`. The Contents page is seeded as a built-in page (alongside Library and Quick add) but holds ordinary user blocks. That made `<mirror-page!` return `{:status :skipped :reason :excluded-page}` and omitted Contents from full regeneration, so user content never reached `mirror/markdown/pages/Contents.md`.

## Change

Keep excluding built-in, hidden, property, and user-email pages. Allow the Contents page by `:block/name` (`"contents"`). `deleted-page?` and `page-job` already use the same predicate, so Contents stays a write/update job instead of a delete on later txs.

## Tests

- Contents is mirrored to `pages/Contents.md` even when `built-in?` is true
- Library, Quick add, Recycle, hidden user pages, and property pages still skip with `:excluded-page`
- Full regeneration writes Contents and still omits Library / Quick add / built-in / property pages
- Editing Contents updates the mirror without deleting it
- An unrelated page tx does not delete a pre-existing Contents mirror

`bb lint:dev` passed. `frontend.worker.markdown-mirror-test` passed: 48 tests, 98 assertions, 0 failures.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de63dbaf-df2f-423b-8b9d-c01cc800f031?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de63dbaf-df2f-423b-8b9d-c01cc800f031&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

