### PR TITLE
fix: URL property value editor UX

### DIFF
--- a/deps/outliner/src/logseq/outliner/core.cljs
+++ b/deps/outliner/src/logseq/outliner/core.cljs
@@ -779,16 +779,15 @@
                  (rest blocks)))))))
 
 (defn- url-property-value?
-  "URL-type property values are not containers; they must not have child blocks."
+  "URL-type property values are leaves; they must not have child or sibling blocks."
   [block]
   (= :url (:logseq.property/type (:logseq.property/created-from-property block))))
 
-(defn- url-property-value-child-target?
-  "True when insert/move would make a URL-type property value the parent."
+(defn- url-property-value-forbidden-target?
+  "True when insert/move would create a child of a URL value or a sibling of one."
   [target-block sibling?]
-  (url-property-value? (if sibling?
-                         (:block/parent target-block)
-                         target-block)))
+  (or (url-property-value? target-block)
+      (and sibling? (url-property-value? (:block/parent target-block)))))
 
 (defn ^:api ^:large-vars/cleanup-todo insert-blocks
   "Insert blocks as children (or siblings) of target-node.
@@ -851,7 +850,7 @@
                                       (string/blank? (:block/title target-block))
                                       (> (count blocks) 1)))]
      (when (and (seq blocks)
-                (not (url-property-value-child-target? target-block sibling?)))
+                (not (url-property-value-forbidden-target? target-block sibling?)))
        (let [blocks' (let [blocks' (blocks-with-level blocks)]
                        (cond->> (blocks-with-ordered-list-props blocks' target-block sibling?)
                          update-timestamps?
@@ -1160,7 +1159,7 @@
               original-position? (move-to-original-position? blocks target-block sibling? non-consecutive?)]
           (when (and (every? #(move-source-allowed-for-comments? % sibling?) blocks)
                      (move-target-allowed-for-comments? target-block sibling?)
-                     (not (url-property-value-child-target? target-block sibling?))
+                     (not (url-property-value-forbidden-target? target-block sibling?))
                      (not (contains? (set (map :db/id blocks)) (:db/id target-block)))
                      (not original-position?))
             (let [parents' (->> (ldb/get-block-parents db (:block/uuid target-block) {})

--- a/deps/outliner/src/logseq/outliner/core.cljs
+++ b/deps/outliner/src/logseq/outliner/core.cljs
@@ -779,14 +779,17 @@
                  (rest blocks)))))))
 
 (defn- url-property-value?
-  "URL-type property values are leaves; they must not have child or sibling blocks."
+  "URL-type property values are leaves; they must not have child blocks."
   [block]
   (= :url (:logseq.property/type (:logseq.property/created-from-property block))))
 
 (defn- url-property-value-forbidden-target?
-  "True when insert/move would create a child of a URL value or a sibling of one."
+  "True when insertion or movement would create a URL child or a single-value sibling."
   [target-block sibling?]
-  (or (url-property-value? target-block)
+  (or (and (url-property-value? target-block)
+           (or (not sibling?)
+               (not= :db.cardinality/many
+                     (:db/cardinality (:logseq.property/created-from-property target-block)))))
       (and sibling? (url-property-value? (:block/parent target-block)))))
 
 (defn ^:api ^:large-vars/cleanup-todo insert-blocks
@@ -1098,7 +1101,7 @@
             property-tx (let [retract-property-tx (when block-from-property
                                                     [[:db/retract (:db/id (:block/parent block)) (:db/ident block-from-property) (:db/id block)]
                                                      [:db/retract (:db/id block) :logseq.property/created-from-property]])
-                              add-property-tx (when (and sibling? target-from-property (not block-from-property))
+                              add-property-tx (when (and sibling? target-from-property)
                                                 [[:db/add (:db/id block) :logseq.property/created-from-property (:db/id target-from-property)]
                                                  [:db/add (:db/id (:block/parent target-block)) (:db/ident target-from-property) (:db/id block)]])]
                           (concat retract-property-tx add-property-tx))]

--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -2258,10 +2258,11 @@
         order-list-idx (:own-order-list-index config)
         page-title? (:page-title? config)
         collapsable-page-title? (or page-title? (:collapsable-page-title? config))
-        collapsable? (editor-handler/collapsable? uuid {:semantic? true
-                                                        :block block
-                                                        :ignore-children? page-title?
-                                                        :page-title? collapsable-page-title?})
+        collapsable? (and (not (entity/url-property-value? block))
+                          (editor-handler/collapsable? uuid {:semantic? true
+                                                            :block block
+                                                            :ignore-children? page-title?
+                                                            :page-title? collapsable-page-title?}))
         link? (boolean (:original-block config))
         icon-size (if collapsed? 12 14)
         icon (icon-component/get-node-icon-cp block {:size icon-size :color? true :link? link?})
@@ -2370,10 +2371,18 @@
              [:div (t :block/created-label (date/int->local-time-2 (:block/created-at block)))]
              [:div (t :block/last-edited-label (date/int->local-time-2 (:block/updated-at block)))]]))))]))
 
+(defn- url-property-validation-effect-deps
+  "Re-validate URL property values when the title changes so the error icon updates."
+  [block]
+  [(:db/id block)
+   (some-> (:logseq.property/created-from-property block) :db/id)
+   (:block/title block)])
+
 (hsx/defc subscribed-block-control
   [config block opts]
   (let [child-uuids (db-hooks/use-children (:block/uuid block))
-        has-children? (boolean (seq child-uuids))
+        has-children? (and (not (entity/url-property-value? block))
+                           (boolean (seq child-uuids)))
         block' (assoc block :block.temp/has-children? has-children?)]
     (block-control config block' (assoc opts :has-children? has-children?))))
 
@@ -2508,8 +2517,7 @@
            (set-property-validation-message! nil))
          (set-property-validation-message! nil))
        nil)
-     [(:db/id block)
-      (some-> (:logseq.property/created-from-property block) :db/id)])
+     (url-property-validation-effect-deps block))
     [:div
      (merge
       {:class (if query?
@@ -4603,6 +4611,7 @@
            (query-result config block query-block))))
 
      (when-not (or (:hide-children? config)
+                   (entity/url-property-value? block)
                    table?
                    property?
                    comments-area?

--- a/src/main/frontend/components/page.cljs
+++ b/src/main/frontend/components/page.cljs
@@ -175,12 +175,17 @@
                       (not hide-add-button?)))
          (add-button page child-uuids config))])))
 
