### PR TITLE
fix(cmdk): ignore IME Enter when committing composition

### DIFF
--- a/src/main/frontend/components/cmdk/core.cljs
+++ b/src/main/frontend/components/cmdk/core.cljs
@@ -1084,7 +1084,10 @@
         keyname (.-key e)
         enter? (= keyname "Enter")
         esc? (= keyname "Escape")
-        composing? (util/goog-event-is-composing? e)
+        ;; Native addEventListener keydown, not goog.events. Include keyCode 229 /
+        ;; key "Process" so macOS IME Enter commits composition instead of running
+        ;; the highlighted action (logseq/db-test#1154).
+        composing? (util/native-event-is-composing? e)
         shift? (.-shiftKey e)
         highlighted-group (some-> (state->highlighted-item state) :group)
         show-less (fn []

--- a/src/test/frontend/components/cmdk/core_test.cljs
+++ b/src/test/frontend/components/cmdk/core_test.cljs
@@ -1,9 +1,11 @@
 (ns frontend.components.cmdk.core-test
   (:require
-   [cljs.test :refer [async deftest is]]
+   [cljs.test :refer [async deftest is testing]]
    [frontend.components.cmdk.core :as cmdk]
    [frontend.db.async :as db-async]
    [frontend.handler.editor :as editor-handler]
+   [frontend.util :as util]
+   [goog.object :as gobj]
    [logseq.shui.ui :as shui]
    [promesa.core :as p]))
 
@@ -49,3 +51,60 @@
              "five keystrokes 100 ms apart should trigger one search")
          (done))
        700))))
+
+(defn- keydown-event
+  [{:keys [key key-code composing?]}]
+  (let [stopped? (atom false)
+        event (js-obj)]
+    (gobj/set event "key" key)
+    (gobj/set event "keyCode" key-code)
+    (gobj/set event "isComposing" (boolean composing?))
+    (gobj/set event "ctrlKey" false)
+    (gobj/set event "metaKey" false)
+    (gobj/set event "shiftKey" false)
+    (gobj/set event "stopPropagation" #(reset! stopped? true))
+    {:event event
+     :stopped? stopped?}))
+
+(defn- cmdk-keydown-state
+  []
+  {::cmdk/input (atom "nihao")
+   ::cmdk/filter (atom nil)
+   ::cmdk/highlighted-item (atom {:text "Create page" :source-create :page :group :create})
+   ::cmdk/all-items-cache (atom [])
+   ::cmdk/focus-source (atom :keyboard)
+   ::cmdk/results (atom {})
+   ::cmdk/scroll-container-ref (atom nil)})
+
+(defn- enter-action-calls
+  [event]
+  (let [calls (atom [])]
+    (with-redefs [shui/shortcut-press! (fn [shortcut & _]
+                                         (swap! calls conj [:shortcut shortcut]))
+                  cmdk/handle-action (fn [action & _]
+                                       (swap! calls conj [:action action]))
+                  util/stop-propagation (fn [_]
+                                          (swap! calls conj [:stop-propagation]))]
+      (#'cmdk/keydown-handler (cmdk-keydown-state) event))
+    @calls))
+
+(deftest keydown-handler-ignores-ime-composition-enter
+  (testing "macOS IME commit Enter (keyCode 229) does not run the highlighted action"
+    (let [{:keys [event]} (keydown-event {:key "Enter" :key-code 229 :composing? false})]
+      (is (empty? (enter-action-calls event)))))
+
+  (testing "isComposing Enter does not run the highlighted action"
+    (let [{:keys [event]} (keydown-event {:key "Enter" :key-code 13 :composing? true})]
+      (is (empty? (enter-action-calls event)))))
+
+  (testing "Process key from IME does not run the highlighted action"
+    (let [{:keys [event]} (keydown-event {:key "Process" :key-code 229 :composing? false})]
+      (is (empty? (enter-action-calls event))))))
+
+(deftest keydown-handler-runs-highlighted-action-on-plain-enter
+  (testing "plain Enter still selects the highlighted cmdk item"
+    (let [{:keys [event]} (keydown-event {:key "Enter" :key-code 13 :composing? false})]
+      (is (= [[:shortcut "return"]
+              [:action :default]
+              [:stop-propagation]]
+             (enter-action-calls event))))))

--- a/src/test/frontend/util_test.cljs
+++ b/src/test/frontend/util_test.cljs
@@ -1,6 +1,7 @@
 (ns frontend.util-test
   (:require [cljs.test :refer [deftest is testing]]
-            [frontend.util :as util]))
+            [frontend.util :as util]
+            [goog.object :as gobj]))
 
 (deftest test-split-graphemes
   (testing "split-graphemes returns individual grapheme clusters"
@@ -71,3 +72,32 @@
       (is (= @actual-ops 4))
       (is (= (m+ 3 5) 8))
       (is (= @actual-ops 4)))))
