### PR TITLE
fix: hide unset property defaults in table cells

### DIFF
--- a/src/main/frontend/components/property/value.cljs
+++ b/src/main/frontend/components/property/value.cljs
@@ -2261,21 +2261,29 @@
        (multiple-values-inner block property value' opts)))
 
 (defn- resolved-property-value-for-render
-  [block property multiple-values?]
-  (let [v (get block (:db/ident property))
-        block-loaded? (some? (:block/uuid block))]
-    (or
-     (cond
-       (and multiple-values? (or (set? v) (coll? v) (nil? v)))
-       v
-       multiple-values?
-       #{v}
-       (set? v)
-       (first v)
-       :else
-       v)
-     (when block-loaded?
-       (:logseq.property/default-value property)))))
+  "Resolve the value to render for a property cell.
+
+  Table/query cells receive canonical row maps that only include properties
+  actually set on the entity. Do not fall back to the property default there —
+  an unset column must stay empty (db-test#1160). Non-table surfaces still
+  show the default for loaded blocks (class property rows, block-below pills)."
+  ([block property multiple-values?]
+   (resolved-property-value-for-render block property multiple-values? {}))
+  ([block property multiple-values? {:keys [table-view?]}]
+   (let [v (get block (:db/ident property))
+         block-loaded? (some? (:block/uuid block))]
+     (or
+      (cond
+        (and multiple-values? (or (set? v) (coll? v) (nil? v)))
+        v
+        multiple-values?
+        #{v}
+        (set? v)
+        (first v)
+        :else
+        v)
+      (when (and block-loaded? (not table-view?))
+        (:logseq.property/default-value property))))))
 
 (hsx/defc ^:large-vars/cleanup-todo property-value
   [block property {:keys [show-tooltip? p-block p-property editing?]
@@ -2293,7 +2301,7 @@
             editor-id (str dom-id "-editor")
             type (:logseq.property/type property)
             multiple-values? (db-property/many? property)
-            v (resolved-property-value-for-render block property multiple-values?)
+            v (resolved-property-value-for-render block property multiple-values? opts)
             self-value-or-embedded? (fn [v]
                                       (or (= (:db/id v) (:db/id block))
                                           ;; property value self embedded

--- a/src/test/frontend/components/property/value_test.cljs
+++ b/src/test/frontend/components/property/value_test.cljs
@@ -122,23 +122,45 @@
                           (is false (str error))
                           (done)))))))
 
