### PR TITLE
fix: open Contents from the right-sidebar page menu

### DIFF
--- a/clj-e2e/test/logseq/e2e/right_sidebar_basic_test.clj
+++ b/clj-e2e/test/logseq/e2e/right_sidebar_basic_test.clj
@@ -97,3 +97,15 @@
       (w/wait-for-not-visible
        (format "#ls-block-%s .block-title-wrap:text('%s')"
                block-uuid initial-title)))))
+
+(deftest contents-open-as-page-navigates-to-contents
+  (testing "Contents sidebar more menu opens the Contents page"
+    (let [source-page (p/get-page-name)]
+      (w/click ".toggle-right-sidebar")
+      (assert/assert-is-visible ".cp__right-sidebar.open .sidebar-item.item-type-contents")
+      (w/click ".cp__right-sidebar .item-type-contents [data-testid='sidebar-item-more']")
+      (assert/assert-is-visible (loc/filter "[role='menuitem']" :has-text "Open as page"))
+      (w/click (loc/filter "[role='menuitem']" :has-text "Open as page"))
+      (w/wait-for "div[data-testid='page title'] .block-title-wrap:text('Contents')")
+      (is (= "Contents" (p/get-page-name)))
+      (is (not= source-page (p/get-page-name))))))

--- a/src/main/frontend/components/right_sidebar.cljs
+++ b/src/main/frontend/components/right_sidebar.cljs
@@ -8,6 +8,7 @@
             [frontend.components.onboarding :as onboarding]
             [frontend.components.page :as page]
             [frontend.components.profiler :as profiler]
+            [frontend.components.right-sidebar-util :as right-sidebar-util]
             [frontend.components.shortcut-help :as shortcut-help]
             [frontend.components.plugins :as plugins]
             [frontend.config :as config]
