### PR TITLE
fix: show default Task status icon for tag-only blocks

### DIFF
--- a/src/main/frontend/worker/handler/block.cljs
+++ b/src/main/frontend/worker/handler/block.cljs
@@ -307,7 +307,7 @@
 (defn- plain-render-block?
   [db block]
   (empty? (remove #{:block/tags}
-                  (property-handler/direct-block-property-ids db (:db/id block)))))
+                  (property-handler/block-property-keys db block))))
 
 (defn- block-positioned-properties-map
   [db block]

--- a/src/main/frontend/worker/handler/property.cljs
+++ b/src/main/frontend/worker/handler/property.cljs
@@ -779,6 +779,14 @@
   [db block-id property-id]
   (entity-direct-value db block-id property-id))
 
+(defn- positioned-property-empty?
+  "True when the block has no written value and the property has no default.
+  Class defaults such as Task status are not empty."
+  [db block-id property]
+  (and (nil? (block-direct-property-value db block-id (:db/ident property)))
+       (nil? (:logseq.property/default-value property))
+       (nil? (:logseq.property/scalar-default-value property))))
+
 (defn- render-positioned-property?
   [db block-id property-id position {:keys [allow-empty-block-below?]}]
   (when-let [property (d/entity db property-id)]
@@ -788,7 +796,7 @@
        (not (false? (:logseq.property/public? property)))
        (= property-position position)
        (not (and (:logseq.property/hide-empty-value property)
-                 (nil? property-value)))
+                 (positioned-property-empty? db block-id property)))
        (not (:logseq.property/hide? property))
        (not (and
              (= property-position :block-below)

--- a/src/test/frontend/worker/handler/block_test.cljs
+++ b/src/test/frontend/worker/handler/block_test.cljs
@@ -605,6 +605,53 @@
                  (canonical-block @conn (d/entity @conn (:db/id with-class)))))
           "Canonical renderer maps persist class-provided property keys."))))
 
+(deftest canonical-block-positions-default-task-status-test
+  (when-let [canonical-block (canonical-block-api)]
+    (let [conn (db-test/create-conn-with-blocks
+                [{:page {:block/title "Page"}
+                  :blocks [{:block/title "task only"
+                            :build/tags [:logseq.class/Task]}
+                           {:block/title "task doing"
+                            :build/tags [:logseq.class/Task]
+                            :build/properties {:logseq.property/status :logseq.property/status.doing}}]}])
+          task-only (db-test/find-block-by-content @conn "task only")
+          task-doing (db-test/find-block-by-content @conn "task doing")
+          status-uuid (:block/uuid (d/entity @conn :logseq.property/status))]
+      (d/transact! conn [{:db/id (:db/id task-only) :block/tx-id 1}
+                         {:db/id (:db/id task-doing) :block/tx-id 1}])
+      (let [only-block (canonical-block @conn (d/entity @conn (:db/id task-only)))
+            doing-block (canonical-block @conn (d/entity @conn (:db/id task-doing)))
+            only-left (set (get-in only-block [:block.temp/positioned-properties :block-left]))
+            doing-left (set (get-in doing-block [:block.temp/positioned-properties :block-left]))]
+        (is (contains? only-left status-uuid)
+            "Tag-only #Task still exposes the default status icon.")
+        (is (not (contains? only-block :logseq.property/status))
+            "Canonical row maps omit unset status so table/query cells stay empty.")
+        (is (contains? doing-left status-uuid)
+            "Explicit status still positions.")
+        (is (some? (:logseq.property/status doing-block)))))))
+
+(deftest get-block-and-children-positions-default-task-status-test
+  (let [conn (db-test/create-conn-with-blocks
+              [{:page {:block/title "Page"}
+                :blocks [{:block/title "task only"
+                          :build/tags [:logseq.class/Task]}
+                         {:block/title "plain"}]}])
+        task-only (db-test/find-block-by-content @conn "task only")
+        plain (db-test/find-block-by-content @conn "plain")
+        task-result (:block (block-handler/get-block-and-children
+                             @conn (:db/id task-only)
+                             {:children? false :render-data? true}))
+        plain-result (:block (block-handler/get-block-and-children
+                              @conn (:db/id plain)
+                              {:children? false :render-data? true}))
+        task-left (set (map :db/ident
+                            (get-in task-result [:block.temp/positioned-properties :block-left])))]
+    (is (contains? task-left :logseq.property/status)
+        "Tag-only #Task is not treated as a plain block for positioned status.")
+    (is (empty? (get-in plain-result [:block.temp/positioned-properties :block-left]))
+        "Untagged blocks still skip positioned status.")))
+
 (defn- cover-row-fixture
   []
   (let [conn (db-test/create-conn)

--- a/src/test/frontend/worker/handler/property_test.cljs
+++ b/src/test/frontend/worker/handler/property_test.cljs
@@ -83,3 +83,40 @@
       (let [after (worker-property/display-property-map @conn :user.property/color)]
         (is (= "Red" (get-in before [:logseq.property/default-value :block/title])))
         (is (= "Crimson" (get-in after [:logseq.property/default-value :block/title])))))))
