### PR TITLE
fix: tag Recycle as Page so File→DB page delete works

### DIFF
--- a/deps/outliner/src/logseq/outliner/recycle.cljs
+++ b/deps/outliner/src/logseq/outliner/recycle.cljs
@@ -24,6 +24,7 @@
      :block/uuid (common-uuid/gen-uuid :builtin-block-uuid recycle-page-title)
      :block/name (common-util/page-name-sanity-lc recycle-page-title)
      :block/title recycle-page-title
+     :block/tags [:logseq.class/Page]
      :block/created-at now
      :block/updated-at now
      :logseq.property/hide? true
@@ -33,12 +34,17 @@
   [db]
   (ldb/get-built-in-page db recycle-page-title))
 
+(defn- recycle-page-tag-tx
+  [page]
+  (when-not (ldb/page? page)
+    [[:db/add (:db/id page) :block/tags :logseq.class/Page]]))
+
 (defn- ensure-recycle-page
   [db]
   (if-let [page (recycle-page db)]
     {:page page
      :page-id (:db/id page)
-     :tx-data []}
+     :tx-data (vec (recycle-page-tag-tx page))}
     {:page nil
      :page-id "recycle-page"
      :tx-data [(build-recycle-page-tx "recycle-page")]}))

--- a/deps/outliner/src/logseq/outliner/recycle.cljs
+++ b/deps/outliner/src/logseq/outliner/recycle.cljs
@@ -36,7 +36,7 @@
 
 (defn- recycle-page-tag-tx
   [page]
-  (when-not (ldb/page? page)
+  (when-not (ldb/internal-page? page)
     [[:db/add (:db/id page) :block/tags :logseq.class/Page]]))
 
 (defn- ensure-recycle-page

--- a/deps/outliner/test/logseq/outliner/page_test.cljs
+++ b/deps/outliner/test/logseq/outliner/page_test.cljs
@@ -136,6 +136,36 @@
                      (:db/id d1)))
       (is (= (:block/uuid d1') (:block/uuid (:block/page b1')))))))
 
