### PR TITLE
fix: load block breadcrumbs on demand

### DIFF
--- a/src/main/frontend/components/block.cljs
+++ b/src/main/frontend/components/block.cljs
@@ -3794,7 +3794,8 @@
   [config block opts effective-variant]
   (let [block-id (or (:block/uuid block) (:db/id block))
         loaded-block (db-hooks/use-block block-id)
-        block' (or loaded-block block)
+        block' (breadcrumb-model/with-breadcrumb-ref-titles
+                (or loaded-block block) (:ref-titles opts))
         segment (breadcrumb-model/block->breadcrumb-segment block')]
     (when segment
       (let [label (breadcrumb-segment-label segment block')]
@@ -3837,7 +3838,7 @@
        {:class "max-h-[min(50vh,420px)] overflow-y-auto"}
        (for [block-uuid hidden-uuids]
          ^{:key (str block-uuid)}
-         (breadcrumb-dropdown-row config block-uuid ref-titles opts))))))
+         [:<> (breadcrumb-dropdown-row config block-uuid ref-titles opts)])))))
 
 (hsx/defc breadcrumb-overflow-dropdown
   "Renders an ellipsis button that exposes hidden ancestor segments in a dropdown."
@@ -3920,10 +3921,12 @@
 
 (hsx/defc subscribed-breadcrumb
   [config block-id opts]
-  (let [block (db-hooks/use-block block-id)
-        breadcrumb-ancestors (:block.temp/breadcrumb block)]
-    (when (seq breadcrumb-ancestors)
-      (breadcrumb-aux config block-id opts breadcrumb-ancestors))))
+  (when-let [breadcrumb-data (db-hooks/use-resource [:block-breadcrumb block-id 16])]
+    (when (seq (:ancestor-uuids breadcrumb-data))
+      (breadcrumb-aux config block-id
+                      (assoc opts :ref-titles (:ref-titles breadcrumb-data))
+                      (mapv (fn [ancestor-uuid] {:block/uuid ancestor-uuid})
+                            (:ancestor-uuids breadcrumb-data))))))
 
 (defn breadcrumb
   [config _repo block-id {:keys [block] :as opts}]

--- a/src/main/frontend/worker/handler/block.cljs
+++ b/src/main/frontend/worker/handler/block.cljs
@@ -139,8 +139,6 @@
                      (property-handler/block-property-keys db entity)
                      :block.temp/positioned-properties
                      (canonical-positioned-properties-map db entity)
-                     :block.temp/breadcrumb
-                     (block-breadcrumb/block-breadcrumb db entity)
                      :block.temp/refs-count
                      (block-refs-count db entity-id))
         (string? raw-title)
