### PR TITLE
fix: keep shared default shortcuts when resetting

### DIFF
--- a/src/main/frontend/components/shortcut.cljs
+++ b/src/main/frontend/components/shortcut.cljs
@@ -442,6 +442,38 @@
                       (into #{} (map shortcut-utils/canonicalize-binding) (editable-binding-vec bs)))]
       (= (canon-set binding) (canon-set binding-vec)))))
 
+(defn- default-binding-key-set
+  "Canonical key set from an action's configured default binding."
+  [action-id]
+  (when-let [{:keys [binding]} (dh/shortcut-item action-id)]
+    (into #{} (map shortcut-utils/canonicalize-binding)
+          (editable-binding-vec binding))))
+
+(defn- reset-conflict-update
+  "Build a persist update that strips reset keys from a conflicting action.
+
+   Keys that are also on the peer's default binding are kept so shared
+   defaults (e.g. Backspace on :editor/backspace and :editor/delete-selection)
+   survive reset. User-customized collisions are still stripped.
+
+   Returns nil when the peer should keep its current binding."
+  [conflicting-id their-binding keys-to-strip]
+  (let [peer-default-keys (or (default-binding-key-set conflicting-id) #{})
+        canonical-keys (->> keys-to-strip
+                            (map shortcut-utils/canonicalize-binding)
+                            (remove peer-default-keys)
+                            set)]
+    (when (seq canonical-keys)
+      (let [filtered (vec (remove (fn [b]
+                                    (contains? canonical-keys
+                                               (shortcut-utils/canonicalize-binding b)))
+                                  their-binding))]
+        {:action-id conflicting-id
+         :new-binding (cond
+                        (empty? filtered) []
+                        (matches-default-binding? conflicting-id filtered) nil
+                        :else filtered)}))))
+
 (defn persisted-binding-value
   "Returns the value that should be stored for a shortcut customization."
   [action-id binding-vec]
@@ -577,10 +609,10 @@
 (defn- compute-reset-plan
   "Compute conflict-stripping data needed when resetting a shortcut to default.
    For each key in the default binding, checks if another action currently owns
-   that key and plans to strip it.
+   that key and plans to strip user-customized collisions.
 
-   Returns nil if no conflicts, otherwise a map with:
-   :undo-entries, :conflict-updates"
+   Shared default keys are left on peer commands. Returns nil when nothing
+   should be stripped, otherwise a map with :undo-entries and :conflict-updates."
   [action-id handler-id default-binding current-binding]
   (let [all-conflicts
         (for [b default-binding
@@ -599,24 +631,19 @@
         conflicts-by-id
         (reduce (fn [acc {:keys [conflicting-id accepted-key]}]
                   (update acc conflicting-id (fnil conj #{}) accepted-key))
-                {} all-conflicts)]
-    (when (seq conflicts-by-id)
-      (let [conflict-updates
-            (for [[conflicting-id keys-to-strip] conflicts-by-id]
-              (let [their-binding (dh/shortcut-binding conflicting-id)
-                    canonical-keys (set (map shortcut-utils/canonicalize-binding keys-to-strip))
-                    filtered (vec (remove (fn [b]
-                                            (contains? canonical-keys
-                                                       (shortcut-utils/canonicalize-binding b)))
-                                          their-binding))]
-                {:action-id conflicting-id
-                 :new-binding (cond
-                                (empty? filtered) []
-                                (matches-default-binding? conflicting-id filtered) nil
-                                :else filtered)}))
+                {} all-conflicts)
+        conflict-updates
+        (keep (fn [[conflicting-id keys-to-strip]]
+                (reset-conflict-update conflicting-id
+                                       (dh/shortcut-binding conflicting-id)
+                                       keys-to-strip))
+              conflicts-by-id)]
+    (when (seq conflict-updates)
+      (let [updated-ids (into #{} (map :action-id) conflict-updates)
             undo-entries
             (into [{:action-id action-id :previous-binding current-binding}]
-                  (for [[conflicting-id _] conflicts-by-id]
+                  (for [conflicting-id (keys conflicts-by-id)
+                        :when (contains? updated-ids conflicting-id)]
                     {:action-id conflicting-id
                      :previous-binding (dh/shortcut-binding conflicting-id)}))]
         {:undo-entries undo-entries

--- a/src/main/frontend/components/shortcut.cljs
+++ b/src/main/frontend/components/shortcut.cljs
@@ -433,21 +433,17 @@
                (.preventDefault e)
                false)))}}))))
 
+(defn- canonical-binding-set
+  [binding]
+  (into #{} (map shortcut-utils/canonicalize-binding)
+        (editable-binding-vec binding)))
+
 (defn- matches-default-binding?
   "Check if a binding vector matches the default binding for an action.
    Uses canonical comparison to handle platform-dependent modifier aliases."
   [action-id binding-vec]
   (when-let [{:keys [binding]} (dh/shortcut-item action-id)]
-    (let [canon-set (fn [bs]
-                      (into #{} (map shortcut-utils/canonicalize-binding) (editable-binding-vec bs)))]
-      (= (canon-set binding) (canon-set binding-vec)))))
-
-(defn- default-binding-key-set
-  "Canonical key set from an action's configured default binding."
-  [action-id]
-  (when-let [{:keys [binding]} (dh/shortcut-item action-id)]
-    (into #{} (map shortcut-utils/canonicalize-binding)
-          (editable-binding-vec binding))))
+    (= (canonical-binding-set binding) (canonical-binding-set binding-vec))))
 
 (defn- reset-conflict-update
   "Build a persist update that strips reset keys from a conflicting action.
@@ -458,7 +454,7 @@
 
    Returns nil when the peer should keep its current binding."
   [conflicting-id their-binding keys-to-strip]
-  (let [peer-default-keys (or (default-binding-key-set conflicting-id) #{})
+  (let [peer-default-keys (canonical-binding-set (:binding (dh/shortcut-item conflicting-id)))
         canonical-keys (->> keys-to-strip
                             (map shortcut-utils/canonicalize-binding)
                             (remove peer-default-keys)

--- a/src/main/frontend/components/shortcut.cljs
+++ b/src/main/frontend/components/shortcut.cljs
@@ -639,11 +639,9 @@
                                        keys-to-strip))
               conflicts-by-id)]
     (when (seq conflict-updates)
-      (let [updated-ids (into #{} (map :action-id) conflict-updates)
-            undo-entries
+      (let [undo-entries
             (into [{:action-id action-id :previous-binding current-binding}]
-                  (for [conflicting-id (keys conflicts-by-id)
-                        :when (contains? updated-ids conflicting-id)]
+                  (for [{conflicting-id :action-id} conflict-updates]
                     {:action-id conflicting-id
                      :previous-binding (dh/shortcut-binding conflicting-id)}))]
         {:undo-entries undo-entries

--- a/src/test/frontend/components/shortcut_test.cljs
+++ b/src/test/frontend/components/shortcut_test.cljs
@@ -1,6 +1,8 @@
 (ns frontend.components.shortcut-test
   (:require [cljs.test :refer [deftest is testing]]
             [frontend.components.shortcut :as shortcut]
+            [frontend.modules.shortcut.data-helper :as dh]
+            [frontend.state :as state]
             [frontend.util :as util]))
 
 (deftest test-persisted-binding-value
@@ -22,3 +24,49 @@
 
     (testing "rows without an action id are not editable"
       (is (false? (customizable-shortcut-row? nil false))))))
+
+(deftest test-compute-reset-plan-shared-defaults
+  (let [compute-reset-plan #'shortcut/compute-reset-plan
+        reset-conflict-update #'shortcut/reset-conflict-update
+        conflict-action-ids (fn [plan]
+                              (into #{} (map :action-id) (:conflict-updates plan)))]
+    (testing "resetting Delete Backward keeps shared default Backspace on Delete Selected Block"
+      (let [plan (compute-reset-plan :editor/backspace
+                                     (dh/get-group :editor/backspace)
+                                     ["backspace"]
+                                     [])]
+        (is (not (contains? (conflict-action-ids plan) :editor/delete-selection)))))
+
+    (testing "resetting Delete Selected Block keeps shared defaults on peer commands"
+      (let [plan (compute-reset-plan :editor/delete-selection
+                                     (dh/get-group :editor/delete-selection)
+                                     ["backspace" "delete"]
+                                     [])]
+        (is (not (contains? (conflict-action-ids plan) :editor/backspace)))
+        (is (not (contains? (conflict-action-ids plan) :editor/delete)))))
+
+    (testing "shared default Backspace is not stripped from a peer still using defaults"
+      (is (nil? (reset-conflict-update :editor/delete-selection
+                                       ["backspace" "delete"]
+                                       #{"backspace"}))))
+
+    (testing "user-customized conflict still strips the colliding key"
+      (is (= {:action-id :editor/bold :new-binding []}
+             (reset-conflict-update :editor/bold ["backspace"] #{"backspace"}))))
+
+    (testing "user-customized extra key is stripped while the command's own default remains"
+      (is (= {:action-id :editor/copy :new-binding nil}
+             (reset-conflict-update :editor/copy
+                                    [(if util/mac? "meta+c" "ctrl+c") "backspace"]
+                                    #{"backspace"}))))))
+
+(deftest test-compute-reset-plan-customized-conflict
+  (let [compute-reset-plan #'shortcut/compute-reset-plan]
+    (with-redefs [state/custom-shortcuts (fn [] {:editor/bold ["backspace"]})]
+      (let [plan (compute-reset-plan :editor/backspace
+                                     (dh/get-group :editor/backspace)
+                                     ["backspace"]
+                                     [])]
+        (is (= [{:action-id :editor/bold :new-binding []}]
+               (vec (:conflict-updates plan)))
+            "reset still clears a user-assigned Backspace that is not a peer default")))))

--- a/src/test/frontend/components/shortcut_test.cljs
+++ b/src/test/frontend/components/shortcut_test.cljs
@@ -25,48 +25,14 @@
     (testing "rows without an action id are not editable"
       (is (false? (customizable-shortcut-row? nil false))))))
 
-(deftest test-compute-reset-plan-shared-defaults
-  (let [compute-reset-plan #'shortcut/compute-reset-plan
-        reset-conflict-update #'shortcut/reset-conflict-update
-        conflict-action-ids (fn [plan]
-                              (into #{} (map :action-id) (:conflict-updates plan)))]
-    (testing "resetting Delete Backward keeps shared default Backspace on Delete Selected Block"
-      (let [plan (compute-reset-plan :editor/backspace
-                                     (dh/get-group :editor/backspace)
-                                     ["backspace"]
-                                     [])]
-        (is (not (contains? (conflict-action-ids plan) :editor/delete-selection)))))
-
-    (testing "resetting Delete Selected Block keeps shared defaults on peer commands"
-      (let [plan (compute-reset-plan :editor/delete-selection
-                                     (dh/get-group :editor/delete-selection)
-                                     ["backspace" "delete"]
-                                     [])]
-        (is (not (contains? (conflict-action-ids plan) :editor/backspace)))
-        (is (not (contains? (conflict-action-ids plan) :editor/delete)))))
-
-    (testing "shared default Backspace is not stripped from a peer still using defaults"
-      (is (nil? (reset-conflict-update :editor/delete-selection
-                                       ["backspace" "delete"]
-                                       #{"backspace"}))))
-
-    (testing "user-customized conflict still strips the colliding key"
-      (is (= {:action-id :editor/bold :new-binding []}
-             (reset-conflict-update :editor/bold ["backspace"] #{"backspace"}))))
-
-    (testing "user-customized extra key is stripped while the command's own default remains"
-      (is (= {:action-id :editor/copy :new-binding nil}
-             (reset-conflict-update :editor/copy
-                                    [(if util/mac? "meta+c" "ctrl+c") "backspace"]
-                                    #{"backspace"}))))))
-
-(deftest test-compute-reset-plan-customized-conflict
-  (let [compute-reset-plan #'shortcut/compute-reset-plan]
-    (with-redefs [state/custom-shortcuts (fn [] {:editor/bold ["backspace"]})]
-      (let [plan (compute-reset-plan :editor/backspace
-                                     (dh/get-group :editor/backspace)
-                                     ["backspace"]
-                                     [])]
-        (is (= [{:action-id :editor/bold :new-binding []}]
-               (vec (:conflict-updates plan)))
-            "reset still clears a user-assigned Backspace that is not a peer default")))))
+(deftest test-compute-reset-plan
+  (with-redefs [state/custom-shortcuts (fn [] {:editor/backspace []
+                                           :editor/bold ["backspace"]})]
+    (is (= {:conflict-updates [{:action-id :editor/bold :new-binding []}]
+            :undo-entries [{:action-id :editor/backspace :previous-binding []}
+                           {:action-id :editor/bold :previous-binding ["backspace"]}]}
+           (#'shortcut/compute-reset-plan :editor/backspace
+                                         (dh/get-group :editor/backspace)
+                                         ["backspace"]
+                                         []))
+        "Reset preserves shared defaults and records only changed bindings for undo")))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [db-test#1152](https://github.com/logseq/db-test/issues/1152).

Resetting a command that shares a default key (for example Backspace on Delete Backward and Delete Selected Block) no longer removes that key from the peer command that still uses the default.

## What changed

`compute-reset-plan` still detects keys owned by other commands, but it now leaves keys that belong to the peer's default binding. Only user-customized collisions are stripped and persisted.

## Tests

- A reset-plan contract test verifies that resetting `:editor/backspace` preserves shared defaults, clears a user-assigned Backspace conflict, and records only changed commands for undo.
- Validation: 3 tests, 6 assertions; 0 failures and 0 errors.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ee7d91c-ea98-4a1b-9621-3fd7585081eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ee7d91c-ea98-4a1b-9621-3fd7585081eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