+
+(deftest native-event-is-composing?-detects-ime-process-enter
+  (testing "plain native Enter is not composing"
+    (let [event (js-obj)]
+      (gobj/set event "key" "Enter")
+      (gobj/set event "keyCode" 13)
+      (gobj/set event "isComposing" false)
+      (is (false? (boolean (util/native-event-is-composing? event))))))
+
+  (testing "macOS IME commit Enter uses keyCode 229"
+    (let [event (js-obj)]
+      (gobj/set event "key" "Enter")
+      (gobj/set event "keyCode" 229)
+      (gobj/set event "isComposing" false)
+      (is (true? (util/native-event-is-composing? event)))))
+
+  (testing "IME Process key is composing"
+    (let [event (js-obj)]
+      (gobj/set event "key" "Process")
+      (gobj/set event "keyCode" 229)
+      (gobj/set event "isComposing" false)
+      (is (true? (util/native-event-is-composing? event)))))
+
+  (testing "isComposing true is composing even with keyCode 13"
+    (let [event (js-obj)]
+      (gobj/set event "key" "Enter")
+      (gobj/set event "keyCode" 13)
+      (gobj/set event "isComposing" true)
+      (is (true? (util/native-event-is-composing? event))))))

--- a/src/test/frontend/util_test.cljs
+++ b/src/test/frontend/util_test.cljs
@@ -73,6 +73,15 @@
       (is (= (m+ 3 5) 8))
       (is (= @actual-ops 4)))))
 
+(deftest goog-event-is-composing?-ignores-native-cmdk-events
+  (testing "native addEventListener IME Enter is invisible to goog-event-is-composing?"
+    (let [event (js-obj)]
+      (gobj/set event "key" "Enter")
+      (gobj/set event "keyCode" 229)
+      (gobj/set event "isComposing" true)
+      (is (nil? (util/goog-event-is-composing? event)))
+      (is (nil? (util/goog-event-is-composing? event true))))))
+
 (deftest native-event-is-composing?-detects-ime-process-enter
   (testing "plain native Enter is not composing"
     (let [event (js-obj)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes IME Enter in Cmd+K so composition commit does not run the highlighted result.

https://github.com/logseq/db-test/issues/1154

## Problem

On macOS, pressing Enter to commit Chinese IME composition inside Cmd+K immediately ran the highlighted search item (open/create page) using uncommitted text.

## Root cause

Cmd+K attaches a native `addEventListener` keydown handler, then called `util/goog-event-is-composing?` with one argument.

That helper only inspects goog.events (it requires `getBrowserEvent`) and, with one argument, also ignores keyCode 229 / key `"Process"`. Native IME Enter therefore looked like a normal confirm key. Passing `include-process? true` is not enough here, because the event is not a goog event.

## Fix

Use `util/native-event-is-composing?`, which already handles native/React events and treats `isComposing`, keyCode 229, and key `"Process"` as composing. The editor path already uses the equivalent include-process check.

## Behavior

- Enter during IME composition/commit does not run the highlighted cmdk action
- Plain Enter (no IME) still selects/runs the highlighted item

## Tests

- `frontend.components.cmdk.core-test`: keydown handler ignores IME Enter / Process and still runs plain Enter
- `frontend.util-test`: `native-event-is-composing?` covers keyCode 229, Process, and `isComposing`; `goog-event-is-composing?` returns nil for native IME events

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89c2d059-8562-44d1-bb84-31777e769d36?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89c2d059-8562-44d1-bb84-31777e769d36&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

