### PR TITLE
fix: arrow keys skip empty icon bottom-property row

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -3055,12 +3055,38 @@
                             trigger-bottom-pill-edit!))}
        (ui/icon "edit" {:size 15})])]]))
 
+(defn- hidden-block-below-property?
+  "Icon is rendered on the block itself, never as a bottom pill."
+  [property]
+  (or (= :logseq.property/icon property)
+      (= :logseq.property/icon (:db/ident property))))
+
+(defn- property-item-uuid
+  [property]
+  (cond
+    (uuid? property) property
+    (map? property) (:block/uuid property)))
+
+(defn- visible-block-below-property-uuids
+  [property-uuids]
+  (into [] (remove hidden-block-below-property?) property-uuids))
+
+(defn- show-block-below-properties-row?
+  [visible-property-uuids {:keys [show-hidden-properties-pill-toggle?
+                                  show-hidden-properties-control?
+                                  show-add-property-button?]}]
+  (boolean
+   (or (seq visible-property-uuids)
+       show-hidden-properties-pill-toggle?
+       show-hidden-properties-control?
+       show-add-property-button?)))
+
 (hsx/defc positioned-property-row
   [block property-uuid opts]
   (let [property (db-hooks/use-block property-uuid)]
     (when (and property
                (not (and (= :block-below (:property-position opts))
-                         (= :logseq.property/icon (:db/ident property)))))
+                         (hidden-block-below-property? property))))
       (if (= :block-below (:property-position opts))
         (bottom-property-pill-cp block property opts)
         (pv/property-value block property (assoc opts :show-tooltip? true))))))
@@ -3127,7 +3153,7 @@
                   "flex-wrap overflow-x-hidden"
                   "flex-nowrap overflow-x-hidden")])
        :data-expanded (str expanded?)
-       :data-bottom-properties-row (:block/uuid block)
+       :data-bottom-properties-row (str (:block/uuid block))
        :tab-index -1
        :on-key-down handle-bottom-properties-row-key-down!}
       [:div.bottom-properties-pills-strip.flex.flex-row.gap-2.items-center.min-w-0.flex-1.basis-0
@@ -3153,6 +3179,43 @@
                                                      :icon-only? true
                                                      :tab-index 0)))]]))
 