@@ -451,8 +449,6 @@
         block-uuid (:block/uuid block)]
     (cond-> (assoc block
                    :block.temp/refs-count (block-refs-count db block-id)
-                   :block.temp/breadcrumb
-                   (block-breadcrumb/block-breadcrumb db block)
                    :block.temp/comment-thread-present?
                    (contains? commented-block-uuids (str block-uuid))
                    :block.temp/sync-conflicts

--- a/src/test/frontend/components/block/breadcrumb_test.cljs
+++ b/src/test/frontend/components/block/breadcrumb_test.cljs
@@ -1,0 +1,109 @@
+(ns frontend.components.block.breadcrumb-test
+  (:require ["react" :as react]
+            ["react-dom/server" :as react-dom-server]
+            [cljs.test :refer [deftest is]]
+            [clojure.string :as string]
+            [frontend.components.block :as block]
+            [frontend.components.block.breadcrumb-model :as model]
+            [frontend.db.hooks :as db-hooks]
+            [goog.object :as gobj]
+            [logseq.shui.ui :as shui]))
+
+(defn- render-static
+  [element]
+  (let [previous-react (gobj/get js/globalThis "React")]
+    (gobj/set js/globalThis "React" react)
+    (try
+      (.renderToStaticMarkup react-dom-server element)
+      (finally
+        (if (some? previous-react)
+          (gobj/set js/globalThis "React" previous-react)
+          (js-delete js/globalThis "React"))))))
+
+(defn- breadcrumb-fixture
+  []
+  (let [breadcrumb-ancestors (mapv (fn [index]
+                          {:block/uuid (random-uuid)
+                           :block/title (str "Ancestor " index)})
+                        (range 7))]
+    {:target (random-uuid)
+     :breadcrumb-ancestors breadcrumb-ancestors
+     :entities (into {} (map (juxt :block/uuid identity)) breadcrumb-ancestors)}))
+
+(deftest breadcrumb-loads-resource-and-only-visible-ancestors-test
+  (let [{:keys [target breadcrumb-ancestors entities]} (breadcrumb-fixture)
+        resources (atom [])
+        loaded (atom [])]
+    (with-redefs [db-hooks/use-resource
+                  (fn [resource-key]
+                    (swap! resources conj resource-key)
+                    {:ancestor-uuids (mapv :block/uuid breadcrumb-ancestors) :ref-titles {}})
+                  db-hooks/use-block
+                  (fn [block-uuid]
+                    (swap! loaded conj block-uuid)
+                    (get entities block-uuid))
+                  block/breadcrumb-overflow-dropdown (fn [& _] [:span "overflow"])]
+      (let [markup (render-static (block/breadcrumb {} nil target {:disabled? true}))]
+        (is (= [[:block-breadcrumb target 16]] @resources))
+        (is (= (mapv :block/uuid [(first breadcrumb-ancestors) (nth breadcrumb-ancestors 5) (last breadcrumb-ancestors)])
+               @loaded))
+        (is (string/includes? markup "Ancestor 0"))
+        (is (string/includes? markup "Ancestor 5"))
+        (is (string/includes? markup "Ancestor 6"))
+        (is (string/includes? markup "overflow"))
+        (is (not (string/includes? markup "Ancestor 3")))))))
+
+(deftest breadcrumb-resource-hydrates-title-references-test
+  (let [target (random-uuid)
+        ancestor (random-uuid)
+        referenced (random-uuid)
+        title (str "See [[" referenced "]]")]
+    (with-redefs [db-hooks/use-resource
+                  (constantly {:ancestor-uuids [ancestor]
+                               :ref-titles {referenced "Referenced title"}})
+                  db-hooks/use-block
+                  (fn [block-uuid]
+                    (when (= block-uuid ancestor)
+                      {:block/uuid ancestor
+                       :block/title title
+                       :block/raw-title title
+                       :block/refs [{:block/uuid referenced}]}))]
+      (let [markup (render-static (block/breadcrumb {} nil target {:disabled? true}))]
+        (is (string/includes? markup "See [[Referenced title]]"))
+        (is (not (string/includes? markup (str referenced))))))))
+
+(deftest breadcrumb-does-not-load-ancestors-before-resource-is-ready-test
+  (doseq [resource [nil {:ancestor-uuids [] :ref-titles {}}]]
+    (with-redefs [db-hooks/use-resource (constantly resource)
+                  db-hooks/use-block (fn [_] (is false "No block should be loaded"))]
+      (is (= "" (render-static (block/breadcrumb {} nil (random-uuid) {})))))))
+
+(deftest search-breadcrumb-keeps-inline-payload-test
+  (with-redefs [db-hooks/use-resource (fn [_] (is false "Search already supplied breadcrumb-ancestors"))
+                db-hooks/use-block (constantly nil)]
+    (let [ancestor {:block/uuid (random-uuid) :block/title "Search ancestor"}
+          markup (render-static
+                  (block/breadcrumb {:search? true} nil (random-uuid)
+                                    {:block {:block.temp/breadcrumb [ancestor]}}))]
+      (is (string/includes? markup "Search ancestor")))))
+
+(deftest breadcrumb-overflow-loads-hidden-resource-ancestors-test
+  (let [{:keys [target breadcrumb-ancestors entities]} (breadcrumb-fixture)
+        resources (atom [])
+        loaded (atom [])]
+    (with-redefs [db-hooks/use-resource
+                  (fn [resource-key]
+                    (swap! resources conj resource-key)
+                    {:ancestor-uuids (mapv :block/uuid breadcrumb-ancestors) :ref-titles {}})
+                  db-hooks/use-block
+                  (fn [block-uuid]
+                    (swap! loaded conj block-uuid)
+                    (get entities block-uuid))
+                  shui/dropdown-menu-content (fn [_opts & children] (into [:div] children))
+                  shui/dropdown-menu-item (fn [_opts & children] (into [:div] children))]
+      (let [markup (render-static
+                    (block/breadcrumb-overflow-content
+                     {} target {:disabled? true} (model/variant-options :block-page) true))]
+        (is (= [[:block-breadcrumb target 1000]] @resources))
+        (is (= (mapv :block/uuid (subvec breadcrumb-ancestors 1 5)) @loaded))
+        (is (string/includes? markup "Ancestor 3"))))))

--- a/src/test/frontend/worker/db_core_test.cljs
+++ b/src/test/frontend/worker/db_core_test.cljs
@@ -2293,6 +2293,8 @@
              plain-results (remove #(= "Block 2" (:block/title %)) children)
              unrelated-result (some #(when (= "Block 3" (:block/title %)) %) children)]
          (is (= 165 (count children)))
+         (is (every? #(not (contains? % :block.temp/breadcrumb)) (cons block children))
+             "Ordinary tree metadata does not preload breadcrumbs.")
          (is (contains? block :block.temp/display-properties)
              "The journal root should carry full render data in its initial tree response.")
          (is (contains? block :block.temp/positioned-properties))

--- a/src/test/frontend/worker/handler/block_test.cljs
+++ b/src/test/frontend/worker/handler/block_test.cljs
@@ -235,7 +235,7 @@
       (is (= 1 (:block.temp/order-list-index block))
           "Canonical blocks retain worker-derived ordered-list indexes.")
       (is (map? (:block.temp/positioned-properties block)))
-      (is (vector? (:block.temp/breadcrumb block)))
+      (is (not (contains? block :block.temp/breadcrumb)))
       (is (integer? (:block.temp/refs-count block)))
       (is (some #{:user.property/priority} (:block.temp/property-keys block))
           "Own property idents are persisted for collapse.")
@@ -244,7 +244,6 @@
       (is (not-any? #(and (keyword? %)
                           (= "block.temp" (namespace %)))
                     (remove #{:block.temp/order-list-index
-                              :block.temp/breadcrumb
                               :block.temp/positioned-properties
                               :block.temp/property-keys
                               :block.temp/refs-count}

--- a/src/test/frontend/worker/handler/render_resource_test.cljs
+++ b/src/test/frontend/worker/handler/render_resource_test.cljs
@@ -519,7 +519,6 @@
   (is (not (contains? block :block/properties)))
   (is (not (contains? block :block/properties-text-values)))
   (is (every? #{:block.temp/positioned-properties
-                :block.temp/breadcrumb
                 :block.temp/refs-count
                 :block.temp/order-list-index
                 :block.temp/property-keys}
@@ -1062,8 +1061,8 @@
                             #"Unknown renderer resource key"
                             (call-resource-raw api conn resource-key))))))
 
-(deftest canonical-visible-blocks-include-ready-properties-and-breadcrumbs-test
-  (let [{:keys [conn page resource-block positioned-property]}
+(deftest canonical-visible-blocks-keep-properties-without-preloading-breadcrumbs-test
+  (let [{:keys [conn resource-block positioned-property]}
         (render-resource-fixture)
         positioned-property-id (:db/id (d/entity @conn
                                                   [:block/uuid positioned-property]))
@@ -1072,9 +1071,8 @@
         target (get-in response [:blocks resource-block])]
     (is (contains? (:blocks response) positioned-property)
         "A positioned property row is ready in the same visible block load.")
-    (is (= [page]
-           (mapv :block/uuid (:block.temp/breadcrumb target)))
-        "The primary breadcrumb is ready with its owning block.")
+    (is (not (contains? target :block.temp/breadcrumb))
+        "Ancestor data loads only when a breadcrumb is displayed.")
     (is (= response
            (-> response ldb/write-transit-str ldb/read-transit-str)))))
 


### PR DESCRIPTION
Canonical block loads and block-metadata tree responses calculate and transmit ancestor summaries for every block, even when no breadcrumb is displayed. Remove that eager metadata and request the existing breadcrumb resource when a breadcrumb component renders. Only visible ancestor rows load canonical blocks; referenced titles come from the resource. Search keeps its opt-in breadcrumb snapshots, and the overflow menu keeps loading hidden ancestors on demand.

Add regression coverage for ordinary block/tree payloads, visible-only ancestor loading, referenced labels, loading/empty states, search snapshots, and overflow rendering. Correct the overflow row key placement exposed by the React render test.

Validation: all root CI lint commands pass. Breadcrumb renderer/model, canonical block, render-resource, search, and journal-tree tests pass: 160 tests, 1,041 assertions. Desktop UI was not manually exercised; renderer coverage uses React static rendering.