+
+(defn- positioned-idents
+  [db block-id position]
+  (set (map :db/ident (worker-property/block-positioned-properties db block-id position))))
+
+(deftest task-tag-only-positions-default-status
+  (let [conn (db-test/create-conn-with-blocks
+              [{:page {:block/title "page"}
+                :blocks [{:block/title "task only"
+                          :build/tags [:logseq.class/Task]}
+                         {:block/title "task doing"
+                          :build/tags [:logseq.class/Task]
+                          :build/properties {:logseq.property/status :logseq.property/status.doing}}
+                         {:block/title "plain"}]}])
+        db @conn
+        task-only (db-test/find-block-by-content db "task only")
+        task-doing (db-test/find-block-by-content db "task doing")
+        plain (db-test/find-block-by-content db "plain")]
+    (testing "tagging only #Task still positions the class default status"
+      (is (contains? (positioned-idents db (:db/id task-only) :block-left)
+                     :logseq.property/status))
+      (is (nil? (worker-property/entity-direct-value db task-only :logseq.property/status))
+          "Status is resolved from the property default, not a written datom"))
+    (testing "explicit status still positions"
+      (is (contains? (positioned-idents db (:db/id task-doing) :block-left)
+                     :logseq.property/status))
+      (is (some? (worker-property/entity-direct-value db task-doing :logseq.property/status))))
+    (testing "unset priority stays hidden because it has no default"
+      (is (not (contains? (positioned-idents db (:db/id task-only) :block-left)
+                          :logseq.property/priority))))
+    (testing "untagged blocks do not get a status icon"
+      (is (not (contains? (positioned-idents db (:db/id plain) :block-left)
+                          :logseq.property/status))))
+    (testing "removing the default hides empty status again"
+      (d/transact! conn [[:db/retract :logseq.property/status :logseq.property/default-value]])
+      (is (not (contains? (positioned-idents @conn (:db/id task-only) :block-left)
+                          :logseq.property/status))))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [db-test#1161](https://github.com/logseq/db-test/issues/1161).

## Problem

In a DB graph, tagging a block with only `#Task` / `#task` does not show the default todo (or configured default) status icon. Users expect the same status icon as other Task blocks.

This is distinct from [db-test#1160](https://github.com/logseq/db-test/issues/1160) / table cells. Unset property defaults in query Table View stay omitted from canonical row maps.

## Cause

Applying `#Task` writes `:block/tags` only. Status resolves through `:logseq.property/default-value` and has no direct `:logseq.property/status` datom.

`render-positioned-property?` treated that as empty because it used `entity-direct-value` together with `:logseq.property/hide-empty-value`. `plain-render-block?` also treated tag-only blocks as plain and forced `:block.temp/positioned-properties` to `{}`.

## Change

- Treat a property default as a present value when deciding whether `hide-empty-value` should hide a positioned property.
- Use class-provided property keys (not only direct datoms) when deciding whether a block is plain.

Unset properties without a default (priority, deadline, scheduled) stay hidden. Canonical block maps still omit unset `:logseq.property/status`, so table/query cells do not gain a written default.

## Tests

- `task-tag-only-positions-default-status`
- `canonical-block-positions-default-task-status-test`
- `get-block-and-children-positions-default-task-status-test`

Targeted run after compile:

```
bb dev:test -v frontend.worker.handler.property-test/task-tag-only-positions-default-status \
  -v frontend.worker.handler.block-test/canonical-block-positions-default-task-status-test \
  -v frontend.worker.handler.block-test/get-block-and-children-positions-default-task-status-test
```

Pre-fix (same tests against unpatched worker): 3 failures — `#Task`-only blocks had empty `:block-left` positioned properties.

Post-fix: 5 tests, 16 assertions, 0 failures, including the existing table-like placeholder-row default skip.

Related namespaces (`property-test`, `block-test`, `value-test`): 46 tests, 177 assertions, 0 failures.

clj-kondo on the changed files: 0 errors, 0 warnings.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03c0a832-2537-4bed-9eee-9b018fa394e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03c0a832-2537-4bed-9eee-9b018fa394e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