+(defn- hide-block-route-add-button?
+  "URL property values are not containers; do not offer a create-sub-block control."
+  [block hide-add-button?]
+  (or hide-add-button? (entity/url-property-value? block)))
+
 (hsx/defc block-route-root
   [block-uuid block config hide-add-button?]
   (let [child-uuids (db-hooks/use-children block-uuid)]
     [:div.page-blocks-inner.relative
      (block/plain-block-list config [block-uuid])
-     (when-not hide-add-button?
+     (when-not (hide-block-route-add-button? block hide-add-button?)
        (add-button block child-uuids config))]))
 
 (hsx/defc page-blocks-cp

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -429,11 +429,17 @@
                      (some-> current-page parse-uuid))]
     (= uuid block-id)))
 
+(defn- url-property-value-insert-blocked?
+  [config block]
+  (and (entity/url-property-value? block)
+       (or (not= :db.cardinality/many
+                 (:db/cardinality (:logseq.property/created-from-property block)))
+           (block-self-alone-when-insert? config (:block/uuid block)))))
+
 (defn- skip-insert-for-url-property-value!
-  "URL property values are leaves. Save the full title and exit instead of
-  creating a child or sibling."
-  [block]
-  (when (entity/url-property-value? block)
+  "Save and exit when insertion would create a URL child or a single-value sibling."
+  [config block]
+  (when (url-property-value-insert-blocked? config block)
     (escape-editing)
     (p/resolved [nil nil nil])))
 
@@ -518,7 +524,7 @@
 
 (defn insert-new-block-before-block-aux!
   [config block value]
-  (or (skip-insert-for-url-property-value! block)
+  (or (skip-insert-for-url-property-value! config block)
       (let [edit-input-id (state/get-edit-input-id)
             input (gdom/getElement edit-input-id)
             input-text-selected? (util/input-text-selected? input)
@@ -556,7 +562,7 @@
    {:block/keys [uuid]
     :as block}
    value]
-  (or (skip-insert-for-url-property-value! block)
+  (or (skip-insert-for-url-property-value! config block)
       (let [repo (state/get-current-repo)
             block-self? (block-self-alone-when-insert? config uuid)
             input (gdom/getElement (state/get-edit-input-id))
@@ -678,7 +684,7 @@
   ([state block-value _right-sibling]
    (when (not config/publishing?)
      (when state
-       (if (entity/url-property-value? (:block state))
+       (if (url-property-value-insert-blocked? (:config state) (:block state))
          (escape-editing)
          (do
            (start-pending-new-block!)
@@ -2623,7 +2629,7 @@
                             (inside-of-single-block (:node state)))]
           (cond
             (or (get-in state [:config :page-title?])
-                (entity/url-property-value? (:block state)))
+                (url-property-value-insert-blocked? (:config state) (:block state)))
             (do
               (when e (.preventDefault e))
               (escape-editing))

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -682,41 +682,41 @@
          (escape-editing)
          (do
            (start-pending-new-block!)
-           (let [{:keys [block value config]} state)
-             value (if (string? block-value) block-value value)
-             block-id (:block/uuid block)
-             block-self? (block-self-alone-when-insert? config block-id)
-             input (:node state)
-             selection-start (util/get-selection-start input)
-             selection-end (util/get-selection-end input)
-             [fst-block-text snd-block-text] (compute-fst-snd-block-text value selection-start selection-end)
-             insert-above? (and (string/blank? fst-block-text) (not (string/blank? snd-block-text)))
-             block' block
-             original-block (:original-block config)
-             block'' (or
-                      (when original-block
-                        (let [e block']
-                          (if (and (worker-has-children? e)
-                                   (not (:block/collapsed? e)))
+           (let [{:keys [block value config]} state
+                 value (if (string? block-value) block-value value)
+                 block-id (:block/uuid block)
+                 block-self? (block-self-alone-when-insert? config block-id)
+                 input (:node state)
+                 selection-start (util/get-selection-start input)
+                 selection-end (util/get-selection-end input)
+                 [fst-block-text snd-block-text] (compute-fst-snd-block-text value selection-start selection-end)
+                 insert-above? (and (string/blank? fst-block-text) (not (string/blank? snd-block-text)))
+                 block' block
+                 original-block (:original-block config)
+                 block'' (or
+                          (when original-block
+                            (let [e block']
+                              (if (and (worker-has-children? e)
+                                       (not (:block/collapsed? e)))
                           ;; object has children and not collapsed
-                            block'
-                            original-block)))
-                      block')
-             insert-fn (cond
-                         block-self?
-                         insert-new-block-aux!
+                                block'
+                                original-block)))
+                          block')
+                 insert-fn (cond
+                             block-self?
+                             insert-new-block-aux!
 
-                         insert-above?
-                         insert-new-block-before-block-aux!
+                             insert-above?
+                             insert-new-block-before-block-aux!
 
-                         :else
-                         insert-new-block-aux!)]
+                             :else
+                             insert-new-block-aux!)]
              (-> (p/let [insert-result (insert-fn config block'' value)
-                     _ (first insert-result)]
-               (clear-when-saved!))
-             (p/catch (fn [error]
-                        (clear-pending-new-block!)
-                        (throw error)))))))))))
+                         _ (first insert-result)]
+                   (clear-when-saved!))
+                 (p/catch (fn [error]
+                            (clear-pending-new-block!)
+                            (throw error)))))))))))
 
 (defn api-insert-new-block!
   [content {:keys [page block-uuid

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2608,8 +2608,6 @@
   [el]
   (some? (dom/closest el ".block-editor")))
 
-(declare escape-editing)
-
 (defn keydown-new-block-handler [^js e]
   (let [target (when e (.-target e))
         state (cond-> (get-state)

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -429,6 +429,16 @@
                      (some-> current-page parse-uuid))]
     (= uuid block-id)))
 
+(defn- insert-new-block-as-sibling?
+  "URL property values cannot own children, so Enter must insert a sibling even
+  when the value is treated as the zoomed/page root."
+  [block block-self?]
+  (cond
+    (entity/url-property-value? block) true
+    (get-in block [:block/link :block/collapsed?]) true
+    block-self? false
+    :else nil))
+
 (defn- start-pending-new-block!
   []
   (state/set-state! :editor/pending-new-block {:typed-text ""}))
@@ -564,7 +574,7 @@
             next-block (-> (merge (select-keys block [:block/parent :block/format :block/page])
                                   new-m)
                            (wrap-parse-block))
-            sibling? (or (get-in block [:block/link :block/collapsed?]) (when block-self? false))
+            sibling? (insert-new-block-as-sibling? block block-self?)
             container-id (or (get-new-container-id :insert {:sibling? sibling?})
                              (:container-id config))
             config (assoc config :editor/edit-block-fn

--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -375,7 +375,7 @@
        (or (= (block-parent-id source-block) (block-parent-id target-block))
            (not (worker-has-children? source-block)))))
 
-(declare save-block-aux! save-current-block! <left-sibling-or-parent)
+(declare save-block-aux! save-current-block! <left-sibling-or-parent escape-editing)
 
 (defn outliner-insert-block!
   [config current-block new-block {:keys [sibling? keep-uuid? ordered-list?
@@ -429,15 +429,13 @@
                      (some-> current-page parse-uuid))]
     (= uuid block-id)))
 
-(defn- insert-new-block-as-sibling?
-  "URL property values cannot own children, so Enter must insert a sibling even
-  when the value is treated as the zoomed/page root."
-  [block block-self?]
-  (cond
-    (entity/url-property-value? block) true
-    (get-in block [:block/link :block/collapsed?]) true
-    block-self? false
-    :else nil))
+(defn- skip-insert-for-url-property-value!
+  "URL property values are leaves. Save the full title and exit instead of
+  creating a child or sibling."
+  [block]
+  (when (entity/url-property-value? block)
+    (escape-editing)
+    (p/resolved [nil nil nil])))
 
 (defn- start-pending-new-block!
   []
@@ -520,29 +518,30 @@
 
 (defn insert-new-block-before-block-aux!
   [config block value]
-  (let [edit-input-id (state/get-edit-input-id)
-        input (gdom/getElement edit-input-id)
-        input-text-selected? (util/input-text-selected? input)
-        new-m {:block/uuid (ldb/new-block-id)
-               :block/title ""}
-        prev-block (-> (merge (select-keys block [:block/parent :block/format :block/page])
-                              new-m)
-                       (wrap-parse-block))
-        repo (state/get-current-repo)]
-    (when input-text-selected?
-      (let [selection-start (util/get-selection-start input)
-            selection-end (util/get-selection-end input)
-            [_ new-content] (compute-fst-snd-block-text value selection-start selection-end)]
-        (state/set-edit-content! edit-input-id new-content)))
-    (p/let [left-or-parent (<left-sibling-or-parent repo block)]
-      (let [sibling? (not= (:db/id left-or-parent) (block-parent-id block))
-            container-id (or (get-new-container-id :insert {:sibling? sibling?})
-                             (:container-id config))
-            config (assoc config :editor/edit-block-fn
-                          (inserted-block-edit-fn block prev-block container-id))
-            result (outliner-insert-block! config left-or-parent prev-block {:sibling? sibling?
-                                                                             :keep-uuid? true})]
-        [result sibling? prev-block]))))
+  (or (skip-insert-for-url-property-value! block)
+      (let [edit-input-id (state/get-edit-input-id)
+            input (gdom/getElement edit-input-id)
+            input-text-selected? (util/input-text-selected? input)
+            new-m {:block/uuid (ldb/new-block-id)
+                   :block/title ""}
+            prev-block (-> (merge (select-keys block [:block/parent :block/format :block/page])
+                                  new-m)
+                           (wrap-parse-block))
+            repo (state/get-current-repo)]
+        (when input-text-selected?
+          (let [selection-start (util/get-selection-start input)
+                selection-end (util/get-selection-end input)
+                [_ new-content] (compute-fst-snd-block-text value selection-start selection-end)]
+            (state/set-edit-content! edit-input-id new-content)))
+        (p/let [left-or-parent (<left-sibling-or-parent repo block)]
+          (let [sibling? (not= (:db/id left-or-parent) (block-parent-id block))
+                container-id (or (get-new-container-id :insert {:sibling? sibling?})
+                                 (:container-id config))
+                config (assoc config :editor/edit-block-fn
+                              (inserted-block-edit-fn block prev-block container-id))
+                result (outliner-insert-block! config left-or-parent prev-block {:sibling? sibling?
+                                                                                 :keep-uuid? true})]
+            [result sibling? prev-block])))))
 
 ;; This used to be a list of file attributes. Unclear if remaining ones should be removed
 (def retract-attributes
@@ -557,31 +556,32 @@
    {:block/keys [uuid]
     :as block}
    value]
-  (let [repo (state/get-current-repo)
-        block-self? (block-self-alone-when-insert? config uuid)
-        input (gdom/getElement (state/get-edit-input-id))
-        selection-start (util/get-selection-start input)
-        selection-end (util/get-selection-end input)]
-    (p/let [worker-result (when-let [block-id (:db/id block)]
-                            (db-async/<get-block-with-children
-                             repo block-id {:children? true}))]
-      (let [block (block-with-worker-children block worker-result)
-            [fst-block-text snd-block-text] (compute-fst-snd-block-text value selection-start selection-end)
-            current-block (current-block-with-title block fst-block-text)
-            current-block (apply dissoc current-block retract-attributes)
-            new-m {:block/uuid (ldb/new-block-id)
-                   :block/title snd-block-text}
-            next-block (-> (merge (select-keys block [:block/parent :block/format :block/page])
-                                  new-m)
-                           (wrap-parse-block))
-            sibling? (insert-new-block-as-sibling? block block-self?)
-            container-id (or (get-new-container-id :insert {:sibling? sibling?})
-                             (:container-id config))
-            config (assoc config :editor/edit-block-fn
-                          (inserted-block-edit-fn current-block next-block container-id))
-            result (outliner-insert-block! config current-block next-block {:sibling? sibling?
-                                                                            :keep-uuid? true})]
-        [result sibling? next-block]))))
+  (or (skip-insert-for-url-property-value! block)
+      (let [repo (state/get-current-repo)
+            block-self? (block-self-alone-when-insert? config uuid)
+            input (gdom/getElement (state/get-edit-input-id))
+            selection-start (util/get-selection-start input)
+            selection-end (util/get-selection-end input)]
+        (p/let [worker-result (when-let [block-id (:db/id block)]
+                                (db-async/<get-block-with-children
+                                 repo block-id {:children? true}))]
+          (let [block (block-with-worker-children block worker-result)
+                [fst-block-text snd-block-text] (compute-fst-snd-block-text value selection-start selection-end)
+                current-block (current-block-with-title block fst-block-text)
+                current-block (apply dissoc current-block retract-attributes)
+                new-m {:block/uuid (ldb/new-block-id)
+                       :block/title snd-block-text}
+                next-block (-> (merge (select-keys block [:block/parent :block/format :block/page])
+                                      new-m)
+                               (wrap-parse-block))
+                sibling? (or (get-in block [:block/link :block/collapsed?]) (when block-self? false))
+                container-id (or (get-new-container-id :insert {:sibling? sibling?})
+                                 (:container-id config))
+                config (assoc config :editor/edit-block-fn
+                              (inserted-block-edit-fn current-block next-block container-id))
+                result (outliner-insert-block! config current-block next-block {:sibling? sibling?
+                                                                                :keep-uuid? true})]
+            [result sibling? next-block])))))
 
 (defn clear-when-saved!
   []
@@ -678,8 +678,11 @@
   ([state block-value _right-sibling]
    (when (not config/publishing?)
      (when state
-       (start-pending-new-block!)
-       (let [{:keys [block value config]} state
+       (if (entity/url-property-value? (:block state))
+         (escape-editing)
+         (do
+           (start-pending-new-block!)
+           (let [{:keys [block value config]} state)
              value (if (string? block-value) block-value value)
              block-id (:block/uuid block)
              block-self? (block-self-alone-when-insert? config block-id)
@@ -708,12 +711,12 @@
 
                          :else
                          insert-new-block-aux!)]
-         (-> (p/let [insert-result (insert-fn config block'' value)
+             (-> (p/let [insert-result (insert-fn config block'' value)
                      _ (first insert-result)]
                (clear-when-saved!))
              (p/catch (fn [error]
                         (clear-pending-new-block!)
-                        (throw error)))))))))
+                        (throw error)))))))))))
 
 (defn api-insert-new-block!
   [content {:keys [page block-uuid
@@ -2621,7 +2624,8 @@
         (let [new-line? (or (state/doc-mode-enter-for-new-line?)
                             (inside-of-single-block (:node state)))]
           (cond
-            (get-in state [:config :page-title?])
+            (or (get-in state [:config :page-title?])
+                (entity/url-property-value? (:block state)))
             (do
               (when e (.preventDefault e))
               (escape-editing))

--- a/src/main/frontend/util/entity.cljs
+++ b/src/main/frontend/util/entity.cljs
@@ -38,6 +38,12 @@
       (class? entity)
       (property? entity)))
 
+(defn url-property-value?
+  "URL-type property values are not containers. They must not have child blocks
+  or expose sub-block UX when zoomed."
+  [entity]
+  (= :url (:logseq.property/type (:logseq.property/created-from-property entity))))
+
 (defn get-entity-types
   [entity]
   (cond-> #{}

--- a/src/main/frontend/util/entity.cljs
+++ b/src/main/frontend/util/entity.cljs
@@ -39,8 +39,8 @@
       (property? entity)))
 
 (defn url-property-value?
-  "URL-type property values are leaves. They must not have child or sibling
-  blocks, or expose sub-block UX when zoomed."
+  "URL-type property values are leaves. They must not have child blocks
+  or expose sub-block UX when zoomed."
   [entity]
   (= :url (:logseq.property/type (:logseq.property/created-from-property entity))))
 

--- a/src/main/frontend/util/entity.cljs
+++ b/src/main/frontend/util/entity.cljs
@@ -39,8 +39,8 @@
       (property? entity)))
 
 (defn url-property-value?
-  "URL-type property values are not containers. They must not have child blocks
-  or expose sub-block UX when zoomed."
+  "URL-type property values are leaves. They must not have child or sibling
+  blocks, or expose sub-block UX when zoomed."
   [entity]
   (= :url (:logseq.property/type (:logseq.property/created-from-property entity))))
 

--- a/src/main/frontend/worker/handler/block_breadcrumb.cljs
+++ b/src/main/frontend/worker/handler/block_breadcrumb.cljs
@@ -27,6 +27,8 @@
         (mapv (fn [choice]
                 (select-keys choice [:db/id :block/uuid :db/ident]))
               (:logseq.property/choice-exclusions ref))
+        property-type (:logseq.property/type ref)
+        cardinality (:db/cardinality ref)
         property-value (:logseq.property/value ref)
         property-icon (:logseq.property/icon ref)
         hide-from-node (:logseq.property.class/hide-from-node ref)
@@ -54,6 +56,8 @@
       (seq ref-tags) (assoc :block/tags ref-tags)
       (seq choice-exclusions)
       (assoc :logseq.property/choice-exclusions choice-exclusions)
+      (some? property-type) (assoc :logseq.property/type property-type)
+      (some? cardinality) (assoc :db/cardinality cardinality)
       (some? property-value) (assoc :logseq.property/value property-value)
       (some? property-icon) (assoc :logseq.property/icon property-icon)
       (some? hide-from-node) (assoc :logseq.property.class/hide-from-node hide-from-node)

--- a/src/test/frontend/components/block/url_property_test.cljs
+++ b/src/test/frontend/components/block/url_property_test.cljs
@@ -1,0 +1,30 @@
+(ns frontend.components.block.url-property-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [frontend.components.block :as block]
+            [frontend.components.page :as page]
+            [frontend.util.entity :as entity]))
+
+(deftest url-property-validation-effect-deps-include-title-test
+  (let [property {:db/id 2 :logseq.property/type :url}
+        invalid {:db/id 1
+                 :block/title "not-a-url"
+                 :logseq.property/created-from-property property}
+        valid (assoc invalid :block/title "https://logseq.com")]
+    (is (= [1 2 "not-a-url"]
+           (#'block/url-property-validation-effect-deps invalid)))
+    (is (= [1 2 "https://logseq.com"]
+           (#'block/url-property-validation-effect-deps valid)))
+    (is (not= (#'block/url-property-validation-effect-deps invalid)
+              (#'block/url-property-validation-effect-deps valid))
+        "Changing the title must change effect deps so invalid URLs re-validate.")))
+
+(deftest zoomed-url-property-value-hides-sub-block-ux-test
+  (testing "URL property values hide leftover children and the add-block control"
+    (let [url-value {:block/title "https://logseq.com"
+                     :logseq.property/created-from-property {:logseq.property/type :url}}
+          text-value {:block/title "text value"
+                      :logseq.property/created-from-property {:logseq.property/type :default}}]
+      (is (entity/url-property-value? url-value))
+      (is (true? (#'page/hide-block-route-add-button? url-value false)))
+      (is (false? (#'page/hide-block-route-add-button? text-value false)))
+      (is (true? (#'page/hide-block-route-add-button? text-value true))))))

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -1525,6 +1525,109 @@
     (is (#'editor/block-map-has-children? parent))
     (is (not (#'editor/block-map-has-children? leaf)))))
 
+(deftest insert-new-block-as-sibling-for-url-property-value-test
+  (let [url-value {:block/title "https://example.com/path"
+                   :logseq.property/created-from-property {:logseq.property/type :url}}
+        text-value {:block/title "text value"
+                    :logseq.property/created-from-property {:logseq.property/type :default}}
+        ordinary {:block/title "ordinary"}]
+    (is (true? (#'editor/insert-new-block-as-sibling? url-value true))
+        "Zoomed or property-root URL values still insert as siblings")
+    (is (true? (#'editor/insert-new-block-as-sibling? url-value false)))
+    (is (false? (#'editor/insert-new-block-as-sibling? text-value true))
+        "Default/text property values can still receive children when they are the insert root")
+    (is (nil? (#'editor/insert-new-block-as-sibling? ordinary false)))
+    (is (false? (#'editor/insert-new-block-as-sibling? ordinary true)))
+    (is (true? (#'editor/insert-new-block-as-sibling?
+                (assoc ordinary :block/link {:block/collapsed? true}) false)))))
+
+(deftest insert-new-block-aux-splits-url-property-value-as-sibling-test
+  (async done
+    (let [url-uuid #uuid "11111111-1111-1111-1111-111111111111"
+          url "https://example.com/path"
+          url-block {:db/id 1
+                     :block/uuid url-uuid
+                     :block/title url
+                     :block/parent {:db/id 10}
+                     :block/page {:db/id 10}
+                     :logseq.property/created-from-property {:logseq.property/type :url}}
+          insertion (atom nil)
+          input #js {:value url}]
+      (-> (p/with-redefs [state/get-current-repo (constantly "repo")
+                          state/get-edit-input-id (constantly "edit-block-url")
+                          gdom/getElement (constantly input)
+                          util/get-selection-start (constantly 19)
+                          util/get-selection-end (constantly 19)
+                          db-async/<get-block-with-children
+                          (fn [& _] (p/resolved {:block url-block :children []}))
+                          editor/wrap-parse-block identity
+                          editor/get-state (constantly nil)
+                          editor/outliner-insert-block!
+                          (fn [config current-block next-block opts]
+                            (reset! insertion {:config config
+                                               :current-block current-block
+                                               :next-block next-block
+                                               :opts opts}))]
+            (editor/insert-new-block-aux!
+             {:id (str url-uuid)}
+             url-block
+             url))
+          (p/then
+           (fn [_]
+             (is (true? (get-in @insertion [:opts :sibling?]))
+                 "Enter on a zoomed/property-root URL value must not request a child insert")
+             (is (= "https://example.com"
+                    (get-in @insertion [:current-block :block/title]))
+                 "Text before the cursor stays on the URL value")
+             (is (= "/path"
+                    (get-in @insertion [:next-block :block/title]))
+                 "Text after the cursor becomes the next sibling instead of being discarded")
+             (done)))
+          (p/catch (fn [error]
+                     (is false (str error))
+                     (done)))))))
+
+(deftest insert-new-block-aux-creates-sibling-at-end-of-url-property-value-test
+  (async done
+    (let [url-uuid #uuid "22222222-2222-2222-2222-222222222222"
+          url "https://logseq.com"
+          url-block {:db/id 2
+                     :block/uuid url-uuid
+                     :block/title url
+                     :block/parent {:db/id 10}
+                     :block/page {:db/id 10}
+                     :logseq.property/created-from-property {:logseq.property/type :url}}
+          insertion (atom nil)
+          input #js {:value url}]
+      (-> (p/with-redefs [state/get-current-repo (constantly "repo")
+                          state/get-edit-input-id (constantly "edit-block-url-end")
+                          gdom/getElement (constantly input)
+                          util/get-selection-start (constantly (count url))
+                          util/get-selection-end (constantly (count url))
+                          db-async/<get-block-with-children
+                          (fn [& _] (p/resolved {:block url-block :children []}))
+                          editor/wrap-parse-block identity
+                          editor/get-state (constantly nil)
+                          editor/outliner-insert-block!
+                          (fn [_config current-block next-block opts]
+                            (reset! insertion {:current-block current-block
+                                               :next-block next-block
+                                               :opts opts}))]
+            (editor/insert-new-block-aux!
+             {:id (str url-uuid)}
+             url-block
+             url))
+          (p/then
+           (fn [_]
+             (is (true? (get-in @insertion [:opts :sibling?]))
+                 "Enter at the end of a zoomed URL value creates a sibling instead of no-op")
+             (is (= url (get-in @insertion [:current-block :block/title])))
+             (is (= "" (get-in @insertion [:next-block :block/title])))
+             (done)))
+          (p/catch (fn [error]
+                     (is false (str error))
+                     (done)))))))
+
 (deftest loaded-block-builds-master-compatible-focus
   (let [previous {:db/id 1
                   :block/uuid #uuid "11111111-1111-1111-1111-111111111111"

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -1525,108 +1525,85 @@
     (is (#'editor/block-map-has-children? parent))
     (is (not (#'editor/block-map-has-children? leaf)))))
 
-(deftest insert-new-block-as-sibling-for-url-property-value-test
-  (let [url-value {:block/title "https://example.com/path"
+(deftest enter-on-url-property-value-saves-and-exits-instead-of-inserting-test
+  (let [url-block {:db/id 1
+                   :block/uuid #uuid "11111111-1111-1111-1111-111111111111"
+                   :block/title "https://example.com/path"
                    :logseq.property/created-from-property {:logseq.property/type :url}}
-        text-value {:block/title "text value"
-                    :logseq.property/created-from-property {:logseq.property/type :default}}
-        ordinary {:block/title "ordinary"}]
-    (is (true? (#'editor/insert-new-block-as-sibling? url-value true))
-        "Zoomed or property-root URL values still insert as siblings")
-    (is (true? (#'editor/insert-new-block-as-sibling? url-value false)))
-    (is (false? (#'editor/insert-new-block-as-sibling? text-value true))
-        "Default/text property values can still receive children when they are the insert root")
-    (is (nil? (#'editor/insert-new-block-as-sibling? ordinary false)))
-    (is (false? (#'editor/insert-new-block-as-sibling? ordinary true)))
-    (is (true? (#'editor/insert-new-block-as-sibling?
-                (assoc ordinary :block/link {:block/collapsed? true}) false)))))
+        target #js {:value "https://example.com/path"
+                    :selectionStart 19}
+        calls (atom [])
+        event #js {:target target
+                   :preventDefault (fn []
+                                     (swap! calls conj :prevent-default))}]
+    (with-redefs [editor/get-state (constantly {:block url-block
+                                                :config {:id (str (:block/uuid url-block))}
+                                                :node target
+                                                :value "https://example.com/path"
+                                                :pos 19})
+                  editor/inside-of-editor-block (constantly true)
+                  editor/pending-new-block? (constantly false)
+                  state/doc-mode-enter-for-new-line? (constantly false)
+                  editor/inside-of-single-block (constantly false)
+                  editor/escape-editing (fn [& _args]
+                                          (swap! calls conj :escape-editing))
+                  editor/keydown-new-block (fn [_state]
+                                             (swap! calls conj :new-block))
+                  editor/insert-new-block! (fn [& _args]
+                                             (swap! calls conj :insert-new-block))]
+      (editor/keydown-new-block-handler event)
+      (is (= [:prevent-default :escape-editing] @calls)
+          "Enter on a URL property value must save and exit without creating a child or sibling."))))
 
-(deftest insert-new-block-aux-splits-url-property-value-as-sibling-test
+(deftest insert-new-block-aux-does-not-split-url-property-value-test
   (async done
-    (let [url-uuid #uuid "11111111-1111-1111-1111-111111111111"
-          url "https://example.com/path"
+    (let [url "https://example.com/path"
           url-block {:db/id 1
-                     :block/uuid url-uuid
+                     :block/uuid #uuid "11111111-1111-1111-1111-111111111111"
                      :block/title url
-                     :block/parent {:db/id 10}
-                     :block/page {:db/id 10}
                      :logseq.property/created-from-property {:logseq.property/type :url}}
-          insertion (atom nil)
-          input #js {:value url}]
-      (-> (p/with-redefs [state/get-current-repo (constantly "repo")
-                          state/get-edit-input-id (constantly "edit-block-url")
-                          gdom/getElement (constantly input)
-                          util/get-selection-start (constantly 19)
-                          util/get-selection-end (constantly 19)
-                          db-async/<get-block-with-children
-                          (fn [& _] (p/resolved {:block url-block :children []}))
-                          editor/wrap-parse-block identity
-                          editor/get-state (constantly nil)
+          calls (atom [])]
+      (-> (p/with-redefs [editor/escape-editing (fn [& _args]
+                                                  (swap! calls conj :escape-editing))
                           editor/outliner-insert-block!
-                          (fn [config current-block next-block opts]
-                            (reset! insertion {:config config
-                                               :current-block current-block
-                                               :next-block next-block
-                                               :opts opts}))]
-            (editor/insert-new-block-aux!
-             {:id (str url-uuid)}
-             url-block
-             url))
+                          (fn [& _args]
+                            (swap! calls conj :insert)
+                            (p/resolved nil))
+                          db-async/<get-block-with-children
+                          (fn [& _]
+                            (swap! calls conj :load-children)
+                            (p/resolved {:block url-block :children []}))]
+            (editor/insert-new-block-aux! {:id (str (:block/uuid url-block))} url-block url))
           (p/then
-           (fn [_]
-             (is (true? (get-in @insertion [:opts :sibling?]))
-                 "Enter on a zoomed/property-root URL value must not request a child insert")
-             (is (= "https://example.com"
-                    (get-in @insertion [:current-block :block/title]))
-                 "Text before the cursor stays on the URL value")
-             (is (= "/path"
-                    (get-in @insertion [:next-block :block/title]))
-                 "Text after the cursor becomes the next sibling instead of being discarded")
+           (fn [result]
+             (is (= [:escape-editing] @calls)
+                 "Enter must not save a truncated title or insert around a URL value")
+             (is (= [nil nil nil] result))
              (done)))
           (p/catch (fn [error]
                      (is false (str error))
                      (done)))))))
 
-(deftest insert-new-block-aux-creates-sibling-at-end-of-url-property-value-test
-  (async done
-    (let [url-uuid #uuid "22222222-2222-2222-2222-222222222222"
-          url "https://logseq.com"
-          url-block {:db/id 2
-                     :block/uuid url-uuid
-                     :block/title url
-                     :block/parent {:db/id 10}
-                     :block/page {:db/id 10}
-                     :logseq.property/created-from-property {:logseq.property/type :url}}
-          insertion (atom nil)
-          input #js {:value url}]
-      (-> (p/with-redefs [state/get-current-repo (constantly "repo")
-                          state/get-edit-input-id (constantly "edit-block-url-end")
-                          gdom/getElement (constantly input)
-                          util/get-selection-start (constantly (count url))
-                          util/get-selection-end (constantly (count url))
-                          db-async/<get-block-with-children
-                          (fn [& _] (p/resolved {:block url-block :children []}))
-                          editor/wrap-parse-block identity
-                          editor/get-state (constantly nil)
-                          editor/outliner-insert-block!
-                          (fn [_config current-block next-block opts]
-                            (reset! insertion {:current-block current-block
-                                               :next-block next-block
-                                               :opts opts}))]
-            (editor/insert-new-block-aux!
-             {:id (str url-uuid)}
-             url-block
-             url))
-          (p/then
-           (fn [_]
-             (is (true? (get-in @insertion [:opts :sibling?]))
-                 "Enter at the end of a zoomed URL value creates a sibling instead of no-op")
-             (is (= url (get-in @insertion [:current-block :block/title])))
-             (is (= "" (get-in @insertion [:next-block :block/title])))
-             (done)))
-          (p/catch (fn [error]
-                     (is false (str error))
-                     (done)))))))
+(deftest insert-new-block-skips-url-property-value-test
+  (let [url-block {:db/id 1
+                   :block/uuid #uuid "11111111-1111-1111-1111-111111111111"
+                   :block/title "https://logseq.com"
+                   :logseq.property/created-from-property {:logseq.property/type :url}}
+        calls (atom [])]
+    (with-redefs [editor/escape-editing (fn [& _args]
+                                          (swap! calls conj :escape-editing))
+                  editor/start-pending-new-block! (fn [& _args]
+                                                    (swap! calls conj :pending))
+                  editor/insert-new-block-aux! (fn [& _args]
+                                                 (swap! calls conj :insert-aux)
+                                                 (p/resolved [nil nil nil]))]
+      (editor/insert-new-block! {:block url-block
+                                 :value "https://logseq.com"
+                                 :config {:id (str (:block/uuid url-block))}}
+                                "https://logseq.com"
+                                nil)
+      (is (= [:escape-editing] @calls)
+          "insert-new-block! must not create a next block from a URL value."))))
 
 (deftest loaded-block-builds-master-compatible-focus
   (let [previous {:db/id 1

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -1555,6 +1555,29 @@
       (is (= [:prevent-default :escape-editing] @calls)
           "Enter on a URL property value must save and exit without creating a child or sibling."))))
 
+(deftest enter-on-multiple-url-property-value-allows-siblings-only-test
+  (doseq [zoomed? [false true]]
+    (let [block-uuid (random-uuid)
+          url-block {:block/uuid block-uuid
+                     :logseq.property/created-from-property
+                     {:logseq.property/type :url
+                      :db/cardinality :db.cardinality/many}}
+          target #js {:value "https://example.com" :selectionStart 19}
+          calls (atom [])]
+      (with-redefs [editor/get-state
+                    (constantly {:block url-block
+                                 :config {:id (str (if zoomed? block-uuid (random-uuid)))}
+                                 :node target})
+                    editor/inside-of-editor-block (constantly true)
+                    editor/pending-new-block? (constantly false)
+                    state/doc-mode-enter-for-new-line? (constantly false)
+                    editor/inside-of-single-block (constantly false)
+                    editor/escape-editing #(swap! calls conj :escape)
+                    editor/keydown-new-block (fn [_] (swap! calls conj :insert))]
+        (editor/keydown-new-block-handler
+         #js {:target target :preventDefault (fn [])})
+        (is (= [(if zoomed? :escape :insert)] @calls))))))
+
 (deftest insert-new-block-aux-does-not-split-url-property-value-test
   (async done
     (let [url "https://example.com/path"

--- a/src/test/frontend/util/entity_test.cljs
+++ b/src/test/frontend/util/entity_test.cljs
@@ -16,3 +16,14 @@
     (is (not (entity/page? {:block/tags [:logseq.class/Task]})))
     (is (not (entity/page? 1)))
     (is (not (entity/page? nil)))))
+
+(deftest url-property-value-predicate-test
+  (testing "URL-type property values are identified from created-from-property"
+    (is (entity/url-property-value?
+         {:block/title "https://logseq.com"
+          :logseq.property/created-from-property {:logseq.property/type :url}}))
+    (is (not (entity/url-property-value?
+              {:block/title "text value"
+               :logseq.property/created-from-property {:logseq.property/type :default}})))
+    (is (not (entity/url-property-value? {:block/title "ordinary block"})))
+    (is (not (entity/url-property-value? nil)))))

--- a/src/test/frontend/worker/handler/block_test.cljs
+++ b/src/test/frontend/worker/handler/block_test.cljs
@@ -106,6 +106,7 @@
           (keyword? (:db/ident reference))))
   (is (every? #{:db/id :block/uuid :db/ident :block/title :block/name
                 :block/tags :logseq.property/value :logseq.property/icon
+                :logseq.property/type :db/cardinality
                 :logseq.property.class/hide-from-node
                 :logseq.property/choice-exclusions
                 :logseq.property.asset/type
@@ -165,6 +166,34 @@
             (is (= tag-ident (get-in value [:block/tags 0 :db/ident])))
             (is (predicate value)
                 "Reference-valued properties retain their renderer type identity")))))))
+
+(deftest canonical-property-values-retain-source-property-type-test
+  (let [{:keys [conn target-uuid page-uuid]} (canonical-block-fixture)
+        property-uuid (random-uuid)]
+    (d/transact! conn [{:db/id -1
+                       :block/uuid property-uuid
+                       :block/title "URL"
+                       :db/ident :user.property/URL
+                       :db/valueType :db.type/ref
+                       :db/cardinality :db.cardinality/many
+                       :block/tags :logseq.class/Property
+                       :logseq.property/type :url}
+                      {:block/uuid target-uuid
+                       :logseq.property/created-from-property -1}])
+    (doseq [property-type [:url :default]]
+      (d/transact! conn [{:block/uuid property-uuid
+                         :logseq.property/type property-type}])
+      (let [block (block-handler/canonical-block
+                   @conn (d/entity @conn [:block/uuid target-uuid]))]
+        (is (= property-type
+               (get-in block [:logseq.property/created-from-property
+                              :logseq.property/type])))
+        (is (= :db.cardinality/many
+               (get-in block [:logseq.property/created-from-property :db/cardinality])))
+        (is (= (= :url property-type) (entity/url-property-value? block)))))
+    (is (not (entity/url-property-value?
+              (block-handler/canonical-block
+               @conn (d/entity @conn [:block/uuid page-uuid])))))))
 
 (deftest canonical-block-keeps-own-attributes-and-only-shallow-references-test
   (when-let [canonical-block (canonical-block-api)]

--- a/src/test/logseq/outliner/url_property_children_test.cljs
+++ b/src/test/logseq/outliner/url_property_children_test.cljs
@@ -136,8 +136,9 @@
                  :pages-and-blocks
                  [{:page {:block/title "page1"
                           :build/properties {:default-many #{"text a" "text b"}}}}]})
-          page (ldb/get-page @conn "page1")
-          [text-a text-b] (->> (:user.property/default-many page)
+          [text-a text-b] (->> [(db-test/find-block-by-content @conn "text a")
+                                (db-test/find-block-by-content @conn "text b")]
+                               (remove nil?)
                                ldb/sort-by-order)
           left (ldb/get-left-sibling text-b)]
       (is (= 2 (count [text-a text-b])))

--- a/src/test/logseq/outliner/url_property_children_test.cljs
+++ b/src/test/logseq/outliner/url_property_children_test.cljs
@@ -11,7 +11,7 @@
        ldb/sort-by-order
        (mapv :block/title)))
 
-(deftest url-property-value-rejects-children-and-siblings
+(deftest url-property-value-rejects-children-and-single-value-siblings
   (testing "insert as child of a URL property value is rejected"
     (let [conn (db-test/create-conn-with-blocks
                 {:properties {:url {:logseq.property/type :url}}
@@ -149,3 +149,30 @@
             text-b' (d/entity @conn (:db/id text-b))]
         (is (= [(:block/title text-b)] (child-titles text-a')))
         (is (= (:db/id text-a') (:db/id (:block/parent text-b'))))))))
+
+(deftest multiple-url-property-values-allow-sibling-insert-and-move
+  (doseq [operation [:insert :move]]
+    (let [conn (db-test/create-conn-with-blocks
+                {:properties {:url-many {:logseq.property/type :url
+                                         :db/cardinality :db.cardinality/many}}
+                 :pages-and-blocks
+                 [{:page {:block/title "page1"
+                          :build/properties {:url-many #{"https://a.example"
+                                                         "https://b.example"
+                                                         "https://c.example"}}}}]})
+          page (ldb/get-page @conn "page1")
+          [first-value _ last-value] (ldb/sort-by-order (:user.property/url-many page))
+          sibling-uuid (if (= :insert operation) (random-uuid) (:block/uuid last-value))]
+      (case operation
+        :insert (outliner-core/insert-blocks!
+                 conn [{:block/uuid sibling-uuid :block/title "https://new.example"}]
+                 first-value {:sibling? true :keep-uuid? true})
+        :move (outliner-core/move-blocks! conn [last-value] first-value {:sibling? true}))
+      (let [sibling (d/entity @conn [:block/uuid sibling-uuid])
+            values (:user.property/url-many (d/entity @conn (:db/id page)))]
+        (is (= (if (= :insert operation) 4 3) (count values)))
+        (is (= (:db/id first-value) (:db/id (ldb/get-left-sibling sibling))))
+        (is (= (:db/id page) (:db/id (:block/parent sibling))))
+        (is (= :user.property/url-many
+               (:db/ident (:logseq.property/created-from-property sibling))))
+        (is (every? #(empty? (child-titles %)) values))))))

--- a/src/test/logseq/outliner/url_property_children_test.cljs
+++ b/src/test/logseq/outliner/url_property_children_test.cljs
@@ -86,8 +86,8 @@
         (is (= original-parent-id (:db/id (:block/parent page-child'))))
         (is (= original-left (:db/id (ldb/get-left-sibling page-child')))))))
 
-  (testing "sibling insert next to a URL property value is rejected")
-    (let [conn (db-test/create-conn-with-blocks
+  (testing "sibling insert next to a URL property value is rejected"
+    (let [conn (db-test/create-conn-with-blocks)
                 {:properties {:url {:logseq.property/type :url}}
                  :pages-and-blocks
                  [{:page {:block/title "page1"
@@ -108,7 +108,7 @@
         (is (empty? (child-titles url-value')))
         (is (= (:db/id (:block/parent url-value'))
                (:db/id (:block/parent page-child')))
-            "Existing page children stay in place"))))))
+            "Existing page children stay in place")))))
 
 (deftest default-property-value-allows-children
   (testing "insert as child of a default/text property value is allowed"

--- a/src/test/logseq/outliner/url_property_children_test.cljs
+++ b/src/test/logseq/outliner/url_property_children_test.cljs
@@ -11,7 +11,7 @@
        ldb/sort-by-order
        (mapv :block/title)))
 
-(deftest url-property-value-rejects-children
+(deftest url-property-value-rejects-children-and-siblings
   (testing "insert as child of a URL property value is rejected"
     (let [conn (db-test/create-conn-with-blocks
                 {:properties {:url {:logseq.property/type :url}}
@@ -70,13 +70,31 @@
         (is (empty? (child-titles url-value')))
         (is (= original-parent-id (:db/id (:block/parent sibling')))))))
 
-  (testing "sibling insert next to a URL property value still works"
+  (testing "move as sibling of a URL property value is rejected"
     (let [conn (db-test/create-conn-with-blocks
                 {:properties {:url {:logseq.property/type :url}}
                  :pages-and-blocks
                  [{:page {:block/title "page1"
-                          :build/properties {:url "https://logseq.com"}}}]})
-          url-value (db-test/find-block-by-content @conn "https://logseq.com")]
+                          :build/properties {:url "https://logseq.com"}}
+                   :blocks [{:block/title "page child"}]}]})
+          url-value (db-test/find-block-by-content @conn "https://logseq.com")
+          page-child (db-test/find-block-by-content @conn "page child")
+          original-left (:db/id (ldb/get-left-sibling page-child))
+          original-parent-id (:db/id (:block/parent page-child))]
+      (outliner-core/move-blocks! conn [page-child] url-value {:sibling? true})
+      (let [page-child' (d/entity @conn (:db/id page-child))]
+        (is (= original-parent-id (:db/id (:block/parent page-child'))))
+        (is (= original-left (:db/id (ldb/get-left-sibling page-child')))))))
+
+  (testing "sibling insert next to a URL property value is rejected")
+    (let [conn (db-test/create-conn-with-blocks
+                {:properties {:url {:logseq.property/type :url}}
+                 :pages-and-blocks
+                 [{:page {:block/title "page1"
+                          :build/properties {:url "https://logseq.com"}}
+                   :blocks [{:block/title "page child"}]}]})
+          url-value (db-test/find-block-by-content @conn "https://logseq.com")
+          page-child (db-test/find-block-by-content @conn "page child")]
       (outliner-core/insert-blocks!
        conn
        [{:block/uuid (random-uuid)
@@ -84,12 +102,13 @@
        url-value
        {:sibling? true
         :keep-uuid? true})
-      (let [inserted (db-test/find-block-by-content @conn "after url")
-            url-value' (d/entity @conn (:db/id url-value))]
-        (is (some? inserted))
+      (let [url-value' (d/entity @conn (:db/id url-value))
+            page-child' (d/entity @conn (:db/id page-child))]
+        (is (nil? (db-test/find-block-by-content @conn "after url")))
+        (is (empty? (child-titles url-value')))
         (is (= (:db/id (:block/parent url-value'))
-               (:db/id (:block/parent inserted))))
-        (is (empty? (child-titles url-value')))))))
+               (:db/id (:block/parent page-child')))
+            "Existing page children stay in place"))))))
 
 (deftest default-property-value-allows-children
   (testing "insert as child of a default/text property value is allowed"

--- a/src/test/logseq/outliner/url_property_children_test.cljs
+++ b/src/test/logseq/outliner/url_property_children_test.cljs
@@ -87,7 +87,7 @@
         (is (= original-left (:db/id (ldb/get-left-sibling page-child')))))))
 
   (testing "sibling insert next to a URL property value is rejected"
-    (let [conn (db-test/create-conn-with-blocks)
+    (let [conn (db-test/create-conn-with-blocks
                 {:properties {:url {:logseq.property/type :url}}
                  :pages-and-blocks
                  [{:page {:block/title "page1"


### PR DESCRIPTION
Fixes [logseq/db-test#1162](https://github.com/logseq/db-test/issues/1162).

URL property values now receive their source property's type and cardinality in worker payloads, so the renderer can identify them correctly. URL validation reruns when the title changes, and zoomed URL values hide child controls and collapse indicators.

URL values cannot have children. Enter on a single-value URL property or a zoomed URL value saves the full title and exits editing. Properties that allow multiple URL values support sibling insertion and reordering; moving an existing value preserves its property association. Default/text property values still support children.

Validation: root and outliner CI lint commands pass locally. The editor, canonical block payload, URL outliner, and outliner core test namespaces pass: 122 tests, 427 assertions. Regression coverage includes source type/cardinality serialization, inline versus zoomed Enter behavior, sibling insertion/reordering, and child rejection. Desktop UI was not manually reverified in this update.
