### PR TITLE
fix: encode block highlight in Text/OPML/HTML export

### DIFF
--- a/src/main/frontend/handler/export/common.cljs
+++ b/src/main/frontend/handler/export/common.cljs
@@ -6,7 +6,11 @@
 
 (defn get-content-config []
   {:export-bullet-indentation (state/get-export-bullet-indentation)
-   :date-formatter (state/get-date-formatter)})
+   :date-formatter (state/get-date-formatter)
+   ;; Encode block background-color highlights as ^^text^^ so they survive
+   ;; Text/OPML/HTML export instead of being silently dropped (the property
+   ;; is otherwise hidden from export like other :hide? true properties).
+   :encode-highlight-as-mark? true})
 
 (defn <export-blocks-as-format
   [repo root-block-uuids-or-page-uuid format-type options]

--- a/src/main/logseq/common/export/file.cljs
+++ b/src/main/logseq/common/export/file.cljs
@@ -283,6 +283,12 @@
         (str (apply str (repeat heading-level "#")) " " (strip-heading-prefix content))
         content))))
 
+(defn- highlighted-block?
+  "Whether a block has a background color set (the block-level highlight
+  feature, distinct from inline ^^text^^ highlighting)."
+  [db b]
+  (some? (:logseq.property/background-color (d/entity db (:db/id b)))))
+
 (defn- transform-content
   [db b level {:keys [heading-to-list? include-properties?]
                :or {include-properties? true}} context]
@@ -290,6 +296,16 @@
         ;; replace [[uuid]] with block's content
         title (block-title-content db b context)
         content (or title "")
+        ;; Encode the block's background-color highlight as inline ^^text^^
+        ;; markup so it round-trips through mldoc and renders as <mark> in
+        ;; HTML export (and stays as ^^text^^ in Text/OPML export). Only done
+        ;; for the explicit "Export page" feature (see :encode-highlight-as-mark?
+        ;; in get-content-config), not for markdown-mirror generation.
+        content (if (and (:encode-highlight-as-mark? context)
+                         (not (string/blank? content))
+                         (highlighted-block? db b))
+                  (str "^^" content "^^")
+                  content)
         level (if (and heading-to-list? heading)
                 (if (> heading 1)
                   (dec heading)

--- a/src/test/frontend/worker/markdown_mirror_test.cljs
+++ b/src/test/frontend/worker/markdown_mirror_test.cljs
@@ -418,6 +418,29 @@
           (p/catch (fn [e] (is false (str "unexpected error: " e))))
           (p/finally done)))))
 
+(deftest page-mirror-does-not-encode-background-color-as-highlight-test
+  (async done
+    (let [{:keys [platform files]} (fake-platform)
+          conn (db-test/create-conn-with-blocks
+                {:pages-and-blocks
+                 [{:page {:block/title "Highlighted"}
+                   :blocks [{:block/title "Highlighted block"
+                             :build/properties {:logseq.property/background-color "red"}}]}]})
+          page (db-test/find-page-by-title @conn "Highlighted")]
+      (-> (markdown-mirror/<mirror-page! test-repo @conn (:db/id page) {:platform platform})
+          (p/then (fn [_]
+                    (let [content (get @files (page-path "pages/Highlighted.md"))]
+                      ;; The :encode-highlight-as-mark? behaviour added for the
+                      ;; "Export page" feature must not leak into the
+                      ;; markdown-mirror, which shares the same underlying
+                      ;; logseq.common.export.file code.
+                      (is (not (re-find #"\^\^" content)))
+                      (is (= (str (page-marker (:block/uuid page)) "\n\n"
+                                  "- Highlighted block")
+                             content)))))
+          (p/catch (fn [e] (is false (str "unexpected error: " e))))
+          (p/finally done)))))
+
 (deftest page-mirror-preserves-markdown-semantic-block-formatting-test
   (async done
     (let [{:keys [platform files]} (fake-platform)


### PR DESCRIPTION
## Fixes #8663

## Problem
Highlighting a block (right-click bullet → pick a color) is completely dropped when exporting a page as Text, OPML, or HTML. The highlight is stored as the `:logseq.property/background-color` block property, but that property is marked `:hide? true` (so it doesn't clutter the properties UI), and export code filters out all `:hide? true` properties, dropping the highlight along with it.

## Fix
When generating export content, wrap a highlighted block's text in `^^...^^` (Logseq's existing inline highlight markup) if the block has `background-color` set. This is gated behind a new `:encode-highlight-as-mark?` option only passed by the actual "Export page" feature, so it does not affect markdown-mirror generation (which shares the same underlying `file.cljs` code). Text and OPML export then just preserve `^^...^^` as-is (already handled), and HTML export already turns `^^...^^` into a real `<mark>` tag, so the block renders as visibly highlighted.

Note: this preserves *that* a block was highlighted, not *which* of the 7 colors was picked, since `^^text^^` has no color parameter. Capturing the exact color would need a new syntax extension, which felt like a separate, larger discussion.

## Testing
Reproduced and verified manually against a fresh DB graph, including two highlighted blocks in a parent/child structure:
- Before fix: none of the 3 export formats showed any trace of the highlight.
- After fix: Text/OPML preserve `^^text^^`, HTML renders `<mark>text</mark>` for both blocks at both nesting levels.
- Added a unit test confirming the markdown-mirror feature is unaffected (it shares the same underlying code but should never encode highlights, since it isn't the "Export page" feature).
- `bb dev:lint-and-test`: 0 lint errors/warnings, full unit test suite passes (0 failures/errors).