+(def ^:private default-status-property
+  {:db/ident :logseq.property/status
+   :logseq.property/default-value {:db/id 3
+                                   :db/ident :logseq.property/status.todo
+                                   :block/title "Todo"}})
+
+(def ^:private loaded-block-without-status
+  {:db/id 1
+   :block/uuid #uuid "11111111-1111-1111-1111-111111111111"})
+
 (deftest resolved-property-value-for-render-skips-default-for-placeholder-row-test
-  (let [property {:db/ident :logseq.property/status
-                  :logseq.property/default-value {:db/id 3
-                                                  :db/ident :logseq.property/status.todo
-                                                  :block/title "Todo"}}
-        placeholder-block {:db/id 1}]
-    (is (nil? (#'property-value/resolved-property-value-for-render placeholder-block property false)))))
+  (let [placeholder-block {:db/id 1}]
+    (is (nil? (#'property-value/resolved-property-value-for-render placeholder-block default-status-property false)))))
 
 (deftest resolved-property-value-for-render-uses-default-for-loaded-block-test
-  (let [property {:db/ident :logseq.property/status
-                  :logseq.property/default-value {:db/id 3
-                                                  :db/ident :logseq.property/status.todo
-                                                  :block/title "Todo"}}
-        loaded-block {:db/id 1
-                      :block/uuid #uuid "11111111-1111-1111-1111-111111111111"}]
-    (is (= (:logseq.property/default-value property)
-           (#'property-value/resolved-property-value-for-render loaded-block property false)))))
+  (is (= (:logseq.property/default-value default-status-property)
+         (#'property-value/resolved-property-value-for-render loaded-block-without-status default-status-property false)))
+      "Non-table surfaces still show the property default for a loaded block."))
+
+(deftest resolved-property-value-for-render-skips-default-for-table-view-unset-property-test
+  (is (nil? (#'property-value/resolved-property-value-for-render
+             loaded-block-without-status default-status-property false {:table-view? true}))
+      "Table/query cells must stay empty when the row does not have the property (db-test#1160)."))
+
+(deftest resolved-property-value-for-render-keeps-set-value-in-table-view-test
+  (let [doing {:db/id 4
+               :db/ident :logseq.property/status.doing
+               :block/title "Doing"}
+        loaded-block (assoc loaded-block-without-status :logseq.property/status doing)]
+    (is (= doing
+           (#'property-value/resolved-property-value-for-render
+            loaded-block default-status-property false {:table-view? true}))
+        "Table/query cells still render the value that is actually set on the row.")))
+
+(deftest resolved-property-value-for-render-skips-default-for-table-view-many-cardinality-test
+  (let [many-property (assoc default-status-property :db/cardinality :db.cardinality/many)]
+    (is (nil? (#'property-value/resolved-property-value-for-render
+               loaded-block-without-status many-property true {:table-view? true}))
+        "Many-cardinality table cells also stay empty when the property is unset.")))
 
 (deftest asset-selected-ids-test
   (let [property {:db/ident :asset}]

--- a/src/test/frontend/components/property/value_test.cljs
+++ b/src/test/frontend/components/property/value_test.cljs
@@ -138,7 +138,8 @@
 
 (deftest resolved-property-value-for-render-uses-default-for-loaded-block-test
   (is (= (:logseq.property/default-value default-status-property)
-         (#'property-value/resolved-property-value-for-render loaded-block-without-status default-status-property false)))
+         (#'property-value/resolved-property-value-for-render
+          loaded-block-without-status default-status-property false))
       "Non-table surfaces still show the property default for a loaded block."))
 
 (deftest resolved-property-value-for-render-skips-default-for-table-view-unset-property-test

--- a/src/test/frontend/worker/handler/block_test.cljs
+++ b/src/test/frontend/worker/handler/block_test.cljs
@@ -605,6 +605,38 @@
                  (canonical-block @conn (d/entity @conn (:db/id with-class)))))
           "Canonical renderer maps persist class-provided property keys."))))
 
+(deftest canonical-block-omits-unset-property-default-value-test
+  (when-let [canonical-block (canonical-block-api)]
+    (let [conn (db-test/create-conn-with-blocks
+                {:properties {:note {:logseq.property/type :default
+                                     :build/properties
+                                     {:logseq.property/default-value "fallback"}
+                                     :build/properties-ref-types {:entity :number}}}
+                 :pages-and-blocks
+                 [{:page {:block/title "Page"}
+                   :blocks [{:block/title "unset"}
+                            {:block/title "set"
+                             :build/properties {:note "written"}}]}]})
+          db @conn
+          unset (db-test/find-block-by-content db "unset")
+          set-block (db-test/find-block-by-content db "set")
+          _ (d/transact! conn [{:db/id (:db/id unset) :block/tx-id 1}
+                               {:db/id (:db/id set-block) :block/tx-id 1}])
+          db @conn
+          unset (d/entity db (:db/id unset))
+          set-block (d/entity db (:db/id set-block))
+          property (d/entity db :user.property/note)
+          unset-map (canonical-block db unset)
+          set-map (canonical-block db set-block)]
+      (is (some? (:logseq.property/default-value property))
+          "The property has a default value configured.")
+      (is (empty? (d/datoms db :eavt (:db/id unset) :user.property/note))
+          "The unset block has no own property datom.")
+      (is (not (contains? unset-map :user.property/note))
+          "Canonical row maps used by table cells omit unset properties even when the property has a default (db-test#1160).")
+      (is (some? (get set-map :user.property/note))
+          "A row that has the property still carries its written value."))))
+
 (defn- cover-row-fixture
   []
   (let [conn (db-test/create-conn)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [db-test#1160](https://github.com/logseq/db-test/issues/1160).

## Problem

In a DB graph query Table View, adding a property column showed that property's default value on rows that do not have the property. Those cells should be empty.

This is a display/resolution bug. It is distinct from db-test#1073 (orphaned previous values when updating `:default`).

## Cause

`resolved-property-value-for-render` does `(get block prop-ident)` and, for any loaded block (`:block/uuid` present), falls back to `(:logseq.property/default-value property)`.

Table/query cells already receive canonical row maps that only include properties actually set on the entity. The fallback then painted the default as if it were set.

`lookup-kv-with-default-value` still injects defaults for live Datascript entity lookups (queries, property clear, checkbox scalar defaults). That path is not what table cells render.

## Change

Skip the default fallback when rendering with `:table-view? true`. Non-table surfaces (class property rows, block-below pills) still show defaults for loaded blocks. Creating entities that write defaults is unchanged.

## Tests

- `resolved-property-value-for-render-skips-default-for-table-view-unset-property-test`
- `resolved-property-value-for-render-keeps-set-value-in-table-view-test`
- `resolved-property-value-for-render-skips-default-for-table-view-many-cardinality-test`
- `canonical-block-omits-unset-property-default-value-test` (row maps omit unset properties even when the property has a default)

Targeted run after compile:

```
node static/tests.js -n frontend.components.property.value-test -n frontend.worker.handler.block-test
Ran 44 tests containing 160 assertions. 0 failures, 0 errors.
```

clj-kondo on the changed files: 0 errors, 0 warnings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aeff7665-c857-4f18-a088-ef57c2a357fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aeff7665-c857-4f18-a088-ef57c2a357fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