+(hsx/defc block-below-positioned-properties-gate
+  [block property-uuids opts show-hidden-properties-pill-toggle? show-hidden-properties-control? show-add-property-button?]
+  (let [property-item-uuids (into [] (keep property-item-uuid) property-uuids)
+        resolved-properties (db-hooks/use-blocks property-item-uuids)
+        all-identifiable? (and (seq property-uuids)
+                               (every? (fn [property]
+                                         (or (keyword? property)
+                                             (some? (:db/ident property))))
+                                       property-uuids))
+        visible-property-uuids
+        (cond
+          all-identifiable?
+          (into [] (keep property-item-uuid) (visible-block-below-property-uuids property-uuids))
+
+          (nil? resolved-properties)
+          nil
+
+          :else
+          (into []
+                (keep (fn [property]
+                        (when (and property
+                                   (not (hidden-block-below-property? property)))
+                          (:block/uuid property))))
+                resolved-properties))]
+    (when (and (some? visible-property-uuids)
+               (show-block-below-properties-row?
+                visible-property-uuids
+                {:show-hidden-properties-pill-toggle? show-hidden-properties-pill-toggle?
+                 :show-hidden-properties-control? show-hidden-properties-control?
+                 :show-add-property-button? show-add-property-button?}))
+      [block-below-positioned-properties-cp block
+       visible-property-uuids
+       opts
+       show-hidden-properties-pill-toggle?
+       show-hidden-properties-control?
+       show-add-property-button?])))
+
 (hsx/defc positioned-properties-content
   [config block position property-uuids]
   (let [opts (merge config
@@ -3177,7 +3240,8 @@
         show-add-property-button? show-page-add-property?]
     (case position
         :block-below
-        [block-below-positioned-properties-cp block
+        [block-below-positioned-properties-gate
+         block
          property-uuids
          opts
          show-hidden-properties-pill-toggle?

--- a/src/main/frontend/components/icon.cljs
+++ b/src/main/frontend/components/icon.cljs
@@ -383,6 +383,11 @@
         {:id :icons-color-picker}
         (content-fn)))))
 
+(defn- icon-search-keydown
+  [^js e]
+  (when (contains? #{"ArrowLeft" "ArrowRight"} (.-key e))
+    (util/stop-propagation e)))
+
 (hsx/defc ^:large-vars/cleanup-todo icon-search
   [{:keys [on-chosen del-btn? color-auto-chosen? icon-value] :as opts}]
   (let [[q set-q!] (hooks/use-state "")
@@ -422,7 +427,8 @@
          (set-tab! tab)))
      [tab default-tab])
     [:div.cp__emoji-icon-picker
-     {:data-keep-selection true}
+     {:data-keep-selection true
+      :on-key-down icon-search-keydown}
      ;; header
      [:div.hd.bg-popover
       (tab-observer tab {:reset-q! reset-q!})

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2696,8 +2696,11 @@
   (some-> node (.closest ".bottom-properties-row")))
 
 (defn- bottom-properties-row-in-block
+  "Find the bottom-properties row owned by this block, not a descendant child."
   [block-node]
-  (some-> block-node (.querySelector ".bottom-properties-row")))
+  (when-let [block-id (node-attr block-node "blockid")]
+    (some-> block-node
+            (.querySelector (str "[data-bottom-properties-row=\"" block-id "\"]")))))
 
 (defn- focus-bottom-properties-row!
   [row]

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2695,13 +2695,6 @@
   [node]
   (some-> node (.closest ".bottom-properties-row")))
 
-(defn- bottom-properties-row-in-block
-  "Find the bottom-properties row owned by this block, not a descendant child."
-  [block-node]
-  (when-let [block-id (node-attr block-node "blockid")]
-    (some-> block-node
-            (.querySelector (str "[data-bottom-properties-row=\"" block-id "\"]")))))
-
 (defn- focus-bottom-properties-row!
   [row]
   (when row
@@ -2714,6 +2707,13 @@
   (or (some-> node (gobj/get attr))
       (when (and node (gobj/get node "getAttribute"))
         (dom/attr node attr))))
+
+(defn- bottom-properties-row-in-block
+  "Find the bottom-properties row owned by this block, not a descendant child."
+  [block-node]
+  (when-let [block-id (node-attr block-node "blockid")]
+    (some-> block-node
+            (.querySelector (str "[data-bottom-properties-row=\"" block-id "\"]")))))
 
 (defn- comment-item-node?
   [node]

--- a/src/test/frontend/components/block/positioned_properties_test.cljs
+++ b/src/test/frontend/components/block/positioned_properties_test.cljs
@@ -1,0 +1,126 @@
+(ns frontend.components.block.positioned-properties-test
+  (:require ["react" :as react]
+            ["react-dom/server" :as react-dom-server]
+            [cljs.test :refer [deftest is testing]]
+            [clojure.string :as string]
+            [frontend.components.block :as block]
+            [frontend.components.property :as property-component]
+            [frontend.components.property.value :as property-value]
+            [frontend.db.hooks :as db-hooks]
+            [goog.object :as gobj]
+            [logseq.shui.hooks :as hooks]))
+
+(defn- render-static
+  [element]
+  (let [previous-react (gobj/get js/globalThis "React")]
+    (gobj/set js/globalThis "React" react)
+    (try
+      (.renderToStaticMarkup react-dom-server element)
+      (finally
+        (if (some? previous-react)
+          (gobj/set js/globalThis "React" previous-react)
+          (js-delete js/globalThis "React"))))))
+
+(defn- render-block-below
+  [block properties property-by-uuid]
+  (with-redefs [property-component/use-has-hidden-properties (constantly false)
+                db-hooks/use-blocks (fn [property-uuids]
+                                      (mapv property-by-uuid property-uuids))
+                db-hooks/use-block (fn [property-uuid]
+                                     (property-by-uuid property-uuid))
+                property-component/property-key-cp (fn [_block property _opts]
+                                                     [:span.property-key (:block/title property)])
+                property-value/property-value (fn [_block property _opts]
+                                                [:span.property-value (:db/ident property)])
+                hooks/use-ref (fn [_] #js {:current nil})
+                hooks/use-memo (fn [f _deps] (f))
+                hooks/use-atom (fn [a] [@a (fn [_])])
+                hooks/use-state (fn [init] [init (fn [_])])
+                hooks/use-effect! (fn [_f _deps] nil)]
+    (render-static
+     (block/block-positioned-properties
+      {}
+      (assoc block :block.temp/positioned-properties {:block-below properties})
+      :block-below))))
+
+(deftest hidden-block-below-property-skips-icon
+  (testing "icon is never a visible block-below pill"
+    (is (true? (#'block/hidden-block-below-property? :logseq.property/icon)))
+    (is (true? (#'block/hidden-block-below-property? {:db/ident :logseq.property/icon})))
+    (is (false? (#'block/hidden-block-below-property? {:db/ident :logseq.property/scheduled}))))
+  (testing "icon-only lists collapse to no visible pills"
+    (is (= []
+           (#'block/visible-block-below-property-uuids
+            [{:db/ident :logseq.property/icon}
+             :logseq.property/icon])))
+    (is (= [{:db/ident :logseq.property/scheduled}]
+           (#'block/visible-block-below-property-uuids
+            [{:db/ident :logseq.property/icon}
+             {:db/ident :logseq.property/scheduled}]))))
+  (testing "empty pill lists still render when another bottom control is present"
+    (is (false? (#'block/show-block-below-properties-row? [] {})))
+    (is (true? (#'block/show-block-below-properties-row?
+                []
+                {:show-add-property-button? true})))
+    (is (true? (#'block/show-block-below-properties-row?
+                [:logseq.property/scheduled]
+                {})))))
+
+(deftest icon-only-block-does-not-emit-bottom-properties-row
+  (let [icon-uuid #uuid "11111111-1111-1111-1111-111111111111"
+        block-uuid #uuid "22222222-2222-2222-2222-222222222222"
+        icon-property {:block/uuid icon-uuid
+                       :db/ident :logseq.property/icon
+                       :block/title "Icon"
+                       :logseq.property/type :map}
+        markup (render-block-below
+                {:block/uuid block-uuid
+                 :block/title "icon block"}
+                [icon-uuid]
+                {icon-uuid icon-property})]
+    (is (not (string/includes? markup "bottom-properties-row"))
+        "An icon-only block must not emit a focusable bottom-properties row")
+    (is (not (string/includes? markup "data-bottom-properties-row"))
+        "An icon-only block is not a keyboard navigation stop")))
+
+(deftest icon-map-block-does-not-emit-bottom-properties-row
+  (let [icon-uuid #uuid "33333333-3333-3333-3333-333333333333"
+        block-uuid #uuid "44444444-4444-4444-4444-444444444444"
+        icon-property {:block/uuid icon-uuid
+                       :db/ident :logseq.property/icon
+                       :block/title "Icon"
+                       :logseq.property/type :map}
+        markup (render-block-below
+                {:block/uuid block-uuid
+                 :block/title "icon block"}
+                [icon-property]
+                {icon-uuid icon-property})]
+    (is (not (string/includes? markup "bottom-properties-row"))
+        "Icon property maps are filtered before the bottom row mounts")))
+
+(deftest scheduled-block-below-property-still-renders
+  (let [scheduled-uuid #uuid "55555555-5555-5555-5555-555555555555"
+        icon-uuid #uuid "66666666-6666-6666-6666-666666666666"
+        block-uuid #uuid "77777777-7777-7777-7777-777777777777"
+        scheduled-property {:block/uuid scheduled-uuid
+                            :db/ident :logseq.property/scheduled
+                            :block/title "Scheduled"
+                            :logseq.property/type :datetime}
+        icon-property {:block/uuid icon-uuid
+                       :db/ident :logseq.property/icon
+                       :block/title "Icon"
+                       :logseq.property/type :map}
+        markup (render-block-below
+                {:block/uuid block-uuid
+                 :block/title "dated block"}
+                [icon-uuid scheduled-uuid]
+                {icon-uuid icon-property
+                 scheduled-uuid scheduled-property})]
+    (is (string/includes? markup "bottom-properties-row")
+        "Real block-below properties still mount a bottom-properties row")
+    (is (string/includes? markup (str "data-bottom-properties-row=\"" block-uuid "\""))
+        "The row is owned by the current block uuid")
+    (is (string/includes? markup "Scheduled")
+        "The scheduled pill is visible")
+    (is (not (string/includes? markup "Icon"))
+        "Icon is not rendered as a bottom pill")))

--- a/src/test/frontend/components/icon_test.cljs
+++ b/src/test/frontend/components/icon_test.cljs
@@ -2,6 +2,24 @@
   (:require [cljs.test :refer [deftest is testing]]
             [frontend.components.icon :as icon]))
 
+(deftest icon-search-keeps-horizontal-arrows-inside-picker
+  (doseq [key ["ArrowLeft" "ArrowRight"]]
+    (testing key
+      (let [event (js/Event. "keydown" #js {:bubbles true :cancelable true})]
+        (set! (.-key event) key)
+        (#'icon/icon-search-keydown event)
+        (is (.-cancelBubble event)
+            "Horizontal arrows must not reach editor navigation")
+        (is (not (.-defaultPrevented event))
+            "Search input caret movement must retain its native behavior"))))
+  (doseq [key ["Escape" "Enter" "Tab" "a"]]
+    (testing key
+      (let [event (js/Event. "keydown" #js {:bubbles true :cancelable true})]
+        (set! (.-key event) key)
+        (#'icon/icon-search-keydown event)
+        (is (not (.-cancelBubble event)))
+        (is (not (.-defaultPrevented event)))))))
+
 (deftest node-icon-precedence-matches-sidebar-and-command-results-test
   (let [own-icon {:type :emoji :id "sparkles"}
         tag-icon {:type :tabler-icon :id "rocket" :color "#ff0000"}

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -2575,3 +2575,30 @@
       (#'editor/enter-comments-area-node! comments-node)
       (is (= [comments-node] @selected)
           "Collapsed comments should be selected for keyboard shortcuts"))))
+
+(deftest bottom-properties-row-in-block-matches-owned-row-only-test
+  (let [parent-id (str #uuid "11111111-1111-1111-1111-111111111111")
+        child-id (str #uuid "22222222-2222-2222-2222-222222222222")
+        child-row (js-obj "id" "child-row"
+                          "data-bottom-properties-row" child-id)
+        parent-row (js-obj "id" "parent-row"
+                           "data-bottom-properties-row" parent-id)
+        descendant-selector (str "[data-bottom-properties-row=\"" parent-id "\"]")
+        parent-without-own-row
+        (js-obj "blockid" parent-id
+                "querySelector" (fn [selector]
+                                  (cond
+                                    (= selector ".bottom-properties-row") child-row
+                                    (= selector descendant-selector) nil
+                                    :else nil)))
+        parent-with-own-row
+        (js-obj "blockid" parent-id
+                "querySelector" (fn [selector]
+                                  (cond
+                                    (= selector ".bottom-properties-row") child-row
+                                    (= selector descendant-selector) parent-row
+                                    :else nil)))]
+    (is (nil? (#'editor/bottom-properties-row-in-block parent-without-own-row))
+        "A parent must not treat a child icon/bottom row as its own navigation stop")
+    (is (identical? parent-row (#'editor/bottom-properties-row-in-block parent-with-own-row))
+        "A parent still resolves the bottom-properties row it owns")))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes logseq/db-test#1145

Icon-only blocks were classified as `:block-below` (`:logseq.property/icon` is a `:map`) and mounted an empty `.bottom-properties-row` (`tab-index -1`). That invisible row became a Down stop, and `bottom-properties-row-in-block` used `.querySelector(".bottom-properties-row")`, so Up from a child icon block could match the child's row inside the parent.

This change:
- Filters `:logseq.property/icon` out of the block-below list before mounting the row, and skips the row when there are no visible pills and no expand / add-property / hidden-properties controls
- Resolves a block's bottom row by `[data-bottom-properties-row="<uuid>"]` so a parent never owns a child's row
- Leaves Status / Scheduled / other real bottom pills in place

Tests cover icon-only blocks not emitting a nav stop, parent lookup ignoring a child's row, and scheduled still rendering on the bottom row.

Lint and tests:
- `bb lint:dev` passed (clj-kondo 0 errors / 0 warnings, carve, large-vars, worker/frontend split, translations, ns-docstrings)
- `pnpm cljs:test` compiled with 0 warnings
- `frontend.components.block.positioned-properties-test` and `frontend.handler.editor-test`: 86 tests, 230 assertions, 0 failures
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ce871bc-d419-400d-ae70-3628788d1493?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ce871bc-d419-400d-ae70-3628788d1493&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

