### PR TITLE
fix: skip editor autopair during native IME keydown

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -3359,7 +3359,7 @@
         (contains? #{"ArrowLeft" "ArrowRight"} key)
         (state/clear-editor-action!)
 
-        (and (util/goog-event-is-composing? e true) ;; #3218
+        (and (util/native-event-is-composing? e true) ;; #3218 #12966
              (not hashtag?) ;; #3283 @Rime
              (not (state/get-editor-show-page-search-hashtag?))) ;; #3283 @MacOS pinyin
         nil
@@ -3526,7 +3526,7 @@
 (defn keyup-handler
   [_state input]
   (fn [e key-code]
-    (when-not (util/goog-event-is-composing? e)
+    (when-not (util/native-event-is-composing? e false)
       (let [current-pos (cursor/pos input)
             value (gobj/get input "value")
             c (util/nth-safe value (dec current-pos))
@@ -3552,8 +3552,8 @@
                (if (mobile-util/native-android?)
                  (gobj/get e "key")
                  (event-code e))
-               ;; #3440
-               (util/goog-event-is-composing? e true)])
+               ;; #3440 #12966 — native window keyup events
+               (util/native-event-is-composing? e true)])
             comment-editor? (:comment-editor? (last (state/get-editor-args)))]
         (cond
           (= value "``````") ; turn this block into a code block

--- a/src/main/frontend/util.cljc
+++ b/src/main/frontend/util.cljc
@@ -1140,21 +1140,27 @@
 
 #?(:cljs
    (defn native-event-is-composing?
-     "Check if onchange event of Input is a composing (IME) event.
-       Always ignore the IME process."
-     [^js e]
-     (when-let [^js native-event
-                (and e (cond
-                         (goog-event? e)
-                         (.getBrowserEvent e)
+     "Check if a KeyboardEvent (native, React synthetic, or goog-wrapped) is an
+      IME composing event. Always ignore the IME process by default (keyCode 229 /
+      key Process), matching the include-process?=true path of goog-event-is-composing?."
+     ([^js e]
+      (native-event-is-composing? e true))
+     ([^js e include-process?]
+      (when-let [^js native-event
+                 (and e (cond
+                          (goog-event? e)
+                          (.getBrowserEvent e)
 
-                         (js-in "_reactName" e)
-                         (.-nativeEvent e)
+                          (js-in "_reactName" e)
+                          (.-nativeEvent e)
 
-                         :else e))]
-       (or (.-isComposing native-event)
-           (= (gobj/get native-event "keyCode") 229)
-           (= (gobj/get native-event "key") "Process")))))
+                          :else e))]
+        (let [event-composing? (.-isComposing native-event)]
+          (if include-process?
+            (or event-composing?
+                (= (gobj/get native-event "keyCode") 229)
+                (= (gobj/get native-event "key") "Process"))
+            event-composing?))))))
 
 #?(:cljs
    (defn open-url

--- a/src/test/frontend/handler/editor_test.cljs
+++ b/src/test/frontend/handler/editor_test.cljs
@@ -24,6 +24,7 @@
             [frontend.util :as util]
             [frontend.util.cursor :as cursor]
             [goog.dom :as gdom]
+            [goog.object :as gobj]
             [logseq.db :as ldb]
             [logseq.db.sqlite.build :as sqlite-build]
             [logseq.graph-parser.block :as gp-block]
@@ -1291,6 +1292,51 @@
           :cursor-pos 9}
          (keydown-dollar-without-selection-result {:value "inline $$"
                                                    :cursor-pos 8}))))
