### PR TITLE
fix: scroll long table Column visibility and Group by menus

### DIFF
--- a/deps/shui/src/logseq/shui/components.cljs
+++ b/deps/shui/src/logseq/shui/components.cljs
@@ -345,8 +345,12 @@
     (when (input-target? (event-target event))
       (prevent-base-ui-handler! event))))
 
+;; Cap height when Base UI's --available-height is missing or larger than the window.
+(def ^:private popup-max-height
+  "min(var(--available-height, 100vh), calc(100vh - 16px))")
+
 (def ^:private popup-scroll-style
-  #js {:maxHeight "var(--available-height)"
+  #js {:maxHeight popup-max-height
        :overflowY "auto"
        :overflowX "hidden"})
 
@@ -432,7 +436,7 @@
         (react/createElement component props'))))))
 
 (defn- composed-popup
-  [portal positioner popup base-class & {:keys [extra-class-fn]}]
+  [portal positioner popup base-class & {:keys [extra-class-fn sticky?]}]
   (react/forwardRef
    (fn [^js props ref]
      (let [portal-props (merge-object-props! (copy-named-props props portal-prop-names)
@@ -445,7 +449,11 @@
            on-key-down (prop popup-props "onKeyDown")
            children (prop props "children")]
        (set-prop! positioner-props "style"
-                  (merge-object-props! #js {:zIndex 99999} (prop positioner-props "style")))
+                  (merge-object-props! #js {:zIndex 99999
+                                            :maxHeight popup-max-height}
+                                       (prop positioner-props "style")))
+       (when (and sticky? (nil? (prop positioner-props "sticky")))
+         (set-prop! positioner-props "sticky" true))
        (apply-default-collision-avoidance! positioner-props)
        (set-prop! popup-props "style"
                   (merge-object-props! (popup-normal-style) (prop popup-props "style")))
@@ -736,10 +744,11 @@
 (def DropdownMenuRadioGroup MenuRadioGroupPart)
 (def DropdownMenuContent
   (composed-popup MenuPortalPart MenuPositionerPart MenuPopupPart
-                  "ui__dropdown-menu-content z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-md"))
+                  "ui__dropdown-menu-content z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-md overflow-y-auto"))
 (def DropdownMenuSubContent
   (composed-popup MenuPortalPart MenuPositionerPart MenuPopupPart
-                  "ui__dropdown-menu-sub-content z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg"))
+                  "ui__dropdown-menu-sub-content z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg overflow-y-auto"
+                  :sticky? true))
 (def DropdownMenuItem
   (react/forwardRef
    (fn [^js props ref]
@@ -796,10 +805,11 @@
 (def ContextMenuRadioGroup ContextMenuRadioGroupPart)
 (def ContextMenuContent
   (composed-popup ContextMenuPortalPart ContextMenuPositionerPart ContextMenuPopupPart
-                  "ui__context-menu-content z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-md outline-none focus:outline-none focus-visible:outline-none"))
+                  "ui__context-menu-content z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-md outline-none focus:outline-none focus-visible:outline-none overflow-y-auto"))
 (def ContextMenuSubContent
   (composed-popup ContextMenuPortalPart ContextMenuPositionerPart ContextMenuPopupPart
-                  "ui__context-menu-sub-content z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg outline-none focus:outline-none focus-visible:outline-none"))
+                  "ui__context-menu-sub-content z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg outline-none focus:outline-none focus-visible:outline-none overflow-y-auto"
+                  :sticky? true))
 (def ContextMenuItem (forward-part ContextMenuItemPart "ui__context-menu-item relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[highlighted]:bg-muted data-[disabled]:pointer-events-none data-[disabled]:opacity-50"))
 (def ContextMenuCheckboxItem (forward-part ContextMenuCheckboxItemPart "ui__context-menu-checkbox-item relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[highlighted]:bg-muted data-[disabled]:pointer-events-none data-[disabled]:opacity-50"))
 (def ContextMenuRadioItem (forward-part ContextMenuRadioItemPart "ui__context-menu-radio-item relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[highlighted]:bg-muted data-[disabled]:pointer-events-none data-[disabled]:opacity-50"))

--- a/resources/css/shui.css
+++ b/resources/css/shui.css
@@ -463,17 +463,17 @@ kbd.shui-shortcut-key-pressed,
   background-color: var(--lx-accent-08-alpha, var(--color-level-4));
 }
 