+(deftest delete-page-succeeds-when-recycle-missing
+  (let [conn (db-test/create-conn-with-blocks
+              [{:page {:block/title "D-missing"}}])
+        page (ldb/get-page @conn "D-missing")
+        recycle (ldb/get-built-in-page @conn common-config/recycle-page-name)]
+    (d/transact! conn [[:db/retractEntity (:db/id recycle)]])
+    (is (nil? (ldb/get-built-in-page @conn common-config/recycle-page-name)))
+    (is (true? (outliner-page/delete! conn (:block/uuid page))))
+    (let [page' (d/entity @conn (:db/id page))
+          recycle' (ldb/get-built-in-page @conn common-config/recycle-page-name)]
+      (is (true? (ldb/page? recycle')))
+      (is (contains? (set (map :db/ident (:block/tags recycle'))) :logseq.class/Page))
+      (is (true? (ldb/recycled? page')))
+      (is (= (:db/id recycle') (:db/id (:block/parent page')))))))
+
+(deftest delete-page-succeeds-when-recycle-untagged
+  (let [conn (db-test/create-conn-with-blocks
+              [{:page {:block/title "D-untagged"}}])
+        page (ldb/get-page @conn "D-untagged")
+        recycle (ldb/get-built-in-page @conn common-config/recycle-page-name)]
+    (d/transact! conn [[:db/retract (:db/id recycle) :block/tags :logseq.class/Page]])
+    (is (not (ldb/page? (d/entity @conn (:db/id recycle)))))
+    (is (true? (outliner-page/delete! conn (:block/uuid page))))
+    (let [page' (d/entity @conn (:db/id page))
+          recycle' (d/entity @conn (:db/id recycle))]
+      (is (true? (ldb/page? recycle')))
+      (is (contains? (set (map :db/ident (:block/tags recycle'))) :logseq.class/Page))
+      (is (true? (ldb/recycled? page')))
+      (is (= (:db/id recycle') (:db/id (:block/parent page')))))))
+
 (deftest delete-class-page-hard-retracts-page-tree
   (let [conn (db-test/create-conn-with-blocks {:classes {:Movie {}}})
         class-page (ldb/get-page @conn "Movie")

--- a/deps/outliner/test/logseq/outliner/recycle_test.cljs
+++ b/deps/outliner/test/logseq/outliner/recycle_test.cljs
@@ -1,11 +1,59 @@
 (ns logseq.outliner.recycle-test
   (:require [cljs.test :refer [deftest is]]
             [datascript.core :as d]
+            [logseq.common.config :as common-config]
             [logseq.common.util :as common-util]
             [logseq.db :as ldb]
             [logseq.db.test.helper :as db-test]
             [logseq.outliner.op :as outliner-op]
             [logseq.outliner.recycle :as recycle]))
+
+(defn- recycle-page
+  [db]
+  (ldb/get-built-in-page db common-config/recycle-page-name))
+
+(defn- retract-recycle-page!
+  [conn]
+  (when-let [page (recycle-page @conn)]
+    (d/transact! conn [[:db/retractEntity (:db/id page)]])))
+
+(defn- untag-recycle-page!
+  [conn]
+  (when-let [page (recycle-page @conn)]
+    (d/transact! conn [[:db/retract (:db/id page) :block/tags :logseq.class/Page]])))
+
+(defn- assert-page-recycled-under-tagged-recycle
+  [db page-id]
+  (let [page (d/entity db page-id)
+        recycle (recycle-page db)]
+    (is (some? recycle))
+    (is (true? (ldb/page? recycle)))
+    (is (contains? (set (map :db/ident (:block/tags recycle))) :logseq.class/Page))
+    (is (true? (ldb/recycled? page)))
+    (is (= (:db/id recycle) (:db/id (:block/parent page))))))
+
+(deftest recycle-page-creates-page-tagged-recycle-when-missing
+  (let [conn (db-test/create-conn-with-blocks
+              [{:page {:block/title "page1"}}])
+        page (ldb/get-page @conn "page1")
+        page-id (:db/id page)]
+    (retract-recycle-page! conn)
+    (is (nil? (recycle-page @conn)))
+    (ldb/transact! conn (recycle/recycle-page-tx-data @conn page {}) {:outliner-op :delete-page})
+    (assert-page-recycled-under-tagged-recycle @conn page-id)))
+
+(deftest recycle-page-repairs-untagged-recycle
+  (let [conn (db-test/create-conn-with-blocks
+              [{:page {:block/title "page1"}}])
+        page (ldb/get-page @conn "page1")
+        page-id (:db/id page)
+        recycle (recycle-page @conn)]
+    (untag-recycle-page! conn)
+    (is (some? recycle))
+    (is (not (ldb/page? (d/entity @conn (:db/id recycle)))))
+    (ldb/transact! conn (recycle/recycle-page-tx-data @conn page {}) {:outliner-op :delete-page})
+    (assert-page-recycled-under-tagged-recycle @conn page-id)
+    (is (= (:db/id recycle) (:db/id (recycle-page @conn))))))
 
 (deftest restore-recycled-page-removes-recycle-parent
   (let [conn (db-test/create-conn-with-blocks


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes page delete on File→DB imported graphs (and any graph whose Recycle page is missing or untagged).

## Problem

Deleting a page on a File→DB imported graph fails with `:transact-failed` / `Page can't have block as parent`. Fresh DB graphs are unaffected.

This happens because `ensure-recycle-page` lazily creates Recycle without `:block/tags [:logseq.class/Page]`. Parenting the deleted page under that untagged Recycle trips `throw-if-page-has-block-parent!`. Fresh graphs already get a correctly tagged Recycle from `create_graph`.

Issue: [logseq/db-test#1164](https://github.com/logseq/db-test/issues/1164) (transferred from logseq/logseq#12801).

## Change

- New Recycle pages created at delete time now include `:logseq.class/Page`, matching `create_graph`.
- Existing untagged Recycle pages are tagged in the same delete transaction, so older imported graphs do not need manual surgery.

## Tests

- `recycle-page-creates-page-tagged-recycle-when-missing`
- `recycle-page-repairs-untagged-recycle`
- `delete-page-succeeds-when-recycle-missing`
- `delete-page-succeeds-when-recycle-untagged`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f116e6f2-6ed1-481e-b417-174607a7e586?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f116e6f2-6ed1-481e-b417-174607a7e586&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