+
+(defn- keydown-bracket-autopair-result
+  "Drive keydown-not-matched-handler for `[` with a native KeyboardEvent-shaped
+  object (window addEventListener path). Returns whether autopair ran."
+  [{:keys [key key-code composing? value cursor-pos]
+    :or {key "[" key-code 219 composing? false value "" cursor-pos 0}}]
+  (let [content (atom nil)
+        stopped? (atom false)
+        input #js {:id "edit-block-test"
+                   :value value}
+        event (js-obj)]
+    (gobj/set event "key" key)
+    (gobj/set event "keyCode" key-code)
+    (gobj/set event "isComposing" (boolean composing?))
+    (gobj/set event "ctrlKey" false)
+    (gobj/set event "metaKey" false)
+    (with-redefs [state/get-edit-input-id (constantly "edit-block-test")
+                  state/get-input (constantly input)
+                  state/get-editor-action (constantly nil)
+                  state/get-state (constantly nil)
+                  state/set-state! (constantly nil)
+                  state/set-block-content-and-last-pos! (fn [_input-id value' _pos']
+                                                          (reset! content value'))
+                  gdom/getElement (constantly input)
+                  util/get-selected-text (constantly "")
+                  util/stop (fn [_] (reset! stopped? true))
+                  cursor/pos (constantly cursor-pos)
+                  cursor/move-cursor-to (constantly nil)
+                  cursor/get-caret-pos (constantly {:pos cursor-pos})]
+      ((editor/keydown-not-matched-handler :markdown) event key-code)
+      {:content @content
+       :stopped? @stopped?})))
+
+(deftest keydown-not-matched-handler-skips-bracket-autopair-during-ime
+  ;; #12966: native window keydown events are invisible to goog-event-is-composing?,
+  ;; so Japanese IME `[` → 「 was swallowed by [] autopair.
+  (testing "IME process keyCode 229 must not autopair"
+    (is (= {:content nil :stopped? false}
+           (keydown-bracket-autopair-result {:key "[" :key-code 229 :composing? false}))))
+  (testing "isComposing true must not autopair"
+    (is (= {:content nil :stopped? false}
+           (keydown-bracket-autopair-result {:key "[" :key-code 219 :composing? true}))))
+  (testing "plain `[` without IME still autopairs"
+    (is (= {:content "[]" :stopped? true}
+           (keydown-bracket-autopair-result {:key "[" :key-code 219 :composing? false})))))
 
 (defn- delete-block-at-zero-pos-result
   [block & {:keys [left-sibling]}]

--- a/src/test/frontend/util_test.cljs
+++ b/src/test/frontend/util_test.cljs
@@ -95,7 +95,8 @@
       (gobj/set event "key" "Enter")
       (gobj/set event "keyCode" 229)
       (gobj/set event "isComposing" false)
-      (is (true? (util/native-event-is-composing? event)))))
+      (is (true? (util/native-event-is-composing? event)))
+      (is (false? (boolean (util/native-event-is-composing? event false))))))
 
   (testing "IME Process key is composing"
     (let [event (js-obj)]
@@ -109,4 +110,5 @@
       (gobj/set event "key" "Enter")
       (gobj/set event "keyCode" 13)
       (gobj/set event "isComposing" true)
-      (is (true? (util/native-event-is-composing? event))))))
+      (is (true? (util/native-event-is-composing? event)))
+      (is (true? (util/native-event-is-composing? event false))))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #12966

## Problem

Editor `keydown` / `keyup` listeners are attached with native `window.addEventListener`, but composing checks used `goog-event-is-composing?`, which only works on goog-wrapped events. Native IME events (`isComposing` / `keyCode` 229 / `Process`) were treated as non-composing, so `[` autopair called `preventDefault` and inserted `[]`, swallowing Japanese IME `「` (and similar auto-paired keys).

## Fix

- Use `native-event-is-composing?` in `keydown-not-matched-handler` and `keyup-handler`.
- Give `native-event-is-composing?` an `include-process?` arity so keyup can keep `isComposing`-only filtering while still detecting IME process keys where needed.

## Evidence

- Pre-fix unit test: native `[` + `keyCode` 229 / `isComposing` incorrectly inserted `[]`.
- Post-fix unit test: same cases skip autopair; plain `[` still autopairs.
- `:app` REPL: `native-event-is-composing?` detects native IME events; `goog-event-is-composing?` returns `nil` for the same events.

## Tests

- `frontend.handler.editor-test/keydown-not-matched-handler-skips-bracket-autopair-during-ime`
- `frontend.util-test/native-event-is-composing?-detects-ime-process-enter`
- Regression: dollar autopair without selection

Manual Japanese IME UI verification was not available here (no Japanese input source).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a081bf-789c-7696-b0e1-a08511e123ff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a081bf-789c-7696-b0e1-a08511e123ff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