-.ui__dropdown-menu-content, div[data-radix-menu-content],
+.ui__dropdown-menu-content,
+.ui__dropdown-menu-sub-content,
+.ui__context-menu-content,
+.ui__context-menu-sub-content,
+div[data-radix-menu-content],
 .ui__select-content {
-  @apply overflow-y-auto;
+  @apply overflow-x-hidden overflow-y-auto;
 
-  &[data-side=top] {
-    max-height: calc(var(--radix-dropdown-menu-content-available-height) - 20px);
-  }
-
-  &[data-side=bottom] {
-    max-height: calc(var(--radix-dropdown-menu-content-available-height) - 10px);
-  }
+  /* Base UI sets --available-height on the positioner; inherit it for all sides,
+     including left/right and inline-* submenus that the old top/bottom rules missed. */
+  max-height: min(var(--available-height, 100vh), calc(100vh - 16px));
 
   &.text-popover-foreground {
     color: inherit;

--- a/src/test/logseq/shui/components_test.cljs
+++ b/src/test/logseq/shui/components_test.cljs
@@ -1,0 +1,21 @@
+(ns logseq.shui.components-test
+  (:require [cljs.test :refer [deftest is]]
+            [clojure.string :as string]
+            [logseq.shui.components :as components]))
+
+(deftest popup-scroll-style-keeps-long-menus-in-viewport
+  (let [style (#'components/popup-scroll-style)
+        max-height (.-maxHeight style)]
+    (is (= "auto" (.-overflowY style)))
+    (is (= "hidden" (.-overflowX style)))
+    (is (string/includes? max-height "--available-height"))
+    (is (string/includes? max-height "100vh"))))
+
+(deftest submenu-css-allows-vertical-scroll-on-every-side
+  (let [fs (js/require "fs")
+        path (js/require "path")
+        css (.readFileSync fs (.resolve path "resources/css/shui.css") "utf8")]
+    (is (string/includes? css ".ui__dropdown-menu-sub-content"))
+    (is (string/includes? css ".ui__context-menu-sub-content"))
+    (is (string/includes? css "--available-height"))
+    (is (string/includes? css "overflow-y-auto"))))

--- a/src/test/logseq/shui/components_test.cljs
+++ b/src/test/logseq/shui/components_test.cljs
@@ -4,7 +4,7 @@
             [logseq.shui.components :as components]))
 
 (deftest popup-scroll-style-keeps-long-menus-in-viewport
-  (let [style (#'components/popup-scroll-style)
+  (let [style @#'components/popup-scroll-style
         max-height (.-maxHeight style)]
     (is (= "auto" (.-overflowY style)))
     (is (= "hidden" (.-overflowX style)))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes logseq/db-test#1159

## Problem

In Table View, **Column visibility** and **Group by** submenus do not scroll when there are more options than fit on screen. Left/right submenu placements were not height-capped, so items below the viewport were unreachable.

## Change

- Cap dropdown and context-menu height with `min(var(--available-height, 100vh), calc(100vh - 16px))` and `overflow-y: auto` on both the popup and its positioner.
- Apply the same CSS to `.ui__dropdown-menu-sub-content` and `.ui__context-menu-sub-content` for every side, not only `data-side=top|bottom`.
- Keep long submenus attached to the viewport with `sticky` positioning so they shift into view and then scroll.
- Add unit tests for the shared scroll style and submenu CSS.

## Test plan

- [x] Unit tests for popup scroll style and submenu CSS selectors
- [ ] Manual: open a table/query with many properties → ⋯ → Column visibility / Group by → confirm the submenu scrolls and every option is reachable

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c23178f7-28ae-4142-afca-1e936798dffd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c23178f7-28ae-4142-afca-1e936798dffd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