@@ -206,12 +207,10 @@
         page? (or (contains? #{:page :contents} type) (entity/page? block))]
     (hooks/use-effect!
      (fn []
-       (if (integer? db-id)
-         (p/let [block (db-async/<get-block (state/get-current-repo) db-id {:children? false})]
-           (set-block! block))
-         (set-block! nil))
+       (p/let [block (right-sidebar-util/<sidebar-action-block (state/get-current-repo) db-id type)]
+         (set-block! block))
        nil)
-     [db-id])
+     [db-id type])
     [:<>
      (menu-item {:on-click #(state/sidebar-remove-block! idx)} (t :sidebar.right/close))
      (when multi-items? (menu-item {:on-click #(state/sidebar-remove-rest! db-id)} (t :sidebar.right/close-others)))
@@ -227,7 +226,10 @@
      (when multi-items? (menu-item {:on-click #(state/sidebar-block-set-collapsed-all! false)} (t :sidebar.right/expand-all)))
      (when page? [:hr.menu-separator])
      (when page?
-       (menu-item {:on-click (fn [] (route-handler/redirect-to-page! (:block/uuid block)))}
+       (menu-item {:on-click (fn []
+                               (p/let [target (right-sidebar-util/<sidebar-action-block
+                                               (state/get-current-repo) db-id type)]
+                                 (route-handler/redirect-to-page! (:block/uuid target))))}
                   (t :sidebar.right/open-as-page)))]))
 
 (hsx/defc drop-indicator
@@ -310,6 +312,7 @@
               (shui/button
                {:class "px-2 py-2 h-8 w-8 text-muted-foreground"
                 :variant :ghost
+                :data-testid "sidebar-item-more"
                 :on-click #(shui/popup-show!
                             (.-target %)
                             (actions-menu-content db-id idx block-type collapsed? block-count)

--- a/src/main/frontend/components/right_sidebar_util.cljs
+++ b/src/main/frontend/components/right_sidebar_util.cljs
@@ -1,0 +1,23 @@
+(ns frontend.components.right-sidebar-util
+  "Helpers for right sidebar item actions"
+  (:require [frontend.db.async :as db-async]
+            [promesa.core :as p]))
+
+(defn sidebar-action-block-lookup
+  "Return the id or page name used to load the sidebar item that Open as Page
+  should open.
+
+  Contents sidebar items use the string db-id \"contents\", which is not a block
+  entity id. Resolve them by the built-in Contents page name, matching
+  `<build-sidebar-item`."
+  [db-id type]
+  (cond
+    (= :contents (keyword type)) "Contents"
+    (or (integer? db-id) (uuid? db-id)) db-id
+    :else nil))
+
+(defn <sidebar-action-block
+  [repo db-id type]
+  (if-let [id (sidebar-action-block-lookup db-id type)]
+    (db-async/<get-block repo id {:children? false})
+    (p/resolved nil)))

--- a/src/test/frontend/components/right_sidebar_test.cljs
+++ b/src/test/frontend/components/right_sidebar_test.cljs
@@ -1,0 +1,49 @@
+(ns frontend.components.right-sidebar-test
+  (:require [cljs.test :refer [async deftest is testing]]
+            [frontend.components.right-sidebar-util :as right-sidebar-util]
+            [frontend.db.async :as db-async]
+            [promesa.core :as p]))
+
+(deftest sidebar-action-block-lookup-test
+  (testing "Contents sidebar items resolve the Contents page by name"
+    (is (= "Contents" (right-sidebar-util/sidebar-action-block-lookup "contents" :contents)))
+    (is (= "Contents" (right-sidebar-util/sidebar-action-block-lookup "contents" "contents"))))
+  (testing "page and block items keep their entity id"
+    (is (= 42 (right-sidebar-util/sidebar-action-block-lookup 42 :page)))
+    (let [block-uuid #uuid "11111111-1111-1111-1111-111111111111"]
+      (is (= block-uuid (right-sidebar-util/sidebar-action-block-lookup block-uuid :block)))))
+  (testing "non-entity sidebar items have no Open as Page target"
+    (is (nil? (right-sidebar-util/sidebar-action-block-lookup "help" :help)))
+    (is (nil? (right-sidebar-util/sidebar-action-block-lookup "contents" :help)))))
+
+(deftest sidebar-action-block-fetches-contents-by-name
+  (async done
+    (let [calls (atom [])
+          contents-uuid #uuid "22222222-2222-2222-2222-222222222222"]
+      (-> (p/with-redefs [db-async/<get-block
+                          (fn [repo id opts]
+                            (swap! calls conj [repo id opts])
+                            (p/resolved {:block/uuid contents-uuid
+                                         :block/title "Contents"}))]
+            (p/let [block (right-sidebar-util/<sidebar-action-block "logseq_db_test" "contents" :contents)]
+              (is (= [["logseq_db_test" "Contents" {:children? false}]] @calls))
+              (is (= contents-uuid (:block/uuid block)))))
+          (p/catch
+           (fn [error]
+             (is false (str error))))
+          (p/finally done)))))
+
+(deftest sidebar-action-block-skips-non-entity-items
+  (async done
+    (let [calls (atom [])]
+      (-> (p/with-redefs [db-async/<get-block
+                          (fn [repo id opts]
+                            (swap! calls conj [repo id opts])
+                            (p/resolved {:block/uuid #uuid "33333333-3333-3333-3333-333333333333"}))]
+            (p/let [block (right-sidebar-util/<sidebar-action-block "logseq_db_test" "help" :help)]
+              (is (empty? @calls))
+              (is (nil? block))))
+          (p/catch
+           (fn [error]
+             (is false (str error))))
+          (p/finally done)))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes logseq/db-test#1158.

## Problem

On DB graphs, the Contents panel in the right sidebar shows **Open as page** in the three-dot menu, but choosing it does not navigate to the Contents page.

Contents sidebar items are stored as `["contents" :contents]`. The menu treated that type as a page, so the item appeared, but it only loaded a block entity when `db-id` was an integer. The string id left `block` nil, and `redirect-to-page!` received no UUID.

## Change

Resolve the Open as page target the same way sidebar rendering already resolves Contents: look up the built-in Contents page by name. Page and block items still use their entity id.

The click handler also fetches that target at click time, so the action does not depend on the menu-open effect finishing first.

## Tests

- Unit tests for the sidebar action lookup and Contents-by-name fetch: `bb dev:test -v frontend.components.right-sidebar-test` (3 tests, 10 assertions, pass)
- clj-e2e: Contents more menu navigates the main view to the Contents page, plus the existing right-sidebar basic tests: `bb -f clj-e2e/bb.edn test -n logseq.e2e.right-sidebar-basic-test` (4 tests, 7 assertions, pass)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adb66961-b13f-4f3e-b04a-f34e95c88c13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adb66961-b13f-4f3e-b04a-f34e95c88c13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

